### PR TITLE
Post message current page's script's URL to SW for caching

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -700,7 +700,6 @@ const forbiddenTermsSrcInclusive = {
   '\\.getBoundingClientRect\\(': bannedTermsHelpString,
   '\\.getClientRects\\(': bannedTermsHelpString,
   '\\.getMatchedCSSRules\\(': bannedTermsHelpString,
-  '\\.postMessage\\(': bannedTermsHelpString,
   '\\.scrollBy\\(': bannedTermsHelpString,
   '\\.scrollIntoView\\(': bannedTermsHelpString,
   '\\.scrollIntoViewIfNeeded\\(': bannedTermsHelpString,
@@ -708,6 +707,12 @@ const forbiddenTermsSrcInclusive = {
   '\\.webkitConvertPointFromNodeToPage\\(': bannedTermsHelpString,
   '\\.webkitConvertPointFromPageToNode\\(': bannedTermsHelpString,
   '\\.scheduleUnlayout\\(': bannedTermsHelpString,
+  '\\.postMessage\\(': {
+    message: bannedTermsHelpString,
+    whitelist: [
+      'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js',
+    ],
+  },
   'getComputedStyle\\(': {
     message: 'Due to various bugs in Firefox, you must use the computedStyle ' +
     'helper in style.js.',

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -22,6 +22,7 @@ import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
 import {removeFragment} from '../../../src/url';
 import {toggle} from '../../../src/style';
+import {urls} from '../../../src/config';
 
 /** @private @const {string} */
 const TAG = 'amp-install-serviceworker';
@@ -322,7 +323,7 @@ function sendAmpScriptToSwOnFirstVisit(registration, win) {
       // Fetch all AMP-scripts used on the page
       const ampScriptsUsed = win.performance.getEntriesByType('resource')
           .filter(item => item.initiatorType === 'script' &&
-              /https:\/\/cdn.ampproject.org\//.test(item.name))
+            item.name.indexOf(urls.cdn) !== -1)
           .map(script => script.name);
       // using https://github.com/redux-utilities/flux-standard-action
       controllerSw.postMessage(JSON.stringify(dict({

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -173,8 +173,8 @@ describes.realWin('amp-install-serviceworker', {
             expect(fakeRegistration.installing.addEventListener)
                 .to.be.calledWith('statechange', sinon.match.func);
             expect(postMessageStub).to.be.calledWith(JSON.stringify({
-              type: 'first-visit-caching',
-              data: AMP_SCRIPTS,
+              type: 'FIRST_VISIT_CACHING',
+              payload: AMP_SCRIPTS,
             }));
           });
         });

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -109,6 +109,77 @@ describes.realWin('amp-install-serviceworker', {
         });
   });
 
+  it('should postMessage all AMP scripts used to the service worker', () => {
+    const install = doc.createElement('div');
+    container.appendChild(install);
+    install.getAmpDoc = () => ampdoc;
+    install.setAttribute('src', 'https://example.com/sw.js');
+    const implementation = new AmpInstallServiceWorker(install);
+    const AMP_SCRIPTS = [
+      'https://cdn.ampproject.org/rtv/001525381599226/v0.js',
+      'https://cdn.ampproject.org/rtv/001810022028350/v0/amp-mustache-0.1.js',
+    ];
+    const eventListener = (evtName, cb) => {
+      cb({
+        target: {
+          state: 'activated',
+        },
+      });
+    };
+    const fakeRegistration = {
+      installing: {
+        addEventListener: sandbox.spy(eventListener),
+      },
+    };
+    const p = Promise.resolve(fakeRegistration);
+    const postMessageStub = sandbox.stub();
+    implementation.win = {
+      complete: true,
+      location: {
+        href: 'https://example.com/some/path',
+      },
+      navigator: {
+        serviceWorker: {
+          register: () => {
+            return p;
+          },
+          controller: {
+            postMessage: postMessageStub,
+          },
+        },
+      },
+      performance: {
+        getEntriesByType: () => {
+          return AMP_SCRIPTS.concat('https://code.jquery.com/jquery-3.3.1.min.js').map(script => {
+            return {
+              initiatorType: 'script',
+              name: script,
+            };
+          });
+        },
+      },
+    };
+    whenVisible = Promise.resolve();
+    registerServiceBuilder(implementation.win, 'viewer', function() {
+      return {
+        whenFirstVisible: () => whenVisible,
+        isVisible: () => true,
+      };
+    });
+    implementation.buildCallback();
+    return Promise.all([whenVisible, loadPromise(implementation.win)]).then(
+        () => {
+          return p.then(fakeRegistration => {
+            expect(fakeRegistration.installing.addEventListener)
+                .to.be.calledWith('statechange', sinon.match.func);
+            expect(postMessageStub).to.be.calledWith(JSON.stringify({
+              type: 'first-visit-caching',
+              data: AMP_SCRIPTS,
+            }));
+          });
+        });
+  });
+
   it('should be ok without service worker.', () => {
     const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;


### PR DESCRIPTION
As a part of Auto-PWA effort AMP will build a lazy service worker for publishers. Being lazy, these service workers will have no access to what resources are used to cache for first visit.

- This change will use see if there is a new serviceworker being installed
- If yes, it'll wait for that serviceworker to be active
- use ResourceTiming API to see what AMP scripts were used in the current page and postMessage them to service worker to add them to SW cache.
