### PR TITLE
Support external templates in amp-date-countdown

### DIFF
--- a/examples/amp-date-countdown.amp.html
+++ b/examples/amp-date-countdown.amp.html
@@ -135,25 +135,21 @@
       </div>
     </template>
   </amp-date-countdown>
-  <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360">
-    <template type="amp-mustache">
-      <div class="date-count-down">
-        {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-        {{h}} <span>{{hours}}</span>
-        {{m}} <span>{{minutes}}</span>
-        {{s}} <span>{{seconds}}</span>
-      </div>
-    </template>
-</amp-date-countdown>
-<amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="stop" locale='de' height="50" width="360">
-  <template type="amp-mustache">
-      <div class="date-count-down">
-          {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-          {{h}} <span>{{hours}}</span>
-          {{m}} <span>{{minutes}}</span>
-          {{s}} <span>{{seconds}}</span>
-        </div>
+
+  <template type="amp-mustache" id="myTemplate">
+    <div class="date-count-down">
+      {{#d}} {{d}} <span>{{days}}</span> {{/d}}
+      {{h}} <span>{{hours}}</span>
+      {{m}} <span>{{minutes}}</span>
+      {{s}} <span>{{seconds}}</span>
+    </div>
   </template>
-</amp-date-countdown>
+
+  <!-- Should support the `template` attribute to reference <template> by ID. -->
+  <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360" template="myTemplate">
+  </amp-date-countdown>
+
+  <amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+  </amp-date-countdown>
 </body>
 </html>

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -324,9 +324,15 @@ export class AmpDateCountdown extends AMP.BaseElement {
    */
   rendered_(element) {
     return this.mutateElement(() => {
-      const template = this.element.firstElementChild;
+      // TODO(UI): The rendered content should be added to a container child
+      // to avoid removal/re-addition of the <template> child. See amp-list.
+      const template = this.templates_.findTemplate(this.element);
+      const isChildTemplate = this.element.contains(template);
       removeChildren(this.element);
-      this.element.appendChild(template);
+      // Re-add template if it was a child element (vs. referenced by ID).
+      if (isChildTemplate) {
+        this.element.appendChild(template);
+      }
       this.element.appendChild(element);
     });
   }

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
@@ -140,25 +140,21 @@
       </div>
     </template>
   </amp-date-countdown>
-  <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360">
-    <template type="amp-mustache">
-      <div class="date-count-down">
-        {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-        {{h}} <span>{{hours}}</span>
-        {{m}} <span>{{minutes}}</span>
-        {{s}} <span>{{seconds}}</span>
-      </div>
-    </template>
+
+  <template type="amp-mustache" id="myTemplate">
+    <div class="date-count-down">
+      {{#d}} {{d}} <span>{{days}}</span> {{/d}}
+      {{h}} <span>{{hours}}</span>
+      {{m}} <span>{{minutes}}</span>
+      {{s}} <span>{{seconds}}</span>
+    </div>
+  </template>
+
+  <!-- Should support the `template` attribute to reference <template> by ID. -->
+  <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360" template="myTemplate">
   </amp-date-countdown>
-  <amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360">
-    <template type="amp-mustache">
-        <div class="date-count-down">
-            {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-            {{h}} <span>{{hours}}</span>
-            {{m}} <span>{{minutes}}</span>
-            {{s}} <span>{{seconds}}</span>
-          </div>
-    </template>
+
+  <amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
   </amp-date-countdown>
 </body>
 </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
@@ -141,25 +141,21 @@ PASS
 |        </div>
 |      </template>
 |    </amp-date-countdown>
-|    <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360">
-|      <template type="amp-mustache">
-|        <div class="date-count-down">
-|          {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-|          {{h}} <span>{{hours}}</span>
-|          {{m}} <span>{{minutes}}</span>
-|          {{s}} <span>{{seconds}}</span>
-|        </div>
-|      </template>
+|
+|    <template type="amp-mustache" id="myTemplate">
+|      <div class="date-count-down">
+|        {{#d}} {{d}} <span>{{days}}</span> {{/d}}
+|        {{h}} <span>{{hours}}</span>
+|        {{m}} <span>{{minutes}}</span>
+|        {{s}} <span>{{seconds}}</span>
+|      </div>
+|    </template>
+|
+|    <!-- Should support the `template` attribute to reference <template> by ID. -->
+|    <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360" template="myTemplate">
 |    </amp-date-countdown>
-|    <amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360">
-|      <template type="amp-mustache">
-|          <div class="date-count-down">
-|              {{#d}} {{d}} <span>{{days}}</span> {{/d}}
-|              {{h}} <span>{{hours}}</span>
-|              {{m}} <span>{{minutes}}</span>
-|              {{s}} <span>{{seconds}}</span>
-|            </div>
-|      </template>
+|
+|    <amp-date-countdown timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
 |    </amp-date-countdown>
 |  </body>
 |  </html>

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -64,6 +64,9 @@ tags: {  # <amp-date-countdown>
     name: "offset-seconds"
     value_regex: "-?\\d+"
   }
+  # TODO(gregable): Implement validation that requires the template attr value
+  # to reference the id of an existing template element.
+  attrs: { name: "template" }
   attrs: {
     name: "timestamp-ms"
     mandatory_oneof: "['end-date', 'timestamp-ms', 'timestamp-seconds']"


### PR DESCRIPTION
Fixes #18360. Tested on examples/amp-date-countdown.amp.html.