### PR TITLE
🐛 Tweaks to the extension generator

### DIFF
--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -87,7 +87,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# <a name="\`${name}\`"></a> \`${name}\`
+# \`${name}\`
 
 <table>
   <tr>

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -100,7 +100,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/${name}-0.1.js">&lt;/script></code></td>
+    <td><code>&lt;script async custom-element="${name}" src="https://cdn.ampproject.org/v0/${name}-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>


### PR DESCRIPTION
The `name` attribute is deprecated, and it looks like the `<a>` tag is unnecessary since markdown viewers add their own anchors to titles. Does ampproject.org consume the anchor tag, or can we safely remove it? I don't see it used in the output:
<img width="863" alt="screen shot 2018-10-09 at 10 04 33" src="https://user-images.githubusercontent.com/2363700/46674679-c84a6e00-cbaa-11e8-8925-66071d63e63a.png">

I also saw and updated `custom-element="amp-form"`