### PR TITLE
🏗 Compare bundle size to branch point first, before comparing to the allowed max size

### DIFF
--- a/build-system/.eslintrc
+++ b/build-system/.eslintrc
@@ -8,6 +8,7 @@
     "exports": false
   },
   "rules": {
+    "amphtml-internal/no-array-destructuring": 0,
     "amphtml-internal/no-for-of-statement": 0,
     "amphtml-internal/no-has-own-property-method": 0,
     "require-jsdoc": 0

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -23,7 +23,7 @@ const log = require('fancy-log');
 const octokit = require('@octokit/rest')();
 const path = require('path');
 const {getStdout} = require('../exec');
-const {gitCommitHash, gitOriginUrl} = require('../git');
+const {gitBranchPoint, gitCommitHash, gitOriginUrl} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -35,10 +35,15 @@ const expectedGitHubProject = 'ampproject/amphtml';
 
 const {green, red, cyan, yellow} = colors;
 
+// Status values returned from running `npx bundlesize`
+const STATUS_PASS = 0;
+const STATUS_FAIL = 1;
+const STATUS_ERROR = 2;
+
 /**
  * Get the max bundle size from the build artifacts repository.
  *
- * @return {number} the max allowed bundle size.
+ * @return {string} the max allowed bundle size.
  */
 async function getMaxBundleSize() {
   if (process.env.GITHUB_ARTIFACTS_RO_TOKEN) {
@@ -61,6 +66,36 @@ async function getMaxBundleSize() {
     log(red('ERROR: Failed to retrieve the max allowed bundle size from' +
             ' GitHub.'));
     throw error;
+  });
+}
+
+/**
+ * Get the bundle size of the ancenstor commit from when this branch was split
+ * off from the `master` branch.
+ *
+ * @return {string} the `master` ancestor's bundle size.
+ */
+async function getAncestorBundleSize() {
+  const fromMerge =
+      process.env.TRAVIS && process.env.TRAVIS_EVENT_TYPE === 'pull_request';
+  const gitBranchPointSha = gitBranchPoint(fromMerge);
+  const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
+  log('Branch point from master is', cyan(gitBranchPointShortSha));
+  return await octokit.repos.getContent(
+      Object.assign(buildArtifactsRepoOptions, {
+        path: path.join('bundle-size', gitBranchPointSha),
+      })
+  ).then(result => {
+    const ancestorBundleSize =
+        Buffer.from(result.data.content, 'base64').toString().trim();
+    log('Bundle size of', cyan(gitBranchPointShortSha), 'is',
+        ancestorBundleSize);
+    return ancestorBundleSize;
+  }).catch(() => {
+    log(yellow('WARNING: Failed to retrieve bundle size of'),
+        cyan(gitBranchPointShortSha));
+    log(yellow('Falling back to comparing to the max bundle size only'));
+    return null;
   });
 }
 
@@ -122,6 +157,24 @@ function storeBundleSize(bundleSize) {
   });
 }
 
