### PR TITLE
Layers: fix Resource detection of measurement changes

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -439,13 +439,13 @@ export class Resource {
 
     this.isMeasureRequested_ = false;
 
-    const oldBox = this.getPageLayoutBox();
+    const oldBox = this.layoutBox_;
     if (this.useLayers_) {
       this.measureViaLayers_();
     } else {
       this.measureViaResources_();
     }
-    const box = this.getPageLayoutBox();
+    const box = this.layoutBox_;
 
     // Note that "left" doesn't affect readiness for the layout.
     const sizeChanges = !layoutRectSizeEquals(oldBox, box);
@@ -516,6 +516,7 @@ export class Resource {
      * for both 2 and 3, we need for force it.
      */
     layers.remeasure(element, /* opt_force */ true);
+    this.layoutBox_ = this.getPageLayoutBox();
   }
 
   /**


### PR DESCRIPTION
Layers tries to eagerly remeasure whatever is necessary. In some cases, that means that we could remeasure a child element _before_ necessary, even though Resources will still think it needs remeasure.

In most cases, this would be fine. But, because we were using the latest value of `getPageLayoutBox`, it would fail to detect that measurements changed. Instead, we need to keep track of the last time we measured, and compare against that.