### PR TITLE
🐛 Check if doc is RTL before instantiating page-advancement in amp-story

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -191,6 +191,11 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win);
 
+    // Check if story is RTL.
+    if (isRTL(this.win.document)) {
+      this.storeService_.dispatch(Action.TOGGLE_RTL, true);
+    }
+
     /** @private {!NavigationState} */
     this.navigationState_ =
         new NavigationState(this.win, () => this.hasBookend_());
@@ -323,11 +328,6 @@ export class AmpStory extends AMP.BaseElement {
   buildCallback() {
     if (this.isStandalone_()) {
       this.initializeStandaloneStory_();
-    }
-
-    // Check if story is RTL.
-    if (isRTL(this.win.document)) {
-      this.storeService_.dispatch(Action.TOGGLE_RTL, true);
     }
 
     const pageEl = this.element.querySelector('amp-story-page');


### PR DESCRIPTION
Fixes #18685

With the introduction of the `page-advancement` at the story level(#18154), we instantiated it before checking if the document is RTL. Which we shouldn't do because the manual advancement needs this information to know how to partition the sections depending on the language settings. Checking if the document is RTL is one of the first things we should do.