### PR TITLE
Add handler to forward keyboard events to viewer

### DIFF
--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -20,6 +20,7 @@ import {
   HighlightInfoDef,
   getHighlightParam,
 } from './highlight-handler';
+import {KeyboardHandler} from './keyboard-handler';
 import {
   Messaging,
   WindowPortEmulator,
@@ -195,6 +196,9 @@ export class AmpViewerIntegration {
     if (viewer.hasCapability('swipe')) {
       this.initTouchHandler_(messaging);
     }
+    if (viewer.hasCapability('keyboard')) {
+      this.initKeyboardHandler_(messaging);
+    }
     if (this.highlightHandler_ != null) {
       this.highlightHandler_.setupMessaging(messaging);
     }
@@ -216,6 +220,14 @@ export class AmpViewerIntegration {
    */
   initTouchHandler_(messaging) {
     new TouchHandler(this.win, messaging);
+  }
+
+  /**
+   * @param {!Messaging} messaging
+   * @private
+   */
+  initKeyboardHandler_(messaging) {
+    new KeyboardHandler(this.win, messaging);
   }
 }
 

--- a/extensions/amp-viewer-integration/0.1/keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/keyboard-handler.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {KeyCodes} from '../../../src/utils/key-codes';
+import {dict} from '../../../src/utils/object';
+import {listen} from '../../../src/event-helper';
+
+/**
+ * The list of keyboard event properites to forward to the viewer. This should
+ * be kept up-to-date with
+ * https://www.w3.org/TR/uievents/#keyboardevent-keyboardevent.
+ *
+ * @type {!Array<string>}
+ */
+const eventProperties = [
+  'key',
+  'code',
+  'location',
+
+  'ctrlKey',
+  'shiftKey',
+  'altKey',
+  'metaKey',
+
+  'repeat',
+  'isComposing',
+
+  // Properties for legacy user agents.
+  'charCode',
+  'keyCode',
+  'which',
+];
+
+/**
+ * Forwards keyboard events from the AMP doc to the viewer in the format of a
+ * `KeyboardEventInit` object (http://mdn.io/KeyboardEvent/KeyboardEvent).
+ * `JsonObject`.
+ *
+ * Keyboard events that are forwarded must meet the *one* of the following
+ * conditions:
+ *
+ * - The key is the escape key
+ * - The focus is on a checkbox and the key is not the space key
+ * - The focus is not on any input control, including elements with the
+ *   `contenteditable` attribute
+ *
+ * @package @final
+ */
+export class KeyboardHandler {
+  /**
+   * @param {!Window} win
+   * @param {!./messaging/messaging.Messaging} messaging
+   */
+  constructor(win, messaging) {
+    /** @const {!Window} */
+    this.win = win;
+
+    /** @const @private {!./messaging/messaging.Messaging} */
+    this.messaging_ = messaging;
+
+    this.listenForKeyboardEvents_();
+  }
+
+  /** @private */
+  listenForKeyboardEvents_() {
+    const handleEvent = this.handleEvent_.bind(this);
+    listen(this.win, 'keydown', handleEvent);
+    listen(this.win, 'keypress', handleEvent);
+    listen(this.win, 'keyup', handleEvent);
+  }
+
+  /**
+   * @param {!Event} e
+   * @private
+   */
+  handleEvent_(e) {
+    if (e.target && isHandledByEventTarget(e.keyCode, e.target)) {
+      return;
+    }
+    this.forwardEventToViewer_(e);
+  }
+
+  /**
+   * @param {!Event} e
+   * @private
+   */
+  forwardEventToViewer_(e) {
+    this.messaging_.sendRequest(
+        e.type, getKeyboardEventInit(e), /* awaitResponse */ false);
+  }
+}
+
+/**
+ * Checks whether the given key code is expected to be handled by the given
+ * eventTarget.
+ *
+ * @param {number} keyCode
+ * @param {!EventTarget} eventTarget
+ * @return {boolean}
+ */
+function isHandledByEventTarget(keyCode, eventTarget) {
+  if (keyCode == KeyCodes.ESCAPE) {
+    // ESC is always a valid key for things like keyboard shortcuts, even if the
+    // focus is on an input control, for example.
+    return false;
+  }
+  switch (eventTarget.nodeName) {
+    case 'INPUT':
+      // For checkboxes, only allow swallowing the space key event.
+      return eventTarget.type != 'checkbox' || keyCode == KeyCodes.SPACE;
+    case 'TEXTAREA':
+    case 'BUTTON':
+    case 'SELECT':
+    case 'OPTION':
+      return true;
+  }
+
+  // Top-level event targets like `window` and `document` are not instance
+  // of `Element` and do not have a `hasAttribute` function.
+  return eventTarget.hasAttribute &&
+      eventTarget.hasAttribute('contenteditable');
+}
+
+/**
+ * @param {!Event} e
+ * @return {!JsonObject}
+ */
+function getKeyboardEventInit(e) {
+  const copiedEvent = dict();
+  eventProperties.forEach(eventProperty => {
+    if (e[eventProperty] !== undefined) {
+      copiedEvent[eventProperty] = e[eventProperty];
+    }
+  });
+  return copiedEvent;
+}

--- a/extensions/amp-viewer-integration/0.1/keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/keyboard-handler.js
@@ -87,7 +87,7 @@ export class KeyboardHandler {
    * @private
    */
   handleEvent_(e) {
-    if (e.target && isHandledByEventTarget(e.keyCode, e.target)) {
+    if (isHandledByEventTarget(e)) {
       return;
     }
     this.forwardEventToViewer_(e);
@@ -104,23 +104,26 @@ export class KeyboardHandler {
 }
 
 /**
- * Checks whether the given key code is expected to be handled by the given
- * eventTarget.
+ * Checks whether the given keyboard event is expected to be handled by its
+ * event target.
  *
- * @param {number} keyCode
- * @param {!EventTarget} eventTarget
+ * @param {!Event} e
  * @return {boolean}
  */
-function isHandledByEventTarget(keyCode, eventTarget) {
-  if (keyCode == KeyCodes.ESCAPE) {
+function isHandledByEventTarget(e) {
+  if (e.defaultPrevented) {
+    // Various AMP components consume keyboard events by preventing the default.
+    return true;
+  }
+  if (e.keyCode == KeyCodes.ESCAPE) {
     // ESC is always a valid key for things like keyboard shortcuts, even if the
     // focus is on an input control, for example.
     return false;
   }
-  switch (eventTarget.nodeName) {
+  switch (e.target.nodeName) {
     case 'INPUT':
       // For checkboxes, only allow swallowing the space key event.
-      return eventTarget.type != 'checkbox' || keyCode == KeyCodes.SPACE;
+      return e.target.type != 'checkbox' || e.keyCode == KeyCodes.SPACE;
     case 'TEXTAREA':
     case 'BUTTON':
     case 'SELECT':
@@ -130,8 +133,8 @@ function isHandledByEventTarget(keyCode, eventTarget) {
 
   // Top-level event targets like `window` and `document` are not instance
   // of `Element` and do not have a `hasAttribute` function.
-  return eventTarget.hasAttribute &&
-      eventTarget.hasAttribute('contenteditable');
+  return e.target.hasAttribute &&
+      e.target.hasAttribute('contenteditable');
 }
 
 /**

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -112,7 +112,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           expect(sendRequestSpy.lastCall.args[2]).to.equal(true);
         });
 
-        it('should not initiate the Touch Handler', () => {
+        it('should not initiate touch handler without capability', () => {
           sandbox.stub(messaging, 'sendRequest').callsFake(() => {
             return Promise.resolve();
           });
@@ -124,17 +124,44 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           expect(initTouchHandlerStub).to.not.be.called;
         });
 
-        it('should initiate the Touch Handler', () => {
+        it('should initiate touch handler with capability', () => {
           sandbox.stub(messaging, 'sendRequest').callsFake(() => {
             return Promise.resolve();
           });
-          sandbox.stub(viewer, 'hasCapability').returns(true);
+          sandbox.stub(viewer, 'hasCapability').withArgs('swipe').returns(true);
           const initTouchHandlerStub =
             sandbox.stub(ampViewerIntegration, 'initTouchHandler_');
           ampViewerIntegration.unconfirmedViewerOrigin_ = '';
           ampViewerIntegration.openChannelAndStart_(
               viewer, env.ampdoc, origin, messaging).then(() => {
             expect(initTouchHandlerStub).to.be.called;
+          });
+        });
+
+        it('should not initiate keyboard handler without capability', () => {
+          sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            return Promise.resolve();
+          });
+          const initKeyboardHandlerStub =
+            sandbox.stub(ampViewerIntegration, 'initKeyboardHandler_');
+          ampViewerIntegration.openChannelAndStart_(
+              viewer, env.ampdoc, origin, messaging);
+
+          expect(initKeyboardHandlerStub).to.not.be.called;
+        });
+
+        it('should initiate keyboard handler with capability', () => {
+          sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            return Promise.resolve();
+          });
+          sandbox.stub(viewer, 'hasCapability').withArgs('keyboard')
+              .returns(true);
+          const initKeyboardHandlerStub =
+            sandbox.stub(ampViewerIntegration, 'initKeyboardHandler_');
+          ampViewerIntegration.unconfirmedViewerOrigin_ = '';
+          ampViewerIntegration.openChannelAndStart_(
+              viewer, env.ampdoc, origin, messaging).then(() => {
+            expect(initKeyboardHandlerStub).to.be.called;
           });
         });
       });

--- a/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
@@ -1,0 +1,330 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {KeyCodes} from '../../../../src/utils/key-codes';
+import {KeyboardHandler} from '../keyboard-handler';
+import {Messaging} from '../messaging/messaging';
+
+describes.realWin('KeyboardHandler', {}, env => {
+  let messages;
+
+  class WindowPortEmulator {
+    constructor(win, origin) {
+      /** @const {!Window} */
+      this.win = win;
+      /** @private {string} */
+      this.origin_ = origin;
+    }
+
+    addEventListener() {}
+
+    postMessage(data, unusedOrigin) {
+      messages.push({
+        name: data['name'],
+        data: data['data'],
+      });
+    }
+
+    start() {}
+  }
+
+  beforeEach(() => {
+    messages = [];
+    new KeyboardHandler(
+        env.win,
+        new Messaging(
+            env.win, new WindowPortEmulator(env.win, 'origin doesnt matter')));
+  });
+
+  ['keydown', 'keypress', 'keyup'].forEach(eventType => {
+    describe(`for ${eventType} events`, () => {
+      describe('when event targeted on window', () => {
+        it('forwards ESC events', () => {
+          env.win.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('forwards non-ESC events', () => {
+          env.win.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          }]);
+        });
+      });
+
+      describe('when event targeted on document', () => {
+        it('forwards ESC events', () => {
+          env.win.document.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('forwards non-ESC events', () => {
+          env.win.document.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          }]);
+        });
+      });
+
+      describe('when event targeted on <html>', () => {
+        it('forwards ESC events', () => {
+          env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('forwards non-ESC events', () => {
+          env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          }]);
+        });
+      });
+
+      describe('when event targeted on <body>', () => {
+        it('forwards ESC events', () => {
+          env.win.document.body.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('forwards non-ESC events', () => {
+          env.win.document.body.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          }]);
+        });
+      });
+
+      describe('when event targeted on checkboxes', () => {
+        let checkbox;
+
+        beforeEach(() => {
+          checkbox = env.win.document.createElement('input');
+          checkbox.type = 'checkbox';
+          env.win.document.body.appendChild(checkbox);
+        });
+
+        it('forwards ESC events', () => {
+          checkbox.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('forwards non-ESC non-space events', () => {
+          checkbox.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          }]);
+        });
+
+        it('does not forward space events', () => {
+          checkbox.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+
+          expect(messages).to.be.empty;
+        });
+      });
+
+      ['TEXTAREA', 'BUTTON', 'SELECT', 'OPTION'].forEach(nodeName => {
+        describe(`when event targeted on ${nodeName}`, () => {
+          let node;
+
+          beforeEach(() => {
+            node = env.win.document.createElement(nodeName);
+            env.win.document.body.appendChild(node);
+          });
+
+          it('forwards ESC events', () => {
+            node.dispatchEvent(new KeyboardEvent(
+                eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+            expect(messages).to.have.deep.members([{
+              name: eventType,
+              data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            }]);
+          });
+
+          it('does not forward non-ESC events', () => {
+            node.dispatchEvent(new KeyboardEvent(
+                eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+
+            expect(messages).to.be.empty;
+          });
+        });
+      });
+
+      describe('when event targeted on `contenteditable` elements', () => {
+        let element;
+
+        beforeEach(() => {
+          element = env.win.document.createElement('p');
+          element.setAttribute('contenteditable', '');
+          env.win.document.body.appendChild(element);
+        });
+
+        it('forwards ESC events', () => {
+          element.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+
+          expect(messages).to.have.deep.members([{
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+          }]);
+        });
+
+        it('does not forward non-ESC events', () => {
+          element.dispatchEvent(new KeyboardEvent(
+              eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+
+          expect(messages).to.be.empty;
+        });
+      });
+
+
+      it('forwards multiple events', () => {
+        env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
+            eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+        env.win.document.body.dispatchEvent(new KeyboardEvent(
+            eventType, {bubbles: true, keyCode: KeyCodes.RIGHT_ARROW}));
+
+        expect(messages).to.have.deep.members([
+          {
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+          },
+          {
+            name: eventType,
+            data: createKeyboardEventInitWithKeyCode(KeyCodes.RIGHT_ARROW),
+          },
+        ]);
+      });
+
+      it('filters event properties', () => {
+        env.win.document.body.dispatchEvent(new KeyboardEvent(eventType, {
+          altKey: true,
+          bubbles: true,
+          cancelBubble: false,
+          cancelable: false,
+          charCode: 1,
+          code: 'KeyE',
+          isComposing: true,
+          ctrlKey: true,
+          detail: 1,
+          key: 'e',
+          keyCode: 69,
+          location: 3,
+          metaKey: true,
+          repeat: true,
+          shiftKey: true,
+          which: 69,
+        }));
+
+        expect(messages).to.have.deep.members([{
+          name: eventType,
+          data: {
+            altKey: true,
+            charCode: 1,
+            code: 'KeyE',
+            isComposing: true,
+            ctrlKey: true,
+            key: 'e',
+            keyCode: 69,
+            location: 3,
+            metaKey: true,
+            repeat: true,
+            shiftKey: true,
+            which: 69,
+          },
+        }]);
+      });
+    });
+  });
+});
+
+/**
+ * Creates a `KeyboardEventInit` object with default properties overridden by
+ * the given key code.
+ *
+ * @param {number} keyCode
+ * @return {!JsonObject}
+ */
+function createKeyboardEventInitWithKeyCode(keyCode) {
+  return createKeyboardEventInit({keyCode, which: keyCode});
+}
+
+/**
+ * Creates a `KeyboardEventInit` object with default properties overridden by
+ * the given partial override init object.
+ *
+ * @param {!JsonObject} overrideKeyboardEventInit
+ * @return {!JsonObject}
+ */
+function createKeyboardEventInit(overrideKeyboardEventInit) {
+  return Object.assign(
+      {
+        key: '',
+        code: '',
+        location: 0,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        repeat: false,
+        isComposing: false,
+        charCode: 0,
+        keyCode: 0,
+        which: 0,
+      },
+      overrideKeyboardEventInit);
+}

--- a/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
@@ -71,6 +71,19 @@ describes.realWin('KeyboardHandler', {}, env => {
             data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
           }]);
         });
+
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          env.win.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
+        });
       });
 
       describe('when event targeted on document', () => {
@@ -92,6 +105,19 @@ describes.realWin('KeyboardHandler', {}, env => {
             name: eventType,
             data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
           }]);
+        });
+
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          env.win.document.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
         });
       });
 
