### PR TITLE
Don't parse CC output for swg.js warnings -- just fix them

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -408,8 +408,11 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           // Exit on type errors and warnings _except_ warnings from swg.js.
           // This is a temporary workaround for a Closure Compiler upgrade that
           // causes backwards-incompatible changes. See #18552.
-          if (hasClosureTypeErrors(message)
-            || hasNonSwgErrorsOrWarnings(message)) {
+          if (hasClosureTypeErrors(message)) {
+            console./*OK*/error('Exiting due to type errors.');
+            process.exit(1);
+          } else if (hasNonSwgErrorsOrWarnings(message)) {
+            console./*OK*/error('Exiting due to non-swg type warnings.');
             process.exit(1);
           } else {
             resolve();
@@ -441,7 +444,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
  * @return {boolean}
  */
 function hasClosureTypeErrors(message) {
-  const re = /\n(\d+) error\(s\), (\d+) warning\(s\), (\d*\d\.\d)% typed\n/g;
+  const re = /^(\d+) error\(s\), (\d+) warning\(s\)(.*)$/gm;
   const matches = re.exec(message);
   return !matches || matches[1] !== '0';
 }

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -405,20 +405,8 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           console./*OK*/error(colors.red(
               'Compiler issues for ' + outputFilename + ':\n') +
               formatClosureCompilerError(message));
-          // Exit on type errors and warnings _except_ warnings from swg.js.
-          // This is a temporary workaround for a Closure Compiler upgrade that
-          // causes backwards-incompatible changes. See #18552.
-          if (hasClosureTypeErrors(message)) {
-            console./*OK*/error('Exiting due to type errors.');
-            process.exit(1);
-          } else if (hasNonSwgErrorsOrWarnings(message)) {
-            console./*OK*/error('Exiting due to non-swg type warnings.');
-            process.exit(1);
-          } else {
-            resolve();
-          }
+          process.exit(1);
         });
-
     // If we're only doing type checking, no need to output the files.
     if (!argv.typecheck_only && !options.typeCheckOnly) {
       stream = stream
@@ -437,31 +425,4 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     }
     return stream;
   });
