### PR TITLE
✨ Add no-verify attribute to exclude elements from verify-xhr

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -704,6 +704,10 @@
             <span>City</span>
             <input type="text" name="city" required>
         </label>
+        <label>
+            <span>Not sent to verify</span>
+            <input type="text" name="do-not-verify" no-verify>
+        </label>
         <p>Throw an error?</p>
         <label>Yes: <input type="radio" name="error" value="true" required></label>
         <label>No: <input type="radio" name="error" value="false" required checked></label>

--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -20,6 +20,7 @@ import {user} from '../../../src/log';
 
 export const FORM_VERIFY_PARAM = '__amp_form_verify';
 
+export const FORM_VERIFY_OPTOUT = 'no-verify';
 
 /**
  * @typedef {{

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -116,6 +116,14 @@ describes.repeated('', {
     function getVerificationForm() {
       const form = getForm();
       form.setAttribute('verify-xhr', '');
+
+      const noVerifyInput = createElement('input');
+      noVerifyInput.id = 'noVerify';
+      noVerifyInput.setAttribute('name', 'noVerify');
+      noVerifyInput.setAttribute('type', 'text');
+      noVerifyInput.setAttribute('no-verify', '');
+      form.appendChild(noVerifyInput); // This one is not required
+
       return form;
     }
 
@@ -615,6 +623,43 @@ describes.repeated('', {
         }).then(() => {
           expect(input.validity.customError).to.be.true;
           expect(input.validationMessage).to.equal('Second request error');
+        });
+      });
+    });
+
+    it('should not send verifying elements with a no-verify attribute', () => {
+      const formPromise = getAmpForm(getVerificationForm());
+      const fetchRejectPromise = Promise.reject({
+        response: {
+          status: 400,
+          json() {
+            return Promise.resolve({
+              verifyErrors: [{
+                name: 'name',
+                message: 'This name is just wrong.',
+              }],
+            });
+          },
+        },
+      });
+
+      return formPromise.then(ampForm => {
+        const fetchStub =
+            sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
+
+        const form = ampForm.form_;
+        const input = form.name;
+        form.name.value = 'Frank';
+        const noVerifyInput = form.noVerify;
+        noVerifyInput.value = 'do not send';
+
+        return ampForm.verifier_.onCommit().then(() => {
+          expect(fromIterator(fetchStub.getCall(0).args[1].body.entries())).to
+              .deep.equal([['name', 'Frank'], ['__amp_form_verify', 'true']]);
+          // expect(fromIterator(fetchStub.getCall(0).args[1].body.entries()))
+          //     .to.not.have.deep.members(['noVerify', 'do not send']);
+          expect(input.validity.customError).to.be.true;
+          expect(input.validationMessage).to.equal('This name is just wrong.');
         });
       });
     });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -656,8 +656,6 @@ describes.repeated('', {
         return ampForm.verifier_.onCommit().then(() => {
           expect(fromIterator(fetchStub.getCall(0).args[1].body.entries())).to
               .deep.equal([['name', 'Frank'], ['__amp_form_verify', 'true']]);
-          // expect(fromIterator(fetchStub.getCall(0).args[1].body.entries()))
-          //     .to.not.have.deep.members(['noVerify', 'do not send']);
           expect(input.validity.customError).to.be.true;
           expect(input.validationMessage).to.equal('This name is just wrong.');
         });

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -427,6 +427,10 @@ Here's an example:
             <span>City</span>
             <input type="text" name="city" required>
         </label>
+        <label>
+            <span>Document</span>
+            <input type="file" name="document" no-verify>
+        </label>
         <div class="spinner"></div>
         <input type="submit" value="Submit">
     </fieldset>
@@ -462,6 +466,9 @@ Here is how an error response should look for verification:
   ]
 }
 ```
+
+To remove a field from the `verify-xhr` request, add the `no-verify` attribute
+to the input element.
 
 For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 

--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -72,6 +72,8 @@ export class FormDataWrapper {
    *
    * For more details on this, see http://mdn.io/FormData/append.
    *
+   * TODO(cvializ): Update file support
+   *
    * @param {string} name The name of the field whose data is contained in
    *     `value`.
    * @param {string} value The field's value.
@@ -84,6 +86,25 @@ export class FormDataWrapper {
     }
 
     return this.formData_.append(name, value);
+  }
+
+  /**
+   * Remove the given value from the FormData.
+   * This function is unsupported in IE.
+
+   * For more details on this, see http://mdn.io/FormData/delete.
+   *
+   * @param {string} name The name of the field to remove from the FormData.
+   */
+  delete(name) {
+    if (this.formData_.delete) {
+      this.formData_.delete(name);
+      return;
+    }
+
+    if (!this.fieldValues_['entries']) {
+      delete this.fieldValues_[name];
+    }
   }
 
   /**

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -193,5 +193,10 @@
       <template type="amp-mustache">Verify in inlined template</template>
     </div>
   </form>
+  <!-- Valid: form with verify-xhr and input with no-verify-->
+  <form method="post" action-xhr="https://example.com/subscribe" verify-xhr="https://example.com/verify" target="_blank">
+    <input name="do-not-verify" no-verify>
+    <input type="submit" value="Subscribe">
+  </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -224,5 +224,10 @@ feature_tests/forms.html:190:6 The tag 'template' may not appear as a descendant
 feature_tests/forms.html:193:6 The tag 'template' may not appear as a descendant of tag 'form div [verify-error][template]'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
 |      </div>
 |    </form>
+|    <!-- Valid: form with verify-xhr and input with no-verify-->
+|    <form method="post" action-xhr="https://example.com/subscribe" verify-xhr="https://example.com/verify" target="_blank">
+|      <input name="do-not-verify" no-verify>
+|      <input type="submit" value="Subscribe">
+|    </form>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4139,13 +4139,6 @@ attr_lists: {
         ")(\\s|$)"
   }
 }
-attr_lists: {
-  name: "input-amp-form-attr"
-  attrs: {
-    name: "no-verify"
-    value: ""
-  }
-}
 # 4.10.4 The label element
 tags: {
   html_format: AMP
@@ -4163,6 +4156,10 @@ tags: {
   html_format: EXPERIMENTAL
   tag_name: "INPUT"
   attrs: {
+    name: "no-verify"
+    value: ""
+  }
+  attrs: {
     name: "type"
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated.
         "button|"
@@ -4171,7 +4168,6 @@ tags: {
         "password|"
         ")(\\s|$)"
   }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   # Note that this amp-bind attribute is not available for the AMP4Email format
@@ -4183,13 +4179,16 @@ tags: {
   html_format: AMP
   tag_name: "INPUT"
   spec_name: "INPUT [type=file]"
+   attrs: {
+    name: "no-verify"
+    value: ""
+  }
   attrs: {
     name: "type"
     value_casei: "file"
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   mandatory_ancestor: "FORM [method=POST]"
@@ -4205,7 +4204,6 @@ tags: {
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   mandatory_ancestor: "FORM [method=POST]"
@@ -4225,7 +4223,6 @@ tags: {
         "password|"
         ")(\\s|$)"
   }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
@@ -4292,6 +4289,10 @@ tags: {
   attrs: { name: "autofocus" }
   attrs: { name: "disabled" }
   attrs: { name: "multiple" }
+  attrs: {
+    name: "no-verify"
+    value: ""
+  }
   attrs: { name: "required" }
   attrs: { name: "size" }
   # <amp-bind>
@@ -4300,7 +4301,6 @@ tags: {
   attrs: { name: "[multiple]" }
   attrs: { name: "[required]" }
   attrs: { name: "[size]" }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }
@@ -4359,6 +4359,10 @@ tags: {
   attrs: { name: "disabled" }
   attrs: { name: "maxlength" }
   attrs: { name: "minlength" }
+  attrs: {
+    name: "no-verify"
+    value: ""
+  }
   attrs: { name: "placeholder" }
   attrs: { name: "readonly" }
   attrs: { name: "required" }
@@ -4384,7 +4388,6 @@ tags: {
   attrs: { name: "[selectionstart]" }
   attrs: { name: "[spellcheck]" }
   attrs: { name: "[wrap]" }
-  attr_lists: "input-amp-form-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4139,6 +4139,13 @@ attr_lists: {
         ")(\\s|$)"
   }
 }
+attr_lists: {
+  name: "input-amp-form-attr"
+  attrs: {
+    name: "no-verify"
+    value: ""
+  }
+}
 # 4.10.4 The label element
 tags: {
   html_format: AMP
@@ -4164,6 +4171,7 @@ tags: {
         "password|"
         ")(\\s|$)"
   }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   # Note that this amp-bind attribute is not available for the AMP4Email format
@@ -4181,6 +4189,7 @@ tags: {
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   mandatory_ancestor: "FORM [method=POST]"
@@ -4196,6 +4205,7 @@ tags: {
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   mandatory_ancestor: "FORM [method=POST]"
@@ -4215,6 +4225,7 @@ tags: {
         "password|"
         ")(\\s|$)"
   }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-common-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
@@ -4289,6 +4300,7 @@ tags: {
   attrs: { name: "[multiple]" }
   attrs: { name: "[required]" }
   attrs: { name: "[size]" }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }
@@ -4372,6 +4384,7 @@ tags: {
   attrs: { name: "[selectionstart]" }
   attrs: { name: "[spellcheck]" }
   attrs: { name: "[wrap]" }
+  attr_lists: "input-amp-form-attr"
   attr_lists: "input-name-attr"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/13262

Implements, tests and documents the `input[no-verify]` attribute. 
Implements the functionality by adding a blacklist to `requestForFormFetch` and `doXhr_` methods, which remove values from the `FormDataWrapper` or JSON object sent in the request. Implemented and tested the `FormDataWrapper#delete` method to remove that object's values.

/to @nainar @aghassemi for review
/to @honeybadgerdontcare for validator review