### PR TITLE
🐛 Chrome 70 array.sort uses stable TimSort which exposed bunch of bugs

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -942,9 +942,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       }).then(() => {
         impl.onLayoutMeasure();
         // Right margin is 9px from containerContainer and 25px from container.
-        // TODO(charliereams): In the test harness it is also offset by 15px due
-        // to strange scrollbar behavior. Figure out how to disable this.
-        expect(element.style.marginRight).to.be.equal('-124px');
+        expect(element.style.marginRight).to.be.equal('-109px');
         expect(element.style.marginLeft).to.be.equal('');
       });
     });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -569,7 +569,7 @@ describes.realWin('amp-ad-3p-impl', {
           // Right margin is 9px from containerContainer and 25px from
           // container.
           expect(element.style.marginLeft).to.be.equal('');
-          expect(element.style.marginRight).to.be.equal('-49px');
+          expect(element.style.marginRight).to.be.equal('-34px');
         });
       });
     });

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -267,12 +267,12 @@ describe('BindExpression', () => {
 
     it('custom Array#sort()', () => {
       expect(evaluate('[11, 1, 2].sort()')).to.deep.equal([1, 11, 2]);
-      expect(evaluate('[11, 1, 2].sort((x, y) => x > y)'))
+      expect(evaluate('[11, 1, 2].sort((x, y) => x - y)'))
           .to.deep.equal([1, 2, 11]);
 
       const a = [11, 1, 2];
       expect(evaluate('a.sort()', {a})).to.deep.equal([1, 11, 2]);
-      expect(evaluate('a.sort((x, y) => x > y)', {a}))
+      expect(evaluate('a.sort((x, y) => x - y)', {a}))
           .to.deep.equal([1, 2, 11]);
 
       // Sort should be out-of-place i.e. does not sort the caller.

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -468,8 +468,8 @@ export class PlatformStore {
     platformWeights.sort((platform1, platform2) => {
       // Force local platform to win ties
       if (platform2.weight == platform1.weight &&
-        platform2.platform == localPlatform) {
-        return 1;
+        platform1.platform == localPlatform) {
+        return -1;
       }
       return platform2.weight - platform1.weight;
     });

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -434,7 +434,7 @@ describes.realWin('Platform store', {}, () => {
           .to.equal(anotherPlatform);
     });
 
-    it.only('should tie-break to local', () => {
+    it('should tie-break to local', () => {
       localFactors['supportsViewer'] = 1;
       anotherFactors['supportsViewer'] = 1;
       expect(platformStore.selectPlatformForLogin())

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -434,7 +434,7 @@ describes.realWin('Platform store', {}, () => {
           .to.equal(anotherPlatform);
     });
 
-    it('should tie-break to local', () => {
+    it.only('should tie-break to local', () => {
       localFactors['supportsViewer'] = 1;
       anotherFactors['supportsViewer'] = 1;
       expect(platformStore.selectPlatformForLogin())

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -125,7 +125,7 @@ export class FixedLayer {
     this.trySetupSelectorsNoInline(fixedSelectors, stickySelectors);
 
     // Sort in document order.
-    this.sortInDomOrder_();
+    this.sortInDomOrder_(this.elements_);
 
     const platform = Services.platformFor(this.ampdoc.win);
     if (this.elements_.length > 0 && !this.transfer_ && platform.isIos()) {
@@ -210,7 +210,7 @@ export class FixedLayer {
         /* selector */ '*',
         /* position */ 'fixed',
         opt_forceTransfer);
-    this.sortInDomOrder_();
+    this.sortInDomOrder_(this.elements_);
     return this.update();
   }
 
@@ -548,16 +548,26 @@ export class FixedLayer {
     return removed;
   }
 
-  /** @private */
-  sortInDomOrder_() {
-    this.elements_.sort(function(fe1, fe2) {
-      // 8 | 2 = 0x0A
-      // 2 - preceeding
-      // 8 - contains
-      if (fe1.element.compareDocumentPosition(fe2.element) & 0x0A != 0) {
-        return 1;
+  /**
+   * @param {!Array<ElementDef>} elements
+   * @private */
+  sortInDomOrder_(elements) {
+    elements.sort(function(fe1, fe2) {
+      if (fe1.element && (fe1.element == fe2.element)) {
+        return 0;
       }
-      return -1;
+
+      // See https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+      const pos = fe1.element.compareDocumentPosition(fe2.element);
+
+      // if fe2 is preceeding or contains fe1 then, fe1 is after fe2
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING ||
+          pos & Node.DOCUMENT_POSITION_CONTAINS) {
+        return 1;
+      } else {
+        // if fe2 is following or contained by fe1, then fe1 is before fe2
+        return -1;
+      }
     });
   }
 

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -33,6 +33,7 @@ describes.sandboxed('FixedLayer', {}, () => {
   let element3;
   let element4;
   let element5;
+  let element6;
   let allRules;
 
   beforeEach(() => {
@@ -47,11 +48,13 @@ describes.sandboxed('FixedLayer', {}, () => {
     element3 = createElement('element3');
     element4 = createElement('element4');
     element5 = createElement('element5');
+    element6 = createElement('element6');
     docBody.appendChild(element1);
     docBody.appendChild(element2);
     docBody.appendChild(element3);
     docBody.appendChild(element4);
     docBody.appendChild(element5);
+    docBody.appendChild(element6);
 
     const invalidRule = createValidRule('#invalid', 'fixed',
         [element1, element3]);
@@ -441,45 +444,45 @@ describes.sandboxed('FixedLayer', {}, () => {
       expect(fixedLayer.elements_).to.have.length(5);
 
       // Add.
-      fixedLayer.addElement(element3);
+      fixedLayer.addElement(element6);
       expect(updateStub).to.be.calledOnce;
       expect(fixedLayer.elements_).to.have.length(6);
       const fe = fixedLayer.elements_[5];
       expect(fe.id).to.equal('F5');
-      expect(fe.element).to.equal(element3);
+      expect(fe.element).to.equal(element6);
       expect(fe.selectors).to.deep.equal(['*']);
       expect(fe.forceTransfer).to.be.undefined;
 
       // Remove.
-      fixedLayer.removeElement(element3);
+      fixedLayer.removeElement(element6);
       expect(fixedLayer.elements_).to.have.length(5);
 
       // Add with forceTransfer=true.
-      fixedLayer.addElement(element3, true);
+      fixedLayer.addElement(element6, true);
       expect(updateStub).to.have.callCount(2);
       expect(fixedLayer.elements_).to.have.length(6);
       const fe1 = fixedLayer.elements_[5];
       expect(fe1.id).to.equal('F6');
-      expect(fe1.element).to.equal(element3);
+      expect(fe1.element).to.equal(element6);
       expect(fe1.selectors).to.deep.equal(['*']);
       expect(fe1.forceTransfer).to.be.true;
 
       // Remove.
-      fixedLayer.removeElement(element3);
+      fixedLayer.removeElement(element6);
       expect(fixedLayer.elements_).to.have.length(5);
 
       // Add with forceTransfer=false.
-      fixedLayer.addElement(element3, false);
+      fixedLayer.addElement(element6, false);
       expect(updateStub).to.have.callCount(3);
       expect(fixedLayer.elements_).to.have.length(6);
       const fe2 = fixedLayer.elements_[5];
       expect(fe2.id).to.equal('F7');
-      expect(fe2.element).to.equal(element3);
+      expect(fe2.element).to.equal(element6);
       expect(fe2.selectors).to.deep.equal(['*']);
       expect(fe2.forceTransfer).to.be.false;
 
       // Remove.
-      fixedLayer.removeElement(element3);
+      fixedLayer.removeElement(element6);
       expect(fixedLayer.elements_).to.have.length(5);
     });
 
@@ -936,11 +939,11 @@ describes.sandboxed('FixedLayer', {}, () => {
       expect(fixedLayer.elements_).to.have.length(5);
 
       // Add.
-      fixedLayer.addElement(element3, '*');
+      fixedLayer.addElement(element6, '*');
       expect(fixedLayer.elements_).to.have.length(6);
       const fe = fixedLayer.elements_[5];
       expect(fe.id).to.equal('F5');
-      expect(fe.element).to.equal(element3);
+      expect(fe.element).to.equal(element6);
       expect(fe.selectors).to.deep.equal(['*']);
       fixedLayer.mutateElement_(fe, 1, {
         fixed: true,
@@ -955,9 +958,9 @@ describes.sandboxed('FixedLayer', {}, () => {
           callback();
         },
       };
-      fixedLayer.removeElement(element3);
+      fixedLayer.removeElement(element6);
       expect(fixedLayer.elements_).to.have.length(5);
-      expect(element3.style.top).to.equal('');
+      expect(element6.style.top).to.equal('');
     });
 
     it('should reset sticky top upon being removed from fixedlayer', () => {

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -263,10 +263,10 @@ describes.sandboxed('FixedLayer', {}, () => {
       },
       matches: () => true,
       compareDocumentPosition: other => {
-        if (id < other.id) {
-          return 0x0A;
+        if (other.id > id) {
+          return Node.DOCUMENT_POSITION_FOLLOWING;
         }
-        return 0;
+        return Node.DOCUMENT_POSITION_PRECEDING;
       },
       hasAttribute: name => {
         return Object.prototype.hasOwnProperty.call(attrs, name);
@@ -1367,12 +1367,21 @@ describes.realWin('FixedLayer', {}, env => {
   let win, doc;
   let ampdoc;
   let fixedLayer;
-  let vsyncApi;
-  let vsyncTasks;
   let transferLayer;
   let root;
   let shadowRoot;
   let container;
+
+  const vsyncTasks = [];
+  const vsyncApi = {
+    runPromise: task => {
+      vsyncTasks.push(task);
+      return Promise.resolve();
+    },
+    mutate: mutator => {
+      vsyncTasks.push({mutate: mutator});
+    },
+  };
 
   // Can only test when Shadow DOM is available.
   describe.configure().if(() => Element.prototype.attachShadow).run('shadow ' +
@@ -1380,16 +1389,7 @@ describes.realWin('FixedLayer', {}, env => {
     beforeEach(function() {
       win = env.win;
       doc = win.document;
-      vsyncTasks = [];
-      vsyncApi = {
-        runPromise: task => {
-          vsyncTasks.push(task);
-          return Promise.resolve();
-        },
-        mutate: mutator => {
-          vsyncTasks.push({mutate: mutator});
-        },
-      };
+
       installPlatformService(win);
       ampdoc = new AmpDocSingle(win);
       shadowRoot = win.document.body.attachShadow({mode: 'open'});
@@ -1451,6 +1451,45 @@ describes.realWin('FixedLayer', {}, env => {
       transferLayer.transferTo(fe);
       expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
       expect(root.children).to.have.length(1);
+    });
+  });
+
+  describe('Sorting DOM elements', () => {
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      ampdoc = new AmpDocSingle(win);
+      fixedLayer = new FixedLayer(ampdoc, vsyncApi,
+          /* borderTop */ 0, /* paddingTop */ 11, /* transfer */ true);
+    });
+
+    it('should sort elements by dom order', () => {
+      //
+      // <div id='elem1'>
+      //   <div id='elem2'>
+      //      <div id='elem3'>
+      // <div id='elem4'>
+      //
+
+      const elem1 = doc.createElement('div');
+      const elem2 = doc.createElement('div');
+      const elem3 = doc.createElement('div');
+      const elem4 = doc.createElement('div');
+
+      elem1.appendChild(elem2);
+      elem2.appendChild(elem3);
+      elem1.appendChild(elem4);
+      doc.body.appendChild(elem1);
+
+      const fe1 = {element: elem1, id: 'elem1'};
+      const fe2 = {element: elem2, id: 'elem2'};
+      const fe3 = {element: elem3, id: 'elem3'};
+      const fe4 = {element: elem4, id: 'elem4'};
+
+      // random order list
+      const list = [fe3, fe1, fe4, fe2];
+      fixedLayer.sortInDomOrder_(list);
+      expect(list).to.deep.equal([fe1, fe2, fe3, fe4]);
     });
   });
 });


### PR DESCRIPTION
Chrome switched to a version of V8 that has implemented a new sorting algorithm (TimSort instead of QuickSort) which is stable. We have had bunch of bad compare functions and had been lucky so far with unstable result matching our expectations but, well lucky streak is over.

See https://twitter.com/mathias/status/1036626116654637057 

Additionally the 15px scrollbar is gone in Chrome 70

Back to sort issues:
1- `sortInDomOrder` in fixed layer was mostly wrong. 
2- can't do `sort((x, y) => x > y` anymore (sure it was wrong in the first place, but... it worked)
3- `platform-store.js`'s sort was unstable.