### PR TITLE
Rollback CC upgrade (#18552)

### DIFF
--- a/ads/adventive.js
+++ b/ads/adventive.js
@@ -139,13 +139,10 @@ function getUrl(context, data, ns) {
  *    representation of the url search query.
  */
 function reduceSearch(ns, placementId, click, referrer) {
-  const isRecipeLoaded = hasOwn(ns.args, 'placementId');
-  let isRecipeStale = true;
-  if (isRecipeLoaded) {
-    const info = ns.args[placementId];
-    isRecipeStale = (Date.now() - info['requestTime']) > (60 * cacheTime);
-  }
-  const needsRequest = !isRecipeLoaded || isRecipeStale;
+  const isRecipeLoaded = hasOwn(ns.args, 'placementId'),
+      isRecipeStale = !isRecipeLoaded ? true :
+        (Date.now() - ns.args[placementId].requestTime) > (60 * cacheTime),
+      needsRequest = !isRecipeLoaded || isRecipeStale;
 
   return !needsRequest ? null : dict({
     'click': click,

--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -82,16 +82,11 @@ exports.getFlags = function(config) {
     language_in: 'ES6',
     language_out: config.language_out || 'ES5',
     module_output_path_prefix: config.writeTo || 'out/',
-    module_resolution: 'NODE',
     externs: config.externs,
     define: config.define,
     // Turn off warning for "Unknown @define" since we use define to pass
     // args such as FORTESTING to our runner.
     jscomp_off: ['unknownDefines'],
-    // checkVars: Demote "variable foo is undeclared" errors.
-    // moduleLoad: Demote "module not found" errors to ignore missing files
-    //     in type declarations in the swg.js bundle.
-    jscomp_warning: ['checkVars', 'moduleLoad'],
     jscomp_error: [
       'checkTypes',
       'accessControls',

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -80,6 +80,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setDevirtualizePrototypeMethods(true);
     options.setExtractPrototypeMemberDeclarations(true);
     options.setSmartNameRemoval(true);
+    options.optimizeParameters = true;
+    options.optimizeReturns = true;
     options.optimizeCalls = true;
     if (single_file_compilation) {
       options.renamePrefixNamespace = "_";

--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -158,7 +158,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     newcall.putBooleanProp(Node.FREE_CALL, true);
     newcall.addChildToBack(arg1);
     expr.replaceChild(n, newcall);
-    compiler.reportChangeToEnclosingScope(expr);
+    compiler.reportCodeChange();
   }
 
   private Node getAmpExtensionCallback(Node n) {
@@ -226,7 +226,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
         for (Map.Entry<String, Node> mapping : map.entrySet()) {
           if (varNode.getString() == mapping.getKey()) {
             varNode.replaceChild(varNode.getFirstChild(), mapping.getValue());
-            compiler.reportChangeToEnclosingScope(varNode);
+            compiler.reportCodeChange();
             return;
           }
         }
@@ -276,19 +276,17 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     Node booleanNode = bool ? IR.trueNode() : IR.falseNode();
     booleanNode.useSourceInfoIfMissingFrom(n);
     parent.replaceChild(n, booleanNode);
-    compiler.reportChangeToEnclosingScope(parent);
+    compiler.reportCodeChange();
   }
 
   private void removeExpression(Node n, Node parent) {
-    Node scope = parent;
     if (parent.isExprResult()) {
       Node grandparent = parent.getParent();
       grandparent.removeChild(parent);
-      scope = grandparent;
     } else {
       parent.removeChild(n);
     }
-    compiler.reportChangeToEnclosingScope(scope);
+    compiler.reportCodeChange();
   }
 
   private void maybeEliminateCallExceptFirstParam(Node call, Node parent) {
@@ -308,7 +306,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
 
     firstArg.detachFromParent();
     parent.replaceChild(call, firstArg);
-    compiler.reportChangeToEnclosingScope(parent);
+    compiler.reportCodeChange();
   }
 
   /**

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerPass;
-import com.google.javascript.jscomp.CompilerTestCase;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
 
@@ -16,7 +16,7 @@ import com.google.javascript.rhino.Node;
 /**
  * Tests {@link AmpPass}.
  */
-public class AmpPassTest extends CompilerTestCase {
+public class AmpPassTest extends Es6CompilerTestCase {
 
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of(
       "module$src$log.dev",
@@ -305,7 +305,7 @@ public class AmpPassTest extends CompilerTestCase {
   }
 
   public void testOptimizeGetModeFunction() throws Exception {
-    test(
+    testEs6(
         LINE_JOINER.join(
              "(function() {",
              "const IS_DEV = true;",
@@ -321,7 +321,7 @@ public class AmpPassTest extends CompilerTestCase {
   }
 
   public void testRemoveAmpAddExtensionCallWithExplicitContext() throws Exception {
-    test(
+    testEs6(
         LINE_JOINER.join(
             "var a = 'hello';",
             "self.AMP.extension('hello', '0.1', function(AMP) {",
@@ -339,7 +339,7 @@ public class AmpPassTest extends CompilerTestCase {
   }
 
   public void testRemoveAmpAddExtensionCallWithNoContext() throws Exception {
-    test(
+    testEs6(
         LINE_JOINER.join(
             "var a = 'hello';",
             "AMP.extension('hello', '0.1', function(AMP) {",

--- a/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
@@ -6,15 +6,16 @@ import java.util.Set;
 import com.google.common.collect.ImmutableMap;
 import com.google.javascript.rhino.IR;
 import com.google.javascript.rhino.Node;
+import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerPass;
-import com.google.javascript.jscomp.CompilerTestCase;
+import com.google.javascript.jscomp.Es6CompilerTestCase;
 
 
 /**
  * Tests {@link AmpPass}.
  */
-public class AmpPassTestEnvTest extends CompilerTestCase {
+public class AmpPassTestEnvTest extends Es6CompilerTestCase {
 
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of();
   ImmutableMap<String, Node> assignmentReplacements = ImmutableMap.of(
@@ -96,7 +97,7 @@ public class AmpPassTestEnvTest extends CompilerTestCase {
   }
 
   public void testOptimizeGetModeFunction() throws Exception {
-    test(
+    testEs6(
         LINE_JOINER.join(
              "(function() {",
              "const IS_DEV = true;",

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -54,7 +54,7 @@ exports.closureCompile = function(entryModuleFilename, outputDir,
             next();
             resolve();
           }, function(e) {
-            console./*OK*/error(colors.red('Compilation error:'), e.message);
+            console./* OK*/error(colors.red('Compilation error:', e.message));
             process.exit(1);
           });
     }
@@ -89,13 +89,14 @@ exports.cleanupBuildDir = cleanupBuildDir;
 function formatClosureCompilerError(message) {
   const javaInvocationLine = /Command failed:[^]*--js_output_file=\".*?\"\n/;
   message = message.replace(javaInvocationLine, '');
-  message = highlight(message, {ignoreIllegals: true});
+  message = highlight(message, {ignoreIllegals: true}); // never throws
   message = message.replace(/WARNING/g, colors.yellow('WARNING'));
   message = message.replace(/ERROR/g, colors.red('ERROR'));
   return message;
 }
 
-function compile(entryModuleFilenames, outputDir, outputFilename, options) {
+function compile(entryModuleFilenames, outputDir,
+  outputFilename, options) {
   const hideWarningsFor = [
     'third_party/caja/',
     'third_party/closure-library/sha384-generated.js',
@@ -113,8 +114,10 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     // Generated code.
     'extensions/amp-access/0.1/access-expr-impl.js',
   ];
+
   const baseExterns = [
     'build-system/amp.extern.js',
+    'third_party/closure-compiler/externs/performance_observer.js',
     'third_party/closure-compiler/externs/web_animations.js',
     'third_party/moment/moment.extern.js',
     'third_party/react-externs/externs.js',
@@ -139,11 +142,9 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       define.push('ESM_BUILD=true');
     }
 
-    console/*OK*/.assert(typeof entryModuleFilenames == 'string');
-    const entryModule = entryModuleFilenames;
     // TODO(@cramforce): Run the post processing step
     return singlePassCompile(
-        entryModule,
+        entryModuleFilenames,
         compilationOptions
     ).then(() => {
       return new Promise((resolve, reject) => {
@@ -251,7 +252,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       'third_party/webcomponentsjs/ShadowCSS.js',
       'third_party/rrule/rrule.js',
       'third_party/react-dates/bundle.js',
-      'node_modules/dompurify/dist/purify.es.js',
+      'node_modules/dompurify/dist/purify.cjs.js',
       'node_modules/promise-pjs/promise.js',
       'node_modules/set-dom/src/**/*.js',
       'node_modules/web-animations-js/web-animations.install.js',
@@ -357,7 +358,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           'build/fake-polyfills/',
         ],
         entry_point: entryModuleFilenames,
-        module_resolution: 'NODE',
         process_common_js_modules: true,
         // This strips all files from the input set that aren't explicitly
         // required.
@@ -367,15 +367,12 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
         source_map_location_mapping:
             '|' + sourceMapBase,
         warning_level: 'DEFAULT',
-        jscomp_error: [],
-        // moduleLoad: Demote "module not found" errors to ignore missing files
-        //     in type declarations in the swg.js bundle.
-        jscomp_warning: ['moduleLoad'],
         // Turn off warning for "Unknown @define" since we use define to pass
         // args such as FORTESTING to our runner.
         jscomp_off: ['unknownDefines'],
         define,
         hide_warnings_for: hideWarningsFor,
+        jscomp_error: [],
       },
     };
 

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -175,13 +175,8 @@ function getGraph(entryModule) {
 
   // TODO(erwinm): Try and work this in with `gulp build` so that
   // we're not running browserify twice on travis.
-  const bundler = browserify(entryModule, {debug: true})
-      .transform(babelify, {
-        compact: false,
-        // Transform files in node_modules since deps use ES6 export.
-        // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
-        global: true,
-      });
+  const bundler = browserify(entryModule, {debug: true, deps: true})
+      .transform(babelify, {compact: false});
 
   bundler.pipeline.get('deps').push(through.obj(function(row, enc, next) {
     module.deps.push({

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -63,15 +63,7 @@ module.exports = {
     debug: true,
     basedir: __dirname + '/../../',
     transform: [
-      [
-        'babelify', {
-          compact: false,
-          // Transform files in node_modules since deps use ES6 export.
-          // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
-          global: true,
-          sourceMapsAbsolute: true,
-        },
-      ],
+      ['babelify', {compact: false, sourceMapsAbsolute: true}],
     ],
     // Prevent "cannot find module" errors on Travis. See #14166.
     bundleDelay: process.env.TRAVIS ? 5000 : 1200,

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -501,9 +501,6 @@ function runTests() {
     c.browserify.transform = [
       ['babelify', {
         compact: false,
-        // Transform files in node_modules since deps use ES6 export.
-        // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
-        global: true,
         plugins: [
           ['babel-plugin-istanbul', {
             exclude: [

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -51,7 +51,7 @@ function patchWebAnimations() {
       'node_modules/web-animations-js/' +
       'web-animations.min.js').toString();
   // Wrap the contents inside the install function.
-  file = 'export function installWebAnimations(window) {\n' +
+  file = 'exports.installWebAnimations = function(window) {\n' +
       'var document = window.document;\n' +
       file.replace(/requestAnimationFrame/g, function(a, b) {
         if (file.charAt(b - 1) == '.') {
@@ -80,14 +80,12 @@ function patchRegisterElement() {
   file = fs.readFileSync(
       'node_modules/document-register-element/build/' +
       'document-register-element.node.js').toString();
-
   // Eliminate the immediate side effect.
   if (!/installCustomElements\(global\);/.test(file)) {
     throw new Error('Expected "installCustomElements(global);" ' +
         'to appear in document-register-element');
   }
   file = file.replace('installCustomElements(global);', '');
-
   // Closure Compiler does not generate a `default` property even though
   // to interop CommonJS and ES6 modules. This is the same issue typescript
   // ran into here https://github.com/Microsoft/TypeScript/issues/2719
@@ -96,8 +94,7 @@ function patchRegisterElement() {
         'to appear in document-register-element');
   }
   file = file.replace('module.exports = installCustomElements;',
-      'export {installCustomElements};');
-
+      'exports.installCustomElements = installCustomElements;');
   writeIfUpdated(patchedName, file);
 }
 

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -180,7 +180,7 @@ export class IframeTransport {
               (entry['name'] == 'cross-origin-descendant') &&
               entry.attribution) {
               entry.attribution.forEach(attrib => {
-                if (this.frameUrl_ == attrib['containerSrc'] &&
+                if (this.frameUrl_ == attrib.containerSrc &&
                     ++this.numLongTasks_ % LONG_TASK_REPORTING_THRESHOLD == 0) {
                   user().error(TAG_, `Long Task: Vendor: "${this.type_}"`);
                 }

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -80,7 +80,7 @@ export class AmpMustache extends AMP.BaseTemplate {
     container.appendChild(content);
     /** @private @const {string} */
     this.template_ = container./*OK*/innerHTML;
-    mustacheParse(this.template_, /* tags */ undefined);
+    mustacheParse(this.template_);
   }
 
   /** @override */
@@ -91,8 +91,7 @@ export class AmpMustache extends AMP.BaseTemplate {
       if (typeof data === 'object') {
         mustacheData = Object.assign({}, data, this.nestedTemplates_);
       }
-      html = mustacheRender(this.template_, mustacheData,
-          /* partials */ undefined);
+      html = mustacheRender(this.template_, mustacheData);
     }
     return this.serializeHtml_(html);
   }

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -61,7 +61,7 @@ export class AmpMustache extends AMP.BaseTemplate {
 
     /** @private @const {string} */
     this.template_ = container./*OK*/innerHTML;
-    mustacheParse(this.template_, /* tags */ undefined);
+    mustacheParse(this.template_);
   }
 
   /**
@@ -96,8 +96,7 @@ export class AmpMustache extends AMP.BaseTemplate {
       if (typeof data === 'object') {
         mustacheData = Object.assign({}, data, this.nestedTemplates_);
       }
-      html = mustacheRender(this.template_, mustacheData,
-          /* partials */ undefined);
+      html = mustacheRender(this.template_, mustacheData);
     }
     const diffing = isExperimentOn(self, 'amp-list-diffing');
     const body = purifyHtml(html, diffing);

--- a/extensions/amp-story/0.1/_locales/default.js
+++ b/extensions/amp-story/0.1/_locales/default.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for English strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
     string: 'Privacy settings',
   },
@@ -58,4 +58,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'We\'re sorry, it looks like your browser doesn\'t support ' +
         'this experience',
   },
-});
+};

--- a/extensions/amp-story/0.1/_locales/en.js
+++ b/extensions/amp-story/0.1/_locales/en.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for English strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
     string: 'Privacy settings',
     description: 'Title for a section that allows the user to configure ' +
@@ -161,4 +161,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     description: 'Text for a warning screen that informs the user that ' +
         'their browser does not support stories.',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/ar.js
+++ b/extensions/amp-story/1.0/_locales/ar.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Arabic strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'موافق',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'عذرًا، يبدو أن متصفحك لا يدعم هذه التجربة',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/de.js
+++ b/extensions/amp-story/1.0/_locales/de.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for German strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Akzeptieren',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Es tut uns leid, aber Ihr Browser unterstützt diese Format ' +
         'leider nicht.',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for English strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_TEXT]: {
     string: 'Sound off',
   },
@@ -73,4 +73,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'We\'re sorry, it looks like your browser doesn\'t support ' +
         'this experience',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/en-GB.js
+++ b/extensions/amp-story/1.0/_locales/en-GB.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for English strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accept',
   },
@@ -94,4 +94,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'We\'re sorry, it looks like your browser doesn\'t support ' +
         'this experience',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for English strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_TEXT]: {
     string: 'Sound off',
     description: 'Text that informs users that the sound is off after they ' +
@@ -177,4 +177,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     description: 'Text for a warning screen that informs the user that ' +
         'their browser does not support stories.',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/es-419.js
+++ b/extensions/amp-story/1.0/_locales/es-419.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Latin American Spanish strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Aceptar',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Lo sentimos, parece que su navegador no soporta esta experiencia',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/es.js
+++ b/extensions/amp-story/1.0/_locales/es.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Spanish strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Aceptar',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Lo sentimos, parece que su navegador no soporta esta experiencia',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/fr-CA.js
+++ b/extensions/amp-story/1.0/_locales/fr-CA.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Canadian French strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Acceptez',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Nous sommes désolés, il semble que votre navigateur ne supporte ' +
         'pas cette expérience',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/fr.js
+++ b/extensions/amp-story/1.0/_locales/fr.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for French strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accepter',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Nous sommes désolés, il semble que votre navigateur ne supporte ' +
         'pas cette expérience',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/hi.js
+++ b/extensions/amp-story/1.0/_locales/hi.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Hindi strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'स्वीकार करना',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'हमें खेद है, ऐसा लगता है कि आपका ब्राउज़र इस अनुभव का समर्थन ' +
         'नहीं करता है',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/id.js
+++ b/extensions/amp-story/1.0/_locales/id.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Indonesian strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Menerima',
   },
@@ -94,4 +94,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Maaf, sepertinya browser anda tidak mendukung fitur ini',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/it.js
+++ b/extensions/amp-story/1.0/_locales/it.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Italian strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accetta',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Siamo spiacenti, sembra che il tuo browser non supporti questo ' +
         'contenuto',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/ja.js
+++ b/extensions/amp-story/1.0/_locales/ja.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Japanese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: '受諾する',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'すみません、ご使用のブラウザには対応していません。',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/ko.js
+++ b/extensions/amp-story/1.0/_locales/ko.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Korean strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: '수락',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: '죄송합니다. 사용하고 계신 브라우저는 stories를 서포트 하지 않습니다. ',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/nl.js
+++ b/extensions/amp-story/1.0/_locales/nl.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Dutch strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accepteer',
   },
@@ -94,4 +94,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Helaas lijkt het erop dat uw browser deze inhoud niet ondersteunt',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/no.js
+++ b/extensions/amp-story/1.0/_locales/no.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Norwegian strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Aksepter',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Beklager, det ser ut for at nettleseren din ikke støtter denne ' +
         'opplevelsen',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/pt-BR.js
+++ b/extensions/amp-story/1.0/_locales/pt-BR.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Brazilian Portuguese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Aceitar',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Lamentamos, mas parece que seu navegador não suporta essa ' +
         'experiência',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/pt.js
+++ b/extensions/amp-story/1.0/_locales/pt.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Portuguese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Aceitar',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Lamentamos, mas parece que seu navegador não suporta essa ' +
         'experiência',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/ru.js
+++ b/extensions/amp-story/1.0/_locales/ru.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Russian strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Принять',
   },
@@ -94,4 +94,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Извините, похоже, ваш браузер не поддерживает эту функцию',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/tr.js
+++ b/extensions/amp-story/1.0/_locales/tr.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Turkish strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Kabul ediyorum',
   },
@@ -94,4 +94,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: 'Üzgünüz, tarayıcınız bu deneyimi desteklemiyor gibi görünüyor.',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/vi.js
+++ b/extensions/amp-story/1.0/_locales/vi.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for Vietnamese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Chấp nhận',
   },
@@ -95,4 +95,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'Chúng tôi xin lỗi, hình như là trình duyệt của ' +
         'bạn không hỗ trợ thử nghiệm này',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/zh-TW.js
+++ b/extensions/amp-story/1.0/_locales/zh-TW.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for traditional Chinese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: '接受',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: '非常抱歉，您的遊覽器不支持此插件',
   },
-});
+};

--- a/extensions/amp-story/1.0/_locales/zh.js
+++ b/extensions/amp-story/1.0/_locales/zh.js
@@ -20,7 +20,7 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * Localized string bundle used for simplified Chinese strings.
  * @const {!LocalizedStringBundleDef}
  */
-export default /** @const {!LocalizedStringBundleDef} */ ({
+export default {
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: '接受',
   },
@@ -93,4 +93,4 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string: '非常抱歉，您的游览器不支持此插件',
   },
-});
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1191,9 +1191,6 @@ function compileJs(srcDir, srcFilename, destDir, options) {
   let bundler = browserify(entryPoint, {debug: true})
       .transform(babelify, {
         compact: false,
-        // Transform files in node_modules since deps use ES6 export.
-        // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
-        global: true,
         presets: [
           ['env', {
             targets: {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babel-plugin-istanbul": "5.0.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
-    "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.7.0",
     "babelify": "8.0.0",
     "baconipsum": "0.1.2",

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as DOMPurify from 'dompurify/dist/purify.cjs';
 import {
   checkCorsUrl,
   getSourceUrl,
@@ -27,10 +28,6 @@ import {remove} from './utils/array';
 import {startsWith} from './string';
 import {urls} from './config';
 import {user} from './log';
-import purify from 'dompurify/dist/purify.es';
-
-/** @private @const {{addHook: !Function, removeAllHooks: !Function, sanitize: !Function}} */
-const DOMPurify = purify(self);
 
 /** @private @const {string} */
 const TAG = 'purifier';

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -202,8 +202,8 @@ function isJankMeterEnabled(win) {
  */
 export function isLongTaskApiSupported(win) {
   return !!win.PerformanceObserver
-      && !!win['TaskAttributionTiming']
-      && ('containerName' in win['TaskAttributionTiming'].prototype);
+      && !!win.TaskAttributionTiming
+      && ('containerName' in win.TaskAttributionTiming.prototype);
 }
 
 /**

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -225,8 +225,8 @@ export class Performance {
     if (!this.win.PerformancePaintTiming
         && this.win.chrome
         && typeof this.win.chrome.loadTimes == 'function') {
-      const fpTime = (this.win.chrome.loadTimes()['firstPaintTime'] * 1000)
-          - this.win.performance.timing.navigationStart;
+      const fpTime = (this.win.chrome.loadTimes().firstPaintTime
+          * 1000) - this.win.performance.timing.navigationStart;
       if (fpTime <= 1) {
         // Throw away bad data generated from an apparent Chrome bug
         // that is fixed in later Chrome versions.

--- a/third_party/closure-compiler/externs/performance_observer.js
+++ b/third_party/closure-compiler/externs/performance_observer.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @see https://w3c.github.io/performance-timeline/
+ * @interface
+ */
+class PerformanceObserver {
+  /**
+   * @param {function(!PerformanceObserverEntryList)} callback
+   */
+  constructor(callback) {}
+
+  /**
+   * @param {!Object} options
+   */
+  observe(options) {}
+
+  disconnect() {}
+}
+
+/**
+ * @see https://w3c.github.io/performance-timeline/#dom-performanceobserverentrylist
+ * @interface
+ */
+class PerformanceObserverEntryList {
+
+  /**
+   * @return {!Array<!PerformanceEntry>}
+   */
+  getEntries() {}
+
+  /**
+   * @param {string} type
+   * @return {!Array<!PerformanceEntry>}
+   */
+  getEntriesByType(type) {}
+
+  /**
+   * @param {string} name
+   * @param {string=} type
+   * @return {!Array<!PerformanceEntry>}
+   */
+  getEntriesByName(name, type) {}
+};
+
+/**
+ * @see https://w3c.github.io/longtasks/#sec-TaskAttributionTiming
+ * @typedef {{
+ *   name: string,
+ *   entryType: string,
+ *   startTime: number,
+ *   duration: number,
+ *   containerType: string,
+ *   containerSrc: string,
+ *   containerId: string,
+ *   containerName: string,
+ * }}
+ */
+var TaskAttributionTiming;

--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -599,10 +599,9 @@ class MetaParser {
     // Is locked?
     const accessibleForFree = getMetaTag(this.doc_.getRootNode(),
         'subscriptions-accessible-for-free');
-    let locked = false;
-    if (accessibleForFree && accessibleForFree.toLowerCase() == 'false') {
-      locked = true;
-    }
+    const locked = (accessibleForFree &&
+        accessibleForFree.toLowerCase() == 'false') || false;
+
     return new PageConfig(productId, locked);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,13 +2031,6 @@ babel-plugin-transform-remove-strict-mode@0.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-strict-mode/-/babel-plugin-transform-remove-strict-mode-0.0.2.tgz#913685aab95439f3a0ed88e588fbd5e997890579"
   integrity sha1-kTaFqrlUOfOg7YjliPvV6ZeJBXk=
 
-babel-plugin-transform-runtime@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Rolls back #18552 to unbreak master. There are a few problems of modules not being resolved correctly, for example from `src/polyfills/promise.js`:

```js
a.Promise || (a.Promise = module$node_modules$promise_pjs$promise,
module$node_modules$promise_pjs$promise.default && (a.Promise = module$node_modules$promise_pjs$promise.default),
a.Promise.resolve = module$node_modules$promise_pjs$promise.resolve,
a.Promise.reject = module$node_modules$promise_pjs$promise.reject,
a.Promise.all = module$node_modules$promise_pjs$promise.all,
a.Promise.race = module$node_modules$promise_pjs$promise.race)
```

There are 12 instances of these undefined `module$foo$bar` aliases in v0.js. The other two problematic modules are:

```
cssText$$module$build$css
```
```
module$node_modules$document_register_element$build$document_register_element_patched.installCustomElements
```

I'll roll forward again when I figure out what the issue is.