### PR TITLE
🐛 Do not add flying carpet to fixed layer

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -87,8 +87,6 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
     childNodes.forEach(child => container.appendChild(child));
     clip.appendChild(container);
     this.element.appendChild(clip);
-
-    this.getViewport().addToFixedLayer(container);
   }
 
   /** @override */


### PR DESCRIPTION
The container's parent div is necessary for the clipping visual to
apply. It cannot be transferred outside of this DOM tree.

Fixes https://github.com/ampproject/amphtml/issues/18432.