### PR TITLE
🐛amp-analytics Stop adding triggers if has been detached 

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -152,6 +152,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   detachedCallback() {
+    this.hasDetached_ = true;
     if (this.analyticsGroup_) {
       this.analyticsGroup_.dispose();
       this.analyticsGroup_ = null;
@@ -351,6 +352,11 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @private
    */
   addTriggerNoInline_(config) {
+    if (this.hasDetached_) {
+      // No need to handle trigger for component that has already been detached
+      // from DOM
+      return;
+    }
     try {
       this.analyticsGroup_.addTrigger(
           config, this.handleEvent_.bind(this, config));

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -152,7 +152,6 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   detachedCallback() {
-    this.hasDetached_ = true;
     if (this.analyticsGroup_) {
       this.analyticsGroup_.dispose();
       this.analyticsGroup_ = null;
@@ -352,7 +351,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @private
    */
   addTriggerNoInline_(config) {
-    if (this.hasDetached_) {
+    if (!this.analyticsGroup_) {
       // No need to handle trigger for component that has already been detached
       // from DOM
       return;

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -450,11 +450,16 @@ describes.realWin('amp-analytics', {
   });
 
   it('should tolerate invalid triggers', function() {
-    const analytics = getAnalyticsTag();
-    allowConsoleError(() => { expect(() => {
-      // An incomplete click request.
-      analytics.addTriggerNoInline_({'on': 'click'});
-    }).to.throw(/Failed to process trigger/); });
+    const analytics = getAnalyticsTag({
+      'request': {'foo': 'https://example.com'},
+      'triggers': [],
+    });
+    return waitForNoSendRequest(analytics).then(() => {
+      allowConsoleError(() => { expect(() => {
+        // An incomplete click request.
+        analytics.addTriggerNoInline_({'on': 'click'});
+      }).to.throw(/Failed to process trigger/); });
+    });
   });
 
   it('expands recursive requests', function() {


### PR DESCRIPTION
Attempt to fix #18231 

Note: Ideally we should add the check before initiating every instance, but that's too much check.
Once we've confirmed that detachedCallback is the root cause to #18231, we can remove the `this.hasDetached_` and check for `this.analyticsGroup_` instead. 