### PR TITLE
🚮remove unused docEndCallback

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -8,6 +8,5 @@
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
   <script>draw3p()</script>
 </div>
-<script>if (window.docEndCallback) window.docEndCallback()</script>
 </body>
 </html>

--- a/3p/remote.html
+++ b/3p/remote.html
@@ -23,6 +23,5 @@ document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
       ['your-domain.com']);
   </script>
 </div>
-<script>if (window.docEndCallback) window.docEndCallback()</script>
 </body>
 </html>


### PR DESCRIPTION
Found the docEndCallback added back here https://github.com/ampproject/amphtml/commit/2b255af77f9e50a59740e5423b6222c8c06c3b3d

Which I believe is not used anymore. I don't see an issue deleting them, but let me know if I miss anything. 

cc @cramforce 

