### PR TITLE
Adds a banner detailing our end-of-year pause in releases

### DIFF
--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -1,3 +1,11 @@
+⚡⚡⚡
+
+**Our last release for 2018 will be created on Tuesday, December 11, 2018 (targeting full rollout on December 18).**
+
+After this the next release will be created on Wednesday, January 3, 2019 (targeting full rollout on January 9).
+
+⚡⚡⚡
+
 # Release Schedule
 
 - [Detailed schedule](#detailed-schedule)

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -1,9 +1,10 @@
 ⚡⚡⚡
 
-**Our last release for 2018 will be created on Tuesday, December 11, 2018 (targeting full rollout on December 18).**
+**Our last scheduled release for 2018 will be created on Tuesday, December 11, 2018 (targeting full rollout on December 18).**
 
-After this the next release will be created on Wednesday, January 3, 2019 (targeting full rollout on January 9).
+After this the next scheduled release will be created on Wednesday, January 3, 2019 (targeting full rollout on January 9).
 
+If necessary, fixes for P0 issues may be cherry-picked into the production release and pushed during this time.
 ⚡⚡⚡
 
 # Release Schedule


### PR DESCRIPTION
This adds a banner to release-schedule.md detailing our end-of-year pause in releases.

/cc @rsimha 