### PR TITLE
🐛 Doubleclick-Impl.js: Updates the logic in getPageParameters so that the psts param is not included if empty

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -445,6 +445,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    */
   getPageParameters(consentState, instances) {
     instances = instances || [this];
+    const tokens = getPageviewStateTokensForAdRequest(instances);
     return {
       'npa': consentState == CONSENT_POLICY_STATE.INSUFFICIENT ||
           consentState == CONSENT_POLICY_STATE.UNKNOWN ? 1 : null,
@@ -452,7 +453,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'sfv': DEFAULT_SAFEFRAME_VERSION,
       'u_sd': this.win.devicePixelRatio,
       'gct': this.getLocationQueryParameterValue('google_preview') || null,
-      'psts': getPageviewStateTokensForAdRequest(instances),
+      'psts': tokens.length ? tokens : null,
     };
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -549,6 +549,27 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
+    it('includes psts param when there are pageview tokens', () => {
+      const impl = new AmpAdNetworkDoubleclickImpl(element);
+      const impl2 = new AmpAdNetworkDoubleclickImpl(element);
+      impl.setPageviewStateToken('abc');
+      impl2.setPageviewStateToken('def');
+      return impl.getAdUrl().then(url => {
+        expect(url).to.match(/(\?|&)psts=([^&]+%2C)*def(%2C[^&]+)*(&|$)/);
+        expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*abc(%2C[^&]+)*(&|$)/);
+      });
+    });
+
+    it('does not include psts param when there are no pageview tokens', () => {
+      const impl = new AmpAdNetworkDoubleclickImpl(element);
+      const impl2 = new AmpAdNetworkDoubleclickImpl(element);
+      impl.setPageviewStateToken('abc');
+      return impl.getAdUrl().then(url => {
+        expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*def(%2C[^&]+)*(&|$)/);
+        expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*abc(%2C[^&]+)*(&|$)/);
+      });
+    });
+
     it('handles Single Page Story Ad parameter', () => {
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       impl.isSinglePageStoryAd_ = true;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -562,10 +562,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('does not include psts param when there are no pageview tokens', () => {
       const impl = new AmpAdNetworkDoubleclickImpl(element);
-      const impl2 = new AmpAdNetworkDoubleclickImpl(element);
+      new AmpAdNetworkDoubleclickImpl(element);
       impl.setPageviewStateToken('abc');
       return impl.getAdUrl().then(url => {
-        expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*def(%2C[^&]+)*(&|$)/);
         expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*abc(%2C[^&]+)*(&|$)/);
       });
     });


### PR DESCRIPTION
Changes the logic for adding the psts param to the URL so that it is not included when there are no pageview tokens to include. Also added tests to check for this.