### PR TITLE
🚀Dev Dashboard: Created a function to run before serving dev dashboard

### DIFF
--- a/build-system/app-index/index.js
+++ b/build-system/app-index/index.js
@@ -94,7 +94,6 @@ function isMainPageFromUrl(url) {
   return url == '/';
 }
 
-
 function serveIndex(req, res, next) {
   const isMainPage = isMainPageFromUrl(req.url);
   const basepath = getListingPath(req.url);
@@ -131,7 +130,7 @@ function serveIndex(req, res, next) {
 }
 
 // Promises to run before serving
-async function beforeServeTasks () {
+async function beforeServeTasks() {
   if (shouldCache) {
     await bundleMain();
   }
@@ -140,5 +139,5 @@ async function beforeServeTasks () {
 module.exports = {
   setCacheStatus,
   serveIndex,
-  beforeServeTasks
+  beforeServeTasks,
 };

--- a/build-system/app-index/index.js
+++ b/build-system/app-index/index.js
@@ -94,6 +94,7 @@ function isMainPageFromUrl(url) {
   return url == '/';
 }
 
+
 function serveIndex(req, res, next) {
   const isMainPage = isMainPageFromUrl(req.url);
   const basepath = getListingPath(req.url);
@@ -129,7 +130,15 @@ function serveIndex(req, res, next) {
   })();
 }
 
+// Promises to run before serving
+async function beforeServeTasks () {
+  if (shouldCache) {
+    await bundleMain();
+  }
+}
+
 module.exports = {
   setCacheStatus,
   serveIndex,
+  beforeServeTasks
 };

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1324,4 +1324,7 @@ function generateInfo(filePath) {
       '<h3><a href = /serve_mode=cdn>Change to CDN mode (prod JS)</a></h3>';
 }
 
-module.exports = app;
+module.exports = {
+  middleware: app,
+  beforeServeTasks: devDashboard.beforeServeTasks
+};

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1326,5 +1326,5 @@ function generateInfo(filePath) {
 
 module.exports = {
   middleware: app,
-  beforeServeTasks: devDashboard.beforeServeTasks
+  beforeServeTasks: devDashboard.beforeServeTasks,
 };

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -62,7 +62,7 @@ const middleware = [];
 if (!quiet) {
   middleware.push(morgan('dev'));
 }
-middleware.push(app);
+middleware.push(app.middleware);
 if (sendCachingHeaders) {
   middleware.push(header({
     'cache-control': ' max-age=600',
@@ -80,7 +80,9 @@ if (noCachingExtensions) {
 }
 
 // Start gulp webserver
-gulp.src(process.cwd())
+(async () => {
+  await app.beforeServeTasks();
+  gulp.src(process.cwd())
     .pipe(webserver({
       port,
       host,
@@ -88,4 +90,4 @@ gulp.src(process.cwd())
       https: useHttps,
       middleware,
     }));
-
+})();

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -80,14 +80,14 @@ if (noCachingExtensions) {
 }
 
 // Start gulp webserver
-(async () => {
+(async() => {
   await app.beforeServeTasks();
   gulp.src(process.cwd())
-    .pipe(webserver({
-      port,
-      host,
-      directoryListing: true,
-      https: useHttps,
-      middleware,
-    }));
+      .pipe(webserver({
+        port,
+        host,
+        directoryListing: true,
+        https: useHttps,
+        middleware,
+      }));
 })();

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -263,7 +263,7 @@ module.exports = {
     'karma-super-dots-reporter',
     {
       'middleware:custom': ['factory', function() {
-        return require(require.resolve('../app.js'));
+        return require(require.resolve('../app.js')).middleware;
       }],
     },
   ],

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -263,7 +263,7 @@ module.exports = {
     'karma-super-dots-reporter',
     {
       'middleware:custom': ['factory', function() {
-        return require(require.resolve('../app.js')).middleware;
+        return require(require.resolve('../app.js'));
       }],
     },
   ],


### PR DESCRIPTION
This simply changes the `app.js` to return a middleware for the gulp server AND an async function named `beforeServeTasks`, which simply runs anything (like bundling if we want to cache) before starting the web server. 😄 