### PR TITLE
🚮 Remove deprecated Criteo RTA and Standalone ads

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -351,22 +351,8 @@ data.url;
 // criteo.js
 var Criteo;
 Criteo.DisplayAd;
-Criteo.Log.Debug;
-Criteo.CallRTA;
-Criteo.ComputeDFPTargetingForAMP;
-Criteo.PubTag = {};
-Criteo.PubTag.Adapters = {};
-Criteo.PubTag.Adapters.AMP = {};
-Criteo.PubTag.Adapters.AMP.Standalone;
-Criteo.PubTag.RTA = {};
-Criteo.PubTag.RTA.DefaultCrtgContentName;
-Criteo.PubTag.RTA.DefaultCrtgRtaCookieName
 data.tagtype;
-data.networkid;
-data.cookiename;
-data.varname;
 data.zone;
-data.adserver;
 
 // distroscale.js
 data.tid;

--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import {computeInMasterFrame, loadScript} from '../3p/3p';
-import {doubleclick} from '../ads/google/doubleclick';
-import {tryParseJson} from '../src/json';
+import {dev} from '../src/log';
+import {loadScript} from '../3p/3p';
 
 /* global Criteo: false */
+
+/** @const {string} */
+const TAG = 'CRITEO';
 
 /**
  * @param {!Window} global
@@ -26,59 +28,18 @@ import {tryParseJson} from '../src/json';
  */
 export function criteo(global, data) {
   loadScript(global, 'https://static.criteo.net/js/ld/publishertag.js', () => {
-    if (data.tagtype === 'rta') {
-      // Make sure RTA is called only once
-      computeInMasterFrame(window, 'call-rta', resultCallback => {
-        const params = {
-          networkid: data.networkid,
-          cookiename:
-            data.cookiename || Criteo.PubTag.RTA.DefaultCrtgRtaCookieName,
-          varname:
-            data.varname || Criteo.PubTag.RTA.DefaultCrtgContentName,
-        };
-        Criteo.CallRTA(params);
-        resultCallback(null);
-      }, () => {});
-      setTargeting(global, data, null);
-    } else if (data.tagtype === 'standalone') {
-      Criteo.PubTag.Adapters.AMP.Standalone(data, () => {}, targ => {
-        setTargeting(global, data, targ);
-      });
-    } else if (!data.tagtype || data.tagtype === 'passback') {
+    if (!data.tagtype || data.tagtype === 'passback') {
       Criteo.DisplayAd({
         zoneid: data.zone,
         containerid: 'c',
         integrationmode: 'amp',
       });
+    } else if (data.tagtype === 'rta' || data.tagtype === 'standalone') {
+      dev().error(TAG, 'You are using a deprecated Criteo integration',
+          data.tagtype);
+    } else {
+      dev().error(TAG, 'You are using an unknown Criteo integration',
+          data.tagtype);
     }
   });
 }
-
-/**
- * @param {!Window} global
- * @param {!Object} data
- * @param {?Object} targeting
- */
-function setTargeting(global, data, targeting) {
-  if (data.adserver === 'DFP') {
-    const dblParams = tryParseJson(data.doubleclick) || {};
-    dblParams['slot'] = data.slot;
-    dblParams['targeting'] = dblParams['targeting'] || {};
-    dblParams['width'] = data.width;
-    dblParams['height'] = data.height;
-    dblParams['type'] = 'criteo';
-
-    if (!targeting && data.tagtype === 'rta') {
-      targeting = Criteo.ComputeDFPTargetingForAMP(
-          data.cookiename || Criteo.PubTag.RTA.DefaultCrtgRtaCookieName,
-          data.varname || Criteo.PubTag.RTA.DefaultCrtgContentName);
-    }
-    for (const i in targeting) {
-      dblParams['targeting'][i] = targeting[i];
-    }
-
-    doubleclick(global, dblParams);
-  }
-}
-
-

--- a/ads/criteo.md
+++ b/ads/criteo.md
@@ -16,44 +16,19 @@ limitations under the License.
 
 # Criteo
 
-Criteo support for AMP covers Real Time Audience (RTA), Standalone, Publisher Marketplace (PuMP) and Passback technologies.
+Criteo support for AMP covers Passback technologies.
+
+There is also support for CDB via RTC integrations.
 
 For configuration details and to generate your tags, please refer to [your publisher account](https://publishers.criteo.com) or contact publishers@criteo.com.
 
-## Example - RTA
+## Example - Passback
 
 ```html
 <amp-ad width="300" height="250"
     type="criteo"
-    data-tagtype=“rta”
-    data-networkid=“76543”
-    data-adserver=“DFP”
-    data-slot=“/0987654/rta_zone_amp”
-    data-doubleclick='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"]}'>
-</amp-ad>
-```
-
-## Example - PuMP and Passback
-
-```html
-<amp-ad width="300" height="250"
-    type="criteo"
-    data-tagtype=“passback”
-    data-zone=“567890”>
-</amp-ad>
-```
-
-## Example - Standalone
-
-```html
-<amp-ad width="300" height="250"
-    type="criteo"
-    data-tagtype="standalone"
-    data-timeout="700"
-    data-zone="497747"
-    data-slot="/2729856/AMP_Standalone_AdUnit"
-    data-adserver="DFP"
-    data-line-item-ranges="0..3:0.5">
+    data-tagtype="passback"
+    data-zone="567890">
 </amp-ad>
 ```
 
@@ -61,34 +36,9 @@ For configuration details and to generate your tags, please refer to [your publi
 
 The ad size is based on the setup of your Criteo zone. The `width` and `height` attributes of the `amp-ad` tag should match that.
 
-### RTA
+### Passback
 
 Supported parameters:
 
-- `data-tagtype`: identifies the used Criteo technology. Must be “rta”. Required.
-- `data-adserver`: the name of your adserver. Required. Only “DFP” is supported at this stage.
-- `data-slot`: adserver (DFP) slot slot. Required.
-- `data-networkid`: your Criteo network id. Required.
-- `data-varname`: `crtg_content` variable name to store RTA labels. Optional.
-- `data-cookiename`: `crtg_rta` RTA cookie name. Optional.
-- `data-doubleclick`: custom options to send to doubleclick, in JSON format. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
-
-### PuMP and Passback
-
-Supported parameters:
-
-- `data-tagtype`: identifies the used Criteo technology. Must be “passback”. Required.
+- `data-tagtype`: identifies the used Criteo technology. Must be "passback". Required.
 - `data-zone`: your Criteo zone identifier. Required.
-
-### Standalone
-
-Supported parameters:
-
-- `data-tagtype`: identifies the used Criteo technology. Must be "standalone". Required.
-- `data-adserver`: the name of your adserver. Required. Only "DFP" is supported at this stage.
-- `data-slot`: adserver (DFP) slot. Required.
-- `data-zone`: your Criteo zone identifier. Required.
-- `data-line-item-ranges`: your line item ranges. Required.
-- `data-timeout`: bid timeout override. Optional.
-- `data-doubleclick`: custom options to send to doubleclick, in JSON format. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
-

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -390,8 +390,6 @@ exports.rules = [
       'ads/rubicon.js->ads/google/doubleclick.js',
       'ads/yieldbot.js->ads/google/doubleclick.js',
       /** DO NOT ADD TO WHITELIST **/
-      'ads/criteo.js->ads/google/doubleclick.js',
-      /** DO NOT ADD TO WHITELIST **/
     ],
   },
 ];

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -705,31 +705,6 @@
       data-zone="314159">
   </amp-ad>
 
-  <h2>Criteo Standalone</h2>
-  <p>Due to ad targeting, the slot might not load ad.</p>
-
-  <amp-ad width="300" height="250"
-      type="criteo"
-      data-tagtype="standalone"
-      data-timeout="700"
-      data-zone="497747"
-      data-slot="/2729856/AMP_Standalone_AdUnit"
-      data-adserver="DFP"
-      data-line-item-ranges="0..3:0.5"
-      data-doubleclick='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":1}'>
-  </amp-ad>
-
-  <h2>Criteo RTA</h2>
-  <p>Due to ad targeting, the slot might not load ad.</p>
-
-  <amp-ad width="300" height="250"
-      type="criteo"
-      data-tagtype="rta"
-      data-slot="/2729856/iframe_test_new_tag"
-      data-adserver="DFP"
-      data-networkid="1976">
-  </amp-ad>
-
   <h2>CSA</h2>
   <amp-ad width="auto" height="300"
       type="csa"

--- a/validator/testdata/feature_tests/ads.html
+++ b/validator/testdata/feature_tests/ads.html
@@ -546,17 +546,6 @@
       data-zone="314159">
   </amp-ad>
 
-  <h2>Criteo RTA</h2>
-  <p>Due to ad targeting, the slot might not load ad.</p>
-
-  <amp-ad width="300" height="250"
-      type="criteo"
-      data-tagtype="rta"
-      data-slot="/2729856/iframe_test_new_tag"
-      data-adserver="DFP"
-      data-networkid="1976">
-  </amp-ad>
-
   <h2>CSA</h2>
   <amp-ad width="auto" height="300"
       type="csa"

--- a/validator/testdata/feature_tests/ads.out
+++ b/validator/testdata/feature_tests/ads.out
@@ -547,17 +547,6 @@ PASS
 |        data-zone="314159">
 |    </amp-ad>
 |
-|    <h2>Criteo RTA</h2>
-|    <p>Due to ad targeting, the slot might not load ad.</p>
-|
-|    <amp-ad width="300" height="250"
-|        type="criteo"
-|        data-tagtype="rta"
-|        data-slot="/2729856/iframe_test_new_tag"
-|        data-adserver="DFP"
-|        data-networkid="1976">
-|    </amp-ad>
-|
 |    <h2>CSA</h2>
 |    <amp-ad width="auto" height="300"
 |        type="csa"


### PR DESCRIPTION
Those two integrations depend on [doubleclick.js](https://github.com/ampproject/amphtml/blob/master/ads/google/doubleclick.js) which has been deprecated for a while.

Publishers using Criteo Standalone integrations should switch to AMP RTC, while Criteo RTA has been decommissioned.