### PR TITLE
🏗 Remove `--headless` mode from `gulp visual-diff` task

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -380,7 +380,7 @@ const command = {
           colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.');
       return;
     }
-    let cmd = 'gulp visual-diff --nobuild --headless';
+    let cmd = 'gulp visual-diff --nobuild';
     if (opt_mode === 'skip') {
       cmd += ' --skip';
     } else if (opt_mode === 'master') {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -277,13 +277,10 @@ function verifyBuildStatus(status, buildId) {
  */
 async function launchBrowser() {
   const browserOptions = {
-    args: ['--no-sandbox', '--disable-extensions'],
+    args: ['--no-sandbox', '--disable-extensions', '--disable-gpu'],
     dumpio: argv.chrome_debug,
+    headless: true,
   };
-  browserOptions.headless = !!argv.headless;
-  if (argv.headless) {
-    browserOptions['args'].push('--disable-gpu');
-  }
 
   browser_ = await puppeteer.launch(browserOptions)
       .catch(err => log('fatal', err));
@@ -764,7 +761,6 @@ gulp.task(
         'verify_status':
           '  Verifies the status of the build ID in ./PERCY_BUILD_ID',
         'skip': '  Creates a dummy Percy build with only a blank snapshot',
-        'headless': '  Runs Chrome in headless mode',
         'chrome_debug': '  Prints debug info from Chrome',
         'webserver_debug': '  Prints debug info from the local gulp webserver',
         'debug': '  Prints all the above debug info',

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -104,7 +104,7 @@ Command                                                                 | Descri
 `node build-system/pr-check.js`                                         | Runs all tests that will be run upon pushing a CL.
 `gulp ava`                                                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava).
 `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed.
-`gulp visual-diff`                                                      | Runs all visual diff tests on local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
+`gulp visual-diff`                                                      | Runs all visual diff tests on a headless instance of local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
 `gulp visual-diff --nobuild`                                            | Same as above, but without re-build.
 `gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.
 `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
@@ -252,7 +252,7 @@ gulp visual-diff --nobuild
 ```
 Note that if you drop the `--nobuild` flag, `gulp visual-diff` will run `gulp build` on each execution.
 
-The build will use the Percy credentials set via environment variables in the previous step, and run the tests on your local install of Chrome. You can see the results at `https://percy.io/<org>/<project>`.
+The build will use the Percy credentials set via environment variables in the previous step, and run the tests on your local install of Chrome in headless mode. You can see the results at `https://percy.io/<org>/<project>`.
 
 To see debugging info during Percy runs, you can run:
 ```

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -106,7 +106,6 @@ Command                                                                 | Descri
 `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed.
 `gulp visual-diff`                                                      | Runs all visual diff tests on local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
 `gulp visual-diff --nobuild`                                            | Same as above, but without re-build.
-`gulp visual-diff --headless`                                           | Same as above, but launches local Chrome in headless mode.
 `gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.
 `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
 `gulp firebase`                                                         | Generates a folder `firebase` and copies over all files from `examples` and `test/manual` for firebase deployment.
@@ -234,7 +233,7 @@ The technology stack used is:
 - [Percy](https://percy.io/), a visual regression testing service for webpages
 - [Puppeteer](https://developers.google.com/web/tools/puppeteer/), a driver capable of loading webpages for diffing
 - [Percy-Puppeteer](https://github.com/percy/percy-puppeteer), a framework that integrates Puppeteer with Percy
-- [(Headless) Chrome](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md), the Chrome browser, optionally in headless mode
+- [Headless Chrome](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md), the Chrome/Chromium browser in headless mode
 
 The [`ampproject/amphtml`](https://github.com/ampproject/amphtml) repository on GitHub is linked to the [Percy project](https://percy.io/ampproject/amphtml) of the same name. All PRs will show a check called `percy/amphtml` in addition to the `continuous-integration/travis-ci/pr` check. If your PR results in visual diff(s), clicking on the `details` link will show you the snapshots with the diffs highlighted.
 
@@ -254,11 +253,6 @@ gulp visual-diff --nobuild
 Note that if you drop the `--nobuild` flag, `gulp visual-diff` will run `gulp build` on each execution.
 
 The build will use the Percy credentials set via environment variables in the previous step, and run the tests on your local install of Chrome. You can see the results at `https://percy.io/<org>/<project>`.
-
-To run Chrome in headless mode, use:
-```
- gulp visual-diff --headless
-```
 
 To see debugging info during Percy runs, you can run:
 ```


### PR DESCRIPTION
Non-headless mode no longer works as expected with the introduction of parallelization in PR #17139, because all the tabs share the same viewport size in non-headless mode. If a specific test resizes its viewport, it affects other tests unexpectedly.