### PR TITLE
🐛 Fix thirds layer in Safari

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -261,6 +261,7 @@ amp-story-cta-layer {
 
 /** Grid level */
 amp-story-grid-layer {
+  box-sizing: border-box !important;
   display: grid !important;
   height: 100% !important;
   position: absolute !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -262,6 +262,7 @@ amp-story-cta-layer {
 /** Grid level */
 amp-story-grid-layer {
   display: grid !important;
+  height: 100% !important;
   position: absolute !important;
   top: 0 !important;
   right: 0 !important;


### PR DESCRIPTION
Fixes #13433.

Even though the layer has `position: absolute; bottom: 0; top: 0;`, Safari collapses the height, as [this comment](https://github.com/ampproject/amphtml/issues/13433#issuecomment-422072646) points out.  Setting it explicitly prevents this.