### PR TITLE
allow single pass code to write out to other directories besides dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1688,6 +1688,8 @@ gulp.task('dist', 'Build production binaries', maybeUpdatePackages, dist, {
     extensions: '  Builds only the listed extensions.',
     extensions_from: '  Builds only the extensions from the listed AMP(s).',
     noextensions: '  Builds with no extensions.',
+    single_pass_dest: '  The directory closure compiler will write out to ' +
+            'with --single_pass mode. The default directory is `dist`',
   },
 });
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',


### PR DESCRIPTION
sometimes i need both the old code and new single pass code at the same time, so i don't want single pass to overwrite the directory and files in them