### PR TITLE
Break words in story navigation overlay.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-hint.css
+++ b/extensions/amp-story/1.0/amp-story-hint.css
@@ -45,9 +45,10 @@
 }
 
 .i-amphtml-story-navigation-help-section {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: relative !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 .prev-page {
@@ -184,6 +185,8 @@
   font-family: 'Roboto-Medium', sans-serif !important;
   margin-top: 24px !important;
   text-align: center !important;
+  word-break: break-word !important;
+  padding: 0 6px !important;
 }
 
 @keyframes expandingBubble {


### PR DESCRIPTION
Break words in the story navigation overlay to make sure it can fit any language.
[before](https://user-images.githubusercontent.com/1492044/46439913-dffb9f80-c72f-11e8-856f-5a1a64408b87.png) / [after](https://user-images.githubusercontent.com/1492044/46439916-e68a1700-c72f-11e8-8a5a-034e22f56f23.png)

Fixes #18349