### PR TITLE
Add EPICA to amp-analytics

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -59,6 +59,7 @@
       <option>comscore</option>
       <option>cxense</option>
       <option>dynatrace</option>
+      <option>epica</option>
       <option>euleriananalytics</option>
       <option>facebook-pixel</option>
       <option>gemius</option>
@@ -386,6 +387,32 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End dynatrace example -->
+
+<!-- EPICA analytics tracking -->
+<amp-analytics type="epica" id="epica">
+<script type="application/json">
+{
+  "vars": {
+    "writeKey": "13k442kn312",
+    "name": "Page name"
+  },
+  "extraUrlParams": {
+    "properties.category": "Sport"
+  },
+  "triggers": {
+    "click": {
+      "on": "click",
+      "selector": "#test1",
+      "request": "track",
+      "vars": {
+        "event": "Click"
+      }
+    }
+  }
+}
+</script>
+</amp-analytics>
+<!-- End EPICA analytics example -->
 
 <!-- Eulerian Analytics tracking -->
 <amp-analytics type="euleriananalytics" id="euleriananalytics">
@@ -1079,7 +1106,7 @@ For complete documentation and additional examples please see: https://marketing
       "request": "pageview",
       "vars": {
         "tealium_event": "screen_view"
-      }     
+      }
     },
     "clickOnTest1Trigger": {
       "on": "click",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -77,6 +77,12 @@
     "endpoint": "https://!tenant.live.dynatrace.com:443/ampbf/!tenantpath",
     "pageview": "https://!tenant.live.dynatrace.com:443/ampbf/!tenantpath?type=js&flavor=amp&v=1&a=1%7C1%7C_load_%7C_load_%7C-%7C_nav_timing_%7C_nav_timing_%7C0%2C2%7C2%7C_onload_%7C_load_%7C-%7C_nav_timing_%7C_nav_timing_%7C0&fId=_page_view_id_&vID=_client_id_&referer=_source_url_&title=_title_&sw=_screen_width_&sh=_screen_height_&w=_viewport_width_&h=_viewport_height_&nt=a_nav_type_b_nav_timing_c_nav_timing_d_nav_timing_e_nav_timing_f_nav_timing_g_nav_timing_h_nav_timing_i_nav_timing_j_nav_timing_k_nav_timing_l_nav_timing_m_nav_timing_n_nav_timing_o_nav_timing_p_nav_timing_q_nav_timing_r_nav_timing_s_nav_timing_t_nav_timing_&app=ampapp&time=_timestamp_"
   },
+  "epica": {
+    "host": "https://cat.poder.io/v1/pixel",
+    "base": "?writeKey=!writeKey&context.library.name=amp&anonymousId=_client_id_&context.locale=_browser_language_&context.page.path=_canonical_path_&context.page.url=_canonical_url_&context.page.referrer=_document_referrer_&context.page.title=_title_&context.screen.width=_screen_width_&context.screen.height=_screen_height_",
+    "page": "https://cat.poder.io/v1/pixel/page?writeKey=!writeKey&context.library.name=amp&anonymousId=_client_id_&context.locale=_browser_language_&context.page.path=_canonical_path_&context.page.url=_canonical_url_&context.page.referrer=_document_referrer_&context.page.title=_title_&context.screen.width=_screen_width_&context.screen.height=_screen_height_&name=!name",
+    "track": "https://cat.poder.io/v1/pixel/track?writeKey=!writeKey&context.library.name=amp&anonymousId=_client_id_&context.locale=_browser_language_&context.page.path=_canonical_path_&context.page.url=_canonical_url_&context.page.referrer=_document_referrer_&context.page.title=_title_&context.screen.width=_screen_width_&context.screen.height=_screen_height_&event=!event"
+  },
   "euleriananalytics": {
     "base": "https://!analyticsHost",
     "basePrefix": "-/_random_?euid-amp=_client_id_&url=_source_url_&",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -34,6 +34,7 @@ import {COLANALYTICS_CONFIG} from './vendors/colanalytics';
 import {COMSCORE_CONFIG} from './vendors/comscore';
 import {CXENSE_CONFIG} from './vendors/cxense';
 import {DYNATRACE_CONFIG} from './vendors/dynatrace';
+import {EPICA_CONFIG} from './vendors/epica';
 import {EULERIANANALYTICS_CONFIG} from './vendors/euleriananalytics';
 import {FACEBOOKPIXEL_CONFIG} from './vendors/facebookpixel';
 import {GEMIUS_CONFIG} from './vendors/gemius';
@@ -180,6 +181,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'comscore': COMSCORE_CONFIG,
   'cxense': CXENSE_CONFIG,
   'dynatrace': DYNATRACE_CONFIG,
+  'epica': EPICA_CONFIG,
   'euleriananalytics': EULERIANANALYTICS_CONFIG,
   'facebookpixel': FACEBOOKPIXEL_CONFIG,
   'gemius': GEMIUS_CONFIG,

--- a/extensions/amp-analytics/0.1/vendors/epica.js
+++ b/extensions/amp-analytics/0.1/vendors/epica.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EPICA_CONFIG = /** @type {!JsonObject} */ ({
+  'transport': {
+    'beacon': false,
+    'xhrpost': false,
+    'image': true,
+  },
+  'vars': {
+    'anonymousId': 'CLIENT_ID(epica_amp_id)',
+  },
+  'requests': {
+    'host': 'https://cat.poder.io/v1/pixel',
+    'base': '?writeKey=${writeKey}' +
+      '&context.library.name=amp' +
+      '&anonymousId=${anonymousId}' +
+      '&context.locale=${browserLanguage}' +
+      '&context.page.path=${canonicalPath}' +
+      '&context.page.url=${canonicalUrl}' +
+      '&context.page.referrer=${documentReferrer}' +
+      '&context.page.title=${title}' +
+      '&context.screen.width=${screenWidth}' +
+      '&context.screen.height=${screenHeight}',
+    'page': '${host}/page${base}&name=${name}',
+    'track': '${host}/track${base}&event=${event}',
+  },
+  'triggers': {
+    'page': {
+      'on': 'visible',
+      'request': 'page',
+    },
+  },
+});


### PR DESCRIPTION
Adds EPICA. Closes #18808.

```html
<amp-analytics type="epica">
<script type="application/json">
{
  "vars": {
    "writeKey": "abcde1234",
    "name": "Page name"
  }
}
</script>
</amp-analytics>
```