### PR TITLE
🏗 Ignore errors when navigating to blank.html

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -673,7 +673,8 @@ async function createEmptyBuild(page) {
     ],
   });
   await percy.startBuild();
-  await page.goto(`${BASE_URL}/examples/visual-tests/blank-page/blank.html`);
+  await page.goto(`${BASE_URL}/examples/visual-tests/blank-page/blank.html`)
+      .then(() => {}, () => {});
   await percy.snapshot('Blank page', page, SNAPSHOT_EMPTY_BUILD_OPTIONS);
   await percy.finalizeBuild();
 }


### PR DESCRIPTION
Navigation timeouts are flaky when using Puppeteer. This PR adds code to ignore those errors, which are more likely to be flakes than real nagivation errors, when navigating to the blank page on the internal server.

If this was a real error, then Percy will show us the real error page instead of a blank page in the comparison, but this has yet to happen in real life.