### PR TITLE
Fixing amp-story actions whitelist race condition.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -302,7 +302,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
       }
     });
 
-    this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
+    this.storeService_.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, actions);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -20,7 +20,6 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {Layout} from '../../../src/layout';
-import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {
   closest,
@@ -88,9 +87,6 @@ export class AmpStoryAccess extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-
-    /** @const @private {!../../../src/service/action-impl.ActionService} */
-    this.actions_ = Services.actionServiceForDoc(this.element);
 
     /** @private {?Element} */
     this.containerEl_ = null;
@@ -292,16 +288,21 @@ export class AmpStoryAccess extends AMP.BaseElement {
       }
     }
 
+    const actions = [];
+
     accessConfig.forEach(config => {
       const {login, namespace} = /** @type {{login, namespace}} */ (config);
 
       if (isObject(login)) {
         const types = Object.keys(login);
-        types.forEach(type => this.whitelistAction_(namespace, type));
+        types.forEach(
+            type => actions.push(this.getActionObject_(namespace, type)));
       } else {
-        this.whitelistAction_(namespace);
+        actions.push(this.getActionObject_(namespace));
       }
     });
+
+    this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
   }
 
   /**
@@ -310,8 +311,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @param {string=} type
    * @private
    */
-  whitelistAction_(namespace = undefined, type = undefined) {
+  getActionObject_(namespace = undefined, type = undefined) {
     const method = ['login', namespace, type].filter(s => !!s).join('-');
-    this.actions_.addToWhitelist('SCRIPT', method);
+    return {tagOrTarget: 'SCRIPT', method};
   }
 }

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -227,7 +227,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
         {tagOrTarget: 'AMP-CONSENT', method: 'prompt'},
         {tagOrTarget: 'AMP-CONSENT', method: 'reject'},
       ];
