### PR TITLE
Doubleclick: Re-enable SRA 1% experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -47,7 +47,7 @@
   "amp-carousel-scroll-snap": 1,
   "user-error-reporting": 1,
   "no-initial-intersection": 1,
-  "doubleclickSraExp": 0,
+  "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "doubleclickIdleExp": 0.01,
   "inabox-rov": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -48,7 +48,7 @@
   "user-error-reporting": 1,
   "no-initial-intersection": 1,
   "no-sync-xhr-in-ads": 1,
-  "doubleclickSraExp": 0,
+  "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "doubleclickIdleExp": 0.01,
   "inabox-rov": 1


### PR DESCRIPTION
See fix #18477, verified against dev-channel that issue is no longer present.  Will re-enable on production once fix is global and results on canary look correct.