### PR TITLE
amp-access-laterpay: Laterpay badge changes

### DIFF
--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -36,6 +36,8 @@ const CONFIG_URLS = {
   },
 };
 
+const LATERPAY_BADGE_URL = 'https://blog.laterpay.net/laterpay-academy/what-is-laterpay';
+
 const DEFAULT_REGION = 'eu';
 
 const CONFIG_BASE_PATH = '/api/v2/fetch/amp/?' +
@@ -50,6 +52,8 @@ const DEFAULT_MESSAGES = {
   defaultButton: 'Buy Now',
   alreadyPurchasedLink: 'I already bought this',
   sandbox: 'Site in test mode. No payment required.',
+  laterpayBadgePrefix: 'Powered by ',
+  laterpayBadgeSuffix: '',
 };
 
 /**
@@ -429,13 +433,18 @@ export class LaterpayVendor {
    */
   createLaterpayBadge_() {
     const a = this.createElement_('a');
-    a.href = 'https://laterpay.net';
+    a.href = LATERPAY_BADGE_URL;
     a.target = '_blank';
     a.textContent = 'LaterPay';
     const el = this.createElement_('p');
+    const prefix = this.createElement_('span');
+    prefix.textContent = this.i18n_['laterpayBadgePrefix'];
+    const suffix = this.createElement_('span');
+    suffix.textContent = this.i18n_['laterpayBadgeSuffix'];
     el.className = TAG + '-badge';
-    el.textContent = 'Powered by ';
+    el.appendChild(prefix);
     el.appendChild(a);
+    el.appendChild(suffix);
     return el;
   }
 


### PR DESCRIPTION
This PR allows merchants more configurability on our LaterPay branding badge and changes the base URL linked there to an explainer URL.