### PR TITLE
Fix macro replacement regression

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -245,14 +245,15 @@ export class Expander {
       // If a binding is passed in through opt_bindings it always takes
       // precedence.
       binding = bindingInfo.prioritized;
-    } else if (opt_sync && hasOwn(bindingInfo, 'sync')) {
+    } else if (opt_sync && bindingInfo.sync !== null
+        && bindingInfo.sync !== undefined) {
       // Use the sync resolution if avaliable when called synchronously.
       binding = bindingInfo.sync;
     } else if (opt_sync) {
       // If there is no sync resolution we can not wait.
       user().error(TAG, 'ignoring async replacement key: ', bindingInfo.name);
       binding = '';
-    } else if (hasOwn(bindingInfo, 'async')) {
+    } else if (bindingInfo.async !== null && bindingInfo.async !== undefined) {
       // Prefer the async over the sync but it may not exist.
       binding = bindingInfo.async;
     } else {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -43,6 +43,7 @@ import {
 import {parseUrlDeprecated} from '../../src/url';
 import {registerServiceBuilder} from '../../src/service';
 import {setCookie} from '../../src/cookies';
+import {toggleExperiment} from '../../src/experiments';
 import {user} from '../../src/log';
 
 
@@ -62,6 +63,8 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   function getReplacements(opt_options) {
     return createIframePromise().then(iframe => {
+      // TODO(ccordry): remove this when migration complete.
+      toggleExperiment(iframe.win, 'url-replacement-v2', true);
       ampdoc = iframe.ampdoc;
       iframe.doc.title = 'Pixel Test';
       const link = iframe.doc.createElement('link');


### PR DESCRIPTION
This was broken in #18541

Turned on experiment for `test-url-replacements` so that it would catch bugs like this. I should have done this much earlier :( 