### PR TITLE
[amp-pan-zoom] should clear previous width/height on resetContentDimensions

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -372,30 +372,40 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   resetContentDimensions_() {
     const content = dev().assertElement(this.content_);
-    return this.mutateElement(() => {
-      // Clear content dimensions if any
-      setStyles(content, {
-        width: '',
-        height: '',
-      });
-    }).then(() => {
-      return this.measureMutateElement(
-          () => this.measure_(),
-          () => {
-            // Set the actual dimensions of the content
-            setStyles(content, {
-              width: px(this.contentBox_.width),
-              height: px(this.contentBox_.height),
-            });
-          }, content).then(() => {
-        const contentBox =
-          layoutRectFromDomRect(this.content_./*OK*/getBoundingClientRect());
-        // Set content positions to offset from element box
-        this.contentBox_.top = contentBox.top - this.elementBox_.top;
-        this.contentBox_.left = contentBox.left - this.elementBox_.left;
-        this.updatePanZoomBounds_(this.scale_);
-        return this.updatePanZoom_();
-      });
+    return this.mutateElement(() => this.clearDimensions_())
+        .then(() => {
+          return this.measureMutateElement(
+              () => this.measure_(),
+              () => this.setDimensions_(), content).then(() => {
+            const contentBox =
+              layoutRectFromDomRect(content./*OK*/getBoundingClientRect());
+            // Set content positions to offset from element box
+            this.contentBox_.top = contentBox.top - this.elementBox_.top;
+            this.contentBox_.left = contentBox.left - this.elementBox_.left;
+            this.updatePanZoomBounds_(this.scale_);
+            return this.updatePanZoom_();
+          });
+        });
+  }
+
+  /**
+   * Set content dimensions so that they fit exactly within
+   * amp-pan-zoom.
+   */
+  setDimensions_() {
+    setStyles(dev().assertElement(this.content_), {
+      width: px(this.contentBox_.width),
+      height: px(this.contentBox_.height),
+    });
+  }
+
+  /**
+   * Clears content dimensions if any
+   */
+  clearDimensions_() {
+    setStyles(dev().assertElement(this.content_), {
+      width: '',
+      height: '',
     });
   }
 

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -372,22 +372,30 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   resetContentDimensions_() {
     const content = dev().assertElement(this.content_);
-    return this.measureMutateElement(
-        () => this.measure_(),
-        () => {
-          // Set the actual dimensions of the content
-          setStyles(content, {
-            width: px(this.contentBox_.width),
-            height: px(this.contentBox_.height),
-          });
-        }, content).then(() => {
-      const contentBox =
-        layoutRectFromDomRect(this.content_./*OK*/getBoundingClientRect());
-      // Set content positions to offset from element box
-      this.contentBox_.top = contentBox.top - this.elementBox_.top;
-      this.contentBox_.left = contentBox.left - this.elementBox_.left;
-      this.updatePanZoomBounds_(this.scale_);
-      return this.updatePanZoom_();
+    return this.mutateElement(() => {
+      // Clear content dimensions if any
+      setStyles(content, {
+        width: '',
+        height: '',
+      });
+    }).then(() => {
+      return this.measureMutateElement(
+          () => this.measure_(),
+          () => {
+            // Set the actual dimensions of the content
+            setStyles(content, {
+              width: px(this.contentBox_.width),
+              height: px(this.contentBox_.height),
+            });
+          }, content).then(() => {
+        const contentBox =
+          layoutRectFromDomRect(this.content_./*OK*/getBoundingClientRect());
+        // Set content positions to offset from element box
+        this.contentBox_.top = contentBox.top - this.elementBox_.top;
+        this.contentBox_.left = contentBox.left - this.elementBox_.left;
+        this.updatePanZoomBounds_(this.scale_);
+        return this.updatePanZoom_();
+      });
     });
   }
 

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -371,21 +371,28 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @private
    */
   resetContentDimensions_() {
-    const content = dev().assertElement(this.content_);
     return this.mutateElement(() => this.clearDimensions_())
-        .then(() => {
-          return this.measureMutateElement(
-              () => this.measure_(),
-              () => this.setDimensions_(), content).then(() => {
-            const contentBox =
-              layoutRectFromDomRect(content./*OK*/getBoundingClientRect());
-            // Set content positions to offset from element box
-            this.contentBox_.top = contentBox.top - this.elementBox_.top;
-            this.contentBox_.left = contentBox.left - this.elementBox_.left;
-            this.updatePanZoomBounds_(this.scale_);
-            return this.updatePanZoom_();
-          });
+        .then(() => this.measureMutateElement(
+            () => this.measure_(),
+            () => this.setDimensions_(), dev().assertElement(this.content_))
+        ).then(() => {
+          this.setContentBoxOffsets_();
+          this.updatePanZoomBounds_(this.scale_);
+          return this.updatePanZoom_();
         });
+  }
+
+  /**
+   * Sets the top and left values of the contentBox as offset from
+   * pan-zoom container
+   */
+  setContentBoxOffsets_() {
+    const contentBox =
+    layoutRectFromDomRect(dev().assertElement(this.content_)
+        ./*OK*/getBoundingClientRect());
+    // Set content positions to offset from element box
+    this.contentBox_.top = contentBox.top - this.elementBox_.top;
+    this.contentBox_.left = contentBox.left - this.elementBox_.left;
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -18,6 +18,7 @@ import '../amp-pan-zoom';
 import {createPointerEvent} from '../../../../testing/test-helper';
 import {htmlFor} from '../../../../src/static-template';
 import {listenOncePromise} from '../../../../src/event-helper';
+import {setStyles} from '../../../../src/style';
 
 describes.realWin('amp-pan-zoom', {
   amp: {
@@ -247,6 +248,24 @@ describes.realWin('amp-pan-zoom', {
           expect(svg.style.transform)
               .to.equal('translate(10px, 20px) scale(2)');
         });
+  });
+
+  describe('reset-on-resize', () => {
+    it('should clear inline width/height before measuring', async function() {
+      await getPanZoom();
+      await el.layoutCallback();
+      expect(svg.style.width).to.equal('300px');
+      expect(svg.style.height).to.equal('300px');
+      setStyles(svg, {
+        'width': '50px',
+        'height': '400px',
+      });
+      expect(svg.style.width).to.equal('50px');
+      expect(svg.style.height).to.equal('400px');
+      await impl.resetContentDimensions_();
+      expect(svg.style.width).to.equal('300px');
+      expect(svg.style.height).to.equal('300px');
+    });
   });
 
   describe('gestures', () => {

--- a/test/manual/amp-pan-zoom-initial.amp.html
+++ b/test/manual/amp-pan-zoom-initial.amp.html
@@ -100,7 +100,7 @@
     svg {
       background-color: #4682B4;
       opacity: 0.3;
-      /* padding-top: 30px; */
+      padding-top: 30px;
     }
 
   </style>

--- a/test/manual/amp-pan-zoom-initial.amp.html
+++ b/test/manual/amp-pan-zoom-initial.amp.html
@@ -100,6 +100,7 @@
     svg {
       background-color: #4682B4;
       opacity: 0.3;
+      /* padding-top: 30px; */
     }
 
   </style>
@@ -139,8 +140,8 @@
   <p>The content here is bottom aligned. </p>
   <p [text]="'Current scale: ' + scale">Current scale: 1</p>
     <amp-layout layout="responsive" height="1" width="1">
-      <amp-pan-zoom id="bottom-align" layout="fill" on="transformEnd:AMP.setState({scale: event.scale})">
-      <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
+      <amp-pan-zoom id="bottom-align" reset-on-resize layout="fill" on="transformEnd:AMP.setState({scale: event.scale})">
+      <svg id="hasPadding" viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
           <rect class="area-half" x="5" y="5" />
           <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
               <rect class="seat-selected" [class]="seat == 1 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 1})" x="10" y="10" tabindex="0" role="button" />
@@ -180,7 +181,7 @@
   <p>The content here is top aligned. </p>
   <p [text]="'Current scale: ' + scale">Current scale: 1</p>
     <amp-layout layout="responsive" height="1" width="1">
-      <amp-pan-zoom id="top-align" layout="fill" on="transformEnd:AMP.setState({scale: event.scale})">
+      <amp-pan-zoom reset-on-resize id="top-align" layout="fill" on="transformEnd:AMP.setState({scale: event.scale})">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
           <rect class="area-half" x="5" y="5" />
           <g class="hide" [class]="scale < 2 ? 'hide' : ''" >


### PR DESCRIPTION
This should fix the shrinking svg issue in https://codepen.io/cathyxz/full/aRNdbO/, fixes https://github.com/ampproject/amphtml/issues/18501. 