### PR TITLE
🏗 Add root:true to .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "babel-eslint",
   "plugins": [
     "chai-expect",


### PR DESCRIPTION
I was running `gulp lint` and I was getting a ton of errors reported on an otherwise clean repo. This happened to me because I have the amphtml repo cloned inside of a directory tree that has another `.eslintrc` higher up. Because the amphtml's `.eslintrc` lacks `root:true` then ESLint looks at ancestor directories for additional rules to incorporate. This PR adds `root` to the config to fix this problem. 

For more, see [Configuration Cascading and Hierarchy](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy).