### PR TITLE
Create the `<audio>` element for `<amp-audio>` allowing us to act on non laid out audios

### DIFF
--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -113,6 +113,25 @@ describes.realWin('amp-audio', {
     });
   });
 
+  it('should attach `<audio>` element and execute relevant actions for ' +
+  'layout="nodisplay"', () => {
+    return attachAndRun({
+      src: 'https://origin.com/audio.mp3',
+      preload: 'none',
+      layout: 'nodisplay',
+    }).then(ampAudio => {
+      const audio = ampAudio.querySelector('audio');
+      expect(audio).to.not.be.null;
+
+      const impl = ampAudio.implementation_;
+      impl.executeAction({method: 'play', satisfiesTrust: () => true});
+      expect(impl.isPlaying).to.be.true;
+
+      impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+      expect(impl.isPlaying).to.be.false;
+    });
+  });
+
   it('should load audio through sources', () => {
     return attachAndRun({
       width: 503,


### PR DESCRIPTION
Fixes #18566.

With this change we always create the `<audio>` element when the viewer for the document becomes visible. This allows us to call actions on non displayed `<audio>` elements as well. 

This allows the following case to work as well:
```
  <amp-audio id="audio"
    width="auto" heigh="50"
    src="av/audio.mp3"
    layout="nodisplay">
  </amp-audio>
  <button on="tap:audio.play">Play</button>
```
