### PR TITLE
Add message whitelist functionality to inabox messaging host

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -122,15 +122,14 @@ export class InaboxMessagingHost {
       return false;
     }
 
-    const iframe =
+    const adFrame =
         this.getFrameElement_(message.source, request['sentinel']);
-    if (!iframe) {
+    if (!adFrame) {
       dev().info(TAG, 'Ignored message from untrusted iframe:', message);
       return false;
     }
 
-    const allowedTypes =
-        this.iframeMap_[request['sentinel']].iframe.dataset['ampAllowed'];
+    const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
     // having no whitelist is legacy behavior so assume all types are allowed
     if (allowedTypes &&
         !allowedTypes.split(/ *, */).includes(request['type'])) {
@@ -139,7 +138,7 @@ export class InaboxMessagingHost {
     }
 
     if (!this.msgObservable_.fire(request['type'], this,
-        [iframe, request, message.source, message.origin])) {
+        [adFrame.measurableFrame, request, message.source, message.origin])) {
       dev().warn(TAG, 'Unprocessed AMP message:', message);
       return false;
     }
@@ -255,12 +254,12 @@ export class InaboxMessagingHost {
    *
    * @param {?Window} source
    * @param {string} sentinel
-   * @return {?HTMLIFrameElement}
+   * @return {?AdFrameDef}
    * @private
    */
   getFrameElement_(source, sentinel) {
     if (this.iframeMap_[sentinel]) {
-      return this.iframeMap_[sentinel].measurableFrame;
+      return this.iframeMap_[sentinel];
     }
     const measurableFrame = this.getMeasureableFrame(source);
     if (!measurableFrame) {
@@ -273,7 +272,7 @@ export class InaboxMessagingHost {
         j < 10; j++, tempWin = tempWin.parent) {
         if (iframe.contentWindow == tempWin) {
           this.iframeMap_[sentinel] = {iframe, measurableFrame};
-          return measurableFrame;
+          return this.iframeMap_[sentinel];
         }
         if (tempWin == window.top) {
           break;

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -132,8 +132,7 @@ export class InaboxMessagingHost {
     const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
     // escape the type before including it in the regex
     const type = request['type'].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const hasAllowedTypeRegex =
-        new RegExp(`(^|,)\\s*${type}\\s*($|,)`);
+    const hasAllowedTypeRegex = new RegExp(`(^|,)\\s*${type}\\s*($|,)`);
     // having no whitelist is legacy behavior so assume all types are allowed
     if (allowedTypes && !hasAllowedTypeRegex.test(allowedTypes)) {
       dev().info(TAG, 'Ignored non-whitelisted message type:', message);

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -131,7 +131,7 @@ export class InaboxMessagingHost {
 
     const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
     const hasAllowedTypeRegex =
-        new RegExp(`(^|,)\\s*${request['type']}\\s*($|,)`)
+        new RegExp(`(^|,)\\s*${request['type']}\\s*($|,)`);
     // having no whitelist is legacy behavior so assume all types are allowed
     if (allowedTypes && !hasAllowedTypeRegex.test(allowedTypes)) {
       dev().info(TAG, 'Ignored non-whitelisted message type:', message);

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -130,9 +130,10 @@ export class InaboxMessagingHost {
     }
 
     const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
+    const hasAllowedTypeRegex =
+        new RegExp(`(^|,)\\s*${request['type']}\\s*($|,)`)
     // having no whitelist is legacy behavior so assume all types are allowed
-    if (allowedTypes &&
-        !allowedTypes.split(/ *, */).includes(request['type'])) {
+    if (allowedTypes && !hasAllowedTypeRegex.test(allowedTypes)) {
       dev().info(TAG, 'Ignored non-whitelisted message type:', message);
       return false;
     }

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -129,6 +129,15 @@ export class InaboxMessagingHost {
       return false;
     }
 
+    const allowedTypes =
+        this.iframeMap_[request['sentinel']].iframe.dataset['ampAllowed'];
+    // having no whitelist is legacy behavior so assume all types are allowed
+    if (allowedTypes &&
+        !allowedTypes.split(/ *, */).includes(request['type'])) {
+      dev().info(TAG, 'Ignored non-whitelisted message type:', message);
+      return false;
+    }
+
     if (!this.msgObservable_.fire(request['type'], this,
         [iframe, request, message.source, message.origin])) {
       dev().warn(TAG, 'Unprocessed AMP message:', message);

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -130,11 +130,9 @@ export class InaboxMessagingHost {
     }
 
     const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
-    // escape the type before including it in the regex
-    const type = request['type'].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const hasAllowedTypeRegex = new RegExp(`(^|,)\\s*${type}\\s*($|,)`);
     // having no whitelist is legacy behavior so assume all types are allowed
-    if (allowedTypes && !hasAllowedTypeRegex.test(allowedTypes)) {
+    if (allowedTypes &&
+        !allowedTypes.split(/\s*,\s*/).includes(request['type'])) {
       dev().info(TAG, 'Ignored non-whitelisted message type:', message);
       return false;
     }

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -130,8 +130,10 @@ export class InaboxMessagingHost {
     }
 
     const allowedTypes = adFrame.iframe.dataset['ampAllowed'];
+    // escape the type before including it in the regex
+    const type = request['type'].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const hasAllowedTypeRegex =
-        new RegExp(`(^|,)\\s*${request['type']}\\s*($|,)`);
+        new RegExp(`(^|,)\\s*${type}\\s*($|,)`);
     // having no whitelist is legacy behavior so assume all types are allowed
     if (allowedTypes && !hasAllowedTypeRegex.test(allowedTypes)) {
       dev().info(TAG, 'Ignored non-whitelisted message type:', message);

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -411,8 +411,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMock = topWinMock.document.querySelectorAll()[0];
       const expectedWin = sourceMock.parent.parent;
       host = new InaboxMessagingHost(win, [frameMock]);
-      const measurableFrame =
-          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      const {measurableFrame} = host.getFrameElement_(sourceMock, sentinel);
       expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
@@ -422,8 +421,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMock = topWinMock.document.querySelectorAll()[0];
       const expectedWin = sourceMock;
       host = new InaboxMessagingHost(win, [frameMock]);
-      const measurableFrame =
-          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      const {measurableFrame} = host.getFrameElement_(sourceMock, sentinel);
       expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
@@ -436,8 +434,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const expectedWin = sourceMock;
       host = new InaboxMessagingHost(
           win, [frameMockWrong1, frameMockWrong2, frameMock]);
-      const measurableFrame =
-          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      const {measurableFrame} = host.getFrameElement_(sourceMock, sentinel);
       expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
@@ -449,8 +446,8 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const creativeIframeMock = {};
       host.iframeMap_[sentinel] = {
         'iframe': creativeIframeMock, 'measurableFrame': creativeIframeMock};
-      const measurableFrame =
-          host.getFrameElement_(creativeWinMock, sentinel).measurableFrame;
+      const {measurableFrame} =
+          host.getFrameElement_(creativeWinMock, sentinel);
       expect(measurableFrame).to.equal(creativeIframeMock);
     });
 

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -411,8 +411,9 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMock = topWinMock.document.querySelectorAll()[0];
       const expectedWin = sourceMock.parent.parent;
       host = new InaboxMessagingHost(win, [frameMock]);
-      expect(host.getFrameElement_(sourceMock, sentinel).contentWindow
-      ).to.deep.equal(expectedWin);
+      const measurableFrame =
+          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
     it('should return correct frame when all frames friendly', () => {
@@ -421,8 +422,9 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMock = topWinMock.document.querySelectorAll()[0];
       const expectedWin = sourceMock;
       host = new InaboxMessagingHost(win, [frameMock]);
-      expect(host.getFrameElement_(sourceMock, sentinel).contentWindow
-      ).to.deep.equal(expectedWin);
+      const measurableFrame =
+          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
     it('should return correct frame when many frames registered', () => {
@@ -434,8 +436,9 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const expectedWin = sourceMock;
       host = new InaboxMessagingHost(
           win, [frameMockWrong1, frameMockWrong2, frameMock]);
-      expect(host.getFrameElement_(sourceMock, sentinel).contentWindow
-      ).to.deep.equal(expectedWin);
+      const measurableFrame =
+          host.getFrameElement_(sourceMock, sentinel).measurableFrame;
+      expect(measurableFrame.contentWindow).to.deep.equal(expectedWin);
     });
 
     it('should return cached frame', () => {
@@ -446,8 +449,9 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const creativeIframeMock = {};
       host.iframeMap_[sentinel] = {
         'iframe': creativeIframeMock, 'measurableFrame': creativeIframeMock};
-      expect(host.getFrameElement_(creativeWinMock, sentinel)
-      ).to.equal(creativeIframeMock);
+      const measurableFrame =
+          host.getFrameElement_(creativeWinMock, sentinel).measurableFrame;
+      expect(measurableFrame).to.equal(creativeIframeMock);
     });
 
     it('should return null if frame is not registered', () => {


### PR DESCRIPTION
Right now, any AMP ads in a box can ask the host script to resize itself. Add and verify a per-iframe whitelist to restrict the functionality each creative within the frame has.

Frames without whitelist are still allowed to do anything since corresponding behavior from GPT/AdSense is not yet added.