### PR TITLE
Remove recently added references to `keyCodes`

### DIFF
--- a/extensions/amp-viewer-integration/0.1/keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/keyboard-handler.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {Keys} from '../../../src/utils/key-codes';
 import {dict} from '../../../src/utils/object';
 import {listen} from '../../../src/event-helper';
 
@@ -115,7 +115,7 @@ function isHandledByEventTarget(e) {
     // Various AMP components consume keyboard events by preventing the default.
     return true;
   }
-  if (e.keyCode == KeyCodes.ESCAPE) {
+  if (e.key == Keys.ESCAPE) {
     // ESC is always a valid key for things like keyboard shortcuts, even if the
     // focus is on an input control, for example.
     return false;
@@ -123,7 +123,7 @@ function isHandledByEventTarget(e) {
   switch (e.target.nodeName) {
     case 'INPUT':
       // For checkboxes, only allow swallowing the space key event.
-      return e.target.type != 'checkbox' || e.keyCode == KeyCodes.SPACE;
+      return e.target.type != 'checkbox' || e.key == Keys.SPACE;
     case 'TEXTAREA':
     case 'BUTTON':
     case 'SELECT':

--- a/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import {KeyCodes, Keys} from '../../../../src/utils/key-codes';
 import {KeyboardHandler} from '../keyboard-handler';
-import {Keys} from '../../../../src/utils/key-codes';
 import {Messaging} from '../messaging/messaging';
 
 describes.realWin('KeyboardHandler', {}, env => {
@@ -49,26 +49,34 @@ describes.realWin('KeyboardHandler', {}, env => {
             env.win, new WindowPortEmulator(env.win, 'origin doesnt matter')));
   });
 
-  ['keydown', 'keypress', 'keyup'].forEach(eventType => {
+  ['keydown'].forEach(eventType => {
     describe(`for ${eventType} events`, () => {
       describe('when event targeted on window', () => {
         it('forwards ESC events', () => {
           env.win.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+              eventType,
+              {bubbles: true,
+                key: Keys.LEFT_ARROW,
+                keyCode: KeyCodes.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           }]);
         });
 
@@ -76,7 +84,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -89,21 +97,29 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on document', () => {
         it('forwards ESC events', () => {
           env.win.document.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+              eventType,
+              {bubbles: true,
+                key: Keys.LEFT_ARROW,
+                keyCode: KeyCodes.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           }]);
         });
 
@@ -111,7 +127,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -124,21 +140,29 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on <html>', () => {
         it('forwards ESC events', () => {
           env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+              eventType,
+              {bubbles: true,
+                key: Keys.LEFT_ARROW,
+                keyCode: KeyCodes.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           }]);
         });
 
@@ -146,7 +170,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -159,21 +183,29 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on <body>', () => {
         it('forwards ESC events', () => {
           env.win.document.body.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.body.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+              eventType,
+              {bubbles: true,
+                key: Keys.LEFT_ARROW,
+                keyCode: KeyCodes.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           }]);
         });
 
@@ -181,7 +213,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -202,21 +234,29 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('forwards ESC events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC non-space events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+              eventType,
+              {bubbles: true,
+                key: Keys.LEFT_ARROW,
+                keyCode: KeyCodes.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           }]);
         });
 
@@ -224,7 +264,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -235,7 +275,10 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('does not forward space events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.SPACE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.SPACE,
+                keyCode: KeyCodes.SPACE}));
 
           expect(messages).to.be.empty;
         });
