### PR TITLE
✨ Restore ability to force SRA experiments with #exp.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -345,17 +345,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.win, 'expDfpInvOrigDeprecated')) {
       this.experimentIds.push('21060933');
     }
+    let forcedExperimentId;
     if (urlExperimentId) {
-      const experimentId = {
+      forcedExperimentId = {
         // SRA
         '7': DOUBLECLICK_SRA_EXP_BRANCHES.SRA_CONTROL,
         '8': DOUBLECLICK_SRA_EXP_BRANCHES.SRA,
         '9': DOUBLECLICK_SRA_EXP_BRANCHES.SRA_NO_RECOVER,
 
       }[urlExperimentId];
-      if (experimentId) {
-        this.experimentIds.push(experimentId);
-        return;
+      if (forcedExperimentId) {
+        this.experimentIds.push(forcedExperimentId);
       }
     }
     const experimentInfoMap =
@@ -364,10 +364,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         // Only select into SRA experiments if SRA not already explicitly
         // enabled and refresh is not being used by any slot.
         [DOUBLECLICK_SRA_EXP]: {
-          isTrafficEligible: () => !this.win.document./*OK*/querySelector(
-              'meta[name=amp-ad-enable-refresh], ' +
-              'amp-ad[type=doubleclick][data-enable-refresh], ' +
-              'meta[name=amp-ad-doubleclick-sra]'),
+          isTrafficEligible: () => !forcedExperimentId &&
+              !this.win.document./*OK*/querySelector(
+                  'meta[name=amp-ad-enable-refresh], ' +
+                  'amp-ad[type=doubleclick][data-enable-refresh], ' +
+                  'meta[name=amp-ad-doubleclick-sra]'),
           branches: Object.keys(DOUBLECLICK_SRA_EXP_BRANCHES).map(
               key => DOUBLECLICK_SRA_EXP_BRANCHES[key]),
         },

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1473,9 +1473,12 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
 
       describe('#setPageLevelExperiments', () => {
         let randomlySelectUnsetExperimentsStub;
+        let extractUrlExperimentIdStub;
         beforeEach(() => {
           randomlySelectUnsetExperimentsStub =
             sandbox.stub(impl, 'randomlySelectUnsetExperiments_');
+          extractUrlExperimentIdStub =
+            sandbox.stub(impl, 'extractUrlExperimentId_');
           sandbox.stub(AmpA4A.prototype, 'buildCallback').callsFake(() => {});
           sandbox.stub(impl, 'getAmpDoc').returns({});
           sandbox.stub(Services, 'viewerForDoc').returns(
@@ -1501,9 +1504,16 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         it('should select SRA experiments', () => {
           randomlySelectUnsetExperimentsStub.returns(
               {doubleclickSraExp: '117152667'});
+          extractUrlExperimentIdStub.returns(undefined);
           impl.buildCallback();
           expect(impl.experimentIds.includes('117152667')).to.be.true;
           expect(impl.useSra).to.be.true;
+        });
+
+        it('should force-select SRA experiment from URL experiment ID', () => {
+          randomlySelectUnsetExperimentsStub.returns({});
+          impl.setPageLevelExperiments('8');
+          expect(impl.experimentIds.includes('117152667')).to.be.true;
         });
 
         describe('should properly limit SRA traffic', () => {


### PR DESCRIPTION
PR #17191 changed the way the Doubleclick SRA experiments are selected, so that is now done by random selection in the client. That change also meant that #exp could no longer be used to force the selection of an SRA experiment branch, which presents difficulties for debugging problems in production. This PR restores the use of #exp to force SRA.