### PR TITLE
🖍 Changes the blur CSS to avoid transparent edges

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -174,7 +174,8 @@ export class AmpImg extends BaseElement {
   /** @override **/
   firstLayoutCompleted() {
     const placeholder = this.getPlaceholder();
-    if (placeholder && placeholder.classList.contains('i-amphtml-blur') &&
+    if (placeholder &&
+      placeholder.classList.contains('i-amphtml-blurry-placeholder') &&
       isExperimentOn(this.win, 'blurry-placeholder')) {
       setImportantStyles(placeholder, {'opacity': 0});
     } else {

--- a/css/amp.css
+++ b/css/amp.css
@@ -169,8 +169,6 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
 
 
 .i-amphtml-blur {
-  filter: blur(20px) !important;
-  transform: scale(1.1) !important;
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 

--- a/css/amp.css
+++ b/css/amp.css
@@ -168,7 +168,7 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
 }
 
 
-.i-amphtml-blur {
+.i-amphtml-blurry-placeholder {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
@@ -269,7 +269,7 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-fill-content,
-.i-amphtml-blur {
+.i-amphtml-blurry-placeholder {
   display: block;
   /* These lines are a work around to this issue in iOS:     */
   /* https://bugs.webkit.org/show_bug.cgi?id=155198          */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -658,7 +658,7 @@ class AmpVideo extends AMP.BaseElement {
     const placeholder = this.getPlaceholder();
     // checks for the existence of a visible blurry placeholder
     if (placeholder) {
-      if (placeholder.classList.contains('i-amphtml-blur') &&
+      if (placeholder.classList.contains('i-amphtml-blurry-placeholder') &&
         isExperimentOn(this.win, 'blurry-placeholder')) {
         setImportantStyles(placeholder, {'opacity': 0.0});
         return true;

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -503,7 +503,7 @@ describes.realWin('amp-video', {
         v.getPlaceholder = sandbox.stub();
       }
       if (addBlurClass) {
-        img.classList.add('i-amphtml-blur');
+        img.classList.add('i-amphtml-blurry-placeholder');
       }
       v.setAttribute('poster', 'img.png');
       doc.body.appendChild(v);

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -400,7 +400,7 @@ describe('amp-img', () => {
         el.getPlaceholder = sandbox.stub();
       }
       if (addBlurClass) {
-        img.classList.add('i-amphtml-blur');
+        img.classList.add('i-amphtml-blurry-placeholder');
       }
       el.appendChild(img);
       el.getResources = () => Services.resourcesForDoc(document);


### PR DESCRIPTION
- Address issue #18113 
- Dependent on amp-toolbox/pull/96

