### PR TITLE
🐛 amp-next-page: Fix relative URL handling when served from the cache

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -17,7 +17,6 @@
 import {CSS} from '../../../build/amp-next-page-0.1.css';
 import {Layout} from '../../../src/layout';
 import {NextPageService} from './next-page-service';
-import {Services} from '../../../src/services';
 import {
   UrlReplacementPolicy,
   batchFetchJsonFor,
@@ -30,7 +29,6 @@ import {
   removeElement,
 } from '../../../src/dom';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {getSourceOrigin} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
@@ -101,12 +99,7 @@ export class AmpNextPage extends AMP.BaseElement {
    */
   register_(service, configJson, separator) {
     const {element} = this;
-    const urlService = Services.urlForDoc(element);
-
-    const url = urlService.parse(this.getAmpDoc().getUrl());
-    const sourceOrigin = getSourceOrigin(url);
-
-    const config = assertConfig(element, configJson, url.origin, sourceOrigin);
+    const config = assertConfig(element, configJson, this.getAmpDoc().getUrl());
     service.register(element, config, separator);
     service.setAppendPageHandler(element => this.appendPage_(element));
   }

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -107,13 +107,6 @@ export class AmpNextPage extends AMP.BaseElement {
     const sourceOrigin = getSourceOrigin(url);
 
     const config = assertConfig(element, configJson, url.origin, sourceOrigin);
-
-    if (urlService.isProxyOrigin(url)) {
-      config.pages.forEach(rec => {
-        rec.ampUrl = rec.ampUrl.replace(sourceOrigin, url.origin);
-      });
-    }
-
     service.register(element, config, separator);
     service.setAppendPageHandler(element => this.appendPage_(element));
   }

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -15,6 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
+import {getSourceOrigin} from '../../../src/url';
 import {isArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
@@ -39,19 +40,14 @@ export let AmpNextPageItem;
  * Checks whether the object conforms to the AmpNextPageConfig spec.
  * @param {!Element} context
  * @param {*} config The config to validate.
- * @param {string} origin The origin of the current document
- *     (document.location.origin). All recommendations must be for the same
- *     origin as the current document so the URL can be updated safely.
- * @param {string} sourceOrigin The source origin for the current document.
- *     Will match the value of {@code origin} unless served from the cache.
- *     Any recommendations pointing at {@code sourceOrigin} will be modified
- *     to point to the cache.
+ * @param {string} documentUrl URL of the currently active document, i.e.
+ *     context.getAmpDoc().getUrl()
  * @return {!AmpNextPageConfig}
  */
-export function assertConfig(context, config, origin, sourceOrigin) {
+export function assertConfig(context, config, documentUrl) {
   user().assert(config, 'amp-next-page config must be specified');
   user().assert(isArray(config.pages), 'pages must be an array');
-  assertRecos(context, config.pages, origin, sourceOrigin);
+  assertRecos(context, config.pages, documentUrl);
 
   if ('hideSelectors' in config) {
     user().assert(isArray(config['hideSelectors']),
@@ -65,11 +61,10 @@ export function assertConfig(context, config, origin, sourceOrigin) {
 /**
  * @param {!Element} context
  * @param {!Array<*>} recos
- * @param {string} origin
- * @param {string=} sourceOrigin
+ * @param {string} documentUrl
  */
-function assertRecos(context, recos, origin, sourceOrigin) {
-  recos.forEach(reco => assertReco(context, reco, origin, sourceOrigin));
+function assertRecos(context, recos, documentUrl) {
+  recos.forEach(reco => assertReco(context, reco, documentUrl));
 }
 
 const BANNED_SELECTOR_PATTERNS = [
@@ -95,13 +90,16 @@ function assertSelectors(selectors) {
 /**
  * @param {!Element} context
  * @param {*} reco
- * @param {string} origin
- * @param {string=} sourceOrigin
+ * @param {string} documentUrl
  */
-function assertReco(context, reco, origin, sourceOrigin) {
+function assertReco(context, reco, documentUrl) {
+  user().assertString(reco.ampUrl, 'ampUrl must be a string');
+
   const urlService = Services.urlForDoc(context);
   const url = urlService.parse(reco.ampUrl);
-  user().assertString(reco.ampUrl, 'ampUrl must be a string');
+  const {origin} = urlService.parse(documentUrl);
+  const sourceOrigin = getSourceOrigin(documentUrl);
+
   user().assert(url.origin === origin || url.origin === sourceOrigin,
       'pages must be from the same origin as the current document');
   user().assertString(reco.image, 'image must be a string');

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -15,7 +15,11 @@
  */
 
 import {Services} from '../../../src/services';
-import {getSourceOrigin} from '../../../src/url';
+import {
+  getSourceOrigin,
+  getSourceUrl,
+  resolveRelativeUrl,
+} from '../../../src/url';
 import {isArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
@@ -94,6 +98,10 @@ function assertSelectors(selectors) {
  */
 function assertReco(context, reco, documentUrl) {
   user().assertString(reco.ampUrl, 'ampUrl must be a string');
+
+  // Rewrite relative URLs to absolute, relative to the source URL.
+  const base = getSourceUrl(documentUrl);
+  reco.ampUrl = resolveRelativeUrl(reco.ampUrl, base);
 
   const urlService = Services.urlForDoc(context);
   const url = urlService.parse(reco.ampUrl);

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -17,11 +17,11 @@ import {Services} from '../../../../src/services';
 import {assertConfig} from '../config';
 import {parseUrlDeprecated} from '../../../../src/url';
 
-
 describe('amp-next-page config', () => {
 
   describes.sandboxed('assertConfig', {}, env => {
-    const origin = 'https://example.com';
+    const documentUrl = 'https://example.com/parent';
+    const documentUrlCdn = 'https://example-com.cdn.ampproject.org/c/s/example.com/parent';
 
     beforeEach(() => {
       env.sandbox.stub(Services, 'urlForDoc').returns({
@@ -41,13 +41,13 @@ describe('amp-next-page config', () => {
           'footer',
         ],
       };
-      expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
           .to.not.throw();
     });
 
     it('allows a config with no pages', () => {
       const config = {pages: []};
-      expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
           .to.not.throw();
     });
 
@@ -59,12 +59,11 @@ describe('amp-next-page config', () => {
           title: 'Article 1',
         }],
       };
-      expect(() => assertConfig(/*ctx*/ null, config, document.location.origin))
+      expect(() => assertConfig(/*ctx*/ null, config, document.location))
           .to.not.throw();
     });
 
     it('rewrites canonical URLs when served from the cache', () => {
-      const cdnOrigin = 'https://example-com.cdn.ampproject.org';
       const config = {
         pages: [
           {
@@ -79,7 +78,7 @@ describe('amp-next-page config', () => {
           },
         ],
       };
-      expect(() => assertConfig(/*ctx*/ null, config, cdnOrigin, origin))
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrlCdn))
           .to.not.throw();
       expect(config.pages[0].ampUrl).to.equal(
           'https://example-com.cdn.ampproject.org/c/s/example.com/art1');
@@ -88,8 +87,7 @@ describe('amp-next-page config', () => {
     });
 
     it('rewrites non-HTTPS canonical URLs when served from the cache', () => {
-      const insecureOrigin = 'http://example.com';
-      const cdnOrigin = 'https://example-com.cdn.ampproject.org';
+      const url = documentUrlCdn.replace('/s/', '/');
       const config = {
         pages: [
           {
@@ -100,9 +98,7 @@ describe('amp-next-page config', () => {
         ],
       };
 
-      expect(() =>
-        assertConfig(/*ctx*/ null, config, cdnOrigin, insecureOrigin))
-          .to.not.throw();
+      expect(() => assertConfig(/*ctx*/ null, config, url)).to.not.throw();
 
       expect(config.pages[0].ampUrl).to.equal(
           'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1');
@@ -118,14 +114,14 @@ describe('amp-next-page config', () => {
           },
         ],
       };
-      expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
           .to.not.throw();
       expect(config.pages[0].ampUrl).to.equal('https://example.com/article');
     });
 
     it('throws on null config', () => {
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, null, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, null, documentUrl))
             .to.throw('amp-next-page config must be specified');
       });
     });
@@ -133,7 +129,7 @@ describe('amp-next-page config', () => {
     it('throws on config with no "pages" key', () => {
       const config = {};
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('pages must be an array');
       });
     });
@@ -141,7 +137,7 @@ describe('amp-next-page config', () => {
     it('throws on config with non-array "pages" key', () => {
       const config = {pages: {}};
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('pages must be an array');
       });
     });
@@ -154,7 +150,7 @@ describe('amp-next-page config', () => {
         }],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('title must be a string');
       });
     });
@@ -168,7 +164,7 @@ describe('amp-next-page config', () => {
         }],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('title must be a string');
       });
     });
@@ -181,7 +177,7 @@ describe('amp-next-page config', () => {
         }],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('image must be a string');
       });
     });
@@ -195,7 +191,7 @@ describe('amp-next-page config', () => {
         }],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('image must be a string');
       });
     });
@@ -211,7 +207,7 @@ describe('amp-next-page config', () => {
         ],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw(
                 'pages must be from the same origin as the current document');
       });
@@ -228,7 +224,7 @@ describe('amp-next-page config', () => {
         ],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw(
                 'pages must be from the same origin as the current document');
       });
@@ -245,7 +241,7 @@ describe('amp-next-page config', () => {
         ],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw(
                 'pages must be from the same origin as the current document');
       });