-      this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
+      this.storeService_.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, actions);
 
       this.setAcceptButtonFontColor_();
 

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -222,9 +222,12 @@ export class AmpStoryConsent extends AMP.BaseElement {
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
       // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
-      this.actions_.addToWhitelist('AMP-CONSENT', 'accept');
-      this.actions_.addToWhitelist('AMP-CONSENT', 'prompt');
-      this.actions_.addToWhitelist('AMP-CONSENT', 'reject');
+      const actions = [
+        {tagOrTarget: 'AMP-CONSENT', method: 'accept'},
+        {tagOrTarget: 'AMP-CONSENT', method: 'prompt'},
+        {tagOrTarget: 'AMP-CONSENT', method: 'reject'},
+      ];
+      this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
 
       this.setAcceptButtonFontColor_();
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -383,6 +383,8 @@ export class AmpStoryStoreService {
       [StateProperty.STORY_HAS_AUDIO_STATE]: false,
       [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: true,
       [StateProperty.UI_STATE]: UIType.MOBILE,
+      // amp-story only allows actions on a case-by-case basis to preserve UX
+      // behaviors. By default, no actions are allowed.
       [StateProperty.ACTIONS_WHITELIST]: [],
       [StateProperty.CONSENT_ID]: null,
       [StateProperty.CURRENT_PAGE_ID]: '',

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -81,7 +81,7 @@ export const UIType = {
  *    supportedbrowserstate: boolean,
  *    systemuiisvisiblestate: boolean,
  *    uistate: !UIType,
- *    actionswhitelist: !Array<{tagOrTarget: string, method: string}>
+ *    actionswhitelist: !Array<{tagOrTarget: string, method: string}>,
  *    consentid: ?string,
  *    currentpageid: string,
  *    currentpageindex: number,
@@ -129,6 +129,7 @@ export const StateProperty = {
 
 /** @private @const @enum {string} */
 export const Action = {
+  ADD_TO_ACTIONS_WHITELIST: 'addtoactionswhitelist',
   CHANGE_PAGE: 'setcurrentpageid',
   SET_CONSENT_ID: 'setconsentid',
   TOGGLE_ACCESS: 'toggleaccess',
@@ -153,7 +154,7 @@ export const Action = {
 /**
  * Functions to compare a data structure from the previous to the new state and
  * detect a mutation, when a simple equality test would not work.
- * @private @const {!Object<!StateProperty: !function}
+ * @private @const {!Object<string, !function(*, *):boolean>}
  */
 const stateComparisonFunctions = {
   [StateProperty.ACTIONS_WHITELIST]: (old, curr) => old.length !== curr.length,
@@ -169,9 +170,7 @@ const stateComparisonFunctions = {
  */
 const actions = (state, action, data) => {
   switch (action) {
-    case Action.ADD_TO_ACTION_WHITELIST:
-      // TODO: check the data for the right action properties.
-      // data could be an action, or an array of actions.
+    case Action.ADD_TO_ACTIONS_WHITELIST:
       const newActionsWhitelist =
           [].concat(state[StateProperty.ACTIONS_WHITELIST], data);
       return /** @type {!State} */ (Object.assign(
@@ -345,8 +344,8 @@ export class AmpStoryStoreService {
     Object.keys(this.listeners_).forEach(key => {
       comparisonFn = stateComparisonFunctions[key];
       if (comparisonFn ?
-          comparisonFn(oldState[key], this.state_[key]) :
-          oldState[key] !== this.state_[key]) {
+        comparisonFn(oldState[key], this.state_[key]) :
+        oldState[key] !== this.state_[key]) {
         this.listeners_[key].fire(this.state_[key]);
       }
     });

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -352,11 +352,6 @@ export class AmpStory extends AMP.BaseElement {
     // Removes title in order to prevent incorrect titles appearing on link
     // hover. (See 17654)
     this.element.removeAttribute('title');
-
-    // Disallow all actions in a (standalone) story.
-    // Components then add their own actions.
-    const actions = Services.actionServiceForDoc(this.getAmpDoc());
-    actions.clearWhitelist();
   }
 
   /** @override */
@@ -528,6 +523,14 @@ export class AmpStory extends AMP.BaseElement {
       const data = getDetail(e)['data'];
       this.storeService_.dispatch(action, data);
     });
+
+    // Actions whitelist could be initialized empty, or with some actions some
+    // other components registered.
+    this.storeService_.subscribe(
+        StateProperty.ACTIONS_WHITELIST, actionsWhitelist => {
+          const actions = Services.actionServiceForDoc(this.getAmpDoc());
+          actions.setWhitelist(actionsWhitelist);
+        }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.AD_STATE, isAd => {
       this.onAdStateUpdate_(isAd);
@@ -1882,10 +1885,13 @@ export class AmpStory extends AMP.BaseElement {
     }
     this.storeService_.dispatch(Action.TOGGLE_HAS_SIDEBAR,
         !!this.sidebar_);
-    const actions = Services.actionServiceForDoc(this.getAmpDoc());
-    actions.addToWhitelist('AMP-SIDEBAR', 'open');
-    actions.addToWhitelist('AMP-SIDEBAR', 'close');
-    actions.addToWhitelist('AMP-SIDEBAR', 'toggle');
+
+    const actions = [
+      {tagOrTarget: 'AMP-SIDEBAR', method: 'open'},
+      {tagOrTarget: 'AMP-SIDEBAR', method: 'close'},
+      {tagOrTarget: 'AMP-SIDEBAR', method: 'toggle'},
+    ];
+    this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1891,7 +1891,7 @@ export class AmpStory extends AMP.BaseElement {
       {tagOrTarget: 'AMP-SIDEBAR', method: 'close'},
       {tagOrTarget: 'AMP-SIDEBAR', method: 'toggle'},
     ];
-    this.storeService_.dispatch(Action.ADD_ACTION_TO_WHITELIST, actions);
+    this.storeService_.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, actions);
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {Action, AmpStoryStoreService} from '../amp-story-store-service';
+import {
+  Action,
+  AmpStoryStoreService,
+  StateProperty,
+} from '../amp-story-store-service';
 import {AmpStoryAccess, Type} from '../amp-story-access';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -101,13 +105,11 @@ describes.realWin('amp-story-access', {amp: true}, env => {
   });
 
   it('should whitelist the default <amp-access> actions', () => {
-    const addToWhitelistStub =
-        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
-
     storyAccess.buildCallback();
 
-    expect(addToWhitelistStub).to.have.been.calledOnce;
-    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT', 'login');
+    const actions =
+        storyAccess.storeService_.get(StateProperty.ACTIONS_WHITELIST);
+    expect(actions).to.deep.contain({tagOrTarget: 'SCRIPT', method: 'login'});
   });
 
   it('should whitelist the typed <amp-access> actions', () => {
@@ -117,31 +119,28 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     };
     setConfig(defaultConfig);
 
-    const addToWhitelistStub =
-        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
-
     storyAccess.buildCallback();
 
-    expect(addToWhitelistStub).to.have.been.calledTwice;
-    expect(addToWhitelistStub).to.have.been.calledWith(
-        'SCRIPT', 'login-typefoo');
-    expect(addToWhitelistStub).to.have.been.calledWith(
-        'SCRIPT', 'login-typebar');
+    const actions =
+        storyAccess.storeService_.get(StateProperty.ACTIONS_WHITELIST);
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-typefoo'});
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-typebar'});
   });
 
   it('should whitelist the namespaced and default <amp-access> actions', () => {
     defaultConfig.namespace = 'foo';
     setConfig(defaultConfig);
 
-    const addToWhitelistStub =
-        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
-
     storyAccess.buildCallback();
 
-    expect(addToWhitelistStub).to.have.been.calledTwice;
     // Both namespaced and default actions are allowed.
-    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT', 'login');
-    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT', 'login-foo');
+    const actions =
+        storyAccess.storeService_.get(StateProperty.ACTIONS_WHITELIST);
+    expect(actions).to.deep.contain({tagOrTarget: 'SCRIPT', method: 'login'});
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-foo'});
   });
 
   it('should whitelist namespaced and typed <amp-access> actions', () => {
@@ -157,18 +156,16 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     }];
     setConfig(config);
 
-    const addToWhitelistStub =
-        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
-
     storyAccess.buildCallback();
 
-    expect(addToWhitelistStub).to.have.callCount(3);
-    expect(addToWhitelistStub).to.have.been.calledWith(
-        'SCRIPT', 'login-namespace1-type1');
-    expect(addToWhitelistStub).to.have.been.calledWith(
-        'SCRIPT', 'login-namespace1-type2');
-    expect(addToWhitelistStub).to.have.been.calledWith(
-        'SCRIPT', 'login-namespace2');
+    const actions =
+        storyAccess.storeService_.get(StateProperty.ACTIONS_WHITELIST);
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-namespace1-type1'});
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-namespace1-type2'});
+    expect(actions).to.deep.contain(
+        {tagOrTarget: 'SCRIPT', method: 'login-namespace2'});
   });
 
   it('should require publisher-logo-src to be a URL', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -239,15 +239,16 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should whitelist the <amp-consent> actions', () => {
-    const addToWhitelistStub =
-        sandbox.stub(storyConsent.actions_, 'addToWhitelist');
-
     storyConsent.buildCallback();
 
-    expect(addToWhitelistStub).to.have.callCount(3);
-    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT', 'accept');
-    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT', 'prompt');
-    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT', 'reject');
+    const actions =
+        storyConsent.storeService_.get(StateProperty.ACTIONS_WHITELIST);
+    expect(actions)
+        .to.deep.contain({tagOrTarget: 'AMP-CONSENT', method: 'accept'});
+    expect(actions)
+        .to.deep.contain({tagOrTarget: 'AMP-CONSENT', method: 'prompt'});
+    expect(actions)
+        .to.deep.contain({tagOrTarget: 'AMP-CONSENT', method: 'reject'});
   });
 
   it('should broadcast the amp actions', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -232,4 +232,36 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     // PAUSED_STATE did not get affected.
     expect(storeService.get(StateProperty.PAUSED_STATE)).to.be.true;
   });
+
+  it('should add an action to the whitelist', () => {
+    const action1 = {tagOrTarget: 'foo', method: 1};
+    const action2 = {tagOrTarget: 'foo', method: 2};
+
+    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action1);
+
+    const actionsListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
+
+    const action = {tagOrTarget: 'foo'};
+    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action2);
+
+    expect(actionsListenerSpy)
+        .to.have.been.calledOnceWithExactly([action1, action2]);
+  });
+
+  it('should add an array of actions to the whitelist', () => {
+    const action1 = {tagOrTarget: 'foo', method: 1};
+    const action2 = {tagOrTarget: 'foo', method: 2};
+    const action3 = {tagOrTarget: 'foo', method: 3};
+
+    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action1);
+
+    const actionsListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
+
+    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, [action2, action3]);
+
+    expect(actionsListenerSpy)
+        .to.have.been.calledOnceWithExactly([action1, action2, action3]);
+  });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -237,13 +237,12 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     const action1 = {tagOrTarget: 'foo', method: 1};
     const action2 = {tagOrTarget: 'foo', method: 2};
 
-    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action1);
+    storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action1);
 
     const actionsListenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
 
-    const action = {tagOrTarget: 'foo'};
-    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action2);
+    storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action2);
 
     expect(actionsListenerSpy)
         .to.have.been.calledOnceWithExactly([action1, action2]);
@@ -254,12 +253,12 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     const action2 = {tagOrTarget: 'foo', method: 2};
     const action3 = {tagOrTarget: 'foo', method: 3};
 
-    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, action1);
+    storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action1);
 
     const actionsListenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
 
