### PR TITLE
🐛✨Avoid disabling buttons on submit. Send clicked submit buttons with form submit

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -188,7 +188,7 @@
             <span>Search for</span>
             <input type="search" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
 </form>
 
@@ -201,7 +201,7 @@
             <span>Search for</span>
             <input type="search" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
 </form>
 
@@ -212,7 +212,7 @@
             <span>Search for</span>
             <input type="search" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
 
     </fieldset>
     <div submit-success>
@@ -237,7 +237,7 @@
             <span>Search for</span>
             <input type="search" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
 
     <div submit-success>
@@ -262,7 +262,7 @@
             <span>Your email</span>
             <input type="email" name="email" id="email1" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
     <div submitting>
       <template type="amp-mustache">
@@ -295,7 +295,7 @@
             <span>Your email</span>
             <input type="email" name="email" id="email2" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 
     <div submit-success>
@@ -326,7 +326,7 @@
             <span>Your email</span>
             <input type="email" name="email" id="email3" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 
     <div class="form-message invalid-message">
@@ -379,7 +379,7 @@
             <span>Subscribe</span>
             <input type="email" name="email" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -405,7 +405,7 @@
             <span visible-when-invalid="valueMissing" validation-for="email4"></span>
             <span visible-when-invalid="typeMismatch" validation-for="email4"></span>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -429,7 +429,7 @@
             <span visible-when-invalid="valueMissing" validation-for="email5"></span>
             <span visible-when-invalid="typeMismatch" validation-for="email5"></span>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -463,7 +463,7 @@
             <span>Your email</span>
             <input type="email" name="email" id="email51" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -487,7 +487,7 @@
             <span visible-when-invalid="valueMissing" validation-for="email6"></span>
             <span visible-when-invalid="typeMismatch" validation-for="email6"></span>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -511,7 +511,7 @@
             <span visible-when-invalid="valueMissing" validation-for="email7"></span>
             <span visible-when-invalid="typeMismatch" validation-for="email7"></span>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 </form>
 
@@ -586,10 +586,10 @@
             <span>Your email</span>
             <input type="email" name="email" id="email8" required>
         </label>
-        <input type="submit" value="Subscribe - Input">
-        <input type="submit" value="Subscribe 2 - Input">
-        <button type="submit">Subscribe with a Button</button>
-        <button type="submit">Subscribe with a Button 2</button>
+        <input name="submit-button" type="submit" value="Subscribe - Input">
+        <input name="submit-button" type="submit" value="Subscribe 2 - Input">
+        <button name="submit-button" type="submit" value="Subscribe with a Button">Subscribe with a Button</button>
+        <button name="submit-button" type="submit" value="Subscribe with a Button 2">Subscribe with a Button 2</button>
     </fieldset>
 
     <div submit-success>
@@ -616,7 +616,7 @@
         <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected></amp-img>
         <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="4"></amp-img>
     </amp-selector>
-    <input type="Submit">
+    <input name="submit-button" type="submit" value="Submit">
 </form>
 
 
@@ -630,7 +630,7 @@
             <span>Send us a message</span>
             <input type="text" name="message" id="message1" required>
         </label>
-        <input type="submit" value="Send">
+        <input name="submit-button" type="submit" value="Send">
     </fieldset>
 </form>
 
@@ -649,7 +649,7 @@
             <span>Your email</span>
             <input type="email" name="email" id="email9" required>
         </label>
-        <input type="submit" value="Subscribe">
+        <input name="submit-button" type="submit" value="Subscribe">
     </fieldset>
 
     <div class="form-message invalid-message">
@@ -712,7 +712,7 @@
         <label>Yes: <input type="radio" name="error" value="true" required></label>
         <label>No: <input type="radio" name="error" value="false" required checked></label>
         <div class="spinner"></div>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
     <div submit-success>
         <template type="amp-mustache">
@@ -758,7 +758,7 @@
             <span>Search for</span>
             <input type="search" on="input-debounced:debounced-search.submit" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
 
     <div submit-success>
@@ -791,7 +791,7 @@
             <span>Search for</span>
             <input type="search" name="term" required>
         </label>
-        <input type="submit" value="Search">
+        <input name="submit-button" type="submit" value="Search">
     </fieldset>
 
     <div submit-success template="submit_success_template"></div>
@@ -803,7 +803,7 @@
         <p>Upload a file:</p>
         <input type="file" name="myFile" accept="text/plain">
     </label>
