### PR TITLE
SSR template rendering #3 - re-format requests

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -53,6 +53,7 @@ import {installStylesForDoc} from '../../../src/style-installer';
 import {
   setupAMPCors,
   setupInit,
+  setupInput,
 } from '../../../src/utils/xhr-utils';
 import {toArray, toWin} from '../../../src/types';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
@@ -526,8 +527,11 @@ export class AmpForm {
         }).then(() => {
           request = this.requestForFormFetch(
               dev().assertString(this.xhrAction_), this.method_);
-          setupInit(request.fetchOpt);
-          setupAMPCors(this.win_, request.xhrUrl, request.fetchOpt);
+          request.fetchOpt = setupInit(request.fetchOpt);
+          request.fetchOpt = setupAMPCors(
+            this.win_, request.xhrUrl, request.fetchOpt);
+          request.xhrUrl = setupInput(
+            this.win_, request.xhrUrl, request.fetchOpt);
           return this.ssrTemplateHelper_.fetchAndRenderTemplate(
               this.form_,
               request,

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -529,9 +529,9 @@ export class AmpForm {
               dev().assertString(this.xhrAction_), this.method_);
           request.fetchOpt = setupInit(request.fetchOpt);
           request.fetchOpt = setupAMPCors(
-            this.win_, request.xhrUrl, request.fetchOpt);
+              this.win_, request.xhrUrl, request.fetchOpt);
           request.xhrUrl = setupInput(
-            this.win_, request.xhrUrl, request.fetchOpt);
+              this.win_, request.xhrUrl, request.fetchOpt);
           return this.ssrTemplateHelper_.fetchAndRenderTemplate(
               this.form_,
               request,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -317,7 +317,7 @@ export class AmpList extends AMP.BaseElement {
       const attributes = dict({
         'ampListAttributes': {
           'items': this.element.getAttribute('items') || 'items',
-          'singleItem': this.element.getAttribute('single-item'),
+          'singleItem': this.element.hasAttribute('single-item'),
           'maxItems': this.element.getAttribute('max-items'),
         },
       });

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { dict } from './utils/object';
+import {dict} from './utils/object';
 import {
   fromStructuredCloneable,
   toStructuredCloneable,
@@ -61,7 +61,7 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isSupported() {
-    const { ampdoc } = this.viewer_;
+    const {ampdoc} = this.viewer_;
     if (ampdoc.isSingleDoc()) {
       const htmlElement = ampdoc.getRootNode().documentElement;
       if (htmlElement.hasAttribute('allow-viewer-render-template')) {
@@ -90,17 +90,17 @@ export class SsrTemplateHelper {
         // The document fragment can't be used in the message channel API thus
         // serializeToString for a string representation of the dom tree.
         mustacheTemplate = this.xmls_.serializeToString(
-          this.templates_.findTemplate(element));
+            this.templates_.findTemplate(element));
       }
     }
     return this.viewer_.sendMessageAwaitResponse(
-      'viewerRenderTemplate',
-      this.buildPayload_(
-        request,
-        mustacheTemplate,
-        opt_templates,
-        opt_attributes
-      ));
+        'viewerRenderTemplate',
+        this.buildPayload_(
+            request,
+            mustacheTemplate,
+            opt_templates,
+            opt_attributes
+        ));
   }
 
   /**
@@ -113,7 +113,7 @@ export class SsrTemplateHelper {
    */
   buildPayload_(
     request, mustacheTemplate, opt_templates, opt_attributes = {}) {
-    const ampComponent = dict({ 'type': this.sourceComponent_ });
+    const ampComponent = dict({'type': this.sourceComponent_});
     if (opt_templates['successTemplate'] || mustacheTemplate) {
       ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
@@ -153,10 +153,10 @@ export class SsrTemplateHelper {
    */
   verifySsrResponse(win, response, request) {
     verifyAmpCORSHeaders(
-      win,
-      fromStructuredCloneable(
-        response,
-        request.fetchOpt.responseType),
-      request.fetchOpt);
+        win,
+        fromStructuredCloneable(
+            response,
+            request.fetchOpt.responseType),
+        request.fetchOpt);
   }
 }

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dict} from './utils/object';
+import { dict } from './utils/object';
 import {
   fromStructuredCloneable,
   toStructuredCloneable,
@@ -61,7 +61,7 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isSupported() {
-    const {ampdoc} = this.viewer_;
+    const { ampdoc } = this.viewer_;
     if (ampdoc.isSingleDoc()) {
       const htmlElement = ampdoc.getRootNode().documentElement;
       if (htmlElement.hasAttribute('allow-viewer-render-template')) {
@@ -90,17 +90,17 @@ export class SsrTemplateHelper {
         // The document fragment can't be used in the message channel API thus
         // serializeToString for a string representation of the dom tree.
         mustacheTemplate = this.xmls_.serializeToString(
-            this.templates_.findTemplate(element));
+          this.templates_.findTemplate(element));
       }
     }
     return this.viewer_.sendMessageAwaitResponse(
-        'viewerRenderTemplate',
-        this.buildPayload_(
-            request,
-            mustacheTemplate,
-            opt_templates,
-            opt_attributes
-        ));
+      'viewerRenderTemplate',
+      this.buildPayload_(
+        request,
+        mustacheTemplate,
+        opt_templates,
+        opt_attributes
+      ));
   }
 
   /**
@@ -113,33 +113,34 @@ export class SsrTemplateHelper {
    */
   buildPayload_(
     request, mustacheTemplate, opt_templates, opt_attributes = {}) {
-    const ampComponent = dict({
-      'type': this.sourceComponent_,
-      'successTemplate': {
+    const ampComponent = dict({ 'type': this.sourceComponent_ });
+    if (opt_templates['successTemplate'] || mustacheTemplate) {
+      ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
-        'payload': opt_templates
+        'payload': opt_templates['successTemplate']
           ? this.xmls_.serializeToString(opt_templates['successTemplate'])
           : mustacheTemplate,
-      },
-      'errorTemplate': {
+      };
+    }
+    if (opt_templates['errorTemplate']) {
+      ampComponent['errorTemplate'] = {
         'type': 'amp-mustache',
-        'payload': opt_templates
-          ? this.xmls_.serializeToString(
-              opt_templates['errorTemplate']) : null,
-      },
-    });
-    const data = dict({
-      'originalRequest':
-          toStructuredCloneable(request.xhrUrl, request.fetchOpt),
-      'ampComponent': ampComponent,
-    });
+        'payload': this.xmls_.serializeToString(opt_templates['errorTemplate']),
+      };
+    }
 
     const additionalAttr = opt_attributes && Object.keys(opt_attributes);
     if (additionalAttr) {
       Object.keys(opt_attributes).forEach(key => {
-        data[key] = opt_attributes[key];
+        ampComponent[key] = opt_attributes[key];
       });
     }
+
+    const data = dict({
+      'originalRequest':
+        toStructuredCloneable(request.xhrUrl, request.fetchOpt),
+      'ampComponent': ampComponent,
+    });
 
     return data;
   }
@@ -152,10 +153,10 @@ export class SsrTemplateHelper {
    */
   verifySsrResponse(win, response, request) {
     verifyAmpCORSHeaders(
-        win,
-        fromStructuredCloneable(
-            response,
-            request.fetchOpt.responseType),
-        request.fetchOpt);
+      win,
+      fromStructuredCloneable(
+        response,
+        request.fetchOpt.responseType),
+      request.fetchOpt);
   }
 }

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -81,7 +81,7 @@ export class SsrTemplateHelper {
   fetchAndRenderTemplate(
     element, request, opt_templates = null, opt_attributes = {}) {
     let mustacheTemplate;
-    if (!mustacheTemplate) {
+    if (!opt_templates) {
       mustacheTemplate = this.templates_.maybeFindTemplate(element);
     }
     return this.viewer_.sendMessageAwaitResponse(

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -108,19 +108,23 @@ export class SsrTemplateHelper {
   buildPayload_(
     request, mustacheTemplate, opt_templates, opt_attributes = {}) {
     const ampComponent = dict({'type': this.sourceComponent_});
-    if ((opt_templates && opt_templates['successTemplate'])
-        || mustacheTemplate) {
+
+    const successTemplate = (opt_templates && opt_templates['successTemplate'])
+      ? opt_templates['successTemplate']./*REVIEW*/innerHTML : null;
+    if (successTemplate || mustacheTemplate) {
       ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
-        'payload': (opt_templates && opt_templates['successTemplate'])
-          ? opt_templates['successTemplate']./*REVIEW*/innerHTML
-          : mustacheTemplate,
+        'payload': successTemplate
+          ? successTemplate : mustacheTemplate,
       };
     }
-    if (opt_templates && opt_templates['errorTemplate']) {
+
+    const errorTemplate = (opt_templates && opt_templates['errorTemplate'])
+      ? opt_templates['errorTemplate']./*REVIEW*/innerHTML : null;
+    if (errorTemplate) {
       ampComponent['errorTemplate'] = {
         'type': 'amp-mustache',
-        'payload': opt_templates['errorTemplate']./*REVIEW*/innerHTML,
+        'payload': errorTemplate,
       };
     }
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -84,7 +84,7 @@ export class SsrTemplateHelper {
     if (!opt_templates) {
       const template = this.templates_.maybeFindTemplate(element);
       if (template) {
-        mustacheTemplate = template.innerHTML;
+        mustacheTemplate = template./*REVIEW*/innerHTML;
       }
     }
     return this.viewer_.sendMessageAwaitResponse(
@@ -113,14 +113,14 @@ export class SsrTemplateHelper {
       ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
         'payload': (opt_templates && opt_templates['successTemplate'])
-          ? opt_templates['successTemplate'].innerHTML
+          ? opt_templates['successTemplate']./*REVIEW*/innerHTML
           : mustacheTemplate,
       };
     }
     if (opt_templates && opt_templates['errorTemplate']) {
       ampComponent['errorTemplate'] = {
         'type': 'amp-mustache',
-        'payload': opt_templates['errorTemplate'].innerHTML,
+        'payload': opt_templates['errorTemplate']./*REVIEW*/innerHTML,
       };
     }
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -114,15 +114,15 @@ export class SsrTemplateHelper {
   buildPayload_(
     request, mustacheTemplate, opt_templates, opt_attributes = {}) {
     const ampComponent = dict({'type': this.sourceComponent_});
-    if (opt_templates['successTemplate'] || mustacheTemplate) {
+    if ((opt_templates && opt_templates['successTemplate']) || mustacheTemplate) {
       ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
-        'payload': opt_templates['successTemplate']
+        'payload': (opt_templates && opt_templates['successTemplate'])
           ? this.xmls_.serializeToString(opt_templates['successTemplate'])
           : mustacheTemplate,
       };
     }
-    if (opt_templates['errorTemplate']) {
+    if (opt_templates && opt_templates['errorTemplate']) {
       ampComponent['errorTemplate'] = {
         'type': 'amp-mustache',
         'payload': this.xmls_.serializeToString(opt_templates['errorTemplate']),

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -96,7 +96,7 @@ export class SsrTemplateHelper {
 
   /**
    * @param {!FetchRequestDef} request
-   * @param {?Element} mustacheTemplate
+   * @param {?Element|undefined} mustacheTemplate
    * @param {?SsrTemplateDef=} opt_templates
    * @param {!Object=} opt_attributes
    * @return {!JsonObject}

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -47,9 +47,6 @@ export class SsrTemplateHelper {
     /** @private @const */
     this.templates_ = templates;
 
-    /** @private @const {!XMLSerializer} */
-    this.xmls_ = new XMLSerializer();
-
     /** @private @const */
     this.sourceComponent_ = sourceComponent;
   }
@@ -87,10 +84,7 @@ export class SsrTemplateHelper {
     if (!opt_templates) {
       const template = this.templates_.maybeFindTemplate(element);
       if (template) {
-        // The document fragment can't be used in the message channel API thus
-        // serializeToString for a string representation of the dom tree.
-        mustacheTemplate = this.xmls_.serializeToString(
-            this.templates_.findTemplate(element));
+        mustacheTemplate = template.innerHTML;
       }
     }
     return this.viewer_.sendMessageAwaitResponse(
@@ -114,18 +108,19 @@ export class SsrTemplateHelper {
   buildPayload_(
     request, mustacheTemplate, opt_templates, opt_attributes = {}) {
     const ampComponent = dict({'type': this.sourceComponent_});
-    if ((opt_templates && opt_templates['successTemplate']) || mustacheTemplate) {
+    if ((opt_templates && opt_templates['successTemplate'])
+        || mustacheTemplate) {
       ampComponent['successTemplate'] = {
         'type': 'amp-mustache',
         'payload': (opt_templates && opt_templates['successTemplate'])
-          ? this.xmls_.serializeToString(opt_templates['successTemplate'])
+          ? opt_templates['successTemplate'].innerHTML
           : mustacheTemplate,
       };
     }
     if (opt_templates && opt_templates['errorTemplate']) {
       ampComponent['errorTemplate'] = {
         'type': 'amp-mustache',
-        'payload': this.xmls_.serializeToString(opt_templates['errorTemplate']),
+        'payload': opt_templates['errorTemplate'].innerHTML,
       };
     }
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -72,61 +72,61 @@ export class SsrTemplateHelper {
    * Proxies xhr and template rendering to the viewer and renders the response.
    * @param {!Element} element
    * @param {!FetchRequestDef} request The fetch/XHR related data.
-   * @param {?SsrTemplateDef=} ampFormTemplates Response templates for amp-form
-   *     to pass into the payload. If provided, finding the template (for
-   *     amp-list) in the passed in element is not attempted.
+   * @param {?SsrTemplateDef=} opt_templates Response templates to pass into
+   *     the payload. If provided, finding the template in the passed in
+   *     element is not attempted.
    * @param {!Object=} opt_attributes Additional JSON to send to viewer.
    * return {!Promise<{data:{?JsonObject|string|undefined}}>}
    */
   fetchAndRenderTemplate(
-    element, request, ampFormTemplates = null, opt_attributes = {}) {
-    let ampListTemplate;
-    if (!ampFormTemplates) {
-      ampListTemplate = this.templates_.maybeFindTemplate(element);
+    element, request, opt_templates = null, opt_attributes = {}) {
+    let mustacheTemplate;
+    if (!mustacheTemplate) {
+      mustacheTemplate = this.templates_.maybeFindTemplate(element);
     }
     return this.viewer_.sendMessageAwaitResponse(
         'viewerRenderTemplate',
         this.buildPayload_(
             request,
-            ampListTemplate,
-            ampFormTemplates,
+            mustacheTemplate,
+            opt_templates,
             opt_attributes
         ));
   }
 
   /**
    * @param {!FetchRequestDef} request
-   * @param {string|undefined} ampListTemplate
-   * @param {?SsrTemplateDef=} ampFormTemplates
+   * @param {?Element} mustacheTemplate
+   * @param {?SsrTemplateDef=} opt_templates
    * @param {!Object=} opt_attributes
    * @return {!JsonObject}
    * @private
    */
   buildPayload_(
-    request, ampListTemplate, ampFormTemplates, opt_attributes = {}) {
+    request, mustacheTemplate, opt_templates, opt_attributes = {}) {
     const ampComponent = dict({'type': this.sourceComponent_});
 
     const successTemplateKey = 'successTemplate';
-    const ampFormSuccessTemplate =
-      (ampFormTemplates && ampFormTemplates[successTemplateKey])
-        ? ampFormTemplates[successTemplateKey] : null;
-    if (ampFormSuccessTemplate || ampListTemplate) {
+    const successTemplate =
+      (opt_templates && opt_templates[successTemplateKey])
+        ? opt_templates[successTemplateKey] : null;
+    if (successTemplate || mustacheTemplate) {
       ampComponent[successTemplateKey] = {
         'type': 'amp-mustache',
-        'payload': ampFormSuccessTemplate
-          ? ampFormSuccessTemplate./*REVIEW*/innerHTML
-          : ampListTemplate./*REVIEW*/innerHTML,
+        'payload': successTemplate
+          ? successTemplate./*REVIEW*/innerHTML
+          : mustacheTemplate./*REVIEW*/innerHTML,
       };
     }
 
     const errorTemplateKey = 'errorTemplate';
-    const ampFormErrorTemplate =
-      (ampFormTemplates && ampFormTemplates[errorTemplateKey])
-        ? ampFormTemplates[errorTemplateKey] : null;
-    if (ampFormErrorTemplate) {
+    const errorTemplate =
+      (opt_templates && opt_templates[errorTemplateKey])
+        ? opt_templates[errorTemplateKey] : null;
+    if (errorTemplate) {
       ampComponent[errorTemplateKey] = {
         'type': 'amp-mustache',
-        'payload': ampFormErrorTemplate./*REVIEW*/innerHTML,
+        'payload': errorTemplate./*REVIEW*/innerHTML,
       };
     }
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -109,13 +109,11 @@ export class SsrTemplateHelper {
     const successTemplateKey = 'successTemplate';
     const successTemplate =
       (opt_templates && opt_templates[successTemplateKey])
-        ? opt_templates[successTemplateKey] : null;
-    if (successTemplate || mustacheTemplate) {
+        ? opt_templates[successTemplateKey] : mustacheTemplate;
+    if (successTemplate) {
       ampComponent[successTemplateKey] = {
         'type': 'amp-mustache',
-        'payload': successTemplate
-          ? successTemplate./*REVIEW*/innerHTML
-          : mustacheTemplate./*REVIEW*/innerHTML,
+        'payload': successTemplate./*REVIEW*/innerHTML,
       };
     }
 


### PR DESCRIPTION
Reformat the AmpComponent passed to viewer, to make sure ssr-template-helper:

- returns `successTemplate` or `errorTemplate` as null if it doesn't exist, rather than now always returns both templates but `payload` might be null
- puts `additionalAttr` which correctly only has `ampListAttributes` under `AmpComponent` where makes more sense 
- uses hasAttribute() rather than getAttribute() for `singleItem` which is a boolean to be consistent with normal amp-list and also prevent bugs where different browsers have inconsistent behaviors on whether to return an empty string when the attribute doesn't exist
- provides AMP CORS query parameters for amp-form which always includes credentials
- returns innerHTML for all templates node to get ride of outer <template> tag

This also fixed a bug where if some template doesn't not exist in amp-form, `xmls_.serializeToString` will throw an error saying that:

'''
Form submission failed: TypeError: Failed to execute 'serializeToString' on 'XMLSerializer': parameter 1 is not of type 'Node'.
'''

TESTED=amp-list with items=".", singleItem=true and amp-form with no templates
I will test more later but want to check in this first to make sure our first bunch of AMP4EMAIL(s) work.