### PR TITLE
✨Analytics: CookieWriter

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -289,6 +289,7 @@ requirement: {
   whitelist: 'src/experiments.js'
   whitelist: 'src/service/cid-api.js'
   whitelist: 'src/service/cid-impl.js'
+  whitelist: 'extensions/amp-analytics/0.1/cookie-writer.js'
 }
 
 # Function

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -255,6 +255,8 @@ exports.rules = [
           'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-analytics/0.1/amp-analytics.js->' +
           'src/service/cid-impl.js',
+      'extensions/amp-analytics/0.1/cookie-writer.js->' +
+          'src/service/cid-impl.js',
       'extensions/amp-next-page/0.1/next-page-service.js->' +
           'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-next-page/0.1/next-page-service.js->' +

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -818,6 +818,7 @@ const forbiddenTermsSrcInclusive = {
     whitelist: [
       'extensions/amp-form/0.1/amp-form.js',
       'src/service/url-replacements-impl.js',
+      'extensions/amp-analytics/0.1/cookie-writer.js',
     ],
   },
   '\\.expandInputValueSync\\(': {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -213,7 +213,7 @@ export class AmpAnalytics extends AMP.BaseElement {
             .then(config => {
               this.config_ = config;
               return new CookieWriter(this.win,
-                  this.element, this.config_).whenReady();
+                  this.element, this.config_).write();
             })
             .then(() => {
               this.transport_ =

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -17,6 +17,7 @@
 import {Activity} from './activity-impl';
 import {AnalyticsConfig, mergeObjects} from './config';
 import {AnalyticsEventType} from './events';
+import {CookieWriter} from './cookie-writer';
 import {
   ExpansionOptions,
   installVariableService,
@@ -211,6 +212,10 @@ export class AmpAnalytics extends AMP.BaseElement {
             })
             .then(config => {
               this.config_ = config;
+              return new CookieWriter(this.win,
+                  this.element, this.config_).whenReady();
+            })
+            .then(() => {
               this.transport_ =
                   new Transport(this.win, this.config_['transport'] || {});
             })

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isObject, toWin} from '../../../src/types';
+import {hasOwn, map} from '../../../src/utils/object';
+import {user} from '../../../src/log';
+import {Services} from '../../../src/services';
+import {setCookie} from '../../../src/cookies';
+import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
+import {isInFie} from '../../../src/friendly-iframe-embed';
+import {Deferred} from '../../../src/utils/promise';
+import {isProxyOrigin} from '../../../src/url';
+
+
+const TAG = 'amp-analytics/cookie-writer';
+
+const EXPAND_WHITELIST = {
+  'QUERY_PARAM': true,
+  // TODO: Add linker_param
+}
+
+export class CookieWriter {
+
+  /**
+   * @param {!Window} win
+   * @param {!Element} element
+   * @param {!JsonObject} config
+   */
+  constructor (win, element, config) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {!Element} */
+    this.element_ = element;
+
+    /** @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
+    this.urlReplacementService_ = Services.urlReplacementsForDoc(element);
+
+    /** @private {!Array<!Promise>} */
+    this.promises_ = [];
+
+    /** @private {!../../../src/utils/promise.Deferred} */
+    this.readyPromise_ = new Deferred();
+
+    this.init_(config);
+  }
+
+  /**
+   * @return {!Promise}
+   */
+  whenReady() {
+    return this.readyPromise_.promise;
+  }
+
+  /**
+   * @param {!JsonObject} config
+   */
+  init_(config) {
+    if (!hasOwn(config, 'writeCookies')) {
+      this.readyPromise_.resolve();
+      return;
+    }
+
+    if (!isObject(config['writeCookies'])) {
+      user().error(TAG, 'writeCookies config must be an object');
+      this.readyPromise_.resolve();
+      return;
+    }
+
+    if (isInFie(this.element_)) {
+      // TODO: Need the consider the case for shadow doc.
+      // QQ: Is this even an error since vendor defines it?
+      user().error(TAG, 'writeCookies is disabled in friendly iframe');
+      this.readyPromise_.resolve();
+      return;
+    }
+    if (isProxyOrigin(this.win_.location)) {
+      // Disable cookie writter for proxy origin
+      // It's important to check here so that setCookie doesn't throw error on
+      // "should not attempt ot set cookie on proxy origin"
+      this.readyPromise_.resolve();
+      return;
+    }
+
+    const inputConfig = config['writeCookies'];
+    const ids = Object.keys(inputConfig);
+    for (let i = 0; i < ids.length; i++) {
+      const cookieId = ids[i];
+      const cookieStr = inputConfig[cookieId];
+      if (typeof cookieStr === 'string') {
+        this.promises_.push(this.expandAndWrite_(cookieId, cookieStr));
+      }
+    }
+
+    Promise.all(this.promises_).then(() => {
+      this.readyPromise_.resolve();
+    });
+  }
+
+  /**
+   * Expand the value and write to cookie if necessary
+   * @param {string} cookieId
+   * @param {string} cookieStr
+   * @return {!Promise}
+   */
+  expandAndWrite_(cookieId, cookieStr) {
+    // Note: Have to use `expandStringAsync` because QUERY_PARAM can wait for
+    // trackImpressionPromise and resolve async
+    return this.urlReplacementService_.expandStringAsync(cookieStr,
+      /* TODO: Add opt_binding */ undefined, EXPAND_WHITELIST).then(
+      cookieValue => {
+        // Note: We ignore empty cookieValue, that means currently we don't
+        // provide a way to overwrite or erase existing cookie
+        if (cookieValue) {
+          const expireDate = Date.now() + BASE_CID_MAX_AGE_MILLIS;
+          setCookie(this.win_, cookieId, cookieValue, expireDate);
+        }
+    }).catch(e => {
+      user().error(TAG, 'Error expanding cookie string', e);
+    });
+  }
+}
+

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -16,6 +16,7 @@
 
 import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
 import {Services} from '../../../src/services';
+import {getMode} from '../../../src/mode';
 import {getNameArgs} from './variables';
 import {hasOwn} from '../../../src/utils/object';
 import {isInFie} from '../../../src/friendly-iframe-embed';
@@ -73,8 +74,9 @@ export class CookieWriter {
    */
   init_() {
     // TODO: Need the consider the case for shadow doc.
-    if (isInFie(this.element_) || isProxyOrigin(this.win_.location)) {
-      // Disable cookie writer in friendly iframe and proxy origin.
+    if (isInFie(this.element_) || isProxyOrigin(this.win_.location) ||
+        getMode(this.win_).runtime == 'inabox') {
+      // Disable cookie writer in friendly iframe and proxy origin and inabox.
       // Note: It's important to check origin here so that setCookie doesn't
       // throw error "should not attempt ot set cookie on proxy origin"
       return Promise.resolve();

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import {isObject, toWin} from '../../../src/types';
-import {hasOwn, map} from '../../../src/utils/object';
-import {user} from '../../../src/log';
-import {Services} from '../../../src/services';
-import {setCookie} from '../../../src/cookies';
 import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
-import {isInFie} from '../../../src/friendly-iframe-embed';
 import {Deferred} from '../../../src/utils/promise';
+import {Services} from '../../../src/services';
+import {hasOwn} from '../../../src/utils/object';
+import {isInFie} from '../../../src/friendly-iframe-embed';
+import {isObject} from '../../../src/types';
 import {isProxyOrigin} from '../../../src/url';
+import {setCookie} from '../../../src/cookies';
+import {user} from '../../../src/log';
 
 
 const TAG = 'amp-analytics/cookie-writer';
@@ -30,7 +30,7 @@ const TAG = 'amp-analytics/cookie-writer';
 const EXPAND_WHITELIST = {
   'QUERY_PARAM': true,
   // TODO: Add linker_param
-}
+};
 
 export class CookieWriter {
 
@@ -39,7 +39,7 @@ export class CookieWriter {
    * @param {!Element} element
    * @param {!JsonObject} config
    */
-  constructor (win, element, config) {
+  constructor(win, element, config) {
     /** @private {!Window} */
     this.win_ = win;
 
@@ -120,15 +120,15 @@ export class CookieWriter {
     // Note: Have to use `expandStringAsync` because QUERY_PARAM can wait for
     // trackImpressionPromise and resolve async
     return this.urlReplacementService_.expandStringAsync(cookieStr,
-      /* TODO: Add opt_binding */ undefined, EXPAND_WHITELIST).then(
-      cookieValue => {
+        /* TODO: Add opt_binding */ undefined, EXPAND_WHITELIST).then(
+        cookieValue => {
         // Note: We ignore empty cookieValue, that means currently we don't
         // provide a way to overwrite or erase existing cookie
-        if (cookieValue) {
-          const expireDate = Date.now() + BASE_CID_MAX_AGE_MILLIS;
-          setCookie(this.win_, cookieId, cookieValue, expireDate);
-        }
-    }).catch(e => {
+          if (cookieValue) {
+            const expireDate = Date.now() + BASE_CID_MAX_AGE_MILLIS;
+            setCookie(this.win_, cookieId, cookieValue, expireDate);
+          }
+        }).catch(e => {
       user().error(TAG, 'Error expanding cookie string', e);
     });
   }

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CookieWriter} from '../cookie-writer';
+import * as cookie from '../../../../src/cookies';
+import {dict} from '../../../../src/utils/object';
+
+const TAG = '[amp-analytics/cookie-writer]'
+
+describes.realWin('amp-analytics.cookie-writer', {
+  amp: true,
+  runtimeOn: true,
+}, env => {
+
+  let sandbox;
+  let win;
+  let doc;
+  let setCookieSpy;
+  let element;
+  let ampdoc;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    setCookieSpy = sandbox.spy();
+    win = env.win;
+    ampdoc = env.ampdoc;
+    doc = win.document;
+    sandbox.stub(cookie, 'setCookie').callsFake(
+      (win, name, value, expirationTime) => {
+        setCookieSpy(name, value);
+    });
+    element = doc.createElement('div');
+    doc.body.appendChild(element);
+  });
+
+  describe('whenReady', () => {
+    it('Resolve when no config', () => {
+      const config = dict({});
+      const cookieWriter = new CookieWriter(win, element, config);
+      expect(setCookieSpy).to.not.be.called;
+      return cookieWriter.whenReady();
+    });
+
+    it('Resovle when config is invalid', () => {
+      const config = dict({
+        'writeCookies': 'invalid',
+      });
+      expectAsyncConsoleError(TAG + ' writeCookies config must be an object');
+      const cookieWriter = new CookieWriter(win, element, config);
+      expect(setCookieSpy).to.not.be.called;
+      return cookieWriter.whenReady();
+    });
+
+    it('Resolve when element is in FIE', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'testValue',
+        },
+      });
+      const parent = doc.createElement('div');
+      parent.classList.add('i-amphtml-fie');
+      doc.body.appendChild(parent);
+      parent.appendChild(element);
+      expectAsyncConsoleError(TAG +
+          ' writeCookies is disabled in friendly iframe');
+      const cookieWriter = new CookieWriter(win, element, config);
+      expect(setCookieSpy).to.not.be.called;
+      return cookieWriter.whenReady();
+    });
+
+    it('Resolve when in viewer', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'testValue',
+        },
+      });
+      const mockWin = {
+        location: 'https://www-example-com.cdn.ampproject.org',
+      }
+      const cookieWriter = new CookieWriter(mockWin, element, config);
+      expect(setCookieSpy).to.not.be.called;
+      return cookieWriter.whenReady();
+    });
+
+    it('Resolve with nothing to write', () => {
+      const config = dict({
+        'writeCookies': {},
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      expect(setCookieSpy).to.not.be.called;
+      return cookieWriter.whenReady();
+    });
+  });
+
+  describe('Cookie value', () => {
+    it('Write cookie', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'testValue'
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      return cookieWriter.whenReady().then(() => {
+        expect(setCookieSpy).to.be.calledOnce;
+        expect(setCookieSpy).to.be.calledWith('testId', 'testValue');
+      });
+    });
+
+    it('Write multiple cookie', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'testValue',
+          'testId2': 'testValue2',
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      return cookieWriter.whenReady().then(() => {
+        expect(setCookieSpy).to.be.calledTwice;
+        expect(setCookieSpy).to.be.calledWith('testId', 'testValue');
+        expect(setCookieSpy).to.be.calledWith('testId2', 'testValue2');
+      });
+    });
+
+    it('Expand whitelist macro', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'pre-QUERY_PARAM(noexist)',
+          'testId2': 'pre-RANDOM',
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      return cookieWriter.whenReady().then(() => {
+        expect(setCookieSpy).to.be.calledTwice;;
+        // QUERY_PARAM resolve to empty string
+        expect(setCookieSpy).to.be.calledWith('testId', 'pre-');
+        // Never try to resolve RANDOM
+        expect(setCookieSpy).to.be.calledWith('testId2', 'pre-RANDOM');
+      });
+    });
+
+    it('Do not write when string is empty', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'QUERY_PARAM(noexist)',
+          'testId2': '',
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      return cookieWriter.whenReady().then(() => {
+        // Both cookie value resolve to empty string
+        expect(setCookieSpy).to.not.be.called;
+      });
+    });
+
+    it('Handle expandString error', () => {
+      const config = dict({
+        'writeCookies': {
+          'testId': 'QUERY_PARAM',
+          'testId2': 'testValue',
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      expectAsyncConsoleError(TAG + ' Error expanding cookie string ' +
+          'Error: The first argument to QUERY_PARAM, ' +
+          'the query string param is required​​​');
+      expectAsyncConsoleError('The first argument to QUERY_PARAM, ' +
+          'the query string param is required')
+      return cookieWriter.whenReady().then(() => {
+        // Both cookie value resolve to empty string
+        expect(setCookieSpy).to.be.calledOnce;
+      });
+    });
+  });
+});

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {CookieWriter} from '../cookie-writer';
 import * as cookie from '../../../../src/cookies';
