### PR TITLE
Whitelist amp-selector for use in amp-pan-zoom

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -44,12 +44,12 @@ const TAG = 'amp-pan-zoom';
 const DEFAULT_MAX_SCALE = 3;
 const MAX_ANIMATION_DURATION = 250;
 
-
 const ELIGIBLE_TAGS = {
   'svg': true,
   'DIV': true,
   'AMP-IMG': true,
   'AMP-LAYOUT': true,
+  'AMP-SELECTOR': true,
 };
 
 const SUPPORT_VALIDATION_MSG = `${TAG} should


### PR DESCRIPTION
@cathyxz Curious about the context of this tag whitelist. Is it possible to remove the whitelist and replace with documentation + a runtime warning, or at least relax it e.g. allow anything with `layout=container`?

`b/115690618#comment21`