### PR TITLE
🐛 Do not set last page as active if bookend is open

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -176,7 +176,10 @@ const actions = (state, action, data) => {
         return state;
       }
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.BOOKEND_STATE]: !!data}));
+          {}, state, {
+            [StateProperty.BOOKEND_STATE]: !!data,
+            [StateProperty.PAUSED_STATE]: !!data,
+          }));
     // Shows or hides the info dialog.
     case Action.TOGGLE_INFO_DIALOG:
       return /** @type {!State} */ (Object.assign(

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1319,7 +1319,10 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   onPausedStateUpdate_(isPaused) {
-    if (!this.activePage_) {
+    // Make sure there is an active page and that the bookend is not open before
+    // proceeding.
+    if (!this.activePage_ ||
+        this.storeService_.get(StateProperty.BOOKEND_STATE)) {
       return;
     }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1319,10 +1319,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   onPausedStateUpdate_(isPaused) {
-    // Make sure there is an active page and that the bookend is not open before
-    // proceeding.
-    if (!this.activePage_ ||
-        this.storeService_.get(StateProperty.BOOKEND_STATE)) {
+    if (!this.activePage_) {
       return;
     }
 
@@ -1480,15 +1477,6 @@ export class AmpStory extends AMP.BaseElement {
   onBookendStateUpdate_(isActive) {
     this.toggleElementsOnBookend_(/* display */ isActive);
     this.element.classList.toggle('i-amphtml-story-bookend-active', isActive);
-
-    if (isActive) {
-      this.systemLayer_.hideDeveloperLog();
-      this.activePage_.setState(PageState.PAUSED);
-    }
-
-    if (!isActive) {
-      this.activePage_.setState(PageState.ACTIVE);
-    }
   }
 
 

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -181,16 +181,15 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should unpause the story when closing the bookend', () => {
-    const pausedListenerSpy = sandbox.spy();
-    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
-
     // First open the bookend.
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
 
     // Close the bookend.
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, false);
 
-    expect(pausedListenerSpy).to.have.been.calledTwice;
+    expect(pausedListenerSpy).to.have.been.calledOnce;
     expect(pausedListenerSpy).to.have.been.calledWith(false);
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -172,6 +172,28 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(pausedListenerSpy).to.have.been.calledWith(true);
   });
 
+  it('should pause the story when displaying the bookend', () => {
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+    storeService.dispatch(Action.TOGGLE_BOOKEND, true);
+    expect(pausedListenerSpy).to.have.been.calledOnce;
+    expect(pausedListenerSpy).to.have.been.calledWith(true);
+  });
+
+  it('should unpause the story when closing the bookend', () => {
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+
+    // First open the bookend.
+    storeService.dispatch(Action.TOGGLE_BOOKEND, true);
+
+    // Close the bookend.
+    storeService.dispatch(Action.TOGGLE_BOOKEND, false);
+
+    expect(pausedListenerSpy).to.have.been.calledTwice;
+    expect(pausedListenerSpy).to.have.been.calledWith(false);
+  });
+
   it('should unpause the story when hiding the share menu', () => {
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -165,6 +165,32 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should pause the story when bookend becomes active', () => {
+    createPages(story.element, 1, ['cover']);
+    sandbox.stub(story, 'maybePreloadBookend_').returns();
+    story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.getPageById('cover').state_)
+              .to.equal(PageState.NOT_ACTIVE);
+        });
+  });
+
+  it('should keep the story paused when tab becomes active and bookend ' +
+  'is open', () => {
+    createPages(story.element, 1, ['cover']);
+    sandbox.stub(story, 'maybePreloadBookend_').returns();
+    story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
+
+    return story.layoutCallback()
+        .then(() => {
+          story.pauseCallback();
+          story.resumeCallback();
+          expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+              .to.be.true;
+        });
+  });
+
   it('should preload the bookend if navigating to the last page', () => {
     createPages(story.element, 1, ['cover']);
 
@@ -207,20 +233,6 @@ describes.realWin('amp-story', {
         .then(() => {
           expect(buildShareMenuStub).to.not.have.been.called;
         });
-  });
-
-  // TODO(#11639): Re-enable this test.
-  it.skip('should hide bookend when CLOSE_BOOKEND is triggered', () => {
-    const hideBookendStub = sandbox.stub(
-        element.implementation_, 'hideBookend_', NOOP);
-
-    appendEmptyPage(element);
-
-    element.build();
-
-    element.dispatchEvent(new Event(EventType.CLOSE_BOOKEND));
-
-    expect(hideBookendStub).to.have.been.calledOnce;
   });
 
   it('should return a valid page index', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -25,7 +25,6 @@ import {
 import {ActionTrust} from '../../../../src/action-constants';
 import {AmpStory} from '../amp-story';
 import {AmpStoryConsent} from '../amp-story-consent';
-import {EventType} from '../events';
 import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../localization';
 import {MediaType} from '../media-pool';
@@ -35,7 +34,6 @@ import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
 
-const NOOP = () => {};
 // Represents the correct value of KeyboardEvent.which for the Right Arrow
 const KEYBOARD_EVENT_WHICH_RIGHT_ARROW = 39;
 
@@ -50,21 +48,6 @@ describes.realWin('amp-story', {
   let element;
   let story;
   let replaceStateStub;
-
-  /**
-   * @param {!Element} container
-   * @param {boolean=} opt_active
-   * @return {!Element}
-   */
-  function appendEmptyPage(container, opt_active) {
-    const page = document.createElement('amp-story-page');
-    page.id = '-empty-page';
-    if (opt_active) {
-      page.setAttribute('active', true);
-    }
-    container.appendChild(page);
-    return page;
-  }
 
   /**
    * @param {!Element} container
@@ -165,32 +148,6 @@ describes.realWin('amp-story', {
         });
   });
 
-  it('should pause the story when bookend becomes active', () => {
-    createPages(story.element, 1, ['cover']);
-    sandbox.stub(story, 'maybePreloadBookend_').returns();
-    story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
-    return story.layoutCallback()
-        .then(() => {
-          expect(story.getPageById('cover').state_)
-              .to.equal(PageState.NOT_ACTIVE);
-        });
-  });
-
-  it('should keep the story paused when tab becomes active and bookend ' +
-  'is open', () => {
-    createPages(story.element, 1, ['cover']);
-    sandbox.stub(story, 'maybePreloadBookend_').returns();
-    story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
-
-    return story.layoutCallback()
-        .then(() => {
-          story.pauseCallback();
-          story.resumeCallback();
-          expect(story.storeService_.get(StateProperty.PAUSED_STATE))
-              .to.be.true;
-        });
-  });
-
   it('should preload the bookend if navigating to the last page', () => {
     createPages(story.element, 1, ['cover']);
 
@@ -253,7 +210,6 @@ describes.realWin('amp-story', {
           }
         });
   });
-
 
   it('should pause/resume pages when switching pages', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
@@ -723,7 +679,6 @@ describes.realWin('amp-story', {
           });
     });
   });
-
 
   describe('desktop attributes', () => {
     it('should add next page attribute', () => {


### PR DESCRIPTION
Fixes #18525

Check if bookend is open before setting page as active.