### PR TITLE
✨ amp-brightcove: pass through referrer

### DIFF
--- a/examples/brightcove.amp.html
+++ b/examples/brightcove.amp.html
@@ -23,6 +23,7 @@
   <h2>Brightcove Player</h2>
   <amp-brightcove
     id="myPlayer"
+    data-referrer="EXTERNAL_REFERRER"
     data-account="1290862519001"
     data-video-id="ref:amp-docs-sample"
     data-player-id="SyIOV8yWM"

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -78,6 +78,9 @@ class AmpBrightcove extends AMP.BaseElement {
 
     /**@private {?string} */
     this.playerId_ = null;
+
+    /** @private {?../../../src/service/url-replacements-impl.UrlReplacements} */
+    this.urlReplacements_ = null;
   }
 
   /** @override */
@@ -99,8 +102,10 @@ class AmpBrightcove extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    const ampdoc = this.getAmpDoc();
     const deferred = new Deferred();
 
+    this.urlReplacements_ = Services.urlReplacementsForDoc(ampdoc);
     this.playerReadyPromise_ = deferred.promise;
     this.playerReadyResolver_ = deferred.resolve;
 
@@ -237,6 +242,7 @@ class AmpBrightcove extends AMP.BaseElement {
         'The data-account attribute is required for <amp-brightcove> %s',
         el);
     const embed = (el.getAttribute('data-embed') || 'default');
+    const customReferrer = el.getAttribute('data-referrer');
 
     this.playerId_ = (el.getAttribute('data-player') ||
       el.getAttribute('data-player-id') ||
@@ -249,7 +255,12 @@ class AmpBrightcove extends AMP.BaseElement {
         // These are encodeURIComponent'd in encodeId_().
         (el.getAttribute('data-playlist-id') ?
           '?playlistId=' + this.encodeId_(el.getAttribute('data-playlist-id')) :
-          '?videoId=' + this.encodeId_(el.getAttribute('data-video-id')));
+          '?videoId=' + this.encodeId_(el.getAttribute('data-video-id'))
+        ) +
+        (customReferrer ?
+          `&referrer=${this.urlReplacements_.expandUrlSync(customReferrer)}` :
+          ''
+        );
 
     el.setAttribute('data-param-playsinline', 'true');
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -82,6 +82,10 @@ The Video Cloud playlist id. For AMP HTML uses a video id will normally be used 
 
 This is not used for Perform players by default; use it if you have added a plugin that expects a `playlistId` param in the query string.
 
+##### data-referrer
+
+Sets the referrer to be used for the Video Cloud analytics within the player. Requires Brightcove Player version v6.25.0+. This supports AMP varables such as `EXTERNAL_REFERRER`.
+
 ##### data-param-*
 
 All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.

--- a/extensions/amp-brightcove/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
@@ -45,6 +45,7 @@ tags: {  # <amp-brightcove>
   attrs: { name: "[data-player]" }
   attrs: { name: "[data-playlist-id]" }
   attrs: { name: "[data-video-id]" }
+  attrs: { name: "[data-referrer]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-brightcove"
   amp_layout: {


### PR DESCRIPTION
This enables passing a referrer value through to the Brightcove Player to be used in Video Cloud analytics. A `data-referrer` attribute allows the use of [`EXTERNAL_REFERRER`](https://github.com/ampproject/amphtml/blob/425cf9fd7584529035009961502a05991a8c90a1/spec/amp-var-substitutions.md#external-referrer) and `DOCUMENT_REFERRER`.

This requires that the Brightcove Player used by amp-brightcove is version [6.25.0](https://support.brightcove.com/brightcove-player-pre-release) or higher.

closes #11622