### PR TITLE
🐛Expander: Fix handling of falsey resolvers

### DIFF
--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -443,6 +443,8 @@ describes.realWin('amp-ad-exit', {
   });
 
   it('should replace custom URL variables with vars', () => {
+    // TODO(ccordry): Remove this after url-replacement v1 deletion
+    toggleExperiment(win, 'url-replacement-v2', true);
     const open = sandbox.stub(win, 'open').callsFake(() => {
       return {name: 'fakeWin'};
     });
@@ -469,6 +471,7 @@ describes.realWin('amp-ad-exit', {
     expect(sendBeacon)
         .to.have.been.calledWith(
             'http://localhost:8000/tracking?numVar=0&boolVar=false', '');
+    toggleExperiment(win, 'url-replacement-v2', false);
   });
 
   it('border protection', () => {

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -252,10 +252,14 @@ export class Expander {
       // If there is no sync resolution we can not wait.
       user().error(TAG, 'ignoring async replacement key: ', bindingInfo.name);
       binding = '';
-    } else {
+    } else if (hasOwn(bindingInfo, 'async')) {
       // Prefer the async over the sync but it may not exist.
-      binding = bindingInfo.async || bindingInfo.sync;
+      binding = bindingInfo.async;
+    } else {
+      // Use sync in async resolution if async resolver does not exist.
+      binding = bindingInfo.sync;
     }
+
     return opt_sync ?
       this.evaluateBindingSync_(binding, name, opt_args, opt_collectVars) :
       this.evaluateBindingAsync_(binding, name, opt_args, opt_collectVars);
@@ -338,7 +342,8 @@ export class Expander {
         // may return a promise.
         user().error(TAG, 'ignoring async macro resolution');
         result = '';
-      } else if (typeof value === 'string' || typeof value === 'number') {
+      } else if (typeof value === 'string' || typeof value === 'number' ||
+          typeof value === 'boolean') {
         // Normal case.
         result = NOENCODE_WHITELIST[name] ? value.toString() :
           encodeURIComponent(/** @type {string} */ (value));

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -261,6 +261,14 @@ describes.realWin('Expander', {
               .to.eventually.equal(expected);
         });
 
+        it('should handle falsey values', () => {
+          variableSource.setAsync('ZERO', 0);
+          variableSource.setAsync('FALSE', false);
+          const expander = new Expander(variableSource);
+          return expect(expander.expand('a=ZERO&b=FALSE', mockBindings))
+              .to.eventually.equal('a=0&b=false');
+        });
+
         it('throws on bad input with back ticks', () => {
           const url = 'CONCAT(bad`hello`, world)';
           allowConsoleError(() => { expect(() => {


### PR DESCRIPTION
Fixes a bug where the new expander would not handle falsey values correctly in certain situations.