### PR TITLE
🐛Fix master-breaking lint error

### DIFF
--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -26,7 +26,7 @@ import {tryParseJson} from '../../../src/json';
 
 export class AmpVizVega extends AMP.BaseElement {
 
-/** @param {!AmpElement} element */
+  /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
 

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -438,7 +438,7 @@ export class SubscriptionApi {
       }
       requestCallback(data, source, origin);
     }, this.is3p_,
-        // For 3P frames we also allow nested frames within them to subscribe..
+    // For 3P frames we also allow nested frames within them to subscribe..
     this.is3p_ /* opt_includingNestedWindows */);
   }
 


### PR DESCRIPTION
Master is red due to a lint failure about indentation. I think a linter dependency may have changed its behavior to start linting comments more strictly?

https://travis-ci.org/ampproject/amphtml/builds/443797935