-    <div><input type="submit"></div>
+    <div><input name="submit-button" type="submit" value="Submit"></div>
     <div submit-success><template type="amp-mustache">Way to go 🎉 {{message}}</template></div>
     <div submit-error>Way to fail</div>
 </form>

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -175,10 +175,6 @@ export class AmpForm {
     }
     this.form_.classList.add('i-amphtml-form');
 
-    const submitButtons = this.form_.querySelectorAll('button,[type="submit"]');
-    /** @const @private {!Array<!Element>} */
-    this.submitButtons_ = toArray(submitButtons);
-
     /** @private {!FormState} */
     this.state_ = FormState.INITIAL;
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -175,7 +175,7 @@ export class AmpForm {
     }
     this.form_.classList.add('i-amphtml-form');
 
-    const submitButtons = this.form_.querySelectorAll('[type="submit"]');
+    const submitButtons = this.form_.querySelectorAll('button,[type="submit"]');
     /** @const @private {!Array<!Element>} */
     this.submitButtons_ = toArray(submitButtons);
 
@@ -903,13 +903,6 @@ export class AmpForm {
     this.form_.classList.add(`amp-form-${newState}`);
     this.cleanupRenderedTemplate_(previousState);
     this.state_ = newState;
-    this.submitButtons_.forEach(button => {
-      if (newState == FormState.SUBMITTING) {
-        button.setAttribute('disabled', '');
-      } else {
-        button.removeAttribute('disabled');
-      }
-    });
   }
 
   /**

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -973,20 +973,12 @@ describes.repeated('', {
           target: form,
           preventDefault: sandbox.spy(),
         };
-        const button1 = form.querySelectorAll('input[type=submit]')[0];
-        const button2 = form.querySelectorAll('input[type=submit]')[1];
-        const button3 = form.querySelectorAll('button[type=submit]')[0];
-        expect(button1.hasAttribute('disabled')).to.be.false;
-        expect(button2.hasAttribute('disabled')).to.be.false;
-        expect(button3.hasAttribute('disabled')).to.be.false;
 
         ampForm.handleSubmitEvent_(event);
         expect(ampForm.state_).to.equal('submitting');
 
         return whenCalled(ampForm.xhr_.fetch).then(() => {
           expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
-          expect(button1.hasAttribute('disabled')).to.be.true;
-          expect(button2.hasAttribute('disabled')).to.be.true;
 
           ampForm.handleSubmitEvent_(event);
           ampForm.handleSubmitEvent_(event);
@@ -1001,8 +993,6 @@ describes.repeated('', {
           sandbox.stub(ampForm, 'maybeHandleRedirect_');
 
           return whenCalled(ampForm.maybeHandleRedirect_).then(() => {
-            expect(button1.hasAttribute('disabled')).to.be.false;
-            expect(button2.hasAttribute('disabled')).to.be.false;
             expect(ampForm.state_).to.equal('submit-success');
             expect(form.className).to.not.contain('amp-form-submitting');
             expect(form.className).to.not.contain('amp-form-submit-error');
@@ -1069,13 +1059,7 @@ describes.repeated('', {
           target: form,
           preventDefault: sandbox.spy(),
         };
-        const button1 = form.querySelectorAll('input[type=submit]')[0];
-        const button2 = form.querySelectorAll('input[type=submit]')[1];
-        expect(button1.hasAttribute('disabled')).to.be.false;
-        expect(button2.hasAttribute('disabled')).to.be.false;
         ampForm.handleSubmitEvent_(event);
-        expect(button1.hasAttribute('disabled')).to.be.true;
-        expect(button2.hasAttribute('disabled')).to.be.true;
         expect(event.preventDefault).to.be.called;
         expect(event.stopImmediatePropagation).to.not.be.called;
         expect(ampForm.state_).to.equal('submitting');
@@ -1087,8 +1071,6 @@ describes.repeated('', {
         return ampForm.xhrSubmitPromiseForTesting().then(() => {
           assert.fail('Submit should have failed.');
         }, () => {
-          expect(button1.hasAttribute('disabled')).to.be.false;
-          expect(button2.hasAttribute('disabled')).to.be.false;
           expect(ampForm.state_).to.equal('submit-error');
           expect(form.className).to.not.contain('amp-form-submitting');
           expect(form.className).to.not.contain('amp-form-submit-success');

--- a/src/form.js
+++ b/src/form.js
@@ -40,22 +40,34 @@ export function setFormForElement(element, form) {
 
 /**
  * Returns form data in the passed-in form as an object.
+ * Includes focused submit buttons.
  * @param {!HTMLFormElement} form
  * @return {!JsonObject}
  */
 export function getFormAsObject(form) {
+  const {
+    elements,
+    ownerDocument,
+  } = form;
   const data = /** @type {!JsonObject} */ ({});
-  const inputs = form.elements;
-  const submittableTagsRegex = /^(?:input|select|textarea)$/i;
+  const submittableTagsRegex = /^(?:input|select|textarea|button)$/i;
   const unsubmittableTypesRegex = /^(?:button|image|file|reset)$/i;
   const checkableType = /^(?:checkbox|radio)$/i;
-  for (let i = 0; i < inputs.length; i++) {
-    const input = inputs[i];
-    const {name} = input;
+  for (let i = 0; i < elements.length; i++) {
+    const input = elements[i];
+    const {
+      checked,
+      name,
+      multiple,
+      options,
+      tagName,
+      type,
+      value,
+    } = input;
     if (!name || isDisabled(input) ||
-        !submittableTagsRegex.test(input.tagName) ||
-        unsubmittableTypesRegex.test(input.type) ||
-        (checkableType.test(input.type) && !input.checked)) {
+        !submittableTagsRegex.test(tagName) ||
+        unsubmittableTypesRegex.test(type) ||
+        (checkableType.test(type) && !checked)) {
       continue;
     }
 
@@ -63,15 +75,26 @@ export function getFormAsObject(form) {
       data[name] = [];
     }
 
-    if (input.multiple) {
-      iterateCursor(input.options, option => {
+    if (multiple) {
+      iterateCursor(options, option => {
         if (option.selected) {
           data[name].push(option.value);
         }
       });
-    } else {
-      data[name].push(input.value);
+      continue;
     }
+
+    // Browsers vary on the conditions that focus the form submit button.
+    // Generally, the button is only focused if the user triggers the button
+    // itself. If a script calls `button.click` or `form.submit` the button
+    // will not be focused. If the user presses enter inside a field, the button
+    // will not be focused.
+    if ((type == 'submit' || tagName == 'BUTTON')
+        && input != ownerDocument.activeElement) {
+      continue;
+    }
+
+    data[name].push(value);
   }
 
   // Wait until the end to remove the empty values, since

--- a/src/form.js
+++ b/src/form.js
@@ -84,6 +84,8 @@ export function getFormAsObject(form) {
       continue;
     }
 
+    // In a form, the button's value is only submitted if the button itself was
+    // used to submit the form. We can detect that using the document focus.
     // Browsers vary on the conditions that focus the form submit button.
     // Generally, the button is only focused if the user triggers the button
     // itself. If a script calls `button.click` or `form.submit` the button

--- a/test/functional/test-form.js
+++ b/test/functional/test-form.js
@@ -217,14 +217,28 @@ describes.realWin('getFormAsObject', {}, env => {
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar', 'bang']});
   });
 
-  it('returns submit input entries', () => {
+  it('returns focused submit input entries', () => {
     const input = env.win.document.createElement('input');
     input.type = 'submit';
     input.name = 'foo';
     input.value = 'bar';
 
     form.appendChild(input);
+    expect(getFormAsObject(form)).to.deep.equal({});
 
+    input.focus();
+    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
+  });
+
+  it('returns focused button input entries', () => {
+    const input = env.win.document.createElement('button');
+    input.name = 'foo';
+    input.value = 'bar';
+
+    form.appendChild(input);
+    expect(getFormAsObject(form)).to.deep.equal({});
+
+    input.focus();
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
   });
 

--- a/test/functional/test-form.js
+++ b/test/functional/test-form.js
@@ -226,7 +226,9 @@ describes.realWin('getFormAsObject', {}, env => {
     form.appendChild(input);
     expect(getFormAsObject(form)).to.deep.equal({});
 
-    input.focus();
+    Object.defineProperty(form, 'ownerDocument', {get() {
+      return {activeElement: input};
+    }});
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
   });
 
@@ -238,7 +240,9 @@ describes.realWin('getFormAsObject', {}, env => {
     form.appendChild(input);
     expect(getFormAsObject(form)).to.deep.equal({});
 
-    input.focus();
+    Object.defineProperty(form, 'ownerDocument', {get() {
+      return {activeElement: input};
+    }});
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
   });
 


### PR DESCRIPTION
Closes #18745 
Closes #16461 
Closes #18285

This fix removes the button-disabling behavior, which had little effect anyway since there is a submit handler that prevents submit if the form is currently submitting. Publishers who need to disable their submit buttons on submit can do so with amp-bind.

This PR also adds the clicked submit button value to the request body. The solution here adds the focused submit button to the form data. There are not many good ways to detect which button was used to trigger submit, and the spec provides few details about when a submit button must be included in the request. Using the activeElement property seemed to be the lowest-overhead.

/to @aghassemi
/cc @choumx  