### PR TITLE
🐛Fix validation bubble polyfill in IE11

### DIFF
--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -171,7 +171,13 @@ export class PolyfillDefaultValidator extends FormValidator {
   }
 
   /** @override */
-  onBlur(unusedEvent) {
+  onBlur(e) {
+    // NOTE: IE11 focuses the submit button after submitting a form.
+    // Then amp-form focuses the first field with an error, which causes the
+    // submit button to blur. So we need to disregard the submit button blur.
+    if (e.target.type == 'submit') {
+      return;
+    }
     this.validationBubble_.hide();
   }
 

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -218,8 +218,11 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should hide validation bubble onblur', () => {
+      const mockEvent = {
+        target: {},
+      };
       sandbox.stub(validator.validationBubble_, 'hide');
-      validator.onBlur();
+      validator.onBlur(mockEvent);
       expect(validator.validationBubble_.hide).to.be.calledOnce;
     });
 


### PR DESCRIPTION
Closes #18398

TIL both `<input type="submit">` and `<form ...><button>Submit</button></form>` both have `buttonDomReference.type == 'submit'`