### PR TITLE
Fix some compile errors not being output in console

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -54,7 +54,7 @@ exports.closureCompile = function(entryModuleFilename, outputDir,
             next();
             resolve();
           }, function(e) {
-            console./* OK*/error(colors.red('Compilation error:', e.message));
+            console./*OK*/error(colors.red('Compilation error:'), e.message);
             process.exit(1);
           });
     }


### PR DESCRIPTION
Fix parenthetical oopsies that results in 1-pass errors not being output in console.

Example: https://travis-ci.org/ampproject/amphtml/jobs/438038969