### PR TITLE
✨Update amp-consent.js to allow forced re-reprompt of AMP-consent

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -385,12 +385,19 @@ export class AmpConsent extends AMP.BaseElement {
       promptPromise =
           this.getConsentRemote_(instanceId).then(remoteConfigResponse => {
             if (!remoteConfigResponse ||
-                !hasOwn(remoteConfigResponse, 'promptIfUnknown')) {
-              this.user().error(TAG, 'Expecting promptIfUnknown from ' +
-                'checkConsentHref when promptIfUnknownForGeoGroup is not ' +
-                'specified');
+                (!hasOwn(remoteConfigResponse, 'promptIfUnknown') && 
+                 !hasOwn(remoteConfigResponse, 'revokeAndPrompt'))) {
+              this.user().error(TAG, 'Expecting promptIfUnknown or ' +
+                'revokeAndPrompt from checkConsentHref when ' +
+                'promptIfUnknownForGeoGroup is not specified');
               // Set to false if not defined
               return false;
+            }
+            if (!!remoteConfigResponse['revokeAndPrompt']) {
+              // revoke consent state to unknown & re-prompt for consent
+              this.consentStateManager_.updateConsentInstanceState(
+                this.currentDisplayInstance_, CONSENT_ITEM_STATE.UNKNOWN);
+              return true;
             }
             return !!remoteConfigResponse['promptIfUnknown'];
           });


### PR DESCRIPTION
Create a way for webmasters to force a re-prompt of the consent state if consent has been revoked on the non-amp website.

E.g.: 
User lands on AMP, gives consent > User move to Non-AMP site, revokes consent (via consent settings page) > User goes back to AMP.

In that scenario, we want to re-prompt the status of AMP-consent.
