### PR TITLE
AMP-Cache-Transform: Specify caches.json max age.

### DIFF
--- a/spec/amp-cache-transform.md
+++ b/spec/amp-cache-transform.md
@@ -91,6 +91,9 @@ For each identifier:
  4. Otherwise, the identifier is invalid and cannot be satisfied. The server
     should attempt to match the next one.
 
+The server should ensure its copy of `caches.json` is no more than 60 days
+out-of-date with the canonical linked above.
+
 ### Response header
 
 If the server responds with an SXG, it should include an `AMP-Cache-Transform`


### PR DESCRIPTION
Specify how out-of-date a server may keep its copy of caches.json in
order to remain compliant with the spec. This allows updates to that
file to propagate within a reasonable time.

Fixes #18445.