### PR TITLE
🐛Fix transition when using amp-image-lightbox in a shadow doc.

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -966,7 +966,7 @@ class AmpImageLightbox extends AMP.BaseElement {
             this.sourceImage_.src) {
       transLayer = this.element.ownerDocument.createElement('div');
       transLayer.classList.add('i-amphtml-image-lightbox-trans');
-      this.element.ownerDocument.body.appendChild(transLayer);
+      this.getAmpDoc().getBody().appendChild(transLayer);
 
       const rect = layoutRectFromDomRect(this.sourceImage_
           ./*OK*/getBoundingClientRect());
@@ -1017,7 +1017,7 @@ class AmpImageLightbox extends AMP.BaseElement {
       setStyles(this.element, {opacity: ''});
       setStyles(dev().assertElement(this.container_), {opacity: ''});
       if (transLayer) {
-        this.element.ownerDocument.body.removeChild(transLayer);
+        this.getAmpDoc().getBody().removeChild(transLayer);
       }
     });
   }
@@ -1043,7 +1043,7 @@ class AmpImageLightbox extends AMP.BaseElement {
     if (isLoaded(image) && image.src && this.sourceImage_) {
       transLayer = this.element.ownerDocument.createElement('div');
       transLayer.classList.add('i-amphtml-image-lightbox-trans');
-      this.element.ownerDocument.body.appendChild(transLayer);
+      this.getAmpDoc().getBody().appendChild(transLayer);
 
       const rect = layoutRectFromDomRect(this.sourceImage_
           ./*OK*/getBoundingClientRect());
@@ -1108,7 +1108,7 @@ class AmpImageLightbox extends AMP.BaseElement {
       });
       setStyles(dev().assertElement(this.container_), {opacity: ''});
       if (transLayer) {
-        this.element.ownerDocument.body.removeChild(transLayer);
+        this.getAmpDoc().getBody().removeChild(transLayer);
       }
       this.reset_();
     });

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -979,7 +979,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
                   opacity: 0,
                 });
                 sourceElement.classList.add('i-amphtml-ghost');
-                this.element.ownerDocument.body.appendChild(transLayer);
+                this.getAmpDoc().getBody().appendChild(transLayer);
               });
         }).then(() => {
           return anim.start(duration).thenAlways(() => {
@@ -988,7 +988,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
               setStyles(dev().assertElement(this.carousel_), {opacity: ''});
               sourceElement.classList.remove('i-amphtml-ghost');
               if (transLayer) {
-                this.element.ownerDocument.body.removeChild(transLayer);
+                this.getAmpDoc().getBody().removeChild(transLayer);
               }
             });
           });
@@ -1127,7 +1127,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
           const transitionMutate = () => {
             sourceElement.classList.add('i-amphtml-ghost');
-            this.element.ownerDocument.body.appendChild(transLayer);
+            this.getAmpDoc().getBody().appendChild(transLayer);
             setStyles(dev().assertElement(this.carousel_), {
               opacity: 0,
             });
@@ -1147,7 +1147,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
               });
               toggle(dev().assertElement(this.carousel_), false);
               toggle(this.element, false);
-              this.element.ownerDocument.body.removeChild(transLayer);
+              this.getAmpDoc().getBody().removeChild(transLayer);
             });
           });
         });


### PR DESCRIPTION
Append the transition layer to the correct body. This is needed for 2 reasons:

1. The coordinates are relative to to the containing body and not the page (due to position absolute). If we append to the document body, the coordinates will be incorrect for the shadow doc case. This could also be fixed by using `position: fixed` and not using `layoutRectFromDomRect`.
2. Styles needed for the transition are defined in CSS, which may only available in the shadow document, where the `<amp-image-lightbox>` is defined.

Fixes #18523
