### PR TITLE
Allows fast tap on stories.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -57,6 +57,8 @@ amp-story {
   text-rendering: geometricPrecision !important;
   user-select: none !important;
   width: 100% !important;
+  /* Disables double tap to zoom, and ensures fast-tap is enabled on iOS. */
+  touch-action: manipulation !important;
 }
 
 html.i-amphtml-story-standalone,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -46,10 +46,6 @@ import {AmpStoryPage, PageState} from './amp-story-page';
 import {AmpStoryVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
-import {
-  DoubletapRecognizer,
-  SwipeXYRecognizer,
-} from '../../../src/gesture-recognizers';
 import {EventType, dispatch} from './events';
 import {Gestures} from '../../../src/gesture';
 import {InfoDialog} from './amp-story-info-dialog';
@@ -64,6 +60,7 @@ import {NavigationState} from './navigation-state';
 import {PaginationButtons} from './pagination-buttons';
 import {Services} from '../../../src/services';
 import {ShareMenu} from './amp-story-share-menu';
+import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {SystemLayer} from './amp-story-system-layer';
 import {TapNavigationDirection} from './page-advancement';
 import {UnsupportedBrowserLayer} from './amp-story-unsupported-browser-layer';
@@ -570,12 +567,6 @@ export class AmpStory extends AMP.BaseElement {
   installGestureRecognizers_() {
     const {element} = this;
     const gestures = Gestures.get(element, /* shouldNotPreventDefault */ true);
-
-    // Disables zoom on double-tap.
-    gestures.onGesture(DoubletapRecognizer, gesture => {
-      const {event} = gesture;
-      event.preventDefault();
-    });
 
     // Shows "tap to navigate" hint when swiping.
     gestures.onGesture(SwipeXYRecognizer, gesture => {


### PR DESCRIPTION
The tap events are throttled by the [DoubleTapRecognizer](https://github.com/ampproject/amphtml/blob/master/src/gesture-recognizers.js#L120).
On double tap, browsers usually natively dispatch two tap events + one double tap event. But the DoubleTapRecognizer doesn’t dispatch the second tap event.

Stories use this recognizer to disable the double tap to zoom on iOS Safari. Removing the recognizer removes the throttling and allows the navigation to be a lot smoother, as we stop ignoring tap events.

According to [this webkit blog article](https://webkit.org/blog/5610/more-responsive-tapping-on-ios/), we should be able to remove the recognizer without breaking anything, since #13316 adds `user-scalable=no` and a `minimum-scale` equal to the `maximum-scale` in the meta-tags.
However, to be very safe, I added the CSS rule `touch-action: manipulation;` at the `amp-story` level.

Partial for #18331