### PR TITLE
add a check that expected caches appear in caches.json

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -320,6 +320,7 @@ const command = {
     timedExecOrDie('gulp lint');
   },
   runJsonCheck: function() {
+    timedExecOrDie('gulp caches-json');
     timedExecOrDie('gulp json-syntax');
   },
   buildCss: function() {

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -32,7 +32,6 @@ function checkCachesJson() {
         try {
           const obj = JSON.parse(file.contents.toString());
         } catch (e) {
-          // Do nothing since this is handled in checkValidJson.
           log(colors.yellow('Could not parse caches.json. '
                             'This is most likely a fatal error that '
                             'will be found by checkValidJson'))

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -27,25 +27,28 @@ const expectedCaches = ['cloudflare', 'google'];
  * Fail if caches.json is missing some expected caches.
  */
 function checkCachesJson() {
-  return gulp.src(['caches.json',])
+  return gulp.src(['caches.json'])
       .pipe(through2.obj(function(file) {
         try {
           const obj = JSON.parse(file.contents.toString());
         } catch (e) {
           // Do nothing since this is handled in checkValidJson.
+          log(colors.yellow('Could not parse caches.json. '
+                            'This is most likely a fatal error that '
+                            'will be found by checkValidJson'))
         }
         let foundCaches = [];
-        for (var i = 0; i < obj.caches.length; i++) {
-          foundCaches.push(obj.caches[i].id);
+        for (const foundCache of obj.caches) {
+          foundCaches.push(foundCache.id);
         }
         for (const cache of expectedCaches) {
-          if (!cache in foundCaches) {
+          if (!(cache in foundCaches)) {
             log(colors.red('Missing expected cache "'
                   + cache + '" in caches.json'));
-            process.exit(1);
+            process.exitCode = 1;
           }
         }
-      });
+      })
 }
 
 /**

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -29,25 +29,27 @@ const expectedCaches = ['cloudflare', 'google'];
 function checkCachesJson() {
   return gulp.src(['caches.json'])
       .pipe(through2.obj(function(file) {
+        let obj;
         try {
-          const obj = JSON.parse(file.contents.toString());
+          obj = JSON.parse(file.contents.toString());
         } catch (e) {
           log(colors.yellow('Could not parse caches.json. '
                 + 'This is most likely a fatal error that '
-                + 'will be found by checkValidJson'))
+                + 'will be found by checkValidJson'));
+          return;
         }
         let foundCaches = [];
         for (const foundCache of obj.caches) {
           foundCaches.push(foundCache.id);
         }
         for (const cache of expectedCaches) {
-          if (!(cache in foundCaches)) {
+          if (foundCaches.indexOf(cache) == -1) {
             log(colors.red('Missing expected cache "'
                   + cache + '" in caches.json'));
             process.exitCode = 1;
           }
         }
-      })
+      }));
 }
 
 /**
@@ -73,7 +75,7 @@ function checkValidJson() {
 }
 
 gulp.task('caches-json', 'Check that some expected caches are included.',
-    checkCachesJson);,
+    checkCachesJson);
 
 gulp.task(
     'json-syntax', 'Check that JSON files are valid JSON.', checkValidJson);

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -38,7 +38,7 @@ function checkCachesJson() {
                 + 'will be found by checkValidJson'));
           return;
         }
-        let foundCaches = [];
+        const foundCaches = [];
         for (const foundCache of obj.caches) {
           foundCaches.push(foundCache.id);
         }

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -43,7 +43,7 @@ function checkCachesJson() {
           foundCaches.push(foundCache.id);
         }
         for (const cache of expectedCaches) {
-          if (foundCaches.indexOf(cache) == -1) {
+          if (!foundCaches.includes(cache)) {
             log(colors.red('Missing expected cache "'
                   + cache + '" in caches.json'));
             process.exitCode = 1;

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -33,8 +33,8 @@ function checkCachesJson() {
           const obj = JSON.parse(file.contents.toString());
         } catch (e) {
           log(colors.yellow('Could not parse caches.json. '
-                            'This is most likely a fatal error that '
-                            'will be found by checkValidJson'))
+                + 'This is most likely a fatal error that '
+                + 'will be found by checkValidJson'))
         }
         let foundCaches = [];
         for (const foundCache of obj.caches) {


### PR DESCRIPTION
Partially fixes https://github.com/ampproject/amppackager/issues/156

The AMP Packager will be relying on caches.json and it's important that it at least has some expected caches listed there. This presubmit check verifies that both 'cloudflare' and 'google' are present in caches.json.