### PR TITLE
Hiding the swipe navigation hint when holding to pause the story.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -172,6 +172,11 @@ export class AmpStoryHint {
       this.onRtlStateUpdate_(rtlState);
     }, true /** callToInitialize */);
 
+    this.storeService_.subscribe(
+        StateProperty.SYSTEM_UI_IS_VISIBLE_STATE, isVisible => {
+          this.onSystemUiIsVisibleStateUpdate_(isVisible);
+        });
+
     this.vsync_.mutate(() => {
       this.parentEl_.appendChild(root);
     });
@@ -273,6 +278,17 @@ export class AmpStoryHint {
         this.hintContainer_.setAttribute('dir', 'rtl') :
         this.hintContainer_.removeAttribute('dir');
     });
+  }
+
+  /**
+   * Reacts to system UI visibility state updates.
+   * @param {boolean} isVisible
+   * @private
+   */
+  onSystemUiIsVisibleStateUpdate_(isVisible) {
+    if (!isVisible) {
+      this.hideAllNavigationHint();
+    }
   }
 }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -574,14 +574,17 @@ export class AmpStory extends AMP.BaseElement {
     gestures.onGesture(SwipeXYRecognizer, gesture => {
       const {deltaX, deltaY} = gesture.data;
       if (this.storeService_.get(StateProperty.BOOKEND_STATE) ||
-          this.storeService_.get(StateProperty.ACCESS_STATE)) {
+          this.storeService_.get(StateProperty.ACCESS_STATE) ||
+          !this.storeService_.get(StateProperty.SYSTEM_UI_IS_VISIBLE_STATE) ||
+          !this.storeService_
+              .get(StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT)) {
+        // Cancels the event for this gesture entirely, ensuring the hint won't
+        // show even if the user keeps swiping without releasing the touch.
+        gesture.event && gesture.event.preventDefault();
         return;
       }
-      if (!this.isSwipeLargeEnoughForHint_(deltaX, deltaY)) {
-        return;
-      }
-      if (!this.storeService_
-          .get(StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT)) {
+      if (gesture.event.defaultPrevented ||
+          !this.isSwipeLargeEnoughForHint_(deltaX, deltaY)) {
         return;
       }
 


### PR DESCRIPTION
- Prevents the swipe navigation hint to show when moving the finger on the screen during a hold to pause interaction
- Hides the swipe navigation hint when holding to pause the story, if it was already visible
- Ensures the swipe navigation hint won't show when releasing the hold to pause, which could happen if user moved their finger

[Demo](https://stamp-press-to-pause-hide-ui.firebaseapp.com/examples/s20/body-painting/index.html)

#18714