### PR TITLE
♻️  rename reportPlatformFailure to be more descriptive

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -247,7 +247,7 @@ export class SubscriptionService {
         return entitlement;
       }).catch(reason => {
         const serviceId = subscriptionPlatform.getServiceId();
-        this.platformStore_.reportPlatformFailure(serviceId);
+        this.platformStore_.reportPlatformFailureAndFallback(serviceId);
         throw user().createError(
             `fetch entitlements failed for ${serviceId}`, reason
         );

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -497,10 +497,12 @@ export class PlatformStore {
   }
 
   /**
-   * Records a platform failure and logs error if all platforms have failed.
+   * Records a platform failure
+   * logs error if all platforms have failed
+   * uses fallback if there is one.
    * @param {string} serviceId
    */
-  reportPlatformFailure(serviceId) {
+  reportPlatformFailureAndFallback(serviceId) {
     if (serviceId === this.getLocalPlatform().getServiceId()
       && this.fallbackEntitlement_) {
       this.resolveEntitlement(this.getLocalPlatform().getServiceId(),

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -443,7 +443,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       sandbox.stub(platform, 'getEntitlements')
           .callsFake(() => new Promise(resolve => setTimeout(resolve, 8000)));
       const failureStub = sandbox.stub(subscriptionService.platformStore_,
-          'reportPlatformFailure');
+          'reportPlatformFailureAndFallback');
       subscriptionService.fetchEntitlements_(platform)
           .catch(() => {
             expect(failureStub).to.be.calledOnce;
@@ -455,7 +455,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       sandbox.stub(platform, 'getEntitlements')
           .callsFake(() => Promise.reject());
       const failureStub = sandbox.stub(subscriptionService.platformStore_,
-          'reportPlatformFailure');
+          'reportPlatformFailureAndFallback');
       const promise = subscriptionService.fetchEntitlements_(platform)
           .catch(() => {
             expect(failureStub).to.be.calledOnce;

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -449,7 +449,7 @@ describes.realWin('Platform store', {}, () => {
     });
   });
 
-  describe('reportPlatformFailure_', () => {
+  describe('reportPlatformFailureAndFallback', () => {
     let errorSpy;
     beforeEach(() => {
       errorSpy = sandbox.spy(user(), 'warn');
@@ -459,9 +459,9 @@ describes.realWin('Platform store', {}, () => {
       const platform = new SubscriptionPlatform();
       sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
       sandbox.stub(platformStore, 'getLocalPlatform').callsFake(() => platform);
-      platformStore.reportPlatformFailure('service1');
+      platformStore.reportPlatformFailureAndFallback('service1');
       expect(errorSpy).to.not.be.called;
-      platformStore.reportPlatformFailure('local');
+      platformStore.reportPlatformFailureAndFallback('local');
       expect(errorSpy).to.be.calledOnce;
       expect(platformStore.entitlements_['local'].json())
           .to.deep.equal(fallbackEntitlement.json());
@@ -479,7 +479,7 @@ describes.realWin('Platform store', {}, () => {
           .callsFake(() => 10);
       platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
       platformStore.resolvePlatform('local', platform);
-      platformStore.reportPlatformFailure('local');
+      platformStore.reportPlatformFailureAndFallback('local');
       platformStore.resolveEntitlement(serviceIds[0], entitlementsForService1);
       return platformStore.selectPlatform().then(platform => {
         expect(platformStore.entitlements_['local']).deep.equals(
@@ -502,7 +502,7 @@ describes.realWin('Platform store', {}, () => {
       platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
       platformStore.resolvePlatform('local', platform);
       fallbackEntitlement.grantReason = GrantReason.METERING;
-      platformStore.reportPlatformFailure('local');
+      platformStore.reportPlatformFailureAndFallback('local');
       platformStore.resolveEntitlement(serviceIds[0], entitlementsForService1);
       return platformStore.selectPlatform().then(platform => {
         expect(platformStore.entitlements_['local']).deep.equals(


### PR DESCRIPTION
Rename `reportPlatformFailure` to `reportPlatformFailureAndFallback` to reflect what it actually does.
