### PR TITLE
Linker: remove form listener in unlayout

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -159,6 +159,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     if (this.linkerManager_) {
       this.linkerManager_.dispose();
+      this.linkerManager_ = null;
     }
 
     for (let i = 0; i < this.requests_.length; i++) {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -183,10 +183,10 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.iniPromise_.then(() => {
         // Page was unloaded - free up owned resources.
         this.transport_.deleteIframeTransport();
+        this.linkerManager_.dispose();
       });
     }
 
-    this.linkerManager_.removeListeners();
 
     return super.unlayoutCallback();
   }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -173,7 +173,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.iniPromise_.then(() => {
         this.transport_.maybeInitIframeTransport(
             this.getAmpDoc().win, this.element);
-        this.linkerManager_.enableFormSupport();
+        this.linkerManager_.maybeEnableFormSupport();
       });
     }
   }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -156,6 +156,11 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.analyticsGroup_.dispose();
       this.analyticsGroup_ = null;
     }
+
+    if (this.linkerManager_) {
+      this.linkerManager_.dispose();
+    }
+
     for (let i = 0; i < this.requests_.length; i++) {
       this.requests_[i].dispose();
       delete this.requests_[i];
@@ -168,6 +173,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.iniPromise_.then(() => {
         this.transport_.maybeInitIframeTransport(
             this.getAmpDoc().win, this.element);
+        this.linkerManager_.enableFormSupport();
       });
     }
   }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -101,6 +101,9 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.isInabox_ = getMode(this.win).runtime == 'inabox';
+
+    /** @private {?./linker-manager.LinkerManager} */
+    this.linkerManager_ = null;
   }
 
   /** @override */
@@ -183,6 +186,8 @@ export class AmpAnalytics extends AMP.BaseElement {
       });
     }
 
+    this.linkerManager_.removeListeners();
+
     return super.unlayoutCallback();
   }
 
@@ -222,10 +227,7 @@ export class AmpAnalytics extends AMP.BaseElement {
                   new Transport(this.win, this.config_['transport'] || {});
             })
             .then(this.registerTriggers_.bind(this))
-            .then(() => {
-              const type = this.element.getAttribute('type');
-              new LinkerManager(this.getAmpDoc(), this.config_, type).init();
-            });
+            .then(this.initializeLinker_.bind(this));
     return this.iniPromise_;
   }
 
@@ -465,6 +467,17 @@ export class AmpAnalytics extends AMP.BaseElement {
       }
       this.requests_ = requests;
     }
+  }
+
+  /**
+   * Create the linker-manager that will append linker params as necessary.
+   * @private
+   */
+  initializeLinker_() {
+    const type = this.element.getAttribute('type');
+    this.linkerManager_ = new LinkerManager(this.getAmpDoc(),
+        this.config_, type);
+    this.linkerManager_.init();
   }
 
   /**

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -173,7 +173,6 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.iniPromise_.then(() => {
         this.transport_.maybeInitIframeTransport(
             this.getAmpDoc().win, this.element);
-        this.linkerManager_.maybeEnableFormSupport();
       });
     }
   }
@@ -189,7 +188,6 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.iniPromise_.then(() => {
         // Page was unloaded - free up owned resources.
         this.transport_.deleteIframeTransport();
-        this.linkerManager_.dispose();
       });
     }
 

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -123,7 +123,7 @@ export class LinkerManager {
   /**
    * Remove any listeners created to manage form submission.
    */
-  removeListeners() {
+  dispose() {
     if (this.formSubmitUnlistener_) {
       this.formSubmitUnlistener_();
     }

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -112,12 +112,10 @@ export class LinkerManager {
           this.handleAnchorMutation_.bind(this), Priority.ANALYTICS_LINKER);
     }
 
-    return Promise.all(this.allLinkerPromises_)
-        .then(() => {
-          if (isExperimentOn(this.ampdoc_.win, 'linker-form')) {
-            this.enableFormSupport();
-          }
-        });
+
+    this.maybeEnableFormSupport();
+
+    return this.allLinkerPromises_;
   }
 
   /**
@@ -291,9 +289,20 @@ export class LinkerManager {
   }
 
   /**
+   * Enable form support if experiment is on.
+   * TODO(ccordry): remove this method and make `enableFormSupport_` public
+   * when fully launched.
+   */
+  maybeEnableFormSupport() {
+    if (isExperimentOn(this.ampdoc_.win, 'linker-form')) {
+      this.enableFormSupport_();
+    }
+  }
+
+  /**
    * Register callback that will handle form sumbits.
    */
