### PR TITLE
Layers: prevent multiple references to children layouts

### DIFF
--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -721,7 +721,12 @@ export class LayoutElement {
     dev().assert(this.isLayer());
     dev().assert(this.contains(child));
 
-    this.children_.push(child);
+    // Parents track the children, but not all children are aware of there
+    // parents. When a child finds its parent, it adds itself to the parent.
+    // This might lead to a double tracking.
+    if (this.children_.indexOf(child) === -1) {
+      this.children_.push(child);
+    }
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -661,9 +661,9 @@ export class Resources {
     }
     if (resource.isBuilt()) {
       resource.pauseOnRemove();
-      if (opt_disconnect) {
-        resource.disconnect();
-      }
+    }
+    if (opt_disconnect) {
+      resource.disconnect();
     }
     this.cleanupTasks_(resource, /* opt_removePending */ true);
     dev().fine(TAG_, 'element removed:', resource.debugid);


### PR DESCRIPTION
Parent layers are always aware of there children, but children may not
be aware of there parent layers. When a child finds its parent, it adds
itself to the parent (ie, when a new element is added to the DOM, it
adds itself to the parent).

In some circumstances, this lead to multiple references of child layouts.
When FIE destroyed itself, the first reference was being destroyed, but
that's it. Those extra references were kept alive, and the next time
they were measured an error is thrown because the child layouts window
context is destroyed (preventing accurate measurements).

Fixes #18203.
Fixes #17837