### PR TITLE
📖 AMP-Cache-Transform: explain caches registry.

### DIFF
--- a/spec/amp-cache-transform.md
+++ b/spec/amp-cache-transform.md
@@ -118,6 +118,16 @@ are available, and a [reference implementation](https://github.com/ampproject/am
 will soon be available. In the interim, the Google AMP Cache will not require
 any rewrites (and, as a result, will not prefetch any subresources).
 
+The list of rewrites is limited to base URLs within `caches.json` in order to
+provide the publisher some assurance that the rewritten subresources are
+faithful representations of the original subresources.
+
+For the sake of security, all script source URLs will need to be on
+`cdn.ampproject.org`, regardless of the target AMP cache. This provides the
+publisher additional assurance that the JS is not an arbitrary payload. It would be
+nice to get rid of this dependency; something like [signature-based
+SRI](https://github.com/mikewest/signature-based-sri) might be feasible.
+
 ## Interaction with content negotation
 
 If the URL serves multiple variants, and is thus subject to [HTTP proactive


### PR DESCRIPTION
Briefly explain the reasoning behind limiting subresource URLs to those
under caches.json, and add a stricter requirement for JS URLs, given
their stronger security relevance.

Fixes #18454.