### PR TITLE
Fixes audio UX message if there's a story level audio.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -77,7 +77,8 @@ export const UIType = {
  *    rtlState: boolean,
  *    shareMenuState: boolean,
  *    sidebarState: boolean,
- *    storyAudioState: boolean,
+ *    storyHasAudioState: boolean,
+ *    storyHasBackgroundAudioState: boolean,
  *    supportedBrowserState: boolean,
  *    systemUiIsVisibleState: boolean,
  *    uiState: !UIType,
@@ -115,7 +116,10 @@ export const StateProperty = {
   SHARE_MENU_STATE: 'shareMenuState',
   SIDEBAR_STATE: 'sidebarState',
   SUPPORTED_BROWSER_STATE: 'supportedBrowserState',
-  STORY_HAS_AUDIO_STATE: 'storyAudioState',
+  // Any page has audio, or amp-story has a `background-audio` attribute.
+  STORY_HAS_AUDIO_STATE: 'storyHasAudioState',
+  // amp-story has a `background-audio` attribute.
+  STORY_HAS_BACKGROUND_AUDIO_STATE: 'storyHasBackgroundAudioState',
   SYSTEM_UI_IS_VISIBLE_STATE: 'systemUiIsVisibleState',
   UI_STATE: 'uiState',
 
@@ -146,6 +150,7 @@ export const Action = {
   TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_SUPPORTED_BROWSER: 'toggleSupportedBrowser',
   TOGGLE_STORY_HAS_AUDIO: 'toggleStoryHasAudio',
+  TOGGLE_STORY_HAS_BACKGROUND_AUDIO: 'toggleStoryHasBackgroundAudio',
   TOGGLE_SYSTEM_UI_IS_VISIBLE: 'toggleSystemUiIsVisible',
   TOGGLE_UI: 'toggleUi',
 };
@@ -212,6 +217,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_STORY_HAS_AUDIO:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.STORY_HAS_AUDIO_STATE]: !!data}));
+    case Action.TOGGLE_STORY_HAS_BACKGROUND_AUDIO:
+      return /** @type {!State} */ (Object.assign({}, state,
+          {[StateProperty.STORY_HAS_BACKGROUND_AUDIO_STATE]: !!data}));
     case Action.TOGGLE_LANDSCAPE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.LANDSCAPE_STATE]: !!data}));
