### PR TITLE
🏗Ignore the firebase directory during gulp check-types

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -148,6 +148,7 @@ module.exports = {
     '!examples/**/*',
     '!examples/visual-tests/**/*',
     '!test/coverage/**/*.*',
+    '!firebase/**/*.*',
   ],
   changelogIgnoreFileTypes: /\.md|\.json|\.yaml|LICENSE|CONTRIBUTORS$/,
 };


### PR DESCRIPTION
`gulp check-types` was reading into the `amphtml/firebase` directory if it was present