### PR TITLE
amp-list: Reset pending change-size request after render

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -465,6 +465,13 @@ export class AmpList extends AMP.BaseElement {
           AmpEvents.DOM_UPDATE, /* detail */ null, {bubbles: true});
       this.container_.dispatchEvent(event);
 
+      // Now that new contents have been rendered, clear pending size requests
+      // from previous calls to attemptToFit_(). Rejected size requests are
+      // saved as "pending" and are fulfilled later on 'focus' event.
+      // See resources-impl.checkPendingChangeSize_().
+      const r = this.element.getResources().getResourceForElement(this.element);
+      r.resetPendingChangeSize();
+
       // Attempt to resize to fit new rendered contents.
       this.attemptToFit_(this.container_);
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -28,6 +28,7 @@ describes.realWin('amp-list component', {
 }, env => {
   let win, doc, ampdoc, sandbox;
   let element, list, listMock;
+  let resource;
   let setBindService;
   let ssrTemplateHelper;
   let templates;
@@ -45,11 +46,19 @@ describes.realWin('amp-list component', {
     };
     sandbox.stub(Services, 'templatesFor').returns(templates);
 
+    resource = {
+      resetPendingChangeSize: sandbox.stub(),
+    };
+    const resources = {
+      getResourceForElement: e => (e === element) ? resource : null,
+    };
+
     element = doc.createElement('div');
     element.setAttribute('src', 'https://data.com/list.json');
     element.getAmpDoc = () => ampdoc;
     element.getFallback = () => null;
     element.getPlaceholder = () => null;
+    element.getResources = () => resources;
 
     const template = doc.createElement('template');
     template.content.appendChild(doc.createTextNode('{{template}}'));
@@ -143,6 +152,15 @@ describes.realWin('amp-list component', {
       return list.layoutCallback().then(() => rendered).then(() => {
         expect(list.container_.contains(itemElement)).to.be.true;
       });
+    });
+
+    it('should reset pending change-size request after render', function*() {
+      const items = [{title: 'Title1'}];
+      const itemElement = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [itemElement]);
+      yield list.layoutCallback();
+      yield rendered;
+      expect(resource.resetPendingChangeSize).calledOnce;
     });
 
     it('should attemptChangeHeight the placeholder, if present', () => {


### PR DESCRIPTION
Fixes #18759.

TIL that focusing on an element permits it to be resized--the same as clicking on its overflow element.

Components that attempts conditional resizing more than once may hit a similar bug. I can't think of any that do other than amp-list though.

/to @aghassemi @jridgewell 