+function compareBundleSize(maxBundleSize) {
+  const cmd = `npx bundlesize -f "${runtimeFile}" -s "${maxBundleSize}"`;
+  log('Running ' + cyan(cmd) + '...');
+  const output = getStdout(cmd);
+  const bundleSizeFormatMatches = output.match(/: (\d+.?\d*KB)/);
+  if (bundleSizeFormatMatches) {
+    if (output.match(/PASS .*/)) {
+      return [output, STATUS_PASS, bundleSizeFormatMatches[1]];
+    } else if (output.match(/FAIL .*/)) {
+      return [output, STATUS_FAIL, bundleSizeFormatMatches[1]];
+    }
+  } else {
+    log(red('ERROR:'), 'could not infer bundle size from output.');
+    log(yellow(output));
+  }
+  return [output, STATUS_ERROR, ''];
+}
+
 /**
  * Checks gzipped size of existing v0.js (amp.js) against `maxSize`.
  * Does _not_ rebuild: run `gulp dist --fortesting --noextensions` first.
@@ -137,40 +190,56 @@ async function checkBundleSize() {
   }
 
   const maxSize = await getMaxBundleSize();
+  const ancestorBundleSize = await getAncestorBundleSize();
 
-  const cmd = `npx bundlesize -f "${runtimeFile}" -s "${maxSize}"`;
-  log('Running ' + cyan(cmd) + '...');
-  const output = getStdout(cmd);
-  const pass = output.match(/PASS .*/);
-  const fail = output.match(/FAIL .*/);
-  const error = output.match(/ERROR .*/);
-  const bundleSizeFormatMatches = output.match(/: (\d+.?\d*KB)/);
-  if (error && error.length > 0) {
-    log(yellow(error[0]));
-    process.exitCode = 1;
-    return;
-  } else if (!bundleSizeFormatMatches) {
-    log(red('ERROR:'), 'could not infer bundle size from output.');
-    log(yellow(output));
-    process.exitCode = 1;
-    return;
-  } else if (fail && fail.length > 0) {
-    log(red(fail[0]));
-    log(red('ERROR:'), cyan('bundlesize'), red('found that'),
-        cyan(runtimeFile), red('has exceeded its size cap of'),
-        cyan(maxSize) + red('.'));
-    log(red(
-        'This is part of a new effort to reduce AMP\'s binary size (#14392).'));
-    log(red('Please contact @choumx or @jridgewell for assistance.'));
-    process.exitCode = 1;
-  } else if (pass && pass.length > 0) {
-    log(green(pass[0]));
-  } else {
-    log(yellow(output));
+  let compareAgainstMaxSize = true;
+  let output, status, newBundleSize;
+  if (ancestorBundleSize) {
+    [output, status, newBundleSize] = compareBundleSize(ancestorBundleSize);
+    switch (status) {
+      case STATUS_ERROR:
+        log(yellow(output));
+        process.exitCode = 1;
+        return;
+      case STATUS_FAIL:
+        log(yellow('New bundle size of'), cyan(newBundleSize),
+            'is larger than the ancestor\'s bundle size of',
+            cyan(ancestorBundleSize));
+        log('Continuing to compare to max bundle size...');
+        compareAgainstMaxSize = true;
+        break;
+      case STATUS_PASS:
+        log(green(output));
+        compareAgainstMaxSize = false;
+        break;
+    }
+  }
+
+  if (compareAgainstMaxSize) {
+    [output, status, newBundleSize] = compareBundleSize(maxSize);
+    switch (status) {
+      case STATUS_ERROR:
+        log(yellow(output));
+        process.exitCode = 1;
+        return;
+      case STATUS_FAIL:
+        log(red(output));
+        log(red('ERROR:'), cyan('bundlesize'), red('found that'),
+            cyan(runtimeFile), red('has exceeded its size cap of'),
+            cyan(maxSize) + red('.'));
+        log(red('This is part of a new effort to reduce AMP\'s binary size ' +
+                '(#14392).'));
+        log(red('Please contact @choumx or @jridgewell for assistance.'));
+        process.exitCode = 1;
+        return;
+      case STATUS_PASS:
+        log(green(output));
+        break;
+    }
   }
 
   if (argv.store) {
-    return storeBundleSize(bundleSizeFormatMatches[1]);
+    return storeBundleSize(newBundleSize);
   }
 }
 


### PR DESCRIPTION
This PR changes the way bundle-size is calculated:
It retrieves the known bundle size of the branch point of a PR (if it exists in the ampproject/amphtml-build-artifacts repository)
* If the PR's generated bundle size is equals to or smaller than that of its branch point, it approves the bundle size
* If the PR's generated bundle size is larger, or if the branching point's bundle size was not found in the build artifacts repository, the check reverts to the existing behaviour of performing a comparison against the value in the `.max_size` file in the build artifacts repository

Note that there is no "incremental buffer" as of yet, as @choumx wanted to discuss this offline. I will add that in a followup PR (a much, much smaller PR!)
This PR doesn't add new restrictions on bundle sizes, it maintains the existing one and adds a leniency for PRs that were based on a "bad master" (i.e., a commit that was merged to master that somehow went above the .max_size value will _not_ block new PRs based on it from passing the bundle-size check, when those PRs maintain or decrease the bundle size compared to their branching point)

Related to #15134 and #17043