### PR TITLE
📖Update misspelling of behavior in amp-accordion example

### DIFF
--- a/examples/visual-tests/amp-by-example/components/amp-accordion/index.html
+++ b/examples/visual-tests/amp-by-example/components/amp-accordion/index.html
@@ -96,8 +96,8 @@
    </style>
   </head>
   <body>
-  
-    
+
+
       <!-- Start Navbar -->
       <header class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
         <div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger md-hide lg-hide pr2">☰</div>
@@ -557,7 +557,7 @@
       <a href="/" class="block caps h4 py1 abe-primary">AMPHTML</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -573,7 +573,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -643,7 +643,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -677,7 +677,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -694,7 +694,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -709,7 +709,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -734,7 +734,7 @@
       <a href="/amp-ads" class="block caps h4 py1 abe-primary">AMPHTML ads</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -748,7 +748,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -761,7 +761,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -778,7 +778,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -795,7 +795,7 @@
       <a href="/stories" class="block caps h4 py1 abe-primary">AMPHTML stories</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -808,7 +808,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-            
+
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -825,7 +825,7 @@
       </ul>
     </nav>
 
-    
+
   <ul class="ampstart-social-follow list-reset flex justify-around items-center flex-wrap m0 mb4">
       <li class="mr2">
           <a href="https://twitter.com/amphtml" class="inline-block"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="22.2" viewBox="0 0 53 49"><title>Twitter</title><path d="M45 6.9c-1.6 1-3.3 1.6-5.2 2-1.5-1.6-3.6-2.6-5.9-2.6-4.5 0-8.2 3.7-8.2 8.3 0 .6.1 1.3.2 1.9-6.8-.4-12.8-3.7-16.8-8.7C8.4 9 8 10.5 8 12c0 2.8 1.4 5.4 3.6 6.9-1.3-.1-2.6-.5-3.7-1.1v.1c0 4 2.8 7.4 6.6 8.1-.7.2-1.5.3-2.2.3-.5 0-1 0-1.5-.1 1 3.3 4 5.7 7.6 5.7-2.8 2.2-6.3 3.6-10.2 3.6-.6 0-1.3-.1-1.9-.1 3.6 2.3 7.9 3.7 12.5 3.7 15.1 0 23.3-12.6 23.3-23.6 0-.3 0-.7-.1-1 1.6-1.2 3-2.7 4.1-4.3-1.4.6-3 1.1-4.7 1.3 1.7-1 3-2.7 3.6-4.6" class="ampstart-icon ampstart-icon-twitter"/></svg></a>
@@ -843,14 +843,14 @@
       </li>
   </ul>
 
-  
+
     </ul>
   </amp-sidebar>
   <!-- End Sidebar -->
   <!-- End Navbar -->
           <header class="www-header center" id="top-header">
         <h1 class="mb1">
-          amp-accordion 
+          amp-accordion
         </h1>
         <a href="https://github.com/ampproject/amp-by-example/blob/master/src/20_Components/amp-accordion.html" class="block mb4 caps text-decoration-none">Edit on Github</a>
 
@@ -918,7 +918,7 @@
           <h2 id="basic-usage" class="www-heading pb4 mb2 relative h3">Basic Usage</h2>
         </section>
       <section class="www-component-desc">
-          <p class="mb2 px1">  Each of the <code>amp-accordion</code> component’s immediate children is considered a section in the accordion. Each of these nodes must be a <code>&lt;section&gt;</code> tag. Each <code>&lt;section&gt;</code> must contain only two direct children. The first child (of the section) will be considered as the heading of the section. Clicking/tapping on this section will trigger the expand/collapse behaviour. Use the <code>disable-session-states</code> attribute to disable preserving the accordion state across a session.</p>
+          <p class="mb2 px1">  Each of the <code>amp-accordion</code> component’s immediate children is considered a section in the accordion. Each of these nodes must be a <code>&lt;section&gt;</code> tag. Each <code>&lt;section&gt;</code> must contain only two direct children. The first child (of the section) will be considered as the heading of the section. Clicking/tapping on this section will trigger the expand/collapse behavior. Use the <code>disable-session-states</code> attribute to disable preserving the accordion state across a session.</p>
           <div class="abe-code-container">
             <div class="abe-code-preview ampstart-card">
               <h3 class="abe-code p1 caps h4">Example</h3>