@@ -381,6 +389,7 @@ export class AmpStoryStoreService {
       [StateProperty.SIDEBAR_STATE]: false,
       [StateProperty.SUPPORTED_BROWSER_STATE]: true,
       [StateProperty.STORY_HAS_AUDIO_STATE]: false,
+      [StateProperty.STORY_HAS_BACKGROUND_AUDIO_STATE]: false,
       [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: true,
       [StateProperty.UI_STATE]: UIType.MOBILE,
       // amp-story only allows actions on a case-by-case basis to preserve UX

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -193,15 +193,15 @@
   display: block !important;
 }
 
-.audio-playing:not([muted]) .i-amphtml-story-mute-audio-control,
-.audio-playing[muted] .i-amphtml-story-unmute-audio-control {
+.i-amphtml-story-has-audio:not([muted]) .i-amphtml-story-mute-audio-control,
+.i-amphtml-story-has-audio[muted] .i-amphtml-story-unmute-audio-control {
   display: block !important;
 }
 
 
-.audio-playing[muted] .i-amphtml-story-mute-text,
-[i-amphtml-story-audio-state].audio-playing:not([muted]) .i-amphtml-story-unmute-sound-text,
-:not([i-amphtml-story-audio-state]).audio-playing:not([muted]) .i-amphtml-story-unmute-no-sound-text {
+.i-amphtml-story-has-audio[muted] .i-amphtml-story-mute-text,
+[i-amphtml-current-page-has-audio].i-amphtml-story-has-audio:not([muted]) .i-amphtml-story-unmute-sound-text,
+:not([i-amphtml-current-page-has-audio]).i-amphtml-story-has-audio:not([muted]) .i-amphtml-story-unmute-no-sound-text {
   display: block !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -56,7 +56,7 @@ const UNMUTE_CLASS = 'i-amphtml-story-unmute-audio-control';
 const MESSAGE_DISPLAY_CLASS = 'i-amphtml-story-messagedisplay';
 
 /** @private @const {string} */
-const HAS_AUDIO_ATTRIBUTE = 'i-amphtml-story-audio-state';
+const CURRENT_PAGE_HAS_AUDIO_ATTRIBUTE = 'i-amphtml-current-page-has-audio';
 
 /** @private @const {string} */
 const HAS_SIDEBAR_ATTRIBUTE = 'i-amphtml-story-has-sidebar';
@@ -367,7 +367,7 @@ export class SystemLayer {
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.PAGE_HAS_AUDIO_STATE, audio => {
-      this.onPageAudioStateUpdate_(audio);
+      this.onPageHasAudioStateUpdate_(audio);
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.HAS_SIDEBAR_STATE,
@@ -446,27 +446,33 @@ export class SystemLayer {
   }
 
   /**
-   * Reacts to has audio state updates, displays the audio controls if needed.
+   * Reacts to has audio state updates, determining if the story has a global
+   * audio track playing, or if any page has audio.
    * @param {boolean} hasAudio
    * @private
    */
   onStoryHasAudioStateUpdate_(hasAudio) {
     this.vsync_.mutate(() => {
-      this.getShadowRoot().classList.toggle('audio-playing', hasAudio);
+      this.getShadowRoot()
+          .classList.toggle('i-amphtml-story-has-audio', hasAudio);
     });
   }
 
   /**
    * Reacts to the presence of audio on a page to determine which audio messages
    * to display.
-   * @param {boolean} pageAudio
+   * @param {boolean} pageHasAudio
    * @private
    */
-  onPageAudioStateUpdate_(pageAudio) {
+  onPageHasAudioStateUpdate_(pageHasAudio) {
+    pageHasAudio =
+        pageHasAudio || !!this.storeService_.get(
+            StateProperty.STORY_HAS_BACKGROUND_AUDIO_STATE);
     this.vsync_.mutate(() => {
-      pageAudio ?
-        this.getShadowRoot().setAttribute(HAS_AUDIO_ATTRIBUTE, '') :
-        this.getShadowRoot().removeAttribute(HAS_AUDIO_ATTRIBUTE);
+      pageHasAudio ?
+        this.getShadowRoot()
+            .setAttribute(CURRENT_PAGE_HAS_AUDIO_ATTRIBUTE, '') :
+        this.getShadowRoot().removeAttribute(CURRENT_PAGE_HAS_AUDIO_ATTRIBUTE);
     });
   }
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -450,9 +450,9 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildSystemLayer_() {
+    this.updateAudioIcon_();
     const pageIds = this.pages_.map(page => page.element.id);
     this.element.appendChild(this.systemLayer_.build(pageIds));
-    this.updateAudioIcon_();
   }
 
   /** @private */
@@ -1891,10 +1891,13 @@ export class AmpStory extends AMP.BaseElement {
   updateAudioIcon_() {
     const containsMediaElementWithAudio = !!this.element.querySelector(
         'amp-audio, amp-video:not([noaudio]), [background-audio]');
-    const hasStoryAudio = this.element.hasAttribute('background-audio');
+    const storyHasBackgroundAudio =
+        this.element.hasAttribute('background-audio');
 
     this.storeService_.dispatch(Action.TOGGLE_STORY_HAS_AUDIO,
-        containsMediaElementWithAudio || hasStoryAudio);
+        containsMediaElementWithAudio || storyHasBackgroundAudio);
+    this.storeService_.dispatch(
+        Action.TOGGLE_STORY_HAS_BACKGROUND_AUDIO, storyHasBackgroundAudio);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -96,7 +96,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     storeService.dispatch(Action.TOGGLE_MUTED, false);
     expect(systemLayer.getShadowRoot()).to.not.have.attribute('muted');
     expect(systemLayer.getShadowRoot()).to.not.have.attribute(
-        'i-amphtml-story-audio-state');
+        'i-amphtml-current-page-has-audio');
   });
 
   it('should show that the sound is on when unmuted', () => {
@@ -105,7 +105,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     storeService.dispatch(Action.TOGGLE_MUTED, false);
     expect(systemLayer.getShadowRoot()).to.not.have.attribute('muted');
     expect(systemLayer.getShadowRoot()).to.have.attribute(
-        'i-amphtml-story-audio-state');
+        'i-amphtml-current-page-has-audio');
   });
 
   it('should show the sidebar control only if a sidebar exists', () => {


### PR DESCRIPTION
Fixes the audio UX message "This page has no audio" when there is a story level background audio.

Also renaming the `system-layer` attributes to make them more descriptive. 

Fixes #18988