### PR TITLE
Change (deprecated) KeyboardEvent.keyCode -> KeyboardEvent.key

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -16,7 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {Animation} from '../../../src/animation';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
@@ -480,12 +480,12 @@ class AmpAccordion extends AMP.BaseElement {
     }
     const {key} = event;
     switch (key) {
-      case KeyCodes.UP_ARROW: /* fallthrough */
-      case KeyCodes.DOWN_ARROW:
+      case Keys.UP_ARROW: /* fallthrough */
+      case Keys.DOWN_ARROW:
         this.navigationKeyDownHandler_(event);
         return;
-      case KeyCodes.ENTER: /* fallthrough */
-      case KeyCodes.SPACE:
+      case Keys.ENTER: /* fallthrough */
+      case Keys.SPACE:
         if (event.target == event.currentTarget) {
           // Only activate if header element was activated directly.
           // Do not respond to key presses on its children.
@@ -507,7 +507,7 @@ class AmpAccordion extends AMP.BaseElement {
     if (index !== -1) {
       event.preventDefault();
       // Up and down are the same regardless of locale direction.
-      const diff = event.key == KeyCodes.UP_ARROW ? -1 : 1;
+      const diff = event.key == Keys.UP_ARROW ? -1 : 1;
       // If user navigates one past the beginning or end, wrap around.
       let newFocusIndex = (index + diff) % this.headers_.length;
       if (newFocusIndex < 0) {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -478,8 +478,8 @@ class AmpAccordion extends AMP.BaseElement {
     if (event.defaultPrevented) {
       return;
     }
-    const {keyCode} = event;
-    switch (keyCode) {
+    const {key} = event;
+    switch (key) {
       case KeyCodes.UP_ARROW: /* fallthrough */
       case KeyCodes.DOWN_ARROW:
         this.navigationKeyDownHandler_(event);
@@ -507,7 +507,7 @@ class AmpAccordion extends AMP.BaseElement {
     if (index !== -1) {
       event.preventDefault();
       // Up and down are the same regardless of locale direction.
-      const diff = event.keyCode == KeyCodes.UP_ARROW ? -1 : 1;
+      const diff = event.key == KeyCodes.UP_ARROW ? -1 : 1;
       // If user navigates one past the beginning or end, wrap around.
       let newFocusIndex = (index + diff) % this.headers_.length;
       if (newFocusIndex < 0) {

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -355,7 +355,7 @@ describes.realWin('amp-accordion', {
       const headerElements = doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        keyCode: KeyCodes.SPACE,
+        key: KeyCodes.SPACE,
         target: headerElements[0],
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -377,7 +377,7 @@ describes.realWin('amp-accordion', {
       const child = doc.createElement('div');
       headerElements[0].appendChild(child);
       const keyDownEvent = {
-        keyCode: KeyCodes.ENTER,
+        key: KeyCodes.ENTER,
         target: child,
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -397,7 +397,7 @@ describes.realWin('amp-accordion', {
       const headerElements = doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        keyCode: KeyCodes.ENTER,
+        key: KeyCodes.ENTER,
         target: headerElements[1],
         currentTarget: headerElements[1],
         preventDefault: sandbox.spy(),
@@ -421,7 +421,7 @@ describes.realWin('amp-accordion', {
       expect(doc.activeElement)
           .to.equal(headerElements[0]);
       const upArrowEvent = {
-        keyCode: KeyCodes.UP_ARROW,
+        key: KeyCodes.UP_ARROW,
         target: headerElements[0],
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -430,7 +430,7 @@ describes.realWin('amp-accordion', {
       expect(doc.activeElement)
           .to.equal(headerElements[headerElements.length - 1]);
       const downArrowEvent = {
-        keyCode: KeyCodes.DOWN_ARROW,
+        key: KeyCodes.DOWN_ARROW,
         target: headerElements[headerElements.length - 1],
         currentTarget: headerElements[headerElements.length - 1],
         preventDefault: sandbox.spy(),

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-accordion';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {poll} from '../../../../testing/iframe';
 import {tryFocus} from '../../../../src/dom';
 
@@ -355,7 +355,7 @@ describes.realWin('amp-accordion', {
       const headerElements = doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        key: KeyCodes.SPACE,
+        key: Keys.SPACE,
         target: headerElements[0],
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -377,7 +377,7 @@ describes.realWin('amp-accordion', {
       const child = doc.createElement('div');
       headerElements[0].appendChild(child);
       const keyDownEvent = {
-        key: KeyCodes.ENTER,
+        key: Keys.ENTER,
         target: child,
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -397,7 +397,7 @@ describes.realWin('amp-accordion', {
       const headerElements = doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        key: KeyCodes.ENTER,
+        key: Keys.ENTER,
         target: headerElements[1],
         currentTarget: headerElements[1],
         preventDefault: sandbox.spy(),
@@ -421,7 +421,7 @@ describes.realWin('amp-accordion', {
       expect(doc.activeElement)
           .to.equal(headerElements[0]);
       const upArrowEvent = {
-        key: KeyCodes.UP_ARROW,
+        key: Keys.UP_ARROW,
         target: headerElements[0],
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
@@ -430,7 +430,7 @@ describes.realWin('amp-accordion', {
       expect(doc.activeElement)
           .to.equal(headerElements[headerElements.length - 1]);
       const downArrowEvent = {
-        key: KeyCodes.DOWN_ARROW,
+        key: Keys.DOWN_ARROW,
         target: headerElements[headerElements.length - 1],
         currentTarget: headerElements[headerElements.length - 1],
         preventDefault: sandbox.spy(),

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -77,7 +77,7 @@ export class BaseCarousel extends AMP.BaseElement {
     button.classList.add(className);
     button.setAttribute('role', 'button');
     button.onkeydown = event => {
-      if (event.keyCode == KeyCodes.ENTER || event.keyCode == KeyCodes.SPACE) {
+      if (event.key == KeyCodes.ENTER || event.key == KeyCodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           onInteraction();

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 
 /**
@@ -77,7 +77,7 @@ export class BaseCarousel extends AMP.BaseElement {
     button.classList.add(className);
     button.setAttribute('role', 'button');
     button.onkeydown = event => {
-      if (event.key == KeyCodes.ENTER || event.key == KeyCodes.SPACE) {
+      if (event.key == Keys.ENTER || event.key == Keys.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           onInteraction();

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -22,7 +22,7 @@ import {DEFAULT_FORMAT, DEFAULT_LOCALE, FORMAT_STRINGS} from './constants';
 import {DatesList} from './dates-list';
 import {Deferred} from '../../../src/utils/promise';
 import {FiniteStateMachine} from '../../../src/finite-state-machine';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {batchFetchJsonFor} from '../../../src/batched-json';
@@ -948,7 +948,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   handleDocumentKeydown_(e) {
-    if (e.key == KeyCodes.ESCAPE &&
+    if (e.key == Keys.ESCAPE &&
         this.mode_ == DatePickerMode.OVERLAY &&
         this.element.contains(this.document_.activeElement)) {
       this.transitionTo_(DatePickerState.OVERLAY_CLOSED);
@@ -967,7 +967,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       return;
     }
 
-    if (e.key == KeyCodes.DOWN_ARROW) {
+    if (e.key == Keys.DOWN_ARROW) {
       this.updateDateFieldFocus_(target);
       this.transitionTo_(DatePickerState.OVERLAY_OPEN_PICKER);
       if (this.mode_ === DatePickerMode.STATIC) {
@@ -978,7 +978,7 @@ export class AmpDatePicker extends AMP.BaseElement {
         }
       }
       e.preventDefault();
-    } else if (e.key == KeyCodes.ESCAPE) {
+    } else if (e.key == Keys.ESCAPE) {
       this.transitionTo_(DatePickerState.OVERLAY_CLOSED);
     } else {
       this.transitionTo_(DatePickerState.OVERLAY_OPEN_INPUT);

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -948,7 +948,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   handleDocumentKeydown_(e) {
-    if (e.keyCode == KeyCodes.ESCAPE &&
+    if (e.key == KeyCodes.ESCAPE &&
         this.mode_ == DatePickerMode.OVERLAY &&
         this.element.contains(this.document_.activeElement)) {
       this.transitionTo_(DatePickerState.OVERLAY_CLOSED);
@@ -967,7 +967,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       return;
     }
 
-    if (e.keyCode == KeyCodes.DOWN_ARROW) {
+    if (e.key == KeyCodes.DOWN_ARROW) {
       this.updateDateFieldFocus_(target);
       this.transitionTo_(DatePickerState.OVERLAY_OPEN_PICKER);
       if (this.mode_ === DatePickerMode.STATIC) {
@@ -978,7 +978,7 @@ export class AmpDatePicker extends AMP.BaseElement {
         }
       }
       e.preventDefault();
-    } else if (e.keyCode == KeyCodes.ESCAPE) {
+    } else if (e.key == KeyCodes.ESCAPE) {
       this.transitionTo_(DatePickerState.OVERLAY_CLOSED);
     } else {
       this.transitionTo_(DatePickerState.OVERLAY_OPEN_INPUT);

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -849,7 +849,7 @@ class AmpImageLightbox extends AMP.BaseElement {
    * @private
    */
   closeOnEscape_(event) {
-    if (event.keyCode == KeyCodes.ESCAPE) {
+    if (event.key == KeyCodes.ESCAPE) {
       this.close();
     }
   }

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -26,7 +26,7 @@ import {
   TapzoomRecognizer,
 } from '../../../src/gesture-recognizers';
 import {Gestures} from '../../../src/gesture';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
 import {continueMotion} from '../../../src/motion';
@@ -849,7 +849,7 @@ class AmpImageLightbox extends AMP.BaseElement {
    * @private
    */
   closeOnEscape_(event) {
-    if (event.key == KeyCodes.ESCAPE) {
+    if (event.key == Keys.ESCAPE) {
       this.close();
     }
   }

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -190,7 +190,7 @@ describes.realWin('amp-image-lightbox component', {
       ampImage.setAttribute('width', '100');
       ampImage.setAttribute('height', '100');
       impl.activate({caller: ampImage});
-      impl.closeOnEscape_({keyCode: KeyCodes.ESCAPE});
+      impl.closeOnEscape_({key: KeyCodes.ESCAPE});
       expect(setupCloseSpy).to.be.calledOnce;
 
       // Regression test: ensure escape event listener is bound properly

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -20,7 +20,7 @@ import * as lolex from 'lolex';
 import {
   ImageViewer,
 } from '../amp-image-lightbox';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {parseSrcset} from '../../../../src/srcset';
 
@@ -190,7 +190,7 @@ describes.realWin('amp-image-lightbox component', {
       ampImage.setAttribute('width', '100');
       ampImage.setAttribute('height', '100');
       impl.activate({caller: ampImage});
-      impl.closeOnEscape_({key: KeyCodes.ESCAPE});
+      impl.closeOnEscape_({key: Keys.ESCAPE});
       expect(setupCloseSpy).to.be.calledOnce;
 
       // Regression test: ensure escape event listener is bound properly

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1268,8 +1268,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     if (!this.isActive_) {
       return;
     }
-    const {keyCode} = event;
-    switch (keyCode) {
+    const {key} = event;
+    switch (key) {
       case KeyCodes.ESCAPE:
         this.close_();
         break;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -26,7 +26,7 @@ import {
   VIDEO_TAGS,
 } from './service/lightbox-manager-impl';
 import {Gestures} from '../../../src/gesture';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
 import {bezierCurve} from '../../../src/curve';
@@ -1270,17 +1270,17 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     }
     const {key} = event;
     switch (key) {
-      case KeyCodes.ESCAPE:
+      case Keys.ESCAPE:
         this.close_();
         break;
-      case KeyCodes.LEFT_ARROW:
+      case Keys.LEFT_ARROW:
         this.maybeSlideCarousel_(/*direction*/ -1);
         break;
-      case KeyCodes.RIGHT_ARROW:
+      case Keys.RIGHT_ARROW:
         this.maybeSlideCarousel_(/*direction*/ 1);
         break;
       default:
-        // Keycode not registered. Do nothing.
+        // Key not registered. Do nothing.
     }
   }
 

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -18,7 +18,7 @@ import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-lightbox-0.1.css';
 import {Gestures} from '../../../src/gesture';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {
@@ -395,7 +395,7 @@ class AmpLightbox extends AMP.BaseElement {
    * @private
    */
   closeOnEscape_(event) {
-    if (event.key == KeyCodes.ESCAPE) {
+    if (event.key == Keys.ESCAPE) {
       this.close();
     }
   }

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -395,7 +395,7 @@ class AmpLightbox extends AMP.BaseElement {
    * @private
    */
   closeOnEscape_(event) {
-    if (event.keyCode == KeyCodes.ESCAPE) {
+    if (event.key == KeyCodes.ESCAPE) {
       this.close();
     }
   }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -17,7 +17,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-selector-0.1.css';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {areEqualOrdered} from '../../../src/utils/array';
 import {closestBySelector, isRTL, tryFocus} from '../../../src/dom';
@@ -433,16 +433,16 @@ export class AmpSelector extends AMP.BaseElement {
     }
     const {key} = event;
     switch (key) {
-      case KeyCodes.LEFT_ARROW: /* fallthrough */
-      case KeyCodes.UP_ARROW: /* fallthrough */
-      case KeyCodes.RIGHT_ARROW: /* fallthrough */
-      case KeyCodes.DOWN_ARROW:
+      case Keys.LEFT_ARROW: /* fallthrough */
+      case Keys.UP_ARROW: /* fallthrough */
+      case Keys.RIGHT_ARROW: /* fallthrough */
+      case Keys.DOWN_ARROW:
         if (this.kbSelectMode_ != KEYBOARD_SELECT_MODES.NONE) {
           this.navigationKeyDownHandler_(event);
         }
         return;
-      case KeyCodes.ENTER: /* fallthrough */
-      case KeyCodes.SPACE:
+      case Keys.ENTER: /* fallthrough */
+      case Keys.SPACE:
         this.selectionKeyDownHandler_(event);
         return;
     }
@@ -457,19 +457,19 @@ export class AmpSelector extends AMP.BaseElement {
     const doc = this.win.document;
     let dir = 0;
     switch (event.key) {
-      case KeyCodes.LEFT_ARROW:
+      case Keys.LEFT_ARROW:
         // Left is considered 'previous' in LTR and 'next' in RTL.
         dir = isRTL(doc) ? 1 : -1;
         break;
-      case KeyCodes.UP_ARROW:
+      case Keys.UP_ARROW:
         // Up is considered 'previous' in both LTR and RTL.
         dir = -1;
         break;
-      case KeyCodes.RIGHT_ARROW:
+      case Keys.RIGHT_ARROW:
         // Right is considered 'next' in LTR and 'previous' in RTL.
         dir = isRTL(doc) ? -1 : 1;
         break;
-      case KeyCodes.DOWN_ARROW:
+      case Keys.DOWN_ARROW:
         // Down is considered 'next' in both LTR and RTL.
         dir = 1;
         break;
@@ -507,7 +507,7 @@ export class AmpSelector extends AMP.BaseElement {
    */
   selectionKeyDownHandler_(event) {
     const {key} = event;
-    if (key == KeyCodes.SPACE || key == KeyCodes.ENTER) {
+    if (key == Keys.SPACE || key == Keys.ENTER) {
       if (this.options_.includes(event.target)) {
         event.preventDefault();
         const el = dev().assertElement(event.target);

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -431,8 +431,8 @@ export class AmpSelector extends AMP.BaseElement {
     if (this.element.hasAttribute('disabled')) {
       return;
     }
-    const {keyCode} = event;
-    switch (keyCode) {
+    const {key} = event;
+    switch (key) {
       case KeyCodes.LEFT_ARROW: /* fallthrough */
       case KeyCodes.UP_ARROW: /* fallthrough */
       case KeyCodes.RIGHT_ARROW: /* fallthrough */
@@ -456,7 +456,7 @@ export class AmpSelector extends AMP.BaseElement {
   navigationKeyDownHandler_(event) {
     const doc = this.win.document;
     let dir = 0;
-    switch (event.keyCode) {
+    switch (event.key) {
       case KeyCodes.LEFT_ARROW:
         // Left is considered 'previous' in LTR and 'next' in RTL.
         dir = isRTL(doc) ? 1 : -1;
@@ -506,8 +506,8 @@ export class AmpSelector extends AMP.BaseElement {
    * @param {!Event} event
    */
   selectionKeyDownHandler_(event) {
-    const {keyCode} = event;
-    if (keyCode == KeyCodes.SPACE || keyCode == KeyCodes.ENTER) {
+    const {key} = event;
+    if (key == KeyCodes.SPACE || key == KeyCodes.ENTER) {
       if (this.options_.includes(event.target)) {
         event.preventDefault();
         const el = dev().assertElement(event.target);

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-selector';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 
 describes.realWin('amp-selector', {
   win: { /* window spec */
@@ -557,14 +557,14 @@ describes.realWin('amp-selector', {
       yield ampSelector.build();
       let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
-      keyPress(ampSelector, KeyCodes.ENTER, impl.options_[3]);
+      keyPress(ampSelector, Keys.ENTER, impl.options_[3]);
       expect(impl.options_[3].hasAttribute('selected')).to.be.true;
       expect(setSelectionSpy).to.have.been.calledWith(impl.options_[3]);
       expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[1]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
-      keyPress(ampSelector, KeyCodes.ENTER, impl.options_[3]);
+      keyPress(ampSelector, Keys.ENTER, impl.options_[3]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
@@ -585,19 +585,19 @@ describes.realWin('amp-selector', {
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
-      keyPress(ampSelector, KeyCodes.SPACE, impl.options_[4]);
+      keyPress(ampSelector, Keys.SPACE, impl.options_[4]);
       expect(impl.options_[4].hasAttribute('selected')).to.be.true;
       expect(setSelectionSpy).to.have.been.calledWith(impl.options_[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.not.have.been.called;
 
-      keyPress(ampSelector, KeyCodes.SPACE, impl.options_[4]);
+      keyPress(ampSelector, Keys.SPACE, impl.options_[4]);
       expect(impl.options_[4].hasAttribute('selected')).to.be.false;
       expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
-      keyPress(ampSelector, KeyCodes.ENTER, impl.options_[2]);
+      keyPress(ampSelector, Keys.ENTER, impl.options_[2]);
       expect(impl.options_[2].hasAttribute('selected')).to.be.true;
       expect(setSelectionSpy).to.have.been.calledWith(impl.options_[2]);
       expect(setSelectionSpy).to.have.been.calledTwice;
@@ -620,7 +620,7 @@ describes.realWin('amp-selector', {
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
-      keyPress(ampSelector, KeyCodes.SPACE, impl.element.children[0]);
+      keyPress(ampSelector, Keys.SPACE, impl.element.children[0]);
       expect(setSelectionSpy).to.not.have.been.called;
       expect(clearSelectionSpy).to.not.have.been.called;
     });
@@ -943,7 +943,7 @@ describes.realWin('amp-selector', {
             ampSelector.implementation_,
             'navigationKeyDownHandler_');
         ampSelector.build();
-        keyPress(ampSelector, KeyCodes.RIGHT_ARROW);
+        keyPress(ampSelector, Keys.RIGHT_ARROW);
         expect(spy).to.not.have.been.called;
       });
 
@@ -961,11 +961,11 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[0].tabIndex).to.equal(0);
         expect(ampSelector.children[1].tabIndex).to.equal(-1);
         expect(ampSelector.children[2].tabIndex).to.equal(-1);
-        keyPress(ampSelector, KeyCodes.LEFT_ARROW);
+        keyPress(ampSelector, Keys.LEFT_ARROW);
         expect(ampSelector.children[0].tabIndex).to.equal(-1);
         expect(ampSelector.children[1].tabIndex).to.equal(-1);
         expect(ampSelector.children[2].tabIndex).to.equal(0);
-        keyPress(ampSelector, KeyCodes.RIGHT_ARROW);
+        keyPress(ampSelector, Keys.RIGHT_ARROW);
         expect(ampSelector.children[0].tabIndex).to.equal(0);
         expect(ampSelector.children[1].tabIndex).to.equal(-1);
         expect(ampSelector.children[2].tabIndex).to.equal(-1);
@@ -1021,11 +1021,11 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
         expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
         expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
-        keyPress(ampSelector, KeyCodes.DOWN_ARROW);
+        keyPress(ampSelector, Keys.DOWN_ARROW);
         expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
         expect(ampSelector.children[1].hasAttribute('selected')).to.be.true;
         expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
-        keyPress(ampSelector, KeyCodes.UP_ARROW);
+        keyPress(ampSelector, Keys.UP_ARROW);
         expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
         expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
         expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -88,7 +88,7 @@ describes.realWin('amp-selector', {
     function keyPress(ampSelector, key, opt_target) {
       const impl = ampSelector.implementation_;
       const event = {
-        key: key,
+        key,
         preventDefault: () => {},
         target: opt_target,
       };

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -88,7 +88,7 @@ describes.realWin('amp-selector', {
     function keyPress(ampSelector, key, opt_target) {
       const impl = ampSelector.implementation_;
       const event = {
-        keyCode: key,
+        key: key,
         preventDefault: () => {},
         target: opt_target,
       };

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -16,7 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {Toolbar} from './toolbar';
 import {closestByTag, isRTL, tryFocus} from '../../../src/dom';
@@ -149,7 +149,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
-      if (event.key == KeyCodes.ESCAPE) {
+      if (event.key == Keys.ESCAPE) {
         this.close_();
       }
     });

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -149,7 +149,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
-      if (event.keyCode == KeyCodes.ESCAPE) {
+      if (event.key == KeyCodes.ESCAPE) {
         this.close_();
       }
     });

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -321,7 +321,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         if (eventObj.initEvent) {
           eventObj.initEvent('keydown', true, true);
         }
-        eventObj.keyCode = KeyCodes.ESCAPE;
+        eventObj.key = KeyCodes.ESCAPE;
         eventObj.which = KeyCodes.ESCAPE;
         const el = doc.documentElement;
         el.dispatchEvent ?

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -21,6 +21,9 @@ import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
 
+// Represents the correct value of KeyboardEvent.which for the Escape key
+const KEYBOARD_EVENT_WHICH_ESCAPE = 27;
+
 describes.realWin('amp-sidebar 0.1 version', {
   win: { /* window spec */
     location: '...',
@@ -322,7 +325,7 @@ describes.realWin('amp-sidebar 0.1 version', {
           eventObj.initEvent('keydown', true, true);
         }
         eventObj.key = Keys.ESCAPE;
-        eventObj.which = Keys.ESCAPE;
+        eventObj.which = KEYBOARD_EVENT_WHICH_ESCAPE;
         const el = doc.documentElement;
         el.dispatchEvent ?
           el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -17,7 +17,7 @@
 
 import '../amp-sidebar';
 import * as lolex from 'lolex';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
 
@@ -321,8 +321,8 @@ describes.realWin('amp-sidebar 0.1 version', {
         if (eventObj.initEvent) {
           eventObj.initEvent('keydown', true, true);
         }
-        eventObj.key = KeyCodes.ESCAPE;
-        eventObj.which = KeyCodes.ESCAPE;
+        eventObj.key = Keys.ESCAPE;
+        eventObj.which = Keys.ESCAPE;
         const el = doc.documentElement;
         el.dispatchEvent ?
           el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -133,8 +133,8 @@ class AmpSocialShare extends AMP.BaseElement {
    * @private
    */
   handleKeyPress_(event) {
-    const {keyCode} = event;
-    if (keyCode == KeyCodes.SPACE || keyCode == KeyCodes.ENTER) {
+    const {key} = event;
+    if (key == KeyCodes.SPACE || key == KeyCodes.ENTER) {
       event.preventDefault();
       this.handleActivation_();
     }

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -15,7 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-social-share-0.1.css';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {addParamsToUrl, parseQueryString} from '../../../src/url';
 import {dev, user} from '../../../src/log';
@@ -134,7 +134,7 @@ class AmpSocialShare extends AMP.BaseElement {
    */
   handleKeyPress_(event) {
     const {key} = event;
-    if (key == KeyCodes.SPACE || key == KeyCodes.ENTER) {
+    if (key == Keys.SPACE || key == Keys.ENTER) {
       event.preventDefault();
       this.handleActivation_();
     }

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -263,11 +263,11 @@ describes.realWin('amp-social-share', {
     return getShare('twitter').then(el => {
       const nonActivationEvent = {
         preventDefault: () => {},
-        keyCode: KeyCodes.RIGHT_ARROW,
+        key: KeyCodes.RIGHT_ARROW,
       };
       const activationEvent = {
         preventDefault: () => {},
-        keyCode: KeyCodes.SPACE,
+        key: KeyCodes.SPACE,
       };
       el.implementation_.handleKeyPress_(nonActivationEvent);
       expect(el.implementation_.win.open).to.not.have.been.called;

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-social-share';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 
 const STRINGS = {
@@ -263,11 +263,11 @@ describes.realWin('amp-social-share', {
     return getShare('twitter').then(el => {
       const nonActivationEvent = {
         preventDefault: () => {},
-        key: KeyCodes.RIGHT_ARROW,
+        key: Keys.RIGHT_ARROW,
       };
       const activationEvent = {
         preventDefault: () => {},
-        key: KeyCodes.SPACE,
+        key: Keys.SPACE,
       };
       el.implementation_.handleKeyPress_(nonActivationEvent);
       expect(el.implementation_.win.open).to.not.have.been.called;

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -22,7 +22,7 @@ import {
   ScrollableShareWidget,
 } from './amp-story-share';
 import {EventType, dispatch} from './events';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
 import {closest} from '../../../src/dom';
@@ -360,7 +360,7 @@ export class Bookend {
       if (!this.isActive_()) {
         return;
       }
-      if (event.key == KeyCodes.ESCAPE) {
+      if (event.key == Keys.ESCAPE) {
         event.preventDefault();
         this.close_();
       }

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -360,7 +360,7 @@ export class Bookend {
       if (!this.isActive_()) {
         return;
       }
-      if (event.keyCode == KeyCodes.ESCAPE) {
+      if (event.key == KeyCodes.ESCAPE) {
         event.preventDefault();
         this.close_();
       }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -52,7 +52,7 @@ import {
 import {EventType, dispatch} from './events';
 import {Gestures} from '../../../src/gesture';
 import {InfoDialog} from './amp-story-info-dialog';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {
   LocalizationService,
@@ -969,10 +969,10 @@ export class AmpStory extends AMP.BaseElement {
 
     switch (e.key) {
       // TODO(newmuis): This will need to be flipped for RTL.
-      case KeyCodes.LEFT_ARROW:
+      case Keys.LEFT_ARROW:
         this.previous_();
         break;
-      case KeyCodes.RIGHT_ARROW:
+      case Keys.RIGHT_ARROW:
         this.next_();
         break;
     }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -967,7 +967,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    switch (e.keyCode) {
+    switch (e.key) {
       // TODO(newmuis): This will need to be flipped for RTL.
       case KeyCodes.LEFT_ARROW:
         this.previous_();

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -25,7 +25,8 @@ import {registerServiceBuilder} from '../../../../src/service';
 
 const NOOP = () => {};
 const IDENTITY_FN = x => x;
-
+// Represents the correct value of KeyboardEvent.which for the Right Arrow
+const KEYBOARD_EVENT_WHICH_RIGHT_ARROW = 39;
 
 describes.realWin('amp-story', {
   amp: {
@@ -286,7 +287,7 @@ describes.realWin('amp-story', {
 
     const eventObj = createEvent('keydown');
     eventObj.key = Keys.RIGHT_ARROW;
-    eventObj.which = Keys.RIGHT_ARROW;
+    eventObj.which = KEYBOARD_EVENT_WHICH_RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?
       docEl.dispatchEvent(eventObj) :

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -285,7 +285,7 @@ describes.realWin('amp-story', {
         });
 
     const eventObj = createEvent('keydown');
-    eventObj.keyCode = KeyCodes.RIGHT_ARROW;
+    eventObj.key = KeyCodes.RIGHT_ARROW;
     eventObj.which = KeyCodes.RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -17,7 +17,7 @@ import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
 import {EventType} from '../events';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../localization';
 import {PaginationButtons} from '../pagination-buttons';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -285,8 +285,8 @@ describes.realWin('amp-story', {
         });
 
     const eventObj = createEvent('keydown');
-    eventObj.key = KeyCodes.RIGHT_ARROW;
-    eventObj.which = KeyCodes.RIGHT_ARROW;
+    eventObj.key = Keys.RIGHT_ARROW;
+    eventObj.which = Keys.RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?
       docEl.dispatchEvent(eventObj) :

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1152,7 +1152,7 @@ export class AmpStory extends AMP.BaseElement {
 
     const rtlState = this.storeService_.get(StateProperty.RTL_STATE);
 
-    switch (e.keyCode) {
+    switch (e.key) {
       case KeyCodes.LEFT_ARROW:
         rtlState ? this.next_() : this.previous_();
         break;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -49,7 +49,7 @@ import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
 import {Gestures} from '../../../src/gesture';
 import {InfoDialog} from './amp-story-info-dialog';
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {
   LocalizationService,
@@ -1153,10 +1153,10 @@ export class AmpStory extends AMP.BaseElement {
     const rtlState = this.storeService_.get(StateProperty.RTL_STATE);
 
     switch (e.key) {
-      case KeyCodes.LEFT_ARROW:
+      case Keys.LEFT_ARROW:
         rtlState ? this.next_() : this.previous_();
         break;
-      case KeyCodes.RIGHT_ARROW:
+      case Keys.RIGHT_ARROW:
         rtlState ? this.previous_() : this.next_();
         break;
     }

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -267,7 +267,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
       if (!this.isActive_()) {
         return;
       }
-      if (event.keyCode == KeyCodes.ESCAPE) {
+      if (event.key == KeyCodes.ESCAPE) {
         event.preventDefault();
         this.close_();
       }

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -29,7 +29,7 @@ import {
   ScrollableShareWidget,
 } from '../amp-story-share';
 import {EventType, dispatch} from '../events';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizedStringId} from '../localization';
 import {Services} from '../../../../src/services';
 import {closest} from '../../../../src/dom';
@@ -267,7 +267,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
       if (!this.isActive_()) {
         return;
       }
-      if (event.key == KeyCodes.ESCAPE) {
+      if (event.key == Keys.ESCAPE) {
         event.preventDefault();
         this.close_();
       }

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -279,7 +279,7 @@ describes.realWin('amp-story', {
         });
 
     const eventObj = createEvent('keydown');
-    eventObj.keyCode = KeyCodes.RIGHT_ARROW;
+    eventObj.key = KeyCodes.RIGHT_ARROW;
     eventObj.which = KeyCodes.RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -36,7 +36,8 @@ import {registerServiceBuilder} from '../../../../src/service';
 
 
 const NOOP = () => {};
-
+// Represents the correct value of KeyboardEvent.which for the Right Arrow
+const KEYBOARD_EVENT_WHICH_RIGHT_ARROW = 39;
 
 describes.realWin('amp-story', {
   amp: {
@@ -280,7 +281,7 @@ describes.realWin('amp-story', {
 
     const eventObj = createEvent('keydown');
     eventObj.key = Keys.RIGHT_ARROW;
-    eventObj.which = Keys.RIGHT_ARROW;
+    eventObj.which = KEYBOARD_EVENT_WHICH_RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?
       docEl.dispatchEvent(eventObj) :

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -26,7 +26,7 @@ import {ActionTrust} from '../../../../src/action-constants';
 import {AmpStory} from '../amp-story';
 import {AmpStoryConsent} from '../amp-story-consent';
 import {EventType} from '../events';
-import {KeyCodes} from '../../../../src/utils/key-codes';
+import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../localization';
 import {MediaType} from '../media-pool';
 import {PageState} from '../amp-story-page';
@@ -279,8 +279,8 @@ describes.realWin('amp-story', {
         });
 
     const eventObj = createEvent('keydown');
-    eventObj.key = KeyCodes.RIGHT_ARROW;
-    eventObj.which = KeyCodes.RIGHT_ARROW;
+    eventObj.key = Keys.RIGHT_ARROW;
+    eventObj.which = Keys.RIGHT_ARROW;
     const docEl = win.document.documentElement;
     docEl.dispatchEvent ?
       docEl.dispatchEvent(eventObj) :

--- a/extensions/amp-viewer-integration/0.1/touch-handler.js
+++ b/extensions/amp-viewer-integration/0.1/touch-handler.js
@@ -24,7 +24,7 @@ import {listen} from '../../../src/event-helper';
  * @const {!Array<string>}
  */
 const EVENT_PROPERTIES = [
-  'altKey', 'charCode', 'ctrlKey', 'detail', 'eventPhase', 'keyCode',
+  'altKey', 'charCode', 'ctrlKey', 'detail', 'eventPhase', 'key',
   'layerX', 'layerY', 'metaKey', 'pageX', 'pageY', 'returnValue',
   'shiftKey', 'timeStamp', 'type', 'which',
 ];

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {ActionTrust, RAW_OBJECT_ARGS_KEY} from '../action-constants';
-import {KeyCodes} from '../utils/key-codes';
+import {Keys} from '../utils/key-codes';
 import {Services} from '../services';
 import {debounce, throttle} from '../utils/rate-limit';
 import {dev, user} from '../log';
@@ -287,7 +287,7 @@ export class ActionService {
       this.root_.addEventListener('keydown', event => {
         const element = dev().assertElement(event.target);
         const {key} = event;
-        if (key == KeyCodes.ENTER || key == KeyCodes.SPACE) {
+        if (key == Keys.ENTER || key == Keys.SPACE) {
           const role = element.getAttribute('role');
           const isTapEventRole =
               (role && hasOwn(TAPPABLE_ARIA_ROLES, role.toLowerCase()));

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -286,8 +286,8 @@ export class ActionService {
       });
       this.root_.addEventListener('keydown', event => {
         const element = dev().assertElement(event.target);
-        const {keyCode} = event;
-        if (keyCode == KeyCodes.ENTER || keyCode == KeyCodes.SPACE) {
+        const {key} = event;
+        if (key == KeyCodes.ENTER || key == KeyCodes.SPACE) {
           const role = element.getAttribute('role');
           const isTapEventRole =
               (role && hasOwn(TAPPABLE_ARIA_ROLES, role.toLowerCase()));

--- a/src/utils/key-codes.js
+++ b/src/utils/key-codes.js
@@ -15,14 +15,14 @@
  */
 
 /**
- * @enum {number}
+ * @enum {string}
  */
-export const KeyCodes = {
-  ENTER: 13,
-  ESCAPE: 27,
-  SPACE: 32,
-  LEFT_ARROW: 37,
-  UP_ARROW: 38,
-  RIGHT_ARROW: 39,
-  DOWN_ARROW: 40,
+export const Keys = {
+  ENTER: 'Enter',
+  ESCAPE: 'Escape',
+  SPACE: ' ',
+  LEFT_ARROW: 'ArrowLeft',
+  UP_ARROW: 'ArrowUp',
+  RIGHT_ARROW: 'ArrowRight',
+  DOWN_ARROW: 'ArrowDown',
 };

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -23,7 +23,7 @@ import {
 } from '../../src/service/action-impl';
 import {ActionTrust, RAW_OBJECT_ARGS_KEY} from '../../src/action-constants';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
-import {KeyCodes} from '../../src/utils/key-codes';
+import {Keys} from '../../src/utils/key-codes';
 import {createCustomEvent} from '../../src/event-helper';
 import {createElementWithAttributes} from '../../src/dom';
 import {setParentWindow} from '../../src/service';
@@ -1109,7 +1109,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     element.setAttribute('role', 'button');
     const event = {
       target: element,
-      key: KeyCodes.ENTER,
+      key: Keys.ENTER,
       preventDefault: sandbox.stub()};
     handler(event);
     expect(event.preventDefault).to.have.been.called;
@@ -1125,7 +1125,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     element.setAttribute('role', 'option');
     const event = {
       target: element,
-      key: KeyCodes.ENTER,
+      key: Keys.ENTER,
       preventDefault: sandbox.stub()};
     handler(event);
     expect(event.preventDefault).to.have.been.called;
@@ -1138,7 +1138,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('div');
     element.setAttribute('role', 'not-a-button');
-    const event = {target: element, key: KeyCodes.ENTER};
+    const event = {target: element, key: Keys.ENTER};
     handler(event);
     expect(action.trigger).to.not.have.been.called;
   });
@@ -1148,7 +1148,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(window.document.addEventListener).to.have.been.calledWith('keydown');
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('input');
-    const event = {target: element, key: KeyCodes.ENTER};
+    const event = {target: element, key: Keys.ENTER};
     handler(event);
     expect(action.trigger).to.not.have.been.called;
   });

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1109,7 +1109,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     element.setAttribute('role', 'button');
     const event = {
       target: element,
-      keyCode: KeyCodes.ENTER,
+      key: KeyCodes.ENTER,
       preventDefault: sandbox.stub()};
     handler(event);
     expect(event.preventDefault).to.have.been.called;
@@ -1125,7 +1125,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     element.setAttribute('role', 'option');
     const event = {
       target: element,
-      keyCode: KeyCodes.ENTER,
+      key: KeyCodes.ENTER,
       preventDefault: sandbox.stub()};
     handler(event);
     expect(event.preventDefault).to.have.been.called;
@@ -1138,7 +1138,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('div');
     element.setAttribute('role', 'not-a-button');
-    const event = {target: element, keyCode: KeyCodes.ENTER};
+    const event = {target: element, key: KeyCodes.ENTER};
     handler(event);
     expect(action.trigger).to.not.have.been.called;
   });
@@ -1148,7 +1148,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(window.document.addEventListener).to.have.been.calledWith('keydown');
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('input');
-    const event = {target: element, keyCode: KeyCodes.ENTER};
+    const event = {target: element, key: KeyCodes.ENTER};
     handler(event);
     expect(action.trigger).to.not.have.been.called;
   });


### PR DESCRIPTION
Fixes #17553

KeyboardEvent.keyCode is deprecated in favor KeyboardEvent.key.

KeyboardEvent.key has broad support and a better API.
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key