@@ -257,7 +253,7 @@ describe('amp-next-page config', () => {
         hideSelectors: {},
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('amp-next-page hideSelectors should be an array');
       });
     });
@@ -268,7 +264,7 @@ describe('amp-next-page config', () => {
         hideSelectors: ['a', 2],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw('amp-next-page hideSelector value 2 is not a string');
       });
     });
@@ -279,7 +275,7 @@ describe('amp-next-page config', () => {
         hideSelectors: ['   .i-amphtml-something'],
       };
       allowConsoleError(() => {
-        expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+        expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
             .to.throw(/amp-next-page hideSelector .+ not allowed/);
       });
     });

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -51,7 +51,7 @@ describe('amp-next-page config', () => {
           .to.not.throw();
     });
 
-    it('allows pages with relative URLs', () => {
+    it('rewrites relative URLs to absolute', () => {
       const config = {
         pages: [{
           ampUrl: '/article1',
@@ -59,8 +59,24 @@ describe('amp-next-page config', () => {
           title: 'Article 1',
         }],
       };
-      expect(() => assertConfig(/*ctx*/ null, config, document.location))
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
           .to.not.throw();
+      expect(config.pages[0].ampUrl).to.equal(
+          'https://example.com/article1');
+    });
+
+    it('rewrites relative URLs when served from the cache', () => {
+      const config = {
+        pages: [{
+          ampUrl: '/article1',
+          image: '/image.png',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(/*ctx*/ null, config, documentUrlCdn))
+          .to.not.throw();
+      expect(config.pages[0].ampUrl).to.equal(
+          'https://example-com.cdn.ampproject.org/c/s/example.com/article1');
     });
 
     it('rewrites canonical URLs when served from the cache', () => {


### PR DESCRIPTION
Relative page URLs in amp-next-page config don't work right now when served from the cache, as the cache URL already contains a path, which contains the full canonical URL rather than just the document path. Fix by always resolving relative URLs to absolute using the canonical URL first, and then handling it as any other absolute URL (for cache rewriting).

Threw in some added bonus clean up of the `assertConfig` methods :sparkles: 

Fixes #18508