### PR TITLE
🐛 `amp-video-iframe`: Ignore postMessages that aren't valid JSON.

### DIFF
--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -347,7 +347,14 @@ export class AmpVideoIntegration {
  * @param {function(!JsonObject)} onMessage
  */
 function listenTo(win, onMessage) {
-  listen(win, 'message', e => onMessage(tryParseJson(getData(e))));
+  listen(win, 'message', e => {
+    const message = tryParseJson(getData(e));
+    if (!message) {
+      // only process valid JSON.
+      return;
+    }
+    onMessage(message);
+  });
 }
 
 /**


### PR DESCRIPTION
In some cases (ahem, Chrome extensions) the window will receive messages that our integration script cannot parse, causing it to barf.