### PR TITLE
🐛Avoid using display: initial to fix form validation messages in IE11

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -685,7 +685,7 @@ form [submit-error] {
 /**
  * Form validation error messages should be hidden at first.
  */
-[visible-when-invalid] {
+[visible-when-invalid]:not(.visible) {
   display: none;
 }
 

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -46,10 +46,5 @@ form.amp-form-submit-error [submit-error] {
 }
 
 [visible-when-invalid] {
-  display: none;
   color: red;
-}
-
-[visible-when-invalid].visible {
-  display: initial;
 }


### PR DESCRIPTION
Related-to https://github.com/ampproject/amphtml/issues/18398

`initial` is unsupported in IE11, so custom validation errors were not appearing after forms with errors were submitted. This PR avoids using initial by only setting `display: none` if the `visible` class is not present.