### PR TITLE
Set PERCY_TARGET_COMMIT to determine which Percy build to use as baseline for PRs

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -25,9 +25,9 @@ const {getStdout} = require('./exec');
  * Returns the branch point of the current branch off of master.
  * @return {string}
  */
-function gitBranchPoint() {
+exports.gitBranchPoint = function() {
   return getStdout('git merge-base master HEAD').trim();
-}
+};
 
 /**
  * Returns the list of files changed on the local branch relative to the branch
@@ -35,7 +35,7 @@ function gitBranchPoint() {
  * @return {!Array<string>}
  */
 exports.gitDiffNameOnlyMaster = function() {
-  const branchPoint = gitBranchPoint();
+  const branchPoint = exports.gitBranchPoint();
   return getStdout(`git diff --name-only ${branchPoint}`).trim().split('\n');
 };
 
@@ -45,7 +45,7 @@ exports.gitDiffNameOnlyMaster = function() {
  * @return {string}
  */
 exports.gitDiffStatMaster = function() {
-  const branchPoint = gitBranchPoint();
+  const branchPoint = exports.gitBranchPoint();
   return getStdout(`git -c color.ui=always diff --stat ${branchPoint}`);
 };
 
@@ -55,7 +55,7 @@ exports.gitDiffStatMaster = function() {
  * @return {!Array<string>}
  */
 exports.gitDiffAddedNameOnlyMaster = function() {
-  const branchPoint = gitBranchPoint();
+  const branchPoint = exports.gitBranchPoint();
   return getStdout(`git diff --name-only --diff-filter=ARC ${branchPoint}`)
       .trim().split('\n');
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -23,10 +23,15 @@ const {getStdout} = require('./exec');
 
 /**
  * Returns the branch point of the current branch off of master.
+ * @param {boolean} fromMerge true if this is a merge commit.
  * @return {string}
  */
-exports.gitBranchPoint = function() {
-  return getStdout('git merge-base master HEAD').trim();
+exports.gitBranchPoint = function(fromMerge = false) {
+  if (fromMerge) {
+    return getStdout('git merge-base HEAD^1 HEAD^2').trim();
+  } else {
+    return getStdout('git merge-base master HEAD').trim();
+  }
 };
 
 /**

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -139,7 +139,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint(true);
+    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint(/* fromMerge */ true);
   }
 }
 

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -321,6 +321,10 @@ async function runVisualTests(visualTestsConfig) {
   const {buildId} = percy;
   fs.writeFileSync('PERCY_BUILD_ID', buildId);
   log('info', 'Started Percy build', colors.cyan(buildId));
+  if (process.env['PERCY_TARGET_COMMIT']) {
+    log('info', 'The Percy build is baselined on top of commit',
+        colors.cyan(process.env['PERCY_TARGET_COMMIT']));
+  }
 
   // Take the snapshots.
   await generateSnapshots(percy, visualTestsConfig.webpages);

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -133,13 +133,13 @@ function setPercyBranch() {
  * This will let Percy determine which build to use as the baseline for this new
  * build.
  *
- * Does not do anything for --master builds, since master builds are always
- * built on top of the previous commit (we use the squash and merge method for
- * pull requests.)
+ * Only does something on Travis, and for non-master branches, since master
+ * builds are always built on top of the previous commit (we use the squash and
+ * merge method for pull requests.)
  */
 function setPercyTargetCommit() {
-  if (!argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint();
+  if (process.env.TRAVIS && !argv.master) {
+    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint(true);
   }
 }
 


### PR DESCRIPTION
This PR sets the PERCY_TARGET_COMMIT in the `gulp visual-diff` task (for non-`master` builds,) which in turn means that PRs will be compared on Percy with the relevant baseline (i.e., where they were split from `master`) as opposed to the "latest master", which might not be relevant to those PRs.

Fixed #11385