### PR TITLE
Revert "🏗 Retrieve max bundle size from the build artifacts repository on GitHub"

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,6 +26,7 @@ const {getStdout} = require('../exec');
 const {gitCommitHash, gitOriginUrl} = require('../git');
 
 const runtimeFile = './dist/v0.js';
+const maxSize = '82.6KB'; // Only use 0.1 KB of precision (no hundredths digit)
 
 const buildArtifactsRepoOptions = {
   owner: 'ampproject',
@@ -36,33 +37,10 @@ const expectedGitHubProject = 'ampproject/amphtml';
 const {green, red, cyan, yellow} = colors;
 
 /**
- * Get the max bundle size from the build artifacts repository.
- *
- * @return {number} the max allowed bundle size.
- */
-async function getMaxBundleSize() {
-  return await octokit.repos.getContent(
-      Object.assign(buildArtifactsRepoOptions, {
-        path: path.join('bundle-size', '.max_size'),
-      })
-  ).then(result => {
-    const maxSize =
-        Buffer.from(result.data.content, 'base64').toString().trim();
-    log('Max bundle size from GitHub is', cyan(maxSize));
-    return maxSize;
-  }).catch(error => {
-    log(red('ERROR: Failed to retrieve the max allowed bundle size from' +
-            ' GitHub.'));
-    throw error;
-  });
-}
-
-/**
  * Store the bundle size of a commit hash in the build artifacts storage
  * repository to the passed value.
  *
  * @param {string} bundleSize the new bundle size in 99.99KB format.
- * @return {!Promise}
  */
 function storeBundleSize(bundleSize) {
   if (!process.env.TRAVIS || process.env.TRAVIS_EVENT_TYPE !== 'push') {
@@ -119,7 +97,7 @@ function storeBundleSize(bundleSize) {
  * Checks gzipped size of existing v0.js (amp.js) against `maxSize`.
  * Does _not_ rebuild: run `gulp dist --fortesting --noextensions` first.
  */
-async function checkBundleSize() {
+function checkBundleSize() {
   if (!fs.existsSync(runtimeFile)) {
     log(yellow('Could not find'), cyan(runtimeFile) +
         yellow('. Skipping bundlesize check.'));
@@ -128,8 +106,6 @@ async function checkBundleSize() {
         yellow('before'), cyan('gulp bundle-size') + yellow('.'));
     return;
   }
-
-  const maxSize = await getMaxBundleSize();
 
   const cmd = `npx bundlesize -f "${runtimeFile}" -s "${maxSize}"`;
   log('Running ' + cyan(cmd) + '...');


### PR DESCRIPTION
Reverts ampproject/amphtml#18839

Crashes due to GitHub rate limits on unauthenticated API calls. Can be fixed easily by authenticating the file read requests using a read-only bot, but we should unblock development for now.