### PR TITLE
🏗 Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{*.md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
[What is EditorConfig?](https://editorconfig.org/#overview)

> EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of **a file format** for defining coding styles and a collection of **text editor plugins** that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

Contributors to AMP will benefit from having an EditorConfig in that they will be less likely to submit PRs that contain incorrect code style since [many editors](https://editorconfig.org/#download) automatically configure themselves based on this file when present.

The default config should help code conform to the [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html). Markdown files get an exception for `trim_trailing_whitespace` since GitHub uses trailing two spaces to insert a newline.