### PR TITLE
Expose results from HTML5 Geolocation API to AMP

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -133,6 +133,7 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {name: 'amp-geo', version: '0.1', type: TYPES.MISC},
+  {name: 'amp-geolocation',version: '0.1',type: TYPES.MISC},
   {name: 'amp-gfycat', version: '0.1', type: TYPES.MEDIA},
   {name: 'amp-gist', version: '0.1', type: TYPES.MISC},
   {

--- a/examples/amp-geolocation.amp.html
+++ b/examples/amp-geolocation.amp.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-geolocation example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    .hide {display: none;}
+  </style>
+  <script async custom-element="amp-geolocation" src="https://cdn.ampproject.org/v0/amp-geolocation-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-state id="egnews">
+    <script type="application/json">
+    {
+      "visibility": "hide"
+    }
+    </script>
+  </amp-state>
+  <amp-geolocation layout="nodisplay"></amp-geolocation>
+  <h1>amp-geolocation</h1>
+  <h2>window.navigator.geolocation.getCurrentPosition() bind for AMP</h2>
+  <button on="tap:AMP.setState({})">Where am I?</button>
+  <div class="hide" [class]="visibility||'show'">
+    <b>Latitude:</b> <span [text]="ampGeolocation.latitude">0</span> <br />
+    <b>Longitude:</b> <span [text]="ampGeolocation.longitude">0</span> <br />
+    scroll to see iframe
+
+    <br />gibberish text to fill the viewport <br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <br />
+    Assumenda obcaecati voluptatibus laboriosam nemo facere quia, aut minima, asperiores veritatis delectus porro fuga eaque ullam laudantium dignissimos animi neque deserunt quis.<br />
+
+
+    <amp-iframe width=400 height=300
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        layout="fixed"
+        frameborder="0"
+        [src]= "'https://www.google.com/maps/embed/v1/place?key=AIzaSyDG9YXIhKBhqclZizcSzJ0ROiE0qgVfwzI&zoom=12&q='+ampGeolocation.latitude+','+ampGeolocation.longitude"
+        src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDG9YXIhKBhqclZizcSzJ0ROiE0qgVfwzI&q=">
+    </amp-iframe>
+  </div>
+</body>
+</html>

--- a/extensions/amp-geolocation/0.1/amp-geolocation.js
+++ b/extensions/amp-geolocation/0.1/amp-geolocation.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ gulp lint --files extensions/amp-geolocation/0.1/amp-geolocation.js
+ gulp check-types --files extensions/amp-geolocation/0.1/amp-geolocation.js
+ gulp presubmit --files extensions/amp-geolocation/0.1/amp-geolocation.js
+ */
+
+import {Deferred} from '../../../src/utils/promise';
+import {waitForBodyPromise} from '../../../src/dom';
+
+/** @const */
+const TAG = 'amp-geolocation';
+const STATE_ID = 'ampGeolocation';
+const SERVICE_TAG = 'geolocation';
+
+export let GeolocationDef;
+export class AmpGeolocation extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {string} */
+    this.latitude_ = '0';
+    /** @private {string} */
+    this.longitude_ = '0';
+
+  }
+
+  /**
+  * @param {Object} currentPosition
+  * @private
+  */
+  getCurrentPosition_(currentPosition) {
+    this.latitude_ = currentPosition.coords.latitude;
+    this.longitude_ = currentPosition.coords.longitude;
+
+    const geo = this.addToBody_();
+
+    geolocationDeferred.resolve(geo);
+
+  }
+
+  /** @override */
+  buildCallback() {
+    window.navigator.geolocation.getCurrentPosition(
+        this.getCurrentPosition_.bind(this)
+    );
+  }
+
+  /**
+   * @private
+   */
+  addToBody_() {
+    const doc = this.win.document;
+    /** @type {Object} */
+    const states = {};
+    const self = this;
+
+    return waitForBodyPromise(doc).then(() => {
+
+      // Let the runtime know we're mutating the doc.body
+      self.mutateElement(() => {
+        const geolocationState = doc.getElementById(STATE_ID);
+        if (geolocationState) {
+          geolocationState.parentNode.removeChild(geolocationState);
+        }
+        states.latitude = this.latitude_;
+        states.longitude = this.longitude_;
+        const state = doc.createElement('amp-state');
+        const confScript = doc.createElement('script');
+        confScript.setAttribute('type', 'application/json');
+        confScript.textContent =
+            JSON.stringify(/** @type {!JsonObject} */(states)) ;
+        state.appendChild(confScript);
+        state.id = STATE_ID;
+        doc.body.appendChild(state);
+      }, doc.body);
+
+      return {
+        latitude: self.latitude_,
+        longitude: self.longitude_,
+      };
+
+    });
+  }
+
+}
+
+/**
+ * Create the service promise at load time to prevent race between extensions
+ */
+
+/** singleton */
+let geolocationDeferred = null;
+AMP.extension(TAG, '0.1', AMP => {
+  geolocationDeferred = new Deferred();
+  AMP.registerElement(TAG, AmpGeolocation);
+  AMP.registerServiceForDoc(SERVICE_TAG, () => geolocationDeferred.promise);
+});