@@ -252,11 +295,15 @@ describes.realWin('KeyboardHandler', {}, env => {
 
           it('forwards ESC events', () => {
             node.dispatchEvent(new KeyboardEvent(
-                eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+                eventType,
+                {bubbles: true,
+                  key: Keys.ESCAPE,
+                  keyCode: KeyCodes.ESCAPE}));
 
             expect(messages).to.have.deep.members([{
               name: eventType,
-              data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+              data: createKeyboardEventInitWithKeyCode(
+                  Keys.ESCAPE, KeyCodes.ESCAPE),
             }]);
           });
 
@@ -264,7 +311,7 @@ describes.realWin('KeyboardHandler', {}, env => {
             const e = new KeyboardEvent(eventType, {
               bubbles: true,
               cancelable: true,
-              keyCode: Keys.ESCAPE,
+              key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
             });
             e.preventDefault();
 
@@ -275,7 +322,10 @@ describes.realWin('KeyboardHandler', {}, env => {
 
           it('does not forward non-ESC events', () => {
             node.dispatchEvent(new KeyboardEvent(
-                eventType, {bubbles: true, keyCode: Keys.SPACE}));
+                eventType,
+                {bubbles: true,
+                  key: Keys.SPACE,
+                  keyCode: KeyCodes.SPACE}));
 
             expect(messages).to.be.empty;
           });
@@ -293,11 +343,15 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('forwards ESC events', () => {
           element.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.ESCAPE,
+                keyCode: KeyCodes.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.ESCAPE, KeyCodes.ESCAPE),
           }]);
         });
 
@@ -305,7 +359,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: Keys.ESCAPE,
+            key: Keys.ESCAPE, keyCode: KeyCodes.ESCAPE,
           });
           e.preventDefault();
 
@@ -316,7 +370,10 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('does not forward non-ESC events', () => {
           element.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: Keys.SPACE}));
+              eventType,
+              {bubbles: true,
+                key: Keys.SPACE,
+                keyCode: KeyCodes.SPACE}));
 
           expect(messages).to.be.empty;
         });
@@ -325,18 +382,26 @@ describes.realWin('KeyboardHandler', {}, env => {
 
       it('forwards multiple events', () => {
         env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-            eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
+            eventType,
+            {bubbles: true,
+              key: Keys.LEFT_ARROW,
+              keyCode: KeyCodes.LEFT_ARROW}));
         env.win.document.body.dispatchEvent(new KeyboardEvent(
-            eventType, {bubbles: true, keyCode: Keys.RIGHT_ARROW}));
+            eventType,
+            {bubbles: true,
+              key: Keys.RIGHT_ARROW,
+              keyCode: KeyCodes.RIGHT_ARROW}));
 
         expect(messages).to.have.deep.members([
           {
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.LEFT_ARROW, KeyCodes.LEFT_ARROW),
           },
           {
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(Keys.RIGHT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(
+                Keys.RIGHT_ARROW, KeyCodes.RIGHT_ARROW),
           },
         ]);
       });
