### PR TITLE
Url-Replacement: check for false

### DIFF
--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -443,6 +443,7 @@ describes.realWin('amp-ad-exit', {
   });
 
   it('should replace custom URL variables with vars', () => {
+    toggleExperiment(win, 'url-replacement-v2', true);
     const open = sandbox.stub(win, 'open').callsFake(() => {
       return {name: 'fakeWin'};
     });
@@ -469,6 +470,7 @@ describes.realWin('amp-ad-exit', {
     expect(sendBeacon)
         .to.have.been.calledWith(
             'http://localhost:8000/tracking?numVar=0&boolVar=false', '');
+    toggleExperiment(win, 'url-replacement-v2', false);
   });
 
   it('border protection', () => {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -167,6 +167,7 @@ describes.realWin('amp-ad-exit', {
   beforeEach(() => {
     sandbox = sinon.createSandbox({useFakeTimers: true});
     win = env.win;
+    toggleExperiment(win, 'url-replacement-v2', true);
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
     // TEST_3P_VENDOR must be in IFRAME_TRANSPORTS
@@ -184,6 +185,7 @@ describes.realWin('amp-ad-exit', {
     element = undefined;
     // Without the following, will break amp-analytics' test-vendor.js
     delete IFRAME_TRANSPORTS[TEST_3P_VENDOR];
+    toggleExperiment(win, 'url-replacement-v2', false);
   });
 
   it('should reject non-JSON children', () => {
@@ -443,7 +445,6 @@ describes.realWin('amp-ad-exit', {
   });
 
   it('should replace custom URL variables with vars', () => {
-    toggleExperiment(win, 'url-replacement-v2', true);
     const open = sandbox.stub(win, 'open').callsFake(() => {
       return {name: 'fakeWin'};
     });
@@ -470,7 +471,6 @@ describes.realWin('amp-ad-exit', {
     expect(sendBeacon)
         .to.have.been.calledWith(
             'http://localhost:8000/tracking?numVar=0&boolVar=false', '');
-    toggleExperiment(win, 'url-replacement-v2', false);
   });
 
   it('border protection', () => {

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -334,7 +334,8 @@ export class Expander {
         // even if opt_collectVars exists.
         user().error(TAG, 'ignoring async macro resolution');
         result = '';
-      } else if (typeof value === 'string' || typeof value === 'number') {
+      } else if (typeof value === 'string' || typeof value === 'number' ||
+          typeof value === 'boolean') {
         // Normal case.
         this.maybeCollectVars_(name, value, opt_collectVars, opt_args);
         result = NOENCODE_WHITELIST[name] ? value.toString() :


### PR DESCRIPTION
Fixes a bug where boolean values were being replaced with `''` in url substitution.
