### PR TITLE
Apply placeholder to CMP provided iframe

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -40,3 +40,37 @@ amp-consent.amp-active {
 amp-consent.amp-hidden {
   visibility: hidden;
 }
+
+amp-consent.loading {
+  /* TODO: Finalize the placeholder design */
+  height: 30px;
+}
+
+amp-consent.consent-iframe-active {
+  height: 30vh;
+}
+
+.i-amphtml-consent-placeholder {
+  /* TODO: Finalize the placeholder design */
+}
+
+.i-amphtml-consent-placeholder:after {
+  content: "Loading.....";
+}
+
+.i-amphtml-consent-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+@keyframes i-amphtml-consent-ui-in {
+  0% {transform: translateY(100%);}
+  100% {transform: translateY(0);}
+}
+
+.i-amphtml-consent-ui-in {
+  animation: i-amphtml-consent-ui-in 0.5s linear;
+}

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -107,7 +107,7 @@ export class ConsentUI {
   }
 
   /**
-   * Display the UI. TODO: Apply placeholder when necessary
+   * Display the UI.
    */
   show() {
     if (!this.ui_) {
@@ -121,9 +121,11 @@ export class ConsentUI {
     // Add to fixed layer
     this.baseInstance_.getViewport().addToFixedLayer(this.parent_);
     if (this.isCreatedIframe_) {
-      this.iframeReady_ = new Deferred();
-      this.loadIframe_();
-      this.iframeReady_.promise.then(() => {
+      this.loadIframe_().then(() => {
+        // It is safe to assume that the loadIframe_ promise will resolve
+        // before resetIframe_. Because the iframe needs to be shown first
+        // being hidden. CMP iframe is responsible to call consent-iframe-ready
+        // API before consent-response API.
         this.showIframe_();
       });
     } else {
@@ -178,7 +180,7 @@ export class ConsentUI {
    * @return {!Element}
    */
   createPlaceholder_() {
-    // TODO: Allow publishers to provide placeholder upon request
+    // TODO(@zhouyx): Allow publishers to provide placeholder upon request
     const placeholder = this.parent_.ownerDocument.createElement('placeholder');
     toggle(placeholder, false);
     const {classList} = placeholder;
@@ -192,14 +194,17 @@ export class ConsentUI {
   /**
    * Apply placeholder
    * Set up event listener to handle UI related messages.
+   * @return {!Promise}
    */
   loadIframe_() {
+    this.iframeReady_ = new Deferred();
     const {classList} = this.parent_;
     classList.add('loading');
     toggle(dev().assertElement(this.placeholder_), true);
     toggle(dev().assertElement(this.ui_), false);
     this.win_.addEventListener('message', this.boundHandleIframeMessages_);
     insertAfterOrAtStart(this.parent_, dev().assertElement(this.ui_), null);
+    return this.iframeReady_.promise;
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -202,7 +202,8 @@ export class ConsentUI {
     this.iframeReady_ = new Deferred();
     const {classList} = this.parent_;
     if (!elementByTag(this.parent_, 'placeholder')) {
-      insertAfterOrAtStart(this.parent_, this.placeholder_, null);
+      insertAfterOrAtStart(this.parent_,
+          dev().assertElement(this.placeholder_), null);
     }
     classList.add('loading');
     toggle(dev().assertElement(this.placeholder_), true);

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import {Deferred} from '../../../src/utils/promise';
 import {
   assertHttpsUrl,
 } from '../../../src/url';
 import {dev, user} from '../../../src/log';
+import {getData} from '../../../src/event-helper';
 import {
   insertAfterOrAtStart,
   removeElement,
@@ -57,6 +59,15 @@ export class ConsentUI {
     /** @private {!Window} */
     this.win_ = baseInstance.win;
 
+    /** @private {?Deferred} */
+    this.iframeReady_ = null;
+
+    /** @private {?Element} */
+    this.placeholder_ = null;
+
+    /** @private @const {!Function} */
+    this.boundHandleIframeMessages_ = this.handleIframeMessages_.bind(this);
+
     this.init_(config, opt_postPromptUI);
   }
 
@@ -91,6 +102,7 @@ export class ConsentUI {
       this.isCreatedIframe_ = true;
       this.ui_ =
           this.createPromptIframeFromSrc_(promptUISrc);
+      this.placeholder_ = this.createPlaceholder_();
     }
   }
 
@@ -102,22 +114,26 @@ export class ConsentUI {
       // No prompt UI specified, nothing to do
       return;
     }
-    toggle(this.parent_, true);
+    toggle(dev().assertElement(this.parent_), true);
     const {classList} = this.parent_;
     classList.add('amp-active');
     classList.remove('amp-hidden');
     // Add to fixed layer
     this.baseInstance_.getViewport().addToFixedLayer(this.parent_);
-    toggle(this.ui_, true);
     if (this.isCreatedIframe_) {
-      // TODO: Apply placeholder and hide iframe
-      insertAfterOrAtStart(this.parent_, this.ui_, null);
-    }
-    if (!this.isPostPrompt_ && !this.isCreatedIframe_) {
-      // scheduleLayout is required everytime because some AMP element may
-      // get un laid out after toggle display (#unlayoutOnPause)
-      // for example <amp-iframe>
-      this.baseInstance_.scheduleLayout(this.ui_);
+      this.iframeReady_ = new Deferred();
+      this.loadIframe_();
+      this.iframeReady_.promise.then(() => {
+        this.showIframe_();
+      });
+    } else {
+      toggle(this.ui_, true);
+      if (!this.isPostPrompt_) {
+        // scheduleLayout is required everytime because some AMP element may
+        // get un laid out after toggle display (#unlayoutOnPause)
+        // for example <amp-iframe>
+        this.baseInstance_.scheduleLayout(this.ui_);
+      }
     }
   }
 
@@ -138,7 +154,7 @@ export class ConsentUI {
     this.baseInstance_.getViewport().removeFromFixedLayer(this.parent_);
     toggle(this.ui_, false);
     if (this.isCreatedIframe_) {
-      removeElement(this.ui_);
+      this.resetIframe_();
     }
   }
 
@@ -151,6 +167,90 @@ export class ConsentUI {
     const iframe = this.parent_.ownerDocument.createElement('iframe');
     iframe.src = assertHttpsUrl(promptUISrc, this.parent_);
     iframe.setAttribute('sandbox', 'allow-scripts');
+    const {classList} = iframe;
+    classList.add('i-amphtml-consent-fill');
+    // Append iframe lazily to save resources.
     return iframe;
+  }
+
+  /**
+   * Create the default placeholder
+   * @return {!Element}
+   */
+  createPlaceholder_() {
+    // TODO: Allow publishers to provide placeholder upon request
+    const placeholder = this.parent_.ownerDocument.createElement('placeholder');
+    toggle(placeholder, false);
+    const {classList} = placeholder;
+    classList.add('i-amphtml-consent-fill');
+    classList.add('i-amphtml-consent-placeholder');
+    insertAfterOrAtStart(this.parent_, placeholder, null);
+    return placeholder;
+  }
+
+
+  /**
+   * Apply placeholder
+   * Set up event listener to handle UI related messages.
+   */
+  loadIframe_() {
+    const {classList} = this.parent_;
+    classList.add('loading');
+    toggle(dev().assertElement(this.placeholder_), true);
+    toggle(dev().assertElement(this.ui_), false);
+    this.win_.addEventListener('message', this.boundHandleIframeMessages_);
+    insertAfterOrAtStart(this.parent_, dev().assertElement(this.ui_), null);
+  }
+
+  /**
+   * Hide the placeholder
+   * Apply animation to show the iframe
+   */
+  showIframe_() {
+    const {classList} = this.parent_;
+    toggle(dev().assertElement(this.placeholder_), false);
+    toggle(dev().assertElement(this.ui_), true);
+    classList.remove('loading');
+    classList.add('i-amphtml-consent-ui-in');
+    classList.add('consent-iframe-active');
+  }
+
+  /**
+   * Remove the iframe from doc
+   * Remove event listener
+   * Reset UI state
+   */
+  resetIframe_() {
+    const {classList} = this.parent_;
+    classList.remove('i-amphtml-consent-ui-in');
+    classList.remove('consent-iframe-active');
+    this.win_.removeEventListener('message', this.boundHandleIframeMessages_);
+    removeElement(dev().assertElement(this.ui_));
+  }
+
+  /**
+   * Listen to iframe messages and handle events.
+   * Current supported APIs:
+   *
+   * Required message from iframe to hide placeholder and display iframe
+   * {
+   *   type: 'consent-ui-ready'
+   * }
+   * @param {!Event} event
+   */
+  handleIframeMessages_(event) {
+    if (this.ui_.contentWindow !== event.source) {
+      // Ignore messages from else where
+      return;
+    }
+
+    const data = getData(event);
+    if (!data) {
+      return;
+    }
+
+    if (data['type'] == 'consent-ui-ready') {
+      this.iframeReady_.resolve();
+    }
   }
 }

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -19,11 +19,12 @@ import {
   assertHttpsUrl,
 } from '../../../src/url';
 import {dev, user} from '../../../src/log';
-import {getData} from '../../../src/event-helper';
 import {
+  elementByTag,
   insertAfterOrAtStart,
   removeElement,
 } from '../../../src/dom';
+import {getData} from '../../../src/event-helper';
 import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
 
@@ -126,7 +127,9 @@ export class ConsentUI {
         // before resetIframe_. Because the iframe needs to be shown first
         // being hidden. CMP iframe is responsible to call consent-iframe-ready
         // API before consent-response API.
-        this.showIframe_();
+        this.baseInstance_.mutateElement(() => {
+          this.showIframe_();
+        });
       });
     } else {
       toggle(this.ui_, true);
@@ -186,7 +189,6 @@ export class ConsentUI {
     const {classList} = placeholder;
     classList.add('i-amphtml-consent-fill');
     classList.add('i-amphtml-consent-placeholder');
-    insertAfterOrAtStart(this.parent_, placeholder, null);
     return placeholder;
   }
 
@@ -199,6 +201,9 @@ export class ConsentUI {
   loadIframe_() {
     this.iframeReady_ = new Deferred();
     const {classList} = this.parent_;
+    if (!elementByTag(this.parent_, 'placeholder')) {
+      insertAfterOrAtStart(this.parent_, this.placeholder_, null);
+    }
     classList.add('loading');
     toggle(dev().assertElement(this.placeholder_), true);
     toggle(dev().assertElement(this.ui_), false);

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -23,6 +23,13 @@ if (hashMatch) {
   ampWindow = ancestors[depth];
 }
 
+
+setTimeout(() => {
+  parent.postMessage({
+    type: 'consent-ui-ready',
+  }, '*');
+}, 500);
+
 document.querySelector('#a').onclick = function () {
 		// parent.postMessage("message to be sent", "http://the-website-that-will-receive-the-msg.com")
 		parent.postMessage({


### PR DESCRIPTION
This PR does few things
1. Hide the CMP iframe until there's the `consent-ui-ready` message received
2. Apply default placeholder before iframe is ready
3. transition animation

Decisions on the UI
The design to the placeholder is not finalized, so please ignore that part
Decided the initial iframe size is `30vh`

API format
We currently have data type `consent-response`, but that's more related to passing consent information. 
Here we support the data type `consent-ui-ready` that an iframe use to tell AMP consent to display it. 
Later we will be supporting data type `consent-ui-fullscreen`. And maybe `consent-ui-change-size` 

It is 
```
{
  type: 'consent-ui-ready'
}
```

I am will to change it to the following if it is more preferable.
```
{
  type: 'consent-ui',
  action: 'ready/fullscreen/change-size'
}
```

Please let me know if the API looks good. Thank you
