### PR TITLE
Cookie Writer spec improvement

### DIFF
--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -34,14 +34,12 @@ const EXPAND_WHITELIST = {
 };
 
 const RESERVED_KEYS = {
-  'referralDomains': true,
+  'referrerDomains': true,
   'enabled': true,
   'cookiePath': true,
   'cookieMaxAge': true,
   'cookieSecure': true,
   'cookieDomain': true,
-  'cookieHttpOnly': true,
-  'cookieSameSite': true,
 };
 
 export class CookieWriter {
@@ -87,7 +85,7 @@ export class CookieWriter {
    * Parse the config and write to cookie
    * Config looks like
    * cookies: {
-   *   enabled: true/false,
+   *   enabled: true/false, //Default to true
    *   cookieNameA: {
    *     value: cookieValueA (QUERY_PARAM/LINKER_PARAM)
    *   },
@@ -132,7 +130,7 @@ export class CookieWriter {
     for (let i = 0; i < ids.length; i++) {
       const cookieName = ids[i];
       const cookieObj = inputConfig[cookieName];
-      if (this.isCookieValueObjectValid_(cookieName, cookieObj)) {
+      if (this.isValidCookieConfig_(cookieName, cookieObj)) {
         promises.push(this.expandAndWrite_(cookieName, cookieObj['value']));
       }
     }
@@ -149,25 +147,25 @@ export class CookieWriter {
    *  value: string (cookieValue),
    * }
    * @param {string} cookieName
-   * @param {*} cookieObj
+   * @param {*} cookieConfig
    * @return {boolean}
    */
-  isCookieValueObjectValid_(cookieName, cookieObj) {
+  isValidCookieConfig_(cookieName, cookieConfig) {
     if (RESERVED_KEYS[cookieName]) {
       return false;
     }
 
-    if (!isObject(cookieObj)) {
+    if (!isObject(cookieConfig)) {
       user().error(TAG, 'cookieValue must be configured in an object');
       return false;
     }
 
-    if (!hasOwn(cookieObj, 'value')) {
+    if (!hasOwn(cookieConfig, 'value')) {
       user().error(TAG, 'value is required in the cookieValue object');
       return false;
     }
 
-    const str = cookieObj['value'];
+    const str = cookieConfig['value'];
     // Make sure that only QUERY_PARAM and LINKER_PARAM is supported
     const {name} = getNameArgs(str);
     if (!EXPAND_WHITELIST[name]) {

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -239,7 +239,7 @@ describes.realWin('amp-analytics.cookie-writer', {
       const config = dict({
         'cookies': {
           'testId': {
-            'value': 'QUERY_PARAM(abc)'
+            'value': 'QUERY_PARAM(abc)',
           },
         },
       });

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -62,9 +62,9 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Resovle when config is invalid', () => {
       const config = dict({
-        'writeCookies': 'invalid',
+        'cookies': 'invalid',
       });
-      expectAsyncConsoleError(TAG + ' writeCookies config must be an object');
+      expectAsyncConsoleError(TAG + ' cookies config must be an object');
       const cookieWriter = new CookieWriter(win, element, config);
       expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
       return cookieWriter.write().then(() => {
@@ -74,8 +74,10 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Resolve when element is in FIE', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM(test)',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(test)',
+          },
         },
       });
       const parent = doc.createElement('div');
@@ -91,8 +93,10 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Resolve when in viewer', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'testValue',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(test)',
+          },
         },
       });
       const mockWin = {
@@ -109,8 +113,26 @@ describes.realWin('amp-analytics.cookie-writer', {
     it('Resolve when in inabox ad', () => {
       env.win.AMP_MODE.runtime = 'inabox';
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM(test)',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(test)',
+          },
+        },
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+      return cookieWriter.write().then(() => {
+        expect(expandAndWriteSpy).to.not.be.called;
+      });
+    });
+
+    it('Resolve when disabled', () => {
+      const config = dict({
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(test)',
+          },
+          'enabled': false,
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -122,7 +144,55 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Resolve with nothing to write', () => {
       const config = dict({
-        'writeCookies': {},
+        'cookies': {},
+      });
+      const cookieWriter = new CookieWriter(win, element, config);
+      expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+      return cookieWriter.write().then(() => {
+        expect(expandAndWriteSpy).to.not.be.called;
+      });
+    });
+
+    it('Resolve with invalid cookieValue (not object)', () => {
+      const config = dict({
+        'cookies': {
+          'testId': 'QUERY_PARAM(test)',
+        },
+      });
+      expectAsyncConsoleError(TAG +
+          ' cookieValue must be configured in an object');
+      const cookieWriter = new CookieWriter(win, element, config);
+      expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+      return cookieWriter.write().then(() => {
+        expect(expandAndWriteSpy).to.not.be.called;
+      });
+    });
+
+
+    it('Resolve when no value in cookieValue object', () => {
+      const config = dict({
+        'cookies': {
+          'testId': {
+            'novalue': 'QUERY_PARAM(test)',
+          },
+        },
+      });
+      expectAsyncConsoleError(TAG +
+          ' value is required in the cookieValue object');
+      const cookieWriter = new CookieWriter(win, element, config);
+      expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+      return cookieWriter.write().then(() => {
+        expect(expandAndWriteSpy).to.not.be.called;
+      });
+    });
+
+    it('Ignore reserved keys', () => {
+      const config = dict({
+        'cookies': {
+          'cookiePath': {
+            'value': 'QUERY_PARAM(test)',
+          },
+        },
       });
       const cookieWriter = new CookieWriter(win, element, config);
       expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
@@ -133,22 +203,30 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Resolve when cookie value is not supported', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'RANDOM',
-          'testId1': 'static',
-          'testId2': 'QUERY_PARAM(abc)-suf',
-          'testId3': 'pre-QUERY_PARAM(abc)',
+        'cookies': {
+          'testId': {
+            'value': 'RANDOM',
+          },
+          'testId1': {
+            'value': 'static',
+          },
+          'testId2': {
+            'value': 'QUERY_PARAM(abc)-suf',
+          },
+          'testId3': {
+            'value': 'pre-QUERY_PARAM(abc)',
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
       expectAsyncConsoleError(TAG + ' cookie value RANDOM not supported. ' +
-          'Only QUERY_PARAM is supported');
+          'Only QUERY_PARAM and LINKER_PARAM is supported');
       expectAsyncConsoleError(TAG + ' cookie value static not supported. ' +
-          'Only QUERY_PARAM is supported');
+          'Only QUERY_PARAM and LINKER_PARAM is supported');
       expectAsyncConsoleError(TAG + ' cookie value QUERY_PARAM(abc)-suf not ' +
-          'supported. Only QUERY_PARAM is supported');
+          'supported. Only QUERY_PARAM and LINKER_PARAM is supported');
       expectAsyncConsoleError(TAG + ' cookie value pre-QUERY_PARAM(abc) not ' +
-          'supported. Only QUERY_PARAM is supported');
+          'supported. Only QUERY_PARAM and LINKER_PARAM is supported');
       expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
       return cookieWriter.write().then(() => {
         expect(expandAndWriteSpy).to.not.be.called;
@@ -159,8 +237,10 @@ describes.realWin('amp-analytics.cookie-writer', {
   describe('Cookie value', () => {
     it('Write cookie', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM(abc)',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(abc)'
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -175,8 +255,10 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Write LINKER_PARAM value to cookie', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'LINKER_PARAM(testlinker, testid)',
+        'cookies': {
+          'testId': {
+            'value': 'LINKER_PARAM(testlinker, testid)',
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -192,9 +274,13 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Write multiple cookie', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM(abc)',
-          'testId2': 'QUERY_PARAM(def)',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(abc)',
+          },
+          'testId2': {
+            'value': 'QUERY_PARAM(def)',
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -212,8 +298,10 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Do not write when string is empty', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM(noexist)',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM(noexist)',
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);
@@ -228,8 +316,10 @@ describes.realWin('amp-analytics.cookie-writer', {
 
     it('Handle expandString error', () => {
       const config = dict({
-        'writeCookies': {
-          'testId': 'QUERY_PARAM',
+        'cookies': {
+          'testId': {
+            'value': 'QUERY_PARAM',
+          },
         },
       });
       const cookieWriter = new CookieWriter(win, element, config);

--- a/test/manual/amp-analytics-cookie-writer.html
+++ b/test/manual/amp-analytics-cookie-writer.html
@@ -31,7 +31,7 @@
 </head>
 <h1>Instructions</h1>
 <p>
-  This page is intended to test the amp-analytics writeCookies config.
+  This page is intended to test the amp-analytics cookies config.
 </p>
 <p>
   Copy the value in the console and append to the url.
@@ -102,7 +102,7 @@
 
   const serializedIds1 = 'key1*dmFsdWUx*name*Ym9i*color*Z3JlZW4.*car*dGVzbGE.';
   const checksum1 = getCheckSum(serializedIds1);
-  const serializedIds2 = '~key1*123'
+  const serializedIds2 = 'key1*dmFsdWUx';
   const checksum2 = getCheckSum(serializedIds2);
 
   const url1 = `1*${checksum1}*${serializedIds1}`;
@@ -130,9 +130,13 @@
       "xhrpost": "false",
       "image": "true"
     },
-    "writeCookies": {
-      "cookie1": "QUERY_PARAM(test)",
-      "cookie2": "LINKER_PARAM(testlinker, name)"
+    "cookies": {
+      "cookie1": {
+        "value": "QUERY_PARAM(test)"
+      },
+      "cookie2": {
+        "value": "LINKER_PARAM(testlinker, name)"
+      }
     }
   }
   </script>
@@ -155,8 +159,10 @@
       "xhrpost": "false",
       "image": "true"
     },
-    "writeCookies": {
-      "cookie3": "LINKER_PARAM(testlinker, color)"
+    "cookies": {
+      "cookie3": {
+        "value": "LINKER_PARAM(testlinker, color)"
+      }
     }
   }
   </script>
@@ -179,11 +185,19 @@
       "xhrpost": "false",
       "image": "true"
     },
-    "writeCookies": {
-      "cookie4": "LINKER_PARAM(testlinker, key1)",
-      "cookie5": "LINKER_PARAM(testlinker2, key1)",
-      "cookie6": "LINKER_PARAM(noexist, key1)",
-      "cookie7": "QUERY_PARAM(noexist)"
+    "cookies": {
+      "cookie4": {
+        "value": "LINKER_PARAM(testlinker, key1)"
+      },
+      "cookie5": {
+        "value": "LINKER_PARAM(testlinker2, key1)"
+      },
+      "cookie6": {
+        "value": "LINKER_PARAM(noexist, key1)"
+      },
+      "cookie7": {
+        "value": "QUERY_PARAM(noexist)"
+      }
     }
   }
   </script>


### PR DESCRIPTION
As agreed offline. 
Spec design looks like. It's more flexible, also allows us to expand future supports to cookie expiration time and so on. 
```
'cookies': {
  'cookieNameA': {
    'value': 'QUERY_PARAM(test)'
  }
 ...
 'enabled': false/true,
 ... //other reserved keys. 
}
```

cc @calebcordry 