--- a/extensions/amp-geolocation/0.1/test/test-amp-geolocation.js
+++ b/extensions/amp-geolocation/0.1/test/test-amp-geolocation.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import '../amp-hello-world';
+import {AmpGeolocation} from '../amp-geolocation';
+
+
+describes.realWin('amp-geolocation', {
+  amp: {
+    extensions: ['amp-geolocation'],
+  },
+}, env => {
+
+  let win;
+  let element;
+  let comp;
+
+  beforeEach(() => {
+    win = env.win;
+    element = win.document.createElement('amp-geolocation');
+    win.document.body.appendChild(element);
+    comp = new AmpGeolocation(element);
+  });
+
+  it('will fix this if this extension makes sense', () => {
+    comp.buildCallback();
+    expect('amp-geolocation').to.equal('amp-geolocation');
+  });
+});

--- a/extensions/amp-geolocation/OWNERS.yaml
+++ b/extensions/amp-geolocation/OWNERS.yaml
@@ -1,0 +1,1 @@
+- eduardogoncalves

--- a/extensions/amp-geolocation/amp-geolocation.md
+++ b/extensions/amp-geolocation/amp-geolocation.md
@@ -1,0 +1,51 @@
+<!--
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="`amp-geolocation`"></a> `amp-geolocation`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>window.navigator.geolocation.getCurrentPosition() bind for AMP <br />WILL FIX this if this component makes sense.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-geolocation-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+</table>
+
+## Behavior
+
+FILL THIS IN. What does this extension do?
+
+## Attributes
+
+FILL THIS IN. Does this extension allow for properties to configure?
+
+## Validation
+See [amp-geolocation rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-geolocation/validator-amp-geolocation.protoascii) in the AMP validator specification.

--- a/extensions/amp-geolocation/validator-amp-geolocation.protoascii
+++ b/extensions/amp-geolocation/validator-amp-geolocation.protoascii
@@ -1,0 +1,36 @@
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-geolocation
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-geolocation"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-geolocation>
+  html_format: AMP
+  tag_name: "AMP-GEOLOCATION"
+  requires_extension: "amp-geolocation"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-geolocation"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}


### PR DESCRIPTION
Try to implement FR #8929 
Hi, I'm trying to expose results from HTML5 Geolocation API (window.navigator.geolocation.getCurrentPosition()) to AMP. So I can get user's lat/log once the user has consented, to call an weather/map api to provide personalized results in response, based on geo
In the example file [http://localhost:8000/examples/amp-geolocation.amp.html](http://localhost:8000/examples/amp-geolocation.amp.html) I'm able to get user's lat/log. When tapping Where am I? button, it shows users current location on map.
**_I still didn't make any validations/test/documentation, but I will if this PR makes sense._**
Thanks
￼
![captura de tela 2018-10-04 as 18 28 11](https://user-images.githubusercontent.com/4308648/46533947-7638de00-c874-11e8-986d-a25bbdfa7e03.png)

/cc @aghassemi @choumx
