### PR TITLE
🐛 Fix error when adding triggering native change

### DIFF
--- a/third_party/inputmask/README.amp
+++ b/third_party/inputmask/README.amp
@@ -9,3 +9,4 @@ https://github.com/vega/vega/tree/4.x
 Local Modifications:
 Replace the universal module definition with a factory wrapper.
 Changed initial unmask behavior when value patching is disabled.
+Altered trigger implementation to not use CustomElement for triggering events

--- a/third_party/inputmask/inputmask.dependencyLib.js
+++ b/third_party/inputmask/inputmask.dependencyLib.js
@@ -83,7 +83,7 @@ export function factory(window, document) {
                     };
                     if (document.createEvent) {
                         try {
-                            evnt = new CustomEvent(ev, params);
+                            evnt = ['change','input','click'].indexOf(ev) > -1 ? new Event(ev, params) : new CustomEvent(ev, params);
                         } catch (e) {
                             (evnt = document.createEvent("CustomEvent")).initCustomEvent(ev, params.bubbles, params.cancelable, params.detail);
                         }

--- a/third_party/inputmask/inputmask.dependencyLib.js
+++ b/third_party/inputmask/inputmask.dependencyLib.js
@@ -83,7 +83,8 @@ export function factory(window, document) {
                     };
                     if (document.createEvent) {
                         try {
-                            evnt = ['change','input','click'].indexOf(ev) > -1 ? new Event(ev, params) : new CustomEvent(ev, params);
+                            // evnt = new CustomEvent(ev, params);
+                            evnt = ["change","input","click"].indexOf(ev) > -1 ? new Event(ev, params) : new CustomEvent(ev, params);
                         } catch (e) {
                             (evnt = document.createEvent("CustomEvent")).initCustomEvent(ev, params.bubbles, params.cancelable, params.detail);
                         }


### PR DESCRIPTION
action-impl.js mutates `event.details` for native events like `change`, but `details` is immutable on `CustomEvent`.