### PR TITLE
🏗 Fix build on Windows - Use proper shellCmd depending on platform

### DIFF
--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -55,7 +55,7 @@ exports.exec = function(cmd, options) {
  * @param {<Object>} options
  */
 exports.execScriptAsync = function(script, options) {
-  return childProcess.spawn('sh', ['-c', script], options);
+  return childProcess.spawn(shellCmd, [shellFlag, script], options);
 };
 
 /**


### PR DESCRIPTION
Currently, building doesn't work properly on Windows since execScriptAsync will try to invoke /sh instead of cmd. 

There is already a variable in the script that checks the platform and takes care of invoking cmd instead of sh for Windows. This variable is already used in spawnProcess. Should be used in execScriptAsync as well

