### PR TITLE
🐛 Use win.head when checking for extensions, fix test warning

### DIFF
--- a/src/element-service.js
+++ b/src/element-service.js
@@ -123,7 +123,7 @@ export function getElementServiceIfAvailableForDoc(
   return ampdoc.whenBodyAvailable()
       .then(() => waitForExtensionIfPresent(
           ampdoc.win, extension,
-          ampdoc.getHeadNode()))
+          ampdoc.win.document.head))
       .then(() => {
         // If this service is provided by an element, then we can't depend on
         // the service (they may not use the element).

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -178,6 +178,8 @@ describes.realWin('in single ampdoc', {
     });
 
     it('should fail if element is not in page.', () => {
+      expectAsyncConsoleError(
+          /e1 was requested to be provided through element-bar/);
       markElementScheduledForTesting(env.win, 'element-foo');
 
       return getElementService(env.win, 'e1', 'element-bar').then(() => {
@@ -227,6 +229,8 @@ describes.realWin('in single ampdoc', {
     });
 
     it('should fail if element is not in page.', () => {
+      expectAsyncConsoleError(
+          /e1 was requested to be provided through element-bar/);
       markElementScheduledForTesting(env.win, 'element-foo');
 
       return getElementServiceForDoc(ampdoc, 'e1', 'element-bar').then(() => {


### PR DESCRIPTION
Fixes #18762 

We were using `AmpDoc.getHeadNode()` to decide where to search for extensions.  Unfortunately that function is misleading - it returns the shadow root when an amp page is loaded by `shadow-v0.js`.  

This is correct behavior if you want to know where to insert a `<style>` tag (the original use of this function) but it incorrect if you want to find extension `<script>` tags as they always live in `ampDoc.win.document.head`

See [this comment](https://github.com/ampproject/amphtml/issues/18762#issuecomment-430719650) for a description of the failure mode

