### PR TITLE
📖 Change the UK spelling of behaviour to US spelling of behavior

### DIFF
--- a/extensions/amp-access/0.1/access-expr-impl.js
+++ b/extensions/amp-access/0.1/access-expr-impl.js
@@ -59,7 +59,7 @@
 
         options: {
             ranges: boolean           (optional: true ==> token location info will include a .range[] member)
-            flex: boolean             (optional: true ==> flex-like lexing behaviour where the rules are tested exhaustively to find the longest match)
+            flex: boolean             (optional: true ==> flex-like lexing behavior where the rules are tested exhaustively to find the longest match)
             backtrack_lexer: boolean  (optional: true ==> lexer regexes are tested in order and for each matching regex the action code is invoked; the lexer terminates the scan when a token is returned by the action code)
         },
 


### PR DESCRIPTION
Change the UK spelling of "behaviour" to US spelling of "behavior"

Closes issue https://github.com/ampproject/amphtml/issues/18082