### PR TITLE
✨ Recognize details element with open/[open] attributes and summary child element

### DIFF
--- a/examples/bind/details.amp.html
+++ b/examples/bind/details.amp.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind: Details</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+
+  <style amp-custom>
+    button {
+      border: solid 1px black;
+    }
+  </style>
+</head>
+
+<body>
+  <h2>Details open changing example</h2>
+  <p>After clicking the button the <code>details</code> element should toggle whether it is <code>open</code>.<p>
+
+  <amp-state id="detailsOpen">false</amp-state>
+  <button on="tap:AMP.setState({ detailsOpen: ! detailsOpen })" [text]="detailsOpen ? 'Toggle Closed' : 'Toggle Open'">Toggle Open</button>
+
+  <details [open]="detailsOpen">
+    <summary>Learn more</summary>
+    <p>This is more information.</p>
+  </details>
+</body>
+</html>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -307,6 +307,9 @@ function createElementRules_() {
       'type': null,
       'value': null,
     },
+    'DETAILS': {
+      'open': null,
+    },
     'FIELDSET': {
       'disabled': null,
     },

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -476,6 +476,11 @@ Only binding to the following components and attributes are allowed:
     <td>See corresponding <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes">button attributes</a>.</td>
   </tr>
   <tr>
+    <td><code>&lt;details&gt;</code></td>
+    <td><code>[open]</code></td>
+    <td>See corresponding <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Attributes">details attributes</a>.</td>
+  </tr>
+  <tr>
     <td><code>&lt;fieldset&gt;</code></td>
     <td><code>[disabled]</code></td>
     <td>Enables or disables the fieldset.</td>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1505,6 +1505,7 @@ tags: {
     name: "open"
     value: ""
   }
+  attrs: { name: "[open]" }
 }
 # 4.11.2 (HTML5.3) The summary element
 tags: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4443,8 +4443,8 @@ tags: {
 # 4.11.2 (HTML5.3) The summary element
 tags: {
   html_format: AMP
-  mandatory_parent: "DETAILS"
   tag_name: "SUMMARY"
+  mandatory_parent: "DETAILS"
 }
 
 # 4.11 Scripting

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1494,29 +1494,7 @@ tags: {
     value_regex: "[0-9]*"
   }
 }
-# 4.11.1 (HTML5.3) The details element
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  html_format: AMP4EMAIL
-  html_format: EXPERIMENTAL
-  tag_name: "DETAILS"
-  attrs: {
-    name: "open"
-    value: ""
-  }
-  attrs: { name: "[open]" }
-}
-# 4.11.2 (HTML5.3) The summary element
-tags: {
-  html_format: AMP
-  html_format: AMP4ADS
-  html_format: AMP4EMAIL
-  html_format: EXPERIMENTAL
-  tag_name: "SUMMARY"
-  mandatory_parent: "DETAILS"
-}
-# 4.4.9 The dl element
+# 4.4.8 The dl element
 tags: {
   html_format: AMP
   html_format: AMP4ADS
@@ -4449,6 +4427,23 @@ tags: {
   html_format: AMP4EMAIL
   html_format: EXPERIMENTAL
   tag_name: "LEGEND"
+}
+
+# 4.11 (HTML5.3) Interactive elements
+# 4.11.1 (HTML5.3) The details element
+tags: {
+  html_format: AMP
+  tag_name: "DETAILS"
+  attrs: {
+    name: "open"
+    value: ""
+  }
+  attrs: { name: "[open]" }
+}
+# 4.11.2 (HTML5.3) The summary element
+tags: {
+  html_format: AMP
+  mandatory_parent: "DETAILS"
 }
 
 # 4.11 Scripting

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1494,7 +1494,28 @@ tags: {
     value_regex: "[0-9]*"
   }
 }
-# 4.4.8 The dl element
+# 4.11.1 (HTML5.3) The details element
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
+  tag_name: "DETAILS"
+  attrs: {
+    name: "open"
+    value: ""
+  }
+}
+# 4.11.2 (HTML5.3) The summary element
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
+  tag_name: "SUMMARY"
+  mandatory_parent: "DETAILS"
+}
+# 4.4.9 The dl element
 tags: {
   html_format: AMP
   html_format: AMP4ADS

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4444,6 +4444,7 @@ tags: {
 tags: {
   html_format: AMP
   mandatory_parent: "DETAILS"
+  tag_name: "SUMMARY"
 }
 
 # 4.11 Scripting

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4433,6 +4433,9 @@ tags: {
 # 4.11.1 (HTML5.3) The details element
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DETAILS"
   attrs: {
     name: "open"
@@ -4443,6 +4446,9 @@ tags: {
 # 4.11.2 (HTML5.3) The summary element
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SUMMARY"
   mandatory_parent: "DETAILS"
 }


### PR DESCRIPTION
I couldn't find a clear explanation on why the HTML5 [`details` element](https://developer.mozilla.org/en/docs/Web/HTML/Element/details) is not allowed. The only mention of it is https://github.com/ampproject/amphtml/issues/1410 in relation to `amp-accordion`. It would be helpful to support `details` when converting HTML into AMP (such as in the WordPress plugin), since it could be used as-is without having to try to port it over to `amp-accordion` (even though the latter is more powerful), as a `details`-to-`amp-accordion` conversion so would would cause complications with existing styles that target the `details` element and its children.

In this PR:

* Add `details` element.
* Add `details` element's `open` boolean attribute.
* Add `[open]` to `amp-bind` for managing the the `details` element's `open` boolean attribute.
* Add the `summary` element as a child of `details`.

With these changes in place, an AMP document would be able to do:

```html
<amp-state id="detailsOpen">false</amp-state>
<button on="tap:AMP.setState({ detailsOpen: ! detailsOpen })">Toggle Open</button>

<details [open]="detailsOpen">
	<summary>Learn more</summary>
	<p>This is more information.</p>
</details>
```