### PR TITLE
Allow Multi-line CSS styles in AMP doc

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/min_valid_multiline_amp4ads.html
+++ b/validator/testdata/amp4ads_feature_tests/min_valid_multiline_amp4ads.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This is the minimum valid A4A document; it includes all of the required
+  fields from the spec, but nothing else.
+-->
+<!doctype html>
+<html ⚡4ads>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>
+    body {
+      visibility: hidden
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+</head>
+<body>Hello, world.</body>
+</html>

--- a/validator/testdata/amp4ads_feature_tests/min_valid_multiline_amp4ads.out
+++ b/validator/testdata/amp4ads_feature_tests/min_valid_multiline_amp4ads.out
@@ -1,0 +1,35 @@
+PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid A4A document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>
+|      body {
+|        visibility: hidden
+|      }
+|    </style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>Hello, world.</body>
+|  </html>

--- a/validator/testdata/amp4email_feature_tests/min_valid_multiline_amp4email.html
+++ b/validator/testdata/amp4email_feature_tests/min_valid_multiline_amp4email.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This is the minimum valid AMP4EMAIL document; it includes all of the required
+  fields from the spec, but nothing else.
+-->
+<!doctype html>
+<html ⚡4email>
+<head>
+  <meta charset="utf-8">
+  <style amp4email-boilerplate>
+    body {
+      visibility: hidden;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/amp4email_feature_tests/min_valid_multiline_amp4email.out
+++ b/validator/testdata/amp4email_feature_tests/min_valid_multiline_amp4email.out
@@ -1,0 +1,36 @@
+PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP4EMAIL document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡4email>
+|  <head>
+|    <meta charset="utf-8">
+|    <style amp4email-boilerplate>
+|      body {
+|        visibility: hidden;
+|      }
+|    </style>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.html
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.html
@@ -27,15 +27,15 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp-boilerplate>
     body {
-            -webkit-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-            -moz-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-            -ms-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-            animation: -amp-start 8s steps(1,end) 0s 1 normal both
+            -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+            -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+            -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+            animation: -amp-start 8s steps(1, end) 0s 1 normal both
         }
 
         @-webkit-keyframes -amp-start {
             from {
-                visibility: hidden
+                visibility: hidden;
             }
 
             to {
@@ -49,7 +49,7 @@
             }
 
             to {
-                visibility: visible
+                visibility: visible;
             }
         }
 
@@ -59,7 +59,7 @@
             }
 
             to {
-                visibility: visible
+                visibility: visible;
             }
         }
 
