### PR TITLE
AdSense/Doubleclick Referrer timeout expected error

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -251,7 +251,7 @@ export function googlePageParameters(a4a, startTime) {
   const referrerPromise = Services.timerFor(win).timeoutPromise(
       1000, Services.viewerForDoc(ampDoc).getReferrerUrl())
       .catch(() => {
-        dev().error('AMP-A4A', 'Referrer timeout!');
+        dev().expectedError('AMP-A4A', 'Referrer timeout!');
         return '';
       });
   return Promise.all([


### PR DESCRIPTION
Change dev().error report introduced in #18002 to dev().expectedError