### PR TITLE
🐛✨Add behavior to prevent touch device keyboard bouncing, and opt-out

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -716,10 +716,16 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @return {?Element}
    */
   setupDateField_(type) {
+    const input = Services.inputFor(this.win);
     const fieldSelector = this.element.getAttribute(`${type}-selector`);
     const existingField = this.getAmpDoc().getRootNode().querySelector(
         fieldSelector);
     if (existingField) {
+      if (!this.element.hasAttribute('touch-keyboard-editable') &&
+        this.mode_ == DatePickerMode.OVERLAY &&
+        input.isTouchDetected()) {
+        existingField.readOnly = true;
+      }
       return existingField;
     }
 

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -108,9 +108,13 @@
   <!-- Valid: range amp-date-picker with start-date and end-date attributes -->
   <amp-date-picker type="range" layout="fixed-height" height="360" start-date="2018-01-01" end-date="2018-01-01">
   </amp-date-picker>
+  <!-- Valid: overlay amp-date-picker with touch-keyboard-editable -->
+  <amp-date-picker mode="overlay" touch-keyboard-editable input-selector="#a4">
+    <input id="a4">
+  </amp-date-picker>
 
   <!-- Invalid: single amp-date-picker with start-input-selector -->
-  <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
+  <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">
   </amp-date-picker>
   <!-- Invalid: range amp-date-picker with input-selector -->
   <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
@@ -153,6 +157,9 @@
   </amp-date-picker>
   <!-- Invalid: range amp-date-picker with date attribute -->
   <amp-date-picker type="range" layout="fixed-height" height="360" date="2018-01-01">
+  </amp-date-picker>
+  <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
+  <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
   </amp-date-picker>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -109,101 +109,110 @@ FAIL
 |    <!-- Valid: range amp-date-picker with start-date and end-date attributes -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" start-date="2018-01-01" end-date="2018-01-01">
 |    </amp-date-picker>
+|    <!-- Valid: overlay amp-date-picker with touch-keyboard-editable -->
+|    <amp-date-picker mode="overlay" touch-keyboard-editable input-selector="#a4">
+|      <input id="a4">
+|    </amp-date-picker>
 |
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
-|    <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
+|    <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:113:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:117:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:113:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:117:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:113:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:117:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:116:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:120:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:116:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:120:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:119:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:123:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:121:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:125:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:124:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:128:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:124:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:128:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:128:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:128:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:131:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:131:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        first-day-of-week="7">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
 |    <template info-template type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <template date-template dates="2018-01-01" type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:148:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: amp-date-picker with bad minimum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" minimum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:146:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:150:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:146:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:150:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with minimum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" minimum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:149:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:153:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with start-date attribute -->
 |    <amp-date-picker layout="fixed-height" height="360" start-date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:152:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:156:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with date attribute -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:155:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:159:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:155:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:159:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+|    </amp-date-picker>
+|    <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
+|    <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |  </body>
 |  </html>

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -161,8 +161,13 @@ This example demonstrates using a overlay date picker in a form where the user c
   </form>
 ```
 
-<!-- TODO(cvializ): talk about why type="tel" is on the inputs -->
+On touch devices, an `amp-date-picker` in overlay mode automatically adds the
+`readonly` attribute to its `<input>` elements.
+This prevents the device's on-screen keyboard from opening unncessesarily.
+To opt-out of this behavior, add the `touch-keyboard-editable` attribute to the
+`<amp-date-picker>` element.
 
+<!-- TODO(cvializ): talk about why type="tel" is on the inputs -->
 
 ## Selection types
 

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -68,6 +68,7 @@ tags: {
     value_casei: "single"
   }
   attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-overlay-mode-attributes"
   attr_lists: "amp-date-picker-single-type-attributes"
   attr_lists: "extended-amp-global"
   amp_layout: {
@@ -121,6 +122,7 @@ tags: {
     value_casei: "range"
   }
   attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-overlay-mode-attributes"
   attr_lists: "amp-date-picker-range-type-attributes"
   attr_lists: "extended-amp-global"
   amp_layout: {
@@ -198,6 +200,11 @@ attr_lists: {
     name: "fullscreen"
     value: ""
   }
+}
+
+attr_lists: {
+  name: "amp-date-picker-overlay-mode-attributes"
+  attrs: { name: "touch-keyboard-editable" }
 }
 
 # HTML5, 4.11.3 The template element

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -204,7 +204,10 @@ attr_lists: {
 
 attr_lists: {
   name: "amp-date-picker-overlay-mode-attributes"
-  attrs: { name: "touch-keyboard-editable" }
+  attrs: {
+    name: "touch-keyboard-editable"
+    value: ""
+  }
 }
 
 # HTML5, 4.11.3 The template element


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/14017

Use-case: Document authors want mobile device users to not see a keyboard when they click on an overlay date picker input.

Solution: The date picker detects touch devices and adds the `readonly` attribute to the inputs, preventing the on-screen keyboard from appearing. If a document author wishes to avoid this behavior, the `touch-keyboard-editable` attribute may be added to the `<amp-date-picker mode="overlay">` tag.
