### PR TITLE
Add the amp-json-schema extension. (#18012)

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -258,6 +258,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       'third_party/react-dates/bundle.js',
       'third_party/amp-toolbox-cache-url/**/*.js',
       'third_party/inputmask/**/*.js',
+      'node_modules/ajv/dist/ajv.min.js',
       'node_modules/dompurify/dist/purify.es.js',
       'node_modules/promise-pjs/promise.js',
       'node_modules/set-dom/src/**/*.js',

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -170,6 +170,7 @@ exports.extensionBundles = [
   },
   {name: 'amp-install-serviceworker', version: '0.1', type: TYPES.MISC},
   {name: 'amp-izlesene', version: '0.1', type: TYPES.MEDIA},
+  {name: 'amp-json-schema', version: '0.1', type: TYPES.MISC},
   {name: 'amp-jwplayer', version: '0.1', type: TYPES.MEDIA},
   {
     name: 'amp-lightbox',

--- a/examples/amp-json-schema.amp.html
+++ b/examples/amp-json-schema.amp.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-json-schema example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-json-schema {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-json-schema" src="https://cdn.ampproject.org/v0/amp-json-schema-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script id="premutate-schema" type="application/schema+json">
+    {
+      "type": "object",
+      "properties": {
+        "numTickets": {
+          "type": "integer",
+        },
+      },
+      "required": ["numTickets"],
+      "additionalProperties": false
+    }
+  </script>
+</head>
+<body></body>
+</html>

--- a/extensions/amp-json-schema/0.1/amp-json-schema.js
+++ b/extensions/amp-json-schema/0.1/amp-json-schema.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {tryParseJson} from '../../../src/json';
+import {user} from '../../../src/log';
+import Ajv from 'ajv/dist/ajv.min.js';
+
+/** @const {string} */
+const TAG = 'amp-json-schema-validator';
+
+export class AmpJsonSchema {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @const @private */
+    this.ampdoc_ = ampdoc;
+
+    /** @const @private */
+    this.ajv_ = new Ajv();
+  }
+
+  /**
+   * Validates the data against a given schema.
+   * The schema should be declared in the AMP Doc in a script element
+   * with id='{schemaName}'.
+   * @param {string} schemaName The name of the schema defined in the ampdoc.
+   * @param {!Object} data The data to be validated
+   * @return {boolean} Whether or not the data fits the schema
+   */
+  validate(schemaName, data) {
+    const schemaElement = this.ampdoc_.getElementById(schemaName);
+    if (!schemaElement) {
+      user().error(TAG,`${schemaName} element does not exist`);
+      return false;
+    }
+
+    /** @const {!JsonObject|null|undefined} */
+    const schema = tryParseJson(schemaElement.textContent, e => {
+      user().error(TAG,
+          `Failed to parse ${schemaName} Schema JSON: ${e}`);
+    });
+
+    if (!schema) {
+      return false;
+    }
+
+    const valid = this.ajv_.validate(schema, data);
+
+    if (!valid) {
+      user().error(TAG,
+          `Schema validation failed: ${this.ajv_.errorsText()}`);
+    }
+
+    return valid;
+  }
+}
+
+// Register the extension services.
+AMP.extension(TAG, '0.1', function(AMP) {
+  AMP.registerServiceForDoc('json-schema', function(ampdoc) {
+    return new AmpJsonSchema(ampdoc);
+  });
+});

--- a/extensions/amp-json-schema/0.1/test/test-amp-json-schema.js
+++ b/extensions/amp-json-schema/0.1/test/test-amp-json-schema.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {AmpJsonSchema} from '../amp-json-schema';
+
+describes.fakeWin('AmpJsonSchema', {
+  amp: true,
+  location: 'https://pub.com/doc1',
+}, env => {
+
+  let document;
+  let jsonSchemaService;
+  beforeEach(() => {
+    document = env.win.document;
+
+    const element = document.createElement('script');
+    element.setAttribute('id', 'premutate');
+    element.setAttribute('type', 'application/schema+json');
+
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'shoeType': {
+          'type': 'string',
+        },
+      },
+      'required': ['shoeType'],
+      'additionalProperties': false,
+    };
+    element.textContent = JSON.stringify(schema);
+    document.body.appendChild(element);
+    jsonSchemaService = new AmpJsonSchema(env.ampdoc);
+
+  });
+
+  it('Validate should return true if valid data', () => {
+    expect(jsonSchemaService.validate('premutate', {shoeType: 'jordans'}))
+        .to.be.true;
+  });
+
+  it('Validate should fail if data does not match schema', () => {
+    allowConsoleError(() => {
+      expect(jsonSchemaService.validate('premutate', {cat: 'hat'})).to.be.false;
+    });
+  });
+
+  it('Validate should fail is schema has not been defined', () => {
+    allowConsoleError(() => {
+      expect(jsonSchemaService.validate('test', {cat: 'hat'})).to.be.false;
+    });
+  });
+
+  it('Validate should fail if JSON Parse fails', () => {
+    const element = document.createElement('script');
+    element.setAttribute('id', 'test');
+    element.setAttribute('type', 'application/schema+json');
+
+    element.textContent = '{asdf';
+    document.body.appendChild(element);
+    allowConsoleError(() => {
+      expect(jsonSchemaService.validate('test', {cat: 'hat'})).to.be.false;
+    });
+  });
+});

