### PR TITLE
Amp-a4a: detachedCallback destroy creative frame

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1084,6 +1084,12 @@ export class AmpA4A extends AMP.BaseElement {
     this.postAdResponseExperimentFeatures = {};
   }
 
+  /** @override */
+  detachedCallback() {
+    super.detachedCallback();
+    this.destroyFrame(true);
+  }
+
   /**
    * Attempts to remove the current frame and free any associated resources.
    * This function will no-op if this ad slot is currently in the process of

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -412,7 +412,7 @@ describe('amp-a4a', () => {
 
     it('detachedCallback should destroy FIE and detach frame', () => {
       const fieDestroySpy =
-          sandbox.spy(FriendlyIframeEmbed.prototype, 'destroy');
+          sandbox./*OK*/spy(FriendlyIframeEmbed.prototype, 'destroy');
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -410,6 +410,18 @@ describe('amp-a4a', () => {
       });
     });
 
+    it('detachedCallback should destroy FIE and detach frame', () => {
+      const fieDestroySpy =
+          sandbox.spy(FriendlyIframeEmbed.prototype, 'destroy');
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      return a4a.layoutCallback().then(() => {
+        a4a.detachedCallback();
+        expect(fieDestroySpy).to.be.called;
+        expect(a4aElement.querySelector('iframe')).to.not.be.ok;
+      });
+    });
+
     it('for A4A FIE should wait for initial layout', () => {
       let iniLoadResolver;
       const iniLoadPromise = new Promise(resolve => {


### PR DESCRIPTION
Address issue where amp-ad extending amp-a4a- within amp-sticky-ad does not destroy the FIE or remove the frame when a user collapses the sticky. 