### PR TITLE
Renames filterSplice to remove

### DIFF
--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -27,8 +27,8 @@ import {
 } from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';
-import {filterSplice} from '../../../src/utils/array';
 import {isArray, isFiniteNumber} from '../../../src/types';
+import {remove} from '../../../src/utils/array';
 
 const TAG = 'amp-analytics/requests';
 
@@ -464,7 +464,7 @@ function getExtraUrlParamsString(variableService, params) {
  */
 function constructExtraUrlParamStrs(baseUrl, extraUrlParamStrsPromise) {
   return Promise.all(extraUrlParamStrsPromise).then(paramStrs => {
-    filterSplice(paramStrs, item => {return !!item;});
+    remove(paramStrs, item => !item);
     const extraUrlParamsStr = paramStrs.join('&');
     let requestUrl;
     if (baseUrl.indexOf('${extraUrlParams}') >= 0) {

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -17,7 +17,7 @@
 import {BindExpression} from './bind-expression';
 import {BindMacro} from './bind-macro';
 import {BindValidator} from './bind-validator';
-import {filterSplice} from '../../../src/utils/array';
+import {remove} from '../../../src/utils/array';
 
 /**
  * Asynchronously evaluates a set of Bind expressions.
@@ -75,8 +75,8 @@ export class BindEvaluator {
       expressionsToRemove[expressionString] = true;
     });
 
-    filterSplice(this.bindings_, binding =>
-      !expressionsToRemove[binding.expressionString]);
+    remove(this.bindings_, binding =>
+      !!expressionsToRemove[binding.expressionString]);
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -25,7 +25,7 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {deepEquals, getValueForExpr, parseJson} from '../../../src/json';
 import {deepMerge, dict, map} from '../../../src/utils/object';
 import {dev, user} from '../../../src/log';
-import {filterSplice, findIndex} from '../../../src/utils/array';
+import {findIndex, remove} from '../../../src/utils/array';
 import {getDetail} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {installServiceInEmbedScope} from '../../../src/service';
@@ -621,13 +621,13 @@ export class Bind {
    */
   removeBindingsForNodes_(nodes) {
     // Eliminate bound elements that are descendants of `nodes`.
-    filterSplice(this.boundElements_, boundElement => {
+    remove(this.boundElements_, boundElement => {
       for (let i = 0; i < nodes.length; i++) {
         if (nodes[i].contains(boundElement.element)) {
-          return false;
+          return true;
         }
       }
-      return true;
+      return false;
     });
     // Eliminate elements from the expression to elements map that
     // have node as an ancestor. Delete expressions that are no longer
@@ -635,13 +635,13 @@ export class Bind {
     const deletedExpressions = /** @type {!Array<string>} */ ([]);
     for (const expression in this.expressionToElements_) {
       const elements = this.expressionToElements_[expression];
-      filterSplice(elements, element => {
+      remove(elements, element => {
         for (let i = 0; i < nodes.length; i++) {
           if (nodes[i].contains(element)) {
-            return false;
+            return true;
           }
         }
-        return true;
+        return false;
       });
       if (elements.length == 0) {
         deletedExpressions.push(expression);

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -18,9 +18,9 @@ import {addAttributesToElement, closestBySelector} from './dom';
 import {deserializeMessage, isAmpMessage} from './3p-frame-messaging';
 import {dev} from './log';
 import {dict} from './utils/object';
-import {filterSplice} from './utils/array';
 import {getData} from './event-helper';
 import {parseUrlDeprecated} from './url';
+import {remove} from './utils/array';
 import {setStyle} from './style';
 import {tryParseJson} from './json';
 
@@ -449,7 +449,7 @@ export class SubscriptionApi {
    */
   send(type, data) {
     // Remove clients that have been removed from the DOM.
-    filterSplice(this.clientWindows_, client => !!client.win.parent);
+    remove(this.clientWindows_, client => !client.win.parent);
     postMessageToWindows(
         this.iframe_,
         this.clientWindows_,

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -23,8 +23,8 @@ import {
   resolveRelativeUrl,
 } from './url';
 import {dict} from './utils/object';
-import {filterSplice} from './utils/array';
 import {parseSrcset} from './srcset';
+import {remove} from './utils/array';
 import {startsWith} from './string';
 import {urls} from './config';
 import {user} from './log';
@@ -408,15 +408,15 @@ export function purifyHtml(dirty, diffing = false) {
 
     // Restore the `on` attribute which DOMPurify incorrectly flags as an
     // unknown protocol due to presence of the `:` character.
-    filterSplice(this.removed, r => {
+    remove(this.removed, r => {
       if (r.from === node && r.attribute) {
         const {name, value} = r.attribute;
         if (name.toLowerCase() === 'on') {
           node.setAttribute('on', value);
-          return false; // Delete from `removed` array once processed.
+          return true; // Delete from `removed` array once processed.
         }
       }
-      return true;
+      return false;
     });
   };
 

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -17,11 +17,11 @@
 import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev} from '../log';
-import {filterSplice} from '../utils/array';
 import {getFriendlyIframeEmbedOptional} from '../friendly-iframe-embed';
 import {getMode} from '../mode';
 import {listen} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
+import {remove} from '../utils/array';
 import {rootNodeFor} from '../dom';
 
 const LAYOUT_PROP = '__AMP_LAYOUT';
@@ -823,7 +823,7 @@ export class LayoutElement {
     // everything in this layer.
     const contained = layer.contains(this);
 
-    filterSplice(this.children_, layout => {
+    remove(this.children_, layout => {
       if (contained || layer.contains(layout)) {
         // Mark the layout as needing a remeasure, since its offset position
         // has likely changed.
@@ -832,10 +832,10 @@ export class LayoutElement {
         // And transfer ownership to the new layer.
         layout.parentLayer_ = layer;
         layer.children_.push(layout);
-        return false;
+        return true;
       }
 
-      return true;
+      return false;
     });
   }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -27,7 +27,6 @@ import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {computedStyle} from '../style';
 import {dev} from '../log';
 import {dict, hasOwn} from '../utils/object';
-import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
 import {checkAndFix as ieMediaCheckAndFix} from './ie-media-bug';
 import {isArray} from '../types';
@@ -35,6 +34,7 @@ import {isBlockedByConsent, reportError} from '../error';
 import {isExperimentOn} from '../experiments';
 import {loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
+import {remove} from '../utils/array';
 import {tryResolve} from '../utils/promise';
 
 const TAG_ = 'Resources';
@@ -2302,8 +2302,8 @@ export class Resources {
       this.exec_.purge(task => {
         return task.resource == resource;
       });
-      filterSplice(this.requestsChangeSize_, request => {
-        return request.resource != resource;
+      remove(this.requestsChangeSize_, request => {
+        return request.resource === resource;
       });
     }
 

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -40,34 +40,27 @@ export function areEqualOrdered(arr1, arr2) {
 }
 
 /**
- * A bit like Array#filter, but removes elements that filter false from the
- * array. Returns the filtered items.
+ * Removes elements that shouldRemove returns true for from the array.
  *
  * @param {!Array<T>} array
- * @param {function(T, number, !Array<T>):boolean} filter
- * @return {!Array<T>}
+ * @param {function(T, number, !Array<T>):boolean} shouldRemove
  * @template T
  */
-export function filterSplice(array, filter) {
-  const splice = [];
+export function remove(array, shouldRemove) {
   let index = 0;
   for (let i = 0; i < array.length; i++) {
     const item = array[i];
-    if (filter(item, i, array)) {
+    if (!shouldRemove(item, i, array)) {
       if (index < i) {
         array[index] = item;
       }
       index++;
-    } else {
-      splice.push(item);
     }
   }
 
   if (index < array.length) {
     array.length = index;
   }
-
-  return splice;
 }
 
 /**

--- a/test/functional/utils/test-array.js
+++ b/test/functional/utils/test-array.js
@@ -16,10 +16,10 @@
 
 import {
   areEqualOrdered,
-  filterSplice,
   findIndex,
   fromIterator,
   pushIfNotExist,
+  remove,
 } from '../../../src/utils/array';
 
 describe('areEqualOrdered', function() {
@@ -81,32 +81,25 @@ describe('areEqualOrdered', function() {
   });
 });
 
-describe('filterSplice', function() {
+describe('remove', function() {
   let array;
   beforeEach(() => {
     array = [1, 2, 3, 4, 5];
   });
 
-  it('should splice elements that filter true', () => {
-    filterSplice(array, i => i > 2);
-    expect(array).to.deep.equal([3, 4, 5]);
-  });
-
-  it('should return filtered elements', () => {
-    const filtered = filterSplice(array, i => i > 2);
-    expect(filtered).to.deep.equal([1, 2]);
+  it('should remove elements that return true', () => {
+    remove(array, i => i > 2);
+    expect(array).to.deep.equal([1, 2]);
   });
 
   it('handles no removals', () => {
-    const filtered = filterSplice(array, () => true);
+    remove(array, () => false);
     expect(array).to.deep.equal([1, 2, 3, 4, 5]);
-    expect(filtered).to.deep.equal([]);
   });
 
   it('handles consecutive removals', () => {
-    const filtered = filterSplice(array, () => false);
+    remove(array, () => true);
     expect(array).to.deep.equal([]);
-    expect(filtered).to.deep.equal([1, 2, 3, 4, 5]);
   });
 });
 


### PR DESCRIPTION
I noticed no one is using the return value from `filterSplice` (the
spliced out elements). So I removed that.

But then I noticed this isn't really like splice anymore, so I renamed
it to `filter`. But that's too close to `Array.p.filter` (and this is
destructive), so I renamed to `remove` to highlight the difference.