### PR TITLE
Remove Scroll Snap experiment from prod 

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,7 +37,6 @@
   "amp-sidebar toolbar": 1,
   "amp-consent": 1,
   "amp-story-v1": 1,
-  "amp-carousel-scroll-snap": 0.1,
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
   "faster-bind-scan": 1,


### PR DESCRIPTION
Currently there are multiple reports of carousel scrolling being janky on iOS - #18592 and #18558 are examples. 

Disabling Scroll Snap experiment while I take a look at the root cause for the jankiness. 