-  enableFormSupport() {
+  enableFormSupport_() {
     if (this.formSubmitUnlistener_) {
       return;
     }

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -60,6 +60,9 @@ export class LinkerManager {
 
     /** @private {Promise<../../amp-form/0.1/form-submit-service.FormSubmitService>} */
     this.formSubmitService_ = Services.formSubmitPromiseForDoc(ampdoc);
+
+    /** @private {?UnlistenDef} */
+    this.formSubmitUnlistener_ = null;
   }
 
 
@@ -115,6 +118,15 @@ export class LinkerManager {
             this.enableFormSupport_();
           }
         });
+  }
+
+  /**
+   * Remove any listeners created to manage form submission.
+   */
+  removeListeners() {
+    if (this.formSubmitUnlistener_) {
+      this.formSubmitUnlistener_();
+    }
   }
 
   /**
@@ -282,8 +294,10 @@ export class LinkerManager {
    * Register callback that will handle form sumbits.
    */
   enableFormSupport_() {
-    this.formSubmitService_.then(formService =>
-      formService.beforeSubmit(this.handleFormSubmit_.bind(this)));
+    this.formSubmitService_.then(formService => {
+      this.formSubmitUnlistener_ =
+          formService.beforeSubmit(this.handleFormSubmit_.bind(this));
+    });
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -113,7 +113,7 @@ export class LinkerManager {
     }
 
 
-    this.maybeEnableFormSupport();
+    this.maybeEnableFormSupport_();
 
     return Promise.all(this.allLinkerPromises_);
   }
