### PR TITLE
♻️🐛✅Refactor FormDataWrapper and fix select[multiple] and test

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -28,7 +28,7 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
  *
  * @typedef {{
- *   body: (!JsonObject|!FormData|!FormDataWrapper|undefined|string),
+ *   body: (!JsonObject|!FormData|!FormDataWrapperInterface|undefined|string),
  *   cache: (string|undefined),
  *   credentials: (string|undefined),
  *   headers: (!JsonObject|undefined),
@@ -46,10 +46,16 @@ var FetchInitDef;
 var FetchRequestDef;
 
 /** @constructor **/
-var FormDataWrapper = function() {};
+var FormDataWrapperInterface = function() {};
 
-FormDataWrapper.prototype.entries = function() {};
-FormDataWrapper.prototype.getFormData = function() {};
+FormDataWrapperInterface.prototype.entries = function() {};
+FormDataWrapperInterface.prototype.getFormData = function() {};
+
+FormData.prototype.entries = function () {};
+/**
+ * @param {string} unusedName
+ */
+FormData.prototype.delete = function (unusedName) {};
 
 /**
  * A type for Objects that can be JSON serialized or that come from

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -589,7 +589,7 @@ const forbiddenTerms = {
     ],
   },
   'new FormData\\(': {
-    message: 'Use new FormDataWrapper() instead and call ' +
+    message: 'Use createFormDataWrapper() instead and call ' +
         'formDataWrapper.getFormData() to get the native FormData object.',
     whitelist: [
       'src/form-data-wrapper.js',

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -23,7 +23,6 @@ import {
   FORM_VERIFY_PARAM,
   getFormVerifier,
 } from './form-verifiers';
-import {FormDataWrapper} from '../../../src/form-data-wrapper';
 import {FormEvents} from './form-events';
 import {FormSubmitService} from './form-submit-service';
 import {SOURCE_ORIGIN_PARAM, addParamsToUrl} from '../../../src/url';
@@ -38,6 +37,7 @@ import {
   tryFocus,
 } from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
+import {createFormDataWrapper} from '../../../src/form-data-wrapper';
 import {deepMerge, dict} from '../../../src/utils/object';
 import {dev, user} from '../../../src/log';
 import {
@@ -254,7 +254,7 @@ export class AmpForm {
       xhrUrl = addParamsToUrl(url, values);
     } else {
       xhrUrl = url;
-      body = new FormDataWrapper(this.form_);
+      body = createFormDataWrapper(this.form_);
       if (opt_fieldBlacklist) {
         opt_fieldBlacklist.forEach(name => {
           body.delete(name);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -23,11 +23,14 @@ import {
   AmpFormService,
   checkUserValidityAfterInteraction_,
 } from '../amp-form';
-import {FormDataWrapper} from '../../../../src/form-data-wrapper';
 import {Services} from '../../../../src/services';
 import {
   cidServiceForDocForTesting,
 } from '../../../../src/service/cid-impl';
+import {
+  createFormDataWrapper,
+  isFormDataWrapper,
+} from '../../../../src/form-data-wrapper';
 import {fromIterator} from '../../../../src/utils/array';
 import {
   setCheckValiditySupportedForTesting,
@@ -857,9 +860,9 @@ describes.repeated('', {
 
           const xhrCall = ampForm.xhr_.fetch.getCall(0);
           const config = xhrCall.args[1];
-          expect(config.body).to.be.an.instanceof(FormDataWrapper);
+          expect(isFormDataWrapper(config.body)).to.be.true;
           const entriesInForm =
-              fromIterator(new FormDataWrapper(getForm()).entries());
+              fromIterator(createFormDataWrapper(getForm()).entries());
           expect(fromIterator(config.body.entries())).to.have.deep.members(
               entriesInForm);
           expect(config.method).to.equal('POST');

--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -14,22 +14,148 @@
  * limitations under the License.
  */
 
-import {dev} from './log';
 import {getFormAsObject} from './form';
 import {map} from './utils/object';
+
+/**
+ * Create a form data wrapper. The wrapper is necessary to provide a common
+ * API for FormData objects on all browsers. For example, not all browsers
+ * support the FormData#entries or FormData#delete functions.
+ *
+ * @param {!HTMLFormElement=} opt_form
+ * @return {!FormDataWrapperInterface}
+ */
+export function createFormDataWrapper(opt_form) {
+  if (FormData.prototype.entries && FormData.prototype.delete) {
+    return new NativeFormDataWrapper(opt_form);
+  } else {
+    return new PolyfillFormDataWrapper(opt_form);
+  }
+}
+
+/**
+ * Check if the given object is a FormDataWrapper instance
+ * @param {*} o
+ * @return {boolean} True if the object is a FormDataWrapper instance.
+ */
+export function isFormDataWrapper(o) {
+  // instanceof doesn't work as expected, so we detect with duck-typing.
+  return !!o && typeof o.getFormData == 'function';
+}
+
+/**
+ * A polyfill wrapper for a `FormData` object.
+ *
+ * If there's no native `FormData#entries`, chances are there are no native
+ * methods to read the content of the `FormData` after construction, so the
+ * only way to implement `entries` in this class is to capture the fields in
+ * the form passed to the constructor (and the arguments passed to the
+ * `append` method).
+ *
+ * For more details on this, see http://mdn.io/FormData.
+ *
+ * @implements {FormDataWrapperInterface}
+ * @visibleForTesting
+ */
+export class PolyfillFormDataWrapper {
+  /** @override */
+  constructor(opt_form = undefined) {
+    /** @private @const {!Object<string, !Array<string>>} */
+    this.fieldValues_ = opt_form ? getFormAsObject(opt_form) : map();
+  }
+
+  /** @override */
+  append(name, value) {
+    // Coercion to string is required to match
+    // the native FormData.append behavior
+    const nameString = String(name);
+    this.fieldValues_[nameString] = this.fieldValues_[nameString] || [];
+    this.fieldValues_[nameString].push(String(value));
+  }
+
+  /** @override */
+  delete(name) {
+    delete this.fieldValues_[name];
+  }
+
+  /** @override */
+  entries() {
+    const fieldEntries = [];
+    Object.keys(this.fieldValues_).forEach(name => {
+      const values = this.fieldValues_[name];
+      values.forEach(value => fieldEntries.push([name, value]));
+    });
+
+    // Generator functions are not supported by the current Babel configuration,
+    // so we must manually implement the iterator interface.
+    let nextIndex = 0;
+    return /** @type {!Iterator<!Array<string>>} */ ({
+      next() {
+        return nextIndex < fieldEntries.length ?
+          {value: fieldEntries[nextIndex++], done: false} :
+          {value: undefined, done: true};
+      },
+    });
+  }
+
+  /** @override */
+  getFormData() {
+    const formData = new FormData();
+
+    Object.keys(this.fieldValues_).forEach(name => {
+      const values = this.fieldValues_[name];
+      values.forEach(value => formData.append(name, value));
+    });
+
+    return formData;
+  }
+}
+
+/**
+ * Wrap the native FormData implementation.
+ *
+ * @implements {FormDataWrapperInterface}
+ */
+class NativeFormDataWrapper {
+  /** @override */
+  constructor(opt_form) {
+    /** @private @const {!FormData} */
+    this.formData_ = new FormData(opt_form);
+  }
+
+  /** @override */
+  append(name, value) {
+    return this.formData_.append(name, value);
+  }
+
+  /** @override */
+  delete(name) {
+    this.formData_.delete(name);
+  }
+
+  /** @override */
+  entries() {
+    return this.formData_.entries();
+  }
+
+  /** @override */
+  getFormData() {
+    return this.formData_;
+  }
+}
 
 /**
  * A wrapper for a native `FormData` object that allows the retrieval of entries
  * in the form data after construction even on browsers that don't natively
  * support `FormData.prototype.entries`.
  *
- * @final
+ * @interface
  * @note Subclassing `FormData` doesn't work in this case as the transpiler
  *     generates code that calls the super constructor directly using
  *     `Function.prototype.call`. WebKit (Safari) doesn't allow this and
  *     enforces that constructors be called with the `new` operator.
  */
-export class FormDataWrapper {
+class FormDataWrapperInterface {
   /**
    * Creates a new wrapper for a `FormData` object.
    *
@@ -47,46 +173,37 @@ export class FormDataWrapper {
    *     keys and their submitted value for the values. It will also encode file
    *     input content.
    */
-  constructor(opt_form = undefined) {
-    /** @private @const {!FormData} */
-    this.formData_ = new FormData(opt_form);
-
-    /** @private @const {?Object<string, !Array<string>>} */
-    this.fieldValues_ =
-        this.formData_['entries'] ?
-          null :
-          (opt_form ? getFormAsObject(opt_form) : map());
-  }
+  constructor(opt_form) {}
 
   /**
    * Appends a new value onto an existing key inside a `FormData` object, or
    * adds the key if it does not already exist.
    *
-   * If there's no native `FormData#entries`, chances are there are no native
-   * methods to read the content of the `FormData` after construction, so the
-   * only way to implement `entries` in this class is to capture the arguments
-   * passed to the `append` method (and the form passed to the constructor).
-   *
-   * Since AMP doesn't support `<input type="file">`, appending a `File` object
-   * is not supported and the `filename` parameter is ignored for this wrapper.
+   * Appending a `File` object is not yet supported and the `filename`
+   * parameter is ignored for this wrapper.
    *
    * For more details on this, see http://mdn.io/FormData/append.
    *
    * TODO(cvializ): Update file support
    *
+<<<<<<< HEAD
    * @param {string} name The name of the field whose data is contained in
+=======
+   * @param {string} unusedName The name of the field whose data is contained in
+>>>>>>> Refactor FormDataWrapper and fix select[multiple]
    *     `value`.
-   * @param {string} value The field's value.
+   * @param {string} unusedValue The field's value.
    */
-  append(name, value) {
-    if (!this.formData_['entries']) {
-      const nameString = String(name);
-      this.fieldValues_[nameString] = this.fieldValues_[nameString] || [];
-      this.fieldValues_[name].push(String(value));
-    }
+  append(unusedName, unusedValue) {}
 
-    return this.formData_.append(name, value);
-  }
+  /**
+   * Remove the given value from the FormData.
+   *
+   * For more details on this, see http://mdn.io/FormData/delete.
+   *
+   * @param {string} unusedName The name of the field to remove from the FormData.
+   */
+  delete(unusedName) {}
 
   /**
    * Remove the given value from the FormData.
@@ -114,47 +231,12 @@ export class FormDataWrapper {
    *
    * @return {!Iterator<!Array<string>>}
    */
-  entries() {
-    if (this.formData_['entries']) {
-      return this.formData_['entries']();
-    }
-
-    const fieldEntries = [];
-    const fieldValues = /** @type {!Object<string, !Array<string>>} */ (
-      dev().assert(this.fieldValues_));
-    Object.keys(fieldValues).forEach(name => {
-      const values = fieldValues[name];
-      values.forEach(value => fieldEntries.push([name, value]));
-    });
-
-    // Generator functions are not supported by the current Babel configuration,
-    // so we must manually implement the iterator interface.
-    let nextIndex = 0;
-    return /** @type {!Iterator<!Array<string>>} */ ({
-      next() {
-        return nextIndex < fieldEntries.length ?
-          {value: fieldEntries[nextIndex++], done: false} :
-          {value: undefined, done: true};
-      },
-    });
-  }
+  entries() {}
 
   /**
    * Returns the wrapped native `FormData` object.
    *
    * @return {!FormData}
    */
-  getFormData() {
-    return this.formData_;
-  }
-}
-
-/**
- * Check if the given object is a FormDataWrapper instance
- * @param {*} o
- * @return {boolean} True if the object is a FormDataWrapper instance.
- */
-export function isFormDataWrapper(o) {
-  // instanceof doesn't work as expected, so we detect with duck-typing.
-  return !!o && typeof o.getFormData == 'function';
+  getFormData() {}
 }

--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -186,11 +186,7 @@ class FormDataWrapperInterface {
    *
    * TODO(cvializ): Update file support
    *
-<<<<<<< HEAD
-   * @param {string} name The name of the field whose data is contained in
-=======
    * @param {string} unusedName The name of the field whose data is contained in
->>>>>>> Refactor FormDataWrapper and fix select[multiple]
    *     `value`.
    * @param {string} unusedValue The field's value.
    */
@@ -204,25 +200,6 @@ class FormDataWrapperInterface {
    * @param {string} unusedName The name of the field to remove from the FormData.
    */
   delete(unusedName) {}
-
-  /**
-   * Remove the given value from the FormData.
-   * This function is unsupported in IE.
-
-   * For more details on this, see http://mdn.io/FormData/delete.
-   *
-   * @param {string} name The name of the field to remove from the FormData.
-   */
-  delete(name) {
-    if (this.formData_.delete) {
-      this.formData_.delete(name);
-      return;
-    }
-
-    if (!this.fieldValues_['entries']) {
-      delete this.fieldValues_[name];
-    }
-  }
 
   /**
    * Returns an iterator of all key/value pairs contained in this object.

--- a/src/form.js
+++ b/src/form.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {ancestorElementsByTag} from './dom';
+import {
+  ancestorElementsByTag,
+  iterateCursor,
+} from './dom';
 
 /** @const {string} */
 const FORM_PROP_ = '__AMP_FORM';
@@ -58,7 +61,16 @@ export function getFormAsObject(form) {
     if (data[input.name] === undefined) {
       data[input.name] = [];
     }
-    data[input.name].push(input.value);
+
+    if (input.multiple) {
+      iterateCursor(input.options, option => {
+        if (option.selected) {
+          data[input.name].push(option.value);
+        }
+      });
+    } else {
+      data[input.name].push(input.value);
+    }
   }
 
   return data;

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -79,7 +79,9 @@ export class Xhr {
           // will expect a native `FormData` object in the `body` property, so
           // the native `FormData` object needs to be unwrapped.
           if (isFormDataWrapper(init.body)) {
-            init.body = /** @type {!FormDataWrapper} */ (init.body).getFormData();
+            const formDataWrapper =
+              /** @type {!FormDataWrapperInterface} */ (init.body);
+            init.body = formDataWrapper.getFormData();
           }
           return (this.win.fetch).apply(null, arguments);
         });

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -84,8 +84,9 @@ const allowedJsonBodyTypes_ = [isArray, isObject];
 export function toStructuredCloneable(input, init) {
   const newInit = Object.assign({}, init);
   if (isFormDataWrapper(init.body)) {
+    const wrapper = /** @type {!FormDataWrapperInterface} **/ (init.body);
     newInit.headers['Content-Type'] = 'multipart/form-data;charset=utf-8';
-    newInit.body = fromIterator(/** @type {!FormDataWrapper} **/ (init.body).entries());
+    newInit.body = fromIterator(wrapper.entries());
   }
   return {input, init: newInit};
 }

--- a/test/functional/test-form-data-wrapper.js
+++ b/test/functional/test-form-data-wrapper.js
@@ -257,7 +257,7 @@ describes.realWin('FormDataWrapper', {}, env => {
             input2.value = 'qux';
             form.appendChild(input2);
 
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
             formData.delete('foo');
 
             expect(fromIterator(formData.entries())).to.have.deep.members([

--- a/test/functional/test-form-data-wrapper.js
+++ b/test/functional/test-form-data-wrapper.js
@@ -22,14 +22,12 @@ import {fromIterator} from '../../src/utils/array';
 
 describes.realWin('FormDataWrapper', {}, env => {
   describe('entries', () => {
-    let sandbox;
     let nativeEntries;
     let nativeDelete;
     const scenarios = [{
       description: 'when native `entries` is not available',
 
       beforeEach() {
-        sandbox = env.sandbox;
         nativeEntries = FormData.prototype.entries;
         nativeDelete = FormData.prototype.delete;
         // Remove native entries from the prototype in case the browser running
@@ -50,7 +48,6 @@ describes.realWin('FormDataWrapper', {}, env => {
         description: 'when native `entries` is available',
 
         beforeEach() {
-          sandbox = env.sandbox;
           // Do nothing as `env.win.FormData.prototype` already has `entires`.
         },
 
@@ -327,7 +324,7 @@ describes.realWin('FormDataWrapper', {}, env => {
           // For testing in non-supporting browsers like IE.
           // We can't query the state of FormData, but we can check that
           // the polyfill appended to the real FormData enough.
-          const appendSpy = sandbox.spy(FormData.prototype, 'append');
+          const appendSpy = env.sandbox.spy(FormData.prototype, 'append');
           polyfillFormDataWrapper.getFormData();
           expect(appendSpy).to.have.been.calledTwice;
         }

--- a/test/functional/test-form-data-wrapper.js
+++ b/test/functional/test-form-data-wrapper.js
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-import {FormDataWrapper} from '../../src/form-data-wrapper';
+import {
+  PolyfillFormDataWrapper,
+  createFormDataWrapper,
+} from '../../src/form-data-wrapper';
 import {fromIterator} from '../../src/utils/array';
 
 describes.realWin('FormDataWrapper', {}, env => {
   describe('entries', () => {
+    let sandbox;
     let nativeEntries;
     let nativeDelete;
     const scenarios = [{
       description: 'when native `entries` is not available',
 
       beforeEach() {
+        sandbox = env.sandbox;
         nativeEntries = FormData.prototype.entries;
         nativeDelete = FormData.prototype.delete;
         // Remove native entries from the prototype in case the browser running
@@ -39,11 +44,13 @@ describes.realWin('FormDataWrapper', {}, env => {
         FormData.prototype.delete = nativeDelete;
       },
     }];
+
     if (FormData.prototype.entries) {
       scenarios.push({
         description: 'when native `entries` is available',
 
         beforeEach() {
+          sandbox = env.sandbox;
           // Do nothing as `env.win.FormData.prototype` already has `entires`.
         },
 
@@ -60,7 +67,7 @@ describes.realWin('FormDataWrapper', {}, env => {
         afterEach(scenario.afterEach);
 
         it('returns empty if no form passed and no entries appended', () => {
-          const formData = new FormDataWrapper();
+          const formData = createFormDataWrapper();
           expect(fromIterator(formData.entries()))
               .to.be.an('array').that.is.empty;
         });
@@ -68,7 +75,7 @@ describes.realWin('FormDataWrapper', {}, env => {
         describe('when entries appended', () => {
           let formData;
 
-          beforeEach(() => formData = new FormDataWrapper());
+          beforeEach(() => formData = createFormDataWrapper());
 
           it('returns appended string entries', () => {
             formData.append('a', '1');
@@ -123,7 +130,7 @@ describes.realWin('FormDataWrapper', {}, env => {
           });
 
           it('returns empty if no entries in form', () => {
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
             expect(fromIterator(formData.entries()))
                 .to.be.an('array').that.is.empty;
           });
@@ -135,7 +142,7 @@ describes.realWin('FormDataWrapper', {}, env => {
             input.value = 'bar';
             form.appendChild(input);
 
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
 
             expect(fromIterator(formData.entries())).to.have.deep.members([
               ['foo', 'bar'],
@@ -148,7 +155,7 @@ describes.realWin('FormDataWrapper', {}, env => {
             textarea.value = 'bar';
             form.appendChild(textarea);
 
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
 
             expect(fromIterator(formData.entries())).to.have.deep.members([
               ['foo', 'bar'],
@@ -163,7 +170,7 @@ describes.realWin('FormDataWrapper', {}, env => {
             input.checked = true;
             form.appendChild(input);
 
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
 
             expect(fromIterator(formData.entries())).to.have.deep.members([
               ['foo', 'bar'],
@@ -187,10 +194,56 @@ describes.realWin('FormDataWrapper', {}, env => {
             select.appendChild(unselectedOption);
             form.appendChild(select);
 
-            const formData = new FormDataWrapper(form);
+            const formData = createFormDataWrapper(form);
 
             expect(fromIterator(formData.entries())).to.have.deep.members([
               ['foo', 'bar'],
+            ]);
+          });
+
+          it('returns selected multi-select entries in form', () => {
+            const select = env.win.document.createElement('select');
+            select.name = 'foo';
+            select.multiple = true;
+
+            const selectedOption = env.win.document.createElement('option');
+            selectedOption.value = 'bar';
+            selectedOption.selected = true;
+
+            const unselectedOption = env.win.document.createElement('option');
+            unselectedOption.value = 'bang';
+            unselectedOption.selected = true;
+
+            select.appendChild(selectedOption);
+            select.appendChild(unselectedOption);
+            form.appendChild(select);
+
+            const formData = createFormDataWrapper(form);
+
+            expect(fromIterator(formData.entries())).to.have.deep.members([
+              ['foo', 'bar'],
+              ['foo', 'bang'],
+            ]);
+          });
+
+          it('deletes form element values', () => {
+            const input = env.win.document.createElement('input');
+            input.type = 'text';
+            input.name = 'foo';
+            input.value = 'bar';
+            form.appendChild(input);
+
+            const input2 = env.win.document.createElement('input');
+            input2.type = 'text';
+            input2.name = 'baz';
+            input2.value = 'qux';
+            form.appendChild(input2);
+
+            const formData = createFormDataWrapper(form);
+            formData.delete('foo');
+
+            expect(fromIterator(formData.entries())).to.have.deep.members([
+              ['baz', 'qux'],
             ]);
           });
 
@@ -232,7 +285,7 @@ describes.realWin('FormDataWrapper', {}, env => {
           form.appendChild(textarea);
           env.win.document.body.appendChild(form);
 
-          const formData = new FormDataWrapper(form);
+          const formData = createFormDataWrapper(form);
           formData.append('foo1', 'baz');
           formData.append('42', 'bang');
 
@@ -243,6 +296,41 @@ describes.realWin('FormDataWrapper', {}, env => {
             ['42', 'bang'],
           ]);
         });
+      });
+    });
+
+    describe('PolyfillFormDataWrapper', () => {
+      it('getFormData matches native behavior', () => {
+
+        const form = env.win.document.createElement('form');
+
+        const input = env.win.document.createElement('input');
+        input.type = 'text';
+        input.name = 'foo1';
+        input.value = 'bar';
+
+        const textarea = env.win.document.createElement('textarea');
+        textarea.name = 'foo2';
+        textarea.value = 'bar';
+
+        form.appendChild(input);
+        form.appendChild(textarea);
+        env.win.document.body.appendChild(form);
+
+        const polyfillFormDataWrapper = new PolyfillFormDataWrapper(form);
+
+        if (FormData.prototype.entries) {
+          const polyfillFormData = polyfillFormDataWrapper.getFormData();
+          expect(fromIterator(polyfillFormData.entries()))
+              .to.deep.equal(fromIterator(new FormData(form).entries()));
+        } else {
+          // For testing in non-supporting browsers like IE.
+          // We can't query the state of FormData, but we can check that
+          // the polyfill appended to the real FormData enough.
+          const appendSpy = sandbox.spy(FormData.prototype, 'append');
+          polyfillFormDataWrapper.getFormData();
+          expect(appendSpy).to.have.been.calledTwice;
+        }
       });
     });
   });

--- a/test/functional/test-form.js
+++ b/test/functional/test-form.js
@@ -156,6 +156,27 @@ describes.realWin('getFormAsObject', {}, env => {
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
   });
 
+
+  it('returns multiple selected entries in multi-select', () => {
+    const select = env.win.document.createElement('select');
+    select.name = 'foo';
+    select.multiple = true;
+
+    const selectedOption = env.win.document.createElement('option');
+    selectedOption.value = 'bar';
+    selectedOption.selected = true;
+
+    const unselectedOption = env.win.document.createElement('option');
+    unselectedOption.value = 'bang';
+    unselectedOption.selected = true;
+
+    select.appendChild(selectedOption);
+    select.appendChild(unselectedOption);
+    form.appendChild(select);
+
+    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar', 'bang']});
+  });
+
   it('returns submit input entries', () => {
     const input = env.win.document.createElement('input');
     input.type = 'submit';

--- a/test/functional/test-xhr-fetch-polyfill.js
+++ b/test/functional/test-xhr-fetch-polyfill.js
@@ -15,8 +15,8 @@
  */
 
 
-import {FormDataWrapper} from '../../src/form-data-wrapper';
 import {Response, fetchPolyfill} from '../../src/polyfills/fetch';
+import {createFormDataWrapper} from '../../src/form-data-wrapper';
 
 
 describes.sandboxed('fetch', {}, () => {
@@ -98,7 +98,7 @@ describes.sandboxed('fetch', {}, () => {
     });
 
     it('should allow FormData as body', () => {
-      const formData = new FormDataWrapper();
+      const formData = createFormDataWrapper();
       sandbox.stub(JSON, 'stringify');
       formData.append('name', 'John Miller');
       formData.append('age', 56);

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {FormDataWrapper} from '../../src/form-data-wrapper';
 import {Services} from '../../src/services';
 import {assertSuccess} from '../../src/utils/xhr-utils';
+import {createFormDataWrapper} from '../../src/form-data-wrapper';
 import {fetchPolyfill} from '../../src/polyfills/fetch';
 import {getCookie} from '../../src/cookies';
 import {user} from '../../src/log';
@@ -137,7 +137,7 @@ describe.configure().skipSafari().run('XHR', function() {
         });
 
         it('should allow FormData as body', () => {
-          const formData = new FormDataWrapper();
+          const formData = createFormDataWrapper();
           sandbox.stub(JSON, 'stringify');
           formData.append('name', 'John Miller');
           formData.append('age', 56);
@@ -796,7 +796,7 @@ describe.configure().skipSafari().run('XHR', function() {
     it('should post correct structurally-cloneable FormData request', () => {
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      const formData = new FormDataWrapper();
+      const formData = createFormDataWrapper();
       formData.append('a', 42);
       formData.append('b', '24');
       formData.append('b', true);


### PR DESCRIPTION
- Refactor to cleanup `FormDataWrapper` to only feature detect in the factory function. 
- I noticed `<select multiple>` were broken when used with `FormDataWrapper` due to a bug in `getFormAsObject`, so I fixed and added tests

This will help with fixing https://github.com/ampproject/amphtml/issues/18022