### PR TITLE
Ramping up AdSense Auto Ads responsive to 5%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -28,7 +28,7 @@
   "pump-early-frame": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
-  "amp-auto-ads-adsense-responsive": 0.01,
+  "amp-auto-ads-adsense-responsive": 0.05,
   "version-locking": 1,
   "as-use-attr-for-format": 0.01,
   "a4aFastFetchDoubleclickLaunched": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -27,7 +27,7 @@
   "chunked-amp": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
-  "amp-auto-ads-adsense-responsive": 0.01,
+  "amp-auto-ads-adsense-responsive": 0.05,
   "version-locking": 1,
   "as-use-attr-for-format": 0.01,
   "a4aFastFetchDoubleclickLaunched": 0,


### PR DESCRIPTION
Follow up to https://github.com/ampproject/amphtml/pull/17621 which ramped to 1% (note that the description incorrectly says 0.1% -- it is actually 1%).