### PR TITLE
Add fie-metadata-extension experiment

### DIFF
--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -354,6 +354,11 @@ const EXPERIMENTS = [
     name: 'Enables form support in linker',
     cleanupissue: 'https://github.com/ampproject/amphtml/issues/18068',
   },
+  {
+    id: 'fie-metadata-extension',
+    name: 'Use version supporting extension field in amp-ad-metadata.',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/18737',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Alphabetize experiments and add experiment to use the extension field in amp-ad-metadata as the standard for specifying extensions as opposed to customElementExtensions which doesn't have versioning support. This is a safety measure incase cloudfare isn't using the extension field though there is a message thread claiming its support. Once enabled and verified, we can clean up the legacy field.

e.g.
`
	<script amp-ad-metadata type=application/json>
	{
	   "customElementExtensions" : [
	      "amp-analytics"
	   ],
	   "extensions" : [
	      {
	         "custom-element" : "amp-analytics",
	         "src" : "https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
	      }
	   ]
	}
	</script>
`
relevant: https://github.com/ampproject/amphtml/pull/17589