### PR TITLE
Force unique ID for all AMP accordions

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -64,7 +64,7 @@ class AmpAccordion extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {string} */
+    /** @private {number|string} */
     this.suffix_ = element.id ? element.id :
       Math.floor(Math.random() * Math.floor(100));
 

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -64,6 +64,11 @@ class AmpAccordion extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
+    /** @private {string} */
+    this.suffix_ = element.id ? element.id :
+      Math.floor(Math.random() * Math.floor(100));
+
+
   }
 
   /** @override */
@@ -102,10 +107,7 @@ class AmpAccordion extends AMP.BaseElement {
         // we need to make sure that each accordion has a unique ID.
         // In case the accordion doesn't have an ID we use a
         // random number to ensure uniqueness.
-        const suffix = this.element.id ?
-          this.element.id :
-          Math.floor(Math.random() * Math.floor(100));
-        contentId = suffix + '_AMP_content_' + index;
+        contentId = this.suffix_ + '_AMP_content_' + index;
         content.setAttribute('id', contentId);
       }
 

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -98,7 +98,14 @@ class AmpAccordion extends AMP.BaseElement {
       content.classList.add('i-amphtml-accordion-content');
       let contentId = content.getAttribute('id');
       if (!contentId) {
-        contentId = this.element.id + '_AMP_content_' + index;
+        // To ensure that we pass Accessibility audits -
+        // we need to make sure that each accordion has a unique ID.
+        // In case the accordion doesn't have an ID we use a
+        // random number to ensure uniqueness.
+        const suffix = this.element.id ?
+          this.element.id :
+          Math.floor(Math.random() * Math.floor(100));
+        contentId = suffix + '_AMP_content_' + index;
         content.setAttribute('id', contentId);
       }
 

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -80,6 +80,20 @@ describes.realWin('amp-accordion', {
         });
       });
 
+  it('multiple accordions should not have the same IDs on content',
+      () => {
+        return getAmpAccordion().then(() => {
+          return getAmpAccordion().then(() => {
+            const contentElements =
+              doc.getElementsByClassName('i-amphtml-accordion-content');
+            for (let i = 0; i < contentElements.length; i++) {
+              expect(contentElements[i].id.startsWith(
+                  '_AMP_content_')).to.be.false;
+            }
+          });
+        });
+      });
+
   it('should collapse when toggle action is triggered on a expanded section',
       () => {
         return getAmpAccordion().then(ampAccordion => {


### PR DESCRIPTION
Fixes #18516.

Generates a random ID for all accordions that don't have a user specified ID to ensure uniqueness.

Note that this doesn't fix the case where users use the same ID for multiple accordions. That burden still lies on the web developers. 