### PR TITLE
Hold to pause for amp-story.

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  Action,
+  StateProperty,
+  getStoreService,
+} from './amp-story-store-service';
 import {Services} from '../../../src/services';
-import {StateProperty, getStoreService} from './amp-story-store-service';
 import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, escapeCssSelectorIdent} from '../../../src/dom';
@@ -168,7 +172,7 @@ export class AdvancementConfig {
     const win = /** @type {!Window} */ (rootEl.ownerDocument.defaultView);
     const autoAdvanceStr = rootEl.getAttribute('auto-advance-after');
     const supportedAdvancementModes = [
-      ManualAdvancement.fromElement(rootEl),
+      ManualAdvancement.fromElement(win, rootEl),
       TimeBasedAdvancement.fromAutoAdvanceString(autoAdvanceStr, win),
       MediaBasedAdvancement.fromAutoAdvanceString(autoAdvanceStr, win, rootEl),
     ].filter(x => x !== null);
@@ -255,13 +259,20 @@ class MultipleAdvancementConfig extends AdvancementConfig {
  */
 class ManualAdvancement extends AdvancementConfig {
   /**
+   * @param {!Window} win The Window object.
    * @param {!Element} element The element that, when clicked, can cause
    *     advancing to the next page or going back to the previous.
    */
-  constructor(element) {
+  constructor(win, element) {
     super();
+
+    /** @private @const {!Element} */
     this.element_ = element;
-    this.clickListener_ = this.maybePerformNavigation_.bind(this);
+
+    /** @private {?Number} Last touchstart event's timestamp */
+    this.touchstartTimestamp_ = null;
+
+    this.startListening_();
 
     if (element.ownerDocument.defaultView) {
       /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
@@ -289,32 +300,75 @@ class ManualAdvancement extends AdvancementConfig {
   }
 
   /** @override */
-  start() {
-    super.start();
-    this.element_.addEventListener('click', this.clickListener_, true);
-  }
-
-  /** @override */
-  stop() {
-    super.stop();
-    this.element_.removeEventListener('click', this.clickListener_, true);
-  }
-
-  /** @override */
   getProgress() {
     return 1.0;
+  }
+
+  /**
+   * Binds the event listeners.
+   * @private
+   */
+  startListening_() {
+    this.element_
+        .addEventListener('touchstart', this.onTouchstart_.bind(this), true);
+    this.element_
+        .addEventListener('touchend', this.onTouchend_.bind(this), true);
+    this.element_
+        .addEventListener(
+            'click', this.maybePerformNavigation_.bind(this), true);
+  }
+
+  /**
+   * TouchEvent touchstart events handler.
+   * @param {!TouchEvent} event
+   * @private
+   */
+  onTouchstart_(event) {
+    // Don't start the paused state if the target is not a descendant of an
+    // amp-story-page. Also ignores any subsequent touchstart that would happen
+    // before touchend was fired, since it'd reset the touchstartTimestamp (ie:
+    // user touches the screen with a second finger).
+    if (this.touchstartTimestamp_ || !this.isAmpStoryPageDescendant_(event)) {
+      return;
+    }
+
+    this.touchstartTimestamp_ = Date.now();
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+  }
+
+  /**
+   * TouchEvent touchend events handler.
+   * @param {!TouchEvent} event
+   * @private
+   */
+  onTouchend_(event) {
+    // Ignores the event if there's still a user's finger holding the screen.
+    const touchesCount = (event.touches || []).length;
+    if (!this.touchstartTimestamp_ || touchesCount > 0) {
+      return;
+    }
+
+    // Cancels the navigation if user paused the story for over 500ms. Calling
+    // preventDefault on the touchend event ensures the click/tap event won't
+    // fire.
+    if ((Date.now() - this.touchstartTimestamp_) > 500) {
+      event.preventDefault();
+    }
+
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, false);
+    this.touchstartTimestamp_ = null;
   }
 
   /**
    * Determines whether a click should be used for navigation.  Navigate should
    * occur unless the click is on the system layer, or on an element that
    * defines on="tap:..."
-   * @param {!Event} e 'click' event.
+   * @param {!Event} event 'click' event.
    * @return {boolean} true, if the click should be used for navigation.
    * @private
    */
-  isNavigationalClick_(e) {
-    return !closest(dev().assertElement(e.target), el => {
+  isNavigationalClick_(event) {
+    return !closest(dev().assertElement(event.target), el => {
       return hasTapAction(el);
     }, /* opt_stopAt */ this.element_);
   }
@@ -354,7 +408,9 @@ class ManualAdvancement extends AdvancementConfig {
    * @param {!Event} event 'click' event
    */
   maybePerformNavigation_(event) {
-    if (!this.isNavigationalClick_(event) || this.isProtectedTarget_(event) ||
+    if (!this.isRunning() ||
+      !this.isNavigationalClick_(event) ||
+      this.isProtectedTarget_(event) ||
       !this.isAmpStoryPageDescendant_(event)) {
       // If the system doesn't need to handle this click, then we can simply
       // return and let the event propagate as it would have otherwise.
@@ -398,15 +454,16 @@ class ManualAdvancement extends AdvancementConfig {
 
   /**
    * Gets an instance of ManualAdvancement based on the HTML tag of the element.
+   * @param {!Window} win
    * @param {!Element} rootEl
    * @return {?AdvancementConfig} An AdvancementConfig, only if the rootEl is
    *                              an amp-story tag.
    */
-  static fromElement(rootEl) {
+  static fromElement(win, rootEl) {
     if (rootEl.tagName.toLowerCase() !== 'amp-story') {
       return null;
     }
-    return new ManualAdvancement(rootEl);
+    return new ManualAdvancement(win, rootEl);
   }
 }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -23,8 +23,8 @@ import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, escapeCssSelectorIdent} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
-import {isExperimentOn} from '../../../src/experiments';
 import {hasTapAction, timeStrToMillis} from './utils';
+import {isExperimentOn} from '../../../src/experiments';
 import {listenOnce} from '../../../src/event-helper';
 
 /** @private @const {number} */
@@ -270,7 +270,7 @@ class ManualAdvancement extends AdvancementConfig {
     /** @private @const {!Element} */
     this.element_ = element;
 
-    /** @private {?Number} Last touchstart event's timestamp */
+    /** @private {?number} Last touchstart event's timestamp */
     this.touchstartTimestamp_ = null;
 
     /** @private @const {!Window} */
@@ -327,7 +327,7 @@ class ManualAdvancement extends AdvancementConfig {
 
   /**
    * TouchEvent touchstart events handler.
-   * @param {!TouchEvent} event
+   * @param {!Event} event
    * @private
    */
   onTouchstart_(event) {
@@ -345,7 +345,7 @@ class ManualAdvancement extends AdvancementConfig {
 
   /**
    * TouchEvent touchend events handler.
-   * @param {!TouchEvent} event
+   * @param {!Event} event
    * @private
    */
   onTouchend_(event) {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -23,6 +23,7 @@ import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, escapeCssSelectorIdent} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
+import {isExperimentOn} from '../../../src/experiments';
 import {hasTapAction, timeStrToMillis} from './utils';
 import {listenOnce} from '../../../src/event-helper';
 
@@ -272,6 +273,9 @@ class ManualAdvancement extends AdvancementConfig {
     /** @private {?Number} Last touchstart event's timestamp */
     this.touchstartTimestamp_ = null;
 
+    /** @private @const {!Window} */
+    this.win_ = win;
+
     this.startListening_();
 
     if (element.ownerDocument.defaultView) {
@@ -309,10 +313,13 @@ class ManualAdvancement extends AdvancementConfig {
    * @private
    */
   startListening_() {
-    this.element_
-        .addEventListener('touchstart', this.onTouchstart_.bind(this), true);
-    this.element_
-        .addEventListener('touchend', this.onTouchend_.bind(this), true);
+    if (isExperimentOn(this.win_, 'amp-story-hold-to-pause')) {
+      this.element_
+          .addEventListener('touchstart', this.onTouchstart_.bind(this), true);
+      this.element_
+          .addEventListener('touchend', this.onTouchend_.bind(this), true);
+    }
+
     this.element_
         .addEventListener(
             'click', this.maybePerformNavigation_.bind(this), true);

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -28,6 +28,9 @@ import {isExperimentOn} from '../../../src/experiments';
 import {listenOnce} from '../../../src/event-helper';
 
 /** @private @const {number} */
+const HOLD_TOUCH_THRESHOLD_MS = 500;
+
+/** @private @const {number} */
 const NEXT_SCREEN_AREA_RATIO = 0.75;
 
 /** @private @const {number} */
@@ -358,7 +361,7 @@ class ManualAdvancement extends AdvancementConfig {
     // Cancels the navigation if user paused the story for over 500ms. Calling
     // preventDefault on the touchend event ensures the click/tap event won't
     // fire.
-    if ((Date.now() - this.touchstartTimestamp_) > 500) {
+    if ((Date.now() - this.touchstartTimestamp_) > HOLD_TOUCH_THRESHOLD_MS) {
       event.preventDefault();
     }
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -248,6 +248,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16466',
   },
   {
+    id: 'amp-story-hold-to-pause',
+    name: 'Hold to pause an amp-story',
+    spec: 'https://github.com/ampproject/amphtml/issues/18714',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/18715',
+  },
+  {
     id: 'url-replacement-v2',
     name: 'new parsing engine for url variables',
     spec: 'https://github.com/ampproject/amphtml/issues/12119',


### PR DESCRIPTION
Hold to pause for amp-story, behind the `amp-story-hold-to-pause` experiment.
Feature is not complete yet, as we'd have to hide the system layer (code is ready [here](https://github.com/ampproject/amphtml/compare/master...gmajoulet:hold_to_pause_system_layer?expand=1) for a followup PR), and find a solution for desktop. But this should help for end of month's user testing session.

Demo available [here](https://stamp-press-to-pause.firebaseapp.com/examples/amp-story/ampconf.html) or [here](https://stamp-press-to-pause.firebaseapp.com/examples/s20/body-painting/index.html)

Part of #18714 