### PR TITLE
✨amp-timeago: Update fuzzy timestamp on viewportCallback()

### DIFF
--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -32,6 +32,12 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
     /** @private {string} */
     this.title_ = '';
+
+    /** @private {?Element} */
+    this.timeElement_ = null;
+
+    /** @private {boolean} */
+    this.cutOffSet_ = false;
   }
 
   /** @override */
@@ -47,32 +53,43 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.element.title = this.title_;
     this.element.textContent = '';
 
-    const timeElement = document.createElement('time');
-    timeElement.setAttribute('datetime', this.datetime_);
+    this.timeElement_ = document.createElement('time');
+    this.timeElement_.setAttribute('datetime', this.datetime_);
 
-    if (this.element.hasAttribute('cutoff')) {
-      const cutoff = parseInt(this.element.getAttribute('cutoff'), 10);
-      const elDate = new Date(this.datetime_);
-      const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
+    this.setFuzzyTimestampValue_();
+    this.element.appendChild(this.timeElement_);
+  }
 
-      if (secondsAgo > cutoff) {
-        timeElement.textContent = this.title_;
-      } else {
-        timeElement.textContent = timeago(this.datetime_, this.locale_);
-      }
-    } else {
-      timeElement.textContent = timeago(this.datetime_, this.locale_);
+  /** @override */
+  viewportCallback(inViewport) {
+    if (inViewport && !this.cutOffSet_) {
+      this.setFuzzyTimestampValue_();
     }
-
-    this.element.appendChild(timeElement);
   }
 
   /** @override */
   isLayoutSupported(layout) {
     return isLayoutSizeDefined(layout);
   }
-}
 
+  /** @private */
+  setFuzzyTimestampValue_() {
+    if (this.element.hasAttribute('cutoff')) {
+      const cutoff = parseInt(this.element.getAttribute('cutoff'), 10);
+      const elDate = new Date(this.datetime_);
+      const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
+
+      if (secondsAgo > cutoff) {
+        this.timeElement_.textContent = this.title_;
+        this.cutOffSet_ = true;
+      } else {
+        this.timeElement_.textContent = timeago(this.datetime_, this.locale_);
+      }
+    } else {
+      this.timeElement_.textContent = timeago(this.datetime_, this.locale_);
+    }
+  }
+}
 
 AMP.extension('amp-timeago', '0.1', AMP => {
   AMP.registerElement('amp-timeago', AmpTimeAgo);

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -37,7 +37,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.timeElement_ = null;
 
     /** @private {boolean} */
-    this.cutOffSet_ = false;
+    this.cutOffReached_ = false;
   }
 
   /** @override */
@@ -62,7 +62,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
   /** @override */
   viewportCallback(inViewport) {
-    if (inViewport && !this.cutOffSet_) {
+    if (inViewport && !this.cutOffReached_) {
       this.setFuzzyTimestampValue_();
     }
   }
@@ -81,7 +81,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
       if (secondsAgo > cutoff) {
         this.timeElement_.textContent = this.title_;
-        this.cutOffSet_ = true;
+        this.cutOffReached_ = true;
       } else {
         this.timeElement_.textContent = timeago(this.datetime_, this.locale_);
       }

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -55,7 +55,7 @@ describes.realWin('amp-timeago', {
     expect(timeElement.textContent).to.equal('Sunday 1 January 2017');
   });
 
-  it('should display updated fuzzy timestamp when viewportCallback is called', async function() {
+  it('should update fuzzy timestamp on viewportCallback', async function() {
     const date = new Date();
     date.setSeconds(date.getSeconds() - 10);
     element.setAttribute('datetime', date.toISOString());

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -24,6 +24,8 @@ describes.realWin('amp-timeago', {
   let win;
   let element;
 
+  const timeout = ms => new Promise(res => setTimeout(res, ms));
+
   beforeEach(() => {
     win = env.win;
     element = win.document.createElement('amp-timeago');
@@ -52,4 +54,17 @@ describes.realWin('amp-timeago', {
     const timeElement = element.querySelector('time');
     expect(timeElement.textContent).to.equal('Sunday 1 January 2017');
   });
+
+  it('should display updated fuzzy timestamp when viewportCallback is called', async function() {
+    const date = new Date();
+    date.setSeconds(date.getSeconds() - 10);
+    element.setAttribute('datetime', date.toISOString());
+    element.textContent = date.toString();
+    element.build();
+    await timeout(1000);
+    element.viewportCallback(true);
+    const timeElement = element.querySelector('time');
+    expect(timeElement.textContent).to.equal('11 seconds ago');
+  });
+
 });


### PR DESCRIPTION
If an amp-timeago component moves into viewport, set the text content to an updated fuzzy timestamp.

This should partially address the issue #17254.