### PR TITLE
Desktop navigation animation improvements.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -153,8 +153,16 @@ amp-story[standalone][desktop] {
   border-radius: 16px !important;
 }
 
+[dir=rtl] [desktop] amp-story-page.i-amphtml-element {
+  transform: scale(0.9) translateX(calc(-350% - 192px)) translateY(0%) !important;
+}
+
 [desktop] amp-story-page[i-amphtml-visited] {
   transform: scale(0.9) translateX(calc(-350% - 192px)) translateY(0%) !important;
+}
+
+[dir=rtl] [desktop] amp-story-page[i-amphtml-visited] {
+  transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
 }
 
 [desktop] amp-story-page[i-amphtml-desktop-position="-2"],
@@ -181,7 +189,9 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page[active],
-[desktop] amp-story-page[i-amphtml-desktop-position="0"] {
+[dir=rtl] [desktop] amp-story-page[active],
+[desktop] amp-story-page[i-amphtml-desktop-position="0"],
+[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="0"] {
   transform: scale(1.0) translateX(-50%) translateY(0%) !important;
   opacity: 1 !important;
 }

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -84,20 +84,6 @@ amp-story[standalone][desktop] {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-[desktop] amp-story-page[distance] {
-  transform: scale(1.0) translateX(50vw) translateY(0%) !important;
-  opacity: .05 !important;
-  transform-origin: left !important;
-  border-radius: 16px !important;
-}
-
-[desktop] amp-story-page[distance="0"],
-[desktop] amp-story-page[distance="1"] {
-  /* TODO(alanorozco): Enable transition for distance = 2.
-   * For some reason, enabling it breaks layout scheduling. */
-  transition: opacity 300ms linear, transform 300ms cubic-bezier(0.4, 0.0, 0.2, 1) !important;
-}
-
 [desktop] .i-amphtml-story-button-container {
   position: absolute !important;
   top: 0 !important;
@@ -155,36 +141,67 @@ amp-story[standalone][desktop] {
   left: 0 !important;
 }
 
-[desktop] amp-story-page[i-amphtml-visited] {
-  transform: scale(0.9) translateX(-200vw) translateY(0%) !important;
+/**
+ * Page positions and animations.
+ */
+
+[desktop] amp-story-page.i-amphtml-element {
+  transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
+  opacity: 0.05 !important;
+  transform-origin: left !important;
+  border-radius: 16px !important;
 }
 
-[desktop] amp-story-page[i-amphtml-previous-page],
+[desktop] amp-story-page[i-amphtml-visited] {
+  transform: scale(0.9) translateX(calc(-350% - 192px)) translateY(0%) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-desktop-position="-2"],
+[desktop] amp-story-page[i-amphtml-desktop-position="-1"],
+[desktop] amp-story-page[i-amphtml-desktop-position="1"],
+[desktop] amp-story-page[i-amphtml-desktop-position="2"] {
+  transition: opacity 350ms ease-out, transform 350ms cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-desktop-position="0"] {
+  transition: opacity 350ms cubic-bezier(0.0, 0.0, 0.2, 1), transform 350ms cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-desktop-position="-2"],
+[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="2"] {
+  transform: scale(0.9) translateX(calc(-250% - 128px)) translateY(0%) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-desktop-position="-1"],
 .prev-container > .i-amphtml-story-page-sentinel,
-[dir=rtl] [desktop] amp-story-page[i-amphtml-next-page],
+[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="1"],
 [dir=rtl] .next-container > .i-amphtml-story-page-sentinel {
-  /* -150% + 15% */
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
 }
 
-[desktop] amp-story-page[active] {
+[desktop] amp-story-page[active],
+[desktop] amp-story-page[i-amphtml-desktop-position="0"] {
   transform: scale(1.0) translateX(-50%) translateY(0%) !important;
   opacity: 1 !important;
 }
 
-[desktop] amp-story-page[i-amphtml-next-page],
+[desktop] amp-story-page[i-amphtml-desktop-position="1"],
 .next-container > .i-amphtml-story-page-sentinel,
-[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page],
+[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="-1"],
 [dir=rtl] .prev-container > .i-amphtml-story-page-sentinel {
-  /* 50% - 15% */
   transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-desktop-position="2"],
+[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="-2"] {
+  transform: scale(0.9) translate(calc(150% + 128px), 0%) !important;
 }
 
 /**
  * If the next page is protected behind a paywall, blur its content and display
  * a lock icon on top of it.
  */
-[desktop] amp-story-page[i-amphtml-next-page][amp-access-hide]::before {
+[desktop] amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before {
   content: '' !important;
   position: absolute !important;
   top: 50% !important;
@@ -196,7 +213,7 @@ amp-story[standalone][desktop] {
   z-index: 4 !important; /** Above amp-story-cta-layer and amp-story-grid-layer. */
 }
 
-[desktop] amp-story-page[i-amphtml-next-page][amp-access-hide] > * {
+[desktop] amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide] > * {
   filter: blur(8px) !important;
 }
 
@@ -243,17 +260,17 @@ amp-story[standalone][desktop] {
   justify-content: center!important;
   align-items: center!important;
   opacity: .5!important;
-  transition: 150ms opacity linear, 300ms transform linear!important;
+  transition: 150ms opacity linear, 350ms transform linear!important;
   cursor: pointer!important;
   z-index: 100002!important;
   outline: none!important;
 }
 
-.i-amphtml-story-prev-hover > amp-story-page[i-amphtml-previous-page] {
+.i-amphtml-story-prev-hover > amp-story-page[i-amphtml-desktop-position="-1"] {
   opacity: 0.3 !important;
 }
 
-.i-amphtml-story-next-hover > amp-story-page[active] + amp-story-page {
+.i-amphtml-story-next-hover > amp-story-page[i-amphtml-desktop-position="0"] + amp-story-page {
   opacity: 0.3 !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -146,6 +146,7 @@ amp-story[standalone][desktop] {
  */
 
 [desktop] amp-story-page.i-amphtml-element {
+  /* Pages are stacked to the right side of the screen and then animated in. */
   transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
   opacity: 0.05 !important;
   transform-origin: left !important;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -84,7 +84,7 @@ const TAG = 'amp-story-page';
 const ADVERTISEMENT_ATTR_NAME = 'ad';
 
 /** @private @const {number} */
-const REWIND_TIMEOUT_MS = 300;
+const REWIND_TIMEOUT_MS = 350;
 
 /**
  * amp-story-page states.
@@ -708,13 +708,13 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets the ID of the next page in the story (after the current page).
-   * @param {boolean=} opt_isAutomaticAdvance Whether this navigation was caused
+   * @param {boolean=} isAutomaticAdvance Whether this navigation was caused
    *     by an automatic advancement after a timeout.
    * @return {?string} Returns the ID of the next page in the story, or null if
    *     there isn't one.
    */
-  getNextPageId(opt_isAutomaticAdvance) {
-    if (opt_isAutomaticAdvance &&
+  getNextPageId(isAutomaticAdvance = false) {
+    if (isAutomaticAdvance &&
         this.element.hasAttribute('auto-advance-to')) {
       return this.element.getAttribute('auto-advance-to');
     }
@@ -750,11 +750,11 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Navigates to the next page in the story.
-   * @param {boolean=} opt_isAutomaticAdvance Whether this navigation was caused
+   * @param {boolean=} isAutomaticAdvance Whether this navigation was caused
    *     by an automatic advancement after a timeout.
    */
-  next(opt_isAutomaticAdvance) {
-    const pageId = this.getNextPageId(opt_isAutomaticAdvance);
+  next(isAutomaticAdvance = false) {
+    const pageId = this.getNextPageId(isAutomaticAdvance);
 
     if (!pageId) {
       return;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -994,7 +994,9 @@ export class AmpStory extends AMP.BaseElement {
           oldPage.setState(PageState.NOT_ACTIVE);
 
           // Indication that this should be offscreen to left in desktop view.
-          setAttributeInMutate(oldPage, Attributes.VISITED);
+          this.getPageIndex(oldPage) < pageIndex ?
+            setAttributeInMutate(oldPage, Attributes.VISITED) :
+            removeAttributeInMutate(oldPage, Attributes.VISITED);
         }
 
         this.storeService_.dispatch(Action.CHANGE_PAGE, {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -993,7 +993,8 @@ export class AmpStory extends AMP.BaseElement {
         if (oldPage) {
           oldPage.setState(PageState.NOT_ACTIVE);
 
-          // Indication that this should be offscreen to left in desktop view.
+          // Indication to know where to display the page on the desktop
+          // ribbon-like animation.
           this.getPageIndex(oldPage) < pageIndex ?
             setAttributeInMutate(oldPage, Attributes.VISITED) :
             removeAttributeInMutate(oldPage, Attributes.VISITED);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1086,13 +1086,12 @@ export class AmpStory extends AMP.BaseElement {
       }
     }
 
-    const plusOneId = targetPage.getNextPageId(false /** isAutomaticAdvance */);
+    const plusOneId = targetPage.getNextPageId();
     if (plusOneId) {
       const plusOnePage = this.getPageById(plusOneId);
       list.push({page: plusOnePage, position: 1});
 
-      const plusTwoId =
-          plusOnePage.getNextPageId(false /** isAutomaticAdvance */);
+      const plusTwoId = plusOnePage.getNextPageId();
       if (plusTwoId) {
         list.push({page: this.getPageById(plusTwoId), position: 2});
       }
@@ -1106,8 +1105,8 @@ export class AmpStory extends AMP.BaseElement {
           desktopPositionsToReset =
               scopedQuerySelectorAll(
                   this.element,
-                  escapeCssSelectorIdent(
-                      `amp-story-page[${Attributes.DESKTOP_POSITION}]`));
+                  `amp-story-page[
+                      ${escapeCssSelectorIdent(Attributes.DESKTOP_POSITION)}]`);
         },
         /** mutator */
         () => {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -71,6 +71,7 @@ import {
   childElements,
   closest,
   createElementWithAttributes,
+  escapeCssSelectorIdent,
   isRTL,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
@@ -134,8 +135,7 @@ const Attributes = {
   AUTO_ADVANCE_TO: 'auto-advance-to',
   AD_SHOWING: 'ad-showing',
   // Attributes that desktop css looks for to decide where pages will be placed
-  PREVIOUS: 'i-amphtml-previous-page', // shown in left pane
-  NEXT: 'i-amphtml-next-page', // shown in right pane
+  DESKTOP_POSITION: 'i-amphtml-desktop-position',
   VISITED: 'i-amphtml-visited', // stacked offscreen to left
 };
 
@@ -228,12 +228,6 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private {?./amp-story-page.AmpStoryPage} */
     this.activePage_ = null;
-
-    /** @private {?./amp-story-page.AmpStoryPage} */
-    this.previousPage_ = null;
-
-    /** @private {?./amp-story-page.AmpStoryPage} */
-    this.nextPage_ = null;
 
     /** @private @const */
     this.desktopMedia_ = this.win.matchMedia(
@@ -980,6 +974,10 @@ export class AmpStory extends AMP.BaseElement {
       () => {
         oldPage && oldPage.element.removeAttribute('active');
 
+        if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
+          this.setDesktopPositionAttributes_(targetPage);
+        }
+
         // Starts playing the page, if the story is not paused.
         // Note: navigation is prevented when the story is paused, this test
         // covers the case where the story is rendered paused (eg: consent).
@@ -1030,8 +1028,6 @@ export class AmpStory extends AMP.BaseElement {
           this.activePage_.unmuteAllMedia();
         }
 
-        this.handlePreviewAttributes_(targetPage);
-
         this.updateBackground_(targetPage.element, /* initial */ !oldPage);
       },
       // Third and last step contains all the actions that can be delayed after
@@ -1069,32 +1065,60 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Clear existing preview attributes, Check to see if there is a next or
    * previous page, set new attributes.
-   * @param {!./amp-story-page.AmpStoryPage} targetPage
+   * @param {?./amp-story-page.AmpStoryPage} targetPage
    * @private
    */
-  handlePreviewAttributes_(targetPage) {
-    if (this.previousPage_) {
-      removeAttributeInMutate(this.previousPage_, Attributes.PREVIOUS);
-      this.previousPage_ = null;
+  setDesktopPositionAttributes_(targetPage) {
+    if (!targetPage) {
+      return;
     }
 
-    if (this.nextPage_) {
-      removeAttributeInMutate(this.nextPage_, Attributes.NEXT);
-      this.nextPage_ = null;
+    const list = [{page: targetPage, position: 0}];
+
+    const minusOneId = targetPage.getPreviousPageId();
+    if (minusOneId) {
+      const minusOnePage = this.getPageById(minusOneId);
+      list.push({page: minusOnePage, position: -1});
+
+      const minusTwoId = minusOnePage.getPreviousPageId();
+      if (minusTwoId) {
+        list.push({page: this.getPageById(minusTwoId), position: -2});
+      }
     }
 
-    const prevPageId = targetPage.getPreviousPageId();
-    if (prevPageId) {
-      this.previousPage_ = this.getPageById(prevPageId);
-      setAttributeInMutate(this.previousPage_, Attributes.PREVIOUS);
+    const plusOneId = targetPage.getNextPageId(false /** isAutomaticAdvance */);
+    if (plusOneId) {
+      const plusOnePage = this.getPageById(plusOneId);
+      list.push({page: plusOnePage, position: 1});
+
+      const plusTwoId =
+          plusOnePage.getNextPageId(false /** isAutomaticAdvance */);
+      if (plusTwoId) {
+        list.push({page: this.getPageById(plusTwoId), position: 2});
+      }
     }
 
-    const nextPageId = targetPage.getNextPageId(
-        /* opt_isAutomaticAdvance */ false);
-    if (nextPageId) {
-      this.nextPage_ = this.getPageById(nextPageId);
-      setAttributeInMutate(this.nextPage_, Attributes.NEXT);
-    }
+    let desktopPositionsToReset;
+
+    this.measureMutateElement(
+        /** measurer */
+        () => {
+          desktopPositionsToReset =
+              scopedQuerySelectorAll(
+                  this.element,
+                  escapeCssSelectorIdent(
+                      `amp-story-page[${Attributes.DESKTOP_POSITION}]`));
+        },
+        /** mutator */
+        () => {
+          Array.prototype.forEach.call(desktopPositionsToReset, el => {
+            el.removeAttribute(Attributes.DESKTOP_POSITION);
+          });
+
+          list.forEach(({page, position}) => {
+            page.element.setAttribute(Attributes.DESKTOP_POSITION, position);
+          });
+        });
   }
 
 
@@ -1278,6 +1302,7 @@ export class AmpStory extends AMP.BaseElement {
         this.shareMenu_.build();
         break;
       case UIType.DESKTOP:
+        this.setDesktopPositionAttributes_(this.activePage_);
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
         });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -681,29 +681,38 @@ describes.realWin('amp-story', {
   });
 
   describe('desktop attributes', () => {
-    it('should add next page attribute', () => {
-      sandbox.stub(utils, 'setAttributeInMutate').callsFake(
-          (el, attr) => el.element.setAttribute(attr, ''));
+    it('should add desktop-position attributes', () => {
+      const desktopAttribute = 'i-amphtml-desktop-position';
+      const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
 
-      const pages = createPages(story.element, 2, ['page-0', 'page-1']);
-      const page1 = pages[1];
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+
+      story.buildCallback();
+
       return story.layoutCallback()
           .then(() => {
-            expect(page1.hasAttribute('i-amphtml-next-page')).to.be.true;
+            expect(pages[0].getAttribute(desktopAttribute)).to.equal('0');
+            expect(pages[1].getAttribute(desktopAttribute)).to.equal('1');
+            expect(pages[2].getAttribute(desktopAttribute)).to.equal('2');
+            expect(pages[3].hasAttribute(desktopAttribute)).to.be.false;
           });
     });
 
-    it('should add previous page attribute', () => {
-      sandbox.stub(story, 'maybePreloadBookend_').returns();
-      sandbox.stub(utils, 'setAttributeInMutate').callsFake(
-          (el, attr) => el.element.setAttribute(attr, ''));
+    it('should update desktop-position attributes upon navigation', () => {
+      const desktopAttribute = 'i-amphtml-desktop-position';
+      const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
 
-      const pages = createPages(story.element, 2, ['page-0', 'page-1']);
-      const page0 = pages[0];
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+
+      story.buildCallback();
+
       return story.layoutCallback()
-          .then(() => story.switchTo_('page-1'))
+          .then(() => story.switchTo_('2'))
           .then(() => {
-            expect(page0.hasAttribute('i-amphtml-previous-page')).to.be.true;
+            expect(pages[0].getAttribute(desktopAttribute)).to.equal('-2');
+            expect(pages[1].getAttribute(desktopAttribute)).to.equal('-1');
+            expect(pages[2].getAttribute(desktopAttribute)).to.equal('0');
+            expect(pages[3].getAttribute(desktopAttribute)).to.equal('1');
           });
     });
 


### PR DESCRIPTION
(_Based on @addieachan's PR #18408_)

Before: https://stamp-desktop-nav-before.firebaseapp.com/examples/s20/body-painting/index.html
After: https://stamp-desktop-nav-after.firebaseapp.com/examples/s20/body-painting/index.html

This PR fixes many issues with the desktop navigation animation:
- N-2 page used to disappear right away from the screen

N-2 page now translates out of the screen

- N+1 page would instantly appear and overlap with the transitioning active page

N+2 page is positioned correctly and translates to its N+1 position when needed, without overlapping any other page

- active page was positioned with the `[active]` attribute, and N+1/N-1 pages with other attributes that were set later. Animations weren't triggered at the exact same time and it looked very janky

All pages are now positioned against a new `i-amphtml-desktop-position` attribute, that is set in the same `mutate` callback to ensure they're all set in the same browser frame

- Opacity animation curves improvements

The active page becomes visible faster, and the N-1 page disappears a bit faster, to drag the attention on the new active page

Fixes #17985