### PR TITLE
🐛Fix Expander Whitelist

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -56,9 +56,9 @@ export class Expander {
       return opt_sync ? url : Promise.resolve(url);
     }
     const expr = this.variableSource_
-        .getExpr(opt_bindings, /*opt_ignoreArgs */ true, opt_whiteList);
+        .getExpr(opt_bindings, /*opt_ignoreArgs */ true);
 
-    const matches = this.findMatches_(url, expr);
+    const matches = this.findMatches_(url, expr, opt_whiteList);
     // if no keywords move on
     if (!matches.length) {
       return opt_sync ? url : Promise.resolve(url);
@@ -72,10 +72,12 @@ export class Expander {
    * Structures the regex matching into the desired format
    * @param {string} url url to be substituted
    * @param {RegExp} expression regex containing all keywords
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
+   *   that can be substituted.
    * @return {Array<Object<string, string|number>>} array of objects representing
    *  matching keywords
    */
-  findMatches_(url, expression) {
+  findMatches_(url, expression, opt_whiteList) {
     const matches = [];
     url.replace(expression, (match, name, startPosition) => {
       const {length} = match;
@@ -86,7 +88,11 @@ export class Expander {
         name,
         length,
       };
-      matches.push(info);
+
+      if (!opt_whiteList || opt_whiteList[name]) {
+        matches.push(info);
+      }
+
     });
     return matches;
   }

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -257,11 +257,7 @@ export class VariableSource {
     if (this.getUrlMacroWhitelist_()) {
       keys = keys.filter(key => this.getUrlMacroWhitelist_().includes(key));
     }
-    // If a whitelist is passed into the call to GlobalVariableSource.expand_
-    // then we only resolve values contained in the whitelist.
-    if (opt_whiteList) {
-      keys = keys.filter(key => opt_whiteList[key]);
-    }
+
     if (keys.length === 0) {
       const regexThatMatchesNothing = /_^/g; // lgtm [js/regex/unmatchable-caret]
       return regexThatMatchesNothing;

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -139,7 +139,7 @@ describes.realWin('Expander', {
 
       expect(expander.expand(url, mockBindings,
           /* opt_collectVars */ undefined, /* opt_sync */ true,
-          /* opt_whitelist */ {RANDOM: true, ABC:true}))
+          /* opt_whitelist */ {RANDOM: true, ABC: true}))
           .to.equal('http://www.google.com/?test=0.1234&a=three');
     });
   });

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -130,6 +130,18 @@ describes.realWin('Expander', {
           .to.eventually.equal(expected);
     });
 
+    it('should respect different whitelists on different calls', () => {
+      const url = 'http://www.google.com/?test=RANDOM&a=ABC';
+      expect(expander.expand(url, mockBindings,
+          /* opt_collectVars */ undefined, /* opt_sync */ true,
+          /* opt_whitelist */ {RANDOM: true}))
+          .to.equal('http://www.google.com/?test=0.1234&a=ABC');
+
+      expect(expander.expand(url, mockBindings,
+          /* opt_collectVars */ undefined, /* opt_sync */ true,
+          /* opt_whitelist */ {RANDOM: true, ABC:true}))
+          .to.equal('http://www.google.com/?test=0.1234&a=three');
+    });
   });
 
   describe('#expand', () => {


### PR DESCRIPTION
Breaking apart #17949 into smaller PRs.

Move the opt_whiteList logic to the findMatches_ method. Previously it was manipulating the regex to exclude non-whitelisted macros, but was causing problems because the regex can be cached.
