### PR TITLE
🐛Fix navigateTo action when used in a viewer.

### DIFF
--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -191,7 +191,7 @@ export class Navigation {
       options += 'noopener';
     }
 
-    const newWin = win.top.open(url, target, options);
+    const newWin = win.open(url, target, options);
     // For Chrome, since we cannot use noopener.
     if (newWin && !opener) {
       newWin.opener = null;

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -191,7 +191,7 @@ export class Navigation {
       options += 'noopener';
     }
 
-    const newWin = win.open(url, target, options);
+    const newWin = openWindowDialog(win, url, target, options);
     // For Chrome, since we cannot use noopener.
     if (newWin && !opener) {
       newWin.opener = null;


### PR DESCRIPTION
Do not use `win.top` when trying to open a window, it could belong to a different origin.

Fixes #18916