### PR TITLE
Allow forcing the Custom Elements V1 Polyfill

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -40,7 +40,7 @@ installDocContains(self);
 installArrayIncludes(self);
 // isExperimentOn() must be called after Object.assign polyfill is installed.
 if (isExperimentOn(self, 'custom-elements-v1') || getMode().test) {
-  installCustomElements(self, class {});
+  installCustomElements(self);
 } else {
   installRegisterElement(self, 'auto');
 }

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -729,21 +729,22 @@ function subClass(Object, superClass, subClass) {
 }
 
 /**
- * Polyfills Custom Elements v1 API. This has 4 modes:
+ * Polyfills Custom Elements v1 API. This has 5 modes:
  *
  * 1. Custom elements v1 already supported, using native classes
  * 2. Custom elements v1 already supported, using transpiled classes
  * 3. Custom elements v1 not supported, using native classes
  * 4. Custom elements v1 not supported, using transpiled classes
+ * 5. No sample class constructor provided
  *
  * In mode 1, nothing is done. In mode 2, a minimal polyfill is used to support
- * extending the HTMLElement base class. In mode 3 and 4, a full polyfill is
+ * extending the HTMLElement base class. In mode 3, 4, and 5 a full polyfill is
  * done.
  *
  * @param {!Window} win
- * @param {!Function} ctor
+ * @param {!Function=} opt_ctor
  */
-export function install(win, ctor) {
+export function install(win, opt_ctor) {
   if (isPatched(win)) {
     return;
   }
@@ -751,7 +752,7 @@ export function install(win, ctor) {
   let install = true;
   let installWrapper = false;
 
-  if (hasCustomElements(win)) {
+  if (opt_ctor && hasCustomElements(win)) {
     // If ctor is constructable without new, it's a function. That means it was
     // compiled down, and we need to do the minimal polyfill because all you
     // cannot extend HTMLElement without native classes.
@@ -759,8 +760,8 @@ export function install(win, ctor) {
       const {Object, Reflect} = win;
 
       // "Construct" ctor using ES5 idioms
-      const instance = Object.create(ctor.prototype);
-      ctor.call(instance);
+      const instance = Object.create(opt_ctor.prototype);
+      opt_ctor.call(instance);
 
       // If that succeeded, we're in a transpiled environment
       // Let's find out if we can wrap HTMLElement and avoid a full patch.

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -702,6 +702,10 @@ function polyfill(win) {
       registry.observe(shadow);
       return shadow;
     };
+    // Necessary for Shadow AMP
+    elProto.attachShadow.toString = function() {
+      return attachShadow.toString();
+    };
   }
   if (createShadowRoot) {
     /**
@@ -711,6 +715,10 @@ function polyfill(win) {
       const shadow = createShadowRoot.apply(this, arguments);
       registry.observe(shadow);
       return shadow;
+    };
+    // Necessary for Shadow AMP
+    elProto.createShadowRoot.toString = function() {
+      return createShadowRoot.toString();
     };
   }
 

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -688,17 +688,27 @@ function polyfill(win) {
     value: customElements,
   });
 
-  // Have to patch attachShadow now, since there's no way to find shadow trees
+  // Have to patch shadow methods now, since there's no way to find shadow trees
   // later.
   const elProto = Element.prototype;
-  const {attachShadow} = elProto;
+  const {attachShadow, createShadowRoot} = elProto;
   if (attachShadow) {
     /**
-    * @param {!{mode: string}} options
+    * @param {!{mode: string}} unused
     * @return {!ShadowRoot}
     */
-    elProto.attachShadow = function(options) {
-      const shadow = attachShadow.call(this, options);
+    elProto.attachShadow = function(unused) {
+      const shadow = attachShadow.apply(this, arguments);
+      registry.observe(shadow);
+      return shadow;
+    };
+  }
+  if (createShadowRoot) {
+    /**
+    * @return {!ShadowRoot}
+    */
+    elProto.createShadowRoot = function() {
+      const shadow = createShadowRoot.apply(this, arguments);
       registry.observe(shadow);
       return shadow;
     };

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -692,11 +692,17 @@ function polyfill(win) {
   // later.
   const elProto = Element.prototype;
   const {attachShadow} = elProto;
-  elProto.attachShadow = function() {
-    const shadow = attachShadow.apply(this, arguments);
-    registry.observe(shadow);
-    return shadow;
-  };
+  if (attachShadow) {
+    /**
+    * @param {!{mode: string}} options
+    * @return {!ShadowRoot}
+    */
+    elProto.attachShadow = function(options) {
+      const shadow = attachShadow.call(this, options);
+      registry.observe(shadow);
+      return shadow;
+    };
+  }
 
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -690,7 +690,7 @@ function installPolyfillsInChildWindow(parentWin, childWin) {
   installDocContains(childWin);
   installDOMTokenListToggle(childWin);
   if (isExperimentOn(parentWin, 'custom-elements-v1')) {
-    installCustomElements(childWin, class {});
+    installCustomElements(childWin);
   } else {
     installRegisterElement(childWin, 'auto');
   }

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -78,7 +78,7 @@ export function isShadowCssSupported() {
 /**
  * Returns `true` if the passed function is native to the browser, and is not
  * polyfilled
- * @param {function()|undefined} func A function that is attatched to a JS
+ * @param {Function|undefined} func A function that is attatched to a JS
  * object.
  * @return {boolean}
  */

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -583,7 +583,7 @@ class RealWinFixture {
             get: () => customElements,
           });
         } else {
-          installCustomElements(win, class {});
+          installCustomElements(win);
         }
 
         // Intercept event listeners

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -237,7 +237,7 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
           Services.ampdocServiceFor(iframe.contentWindow).getAmpDoc();
       installExtensionsService(iframe.contentWindow);
       installRuntimeServices(iframe.contentWindow);
-      installCustomElements(iframe.contentWindow, class {});
+      installCustomElements(iframe.contentWindow);
       installAmpdocServices(ampdoc);
       Services.resourcesForDoc(ampdoc).ampInitComplete();
       // Act like no other elements were loaded by default.

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -477,8 +477,9 @@ export function expectBodyToBecomeVisible(win, opt_timeout) {
  * @param {!Window} win
  */
 export function doNotLoadExternalResourcesInTest(win) {
-  const {createElement} = win.document;
-  win.document.createElement = function(tagName) {
+  const {prototype} = win.Document;
+  const {createElement} = prototype;
+  prototype.createElement = function(tagName) {
     const element = createElement.apply(this, arguments);
     tagName = tagName.toLowerCase();
     if (tagName == 'iframe' || tagName == 'img') {


### PR DESCRIPTION
Omitting the `ctor` when installing the CE V1 polyfill will now force
the full polyfill installation, since we can't properly test if Native
Classes are being used (necessary for proper native support).

This will allow us to launch the new polyfill without native CE support,
which is the riskiest part of the transition.