### PR TITLE
✨Allow to pass amp-analytics config to CustomEventReporterBuilder

### DIFF
--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -150,6 +150,13 @@ export class CustomEventReporterBuilder {
   }
 
   /**
+   * @param {!JsonObject} transportConfig
+   */
+  setTransportConfig(transportConfig) {
+    this.config_['transport'] = transportConfig;
+  }
+
+  /**
    * The #track() method takes in a unique custom-event name, and the
    * corresponding request url (or an array of request urls). One can call
    * #track() multiple times with different eventType name (order doesn't

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -130,23 +130,17 @@ class CustomEventReporter {
  * CustomEventReporter instance.
  */
 export class CustomEventReporterBuilder {
-  /**
-   * @param {!AmpElement} parent
-   * @param {?JsonObject} config
-   */
-  constructor(parent, config) {
+  /** @param {!AmpElement} parent */
+  constructor(parent) {
 
     /** @private {!AmpElement} */
     this.parent_ = parent;
 
     /** @private {?JsonObject} */
-    this.config_ = /** @type {JsonObject} */ (Object.assign(
-        dict({
-          'requests': {},
-          'triggers': {},
-        }),
-        config
-    ));
+    this.config_ = /** @type {JsonObject} */ ({
+      'requests': {},
+      'triggers': {},
+    });
   }
 
   /**

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -130,17 +130,23 @@ class CustomEventReporter {
  * CustomEventReporter instance.
  */
 export class CustomEventReporterBuilder {
-  /** @param {!AmpElement} parent */
-  constructor(parent) {
+  /**
+   * @param {!AmpElement} parent
+   * @param {?JsonObject} config
+   */
+  constructor(parent, config) {
 
     /** @private {!AmpElement} */
     this.parent_ = parent;
 
     /** @private {?JsonObject} */
-    this.config_ = /** @type {JsonObject} */ ({
-      'requests': {},
-      'triggers': {},
-    });
+    this.config_ = /** @type {JsonObject} */ (Object.assign(
+        dict({
+          'requests': {},
+          'triggers': {},
+        }),
+        config
+    ));
   }
 
   /**

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -175,6 +175,27 @@ describes.realWin('extension-analytics', {
       const reporter = builder.track('test', 'fake.com').build();
       expect(reporter.trigger).to.exist;
     });
+
+    it('Should allow to specify transport config', () => {
+      parent.getResourceId = () => { return 1; };
+      parent.signals = () => {
+        return {
+          whenSignal: () => { return Promise.resolve(); },
+        };
+      };
+      builder.setTransportConfig({
+        'beacon': true,
+        'image': true,
+        'xhrpost': false,
+      });
+
+      const reporter = builder.build();
+      expect(reporter.config_.transport).to.jsonEqual({
+        'beacon': true,
+        'image': true,
+        'xhrpost': false,
+      });
+    });
   });
 
   describe('CustomEventReporter test', () => {


### PR DESCRIPTION
Attempt to solve https://github.com/ampproject/amphtml/issues/19014

Config object can now be passed to CustomEventReporterBuilder as an optional second argument.

