### PR TITLE
📖 Document all the necessary headers for AMP-Redirect-To to work

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -349,7 +349,7 @@ Make sure to update your `Access-Control-Expose-Headers` response header to incl
 
 ```text
 AMP-Redirect-To: https://example.com/forms/thank-you
-Access-Control-Expose-Headers: AMP-Redirect-To, Another-Header, And-Some-More
+Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin, AMP-Redirect-To
 ```
 
 


### PR DESCRIPTION
Add the documentation change suggested by @meistudioli on https://github.com/ampproject/amphtml/issues/18377#issuecomment-424920425

If the `AMP-Redirect-To` header is set and exposed, the `AMP-Access-Control-Allow-Source-Origin` must also be set and exposed, so the documentation must have both in the `Access-Control-Expose-Headers` list.