-}
-
-/**
- * @param {string} message
- * @return {boolean}
- */
-function hasClosureTypeErrors(message) {
-  const re = /^(\d+) error\(s\), (\d+) warning\(s\)(.*)$/gm;
-  const matches = re.exec(message);
-  return !matches || matches[1] !== '0';
-}
-
-/**
- * @param {string} message
- * @return {boolean}
- */
-function hasNonSwgErrorsOrWarnings(message) {
-  const re = /^([^:\n]+):(\d+): (WARNING|ERROR) - (.*)$/gm;
-  let matches;
-  while ((matches = re.exec(message)) !== null) {
-    const source = matches[1];
-    // Only allow type errors/warnings from swg.js.
-    if (source !== 'third_party/subscriptions-project/swg.js') {
-      return true;
-    }
-  }
-  return false;
 }

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -2270,10 +2270,10 @@ const TITLE_LANG_MAP = {
 class ButtonApi {
 
   /**
-   * @param {!../model/doc.Doc} doc
+   * @param {*} doc
    */
   constructor(doc) {
-    /** @private @const {!../model/doc.Doc} */
+    /** @private @const {*} */
     this.doc_ = doc;
   }
 
@@ -2383,14 +2383,14 @@ class Callbacks {
   }
 
   /**
-   * @param {function(!Promise<!../api/entitlements.Entitlements>)} callback
+   * @param {function(!Promise<*>)} callback
    */
   setOnEntitlementsResponse(callback) {
     this.setCallback_(CallbackId.ENTITLEMENTS, callback);
   }
 
   /**
-   * @param {!Promise<!../api/entitlements.Entitlements>} promise
+   * @param {!Promise<*>} promise
    */
   triggerEntitlementsResponse(promise) {
     return this.trigger_(
@@ -2406,14 +2406,14 @@ class Callbacks {
   }
 
   /**
-   * @param {function(!../api/subscriptions.LoginRequest)} callback
+   * @param {function(*)} callback
    */
   setOnLoginRequest(callback) {
     this.setCallback_(CallbackId.LOGIN_REQUEST, callback);
   }
 
   /**
-   * @param {!../api/subscriptions.LoginRequest} request
+   * @param {*} request
    * @return {boolean} Whether the callback has been found.
    */
   triggerLoginRequest(request) {
@@ -2483,14 +2483,14 @@ class Callbacks {
   }
 
   /**
-   * @param {function(!Promise<!../api/subscribe-response.SubscribeResponse>)} callback
+   * @param {function(!Promise<*>)} callback
    */
   setOnSubscribeResponse(callback) {
     this.setCallback_(CallbackId.SUBSCRIBE_RESPONSE, callback);
   }
 
   /**
-   * @param {!Promise<!../api/subscribe-response.SubscribeResponse>} responsePromise
+   * @param {!Promise<*>} responsePromise
    * @return {boolean} Whether the callback has been found.
    */
   triggerSubscribeResponse(responsePromise) {
@@ -2634,7 +2634,7 @@ class View {
   getElement() {}
 
   /**
-   * @param {!./dialog.Dialog} unusedDialog
+   * @param {*} unusedDialog
    * @return {!Promise}
    * @abstract
    */
@@ -2813,7 +2813,7 @@ class ActivityIframeView extends View {
 
   /**
    * @param {!web-activities/activity-ports.ActivityIframePort} port
-   * @param {!../components/dialog.Dialog} dialog
+   * @param {*} dialog
    * @return {!Promise}
    */
   onOpenIframeResponse_(port, dialog) {
@@ -3937,20 +3937,20 @@ function cacheParam(cacheKey) {
  */
 class PayStartFlow {
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    * @param {string} sku
    */
   constructor(deps, sku) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
-    /** @private @const {!./pay-client.PayClient} */
+    /** @private @const {*} */
     this.payClient_ = deps.payClient();
 
-    /** @private @const {!../model/page-config.PageConfig} */
+    /** @private @const {*} */
     this.pageConfig_ = deps.pageConfig();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private @const {string} */
@@ -3995,7 +3995,7 @@ class PayStartFlow {
 class PayCompleteFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   static configurePending(deps) {
     deps.payClient().onResponse(payPromise => {
@@ -4017,19 +4017,19 @@ class PayCompleteFlow {
   }
 
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   constructor(deps) {
     /** @private @const {!Window} */
     this.win_ = deps.win();
 
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private {?ActivityIframeView} */
@@ -4100,7 +4100,7 @@ class PayCompleteFlow {
 
 
 /**
- * @param {!./deps.DepsDef} deps
+ * @param {*} deps
  * @param {!Promise<!Object>} payPromise
  * @param {function():!Promise} completeHandler
  * @return {!Promise<!SubscribeResponse>}
@@ -4112,7 +4112,7 @@ function validatePayResponse(deps, payPromise, completeHandler) {
 
 
 /**
- * @param {!./deps.DepsDef} deps
+ * @param {*} deps
  * @param {*} data
  * @param {function():!Promise} completeHandler
  * @return {!SubscribeResponse}
@@ -4181,9 +4181,9 @@ function parseUserData(swgData) {
 
 
 /**
- * @param {!./deps.DepsDef} deps
+ * @param {*} deps
  * @param {!Object} swgData
- * @return {?../api/entitlements.Entitlements}
+ * @return {*}
  * @package Visible for testing.
  */
 function parseEntitlements(deps, swgData) {
@@ -4217,11 +4217,11 @@ function parseEntitlements(deps, swgData) {
 class DeferredAccountFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
-   * @param {?../api/deferred-account-creation.DeferredAccountCreationRequest} options
+   * @param {*} deps
+   * @param {*} options
    */
   constructor(deps, options) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!Window} */
@@ -4230,7 +4230,7 @@ class DeferredAccountFlow {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private {?ActivityIframeView} */
@@ -4239,12 +4239,12 @@ class DeferredAccountFlow {
     /** @private {?Promise} */
     this.openPromise_ = null;
 
-    /** @type {!../api/deferred-account-creation.DeferredAccountCreationRequest} */
+    /** @type {*} */
     const defaultOptions = {
       entitlements: null,
       consent: true,
     };
-    /** @private @const {!../api/deferred-account-creation.DeferredAccountCreationRequest} */
+    /** @private @const {*} */
     this.options_ = Object.assign(defaultOptions, options || {});
   }
 
@@ -4416,11 +4416,11 @@ function transition(el, props, durationMillis, curve) {
 class Graypane {
 
   /**
-   * @param {!../model/doc.Doc} doc
+   * @param {*} doc
    * @param {number} zIndex
    */
   constructor(doc, zIndex) {
-    /** @private @const {!../model/doc.Doc} */
+    /** @private @const {*} */
     this.doc_ = doc;
 
     /** @private @const {!Element} */
@@ -4761,12 +4761,12 @@ class Dialog {
 
   /**
    * Create a dialog for the provided doc.
-   * @param {!../model/doc.Doc} doc
+   * @param {*} doc
    * @param {!Object<string, string|number>=} importantStyles
    * @param {!Object<string, string|number>=} styles
    */
   constructor(doc, importantStyles = {}, styles = {}) {
-    /** @private @const {!../model/doc.Doc} */
+    /** @private @const {*} */
     this.doc_ = doc;
 
     /** @private @const {!FriendlyIframe} */
@@ -4789,7 +4789,7 @@ class Dialog {
     /** @private {?Element} */
     this.container_ = null;  // Depends on constructed document inside iframe.
 
-    /** @private {?./view.View} */
+    /** @private {*} */
     this.view_ = null;
 
     /** @private {?Promise} */
@@ -4798,7 +4798,7 @@ class Dialog {
     /** @private {boolean} */
     this.hidden_ = false;
 
-    /** @private {?./view.View} */
+    /** @private {*} */
     this.previousProgressView_ = null;
   }
 
@@ -4937,14 +4937,14 @@ class Dialog {
     }
   }
 
-  /** @return {?./view.View} */
+  /** @return {*} */
   getCurrentView() {
     return this.view_;
   }
 
   /**
    * Opens the given view and removes existing view from the DOM if any.
-   * @param {!./view.View} view
+   * @param {*} view
    * @return {!Promise}
    */
   openView(view) {
@@ -4995,7 +4995,7 @@ class Dialog {
 
   /**
    * Resizes the dialog container.
-   * @param {!./view.View} view
+   * @param {*} view
    * @param {number} height
    * @param {boolean=} animated
    * @return {?Promise}
@@ -5181,10 +5181,10 @@ const POPUP_Z_INDEX = 2147483647;
 class DialogManager {
 
   /**
-   * @param {!../model/doc.Doc} doc
+   * @param {*} doc
    */
   constructor(doc) {
-    /** @private @const {!../model/doc.Doc} */
+    /** @private @const {*} */
     this.doc_ = doc;
 
     /** @private {?Dialog} */
@@ -5223,7 +5223,7 @@ class DialogManager {
   }
 
   /**
-   * @param {!./view.View} view
+   * @param {*} view
    * @param {boolean=} hidden
    * @return {!Promise}
    */
@@ -5240,7 +5240,7 @@ class DialogManager {
   }
 
   /**
-   * @param {?./view.View} view
+   * @param {*} view
    */
   completeView(view) {
     // Give a small amount of time for another view to take over the dialog.
@@ -5496,13 +5496,13 @@ const iframeAttributes$1 = {
 class Toast {
 
   /**
-   * @param {!../runtime/deps.DepsDef} deps
+   * @param {*} deps
    * @param {string} src
    * @param {!Object<string, ?>} args
    */
   constructor(deps, src, args) {
 
-    /** @private @const {!../model/doc.Doc} */
+    /** @private @const {*} */
     this.doc_ = deps.doc();
 
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
@@ -5645,24 +5645,24 @@ class EntitlementsManager {
 
   /**
    * @param {!Window} win
-   * @param {!../model/page-config.PageConfig} config
-   * @param {!./fetcher.Fetcher} fetcher
-   * @param {!./deps.DepsDef} deps
+   * @param {*} config
+   * @param {*} fetcher
+   * @param {*} deps
    */
   constructor(win, config, fetcher, deps) {
     /** @private @const {!Window} */
     this.win_ = win;
 
-    /** @private @const {!../model/page-config.PageConfig} */
+    /** @private @const {*} */
     this.config_ = config;
 
     /** @private @const {string} */
     this.publicationId_ = this.config_.getPublicationId();
 
-    /** @private @const {!./fetcher.Fetcher} */
+    /** @private @const {*} */
     this.fetcher_ = fetcher;
 
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!JwtHelper} */
@@ -5677,7 +5677,7 @@ class EntitlementsManager {
     /** @private {boolean} */
     this.blockNextNotification_ = false;
 
-    /** @private @const {!./storage.Storage} */
+    /** @private @const {*} */
     this.storage_ = deps.storage();
   }
 
@@ -6353,7 +6353,7 @@ class XhrFetcher {
 
   /** @override */
   fetchCredentialedJson(url) {
-    const init = /** @type {!../utils/xhr.FetchInitDef} */ ({
+    const init = /** @type {*} */ ({
       method: 'GET',
       headers: {'Accept': 'text/plain, application/json'},
       credentials: 'include',
@@ -6426,19 +6426,19 @@ const LINK_REQUEST_ID = 'swg-link';
 class LinkbackFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   constructor(deps) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../model/page-config.PageConfig} */
+    /** @private @const {*} */
     this.pageConfig_ = deps.pageConfig();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
   }
 
@@ -6469,7 +6469,7 @@ class LinkbackFlow {
 class LinkCompleteFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   static configurePending(deps) {
     /**
@@ -6497,7 +6497,7 @@ class LinkCompleteFlow {
   }
 
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    * @param {?Object} response
    */
   constructor(deps, response) {
@@ -6507,13 +6507,13 @@ class LinkCompleteFlow {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
-    /** @private @const {!./entitlements-manager.EntitlementsManager} */
+    /** @private @const {*} */
     this.entitlementsManager_ = deps.entitlementsManager();
 
-    /** @private @const {!./callbacks.Callbacks} */
+    /** @private @const {*} */
     this.callbacks_ = deps.callbacks();
 
     const index = response && response['index'] || '0';
@@ -6592,26 +6592,26 @@ class LinkCompleteFlow {
 class LinkSaveFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
-   * @param {!../api/subscriptions.SaveSubscriptionRequestCallback} callback
+   * @param {*} deps
+   * @param {*} callback
    */
   constructor(deps, callback) {
     /** @private @const {!Window} */
     this.win_ = deps.win();
 
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
-    /** @private {!../api/subscriptions.SaveSubscriptionRequestCallback} */
+    /** @private {*} */
     this.callback_ = callback;
 
-    /** @private {?Promise<!../api/subscriptions.SaveSubscriptionRequest>} */
+    /** @private {?Promise<*>} */
     this.requestPromise_ = null;
 
     /** @private {?ActivityIframeView} */
@@ -6619,7 +6619,7 @@ class LinkSaveFlow {
   }
 
   /**
-   * @return {?Promise<!../api/subscriptions.SaveSubscriptionRequest>}
+   * @return {?Promise<*>}
    * @package Visible for testing.
    */
   getRequestPromise() {
@@ -6708,10 +6708,10 @@ class LinkSaveFlow {
 
 class LoginPromptApi {
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   constructor(deps) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!Window} */
@@ -6720,7 +6720,7 @@ class LoginPromptApi {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private {?Promise} */
@@ -6787,10 +6787,10 @@ class LoginPromptApi {
 
 class LoginNotificationApi {
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    */
   constructor(deps) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!Window} */
@@ -6799,7 +6799,7 @@ class LoginNotificationApi {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private {?Promise} */
@@ -6898,7 +6898,7 @@ class PayClient {
   }
 
   /**
-   * @param {!../utils/preconnect.Preconnect} pre
+   * @param {*} pre
    */
   preconnect(pre) {
     pre.prefetch(payUrl());
@@ -6990,7 +6990,7 @@ class PayClientBindingSwg {
         // Data is supplied as an encrypted blob.
         const xhr = new Xhr(this.win_);
         const url = payDecryptUrl();
-        const init = /** @type {!../utils/xhr.FetchInitDef} */ ({
+        const init = /** @type {*} */ ({
           method: 'post',
           headers: {'Accept': 'text/plain, application/json'},
           credentials: 'include',
@@ -7027,11 +7027,11 @@ class PayClientBindingSwg {
 
 class WaitForSubscriptionLookupApi {
   /**
-   * @param {!./deps.DepsDef} deps
+   * @param {*} deps
    * @param {?Promise} accountPromise
    */
   constructor(deps, accountPromise) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!Window} */
@@ -7040,7 +7040,7 @@ class WaitForSubscriptionLookupApi {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private {?Promise} */
@@ -7102,20 +7102,20 @@ class WaitForSubscriptionLookupApi {
 class OffersApi {
 
   /**
-   * @param {!../model/page-config.PageConfig} config
-   * @param {!./fetcher.Fetcher} fetcher
+   * @param {*} config
+   * @param {*} fetcher
    */
   constructor(config, fetcher) {
-    /** @private @const {!../model/page-config.PageConfig} */
+    /** @private @const {*} */
     this.config_ = config;
 
-    /** @private @const {!./fetcher.Fetcher} */
+    /** @private @const {*} */
     this.fetcher_ = fetcher;
   }
 
   /**
    * @param {string=} opt_productId
-   * @return {!Promise<!Array<!../api/offer.Offer>>}
+   * @return {!Promise<!Array<*>>}
    */
   getOffers(opt_productId) {
     const productId = opt_productId || this.config_.getProductId();
@@ -7127,7 +7127,7 @@ class OffersApi {
 
   /**
    * @param {string} productId
-   * @return {!Promise<!Array<!../api/offer.Offer>>}
+   * @return {!Promise<!Array<*>>}
    * @private
    */
   fetch_(productId) {
@@ -7171,11 +7171,11 @@ const OFFERS_VIEW_CLOSABLE = true;
 class OffersFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
-   * @param {!../api/subscriptions.OffersRequest|undefined} options
+   * @param {*} deps
+   * @param {*} options
    */
   constructor(deps, options) {
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
     /** @private @const {!Window} */
@@ -7184,7 +7184,7 @@ class OffersFlow {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     let isClosable = options && options.isClosable;
@@ -7253,21 +7253,21 @@ class OffersFlow {
 class SubscribeOptionFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
-   * @param {!../api/subscriptions.OffersRequest|undefined} options
+   * @param {*} deps
+   * @param {*} options
    */
   constructor(deps, options) {
 
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
-    /** @private @const {!../api/subscriptions.OffersRequest|undefined} */
+    /** @private @const {*} */
     this.options_ = options;
 
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private @const {!ActivityIframeView} */
@@ -7333,15 +7333,15 @@ class SubscribeOptionFlow {
 class AbbrvOfferFlow {
 
   /**
-   * @param {!./deps.DepsDef} deps
-   * @param {!../api/subscriptions.OffersRequest=} options
+   * @param {*} deps
+   * @param {*} options
    */
   constructor(deps, options = {}) {
 
-    /** @private @const {!./deps.DepsDef} */
+    /** @private @const {*} */
     this.deps_ = deps;
 
-    /** @private @const {!../api/subscriptions.OffersRequest|undefined} */
+    /** @private @const {*} */
     this.options_ = options;
 
     /** @private @const {!Window} */
@@ -7350,7 +7350,7 @@ class AbbrvOfferFlow {
     /** @private @const {!web-activities/activity-ports.ActivityPorts} */
     this.activityPorts_ = deps.activities();
 
-    /** @private @const {!../components/dialog-manager.DialogManager} */
+    /** @private @const {*} */
     this.dialogManager_ = deps.dialogManager();
 
     /** @private @const {!ActivityIframeView} */
@@ -7646,7 +7646,7 @@ class ConfiguredRuntime {
 
   /**
    * @param {!Window|!Document|!Doc} winOrDoc
-   * @param {!../model/page-config.PageConfig} pageConfig
+   * @param {*} pageConfig
    * @param {{
    *     fetcher: (!Fetcher|undefined),
    *   }=} opt_integr
@@ -7658,10 +7658,10 @@ class ConfiguredRuntime {
     /** @private @const {!Window} */
     this.win_ = this.doc_.getWin();
 
-    /** @private @const {!../api/subscriptions.Config} */
+    /** @private @const {*} */
     this.config_ = defaultConfig();
 
-    /** @private @const {!../model/page-config.PageConfig} */
+    /** @private @const {*} */
     this.pageConfig_ = pageConfig;
 
     /** @private @const {!Promise} */


### PR DESCRIPTION
Update: Don't parse CC output for warnings in swg.js. It doesn't work because CC actually terminates on `moduleLoad` "warnings", and doesn't generate a compiled JS binary.  🤷‍♂️

I manually replaced all relative paths in type annotations with `*` in swg.js in one search/replace with regex `(!|\?)\.[^>)}]*`. I also verified that `amp-subscriptions-google` extension builds again and this should unbreak master.

I'll chat with the SWG folks on whether we should automate this or wait for a proper fix in #18586.