### PR TITLE
✨ add isReadyToPay to amp-subscriptions and amp-subscriptions-google.

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -106,6 +106,9 @@ export class GoogleSubscriptionsPlatform {
     this.isGoogleViewer_ = false;
     this.resolveGoogleViewer_(Services.viewerForDoc(ampdoc));
 
+    /** @private {boolean} */
+    this.isReadyToPay_ = false;
+
     // Install styles.
     installStylesForDoc(ampdoc, CSS, () => {}, false, TAG);
   }
@@ -161,6 +164,13 @@ export class GoogleSubscriptionsPlatform {
   /** @override */
   getEntitlements() {
     return this.runtime_.getEntitlements().then(swgEntitlements => {
+      // Get and store the isReadyToPay signal which is independent of
+      // any entitlments existing.
+      if (swgEntitlements.isReadyToPay) {
+        this.isReadyToPay_ = true;
+      }
+
+      // Get the specifc entitlement we're looking for
       const swgEntitlement = swgEntitlements.getEntitlementForThis();
       if (!swgEntitlement) {
         return null;
@@ -211,6 +221,8 @@ export class GoogleSubscriptionsPlatform {
     switch (factorName) {
       case SubscriptionsScoreFactor.SUPPORTS_VIEWER:
         return this.isGoogleViewer_ ? 1 : 0;
+      case SubscriptionsScoreFactor.IS_READY_TO_PAY:
+        return this.isReadyToPay_ ? 1 : 0;
       default:
         return 0;
     }

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -29,6 +29,8 @@ import {
 } from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../../../amp-subscriptions/0.1/service-adapter';
 import {Services} from '../../../../src/services';
+import {SubscriptionsScoreFactor}
+  from '../../../amp-subscriptions/0.1/score-factors.js';
 
 
 describes.realWin('amp-subscriptions-google', {amp: true}, env => {
@@ -376,6 +378,99 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
       });
       return platform.getEntitlements().then(entitlement => {
         expect(entitlement).to.be.equal(null);
+      });
+    });
+  });
+
+  describe('isReadyToPay', () => {
+    // #TODO(jpettitt) remove fake entitlements when swj.js
+    // isRadyToPay is available
+    /**
+     * return a fake entitlements object
+     * @param {boolean} isReadyToPay
+     * @return {Object}
+     */
+    function fakeEntitlements(isReadyToPay) {
+      return {
+        isReadyToPay,
+        entitlements: {},
+        getEntitlementForThis: () => {},
+      };
+    }
+
+    it('should treat missing isReadyToPay as false', () => {
+      const entitlementResponse = {
+        source: 'google',
+        products: ['example.org:basic'],
+        subscriptionToken: 'tok1',
+      };
+      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+        return Promise.resolve({
+          json: () => {
+            return Promise.resolve({
+              entitlements: entitlementResponse,
+            });
+          },
+        });
+      });
+      return platform.getEntitlements().then(() => {
+        expect(platform
+            .getSupportedScoreFactor(SubscriptionsScoreFactor.IS_READY_TO_PAY))
+            .to.equal(0);
+      });
+    });
+
+    it('should handle isReadyToPay true', () => {
+      const entitlementResponse = {
+        source: 'google',
+        products: ['example.org:basic'],
+        subscriptionToken: 'tok1',
+      };
+      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+        return Promise.resolve({
+          json: () => {
+            return Promise.resolve({
+              isReadyToPay: true,
+              entitlements: entitlementResponse,
+            });
+          },
+        });
+      });
+      //#TODO(jpettitt) remove stub when swj.js isRadyToPay is available
+      sandbox.stub(platform.runtime_, 'getEntitlements')
+          .resolves(fakeEntitlements(true));
+
+      return platform.getEntitlements().then(() => {
+        expect(platform
+            .getSupportedScoreFactor(SubscriptionsScoreFactor.IS_READY_TO_PAY))
+            .to.equal(1);
+      });
+    });
+
+    it('should handle isReadyToPay false', () => {
+      const entitlementResponse = {
+        source: 'google',
+        products: ['example.org:basic'],
+        subscriptionToken: 'tok1',
+      };
+      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+        return Promise.resolve({
+          json: () => {
+            return Promise.resolve({
+              isReadyToPay: false,
+              entitlements: entitlementResponse,
+            });
+          },
+        });
+      });
+      //#TODO(jpettitt) remove stub when swj.js isRadyToPay is available
+      sandbox.stub(platform.runtime_, 'getEntitlements')
+          .resolves(fakeEntitlements(false));
+
+      return platform.getEntitlements().then(() => {
+        expect(platform
+            .getSupportedScoreFactor(SubscriptionsScoreFactor.IS_READY_TO_PAY))
+            .to.equal(0);
       });
     });
   });

--- a/extensions/amp-subscriptions/0.1/score-factors.js
+++ b/extensions/amp-subscriptions/0.1/score-factors.js
@@ -19,6 +19,8 @@
  * @const @enum {string}
  */
 export const SubscriptionsScoreFactor = {
+  // User is known to platform and has a form of payment registered
+  IS_READY_TO_PAY: 'isReadyToPay',
   // Platform supports the current viewer environment
   SUPPORTS_VIEWER: 'supportsViewer',
 };
@@ -28,5 +30,6 @@ export const SubscriptionsScoreFactor = {
  * on page config if needed.
  */
 export const DEFAULT_SCORE_CONFIG = {
+  isReadyToPay: 0,
   supportsViewer: 10,
 };

--- a/extensions/amp-subscriptions/0.1/score-factors.js
+++ b/extensions/amp-subscriptions/0.1/score-factors.js
@@ -26,10 +26,10 @@ export const SubscriptionsScoreFactor = {
 };
 
 /**
- * Optional per factor default score config values, overridden in
- * on page config if needed.
+ * Default value for supportsViewer, requied by selectPlatformForLogin().
+ * All other score factors are ignored if not specifed in the publisher
+ * config so adding a default here would be meaningless.
  */
 export const DEFAULT_SCORE_CONFIG = {
-  isReadyToPay: 0,
   supportsViewer: 10,
 };


### PR DESCRIPTION
This PR adds `isReadyToPay` support to `amp-subscriptions` and `amp-subscriptions-google`.

The code is a no-op until the `isRadyToPay` feature is available in swg.js.

No documentation until the feature is available in `swg.js`

