### PR TITLE
🚮 Fix 5509: remove iframe title attribute, set image alt to Instagram

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -113,7 +113,7 @@ class AmpInstagram extends AMP.BaseElement {
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 
-    image.setAttribute('alt', 'Instagram');
+    image.setAttribute('alt', 'Instagram: ' + this.element.getAttribute('alt'));
     /*
      * Add instagram default styling
      */

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -113,7 +113,7 @@ class AmpInstagram extends AMP.BaseElement {
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 
-    this.propagateAttributes(['alt'], image);
+    image.setAttribute('alt', 'Instagram');
     /*
      * Add instagram default styling
      */
@@ -152,9 +152,7 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.setAttribute('scrolling', 'no');
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
-    //Add title to the iframe for better accessibility.
-    iframe.setAttribute('title', 'Instagram: ' +
-        this.element.getAttribute('alt'));
+
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/' +
         this.captioned_ + '?cr=1&v=9';

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -73,20 +73,19 @@ describes.realWin('amp-instagram', {
     expect(image.getAttribute('layout')).to.equal('fill');
     expect(image.getAttribute('alt')).to.equal('Testing');
     expect(image.getAttribute('referrerpolicy')).to.equal('origin');
+    expect(image.getAttribute('alt')).to.start_with('Instagram:');
   }
 
   function testIframe(iframe) {
     expect(iframe).to.not.be.null;
     expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?cr=1&v=9');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
-    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 
   function testIframeCaptioned(iframe) {
     expect(iframe).to.not.be.null;
     expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/captioned/?cr=1&v=9');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
-    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 
   it('renders', () => {

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -73,7 +73,7 @@ describes.realWin('amp-instagram', {
     expect(image.getAttribute('layout')).to.equal('fill');
     expect(image.getAttribute('alt')).to.equal('Testing');
     expect(image.getAttribute('referrerpolicy')).to.equal('origin');
-    expect(image.getAttribute('alt')).to.start_with('Instagram:');
+    expect(image.getAttribute('alt')).to.startsWith('Instagram:');
   }
 
   function testIframe(iframe) {


### PR DESCRIPTION
🚮Fixes #5509
- remove iframe title attribute, as iframes are no longer exposed to AT 
- set image `alt` attribute to 'Instagram' instead of  `this.propagateAttributes(['alt'], image);`

Tagging @aghassemi @erwinmombay