### PR TITLE
🐛 Make `web-animations-js` compatible with strict mode and unskip failing tests

### DIFF
--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -727,8 +727,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(anim.visible_).to.be.true;
     });
 
-    // TODO(nainar, #18612): This fails when run in strict mode.
-    it.skip('should find target in the embed only via selector', function* () {
+    it('should find target in the embed only via selector', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
       const anim = yield createAnim({},
@@ -746,8 +745,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
       });
     });
 
-    // TODO(nainar, #18612): This fails when run in strict mode.
-    it.skip('should find target in the embed only via target', function* () {
+    it('should find target in the embed only via target', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
       const anim = yield createAnim({},


### PR DESCRIPTION
Some `amp-animations` tests were failing due to the strict mode violations in 3P code described in https://github.com/web-animations/web-animations-js/issues/46.

This PR adds a guard around the offending code while patching `web-animations-js` in `gulp update-packages` and unskips the previously failing tests. With this, `web-animations-js` is strict mode compliant without any change to its functionality.

The patching can be removed once the underlying bug in 3P code is fixed.

Fixes #18612