-    storeService.dispatch(Action.ADD_ACTION_TO_WHITELIST, [action2, action3]);
+    storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, [action2, action3]);
 
     expect(actionsListenerSpy)
         .to.have.been.calledOnceWithExactly([action1, action2, action3]);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -385,7 +385,7 @@ describes.realWin('amp-story', {
   describe('amp-story consent', () => {
     it('should pause the story if there is a consent', () => {
       sandbox.stub(Services, 'actionServiceForDoc')
-          .returns({clearWhitelist: () => {}, trigger: () => {}});
+          .returns({setWhitelist: () => {}, trigger: () => {}});
 
       // Prevents amp-story-consent element from running code that is irrelevant
       // to this test.
@@ -423,7 +423,7 @@ describes.realWin('amp-story', {
 
     it('should play the story after the consent is resolved', () => {
       sandbox.stub(Services, 'actionServiceForDoc')
-          .returns({clearWhitelist: () => {}, trigger: () => {}});
+          .returns({setWhitelist: () => {}, trigger: () => {}});
 
       // Prevents amp-story-consent element from running code that is irrelevant
       // to this test.
@@ -469,7 +469,7 @@ describes.realWin('amp-story', {
 
     it('should play the story if the consent was already resolved', () => {
       sandbox.stub(Services, 'actionServiceForDoc')
-          .returns({clearWhitelist: () => {}, trigger: () => {}});
+          .returns({setWhitelist: () => {}, trigger: () => {}});
 
       // Prevents amp-story-consent element from running code that is irrelevant
       // to this test.
@@ -651,7 +651,7 @@ describes.realWin('amp-story', {
       sandbox.stub(Services, 'actionServiceForDoc')
           .returns({setWhitelist: () => {}, trigger: () => {},
             addToWhitelist: () => {},
-            clearWhitelist: () => {},
+            setWhitelist: () => {},
             execute: executeSpy,
           });
 
@@ -673,7 +673,7 @@ describes.realWin('amp-story', {
       sandbox.stub(Services, 'actionServiceForDoc')
           .returns({setWhitelist: () => {}, trigger: () => {},
             addToWhitelist: () => {},
-            clearWhitelist: () => {},
+            setWhitelist: () => {},
             execute: () => {sidebar.setAttribute('open', '');}});
 
       story.buildCallback();

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -650,8 +650,6 @@ describes.realWin('amp-story', {
       const executeSpy = sandbox.spy();
       sandbox.stub(Services, 'actionServiceForDoc')
           .returns({setWhitelist: () => {}, trigger: () => {},
-            addToWhitelist: () => {},
-            setWhitelist: () => {},
             execute: executeSpy,
           });
 
@@ -672,8 +670,6 @@ describes.realWin('amp-story', {
 
       sandbox.stub(Services, 'actionServiceForDoc')
           .returns({setWhitelist: () => {}, trigger: () => {},
-            addToWhitelist: () => {},
-            setWhitelist: () => {},
             execute: () => {sidebar.setAttribute('open', '');}});
 
       story.buildCallback();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -444,9 +444,12 @@ export class ActionService {
     return !!this.findAction_(target, actionEventType, opt_stopAt);
   }
 
-  /** Empties the current action whitelist (if any). */
-  clearWhitelist() {
-    this.whitelist_ = [];
+  /**
+   * Sets the action whitelist. Can be used to clear it.
+   * @param {!Array<{tagOrTarget: string, method: string}>} whitelist
+   */
+  setWhitelist(whitelist) {
+    this.whitelist_ = whitelist;
   }
 
   /**


### PR DESCRIPTION
The following behavior could happen:

1. `amp-story-consent` gets built and adds its actions to the whitelist
2. `amp-story` gets built and clears the whitelist ([link](https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/1.0/amp-story.js#L359))
3. When trying to accept the consent, we'd get the error: `"AMP-CONSENT.accept" is not whiteliste []`

This PR fixes this by storing all the actions in the story store service. These actions are added to the whitelist once the story is built, and/or as they get registered in the store.

It also introduces a new data structure (array) to the store.
When dispatching an action, we used to do a simple equality check `!==` between the old and the new state to figure out what has been modified, and trigger the listeners, which wouldn't work with the actions whitelist array.
To avoid doing the good old `JSON.stringify` hack to compare two arrays, I implemented a new map that provides comparison functions for a given property of the store, which is way faster. If we ever want to add a new `Object` or `Array` to the store, we'll also have to provide a comparison function so the store stays fast.
For the actions whitelist, since it's not possible to remove actions to the whitelist for now, it simply compares the length of the array.

Demo:
- [amp-story-consent](https://stamp-whitelist-refactoring.firebaseapp.com/examples/amp-story/consent-geo.html#amp-geo=FR)
- [regular story](https://stamp-whitelist-refactoring.firebaseapp.com/examples/s20/body-painting/index.html)

Fixes #18585