### PR TITLE
♻️Linker: Use action-xhr when possible

### DIFF
--- a/examples/linkers.html
+++ b/examples/linkers.html
@@ -74,6 +74,24 @@
   <form method="post"
     action-xhr="https://www.example.com"
     target="_top">
+    post && action-xhr
+    <fieldset>
+      <label>
+        <span>Name:</span>
+        <input type="text"
+          name="name">
+      </label>
+      <br>
+      <br>
+      <input type="submit"
+        value="Subscribe">
+    </fieldset>
+  </form>
+
+  <form method="get"
+    action-xhr="https://www.example.com"
+    target="_top">
+    get && action-xhr
     <fieldset>
       <label>
         <span>Name:</span>
@@ -90,6 +108,7 @@
   <form method="get"
     action="https://www.google.com"
     target="_top">
+    get && action
     <fieldset>
       <label>
         <span>Name:</span>

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -110,7 +110,11 @@ export class LinkerManager {
     }
 
     return Promise.all(this.allLinkerPromises_)
-        .then(this.enableFormSupport_.bind(this));
+        .then(() => {
+          if (isExperimentOn(this.ampdoc_.win, 'linker-form')) {
+            this.enableFormSupport_();
+          }
+        });
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -285,9 +285,11 @@ export class LinkerManager {
   /**
    * Check to see if any linker configs match this form's url, if so, send
    * along the resolved linker value
-   * @param {HTMLFormElement} form
+   * @param {!../../amp-form/0.1/form-submit-service.FormSubmitEventDef} event
    */
-  handleFormSubmit_(form) {
+  handleFormSubmit_(event) {
+    const {form, destinationSetter} = event;
+
     for (const linkerName in this.config_) {
       const config = this.config_[linkerName];
       const /** @type {Array} */ domains = config['destinationDomains'];
@@ -297,7 +299,7 @@ export class LinkerManager {
       const {hostname} = this.urlService_.parse(url);
 
       if (this.isDomainMatch_(hostname, domains)) {
-        this.addDataToForm_(form, linkerName);
+        this.addDataToForm_(form, destinationSetter, linkerName);
       }
     }
   }
@@ -307,9 +309,10 @@ export class LinkerManager {
    * Add the linker data to form. If action-xhr is present we can set a new
    * linker-xhr to use, if not we fallback to adding hidden inputs.
    * @param {!Element} form
+   * @param {function(string)} destinationSetter
    * @param {string} linkerName
    */
-  addDataToForm_(form, linkerName) {
+  addDataToForm_(form, destinationSetter, linkerName) {
     const linkerValue = this.resolvedLinkers_[linkerName];
     if (!linkerValue) {
       return;
@@ -319,9 +322,8 @@ export class LinkerManager {
     // url set as linker-xhr attribute.
     const actionXhrUrl = form.getAttribute('action-xhr');
     if (actionXhrUrl) {
-      form.setAttribute('linker-xhr',
-          addParamToUrl(actionXhrUrl, linkerName, linkerValue));
-      return;
+      const decoratedUrl = addParamToUrl(actionXhrUrl, linkerName, linkerValue);
+      return destinationSetter(decoratedUrl);
     }
 
     // If we are not using `action-xhr` it must be a GET request using the

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -304,8 +304,8 @@ export class LinkerManager {
 
 
   /**
-   * Add the linker data to form. If it is a GET add it to the `action` or
-   * `action-xhr`. If it is a post add it to FINISHSI
+   * Add the linker data to form. If action-xhr is present we can modify its
+   * value, if not we fallback to adding hidden inputs.
    * @param {!Element} form
    * @param {string} linkerName
    */
@@ -324,7 +324,7 @@ export class LinkerManager {
     }
 
     // If we are not using `action-xhr` it must be a GET request using the
-    // vanilla action attribute. Browsers will not let you change this in the
+    // standard action attribute. Browsers will not let you change this in the
     // middle of a submit, so we add the input hidden attributes.
     this.addHiddenInputs_(form, linkerName, linkerValue);
   }

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -304,8 +304,8 @@ export class LinkerManager {
 
 
   /**
-   * Add the linker data to form. If action-xhr is present we can modify its
-   * value, if not we fallback to adding hidden inputs.
+   * Add the linker data to form. If action-xhr is present we can set a new
+   * linker-xhr to use, if not we fallback to adding hidden inputs.
    * @param {!Element} form
    * @param {string} linkerName
    */
@@ -315,7 +315,8 @@ export class LinkerManager {
       return;
     }
 
-    // Runtime controls submits with `action-xhr`, so we can reassign the value.
+    // Runtime controls submits with `action-xhr`, so we can point it at the new
+    // url set as linker-xhr attribute.
     const actionXhrUrl = form.getAttribute('action-xhr');
     if (actionXhrUrl) {
       form.setAttribute('linker-xhr',

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -318,7 +318,7 @@ export class LinkerManager {
     // Runtime controls submits with `action-xhr`, so we can reassign the value.
     const actionXhrUrl = form.getAttribute('action-xhr');
     if (actionXhrUrl) {
-      form.setAttribute('action-xhr',
+      form.setAttribute('linker-xhr',
           addParamToUrl(actionXhrUrl, linkerName, linkerValue));
       return;
     }

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -292,7 +292,7 @@ export class LinkerManager {
    * @param {!../../amp-form/0.1/form-submit-service.FormSubmitEventDef} event
    */
   handleFormSubmit_(event) {
-    const {form, destinationSetter} = event;
+    const {form, actionXhrMutator} = event;
 
     for (const linkerName in this.config_) {
       const config = this.config_[linkerName];
@@ -303,7 +303,7 @@ export class LinkerManager {
       const {hostname} = this.urlService_.parse(url);
 
       if (this.isDomainMatch_(hostname, domains)) {
-        this.addDataToForm_(form, destinationSetter, linkerName);
+        this.addDataToForm_(form, actionXhrMutator, linkerName);
       }
     }
   }
@@ -313,10 +313,10 @@ export class LinkerManager {
    * Add the linker data to form. If action-xhr is present we can update the
    * action-xhr, if not we fallback to adding hidden inputs.
    * @param {!Element} form
-   * @param {function(string)} destinationSetter
+   * @param {function(string)} actionXhrMutator
    * @param {string} linkerName
    */
-  addDataToForm_(form, destinationSetter, linkerName) {
+  addDataToForm_(form, actionXhrMutator, linkerName) {
     const linkerValue = this.resolvedLinkers_[linkerName];
     if (!linkerValue) {
       return;
@@ -327,7 +327,7 @@ export class LinkerManager {
     const actionXhrUrl = form.getAttribute('action-xhr');
     if (actionXhrUrl) {
       const decoratedUrl = addParamToUrl(actionXhrUrl, linkerName, linkerValue);
-      return destinationSetter(decoratedUrl);
+      return actionXhrMutator(decoratedUrl);
     }
 
     // If we are not using `action-xhr` it must be a GET request using the

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -310,8 +310,8 @@ export class LinkerManager {
 
 
   /**
-   * Add the linker data to form. If action-xhr is present we can set a new
-   * linker-xhr to use, if not we fallback to adding hidden inputs.
+   * Add the linker data to form. If action-xhr is present we can update the
+   * action-xhr, if not we fallback to adding hidden inputs.
    * @param {!Element} form
    * @param {function(string)} destinationSetter
    * @param {string} linkerName
@@ -322,8 +322,8 @@ export class LinkerManager {
       return;
     }
 
-    // Runtime controls submits with `action-xhr`, so we can point it at the new
-    // url set as linker-xhr attribute.
+    // Runtime controls submits with `action-xhr`, so we can append the linker
+    // param
     const actionXhrUrl = form.getAttribute('action-xhr');
     if (actionXhrUrl) {
       const decoratedUrl = addParamToUrl(actionXhrUrl, linkerName, linkerValue);

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -546,7 +546,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
         linkerManager.handleFormSubmit_(form);
 
-        const finalUrl = form.getAttriute('linker-xhr');
+        const finalUrl = form.getAttribute('linker-xhr');
         return expect(finalUrl).to.mdatch(/testLinker=1\*\w{5,7}\*foo*\w+/);
       });
     });

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -501,7 +501,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       });
     });
 
-    it('if action-xhr and method=GET it should rewrite action-xhr', () => {
+    it('if action-xhr and method=GET it should add linker-xhr attr', () => {
       const linkerManager = new LinkerManager(ampdoc, {
         linkers: {
           testLinker: {
@@ -521,12 +521,12 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
         linkerManager.handleFormSubmit_(form);
 
-        const finalUrl = form.getAttribute('action-xhr');
+        const finalUrl = form.getAttribute('linker-xhr');
         return expect(finalUrl).to.match(/testLinker=1\*\w{5,7}\*foo*\w+/);
       });
     });
 
-    it('if action-xhr and method=POST it should rewrite action-xhr', () => {
+    it('if action-xhr and method=POST it should add linker-xhr attr', () => {
       const linkerManager = new LinkerManager(ampdoc, {
         linkers: {
           testLinker: {
@@ -546,8 +546,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
         linkerManager.handleFormSubmit_(form);
 
-        const finalUrl = form.getAttribute('action-xhr');
-        return expect(finalUrl).to.match(/testLinker=1\*\w{5,7}\*foo*\w+/);
+        const finalUrl = form.getAttriute('linker-xhr');
+        return expect(finalUrl).to.mdatch(/testLinker=1\*\w{5,7}\*foo*\w+/);
       });
     });
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -490,7 +490,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         const form = createForm();
         form.setAttribute('action', 'https://www.ampproject.com');
         const setterSpy = sandbox.spy();
-        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
+        linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy.notCalled).to.be.true;
         const el = form.firstChild;
@@ -522,7 +522,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('method', 'get');
 
         const setterSpy = sandbox.spy();
-        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
+        linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy.calledOnce).to.be.true;
 
@@ -551,7 +551,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('method', 'post');
 
         const setterSpy = sandbox.spy();
-        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
+        linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy.calledOnce).to.be.true;
 
@@ -579,7 +579,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         const form = createForm();
         form.setAttribute('action-xhr', 'https://www.wrongdomain.com');
         const setterSpy = sandbox.spy();
-        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
+        linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
         expect(setterSpy.notCalled).to.be.true;
         return expect(form.children.length).to.equal(0);
       });
@@ -621,8 +621,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         const form = createForm();
         form.setAttribute('action', 'https://www.source.com');
         const setterSpy = sandbox.spy();
-        manager1.handleFormSubmit_({form, destinationSetter: setterSpy});
-        manager2.handleFormSubmit_({form, destinationSetter: setterSpy});
+        manager1.handleFormSubmit_({form, actionXhrMutator: setterSpy});
+        manager2.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy.notCalled).to.be.true;
         const prefixRegex = new RegExp('1\\*\\w{5,7}\\*.+');

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -547,7 +547,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         linkerManager.handleFormSubmit_(form);
 
         const finalUrl = form.getAttribute('linker-xhr');
-        return expect(finalUrl).to.mdatch(/testLinker=1\*\w{5,7}\*foo*\w+/);
+        return expect(finalUrl).to.match(/testLinker=1\*\w{5,7}\*foo*\w+/);
       });
     });
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -489,8 +489,10 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return linkerManager.init().then(() => {
         const form = createForm();
         form.setAttribute('action', 'https://www.ampproject.com');
-        linkerManager.handleFormSubmit_(form);
+        const setterSpy = sandbox.spy();
+        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
 
+        expect(setterSpy.notCalled).to.be.true;
         const el = form.firstChild;
         expect(el).to.be.ok;
         expect(el.tagName).to.equal('INPUT');
@@ -519,10 +521,14 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('action-xhr', 'https://www.ampproject.com');
         form.setAttribute('method', 'get');
 
-        linkerManager.handleFormSubmit_(form);
+        const setterSpy = sandbox.spy();
+        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
 
-        const finalUrl = form.getAttribute('linker-xhr');
-        return expect(finalUrl).to.match(/testLinker=1\*\w{5,7}\*foo*\w+/);
+        expect(setterSpy.calledOnce).to.be.true;
+
+        const calledWithLinkerUrl = setterSpy
+            .calledWith(sinon.match(/testLinker=1\*\w{5,7}\*foo*\w+/));
+        return expect(calledWithLinkerUrl).to.be.true;
       });
     });
 
@@ -544,10 +550,14 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('action-xhr', 'https://www.ampproject.com');
         form.setAttribute('method', 'post');
 
-        linkerManager.handleFormSubmit_(form);
+        const setterSpy = sandbox.spy();
+        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
 
-        const finalUrl = form.getAttribute('linker-xhr');
-        return expect(finalUrl).to.match(/testLinker=1\*\w{5,7}\*foo*\w+/);
+        expect(setterSpy.calledOnce).to.be.true;
+
+        const calledWithLinkerUrl = setterSpy
+            .calledWith(sinon.match(/testLinker=1\*\w{5,7}\*foo*\w+/));
+        return expect(calledWithLinkerUrl).to.be.true;
       });
     });
 
@@ -568,7 +578,9 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return linkerManager.init().then(() => {
         const form = createForm();
         form.setAttribute('action-xhr', 'https://www.wrongdomain.com');
-        linkerManager.handleFormSubmit_(form);
+        const setterSpy = sandbox.spy();
+        linkerManager.handleFormSubmit_({form, destinationSetter: setterSpy});
+        expect(setterSpy.notCalled).to.be.true;
         return expect(form.children.length).to.equal(0);
       });
     });
@@ -608,9 +620,11 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return Promise.all([p1, p2]).then(() => {
         const form = createForm();
         form.setAttribute('action', 'https://www.source.com');
-        manager1.handleFormSubmit_(form);
-        manager2.handleFormSubmit_(form);
+        const setterSpy = sandbox.spy();
+        manager1.handleFormSubmit_({form, destinationSetter: setterSpy});
+        manager2.handleFormSubmit_({form, destinationSetter: setterSpy});
 
+        expect(setterSpy.notCalled).to.be.true;
         const prefixRegex = new RegExp('1\\*\\w{5,7}\\*.+');
 
         const firstChild = form.children[0];

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -626,10 +626,9 @@ export class AmpForm {
    * @private
    */
   doActionXhr_() {
-    // Since action-xhr can be modified by linker, don't use cached version.
-    return this.doXhr_(
-        dev().assertString(this.getXhrUrl_('action-xhr')),
-        this.method_);
+    // Prefer decorated linker url if it exists, otherwise use action-xhr.
+    const url = this.getXhrUrl_('linker-xhr') || this.xhrAction_;
+    return this.doXhr_(dev().assertString(url), this.method_);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -460,7 +460,7 @@ export class AmpForm {
     try {
       const event = {
         form: this.form_,
-        destinationSetter: this.setXhrAction.bind(this),
+        actionXhrMutator: this.setXhrAction.bind(this),
       };
       this.formSubmitService_.fire(event);
     } catch (e) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -157,7 +157,7 @@ export class AmpForm {
     /** @const @private {string} */
     this.target_ = this.form_.getAttribute('target');
 
-    /** @const @private {?string} */
+    /** @private {?string} */
     this.xhrAction_ = this.getXhrUrl_('action-xhr');
 
     /** @const @private {?string} */
@@ -262,6 +262,13 @@ export class AmpForm {
     };
   }
 
+  /**
+   * Setter to change cached action-xhr.
+   * @param {string} url
+   */
+  setXhrAction(url) {
+    this.xhrAction_ = url;
+  }
 
   /**
    * Handle actions that require at least high trust.
@@ -451,7 +458,11 @@ export class AmpForm {
    */
   submit_(trust) {
     try {
-      this.formSubmitService_.fire(this.form_);
+      const event = {
+        form: this.form_,
+        destinationSetter: this.setXhrAction.bind(this),
+      };
+      this.formSubmitService_.fire(event);
     } catch (e) {
       dev().error(TAG, `Form submit service failed: ${e}`);
     }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -637,9 +637,7 @@ export class AmpForm {
    * @private
    */
   doActionXhr_() {
-    // Prefer decorated linker url if it exists, otherwise use action-xhr.
-    const url = this.getXhrUrl_('linker-xhr') || this.xhrAction_;
-    return this.doXhr_(dev().assertString(url), this.method_);
+    return this.doXhr_(dev().assertString(this.xhrAction_), this.method_);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -628,7 +628,7 @@ export class AmpForm {
   doActionXhr_() {
     // Since action-xhr can be modified by linker, don't use cached version.
     return this.doXhr_(
-        dev().assertString(this.form_.getAttribute('action-xhr')),
+        dev().assertString(this.getXhrUrl_('action-xhr')),
         this.method_);
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -626,7 +626,10 @@ export class AmpForm {
    * @private
    */
   doActionXhr_() {
-    return this.doXhr_(dev().assertString(this.xhrAction_), this.method_);
+    // Since action-xhr can be modified by linker, don't use cached version.
+    return this.doXhr_(
+        dev().assertString(this.form_.getAttribute('action-xhr')),
+        this.method_);
   }
 
   /**

--- a/extensions/amp-form/0.1/form-submit-service.js
+++ b/extensions/amp-form/0.1/form-submit-service.js
@@ -16,6 +16,16 @@
 
 import {Observable} from '../../../src/observable';
 
+
+/**
+ * @typedef {{
+ *   form: HTMLFormElement,
+ *   destinationSetter: function(string)
+ * }}
+ */
+export let FormSubmitEventDef;
+
+
 export class FormSubmitService {
   /**
    * Global service used to register callbacks we wish to execute when an
@@ -27,7 +37,7 @@ export class FormSubmitService {
 
   /**
    * Used to register callbacks.
-   * @param {function(HTMLFormElement)} cb
+   * @param {function(!FormSubmitEventDef)} cb
    */
   beforeSubmit(cb) {
     this.observable_.add(cb);
@@ -35,9 +45,9 @@ export class FormSubmitService {
 
   /**
    * Fired when form is submitted.
-   * @param {!HTMLFormElement} el
+   * @param {!FormSubmitEventDef} event
    */
-  fire(el) {
-    this.observable_.fire(el);
+  fire(event) {
+    this.observable_.fire(event);
   }
 }

--- a/extensions/amp-form/0.1/form-submit-service.js
+++ b/extensions/amp-form/0.1/form-submit-service.js
@@ -20,7 +20,7 @@ import {Observable} from '../../../src/observable';
 /**
  * @typedef {{
  *   form: HTMLFormElement,
- *   destinationSetter: function(string)
+ *   actionXhrMutator: function(string)
  * }}
  */
 export let FormSubmitEventDef;

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -240,7 +240,10 @@ describes.repeated('', {
 
         ampForm.handleSubmitEvent_(event);
         expect(fireStub.calledOnce).to.be.true;
-        return expect(fireStub).calledWith(form);
+        return expect(fireStub).calledWith({
+          form,
+          destinationSetter: sinon.match.func,
+        });
       });
     });
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -242,7 +242,7 @@ describes.repeated('', {
         expect(fireStub.calledOnce).to.be.true;
         return expect(fireStub).calledWith({
           form,
-          destinationSetter: sinon.match.func,
+          actionXhrMutator: sinon.match.func,
         });
       });
     });

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -355,6 +355,11 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/14061',
     cleanupissue: 'https://github.com/ampproject/amphtml/issues/17161',
   },
+  {
+    id: 'linker-form',
+    name: 'Enables form support in linker',
+    cleanupissue: 'https://github.com/ampproject/amphtml/issues/18068',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Previously we were using `<input hidden>` elements on all forms to pass linker data. 

After this PR we prefer changing the `action-xhr` attribute when it is used. We use the hidden elements as fallback case when `action` attribute is used. `amp-form` only supports `action` for `method=get`.