### PR TITLE
Launch amp-story-responsive-units experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,6 +37,7 @@
   "amp-sidebar toolbar": 1,
   "amp-consent": 1,
   "amp-story-hold-to-pause": 1,
+  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -36,6 +36,7 @@
   "amp-sidebar toolbar": 1,
   "amp-consent": 1,
   "amp-story-hold-to-pause": 0,
+  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,


### PR DESCRIPTION
This makes viewport units (`vw`, `vh`, `vmin`, and `vmax`) work within the amp-story 3-panel desktop UI.