### PR TITLE
some errors are not propagated properly from compilation step

### DIFF
--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -452,6 +452,10 @@ exports.singlePassCompile = function(entryModule, options) {
       move(`${singlePassDest}/amp*`, `${singlePassDest}/v0`),
       move(`${singlePassDest}/_base*`, `${singlePassDest}/v0`),
     ]);
+  }, e => {
+    // NOTE: passing the message here to colors.red breaks the output.
+    console./*OK*/error(e.message);
+    process.exit(1);
   });
 };
 


### PR DESCRIPTION
sometimes issues like type errors during compilation don't propagate from single pass code. we need to stop the process if there are any errors