### PR TITLE
✨ amp-next-page: Add support for type="adsense"

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -75,7 +75,7 @@ export class AmpNextPage extends AMP.BaseElement {
       element.classList.add('i-amphtml-next-page');
 
       const src = element.getAttribute('src');
-      let configPromise = Promise.resolve({});
+      let configPromise;
       let pagesPromise = Promise.resolve([]);
 
       const type = element.getAttribute('type');

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -99,7 +99,8 @@ export class AmpNextPage extends AMP.BaseElement {
 
         pagesPromise = consent.then(
             state => this.fetchAdSensePages_(client, slot,
-                state === CONSENT_POLICY_STATE.SUFFICIENT))
+                state === CONSENT_POLICY_STATE.SUFFICIENT ||
+                state === CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED))
             .catch(error => {
               user().warn(
                   TAG, 'error fetching recommendations from AdSense', error);

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {CSS} from '../../../build/amp-next-page-0.1.css';
 import {Layout} from '../../../src/layout';
 import {NextPageService} from './next-page-service';
+import {Services} from '../../../src/services';
 import {
   UrlReplacementPolicy,
   batchFetchJsonFor,
@@ -25,17 +27,22 @@ import {assertConfig} from './config';
 import {
   childElementsByAttr,
   childElementsByTag,
+  elementByTag,
   isJsonScriptTag,
   removeElement,
 } from '../../../src/dom';
+import {dev, user} from '../../../src/log';
+import {fetchDocument} from '../../../src/document-fetcher';
+import {getConsentPolicyState} from '../../../src/consent';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {isExperimentOn} from '../../../src/experiments';
-import {tryParseJson} from '../../../src/json';
-import {user} from '../../../src/log';
+import {parseJson, tryParseJson} from '../../../src/json';
 
 const TAG = 'amp-next-page';
 
 const SERVICE_ID = 'next-page';
+
+const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
 
 export class AmpNextPage extends AMP.BaseElement {
 
@@ -68,24 +75,127 @@ export class AmpNextPage extends AMP.BaseElement {
       element.classList.add('i-amphtml-next-page');
 
       const src = element.getAttribute('src');
+      let configPromise = Promise.resolve({});
+      let pagesPromise = Promise.resolve([]);
+
+      const type = element.getAttribute('type');
+      if (type) {
+        user().assert(type === 'adsense', `${TAG} only supports type=adsense`);
+        const client = element.getAttribute('data-client');
+        const slot = element.getAttribute('data-slot');
+
+        user().assert(/^ca-pub-\d+$/.test(client),
+            `${TAG} AdSense client should be of the format 'ca-pub-123456'`);
+        user().assert(/^\d+$/.test(slot),
+            `${TAG} AdSense slot should be a number`);
+
+        const consentPolicyId = this.getConsentPolicy();
+        const consent = consentPolicyId ?
+          getConsentPolicyState(this.getAmpDoc(), consentPolicyId)
+              .catch(err => {
+                user().error(TAG, 'Error determining consent state', err);
+                return CONSENT_POLICY_STATE.UNKNOWN;
+              }) : Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT);
+
+        pagesPromise = consent.then(
+            state => this.fetchAdSensePages_(client, slot,
+                state === CONSENT_POLICY_STATE.SUFFICIENT))
+            .catch(error => {
+              user().warn(
+                  TAG, 'error fetching recommendations from AdSense', error);
+              // Resolve this promise with an empty array anyway so we can use
+              // the inline/src config as a fallback.
+              return [];
+            });
+      }
+
+      const inlineConfig = this.getInlineConfig_();
+
       if (src) {
-        return this.fetchConfig_().then(
-            config => this.register_(service, config, separator),
+        configPromise = this.fetchConfig_().catch(
             error => user().error(TAG, 'error fetching config', error));
       } else {
-        const scriptElements = childElementsByTag(element, 'SCRIPT');
-        user().assert(scriptElements.length === 1,
-            '%s should contain only one <script> child, or a URL specified '
-            + 'in [src]', TAG);
-        const scriptElement = scriptElements[0];
-        user().assert(isJsonScriptTag(scriptElement),
-            '%s config should be inside a <script> tag with '
-            + 'type="application/json"', TAG);
-        const configJson = tryParseJson(scriptElement.textContent, error => {
-          user().error(TAG, 'failed to parse config', error);
-        });
-        this.register_(service, configJson, separator);
+        configPromise = Promise.resolve(inlineConfig);
       }
+
+      user().assert(inlineConfig || src || type,
+          '%s should contain a <script> child, a URL specified in [src], or a '
+          + '[type]', TAG);
+
+      return Promise.all([configPromise, pagesPromise]).then(values => {
+        const config = values[0] || {};
+        const pages = values[1] || [];
+        config.pages = pages.concat(config.pages || []);
+        this.register_(service, config, separator);
+      });
+    });
+  }
+
+  /**
+   * Reads the inline config from the element.
+   * @return {?*} Config JSON object, or null if no inline config specified.
+   * @private
+   */
+  getInlineConfig_() {
+    const scriptElements = childElementsByTag(this.element, 'SCRIPT');
+    if (!scriptElements.length) {
+      return null;
+    }
+    user().assert(scriptElements.length === 1,
+        `${TAG} should contain at most one <script> child`);
+    const scriptElement = scriptElements[0];
+    user().assert(isJsonScriptTag(scriptElement),
+        `${TAG} config should ` +
+        'be inside a <script> tag with type="application/json"');
+    return tryParseJson(scriptElement.textContent, error => {
+      user().error(TAG, 'failed to parse config', error);
+    });
+  }
+
+  /**
+   * Fetches content recommendations from AdSense and returns a list of {@link
+   * AmpNextPageItem}.
+   * @param {string} client AdSense publisher code.
+   * @param {string} slot AdSense Matched Content ad slotname.
+   * @param {boolean} personalized {@code true} if the request should be
+   *     personalized (with cookies).
+   * @return {!Promise<Array<./config.AmpNextPageItem>>} List of recommended
+   *     pages.
+   * @private
+   */
+  fetchAdSensePages_(client, slot, personalized) {
+    const adUrl = `${ADSENSE_BASE_URL}?client=${client}&slotname=${slot}`
+        + `&url=${encodeURIComponent(this.getAmpDoc().getUrl())}`
+        + '&ecr=1&crui=title&is_amp=3&output=xml';
+    return fetchDocument(this.win, adUrl, {
+      credentials: personalized ? 'include' : 'omit',
+    }).then(doc => {
+      const urlService =
+              Services.urlForDoc(dev().assertElement(this.element));
+      const {origin} = urlService.parse(this.getAmpDoc().getUrl());
+
+      const recs = [];
+      const ads = doc.getElementsByTagName('AD');
+      for (let i = 0; i < ads.length; i++) {
+        const ad = ads[i];
+        const titleEl = elementByTag(ad, 'LINE1');
+        const mediaEl = elementByTag(ad, 'MEDIA_TEMPLATE_DATA');
+
+        const visibleUrl = ad.getAttribute('visible_url');
+        const url = ad.getAttribute('url');
+        const title = extractAdSenseTextContent(titleEl);
+        const image = extractAdSenseImageUrl(mediaEl);
+
+        const isValidOrigin = urlService.parse(visibleUrl).origin === origin;
+        if (isValidOrigin && url && title && image) {
+          recs.push({
+            title,
+            image,
+            ampUrl: url,
+          });
+        }
+      }
+      return recs;
     });
   }
 
@@ -131,6 +241,34 @@ export class AmpNextPage extends AMP.BaseElement {
 function nextPageServiceForDoc(elementOrAmpDoc) {
   return /** @type {!Promise<!NextPageService>} */ (
     getServicePromiseForDoc(elementOrAmpDoc, SERVICE_ID));
+}
+
+/**
+ * Extracts the core_image_url string from the JSON text content of the
+ * MEDIA_TEMPLATE_DATA tag.
+ * @param {Element} el The element containing the media JSON text.
+ * @return {string} The image URL, or empty string if it could not be
+ *     extracted.
+ */
+function extractAdSenseImageUrl(el) {
+  try {
+    // Media payload is a JSON string terminated with a semicolon. Remove it
+    // before parsing.
+    const media = parseJson(el.textContent.trim().slice(0, -1))[0];
+    return media['core_image_url'];
+  } catch (e) {
+    return '';
+  }
+}
+
+/**
+ * Returns the text content of an element, with leading/trailing whitespace
+ * trimmed.
+ * @param {Element} el
+ */
+function extractAdSenseTextContent(el) {
+  const content = (el && el.textContent) || '';
+  return content.trim();
 }
 
 AMP.extension(TAG, '0.1', AMP => {

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -23,6 +23,8 @@ import {
 import {isArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
+const ADSENSE_REC_ORIGIN = 'https://googleads.g.doubleclick.net';
+
 /**
  * @typedef {{
  *   pages: !Array<!AmpNextPageItem>,
@@ -108,7 +110,9 @@ function assertReco(context, reco, documentUrl) {
   const {origin} = urlService.parse(documentUrl);
   const sourceOrigin = getSourceOrigin(documentUrl);
 
-  user().assert(url.origin === origin || url.origin === sourceOrigin,
+  user().assert(
+      url.origin === origin || url.origin === sourceOrigin
+      || isValidAdSenseURL(context, url, origin),
       'pages must be from the same origin as the current document');
   user().assertString(reco.image, 'image must be a string');
   user().assertString(reco.title, 'title must be a string');
@@ -120,4 +124,20 @@ function assertReco(context, reco, documentUrl) {
         encodeURIComponent(url.host) +
         url.pathname + (url.search || '') + (url.hash || '');
   }
+}
+
+/**
+ * @param {!Element} context
+ * @param {!Location} url
+ * @param {string} origin
+ * @return {boolean}
+ */
+function isValidAdSenseURL(context, url, origin) {
+  const matches = url.search.match(/adurl=(.*)(?:&|$)/);
+  if (!matches) {
+    return false;
+  }
+  const urlService = Services.urlForDoc(context);
+  const targetUrl = urlService.parse(matches[1]);
+  return url.origin === ADSENSE_REC_ORIGIN && targetUrl.origin === origin;
 }

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -121,9 +121,7 @@ env => {
         });
 
     it('fetches the next document within 3 viewports away', function* () {
-      const xhrMock = sandbox.mock(Services.xhrFor(win));
-      xhrMock.expects('fetch').returns(Promise.resolve());
-
+      env.fetchMock.get('*', EXAMPLE_PAGE);
       sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
         // 1x viewport away
         return Promise.resolve(
@@ -132,6 +130,8 @@ env => {
 
       win.dispatchEvent(new Event('scroll'));
       yield macroTask();
+
+      expect(env.fetchMock.done(/\/document1/)).to.be.true;
     });
 
     it('only fetches the next document once', function*() {

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -211,8 +211,8 @@ env => {
   describe('remote config', () => {
     it('errors when no config specified', () => {
       return nextPage.buildCallback().should.be.rejectedWith(
-          'amp-next-page should contain only one <script> child, or a URL '
-          + 'specified in [src]​​​');
+          'amp-next-page should contain a <script> child, a URL specified in '
+          + '[src], or a [type]');
     });
 
     it('fetches remote config when specified in src', function* () {
@@ -248,6 +248,206 @@ env => {
       expect(registerSpy.calledWith(element, config)).to.be.true;
     });
   });
+
+  describe('AdSense config', () => {
+    it('errors without client', () => {
+      const error = 'amp-next-page AdSense client should be of the format '
+          + '\'ca-pub-123456\'';
+      expectAsyncConsoleError(error);
+      element.setAttribute('type', 'adsense');
+      element.setAttribute('data-slot', '12345');
+      return nextPage.buildCallback().should.be.rejectedWith(error);
+    });
+
+    it('errors without slot', () => {
+      const error = 'amp-next-page AdSense slot should be a number';
+      expectAsyncConsoleError(error);
+      element.setAttribute('type', 'adsense');
+      element.setAttribute('data-client', 'ca-pub-12345');
+      return nextPage.buildCallback().should.be.rejectedWith(error);
+    });
+
+    it('errors for invalid client format', () => {
+      const error = 'amp-next-page AdSense client should be of the format '
+          + '\'ca-pub-123456\'';
+      expectAsyncConsoleError(error);
+      element.setAttribute('type', 'adsense');
+      element.setAttribute('data-client', 'doggos');
+      element.setAttribute('data-slot', '12345');
+      return nextPage.buildCallback().should.be.rejectedWith(error);
+    });
+
+    it('errors for invalid slot format', () => {
+      const error = 'amp-next-page AdSense slot should be a number';
+      expectAsyncConsoleError(error);
+      element.setAttribute('type', 'adsense');
+      element.setAttribute('data-client', 'ca-pub-12345');
+      element.setAttribute('data-slot', 'doggos');
+      return nextPage.buildCallback().should.be.rejectedWith(error);
+    });
+  });
+
+  describe('valid AdSense config', () => {
+    const client = 'ca-pub-12345';
+    const slot = '12345';
+    let url;
+
+    beforeEach(() => {
+      ampdoc.getUrl = () => 'https://example.com/parent';
+      element.setAttribute('type', 'adsense');
+      element.setAttribute('data-client', client);
+      element.setAttribute('data-slot', slot);
+
+      url = 'https://googleads.g.doubleclick.net/pagead/ads?'
+      + `client=${client}&slotname=${slot}`
+      + `&url=${encodeURIComponent(ampdoc.getUrl())}`
+      + '&ecr=1&crui=title&is_amp=3&output=xml';
+    });
+
+    it('fetches recommendations from AdSense', function* () {
+      fetchDocumentMock.expects('fetchDocument')
+          .withExactArgs(win, url, {credentials: 'include'})
+          .returns(Promise.resolve(createXmlDoc(`
+<GSP VER="3.2">
+  <ADS>
+    <AD n="1" type="text/narrow" 
+        url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article" 
+        visible_url="https://example.com/article">
+    <LINE1>
+      Page title
+    </LINE1>
+    <LINE2/>
+    <LINE3/>
+    <BIDTYPE>CPM</BIDTYPE>
+    <MEDIA_TEMPLATE_DATA>
+    [ { "core_image_url" : "https://example.com/image.png" } ];
+    </MEDIA_TEMPLATE_DATA>
+    </AD>
+  </ADS>
+</GSP>`)));
+
+      const config = {
+        pages: [
+          {
+            ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article',
+            title: 'Page title',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      };
+
+      const nextPageService =
+          yield getServicePromiseForDoc(ampdoc, 'next-page');
+      const registerSpy = sandbox.spy(nextPageService, 'register');
+
+      yield nextPage.buildCallback();
+      yield macroTask();
+
+      expect(registerSpy.calledWith(element, config)).to.be.true;
+    });
+
+    it('makes an unpersonalized request if missing consent', function* () {
+      fetchDocumentMock.expects('fetchDocument')
+          .withExactArgs(win, url, {credentials: 'omit'})
+          .returns(Promise.resolve());
+      element.setAttribute('data-block-on-consent', true);
+      yield nextPage.buildCallback();
+    });
+
+    it('filters pages with visible_urls from different origins', function* () {
+      fetchDocumentMock.expects('fetchDocument')
+          .withExactArgs(win, url, {credentials: 'include'})
+          .returns(Promise.resolve(createXmlDoc(`
+<GSP VER="3.2">
+  <ADS>
+    <AD n="1" type="text/narrow" 
+        url="https://googleads.g.doubleclick.net/aclk?adurl=https://other.com/article" 
+        visible_url="https://other.com/article">
+    <LINE1>
+      Other 1
+    </LINE1>
+    <LINE2/>
+    <LINE3/>
+    <BIDTYPE>CPM</BIDTYPE>
+    <MEDIA_TEMPLATE_DATA>
+    [ { "core_image_url" : "https://other.com/image1.png" } ];
+    </MEDIA_TEMPLATE_DATA>
+    </AD>
+    <AD n="2" type="text/narrow" 
+        url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article" 
+        visible_url="https://example.com/article">
+    <LINE1>
+      Example 1
+    </LINE1>
+    <LINE2/>
+    <LINE3/>
+    <BIDTYPE>CPM</BIDTYPE>
+    <MEDIA_TEMPLATE_DATA>
+    [ { "core_image_url" : "https://example.com/image2.png" } ];
+    </MEDIA_TEMPLATE_DATA>
+    </AD>
+    <AD n="3" type="text/narrow" 
+        url="https://googleads.g.doubleclick.net/aclk?adurl=https://other2.com/article" 
+        visible_url="https://other2.com/article">
+    <LINE1>
+      Other 2
+    </LINE1>
+    <LINE2/>
+    <LINE3/>
+    <BIDTYPE>CPM</BIDTYPE>
+    <MEDIA_TEMPLATE_DATA>
+    [ { "core_image_url" : "https://other2.com/image3.png" } ];
+    </MEDIA_TEMPLATE_DATA>
+    </AD>
+  </ADS>
+</GSP>`)));
+
+      const config = {
+        pages: [
+          {
+            ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article',
+            title: 'Example 1',
+            image: 'https://example.com/image2.png',
+          },
+        ],
+      };
+
+      const nextPageService =
+          yield getServicePromiseForDoc(ampdoc, 'next-page');
+      const registerSpy = sandbox.spy(nextPageService, 'register');
+
+      yield nextPage.buildCallback();
+      yield macroTask();
+
+      expect(registerSpy.calledWith(element, config)).to.be.true;
+    });
+
+    it('falls back to inline config pages if the AdSense request fails',
+        function* () {
+          const config = {
+            pages: [
+              {
+                ampUrl: 'https://example.com/fallback',
+                title: 'Fallback article',
+                image: 'https://example.com/fallback.png',
+              },
+            ],
+          };
+          fetchDocumentMock.expects('fetchDocument').returns(Promise.reject());
+          element.innerHTML = `<script type="application/json">
+                                 ${JSON.stringify(config)}
+                               </script>`;
+
+          const nextPageService =
+              yield getServicePromiseForDoc(ampdoc, 'next-page');
+          const registerSpy = sandbox.spy(nextPageService, 'register');
+
+          yield nextPage.buildCallback();
+          yield macroTask();
+
+          expect(registerSpy.calledWith(element, config)).to.be.true;
+        });
+  });
 });
 
 /**
@@ -270,4 +470,14 @@ function createExampleDocument(doc) {
       <div style="height:1000px"></div>
       <footer>Footer</footer>`;
   return childDoc;
+}
+
+/**
+ * Creates a new XML document from the specified XML text.
+ * @param {string} text XML document text.
+ * @return {!Document} New XML document.
+ */
+function createXmlDoc(text) {
+  const parser = new DOMParser();
+  return parser.parseFromString(text, 'text/xml');
 }

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -339,12 +339,12 @@ describe('amp-next-page config', () => {
       allowConsoleError(() => {
         expect(() => assertConfig(/*ctx*/ null, config1, documentUrl))
             .to.throw(
-                'pages must be from the same origin as the current document​​​');
+                'pages must be from the same origin as the current document');
       });
       allowConsoleError(() => {
         expect(() => assertConfig(/*ctx*/ null, config2, documentUrlCdn))
             .to.throw(
-                'pages must be from the same origin as the current document​​​');
+                'pages must be from the same origin as the current document');
       });
     });
   });

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -295,5 +295,57 @@ describe('amp-next-page config', () => {
             .to.throw(/amp-next-page hideSelector .+ not allowed/);
       });
     });
+
+    it('allows AdSense URLs which target the same origin', () => {
+      const config = {
+        pages: [{
+          ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article',
+          image: 'https://example.com/image.png',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
+          .to.not.throw();
+    });
+
+    it('allows AdSense URLs which target the same CDN origin', () => {
+      const config = {
+        pages: [{
+          ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://example-com.cdn.ampproject.org/c/s/example.com/article',
+          image: 'https://example.com/image.png',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrlCdn))
+          .to.not.throw();
+    });
+
+    it('throws for AdSense URLs which target different origins', () => {
+
+      const config1 = {
+        pages: [{
+          ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://other.com/article',
+          image: 'https://example.com/image.png',
+          title: 'Article 1',
+        }],
+      };
+      const config2 = {
+        pages: [{
+          ampUrl: 'https://googleads.g.doubleclick.net/aclk?adurl=https://other-com.cdn.ampproject.org/c/s/example.com/article',
+          image: 'https://example.com/image.png',
+          title: 'Article 1',
+        }],
+      };
+      allowConsoleError(() => {
+        expect(() => assertConfig(/*ctx*/ null, config1, documentUrl))
+            .to.throw(
+                'pages must be from the same origin as the current document​​​');
+      });
+      allowConsoleError(() => {
+        expect(() => assertConfig(/*ctx*/ null, config2, documentUrlCdn))
+            .to.throw(
+                'pages must be from the same origin as the current document​​​');
+      });
+    });
   });
 });

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page-adsense.html
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page-adsense.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP next page examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-next-page" src="https://cdn.ampproject.org/v0/amp-next-page-0.1.js"></script>
+  <style amp-custom>
+    .amp-next-page-text {
+      font-family: serif;
+    }
+  </style>
+</head>
+<body>
+  <h2>Content discovery</h2>
+  <amp-next-page type="adsense" data-client="ca-pub-7654321" data-slot="321">
+    <div separator>
+      READ ANOTHER ARTICLE FROM OUR SITE!
+    </div>
+  </amp-next-page>
+  <footer>
+    Footer
+  </footer>
+</body>
+</html>

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page-adsense.out
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page-adsense.out
@@ -1,0 +1,30 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>AMP next page examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-next-page" src="https://cdn.ampproject.org/v0/amp-next-page-0.1.js"></script>
+|    <style amp-custom>
+|      .amp-next-page-text {
+|        font-family: serif;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|    <h2>Content discovery</h2>
+|    <amp-next-page type="adsense" data-client="ca-pub-7654321" data-slot="321">
+|      <div separator>
+|        READ ANOTHER ARTICLE FROM OUR SITE!
+|      </div>
+|    </amp-next-page>
+|    <footer>
+|      Footer
+|    </footer>
+|  </body>
+|  </html>

--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -88,7 +88,7 @@ tags: {  # <amp-next-page src>
 tags: {  # <amp-next-page type="adsense">
   html_format: AMP
   tag_name: "AMP-NEXT-PAGE"
-  spec_name: "amp-next-page with AdSense content recommendations"
+  spec_name: "amp-next-page [type=adsense]"
   unique: true
   requires_extension: "amp-next-page"
   attrs: {

--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -85,3 +85,28 @@ tags: {  # <amp-next-page src>
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
 }
+tags: {  # <amp-next-page type="adsense">
+  html_format: AMP
+  tag_name: "AMP-NEXT-PAGE"
+  spec_name: "amp-next-page with AdSense content recommendations"
+  unique: true
+  requires_extension: "amp-next-page"
+  attrs: {
+    name: "data-client"
+    mandatory: true
+  }
+  attrs: {
+    name: "data-slot"
+    mandatory: true
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "adsense"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [separator]"
+    unique: true
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
+}


### PR DESCRIPTION
Adds support for fetching the list of pages to display from the AdSense Matched Content product. This will allow publishers to add amp-next-page to their sites with a single tag and no manual configuration in terms of which pages to recommend.

The tag is configured similarly to amp-ad, taking type="adsense" and data-client="xxx", data-slot="yyy". If `data-block-on-consent` is specified and consent is not sufficient, a non-personalised request will be made.

The AMP documents are fetched via the AdSense ad click URL, for tracking purposes, but we can verify the URL after redirection before rendering the document.

@aghassemi 