### PR TITLE
Setting the first page as [active] when rendering a paused story.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -92,7 +92,7 @@ const REWIND_TIMEOUT_MS = 350;
  */
 export const PageState = {
   NOT_ACTIVE: 0, // Page is not displayed. Could still be visible on desktop.
-  ACTIVE: 1, // Page is currently the main page, and playing.
+  PLAYING: 1, // Page is currently the main page, and playing.
   PAUSED: 2, // Page is currently the main page, but not playing.
 };
 
@@ -250,7 +250,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.pauseCallback();
         this.state_ = state;
         break;
-      case PageState.ACTIVE:
+      case PageState.PLAYING:
         if (this.state_ === PageState.NOT_ACTIVE) {
           this.element.setAttribute('active', '');
           this.resumeCallback();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -970,7 +970,7 @@ export class AmpStory extends AMP.BaseElement {
         // Note: navigation is prevented when the story is paused, this test
         // covers the case where the story is rendered paused (eg: consent).
         if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
-          targetPage.setState(PageState.ACTIVE);
+          targetPage.setState(PageState.PLAYING);
         } else {
           // Even if the page won't be playing, setting the active attribute
           // ensures it gets visible.
@@ -1343,7 +1343,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    const pageState = isPaused ? PageState.PAUSED : PageState.ACTIVE;
+    const pageState = isPaused ? PageState.PAUSED : PageState.PLAYING;
 
     isPaused ? this.advancement_.stop() : this.advancement_.start();
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -81,7 +81,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   it('should set an active attribute when state becomes active', () => {
     page.buildCallback();
     return page.layoutCallback().then(() => {
-      page.setState(PageState.ACTIVE);
+      page.setState(PageState.PLAYING);
 
       expect(page.element).to.have.attribute('active');
     });
@@ -92,7 +92,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
 
     page.buildCallback();
     return page.layoutCallback().then(() => {
-      page.setState(PageState.ACTIVE);
+      page.setState(PageState.PLAYING);
 
       expect(advancementStartStub).to.have.been.calledOnce;
     });
@@ -108,7 +108,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     return page.layoutCallback().then(() => {
       const animateInStub = sandbox.stub(page.animationManager_, 'animateIn');
 
-      page.setState(PageState.ACTIVE);
+      page.setState(PageState.PLAYING);
 
       expect(animateInStub).to.have.been.calledOnce;
     });
@@ -142,7 +142,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
               .withExactArgs(videoEl)
               .once();
 
-          page.setState(PageState.ACTIVE);
+          page.setState(PageState.PLAYING);
 
           // `setState` runs code that creates subtasks (Promise callbacks).
           // Waits for the next frame to make sure all the subtasks are

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -463,7 +463,7 @@ describes.realWin('amp-story', {
             expect(setStateStub.getCall(0))
                 .to.have.been.calledWithExactly(PageState.NOT_ACTIVE);
             expect(setStateStub.getCall(1))
-                .to.have.been.calledWithExactly(PageState.ACTIVE);
+                .to.have.been.calledWithExactly(PageState.PLAYING);
           });
     });
 
@@ -503,7 +503,7 @@ describes.realWin('amp-story', {
             expect(setStateStub.getCall(0))
                 .to.have.been.calledWithExactly(PageState.NOT_ACTIVE);
             expect(setStateStub.getCall(1))
-                .to.have.been.calledWithExactly(PageState.ACTIVE);
+                .to.have.been.calledWithExactly(PageState.PLAYING);
           });
     });
   });


### PR DESCRIPTION
Setting the first page as `[active]` when rendering a paused story, otherwise the second amp-story-page will be displayed.

Fixes #18842