### PR TITLE
📖 Adressing issue #18100. Change 'whitelisted' to 'white listed'

### DIFF
--- a/ads/openx.md
+++ b/ads/openx.md
@@ -63,7 +63,7 @@ OpenX header bidding. Parameters noted in the DoubleClick amp-ad [documentation]
 
 - `json` - Additional json options.
 
-  - `customVars` - please refer to the [documentation](https://docs.openx.com/Content/developers/ad_request_api/custom_variables_in_ad_calls.html).  Also note that OpenX bidder limits these keys by the __whitelisted keys__ set on your publisher settings.
+  - `customVars` - please refer to the [documentation](https://docs.openx.com/Content/developers/ad_request_api/custom_variables_in_ad_calls.html).  Also note that OpenX bidder limits these keys by the __white listed keys__ set on your publisher settings.
 
 ```html
 <amp-ad width="728" height="90"


### PR DESCRIPTION
Closes issue #18100.  
'White listed' was spelled as 'whitelisted'  in
> `ads/openx.md`