### PR TITLE
[amp-list-resize] change to layout container on load if scroll height equals list height

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -492,7 +492,8 @@ export class AmpList extends AMP.BaseElement {
       const height = this.element./*OK*/offsetHeight;
       if (scrollHeight > height) {
         this.attemptChangeHeight(scrollHeight).catch(() => {});
-      } else if (this.element.hasAttribute('auto-resize')) {
+      } else if (scrollHeight == height
+          && this.element.hasAttribute('auto-resize')) {
         this.changeToLayoutContainer_();
       }
     });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -492,6 +492,8 @@ export class AmpList extends AMP.BaseElement {
       const height = this.element./*OK*/offsetHeight;
       if (scrollHeight > height) {
         this.attemptChangeHeight(scrollHeight).catch(() => {});
+      } else if (this.element.hasAttribute('auto-resize')) {
+        this.changeToLayoutContainer_();
       }
     });
   }

--- a/test/manual/amp-list-resize.amp.html
+++ b/test/manual/amp-list-resize.amp.html
@@ -67,7 +67,7 @@
   <h1>AMP List Resize Manual Test</h1>
 
   <h2>AMP List Basic</h2>
-  <p>Test this under slow internet (throttle to slow 3G).</p>
+  <p>This contains an incorrectly sized container where the contents exceed the list height. It should show an overflow button. </p>
   <amp-list width="396" height="80" layout="responsive" auto-resize reset-on-refresh
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">
@@ -84,7 +84,7 @@
   <div class="split"></div>
 
   <h2>AMP List Basic Below fold</h2>
-  <p>Test this under slow internet (throttle to slow 3G).</p>
+  <p>This contains an incorrectly sized container where the contents exceed the list height. It should be changed to layout container. </p>
   <amp-list width="396" height="80" layout="responsive" auto-resize reset-on-refresh
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">


### PR DESCRIPTION
Addresses case 1 in https://github.com/ampproject/amphtml/issues/18376. Basically if we don't need to change size, then immediately change to layout container on load when `auto-resize` is set. This will actually successfully handle the accordion use case as well as the bound CSS use case so long as on initial load, the contents don't exceed the list height. 

Demo link here: https://amp-demo-project-1323a.firebaseapp.com/manual/amp-list-resize.amp.html. 
Caveat: the autosuggest case doesn't work on firebase (only local). 