### PR TITLE
amp-list resize partial fix with signals for overflow-clicked

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -473,7 +473,7 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
 }
 
 .i-amphtml-loading-container {
-  display: block !important;
+  display: block;
   z-index: 1;
 }
 
@@ -484,12 +484,16 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
 /**
  * `i-amphtml-loading-container`, `i-amphtml-loader` and `i-amphtml-loader-dot` all support
  * a "loading indicator" usecase. `i-amphtml-loading-container` is mostly responsible
- * for alighning the loading indicator, while `i-amphtml-loader` and
+ * for aligning the loading indicator, while `i-amphtml-loader` and
  * `i-amphtml-loader-dot` are an implementation for a default loading indicator. The
  * default implementation includes the three-dot layout and animation.
  */
 .i-amphtml-loading-container.amp-hidden {
   visibility: hidden;
+}
+
+amp-list > .i-amphtml-loading-container.amp-hidden {
+  display: none !important;
 }
 
 .i-amphtml-loader-line {

--- a/css/amp.css
+++ b/css/amp.css
@@ -492,8 +492,8 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   visibility: hidden;
 }
 
-amp-list > .i-amphtml-loading-container.amp-hidden {
-  display: none !important;
+amp-list[auto-resize] > .i-amphtml-loading-container.amp-hidden {
+  display: none;
 }
 
 .i-amphtml-loader-line {

--- a/css/amp.css
+++ b/css/amp.css
@@ -492,6 +492,11 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   visibility: hidden;
 }
 
+/**
+ * The default amp-hidden changes visibility, which takes up space. In the case
+ * where amp-list becomes a container via the auto-resize attribute, the loader
+ * should be fully hidden and not take up space.
+ */
 amp-list[auto-resize] > .i-amphtml-loading-container.amp-hidden {
   display: none !important;
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -473,7 +473,7 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
 }
 
 .i-amphtml-loading-container {
-  display: block;
+  display: block !important;
   z-index: 1;
 }
 
@@ -493,7 +493,7 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
 }
 
 amp-list[auto-resize] > .i-amphtml-loading-container.amp-hidden {
-  display: none;
+  display: none !important;
 }
 
 .i-amphtml-loader-line {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -480,18 +480,12 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * If the element has the auto-resize attribute, changes to layout container
-   * for all layouts except FLEX_ITEM.
+   * If the element has the auto-resize attribute, change to layout container.
    * @private
    */
   applyAutoResize_() {
     const layout = this.element.getAttribute('layout');
-    if (layout == Layout.FLEX_ITEM) {
-      // TODO(cathyxz, #17824): Flex-item + reset-on-refresh will add
-      // an invisible loader that fills the amp-list and shoves all
-      // list items out of the amp-list.
-      return true;
-    } else if (layout !== Layout.CONTAINER) {
+    if (layout !== Layout.CONTAINER) {
       this.changeToLayoutContainer_(layout);
     }
   }
@@ -523,6 +517,16 @@ export class AmpList extends AMP.BaseElement {
     switch (previousLayout) {
       case Layout.RESPONSIVE:
         this.element.classList.remove('i-amphtml-layout-responsive');
+        setStyles(this.element, {
+          height: '',
+          width: '',
+        });
+        break;
+      case Layout.FLEX_ITEM:
+        setStyles(this.element, {
+          height: '',
+          width: '',
+        });
         break;
       case Layout.FIXED:
         this.element.classList.remove('i-amphtml-layout-fixed');

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -474,20 +474,9 @@ export class AmpList extends AMP.BaseElement {
         // If the element's size was changed, change to container layout
         // if the auto-resize attribute is set.
         this.element.signals().whenSignal(CommonSignals.SIZE_CHANGED)
-            .then(() => this.applyAutoResize_());
+            .then(() => this.changeToLayoutContainer_());
       }
     });
-  }
-
-  /**
-   * If the element has the auto-resize attribute, change to layout container.
-   * @private
-   */
-  applyAutoResize_() {
-    const layout = this.element.getAttribute('layout');
-    if (layout !== Layout.CONTAINER) {
-      this.changeToLayoutContainer_(layout);
-    }
   }
 
   /**
@@ -553,10 +542,14 @@ export class AmpList extends AMP.BaseElement {
   /**
    * Converts the amp-list to de facto layout container. Must be called in
    * mutation context.
-   * @param {string} previousLayout
    * @private
    */
-  changeToLayoutContainer_(previousLayout) {
+  changeToLayoutContainer_() {
+    const previousLayout = this.element.getAttribute('layout');
+    // If we have already changed to layout container, no need to run again.
+    if (previousLayout == Layout.CONTAINER) {
+      return;
+    }
     this.undoPreviousLayout_(previousLayout);
     this.container_.classList.remove(
         'i-amphtml-fill-content',
@@ -569,7 +562,6 @@ export class AmpList extends AMP.BaseElement {
     if (overflowElement) {
       toggle(overflowElement, false);
     }
-
     this.element.setAttribute('layout', 'container');
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -17,6 +17,7 @@
 import * as setDOM from 'set-dom/src/index';
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
+import {CommonSignals} from '../../../src/common-signals';
 import {Deferred} from '../../../src/utils/promise';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Pass} from '../../../src/pass';
@@ -467,46 +468,49 @@ export class AmpList extends AMP.BaseElement {
       this.container_.dispatchEvent(event);
 
       // Attempt to resize to fit new rendered contents.
-      this.attemptToFit_(this.container_, () => {
-        // If auto-resize is set, then change to container layout instead of
-        // changing height (with one exception).
-        if (this.element.hasAttribute('auto-resize')) {
-          const layout = this.element.getAttribute('layout');
-          if (layout == Layout.FLEX_ITEM) {
-            // TODO(cathyxz, #17824): Flex-item + reset-on-refresh will add
-            // an invisible loader that fills the amp-list and shoves all
-            // list items out of the amp-list.
-            return true;
-          } else if (layout !== Layout.CONTAINER) {
-            this.changeToLayoutContainer_(layout);
-          }
-          return false;
-        }
-        return true;
-      });
+      this.attemptToFit_(this.container_);
+
+      if (this.element.hasAttribute('auto-resize')) {
+        // If the element's size was changed, change to container layout
+        // if the auto-resize attribute is set.
+        this.element.signals().whenSignal(CommonSignals.SIZE_CHANGED)
+            .then(() => this.applyAutoResize_());
+      }
     });
+  }
+
+  /**
+   * If the element has the auto-resize attribute, changes to layout container
+   * for all layouts except FLEX_ITEM.
+   * @private
+   */
+  applyAutoResize_() {
+    const layout = this.element.getAttribute('layout');
+    if (layout == Layout.FLEX_ITEM) {
+      // TODO(cathyxz, #17824): Flex-item + reset-on-refresh will add
+      // an invisible loader that fills the amp-list and shoves all
+      // list items out of the amp-list.
+      return true;
+    } else if (layout !== Layout.CONTAINER) {
+      this.changeToLayoutContainer_(layout);
+    }
   }
 
   /**
    * Attempts to change the height of the amp-list to fit a target child.
    *
-   * If the target's height is greater than the amp-list's height, and
-   * opt_decider returns truthy (or is not provided), then attempt to change the
-   * amp-list's height to fit the target.
+   * If the target's height is greater than the amp-list's height, attempt
+   * to change the amp-list's height to fit the target.
    *
    * @param {!Element} target
-   * @param {function():boolean=} opt_decider
    * @private
    */
-  attemptToFit_(target, opt_decider) {
+  attemptToFit_(target) {
     this.measureElement(() => {
       const scrollHeight = target./*OK*/scrollHeight;
       const height = this.element./*OK*/offsetHeight;
       if (scrollHeight > height) {
-        const shouldResize = !opt_decider || opt_decider();
-        if (shouldResize) {
-          this.attemptChangeHeight(scrollHeight).catch(() => {});
-        }
+        this.attemptChangeHeight(scrollHeight).catch(() => {});
       }
     });
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -473,7 +473,7 @@ export class AmpList extends AMP.BaseElement {
       if (this.element.hasAttribute('auto-resize')) {
         // If the element's size was changed, change to container layout
         // if the auto-resize attribute is set.
-        this.element.signals().whenSignal(CommonSignals.SIZE_CHANGED)
+        this.element.signals().whenSignal(CommonSignals.CHANGE_SIZE_END)
             .then(() => this.changeToLayoutContainer_());
       }
     });

--- a/test/manual/amp-list-resize-flex.amp.html
+++ b/test/manual/amp-list-resize-flex.amp.html
@@ -57,7 +57,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
-  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 </head>
 <body>
@@ -75,7 +75,7 @@
 
   <div class="flex">
     <amp-img src="/examples/img/sample.jpg" width=80 height=60></amp-img>
-    <amp-list width="396" height="80" layout="flex-item"
+    <amp-list width="396" height="80" layout="flex-item" auto-resize
         src="/test/manual/amp-list-data.json?RANDOM">
       <template type="amp-mustache">
         <div class="story-entry">
@@ -94,7 +94,7 @@
   <h2>AMP List Resize with Accordion</h2>
   <div class="flex">
     <amp-img src="/examples/img/sample.jpg" width=80 height=60></amp-img>
-    <amp-list width="396" height="80" layout="flex-item" reset-on-refresh
+    <amp-list width="396" height="80" layout="flex-item" auto-resize reset-on-refresh
         src="/test/manual/amp-list-data.json">
       <template type="amp-mustache">
         <div class="story-entry">
@@ -129,6 +129,7 @@
       height="80"
       layout="flex-item"
       reset-on-refresh
+      auto-resize
       src="/test/manual/amp-list-data.json?RANDOM">
       <template type="amp-mustache">
         <div class="story-entry" [class]="'story-entry ' + listStyle">
@@ -168,6 +169,7 @@
       layout="flex-item"
       src="/search/countries"
       reset-on-refresh
+      auto-resize
       [src]="'/search/countries?q=' + query">
       <template type="amp-mustache">
         {{#results}}

--- a/test/manual/amp-list-resize.amp.html
+++ b/test/manual/amp-list-resize.amp.html
@@ -68,7 +68,7 @@
 
   <h2>AMP List Basic</h2>
   <p>Test this under slow internet (throttle to slow 3G).</p>
-  <amp-list width="396" height="80" layout="responsive" auto-resize
+  <amp-list width="396" height="80" layout="responsive" auto-resize reset-on-refresh
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">
       <div class="story-entry">
@@ -82,6 +82,21 @@
   </amp-list>
 
   <div class="split"></div>
+
+  <h2>AMP List Basic Below fold</h2>
+  <p>Test this under slow internet (throttle to slow 3G).</p>
+  <amp-list width="396" height="80" layout="responsive" auto-resize reset-on-refresh
+      src="/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      <div class="story-entry">
+        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
+        {{title}}
+      </div>
+    </template>
+    <div overflow>
+      SEE MORE
+    </div>
+  </amp-list>
 
   <h2>AMP List Resize with Accordion</h2>
   <amp-list width="396" height="80" layout=responsive reset-on-refresh auto-resize


### PR DESCRIPTION
Partial fix for https://github.com/ampproject/amphtml/issues/18376, depends on #18580. Talked to @aghassemi offline and it seems like we need a relatively urgent fix to prevent people from relying on erroneous behaviour. 

This adds a `size-changed` signal that triggers whenever `changeSize` is called. `<amp-list>` with `auto-resize` listens to this signal and applies `changeToLayoutContainer` whenever a changeSize is triggered. So basically it will only change to layout container after we trigger a change size. 

This does not handle the remaining use cases discussed in https://github.com/ampproject/amphtml/issues/18376. I'll prototype a tap-based / mutation observer based approach to handle that and bring that up in design review. This solution is intended as a quick fix to prevent people from relying on erroneous behavior. 

I will refactor this into so that the `size-change` signal is it's own PR and add tests. This approach guarantees: 
1. No resize will happen if bottom of list is in viewport (overflow element will show). 
2. Change to layout container will happen if bottom of list is not in viewport (attemptChangeSize results in call to `resources.ChangeSize`, which will trigger the `size-changed` signal). 
3. Change to layout container will happen if overflow element is clicked (overflow callback triggers `resources.changeSize`, triggers the `size-changed` signal). 
Caveats: 
1. If `<amp-list>` containing `<amp-accordion>` or togglable CSS attributes is not in viewport at time of load and their heights are correct, they will not ever show the overflow attribute and will never change to layout container. 
TODO: 
- [x] Separate out signals PR + test
- [x] Rebase after broken master is fixed.