+import {CookieWriter} from '../cookie-writer';
 import {dict} from '../../../../src/utils/object';
 
-const TAG = '[amp-analytics/cookie-writer]'
+const TAG = '[amp-analytics/cookie-writer]';
 
 describes.realWin('amp-analytics.cookie-writer', {
   amp: true,
@@ -30,18 +30,16 @@ describes.realWin('amp-analytics.cookie-writer', {
   let doc;
   let setCookieSpy;
   let element;
-  let ampdoc;
 
   beforeEach(() => {
     sandbox = env.sandbox;
     setCookieSpy = sandbox.spy();
     win = env.win;
-    ampdoc = env.ampdoc;
     doc = win.document;
     sandbox.stub(cookie, 'setCookie').callsFake(
-      (win, name, value, expirationTime) => {
-        setCookieSpy(name, value);
-    });
+        (win, name, value) => {
+          setCookieSpy(name, value);
+        });
     element = doc.createElement('div');
     doc.body.appendChild(element);
   });
@@ -89,7 +87,7 @@ describes.realWin('amp-analytics.cookie-writer', {
       });
       const mockWin = {
         location: 'https://www-example-com.cdn.ampproject.org',
-      }
+      };
       const cookieWriter = new CookieWriter(mockWin, element, config);
       expect(setCookieSpy).to.not.be.called;
       return cookieWriter.whenReady();
@@ -109,7 +107,7 @@ describes.realWin('amp-analytics.cookie-writer', {
     it('Write cookie', () => {
       const config = dict({
         'writeCookies': {
-          'testId': 'testValue'
+          'testId': 'testValue',
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -143,7 +141,7 @@ describes.realWin('amp-analytics.cookie-writer', {
       });
       const cookieWriter = new CookieWriter(win, element, config);
       return cookieWriter.whenReady().then(() => {
-        expect(setCookieSpy).to.be.calledTwice;;
+        expect(setCookieSpy).to.be.calledTwice;
         // QUERY_PARAM resolve to empty string
         expect(setCookieSpy).to.be.calledWith('testId', 'pre-');
         // Never try to resolve RANDOM
@@ -177,7 +175,7 @@ describes.realWin('amp-analytics.cookie-writer', {
           'Error: The first argument to QUERY_PARAM, ' +
           'the query string param is required​​​');
       expectAsyncConsoleError('The first argument to QUERY_PARAM, ' +
-          'the query string param is required')
+          'the query string param is required');
       return cookieWriter.whenReady().then(() => {
         // Both cookie value resolve to empty string
         expect(setCookieSpy).to.be.calledOnce;

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -102,6 +102,20 @@ describes.realWin('amp-analytics.cookie-writer', {
       });
     });
 
+    it('Resolve when in inabox ad', () => {
+      env.win.AMP_MODE.runtime = 'inabox';
+      const config = dict({
+        'writeCookies': {
+          'testId': 'QUERY_PARAM(test)',
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+      return cookieWriter.write().then(() => {
+        expect(expandAndWriteSpy).to.not.be.called;
+      });
+    });
+
     it('Resolve with nothing to write', () => {
       const config = dict({
         'writeCookies': {},

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -254,7 +254,7 @@ export class VariableService {
  * @param {string} key The key to be parsed.
  * @return {!FunctionNameArgsDef}
  */
-function getNameArgs(key) {
+export function getNameArgs(key) {
   if (!key) {
     return {name: '', argList: ''};
   }

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -49,7 +49,7 @@ const ONE_DAY_MILLIS = 24 * 3600 * 1000;
 /**
  * We ignore base cids that are older than (roughly) one year.
  */
-const BASE_CID_MAX_AGE_MILLIS = 365 * ONE_DAY_MILLIS;
+export const BASE_CID_MAX_AGE_MILLIS = 365 * ONE_DAY_MILLIS;
 
 const SCOPE_NAME_VALIDATOR = /^[a-zA-Z0-9-_.]+$/;
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -804,10 +804,13 @@ export class UrlReplacements {
    * or override existing ones.
    * @param {string} source
    * @param {!Object<string, *>=} opt_bindings
+   * @param {!Object<string, boolean>=} opt_whiteList
    * @return {!Promise<string>}
    */
-  expandStringAsync(source, opt_bindings) {
-    return /** @type {!Promise<string>} */ (this.expand_(source, opt_bindings));
+  expandStringAsync(source, opt_bindings, opt_whiteList) {
+    return /** @type {!Promise<string>} */ (this.expand_(source, opt_bindings,
+        /* opt_collectVars */ undefined,
+        /* opt_sync */ undefined, opt_whiteList));
   }
 
   /**

--- a/test/manual/amp-analytics-cookie-writer.html
+++ b/test/manual/amp-analytics-cookie-writer.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Analytics</title>
+  <link rel="canonical" href="analytics.amp.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .box {
+      background: #ccc;
+      border: 1px solid #aaa;
+      padding: 10px;
+      margin: 10px;
+    }
+    #container {
+      position: absolute;
+      top: 10000px;
+      height: 10px;
+    }
+    #ele1 {
+      background-color: red;
+      height: 100px;
+      width: 100px;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+
+</head>
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pellentesque augue quis elementum tempus. Pellentesque sit amet neque bibendum, sagittis purus vitae, pellentesque magna. Vestibulum non viverra metus, eget feugiat lacus. Nulla in maximus orci. Maecenas id turpis vel ipsum vestibulum bibendum ut sit amet magna. Nullam hendrerit ex at est eleifend, nec dignissim nibh rutrum. Aliquam quis tellus et nibh faucibus laoreet in eget turpis. Nam quam nisl, porttitor vel ex eget, dapibus placerat dui. Mauris commodo pellentesque leo, eu tempus quam. In hac habitasse platea dictumst. Suspendisse non ante finibus, luctus augue non, luctus orci. Vestibulum ornare lacinia aliquam. In sollicitudin vehicula vulputate. Sed mi elit, commodo nec sapien nec, pretium bibendum leo. Donec id justo tortor. Ut in mauris dapibus, laoreet metus vitae, dictum nisi.
+</p>
+<p>
+Integer dapibus egestas arcu. Nunc vitae velit congue, placerat augue quis, suscipit nisi. Donec suscipit imperdiet turpis pharetra feugiat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus aliquam eleifend dolor, at lacinia orci semper vel. Nunc semper sem vel tincidunt posuere. Nunc lobortis velit vitae condimentum mollis. Morbi eu ullamcorper mauris. Pellentesque ac eros maximus, pulvinar sapien vitae, semper nisi. Curabitur imperdiet non mauris vitae sollicitudin.
+</p>
+<p>
+Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Vestibulum nec ex odio. Quisque at elit nec nunc ultricies lacinia nec non lorem. Maecenas porttitor consequat mauris, vitae porttitor ligula pellentesque ut. Pellentesque rhoncus diam vel lacus lobortis imperdiet. Sed maximus dictum hendrerit. Vivamus ornare, purus in laoreet sagittis, est ante pretium mauris, vel vulputate arcu erat eget mauris. Suspendisse eu lorem metus. Aliquam tempus aliquet urna, vitae mollis lacus pretium vitae. Etiam semper gravida commodo. Maecenas at pulvinar quam. Nullam dolor ipsum, ornare a sollicitudin et, sodales porttitor neque.
+</p>
+<p>
+Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor, vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique. Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
+</p>
+<amp-analytics type="_ping_">
+  <script type="application/json">
+  {
+    "requests": {
+      "old": "https://fake.com/analytics?timer"
+    },
+    "triggers": {
+      "click": {
+        "on": "click",
+        "selector": "#ele1",
+        "request": "old",
+        "important": true,
+        "extraUrlParams": {
+          "extra": "important"
+        }
+      }
+    },
+    "transport": {
+      "beacon": "false",
+      "xhrpost": "false",
+      "image": "true"
+    },
+    "writeCookies": {
+      "testCookie": "QUERY_PARAM(test)",
+      "testCookie2": "pre-QUERY_PARAM(test)-QUERY_PARAM(test2)",
+      "testCookieError": "RANDOM"
+    }
+  }
+  </script>
+</amp-analytics>
+<div id="ele1">click me</div>

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -108,6 +108,7 @@ import {
 } from '../src/polyfills/custom-elements';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installFriendlyIframeEmbed} from '../src/friendly-iframe-embed';
+import {maybeTrackImpression} from '../src/impression';
 import {
   resetScheduledElementForTesting,
 } from '../src/service/custom-element-registry';
@@ -684,6 +685,7 @@ class AmpFixture {
       // Notice that ampdoc's themselves install runtime styles in shadow roots.
       // Thus, not changes needed here.
     }
+    maybeTrackImpression(self);
     const extensionIds = [];
     if (spec.extensions) {
       spec.extensions.forEach(extensionIdWithVersion => {


### PR DESCRIPTION
The PR introduces the change to read the `writeCookies` config. Expand the value and write to cookie. 

Decision highlights. 
1. cookie writer won't work with proxy origin
2. cookie writer won't work in FIE (AMPHTML ad)
3. cookie writer won't work in inabox runtime
3. cookie writer block `<amp-analytics>`'s initialization
4. Start with a whitelist that only contains `QUERY_PARAM` and `LINKER_PARAM`(to be added in separate PR)
5. We agree to support writing static string to cookies, but not empty string. 


cc @calebcordry 