### PR TITLE
♻️🐛 Proxy form as functional stateless component, bugfix

### DIFF
--- a/build-system/app-index/components/proxy-form.js
+++ b/build-system/app-index/components/proxy-form.js
@@ -18,34 +18,32 @@
 
 import {Component, h, render} from 'preact';
 
-export class ProxyForm extends Component {
+function goToProxyUrlOnSubmit(event) {
+  event.preventDefault();
 
-  submit = event => {
-    event.preventDefault();
+  const input = event.target.querySelector('#proxy-input');
+  const suffix = input.value.replace(/^http(s?):\/\//i, '');
+  window.location = `/proxy/s/${suffix}`;
+}
 
-    const input = event.target.querySelector('#proxy-input');
-    const suffix = input.value.replace(/^http(s?):\/\//i, '');
-    window.location = `/proxy/s/${suffix}`;
-  }
-
-  render() {
-    return (
-      <div class="block proxy-form-container">
-        <form id="proxy-form" onSubmit={this.submit}>
-          <label for="proxy-input">
-            <span>Load URL by Proxy</span>
-            <input type="text" class="text-input" id="proxy-input"
-              required aria-required="true"
-              placeholder="https://"
-              pattern="^(https?://)?[^\s]+$" />
-          </label>
-          <div class="form-info">
-            <a href="https://github.com/ampproject/amphtml/blob/master/contributing/TESTING.md#document-proxy">
-                What's this?
-            </a>
-          </div>
-        </form>
-      </div>
-    );
-  }
+export function ProxyForm() {
+  return (
+    <div class="block proxy-form-container">
+      <form id="proxy-form" onSubmit={goToProxyUrlOnSubmit}>
+        <label for="proxy-input">
+          <span>Load URL by Proxy</span>
+          <input type="text" class="text-input" id="proxy-input"
+            required aria-required="true"
+            placeholder="https://"
+            pattern="^(https?://)?[^\\s]+$" />
+        </label>
+        <div class="form-info">
+          <a href="https://github.com/ampproject/amphtml/blob/master/contributing/TESTING.md#document-proxy"
+            target="_blank">
+            What's this?
+          </a>
+        </div>
+      </form>
+    </div>
+  );
 }


### PR DESCRIPTION
- Proxy form requires no state, so it should be stateless.
- Fixes a bug where the regex pattern `[^\s]` would be escaped to `[^s]`, effectively disallowing any URL with an `s` in it.
