### PR TITLE
🏗🐛 Add `AMP_CONFIG` to shadow and ads runtime files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,9 +66,11 @@ const adVendors = [];
 const {green, red, cyan} = colors;
 
 const minifiedRuntimeTarget = 'dist/v0.js';
+const minifiedShadowRuntimeTarget = 'dist/shadow-v0.js';
 const minifiedRuntimeEsmTarget = 'dist/v0-esm.js';
 const minified3pTarget = 'dist.3p/current-min/f.js';
 const unminifiedRuntimeTarget = 'dist/amp.js';
+const unminifiedShadowRuntimeTarget = 'dist/amp-shadow.js';
 const unminifiedRuntimeEsmTarget = 'dist/amp-esm.js';
 const unminified3pTarget = 'dist.3p/current/integration.js';
 
@@ -957,7 +959,9 @@ function dist() {
         if (argv.fortesting) {
           return enableLocalTesting(minifiedRuntimeTarget).then(() => {
             if (!argv.single_pass) {
-              return enableLocalTesting(minifiedRuntimeEsmTarget);
+              return enableLocalTesting(minifiedRuntimeEsmTarget).then(() => {
+                return enableLocalTesting(minifiedShadowRuntimeTarget);
+              });
             }
           });
         }
@@ -1290,6 +1294,8 @@ function compileJs(srcDir, srcFilename, destDir, options) {
               return enableLocalTesting(unminifiedRuntimeEsmTarget);
             } else if (destFilename === 'integration.js') {
               return enableLocalTesting(unminified3pTarget);
+            } else if (destFilename === 'amp-shadow.js') {
+              return enableLocalTesting(unminifiedShadowRuntimeTarget);
             } else {
               return Promise.resolve();
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,12 +65,17 @@ const adVendors = [];
 
 const {green, red, cyan} = colors;
 
+// Minified targets to which AMP_CONFIG must be written.
 const minifiedRuntimeTarget = 'dist/v0.js';
 const minifiedShadowRuntimeTarget = 'dist/shadow-v0.js';
+const minifiedAdsTarget = 'dist/amp4ads-v0.js';
 const minifiedRuntimeEsmTarget = 'dist/v0-esm.js';
 const minified3pTarget = 'dist.3p/current-min/f.js';
+
+// Unminified targets to which AMP_CONFIG must be written.
 const unminifiedRuntimeTarget = 'dist/amp.js';
 const unminifiedShadowRuntimeTarget = 'dist/amp-shadow.js';
+const unminifiedAdsTarget = 'dist/amp-inabox.js';
 const unminifiedRuntimeEsmTarget = 'dist/amp-esm.js';
 const unminified3pTarget = 'dist.3p/current/integration.js';
 
@@ -959,9 +964,13 @@ function dist() {
         if (argv.fortesting) {
           return enableLocalTesting(minifiedRuntimeTarget).then(() => {
             if (!argv.single_pass) {
-              return enableLocalTesting(minifiedRuntimeEsmTarget).then(() => {
-                return enableLocalTesting(minifiedShadowRuntimeTarget);
-              });
+              return enableLocalTesting(minifiedRuntimeEsmTarget)
+                  .then(() => {
+                    return enableLocalTesting(minifiedShadowRuntimeTarget);
+                  })
+                  .then(() => {
+                    return enableLocalTesting(minifiedAdsTarget);
+                  });
             }
           });
         }
@@ -1296,6 +1305,8 @@ function compileJs(srcDir, srcFilename, destDir, options) {
               return enableLocalTesting(unminified3pTarget);
             } else if (destFilename === 'amp-shadow.js') {
               return enableLocalTesting(unminifiedShadowRuntimeTarget);
+            } else if (destFilename === 'amp-inabox.js') {
+              return enableLocalTesting(unminifiedAdsTarget);
             } else {
               return Promise.resolve();
             }


### PR DESCRIPTION
This PR enables local debugging of the shadow runtime and the ads runtime, something we should've been able to do a long time ago.

It also cleans up some redundant / outdated code in `runtime-test.js` that was separately adding `AMP_CONFIG` to just the main runtime prior to running tests, but not the other runtimes. (This is now guaranteed to be done during the build.)