@@ -387,11 +452,12 @@ describes.realWin('KeyboardHandler', {}, env => {
  * Creates a `KeyboardEventInit` object with default properties overridden by
  * the given key code.
  *
+ * @param {string} key
  * @param {number} keyCode
  * @return {!JsonObject}
  */
-function createKeyboardEventInitWithKeyCode(keyCode) {
-  return createKeyboardEventInit({keyCode, which: keyCode});
+function createKeyboardEventInitWithKeyCode(key, keyCode) {
+  return createKeyboardEventInit({key, keyCode, which: keyCode});
 }
 
 /**

--- a/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-keyboard-handler.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {KeyCodes} from '../../../../src/utils/key-codes';
 import {KeyboardHandler} from '../keyboard-handler';
+import {Keys} from '../../../../src/utils/key-codes';
 import {Messaging} from '../messaging/messaging';
 
 describes.realWin('KeyboardHandler', {}, env => {
@@ -54,21 +54,21 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on window', () => {
         it('forwards ESC events', () => {
           env.win.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           }]);
         });
 
@@ -76,7 +76,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -89,21 +89,21 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on document', () => {
         it('forwards ESC events', () => {
           env.win.document.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           }]);
         });
 
@@ -111,7 +111,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -124,21 +124,21 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on <html>', () => {
         it('forwards ESC events', () => {
           env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           }]);
         });
 
@@ -146,7 +146,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -159,21 +159,21 @@ describes.realWin('KeyboardHandler', {}, env => {
       describe('when event targeted on <body>', () => {
         it('forwards ESC events', () => {
           env.win.document.body.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC events', () => {
           env.win.document.body.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           }]);
         });
 
@@ -181,7 +181,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -202,21 +202,21 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('forwards ESC events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
         it('forwards non-ESC non-space events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+              eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           }]);
         });
 
@@ -224,7 +224,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -235,7 +235,7 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('does not forward space events', () => {
           checkbox.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+              eventType, {bubbles: true, keyCode: Keys.SPACE}));
 
           expect(messages).to.be.empty;
         });
@@ -252,11 +252,11 @@ describes.realWin('KeyboardHandler', {}, env => {
 
           it('forwards ESC events', () => {
             node.dispatchEvent(new KeyboardEvent(
-                eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+                eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
             expect(messages).to.have.deep.members([{
               name: eventType,
-              data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+              data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
             }]);
           });
 
@@ -264,7 +264,7 @@ describes.realWin('KeyboardHandler', {}, env => {
             const e = new KeyboardEvent(eventType, {
               bubbles: true,
               cancelable: true,
-              keyCode: KeyCodes.ESCAPE,
+              keyCode: Keys.ESCAPE,
             });
             e.preventDefault();
 
@@ -275,7 +275,7 @@ describes.realWin('KeyboardHandler', {}, env => {
 
           it('does not forward non-ESC events', () => {
             node.dispatchEvent(new KeyboardEvent(
-                eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+                eventType, {bubbles: true, keyCode: Keys.SPACE}));
 
             expect(messages).to.be.empty;
           });
@@ -293,11 +293,11 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('forwards ESC events', () => {
           element.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.ESCAPE}));
+              eventType, {bubbles: true, keyCode: Keys.ESCAPE}));
 
           expect(messages).to.have.deep.members([{
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.ESCAPE),
+            data: createKeyboardEventInitWithKeyCode(Keys.ESCAPE),
           }]);
         });
 
@@ -305,7 +305,7 @@ describes.realWin('KeyboardHandler', {}, env => {
           const e = new KeyboardEvent(eventType, {
             bubbles: true,
             cancelable: true,
-            keyCode: KeyCodes.ESCAPE,
+            keyCode: Keys.ESCAPE,
           });
           e.preventDefault();
 
@@ -316,7 +316,7 @@ describes.realWin('KeyboardHandler', {}, env => {
 
         it('does not forward non-ESC events', () => {
           element.dispatchEvent(new KeyboardEvent(
-              eventType, {bubbles: true, keyCode: KeyCodes.SPACE}));
+              eventType, {bubbles: true, keyCode: Keys.SPACE}));
 
           expect(messages).to.be.empty;
         });
@@ -325,18 +325,18 @@ describes.realWin('KeyboardHandler', {}, env => {
 
       it('forwards multiple events', () => {
         env.win.document.documentElement.dispatchEvent(new KeyboardEvent(
-            eventType, {bubbles: true, keyCode: KeyCodes.LEFT_ARROW}));
+            eventType, {bubbles: true, keyCode: Keys.LEFT_ARROW}));
         env.win.document.body.dispatchEvent(new KeyboardEvent(
-            eventType, {bubbles: true, keyCode: KeyCodes.RIGHT_ARROW}));
+            eventType, {bubbles: true, keyCode: Keys.RIGHT_ARROW}));
 
         expect(messages).to.have.deep.members([
           {
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.LEFT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.LEFT_ARROW),
           },
           {
             name: eventType,
-            data: createKeyboardEventInitWithKeyCode(KeyCodes.RIGHT_ARROW),
+            data: createKeyboardEventInitWithKeyCode(Keys.RIGHT_ARROW),
           },
         ]);
       });

--- a/src/utils/key-codes.js
+++ b/src/utils/key-codes.js
@@ -15,6 +15,19 @@
  */
 
 /**
+ * @enum {number}
+ */
+export const KeyCodes = {
+  ENTER: 13,
+  ESCAPE: 27,
+  SPACE: 32,
+  LEFT_ARROW: 37,
+  UP_ARROW: 38,
+  RIGHT_ARROW: 39,
+  DOWN_ARROW: 40,
+};
+
+/**
  * @enum {string}
  */
 export const Keys = {


### PR DESCRIPTION
This helps get gulp check-types working again. Which is failing since https://github.com/ampproject/amphtml/pull/18437 added instances of `KeyboardEvent.keyCode` after https://github.com/ampproject/amphtml/pull/18530 removed them. 