### PR TITLE
🐛[amp-ad] fix errors occurring during the call of noContentAvailable in capirs

### DIFF
--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -61,7 +61,7 @@ export function capirs(global, data) {
         const reportId = 'capirs-' + banner['banner_id'];
         global.context.reportRenderedEntityIdentifier(reportId);
       },
-      unexist: global.context.noContentAvailable,
+      unexist: function() { global.context.noContentAvailable(); },
     },
   };
 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -1390,7 +1390,6 @@
   </amp-ad>
 
   <h2>Rambler&Co</h2>
-  <div>Due to implementation issue, expect an error 'Cannot read property "sendMessage" of undefined'</div>
   <amp-ad width="500" height="250"
       type="capirs"
       layout="responsive"


### PR DESCRIPTION
Fix the problem described in this PR, https://github.com/ampproject/amphtml/pull/18643
Due to the internal implementation of capirs, callback subscribed to any of events is called in context of banner place
So I rewrote the part with noContentAvailable in order to avoid the wrong behaviour


