### PR TITLE
🖍amp-image-slider : change cursor to semantic cursor

### DIFF
--- a/extensions/amp-image-slider/0.1/amp-image-slider.css
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.css
@@ -24,6 +24,7 @@
   transform: translateZ(0) !important;
   /* Remove webkit tap highlight grayish color */
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+  cursor: col-resize;
 }
 
 .i-amphtml-image-slider-left-mask {

--- a/extensions/amp-image-slider/0.1/amp-image-slider.css
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.css
@@ -24,7 +24,6 @@
   transform: translateZ(0) !important;
   /* Remove webkit tap highlight grayish color */
   -webkit-tap-highlight-color: rgba(0,0,0,0);
-  cursor: col-resize;
 }
 
 .i-amphtml-image-slider-left-mask {
@@ -67,15 +66,25 @@ amp-image-slider amp-img > img {
   right: 0 !important;
   bottom: 0 !important;
   left: 0 !important;
-  z-index: 2 !important;
+  z-index: 3 !important;
 }
 
 .i-amphtml-image-slider-bar-stick {
-  width: 0 !important;
+  width: 20% !important;
   height: 100% !important;
+  cursor: col-resize !important;
+}
+.i-amphtml-image-slider-bar-stick::before {
+  content: '' !important;
+  position: absolute !important;
+  display: block !important;
+  top: 0 !important;
+  left: 50% !important;
+  bottom: 0 !important;
   border: 0.5px solid white !important;
   box-sizing: border-box !important;
-  opacity: 0.5;
+  opacity: 0.5 !important;
+  transform: translate(-50%, 0) !important;
 }
 
 .i-amphtml-image-slider-label-wrapper {


### PR DESCRIPTION
Related Issues: #18056

* now `amp-image-slider` using default cursor.
* So I changed the cursor to `col-resize`.

PTAL :)