### PR TITLE
Proactively refresh overflow to avoid rendering bugs on iOS

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -744,6 +744,18 @@ const forbiddenTermsSrcInclusive = {
       'src/utils/bytes.js',
     ],
   },
+  'contentHeightChanged': {
+    message: bannedTermsHelpString,
+    whitelist: [
+      'src/inabox/inabox-viewport.js',
+      'src/service/resources-impl.js',
+      'src/service/viewport/viewport-binding-def.js',
+      'src/service/viewport/viewport-binding-ios-embed-sd.js',
+      'src/service/viewport/viewport-binding-ios-embed-wrapper.js',
+      'src/service/viewport/viewport-binding-natural.js',
+      'src/service/viewport/viewport-impl.js',
+    ],
+  },
   'preloadExtension': {
     message: bannedTermsHelpString,
     whitelist: [

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -389,6 +389,7 @@ export class ViewportBindingInabox {
   /** @override */ getScrollWidth() {return 0;}
   /** @override */ getScrollHeight() {return 0;}
   /** @override */ getContentHeight() {return 0;}
+  /** @override */ contentHeightChanged() {}
   /** @override */ getBorderTop() {return 0;}
   /** @override */ requiresFixedLayerTransfer() {return false;}
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1202,6 +1202,7 @@ export class Resources {
               dict({'height': measuredContentHeight}), /* cancelUnsent */true);
           this.contentHeight_ = measuredContentHeight;
           dev().fine(TAG_, 'document height changed: ' + this.contentHeight_);
+          this.viewport_.contentHeightChanged();
         }
       });
     }

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -159,6 +159,8 @@ export class ViewportBindingDef {
   /**
    * Resource manager signals to the viewport that content height is changed
    * and some action may need to be taken.
+   * @restricted Use is restricted due to potentially very heavy performance
+   *   impact. Can only be called when not actively scrolling.
    */
   contentHeightChanged() {}
 

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -157,6 +157,12 @@ export class ViewportBindingDef {
   getContentHeight() {}
 
   /**
+   * Resource manager signals to the viewport that content height is changed
+   * and some action may need to be taken.
+   */
+  contentHeightChanged() {}
+
+  /**
    * Returns the rect of the element within the document.
    * @param {!Element} unusedEl
    * @param {number=} unusedScrollLeft Optional arguments that the caller may

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -405,6 +405,24 @@ export class ViewportBindingIosEmbedShadowRoot_ {
   }
 
   /** @override */
+  contentHeightChanged() {
+    if (isExperimentOn(this.win, 'scroll-height-bounce')) {
+      // Refresh the overscroll (`-webkit-overflow-scrolling: touch`) to avoid
+      // iOS rendering bugs. See #8798 for details.
+      this.vsync_.mutate(() => {
+        setImportantStyles(this.scroller_, {
+          '-webkit-overflow-scrolling': 'auto',
+        });
+        this.vsync_.mutate(() => {
+          setImportantStyles(this.scroller_, {
+            '-webkit-overflow-scrolling': 'touch',
+          });
+        });
+      });
+    }
+  }
+
+  /** @override */
   getLayoutRect(el, opt_scrollLeft, opt_scrollTop) {
     const b = el./*OK*/getBoundingClientRect();
     if (this.useLayers_) {

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -43,6 +43,9 @@ export class ViewportBindingIosEmbedWrapper_ {
     /** @const {!Window} */
     this.win = win;
 
+    /** @private {!../vsync-impl.Vsync} */
+    this.vsync_ = Services.vsyncFor(win);
+
     const doc = this.win.document;
     const {documentElement} = doc;
     const topClasses = documentElement.className;
@@ -235,6 +238,22 @@ export class ViewportBindingIosEmbedWrapper_ {
     // scrollTop (as position relative to the viewport changes as you scroll).
     const rect = this.win.document.body./*OK*/getBoundingClientRect();
     return rect.height + rect.top + this.getScrollTop();
+  }
+
+  /** @override */
+  contentHeightChanged() {
+    if (isExperimentOn(this.win, 'scroll-height-bounce')) {
+      // Refresh the overscroll (`-webkit-overflow-scrolling: touch`) to avoid
+      // iOS rendering bugs. See #8798 for details.
+      const doc = this.win.document;
+      const {documentElement} = doc;
+      this.vsync_.mutate(() => {
+        documentElement.classList.remove('i-amphtml-ios-overscroll');
+        this.vsync_.mutate(() => {
+          documentElement.classList.add('i-amphtml-ios-overscroll');
+        });
+      });
+    }
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -15,6 +15,7 @@
  */
 
 import {Observable} from '../../observable';
+import {Services} from '../../services';
 import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -206,6 +206,11 @@ export class ViewportBindingNatural_ {
   }
 
   /** @override */
+  contentHeightChanged() {
+    // Nothing to do here.
+  }
+
+  /** @override */
   getLayoutRect(el, opt_scrollLeft, opt_scrollTop) {
     const b = el./*OK*/getBoundingClientRect();
     if (this.useLayers_) {

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -377,6 +377,14 @@ export class Viewport {
   }
 
   /**
+   * Resource manager signals to the viewport that content height is changed
+   * and some action may need to be taken.
+   */
+  contentHeightChanged() {
+    this.binding_.contentHeightChanged();
+  }
+
+  /**
    * Returns the rect of the viewport which includes scroll positions and size.
    * @return {!../../layout-rect.LayoutRectDef}}
    */

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -379,6 +379,8 @@ export class Viewport {
   /**
    * Resource manager signals to the viewport that content height is changed
    * and some action may need to be taken.
+   * @restricted Use is restricted due to potentially very heavy performance
+   *   impact. Can only be called when not actively scrolling.
    */
   contentHeightChanged() {
     this.binding_.contentHeightChanged();

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1643,12 +1643,14 @@ describes.realWin('Resources contentHeight', {
 }, env => {
   let win;
   let resources;
-  let viewerSendMessageStub;
+  let viewerSendMessageStub, viewportContentHeightChangedStub;
 
   beforeEach(() => {
     win = env.win;
     resources = win.services.resources.obj;
     viewerSendMessageStub = sandbox.stub(resources.viewer_, 'sendMessage');
+    viewportContentHeightChangedStub =
+        sandbox.stub(resources.viewport_, 'contentHeightChanged');
     sandbox.stub(resources.vsync_, 'run').callsFake(task => {
       task.measure({});
     });
@@ -1675,6 +1677,7 @@ describes.realWin('Resources contentHeight', {
     expect(viewerSendMessageStub.lastCall.args[0]).to.equal('documentHeight');
     expect(viewerSendMessageStub.lastCall.args[1].height).to.equal(200);
     expect(viewerSendMessageStub.lastCall.args[2]).to.equal(true);
+    expect(viewportContentHeightChangedStub).to.be.calledOnce;
   });
 
   it('should not send contentHeight to viewer if height is not changed', () => {
@@ -1686,6 +1689,7 @@ describes.realWin('Resources contentHeight', {
     expect(resources.maybeChangeHeight_).to.equal(false);
     expect(resources.contentHeight_).to.equal(contentHeight);
     expect(viewerSendMessageStub).to.not.be.called;
+    expect(viewportContentHeightChangedStub).to.not.be.called;
   });
 
   it('should send contentHeight to viewer if viewport resizes', () => {
@@ -1701,6 +1705,7 @@ describes.realWin('Resources contentHeight', {
     expect(viewerSendMessageStub.lastCall.args[0]).to.equal('documentHeight');
     expect(viewerSendMessageStub.lastCall.args[1].height).to.equal(200);
     expect(viewerSendMessageStub.lastCall.args[2]).to.equal(true);
+    expect(viewportContentHeightChangedStub).to.be.calledOnce;
   });
 
 });

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -774,12 +774,12 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
         binding.contentHeightChanged();
         return vsync.mutatePromise();
       }).then(() => {
-        const args = setStyleStub.lastCall.args;
+        const {args} = setStyleStub.lastCall;
         expect(args[0]).to.equal('-webkit-overflow-scrolling');
         expect(args[1]).to.equal('auto');
         return vsync.mutatePromise();
       }).then(() => {
-        const args = setStyleStub.lastCall.args;
+        const {args} = setStyleStub.lastCall;
         expect(args[0]).to.equal('-webkit-overflow-scrolling');
         expect(args[1]).to.equal('touch');
       });
@@ -791,9 +791,8 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
       const scroller = binding.scroller_;
       const setStyleStub = sandbox.stub(scroller.style, 'setProperty');
       binding.contentHeightChanged();
-      const root = win.document.documentElement;
       return vsync.mutatePromise().then(() => {
-        const args = setStyleStub.lastCall.args;
+        const {args} = setStyleStub.lastCall;
         expect(args[1]).to.not.equal('auto');
       });
     });

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -210,6 +210,7 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
 describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   let win;
   let binding;
+  let vsync;
   let child;
 
   beforeEach(() => {
@@ -225,6 +226,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     installDocService(win, /* isSingleDoc */ true);
     installDocumentStateService(win);
     installVsyncService(win);
+    vsync = Services.vsyncFor(win);
     binding = new ViewportBindingIosEmbedWrapper_(win);
     binding.connect();
   });
@@ -436,6 +438,31 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     wrapperCss = win.getComputedStyle(binding.wrapper_);
     expect(wrapperCss.overflowX).to.equal('hidden');
     expect(wrapperCss.overflowY).to.equal('auto');
+  });
+
+  it('should refresh overscroll when content height changes', () => {
+    toggleExperiment(win, 'scroll-height-bounce', true);
+    const root = win.document.documentElement;
+    return vsync.mutatePromise().then(() => {
+      expect(root).to.have.class('i-amphtml-ios-overscroll');
+      binding.contentHeightChanged();
+      return vsync.mutatePromise();
+    }).then(() => {
+      expect(root).to.not.have.class('i-amphtml-ios-overscroll');
+      return vsync.mutatePromise();
+    }).then(() => {
+      expect(root).to.have.class('i-amphtml-ios-overscroll');
+    });
+  });
+
+  it('should NOT refresh overscroll w/o experiment', () => {
+    // TODO(#19004): cleanup once "scroll-height-bounce" is launched.
+    toggleExperiment(win, 'scroll-height-bounce', false);
+    binding.contentHeightChanged();
+    const root = win.document.documentElement;
+    return vsync.mutatePromise().then(() => {
+      expect(root).to.have.class('i-amphtml-ios-overscroll');
+    });
   });
 });
 
@@ -737,6 +764,38 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
       scrollerCss = win.getComputedStyle(binding.scroller_);
       expect(scrollerCss.overflowX).to.equal('hidden');
       expect(scrollerCss.overflowY).to.equal('auto');
+    });
+
+    it('should refresh overscroll when content height changes', () => {
+      toggleExperiment(win, 'scroll-height-bounce', true);
+      const scroller = binding.scroller_;
+      const setStyleStub = sandbox.stub(scroller.style, 'setProperty');
+      return vsync.mutatePromise().then(() => {
+        binding.contentHeightChanged();
+        return vsync.mutatePromise();
+      }).then(() => {
+        const args = setStyleStub.lastCall.args;
+        expect(args[0]).to.equal('-webkit-overflow-scrolling');
+        expect(args[1]).to.equal('auto');
+        return vsync.mutatePromise();
+      }).then(() => {
+        const args = setStyleStub.lastCall.args;
+        expect(args[0]).to.equal('-webkit-overflow-scrolling');
+        expect(args[1]).to.equal('touch');
+      });
+    });
+
+    it('should NOT refresh overscroll w/o experiment', () => {
+      // TODO(#19004): cleanup once "scroll-height-bounce" is launched.
+      toggleExperiment(win, 'scroll-height-bounce', false);
+      const scroller = binding.scroller_;
+      const setStyleStub = sandbox.stub(scroller.style, 'setProperty');
+      binding.contentHeightChanged();
+      const root = win.document.documentElement;
+      return vsync.mutatePromise().then(() => {
+        const args = setStyleStub.lastCall.args;
+        expect(args[1]).to.not.equal('auto');
+      });
     });
   });
 });

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -948,6 +948,14 @@ describes.fakeWin('Viewport', {}, env => {
     const bindingMock = sandbox.mock(binding);
     bindingMock.expects('getContentHeight').withArgs().returns(117).once();
     expect(viewport.getContentHeight()).to.equal(117);
+    bindingMock.verify();
+  });
+
+  it('should delegate contentHeightChanged', () => {
+    const bindingMock = sandbox.mock(binding);
+    bindingMock.expects('contentHeightChanged').once();
+    viewport.contentHeightChanged();
+    bindingMock.verify();
   });
 
   it('should scroll to target position when the viewer sets scrollTop', () => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -400,6 +400,13 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/17475',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/18897',
   },
+  {
+    id: 'scroll-height-bounce',
+    name: 'Bounces the scrolling when scroll height changes' +
+        ' (fix for #18861 and #8798)',
+    spec: 'https://github.com/ampproject/amphtml/issues/18861',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/19004',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Related to #18861, #8798, #19004
