### PR TITLE
Fix the audio hint text positioning when the info icon is present.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -120,12 +120,12 @@
   transform-origin: right !important;
 }
 
-[info] .i-amphtml-message-container {
+.first-page-active[info] .i-amphtml-message-container {
   /* 48px for info button, add width to padding for additional story buttons. */
   padding-right: 48px !important;
 }
 
-[info][dir=rtl] .i-amphtml-message-container {
+.first-page-active[info][dir=rtl] .i-amphtml-message-container {
   /* 48px for info button, add width to padding for additional story buttons. */
   padding-right: auto !important;
   padding-left: 48px !important;


### PR DESCRIPTION
Addresses this spacing issue when the info button is present but hidden:

![image](https://user-images.githubusercontent.com/1492044/46437912-788f2100-c72a-11e8-8963-35369f932178.png)

Fixes #18449