@@ -290,10 +290,11 @@ export class LinkerManager {
 
   /**
    * Enable form support if experiment is on.
-   * TODO(ccordry): remove this method and make `enableFormSupport_` public
-   * when fully launched.
+   * TODO(ccordry): remove this method and use `enableFormSupport_` when fully
+   * launched.
+   * @private
    */
-  maybeEnableFormSupport() {
+  maybeEnableFormSupport_() {
     if (isExperimentOn(this.ampdoc_.win, 'linker-form')) {
       this.enableFormSupport_();
     }

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -115,7 +115,7 @@ export class LinkerManager {
 
     this.maybeEnableFormSupport();
 
-    return this.allLinkerPromises_;
+    return Promise.all(this.allLinkerPromises_);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -115,7 +115,7 @@ export class LinkerManager {
     return Promise.all(this.allLinkerPromises_)
         .then(() => {
           if (isExperimentOn(this.ampdoc_.win, 'linker-form')) {
-            this.enableFormSupport_();
+            this.enableFormSupport();
           }
         });
   }
@@ -293,7 +293,11 @@ export class LinkerManager {
   /**
    * Register callback that will handle form sumbits.
    */
-  enableFormSupport_() {
+  enableFormSupport() {
+    if (this.formSubmitUnlistener_) {
+      return;
+    }
+
     this.formSubmitService_.then(formService => {
       this.formSubmitUnlistener_ =
           formService.beforeSubmit(this.handleFormSubmit_.bind(this));

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -36,6 +36,7 @@ import {
   installUserNotificationManagerForTesting,
 } from '../../../amp-user-notification/0.1/amp-user-notification';
 import {instrumentationServiceForDocForTesting} from '../instrumentation';
+import {macroTask} from '../../../../testing/yield';
 
 describes.realWin('amp-analytics', {
   amp: {
@@ -204,15 +205,18 @@ describes.realWin('amp-analytics', {
       sandbox.stub(Services, 'viewerForDoc').returns({
         isVisible: () => false,
       });
-
-      const removeStub = sandbox.stub();
+      analytics.iniPromise_ = Promise.resolve();
+      const disposeStub = sandbox.stub();
 
       analytics.linkerManager_ = {
-        removeListeners: removeStub,
+        dispose: disposeStub,
       };
 
       analytics.unlayoutCallback();
-      expect(removeStub.calledOnce).to.be.true;
+      analytics.iniPromise_.then(function*() {
+        yield macroTask();
+        return expect(disposeStub.calledOnce).to.be.true;
+      });
     });
   });
 
@@ -1408,7 +1412,7 @@ describes.realWin('amp-analytics', {
       });
 
       sandbox.stub(viewer, 'isVisible').returns(false);
-      analytics.linkerManager_ = {removeListeners: () => {}};
+      analytics.linkerManager_ = {dispose: () => {}};
 
       analytics.layoutCallback();
       analytics.resumeCallback();

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -36,7 +36,6 @@ import {
   installUserNotificationManagerForTesting,
 } from '../../../amp-user-notification/0.1/amp-user-notification';
 import {instrumentationServiceForDocForTesting} from '../instrumentation';
-import {macroTask} from '../../../../testing/yield';
 
 describes.realWin('amp-analytics', {
   amp: {
@@ -198,24 +197,6 @@ describes.realWin('amp-analytics', {
       analytics.buildCallback();
       return analytics.layoutCallback().then(() => {
         expect(linkerStub.calledOnce).to.be.true;
-      });
-    });
-
-    it('Removes linker listeners.', () => {
-      sandbox.stub(Services, 'viewerForDoc').returns({
-        isVisible: () => false,
-      });
-      analytics.iniPromise_ = Promise.resolve();
-      const disposeStub = sandbox.stub();
-
-      analytics.linkerManager_ = {
-        dispose: disposeStub,
-      };
-
-      analytics.unlayoutCallback();
-      analytics.iniPromise_.then(function*() {
-        yield macroTask();
-        return expect(disposeStub.calledOnce).to.be.true;
       });
     });
   });
@@ -1412,8 +1393,6 @@ describes.realWin('amp-analytics', {
       });
 
       sandbox.stub(viewer, 'isVisible').returns(false);
-      analytics.linkerManager_ = {dispose: () => {}};
-
       analytics.layoutCallback();
       analytics.resumeCallback();
       analytics.unlayoutCallback();

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -199,6 +199,21 @@ describes.realWin('amp-analytics', {
         expect(linkerStub.calledOnce).to.be.true;
       });
     });
+
+    it('Removes linker listeners.', () => {
+      sandbox.stub(Services, 'viewerForDoc').returns({
+        isVisible: () => false,
+      });
+
+      const removeStub = sandbox.stub();
+
+      analytics.linkerManager_ = {
+        removeListeners: removeStub,
+      };
+
+      analytics.unlayoutCallback();
+      expect(removeStub.calledOnce).to.be.true;
+    });
   });
 
   describe('iframe transport', () => {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1408,6 +1408,8 @@ describes.realWin('amp-analytics', {
       });
 
       sandbox.stub(viewer, 'isVisible').returns(false);
+      analytics.linkerManager_ = {removeListeners: () => {}};
+
       analytics.layoutCallback();
       analytics.resumeCallback();
       analytics.unlayoutCallback();

--- a/extensions/amp-form/0.1/form-submit-service.js
+++ b/extensions/amp-form/0.1/form-submit-service.js
@@ -37,7 +37,7 @@ export class FormSubmitService {
 
   /**
    * Used to register callbacks.
-   * @param {function(HTMLFormElement)} cb
+   * @param {function(!FormSubmitEventDef)} cb
    * @return {!UnlistenDef}
    */
   beforeSubmit(cb) {

--- a/extensions/amp-form/0.1/form-submit-service.js
+++ b/extensions/amp-form/0.1/form-submit-service.js
@@ -37,10 +37,11 @@ export class FormSubmitService {
 
   /**
    * Used to register callbacks.
-   * @param {function(!FormSubmitEventDef)} cb
+   * @param {function(HTMLFormElement)} cb
+   * @return {!UnlistenDef}
    */
   beforeSubmit(cb) {
-    this.observable_.add(cb);
+    return this.observable_.add(cb);
   }
 
   /**


### PR DESCRIPTION
When unlayout callback is fired on amp-analytics, it's linker should stop listening for form submissions.
