### PR TITLE
Fixes Safari desktop background fade in.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -69,6 +69,7 @@ amp-story[standalone][desktop] {
   left: -150px !important;
   opacity: 0 !important;
   filter: blur(50px) !important;
+  transform: scale(1.2) !important;
   background-size: cover !important;
   background-color: transparent !important;
   background-position: center center !important;


### PR DESCRIPTION
The blur filter creates white edges on the background image, that are actually transparent on Safari, and would show the previous background that we thought was completely hidden. This was causing the background to flash at the end of the fadeIn animation, as we reset the previous background's opacity to 0.