--- a/extensions/amp-json-schema/amp-json-schema.md
+++ b/extensions/amp-json-schema/amp-json-schema.md
@@ -1,0 +1,65 @@
+<!--
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="`amp-json-schema`"></a> `amp-json-schema`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>This extension allows the user to  specify a JSON schema and validate it using AJV(Another JSON VAlidator).</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-json-schema-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Example</strong></td>
+    <td>
+      <script id="premutate-schema" type="application/schema+json">
+        {
+          "type": "object",
+          "properties": {
+            "numTickets": {
+              "type": "integer",
+            },
+          },
+          "required": ["numTickets"],
+          "additionalProperties": false
+        }
+      </script>
+    </td>
+  </tr>
+</table>
+
+## Overview
+This extension was created primarily to allow other extensions to validate JSON
+data when given a schema
+
+A [JSON Schema](https://json-schema.org/) defines what form the state you pass in
+must look like. You can specify which fields are allowed, and which fields are
+required.
+
+You can think of it as a way to forcefully constrain the initial state of the app.
+If schema validation fails, the page will not load, showing an error instead.
+
+For example, if amp-bind wanted to use schema validation for premutating amp-state
+upon page load, a premutate schema with the id='premutate-schema' can be defined 
+(like the code block above), and then amp-bind would then call 
+jsonSchemaService.validate('premutate-schema', data), where jsonSchemaService is an
+instance of AmpJsonSchema.
+
+## Validation
+See [amp-json-schema rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-json-schema/validator-amp-json-schema.protoascii) in the AMP validator specification.

--- a/extensions/amp-json-schema/validator-amp-json-schema.protoascii
+++ b/extensions/amp-json-schema/validator-amp-json-schema.protoascii
@@ -1,0 +1,54 @@
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-json-schema
+  html_format: AMP
+  html_format: EXPERIMENTAL
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-json-schema"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+
+tags: {  # amp-json-schema (json)
+  html_format: AMP
+  html_format: EXPERIMENTAL
+  tag_name: "SCRIPT"
+  spec_name: "amp-json-schema extension .json script"
+  unique: true
+  mandatory_parent: "HEAD"
+  requires_extension: "amp-json-schema"
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
+  attrs: { name: "nonce" }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/schema+json"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ampproject/animations": "0.1.0",
     "@ampproject/worker-dom": "0.2.2",
+    "ajv": "6.5.4",
     "document-register-element": "1.5.0",
     "dompurify": "1.0.8",
     "promise-pjs": "1.1.3",
@@ -43,7 +44,6 @@
     "@babel/runtime-corejs2": "7.2.0",
     "@octokit/rest": "16.2.0",
     "acorn-globals": "4.3.0",
-    "ajv": "6.5.4",
     "ajv-keywords": "3.2.0",
     "ansi-colors": "3.2.3",
     "ast-replace": "1.1.3",

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -1141,6 +1141,7 @@ describe('ValidatorRulesMakeSense', () => {
           if (attrSpec.name === 'type' && attrSpec.valueCasei.length > 0) {
             for (const value of attrSpec.valueCasei) {
               if (value === 'application/ld+json' ||
+                  value === 'application/schema+json' ||
                   value === 'application/json') {
                 hasJson = true;
               }

--- a/validator/testdata/feature_tests/amp-json-schema.html
+++ b/validator/testdata/feature_tests/amp-json-schema.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-json-schema example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-json-schema" src="https://cdn.ampproject.org/v0/amp-json-schema-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script id="premutate-schema" type="application/schema+json">
+    {
+      "type": "object",
+      "properties": {
+        "numTickets": {
+          "type": "integer",
+        },
+      },
+      "required": ["numTickets"],
+      "additionalProperties": false
+    }
+  </script>
+</head>
+<body></body>
+</html>

--- a/validator/testdata/feature_tests/amp-json-schema.out
+++ b/validator/testdata/feature_tests/amp-json-schema.out
@@ -1,0 +1,26 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-json-schema example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-json-schema" src="https://cdn.ampproject.org/v0/amp-json-schema-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script id="premutate-schema" type="application/schema+json">
+|      {
+|        "type": "object",
+|        "properties": {
+|          "numTickets": {
+|            "type": "integer",
+|          },
+|        },
+|        "required": ["numTickets"],
+|        "additionalProperties": false
+|      }
+|    </script>
+|  </head>
+|  <body></body>
+|  </html>


### PR DESCRIPTION
Add the amp-json-schema extension. This allows the user to  specify a JSON schema and validate it using AJV(Another JSON Validator).

Implements part of https://github.com/ampproject/amphtml/issues/18012

