### PR TITLE
🏗🐛 Fix how we determine branch point for non-merge commits

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -30,7 +30,7 @@ exports.gitBranchPoint = function(fromMerge = false) {
   if (fromMerge) {
     return getStdout('git merge-base HEAD^1 HEAD^2').trim();
   } else {
-    return getStdout('git merge-base master HEAD').trim();
+    return getStdout('git merge-base master HEAD^').trim();
   }
 };
 


### PR DESCRIPTION
The current method fails to find the "parent" when the commit is already on master; this PR fixes it so that commits already on master will also return their direct parent