### PR TITLE
Close `<image>` tags in the leaks.html test

### DIFF
--- a/validator/testdata/feature_tests/leaks.html
+++ b/validator/testdata/feature_tests/leaks.html
@@ -89,8 +89,8 @@
 <img lowsrc="https://leaking.via/img-lowsrc">
 <img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='%68ttp:%2f/leaking.via/svg-via-data'></image></svg>">
 
-<image src="https://leaking.via/image-src">
-<image href="https://leaking.via/image-href">
+<image src="https://leaking.via/image-src"></image>
+<image href="https://leaking.via/image-href"></image>
 
 <picture>
     <source srcset="https://leaking.via/picture-source-srcset">

--- a/validator/testdata/feature_tests/leaks.out
+++ b/validator/testdata/feature_tests/leaks.out
@@ -132,21 +132,21 @@ feature_tests/leaks.html:89:0 The tag 'img' may only appear as a descendant of t
 >> ^~~~~~~~~
 feature_tests/leaks.html:90:0 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
 |
-|  <image src="https://leaking.via/image-src">
+|  <image src="https://leaking.via/image-src"></image>
 >> ^~~~~~~~~
 feature_tests/leaks.html:92:0 The tag 'image' may only appear as a descendant of tag 'svg'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
-|  <image href="https://leaking.via/image-href">
+|  <image href="https://leaking.via/image-href"></image>
 >> ^~~~~~~~~
 feature_tests/leaks.html:93:0 The tag 'image' may only appear as a descendant of tag 'svg'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
 |
 |  <picture>
 >> ^~~~~~~~~
-feature_tests/leaks.html:95:0 The parent tag of tag 'picture' is 'image', but it can only be 'noscript'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+feature_tests/leaks.html:95:0 The parent tag of tag 'picture' is 'body', but it can only be 'noscript'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
 |      <source srcset="https://leaking.via/picture-source-srcset">
 |  </picture>
 |  <picture>
 >> ^~~~~~~~~
-feature_tests/leaks.html:98:0 The parent tag of tag 'picture' is 'image', but it can only be 'noscript'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+feature_tests/leaks.html:98:0 The parent tag of tag 'picture' is 'body', but it can only be 'noscript'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
 |      <img srcset="https://leaking.via/picture-img-srcset">
 >>     ^~~~~~~~~
 feature_tests/leaks.html:99:4 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]


### PR DESCRIPTION
Close `<image>` tags in the leaks.html test to resolve minor error
message differences due to parser differences.