### PR TITLE
`amp-date-countdown` component to support remaining-time in milliseconds

### DIFF
--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -85,6 +85,9 @@ export class AmpDateCountdown extends AMP.BaseElement {
     this.endDate_ = '';
 
     /** @private {number} */
+    this.timeleftMs_ = 0;
+
+    /** @private {number} */
     this.timestampMs_ = 0;
 
     /** @private {number} */
@@ -118,6 +121,10 @@ export class AmpDateCountdown extends AMP.BaseElement {
     //Note: One of end-date, timestamp-ms, timestamp-seconds is required.
     /** @private {string} */
     this.endDate_ = this.element.getAttribute('end-date');
+
+    /** @private {number} */
+    this.timeleftMs_
+       = Number(this.element.getAttribute('timeleft-ms'));
 
     /** @private {number} */
     this.timestampMs_ = Number(this.element.getAttribute('timestamp-ms'));
@@ -209,6 +216,8 @@ export class AmpDateCountdown extends AMP.BaseElement {
 
     if (this.endDate_) {
       epoch = Date.parse(this.endDate_);
+    } else if (this.timeleftMs_) {
+      epoch = Date.parse(new Date()) + this.timeleftMs_;
     } else if (this.timestampMs_) {
       epoch = this.timestampMs_;
     } else if (this.timestampSeconds_) {
@@ -216,8 +225,8 @@ export class AmpDateCountdown extends AMP.BaseElement {
     }
 
     user().assert(!isNaN(epoch),
-        'One of end-date, timestamp-ms, timestamp-seconds is required');
-
+        `One of end-date, timeleft-ms, timestamp-ms, timestamp-seconds
+         is required`);
     return epoch;
   }
 

--- a/extensions/amp-date-countdown/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/amp-date-countdown.md
@@ -105,7 +105,7 @@ Format | Sample Output | Remarks
 
 ## Attributes
 
-You must specify at least one of these required attributes: `end-date`, `timestamp-ms`, `timestamp-seconds`.
+You must specify at least one of these required attributes: `end-date`, `timeleft-ms`, `timestamp-ms`, `timestamp-seconds`.
 
 ##### end-date
 
@@ -118,6 +118,10 @@ A POSIX epoch value in milliseconds; assumed to be UTC timezone. For example, `t
 ##### timestamp-seconds
 
 A POSIX epoch value in seconds; assumed to be UTC timezone. For example, `timestamp-seconds="1521880470"`.
+
+##### timeleft-ms
+
+A value in milliseconds left to be counting down. For example, 48 hours left `timeleft-ms="172800000"`.
 
 ##### offset-seconds (optional)
 

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -38,7 +38,7 @@ tags: {  # <amp-date-countdown>
   }
   attrs: {
     name: "end-date"
-    mandatory_oneof: "['end-date', 'timestamp-ms', 'timestamp-seconds']"
+    mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])"
   }
   attrs: {
@@ -65,13 +65,18 @@ tags: {  # <amp-date-countdown>
     value_regex: "-?\\d+"
   }
   attrs: {
+    name: "timeleft-ms"
+    mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
+    value_regex: "\\d+"
+  }
+  attrs: {
     name: "timestamp-ms"
-    mandatory_oneof: "['end-date', 'timestamp-ms', 'timestamp-seconds']"
+    mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
     value_regex: "\\d{13}"
   }
   attrs: {
     name: "timestamp-seconds"
-    mandatory_oneof: "['end-date', 'timestamp-ms', 'timestamp-seconds']"
+    mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
     value_regex: "\\d{10}"
   }
   attrs: {


### PR DESCRIPTION
I would like to add timeleft-ms option in order to support for the remaining-time in milliseconds requirement.

\cc @aghassemi @cathyxz @cvializ @honeybadgerdontcare 