### PR TITLE
Set display:block to sentinel element of animateScrollToTop_ explicitly

### DIFF
--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -21,7 +21,7 @@ import {listenOnce} from '../../../src/event-helper';
 import {moveLayoutRect} from '../../../src/layout-rect';
 import {parseJson} from '../../../src/json';
 import {parseQueryString} from '../../../src/url';
-import {resetStyles, setStyles} from '../../../src/style';
+import {resetStyles, setInitialDisplay, setStyles} from '../../../src/style';
 
 /**
  * The message name sent by viewers to dismiss highlights.
@@ -258,13 +258,13 @@ export class HighlightHandler {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/bottom
     //
     // TODO(yunabe): Revisit the safer way to implement scroll-animation.
+    setInitialDisplay(sentinel, 'block');
     setStyles(sentinel, {
       'position': 'absolute',
       'top': Math.floor(top) + 'px',
       'height': '1px',
       'left': '0',
       'width': '1px',
-      'display': 'block',
       'pointer-events': 'none',
     });
     const body = this.ampdoc_.getBody();

--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -250,12 +250,21 @@ export class HighlightHandler {
    */
   animateScrollToTop_(top) {
     const sentinel = this.ampdoc_.win.document.createElement('div');
+    // Notes:
+    // The CSS of sentinel can be overwritten by user custom CSS.
+    // We need to set display:block and other CSS fields explicitly here
+    // so that these CSS won't be overwritten.
+    // We use top and height here because they precede bottom
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/bottom
+    //
+    // TODO(yunabe): Revisit the safer way to implement scroll-animation.
     setStyles(sentinel, {
       'position': 'absolute',
       'top': Math.floor(top) + 'px',
-      'bottom': '0',
+      'height': '1px',
       'left': '0',
-      'right': '0',
+      'width': '1px',
+      'display': 'block',
       'pointer-events': 'none',
     });
     const body = this.ampdoc_.getBody();

--- a/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
@@ -125,6 +125,7 @@ describes.realWin('HighlightHandler', {
     expect(scrollStub).to.be.calledOnce;
     expect(scrollStub.firstCall.args.length).to.equal(1);
     expect(scrollStub.firstCall.args[0].style.pointerEvents).to.equal('none');
+    expect(scrollStub.firstCall.args[0].style.display).to.equal('block');
 
     // For some reason, expect(args).to.deep.equal does not work.
     expect(sendMsgStub.callCount).to.equal(2);


### PR DESCRIPTION
Set display:block to sentinel element of animateScrollToTop_ in highlight-handler.js to always display the element.
The CSS attribute of the element can be set to "none" by custom CSS on AMP pages.

