### PR TITLE
Remove triggerTransformEnd from the set function

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -891,15 +891,11 @@ export class AmpPanZoom extends AMP.BaseElement {
         this.posX_ = newPosX;
         this.posY_ = newPosY;
         this.updatePanZoom_();
-        this.triggerTransformEnd_(newScale, newPosX, newPosY);
       });
     } else {
       this.scale_ = newScale;
       this.posX_ = newPosX;
       this.posY_ = newPosY;
-      return this.updatePanZoom_().then(() => {
-        this.triggerTransformEnd_(newScale, newPosX, newPosY);
-      });
     }
   }
 

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -490,7 +490,6 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   onMouseUp_(e) {
     e.preventDefault();
-    debugger;
     this.release_();
     this.unlisten_(this.unlistenMouseMove_);
     this.unlisten_(this.unlistenMouseUp_);

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -29,7 +29,7 @@ import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
 import {clamp} from '../../../src/utils/math';
 import {continueMotion} from '../../../src/motion';
-import {createCustomEvent, getData, listen} from '../../../src/event-helper';
+import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
@@ -519,6 +519,9 @@ export class AmpPanZoom extends AMP.BaseElement {
 
     this.gestures_.onGesture(PinchRecognizer, e => this.handlePinch(e.data));
 
+    // Having a doubletap gesture results in a 200ms delay in tap gestures in
+    // order to differentiate the two gestures. Some users may choose to disable
+    // it to avoid the 200ms tap delay.
     if (!this.disableDoubleTap_) {
       this.gestures_.onGesture(DoubletapRecognizer,
           e => this.handleDoubleTap(e.data));

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -542,7 +542,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   }
 
   /**
-   * @param {!../../../src/gesture-recognizers.DoubletapDef} data
+   * @param {!../../../src/gesture-recognizers.PinchDef} data
    * @return {!Promise}
    * @visibleForTesting
    */

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -273,7 +273,7 @@ describes.realWin('amp-pan-zoom', {
       await el.layoutCallback();
       const transformEndPromise = listenOncePromise(el, 'transformEnd');
       const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
-      impl.handleDoubleTap({data: {clientX: 10, clientY: 10}});
+      impl.handleDoubleTap({clientX: 10, clientY: 10});
       await transformEndPromise;
       expect(actionTriggerSpy).to.be.calledOnce;
     });
@@ -282,14 +282,14 @@ describes.realWin('amp-pan-zoom', {
       await getPanZoom();
       await el.layoutCallback();
       const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
-      await impl.handlePinch({data: {
+      await impl.handlePinch({
         centerClientX: 10,
         centerClientY: 10,
         deltaX: 10,
         deltaY: 10,
         dir: 1,
         last: false,
-      }});
+      });
       expect(actionTriggerSpy).not.to.be.called;
     });
 
@@ -299,14 +299,12 @@ describes.realWin('amp-pan-zoom', {
       const transformEndPromise = listenOncePromise(el, 'transformEnd');
       const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
       impl.handlePinch({
-        data: {
-          centerClientX: 10,
-          centerClientY: 10,
-          deltaX: 10,
-          deltaY: 10,
-          dir: 1,
-          last: true, // This indicates zoom ended
-        },
+        centerClientX: 10,
+        centerClientY: 10,
+        deltaX: 10,
+        deltaY: 10,
+        dir: 1,
+        last: true, // This indicates zoom ended
       });
       await transformEndPromise;
       expect(actionTriggerSpy).to.be.calledOnce;
@@ -316,13 +314,13 @@ describes.realWin('amp-pan-zoom', {
       await getPanZoom();
       await el.layoutCallback();
       const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
-      await impl.handleSwipe({data: {
+      await impl.handleSwipe({
         deltaX: 10,
         deltaY: 10,
         last: false,
         velocityX: 10,
         velocityY: 10,
-      }});
+      });
       expect(actionTriggerSpy).not.to.be.called;
     });
 
@@ -331,13 +329,13 @@ describes.realWin('amp-pan-zoom', {
       await el.layoutCallback();
       const transformEndPromise = listenOncePromise(el, 'transformEnd');
       const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
-      impl.handleSwipe({data: {
+      impl.handleSwipe({
         deltaX: 10,
         deltaY: 10,
         last: true, // This indicates panning ended.
         velocityX: 10,
         velocityY: 10,
-      }});
+      });
       await transformEndPromise;
       expect(actionTriggerSpy).to.be.calledOnce;
     });

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -17,7 +17,6 @@
 import '../amp-pan-zoom';
 import {createPointerEvent} from '../../../../testing/test-helper';
 import {htmlFor} from '../../../../src/static-template';
-import {listenOncePromise} from '../../../../src/event-helper';
 
 describes.realWin('amp-pan-zoom', {
   amp: {
@@ -252,21 +251,16 @@ describes.realWin('amp-pan-zoom', {
   });
 
   describe('gestures', () => {
-    it.skip('should pan correctly via mouse when zoomed', async function() {
+    it('should pan correctly via mouse when zoomed', async function() {
       await getPanZoom();
       await el.layoutCallback();
       await impl.transform(0, 0, 2);
       expect(svg.style.transform).to.equal('translate(0px, 0px) scale(2)');
       const mouseDown = createPointerEvent('mousedown', 10, 10);
       const mouseMove = createPointerEvent('mousemove', 20, 20);
-      const mouseUp = createPointerEvent('mouseup', 20, 20);
-      const transformEndPromise = listenOncePromise(el, 'transformEnd');
       el.dispatchEvent(mouseDown);
-      await timeout(500);
       el.dispatchEvent(mouseMove);
       await timeout(500);
-      el.dispatchEvent(mouseUp);
-      await transformEndPromise;
       expect(svg.style.transform).to.equal('translate(10px, 10px) scale(2)');
     });
   });

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -17,6 +17,7 @@
 import '../amp-pan-zoom';
 import {createPointerEvent} from '../../../../testing/test-helper';
 import {htmlFor} from '../../../../src/static-template';
+import {listenOncePromise} from '../../../../src/event-helper';
 
 describes.realWin('amp-pan-zoom', {
   amp: {
@@ -29,8 +30,6 @@ describes.realWin('amp-pan-zoom', {
   let el;
   let impl;
   let svg;
-
-  const timeout = ms => new Promise(res => setTimeout(res, ms));
 
   const measureMutateElementStub = (measure, mutate) => {
     return Promise.resolve().then(measure).then(mutate);
@@ -258,102 +257,89 @@ describes.realWin('amp-pan-zoom', {
       expect(svg.style.transform).to.equal('translate(0px, 0px) scale(2)');
       const mouseDown = createPointerEvent('mousedown', 10, 10);
       const mouseMove = createPointerEvent('mousemove', 20, 20);
+      const mouseUp = createPointerEvent('mouseup', 20, 20);
+      const transformEndPromise = listenOncePromise(el, 'transformEnd');
       el.dispatchEvent(mouseDown);
       el.dispatchEvent(mouseMove);
-      await timeout(500);
+      el.dispatchEvent(mouseUp);
+      await transformEndPromise;
       expect(svg.style.transform).to.equal('translate(10px, 10px) scale(2)');
     });
   });
 
   describe('transformEnd', () => {
-    it('should trigger only once after double tap zoom', () => {
-      let transformEndSpy;
-      return getPanZoom()
-          .then(() => el.layoutCallback())
-          .then(() => {
-            transformEndSpy = sandbox.spy(impl, 'triggerTransformEnd_');
-            return impl.handleDoubleTap({data: {clientX: 10, clientY: 10}});
-          }).then(() => {
-            expect(transformEndSpy).to.be.calledOnce;
-          });
+    it('should trigger only once after double tap zoom', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      const transformEndPromise = listenOncePromise(el, 'transformEnd');
+      const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+      impl.handleDoubleTap({data: {clientX: 10, clientY: 10}});
+      await transformEndPromise;
+      expect(actionTriggerSpy).to.be.calledOnce;
     });
 
-    it('should not trigger while pinch zooming', () => {
-      let transformEndSpy;
-      return getPanZoom()
-          .then(() => el.layoutCallback())
-          .then(() => {
-            transformEndSpy = sandbox.spy(impl, 'triggerTransformEnd_');
-            return impl.handlePinch({data: {
-              centerClientX: 10,
-              centerClientY: 10,
-              deltaX: 10,
-              deltaY: 10,
-              dir: 1,
-              last: false,
-            }});
-          }).then(() => {
-            expect(transformEndSpy).not.to.be.called;
-          });
+    it('should not trigger while pinch zooming', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+      await impl.handlePinch({data: {
+        centerClientX: 10,
+        centerClientY: 10,
+        deltaX: 10,
+        deltaY: 10,
+        dir: 1,
+        last: false,
+      }});
+      expect(actionTriggerSpy).not.to.be.called;
     });
 
-    it('should trigger exactly once after pinch zoom ends', () => {
-      let transformEndSpy;
-      return getPanZoom()
-          .then(() => el.layoutCallback())
-          .then(() => {
-            transformEndSpy = sandbox.spy(impl, 'triggerTransformEnd_');
-            return impl.handlePinch({
-              data: {
-                centerClientX: 10,
-                centerClientY: 10,
-                deltaX: 10,
-                deltaY: 10,
-                dir: 1,
-                last: true, // This indicates zoom ended
-              },
-            });
-          }).then(() => {
-            expect(transformEndSpy).to.be.calledOnce;
-          });
+    it('should trigger exactly once after pinch zoom ends', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      const transformEndPromise = listenOncePromise(el, 'transformEnd');
+      const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+      impl.handlePinch({
+        data: {
+          centerClientX: 10,
+          centerClientY: 10,
+          deltaX: 10,
+          deltaY: 10,
+          dir: 1,
+          last: true, // This indicates zoom ended
+        },
+      });
+      await transformEndPromise;
+      expect(actionTriggerSpy).to.be.calledOnce;
     });
 
-    it('should not trigger while panning', () => {
-      let transformEndSpy;
-      return getPanZoom()
-          .then(() => el.layoutCallback())
-          .then(() => {
-            transformEndSpy = sandbox.spy(impl, 'triggerTransformEnd_');
-            return impl.handleSwipe({data: {
-              deltaX: 10,
-              deltaY: 10,
-              last: false,
-              velocityX: 10,
-              velocityY: 10,
-            }});
-          }).then(() => {
-            expect(transformEndSpy).not.to.be.called;
-          });
+    it('should not trigger while panning', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+      await impl.handleSwipe({data: {
+        deltaX: 10,
+        deltaY: 10,
+        last: false,
+        velocityX: 10,
+        velocityY: 10,
+      }});
+      expect(actionTriggerSpy).not.to.be.called;
     });
 
-    it('should trigger exactly once after panning ends', () => {
-      let transformEndSpy;
-      return getPanZoom()
-          .then(() => el.layoutCallback())
-          .then(() => {
-            transformEndSpy = sandbox.spy(impl, 'triggerTransformEnd_');
-            return impl.handleSwipe({data: {
-              deltaX: 10,
-              deltaY: 10,
-              last: true, // This indicates panning ended.
-              velocityX: 10,
-              velocityY: 10,
-            }});
-          }).then(() => {
-            expect(transformEndSpy).to.be.calledOnce;
-          });
+    it('should trigger exactly once after panning ends', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      const transformEndPromise = listenOncePromise(el, 'transformEnd');
+      const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+      impl.handleSwipe({data: {
+        deltaX: 10,
+        deltaY: 10,
+        last: true, // This indicates panning ended.
+        velocityX: 10,
+        velocityY: 10,
+      }});
+      await transformEndPromise;
+      expect(actionTriggerSpy).to.be.calledOnce;
     });
-
   });
-
 });

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -26,7 +26,7 @@ const DOUBLETAP_DELAY = 200;
  *   clientY: number
  * }}
  */
-let TapDef;
+export let TapDef;
 
 
 /**
@@ -109,7 +109,7 @@ export class TapRecognizer extends GestureRecognizer {
  *   clientY: number
  * }}
  */
-let DoubletapDef;
+export let DoubletapDef;
 
 
 /**
@@ -645,7 +645,7 @@ export class TapzoomRecognizer extends GestureRecognizer {
  *   velocityY: number
  * }}
  */
-let PinchDef;
+export let PinchDef;
 
 /**
  * Threshold in pixels for how much two touches move away from

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -165,7 +165,7 @@ export function withdrawRequest(win, id) {
 }
 
 export function createPointerEvent(type, x, y) {
-  const event = new /*OK*/CustomEvent(type);
+  const event = new /*OK*/CustomEvent(type, {bubbles: true});
   event.clientX = x;
   event.clientY = y;
   event.pageX = x;


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/18364. 

Tried to write regression tests for this and to refactor the gestures code to make it more testable. Encountered a weird issue with `mouseup` events not triggering. Details inline.