### PR TITLE
Clarify experiment cleanup presubmit

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -558,7 +558,9 @@ function main() {
     console.log(fileLogPrefix, colors.red('ERROR:'),
         'Looks like your PR contains',
         colors.cyan('{prod|canary}-config.json'),
-        'in addition to some other files');
+        'in addition to some other files.  Config and code are not kept in',
+        'sync, and config needs to be backwards compatible with code for at',
+        'least two weeks.  See #8188');
     const nonFlagConfigFiles = files.filter(file => !isFlagConfig(file));
     console.log(fileLogPrefix, colors.red('ERROR:'),
         'Please move these files to a separate PR:',


### PR DESCRIPTION
We have a presubmit that looks like:

   pr-check.js: ERROR: Looks like your PR contains {prod|canary}-config.json
   in addition to some other files

   pr-check.js: ERROR: Please move these files to a separate PR: foo.js

This was added in go/amppr/8448 fixing go/amppr/8188 which says:

   When cleaning up an experiment, the flag removals from the
   config files should happen up to 2 weeks after the code clean
   up (the code needs to be in production before flags are removed).

The current warning gives the impression that all you need to do is submit as two PRs, when you also need to hold off on submitting the flag-change PR until your code change has been submitted for two weeks.