### PR TITLE
🔥Unset inline display:none for nodisplay elements

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -10,10 +10,11 @@ requirement: {
 # Element
 
 requirement: {
-  type: BANNED_PROPERTY_WRITE
+  type: BANNED_PROPERTY_READ
   error_message: 'Use style.js#setStyle or style.js#setStyles'
   value: 'Element.prototype.style'
   whitelist: 'src/style.js'
+  whitelist: 'src/layout.js'
 }
 
 # CSSStyleDeclaration

--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -183,8 +183,10 @@ export class HighlightHandler {
 
     for (let i = 0; i < this.highlightedNodes_.length; i++) {
       const n = this.highlightedNodes_[i];
-      n['style']['backgroundColor'] = '#ff0';
-      n['style']['color'] = '#333';
+      setStyles(n, {
+        backgroundColor: '#ff0',
+        color: '#333',
+      });
     }
 
     const visibility = this.viewer_.getVisibilityState();

--- a/src/layout.js
+++ b/src/layout.js
@@ -335,6 +335,9 @@ export function applyStaticLayout(element) {
           element.querySelector('i-amphtml-sizer') || undefined;
     } else if (layout == Layout.NODISPLAY) {
       toggle(element, false);
+      // TODO(jridgewell): Temporary hack while SSR still adds an inline
+      // `display: none`
+      element['style']['display'] = '';
     }
     return layout;
   }
@@ -433,6 +436,9 @@ export function applyStaticLayout(element) {
     // CSS defines layout=nodisplay automatically with `display:none`. Thus
     // no additional styling is needed.
     toggle(element, false);
+    // TODO(jridgewell): Temporary hack while SSR still adds an inline
+    // `display: none`
+    element['style']['display'] = '';
   } else if (layout == Layout.FIXED) {
     setStyles(element, {
       width: dev().assertString(width),

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -17,6 +17,7 @@
 import {Services} from '../services';
 import {
   computedStyle,
+  getStyle,
   getVendorJsPropertyName,
   setImportantStyles,
   setInitialDisplay,
@@ -456,7 +457,7 @@ export class FixedLayer {
    */
   warnAboutInlineStylesIfNecessary_(element) {
     if (element.hasAttribute('style')
-        && (element.style.top || element.style.bottom)) {
+        && (getStyle(element, 'top') || getStyle(element, 'bottom'))) {
       user().error(TAG, 'Inline styles with `top`, `bottom` and other ' +
           'CSS rules are not supported yet for fixed or sticky elements ' +
           '(#14186). Unexpected behavior may occur.', element);


### PR DESCRIPTION
Server Side Rendering currently injects an inline `display: none` into
`nodisplay` AMP elements. Now that we've [switched](https://github.com/ampproject/amphtml/pull/17988)
to using the `hidden` attribute, we'll need to unset this inline style
when applying the static layouts to the element.

This is temporary until we can update SSR to inject a `hidden` attribute
instead of the inline style.