@@ -79,7 +79,7 @@
             }
 
             to {
-                visibility: visible
+                visibility: visible;
             }
         }
   </style>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.html
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.html
@@ -27,61 +27,61 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp-boilerplate>
     body {
-            -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-            -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-            -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-            animation: -amp-start 8s steps(1, end) 0s 1 normal both
+      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      animation: -amp-start 8s steps(1, end) 0s 1 normal both
+    }
+
+    @-webkit-keyframes -amp-start {
+        from {
+            visibility: hidden;
         }
 
-        @-webkit-keyframes -amp-start {
-            from {
-                visibility: hidden;
-            }
+        to {
+            visibility: visible
+        }
+    }
 
-            to {
-                visibility: visible
-            }
+    @-moz-keyframes -amp-start {
+        from {
+            visibility: hidden
         }
 
-        @-moz-keyframes -amp-start {
-            from {
-                visibility: hidden
-            }
+        to {
+            visibility: visible;
+        }
+    }
 
-            to {
-                visibility: visible;
-            }
+    @-ms-keyframes -amp-start {
+        from {
+            visibility: hidden
         }
 
-        @-ms-keyframes -amp-start {
-            from {
-                visibility: hidden
-            }
+        to {
+            visibility: visible;
+        }
+    }
 
-            to {
-                visibility: visible;
-            }
+    @-o-keyframes -amp-start {
+        from {
+            visibility: hidden
         }
 
-        @-o-keyframes -amp-start {
-            from {
-                visibility: hidden
-            }
+        to {
+            visibility: visible
+        }
+    }
 
-            to {
-                visibility: visible
-            }
+    @keyframes -amp-start {
+        from {
+            visibility: hidden
         }
 
-        @keyframes -amp-start {
-            from {
-                visibility: hidden
-            }
-
-            to {
-                visibility: visible;
-            }
+        to {
+            visibility: visible;
         }
+    }
   </style>
   <noscript>
     <style amp-boilerplate>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.html
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.html
@@ -1,0 +1,101 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This is the minimum valid AMP document; it includes all of the required
+  fields from the spec, but nothing else. This test exercises the new
+  amp boilerplate.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>
+    body {
+            -webkit-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+            -moz-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+            -ms-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+            animation: -amp-start 8s steps(1,end) 0s 1 normal both
+        }
+
+        @-webkit-keyframes -amp-start {
+            from {
+                visibility: hidden
+            }
+
+            to {
+                visibility: visible
+            }
+        }
+
+        @-moz-keyframes -amp-start {
+            from {
+                visibility: hidden
+            }
+
+            to {
+                visibility: visible
+            }
+        }
+
+        @-ms-keyframes -amp-start {
+            from {
+                visibility: hidden
+            }
+
+            to {
+                visibility: visible
+            }
+        }
+
+        @-o-keyframes -amp-start {
+            from {
+                visibility: hidden
+            }
+
+            to {
+                visibility: visible
+            }
+        }
+
+        @keyframes -amp-start {
+            from {
+                visibility: hidden
+            }
+
+            to {
+                visibility: visible
+            }
+        }
+  </style>
+  <noscript>
+    <style amp-boilerplate>
+      body {
+          -webkit-animation: none;
+          -moz-animation: none;
+          -ms-animation: none;
+          animation: none
+      }
+    </style>
+  </noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.out
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.out
@@ -28,15 +28,15 @@ PASS
 |    <meta name="viewport" content="width=device-width,minimum-scale=1">
 |    <style amp-boilerplate>
 |      body {
-|              -webkit-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-|              -moz-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-|              -ms-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
-|              animation: -amp-start 8s steps(1,end) 0s 1 normal both
+|              -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|              -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|              -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|              animation: -amp-start 8s steps(1, end) 0s 1 normal both
 |          }
 |
 |          @-webkit-keyframes -amp-start {
 |              from {
-|                  visibility: hidden
+|                  visibility: hidden;
 |              }
 |
 |              to {
@@ -50,7 +50,7 @@ PASS
 |              }
 |
 |              to {
-|                  visibility: visible
+|                  visibility: visible;
 |              }
 |          }
 |
@@ -60,7 +60,7 @@ PASS
 |              }
 |
 |              to {
-|                  visibility: visible
+|                  visibility: visible;
 |              }
 |          }
 |
@@ -80,7 +80,7 @@ PASS
 |              }
 |
 |              to {
-|                  visibility: visible
+|                  visibility: visible;
 |              }
 |          }
 |    </style>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.out
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.out
@@ -28,61 +28,61 @@ PASS
 |    <meta name="viewport" content="width=device-width,minimum-scale=1">
 |    <style amp-boilerplate>
 |      body {
-|              -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|              -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|              -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|              animation: -amp-start 8s steps(1, end) 0s 1 normal both
+|        -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        animation: -amp-start 8s steps(1, end) 0s 1 normal both
+|      }
+|
+|      @-webkit-keyframes -amp-start {
+|          from {
+|              visibility: hidden;
 |          }
 |
-|          @-webkit-keyframes -amp-start {
-|              from {
-|                  visibility: hidden;
-|              }
+|          to {
+|              visibility: visible
+|          }
+|      }
 |
-|              to {
-|                  visibility: visible
-|              }
+|      @-moz-keyframes -amp-start {
+|          from {
+|              visibility: hidden
 |          }
 |
-|          @-moz-keyframes -amp-start {
-|              from {
-|                  visibility: hidden
-|              }
+|          to {
+|              visibility: visible;
+|          }
+|      }
 |
-|              to {
-|                  visibility: visible;
-|              }
+|      @-ms-keyframes -amp-start {
+|          from {
+|              visibility: hidden
 |          }
 |
-|          @-ms-keyframes -amp-start {
-|              from {
-|                  visibility: hidden
-|              }
+|          to {
+|              visibility: visible;
+|          }
+|      }
 |
-|              to {
-|                  visibility: visible;
-|              }
+|      @-o-keyframes -amp-start {
+|          from {
+|              visibility: hidden
 |          }
 |
-|          @-o-keyframes -amp-start {
-|              from {
-|                  visibility: hidden
-|              }
+|          to {
+|              visibility: visible
+|          }
+|      }
 |
-|              to {
-|                  visibility: visible
-|              }
+|      @keyframes -amp-start {
+|          from {
+|              visibility: hidden
 |          }
 |
-|          @keyframes -amp-start {
-|              from {
-|                  visibility: hidden
-|              }
-|
-|              to {
-|                  visibility: visible;
-|              }
+|          to {
+|              visibility: visible;
 |          }
+|      }
 |    </style>
 |    <noscript>
 |      <style amp-boilerplate>

--- a/validator/testdata/feature_tests/new_multiline_boilerplate.out
+++ b/validator/testdata/feature_tests/new_multiline_boilerplate.out
@@ -1,0 +1,102 @@
+PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else. This test exercises the new
+|    amp boilerplate.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>
+|      body {
+|              -webkit-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+|              -moz-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+|              -ms-animation: -amp-start 8s steps(1,end) 0s 1 normal both;
+|              animation: -amp-start 8s steps(1,end) 0s 1 normal both
+|          }
+|
+|          @-webkit-keyframes -amp-start {
+|              from {
+|                  visibility: hidden
+|              }
+|
+|              to {
+|                  visibility: visible
+|              }
+|          }
+|
+|          @-moz-keyframes -amp-start {
+|              from {
+|                  visibility: hidden
+|              }
+|
+|              to {
+|                  visibility: visible
+|              }
+|          }
+|
+|          @-ms-keyframes -amp-start {
+|              from {
+|                  visibility: hidden
+|              }
+|
+|              to {
+|                  visibility: visible
+|              }
+|          }
+|
+|          @-o-keyframes -amp-start {
+|              from {
+|                  visibility: hidden
+|              }
+|
+|              to {
+|                  visibility: visible
+|              }
+|          }
+|
+|          @keyframes -amp-start {
+|              from {
+|                  visibility: hidden
+|              }
+|
+|              to {
+|                  visibility: visible
+|              }
+|          }
+|    </style>
+|    <noscript>
+|      <style amp-boilerplate>
+|        body {
+|            -webkit-animation: none;
+|            -moz-animation: none;
+|            -ms-animation: none;
+|            animation: none
+|        }
+|      </style>
+|    </noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1170,7 +1170,7 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both(;){0,1}\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;?\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }
@@ -1192,7 +1192,7 @@ tags: {
     # This regex allows arbitrary whitespace around the body statement, but
     # not inside it. This is a compromise to keep things simple, but allow
     # pretty printing tools some latitude.
-    cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#boilerplate"
 }
@@ -1213,7 +1213,7 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }
@@ -1236,7 +1236,7 @@ tags: {
   }
   attrs: { name: "nonce" }
   cdata {
-    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*none\\s*;\\s*-moz-animation\\s*:\\s*none\\s*;\\s*-ms-animation\\s*:\\s*none\\s*;\\s*animation\\s*:\\s*none(;){0,1}\\s*}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*none;\\s*-moz-animation:\\s*none;\\s*-ms-animation:\\s*none;\\s*animation:\\s*none;?\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 742
+spec_file_revision: 743
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -1170,7 +1170,9 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    cdata_regex: "\\s*body{-webkit-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-moz-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-ms-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both}@-webkit-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\\s*"
+    # Old format (remove once new format is tested)
+    #cdata_regex: "\\s*body{-webkit-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-moz-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-ms-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both}@-webkit-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both(;){0,1}\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }
@@ -1192,7 +1194,8 @@ tags: {
     # This regex allows arbitrary whitespace around the body statement, but
     # not inside it. This is a compromise to keep things simple, but allow
     # pretty printing tools some latitude.
-    cdata_regex: "\\s*body{visibility:hidden}\\s*"
+    #cdata_regex: "\\s*body{visibility:hidden}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#boilerplate"
 }
@@ -1213,7 +1216,8 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    cdata_regex: "\\s*body{visibility:hidden}\\s*"
+    #cdata_regex: "\\s*body{visibility:hidden}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }
@@ -1236,7 +1240,8 @@ tags: {
   }
   attrs: { name: "nonce" }
   cdata {
-    cdata_regex: "\\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\\s*"
+    #cdata_regex: "\\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\\s*"
+    cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*none\\s*;\\s*-moz-animation\\s*:\\s*none\\s*;\\s*-ms-animation\\s*:\\s*none\\s*;\\s*animation\\s*:\\s*none(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1170,8 +1170,6 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    # Old format (remove once new format is tested)
-    #cdata_regex: "\\s*body{-webkit-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-moz-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-ms-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both}@-webkit-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\\s*"
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\s*\\(\\s*1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation\\s*:\\s*-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both(;){0,1}\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*to\\s*{\\s*visibility\\s*:\\s*visible(;){0,1}\\s*}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
@@ -1194,7 +1192,6 @@ tags: {
     # This regex allows arbitrary whitespace around the body statement, but
     # not inside it. This is a compromise to keep things simple, but allow
     # pretty printing tools some latitude.
-    #cdata_regex: "\\s*body{visibility:hidden}\\s*"
     cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#boilerplate"
@@ -1216,7 +1213,6 @@ tags: {
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
-    #cdata_regex: "\\s*body{visibility:hidden}\\s*"
     cdata_regex: "\\s*body\\s*{\\s*visibility\\s*:\\s*hidden(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
@@ -1240,7 +1236,6 @@ tags: {
   }
   attrs: { name: "nonce" }
   cdata {
-    #cdata_regex: "\\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\\s*"
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation\\s*:\\s*none\\s*;\\s*-moz-animation\\s*:\\s*none\\s*;\\s*-ms-animation\\s*:\\s*none\\s*;\\s*animation\\s*:\\s*none(;){0,1}\\s*}\\s*"
   }
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"


### PR DESCRIPTION
Resolves Issue #17382

Allow multi-line CSS styles in AMP Doc for:
------------------------------------------
- `<style amp-boilerplate>...</style>` 
- `<noscript><style amp-boilerplate>...</style></noscript>`
- `<style amp4ads-boilerplate>...</style>` 
- `<style amp4email-boilerplate>...</style>` 

The new RegEx allow for:
- Multi-line CSS styles in above `tags`
- Allows zero to any number of white spaces(including `white space`, `new line`, `tab`) after `:` (The key-value separator)
- Allows zero to any number of white spaces(including `white space`, `new line`, `tab`) before and after `{` or `}` (The CSS declaration)

- Optional `;` for the last attribute in the group
   (This would help in case the auto-format extensions adds missing `;` for any CSS properties.

TODO (before merge):
----------------------
- Need to add tests in /validator/test_data/feature_tests/ for `<style amp4ads-boilerplate'> - DONE
- Need to add tests in /validator/test_data/feature_tests/ for `<style amp4email-boilerplate'> - DONE