@@ -1117,10 +1117,10 @@ amp-accordion section:not([expanded]) .show-less {
   </main>
   </amp-selector>
 
-    
+
       <!-- Start Footer -->
       <footer class="ampstart-footer flex flex-column items-center pxy3">
-        
+
     <ul class="ampstart-social-follow list-reset flex justify-around items-center flex-wrap m0 mb4">
         <li class="mr2">
             <a href="https://twitter.com/amphtml" class="inline-block"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="22.2" viewBox="0 0 53 49"><title>Twitter</title><path d="M45 6.9c-1.6 1-3.3 1.6-5.2 2-1.5-1.6-3.6-2.6-5.9-2.6-4.5 0-8.2 3.7-8.2 8.3 0 .6.1 1.3.2 1.9-6.8-.4-12.8-3.7-16.8-8.7C8.4 9 8 10.5 8 12c0 2.8 1.4 5.4 3.6 6.9-1.3-.1-2.6-.5-3.7-1.1v.1c0 4 2.8 7.4 6.6 8.1-.7.2-1.5.3-2.2.3-.5 0-1 0-1.5-.1 1 3.3 4 5.7 7.6 5.7-2.8 2.2-6.3 3.6-10.2 3.6-.6 0-1.3-.1-1.9-.1 3.6 2.3 7.9 3.7 12.5 3.7 15.1 0 23.3-12.6 23.3-23.6 0-.3 0-.7-.1-1 1.6-1.2 3-2.7 4.1-4.3-1.4.6-3 1.1-4.7 1.3 1.7-1 3-2.7 3.6-4.6" class="ampstart-icon ampstart-icon-twitter"/></svg></a>

--- a/examples/visual-tests/amp-by-example/components/amp-accordion/index.html
+++ b/examples/visual-tests/amp-by-example/components/amp-accordion/index.html
@@ -96,8 +96,8 @@
    </style>
   </head>
   <body>
-
-
+  
+    
       <!-- Start Navbar -->
       <header class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
         <div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger md-hide lg-hide pr2">☰</div>
@@ -557,7 +557,7 @@
       <a href="/" class="block caps h4 py1 abe-primary">AMPHTML</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -573,7 +573,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -643,7 +643,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -677,7 +677,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -694,7 +694,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -709,7 +709,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -734,7 +734,7 @@
       <a href="/amp-ads" class="block caps h4 py1 abe-primary">AMPHTML ads</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -748,7 +748,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -761,7 +761,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -778,7 +778,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -795,7 +795,7 @@
       <a href="/stories" class="block caps h4 py1 abe-primary">AMPHTML stories</a>
       <ul class="list-reset m0 p0 caps h5">
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -808,7 +808,7 @@
           <!-- End Dropdown-inline -->
         </li>
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
-
+            
           <!-- Start Dropdown-inline -->
           <amp-accordion layout="container" disable-session-states class="ampstart-dropdown">
             <section>
@@ -825,7 +825,7 @@
       </ul>
     </nav>
 
-
+    
   <ul class="ampstart-social-follow list-reset flex justify-around items-center flex-wrap m0 mb4">
       <li class="mr2">
           <a href="https://twitter.com/amphtml" class="inline-block"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="22.2" viewBox="0 0 53 49"><title>Twitter</title><path d="M45 6.9c-1.6 1-3.3 1.6-5.2 2-1.5-1.6-3.6-2.6-5.9-2.6-4.5 0-8.2 3.7-8.2 8.3 0 .6.1 1.3.2 1.9-6.8-.4-12.8-3.7-16.8-8.7C8.4 9 8 10.5 8 12c0 2.8 1.4 5.4 3.6 6.9-1.3-.1-2.6-.5-3.7-1.1v.1c0 4 2.8 7.4 6.6 8.1-.7.2-1.5.3-2.2.3-.5 0-1 0-1.5-.1 1 3.3 4 5.7 7.6 5.7-2.8 2.2-6.3 3.6-10.2 3.6-.6 0-1.3-.1-1.9-.1 3.6 2.3 7.9 3.7 12.5 3.7 15.1 0 23.3-12.6 23.3-23.6 0-.3 0-.7-.1-1 1.6-1.2 3-2.7 4.1-4.3-1.4.6-3 1.1-4.7 1.3 1.7-1 3-2.7 3.6-4.6" class="ampstart-icon ampstart-icon-twitter"/></svg></a>
@@ -843,14 +843,14 @@
       </li>
   </ul>
 
-
+  
     </ul>
   </amp-sidebar>
   <!-- End Sidebar -->
   <!-- End Navbar -->
           <header class="www-header center" id="top-header">
         <h1 class="mb1">
-          amp-accordion
+          amp-accordion 
         </h1>
         <a href="https://github.com/ampproject/amp-by-example/blob/master/src/20_Components/amp-accordion.html" class="block mb4 caps text-decoration-none">Edit on Github</a>
 
@@ -1117,10 +1117,10 @@ amp-accordion section:not([expanded]) .show-less {
   </main>
   </amp-selector>
 
-
+    
       <!-- Start Footer -->
       <footer class="ampstart-footer flex flex-column items-center pxy3">
-
+        
     <ul class="ampstart-social-follow list-reset flex justify-around items-center flex-wrap m0 mb4">
         <li class="mr2">
             <a href="https://twitter.com/amphtml" class="inline-block"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="22.2" viewBox="0 0 53 49"><title>Twitter</title><path d="M45 6.9c-1.6 1-3.3 1.6-5.2 2-1.5-1.6-3.6-2.6-5.9-2.6-4.5 0-8.2 3.7-8.2 8.3 0 .6.1 1.3.2 1.9-6.8-.4-12.8-3.7-16.8-8.7C8.4 9 8 10.5 8 12c0 2.8 1.4 5.4 3.6 6.9-1.3-.1-2.6-.5-3.7-1.1v.1c0 4 2.8 7.4 6.6 8.1-.7.2-1.5.3-2.2.3-.5 0-1 0-1.5-.1 1 3.3 4 5.7 7.6 5.7-2.8 2.2-6.3 3.6-10.2 3.6-.6 0-1.3-.1-1.9-.1 3.6 2.3 7.9 3.7 12.5 3.7 15.1 0 23.3-12.6 23.3-23.6 0-.3 0-.7-.1-1 1.6-1.2 3-2.7 4.1-4.3-1.4.6-3 1.1-4.7 1.3 1.7-1 3-2.7 3.6-4.6" class="ampstart-icon ampstart-icon-twitter"/></svg></a>


### PR DESCRIPTION
Addressing issue https://github.com/ampproject/amphtml/issues/18106

"Behavior" is misspelled as "behaviour" in the file `examples/visual-tests/amp-by-example/components/amp-accordion/index.html`