@@ -115,6 +141,19 @@ describes.realWin('KeyboardHandler', {}, env => {
             data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
           }]);
         });
+
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          env.win.document.documentElement.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
+        });
       });
 
       describe('when event targeted on <body>', () => {
@@ -136,6 +175,19 @@ describes.realWin('KeyboardHandler', {}, env => {
             name: eventType,
             data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
           }]);
+        });
+
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          env.win.document.body.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
         });
       });
 
@@ -168,6 +220,19 @@ describes.realWin('KeyboardHandler', {}, env => {
           }]);
         });
 
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          checkbox.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
+        });
+
         it('does not forward space events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
               eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
@@ -193,6 +258,19 @@ describes.realWin('KeyboardHandler', {}, env => {
               name: eventType,
               data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
             }]);
+          });
+
+          it('does not forward events with default prevented', () => {
+            const e = new KeyboardEvent(eventType, {
+              bubbles: true,
+              cancelable: true,
+              keyCode: KeyCodes.ESCAPE,
+            });
+            e.preventDefault();
+
+            node.dispatchEvent(e);
+
+            expect(messages).to.be.empty;
           });
 
           it('does not forward non-ESC events', () => {
@@ -221,6 +299,19 @@ describes.realWin('KeyboardHandler', {}, env => {
             name: eventType,
             data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
           }]);
+        });
+
+        it('does not forward events with default prevented', () => {
+          const e = new KeyboardEvent(eventType, {
+            bubbles: true,
+            cancelable: true,
+            keyCode: KeyCodes.ESCAPE,
+          });
+          e.preventDefault();
+
+          element.dispatchEvent(e);
+
+          expect(messages).to.be.empty;
         });
 
         it('does not forward non-ESC events', () => {


### PR DESCRIPTION
This will be useful for AMP viewers that need to support keyboard
shortcuts. Keyboard events fired within the AMP iframe will be
inaccessible by a parent frame at a different origin, so the event must
be forwarded through `postMessage()`.

`b/113569417`

@choumx 