### PR TITLE
🐛Read attributes in buildCallback, not constructor

### DIFF
--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -208,15 +208,19 @@ describes.realWin('amp-date-picker', {
     it('should always render Unix epoch seconds in english digits', () => {
       const {picker} = createDatePicker({locale: 'en', format: 'X'});
       const date = moment();
-      const formattedDate = picker.getFormattedDate_(date);
-      expect(formattedDate).to.equal('1514793600');
+      return picker.buildCallback().then(() => {
+        const formattedDate = picker.getFormattedDate_(date);
+        expect(formattedDate).to.equal('1514793600');
+      });
     });
 
     it('should always render Unix epoch millis in english digits', () => {
       const {picker} = createDatePicker({locale: 'en', format: 'x'});
       const date = moment();
-      const formattedDate = picker.getFormattedDate_(date);
-      expect(formattedDate).to.equal('1514793600000');
+      return picker.buildCallback().then(() => {
+        const formattedDate = picker.getFormattedDate_(date);
+        expect(formattedDate).to.equal('1514793600000');
+      });
     });
   });
 


### PR DESCRIPTION
Fixes a layout error on slow-loading connections where the html for the open tag has loaded, but the attributes aren't present when the element constructor runs.

Initially the attributes were read in the `buildCallback`, but the value of `mode` was needed in `isLayoutSupported`, which runs before `buildCallback` is called. Since the validator enforces the values of `layout` and `mode` are correct together, we don't need to enforce that they are correct together in `isLayoutSupported`. So we are able to move the `getAttribute` calls to `buildCallback`.