### PR TITLE
🐛 [amp-story] Add object-fit to full bleed animated images

### DIFF
--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -25,7 +25,8 @@ amp-story-grid-layer * {
 
 .i-amphtml-story-grid-template-fill > amp-anim img,
 .i-amphtml-story-grid-template-fill > amp-img img,
-.i-amphtml-story-grid-template-fill > amp-video video {
+.i-amphtml-story-grid-template-fill > amp-video video,
+.i-amphtml-story-grid-template-with-full-bleed-animation > amp-img img {
   object-fit: cover;
 }
 


### PR DESCRIPTION
Fixes #18090

Since images animated with full-bleed-animations presets like `zoom-in` or `pan-up` get the styles from `i-amphtml-story-grid-template-fill` removed for custom sizing, they weren't receiving the `object-fit: cover` property from the `amp-story-user-overridable.css`.

This PR adds 

Before:
![image](https://user-images.githubusercontent.com/5449100/45843629-17a92700-bcee-11e8-94f5-08f033b976b0.png)

After:
![image](https://user-images.githubusercontent.com/5449100/45843637-1c6ddb00-bcee-11e8-80e5-b73531c3f130.png)
