### PR TITLE
Fix experiment logic in amp-carousel

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -123,12 +123,17 @@ export class AmpSlideScroll extends BaseSlides {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
+    // Keep CSS Scroll Snap points turned on for the following:
+    // - All iOS devices except for 10.3
+    // - All places where the experiment flag is deliberately set.
+    // Conversely turn CSS Scroll Snap points off for the following:
+    // - iOS devices on version 10.3
+    // - Non iOS devices with the flag turned off.
     /** @private {boolean} */
-    this.shouldDisableCssSnap_ = !isExperimentOn(
-        this.win, 'amp-carousel-scroll-snap') ||
-        startsWith(
-            Services.platformFor(this.win).getIosVersionString(),
-            '10.3');
+    this.shouldDisableCssSnap_ = startsWith(
+        Services.platformFor(this.win).getIosVersionString(),
+        '10.3') ? true : this.isIos_ ? false : !isExperimentOn(
+          this.win, 'amp-carousel-scroll-snap');
   }
 
   /** @override */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -133,7 +133,7 @@ export class AmpSlideScroll extends BaseSlides {
     this.shouldDisableCssSnap_ = startsWith(
         Services.platformFor(this.win).getIosVersionString(),
         '10.3') ? true : this.isIos_ ? false : !isExperimentOn(
-          this.win, 'amp-carousel-scroll-snap');
+          this.win, 'amp-carousel-chrome-scroll-snap');
   }
 
   /** @override */

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -330,7 +330,7 @@ const EXPERIMENTS = [
   },
   {
     id: 'amp-carousel-chrome-scroll-snap',
-    name: 'Enables scroll snap on carousel across all browsers/OSes',
+    name: 'Enables scroll snap on carousel on Chrome browsers',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16508',
   },
   {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -329,7 +329,7 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17243',
   },
   {
-    id: 'amp-carousel-scroll-snap',
+    id: 'amp-carousel-chrome-scroll-snap',
     name: 'Enables scroll snap on carousel across all browsers/OSes',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16508',
   },


### PR DESCRIPTION
Currently CSS Scroll Snap is disabled in all iOS platform:
The condition read:
```
this.shouldDisableCssSnap_ = !isExperimentOn(
        this.win, 'amp-carousel-scroll-snap') ||
        startsWith(
            Services.platformFor(this.win).getIosVersionString(),
            '10.3');
```
Since the experiment was turned off, the experiment check returned `false` which meant we were disabling CSS Scroll Snap on iOS - where it should have been on. 

Fixes #18558, #18592