### PR TITLE
🐛Fixed Analytics Visible Trigger with the Intersection Observer Polyfill

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -181,10 +181,10 @@ describe('refresh', () => {
         x: 0,
         y: 0,
       });
-      
+
       sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
         return {
-          getRect: getRect
+          getRect,
         };
       });
       sandbox.stub(Services, 'ampdoc').callsFake(() => {

--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -181,6 +181,18 @@ describe('refresh', () => {
         x: 0,
         y: 0,
       });
+      
+      sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
+        return {
+          getRect: getRect
+        };
+      });
+      sandbox.stub(Services, 'ampdoc').callsFake(() => {
+        return {
+          getRootNode: () => {return window.document;},
+          win: window,
+        };
+      });
 
       mockA4a.element.setAttribute(DATA_MANAGER_ID_NAME, '0');
       mockA4a.element.viewportCallback = () => {};

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -616,7 +616,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     // Polyfill.
     const intersectionObserverPolyfill = new IntersectionObserverPolyfill(
         this.onIntersectionChanges_.bind(this),
-      {threshold: DEFAULT_THRESHOLD}
+        {threshold: DEFAULT_THRESHOLD}
     );
     const ticker = () => {
       intersectionObserverPolyfill.tick(this.viewport_.getRect());

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -616,7 +616,10 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     // Polyfill.
     const intersectionObserverPolyfill = new IntersectionObserverPolyfill(
         this.onIntersectionChanges_.bind(this),
-        {threshold: DEFAULT_THRESHOLD});
+      {threshold: DEFAULT_THRESHOLD},
+      win,
+      this.viewport_
+    );
     const ticker = () => {
       intersectionObserverPolyfill.tick(this.viewport_.getRect());
     };

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -616,8 +616,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     // Polyfill.
     const intersectionObserverPolyfill = new IntersectionObserverPolyfill(
         this.onIntersectionChanges_.bind(this),
-        {threshold: DEFAULT_THRESHOLD}
-    );
+        {threshold: DEFAULT_THRESHOLD});
     const ticker = () => {
       intersectionObserverPolyfill.tick(this.viewport_.getRect());
     };

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -616,9 +616,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     // Polyfill.
     const intersectionObserverPolyfill = new IntersectionObserverPolyfill(
         this.onIntersectionChanges_.bind(this),
-      {threshold: DEFAULT_THRESHOLD},
-      win,
-      this.viewport_
+      {threshold: DEFAULT_THRESHOLD}
     );
     const ticker = () => {
       intersectionObserverPolyfill.tick(this.viewport_.getRect());

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -294,7 +294,7 @@ export class IntersectionObserverPolyfill {
           this.handleMutationObserverNotification_.bind(this)
       );
       this.mutationObserver_.observe(element.ownerDocument, {
-        attributeFilter: ['class', 'style', 'hidden'],
+        attributes: true,
         subtree: true,
       });
     }
@@ -410,6 +410,7 @@ export class IntersectionObserverPolyfill {
    * @private
    */
   handleMutationObserverNotification_() {
+    console.log('mutation!');
     this.tick(this.viewport_.getRect());
   }
 }

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -109,7 +109,7 @@ export class IntersectionObserverApi {
     /** @private {?function()} */
     this.unlistenOnDestroy_ = null;
 
-    /** @private @const {!./service/viewport/viewport-impl.Viewport} */
+    /** @private {!./service/viewport/viewport-impl.Viewport} */
     this.viewport_ = baseElement.getViewport();
 
     /** @private {?SubscriptionApi} */
@@ -235,13 +235,12 @@ export class IntersectionObserverPolyfill {
      */
     this.observeEntries_ = [];
 
-    /** 
+    /**
      * Mutation observer to fire off on visibility changes
-     * @private {?Object} 
+     * @private {Object|undefined}
      */
-    this.mutationObserver_ = undefined
-    ; 
-    /** @private @const {?./service/viewport/viewport-impl.Viewport} */
+    this.mutationObserver_ = undefined;
+    /** @private {./service/viewport/viewport-impl.Viewport|undefined} */
     this.viewport_ = undefined;
   }
 
@@ -285,17 +284,17 @@ export class IntersectionObserverPolyfill {
         this.callback_([change]);
       }
     }
-    
+
 
     // Add a mutation observer to tick ourself
     if (!this.mutationObserver_) {
-      this.viewport_ = element.implementation_.getViewport();
+      this.viewport_ = Services.viewportForDoc(element);
       this.mutationObserver_ = new MutationObserver(
-        this.handleMutationObserverNotification.bind(this)
+          this.handleMutationObserverNotification_.bind(this)
       );
       this.mutationObserver_.observe(element.ownerDocument, {
         attributeFilter: ['class', 'style', 'hidden'],
-        subtree: true
+        subtree: true,
       });
     }
 
@@ -343,10 +342,10 @@ export class IntersectionObserverPolyfill {
     this.lastIframeRect_ = opt_iframe;
 
     const changes = [];
-    
+
     for (let i = 0; i < this.observeEntries_.length; i++) {
       const change = this.getValidIntersectionChangeEntry_(
-        this.observeEntries_[i], hostViewport, opt_iframe);
+          this.observeEntries_[i], hostViewport, opt_iframe);
       if (change) {
         changes.push(change);
       }
@@ -406,10 +405,10 @@ export class IntersectionObserverPolyfill {
   }
 
   /**
-   * Handle Safari Mutation Oberserver events
-   * @param {!Array<Object>} mutationList
+   * Handle Mutation Oberserver events
+   * @private
    */
-  handleMutationObserverNotification(mutationList) {
+  handleMutationObserverNotification_() {
     this.tick(this.viewport_.getRect());
   }
 }

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -286,7 +286,7 @@ export class IntersectionObserverPolyfill {
 
 
     // Add a mutation observer to tick ourself
-    if (!this.mutationObserver_) {
+    if (MutationObserver && !this.mutationObserver_) {
       this.viewport_ = Services.viewportForDoc(element);
       this.mutationObserver_ = new MutationObserver(
           this.handleMutationObserverNotification_.bind(this)

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -242,11 +242,11 @@ export class IntersectionObserverPolyfill {
      * @private {?Object}
      */
     this.mutationObserver_ = null;
-    
+
     /** @private {?./service/viewport/viewport-impl.Viewport} */
     this.viewport_ = null;
 
-    /** @const @private {?Pass} */
+    /** @private {?Pass} */
     this.mutationPass_ = null;
   }
 
@@ -438,7 +438,10 @@ export class IntersectionObserverPolyfill {
     }
     this.mutationObserver_ = null;
     this.viewport_ = null;
-    this.mutationPass_.cancel();
+    if (this.mutationPass_) {
+      this.mutationPass_.cancel();
+    }
+    this.mutationPass_ = null;
   }
 }
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -188,7 +188,6 @@ export class IntersectionObserverApi {
  * as params. Whenever the element intersection ratio cross a threshold value,
  * IntersectionObserverPolyfill will call the provided callback function with
  * the change entry. Only Works with one document for now.
- * TODO (@torch2424): Allow this to observe elements from multiple documents.
  * @visibleForTesting
  */
 export class IntersectionObserverPolyfill {
@@ -287,15 +286,17 @@ export class IntersectionObserverPolyfill {
 
 
     // Add a mutation observer to tick ourself
+    // TODO (@torch2424): Allow this to observe elements,
+    // from multiple documents.
     const ampdoc = Services.ampdoc(element);
     if (ampdoc.win.MutationObserver && !this.mutationObserver_) {
       this.viewport_ = Services.viewportForDoc(element);
       this.mutationObserver_ = new ampdoc.win.MutationObserver(
           this.handleMutationObserverNotification_.bind(this)
       );
-      this.mutationObserver_.observe(ampdoc.getRootNode(), {
+      this.mutationObserver_.observe(ampdoc.win.document, {
         attributes: true,
-        attributeList: ['hidden'],
+        attributeFilter: ['hidden'],
         subtree: true,
       });
     }

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -256,7 +256,10 @@ export class IntersectionObserverPolyfill {
         this.mutationObserver = new MutationObserver(
           this.handleSafariMutationObserverNotification.bind(this)
         );
-        this.mutationObserver.observe(this.window_.document);
+        this.mutationObserver.observe(this.window_.document, {
+          attributeFilter: ['class', 'style', 'hidden'],
+          subtree: true
+        });
       }
     }
   }
@@ -340,10 +343,13 @@ export class IntersectionObserverPolyfill {
     this.lastIframeRect_ = opt_iframe;
 
     const changes = [];
-
+    
+    // TODO: Intersection changes, not if they intersect. This will require
+    // Pulling out an 'doesIntersect', and do an alternate tick.
     for (let i = 0; i < this.observeEntries_.length; i++) {
       const change = this.getValidIntersectionChangeEntry_(
-          this.observeEntries_[i], hostViewport, opt_iframe);
+        this.observeEntries_[i], hostViewport, opt_iframe);
+      console.log('yooo', this.observeEntries_[i], 'ayeee', change);
       if (change) {
         changes.push(change);
       }
@@ -363,7 +369,7 @@ export class IntersectionObserverPolyfill {
    * @param {!ElementIntersectionStateDef} state
    * @param {!./layout-rect.LayoutRectDef} hostViewport hostViewport's rect
    * @param {./layout-rect.LayoutRectDef=} opt_iframe iframe container rect
-   * @return {?IntersectionObserverEntry} A valid change entry or null if ratio
+   * @return {?IntersectionObserverEntry} A valid change entry or null   if ratio
    * @private
    */
   getValidIntersectionChangeEntry_(state, hostViewport, opt_iframe) {
@@ -408,7 +414,6 @@ export class IntersectionObserverPolyfill {
    */
   handleSafariMutationObserverNotification(mutationList) {
     console.log('hi', mutationList);
-
     this.tick(this.viewport_);
   }
 }

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -410,7 +410,6 @@ export class IntersectionObserverPolyfill {
    * @private
    */
   handleMutationObserverNotification_() {
-    console.log('mutation!');
     this.tick(this.viewport_.getRect());
   }
 }
@@ -420,8 +419,9 @@ export class IntersectionObserverPolyfill {
  * @param {!./layout-rect.LayoutRectDef} smaller
  * @param {!./layout-rect.LayoutRectDef} larger
  * @return {number}
+ * @visibleForTesting
  */
-function intersectionRatio(smaller, larger) {
+export function intersectionRatio(smaller, larger) {
   const smallerBoxArea = smaller.width * smaller.height;
   const largerBoxArea = larger.width * larger.height;
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Pass} from './pass';
 import {Services} from './services';
 import {SubscriptionApi} from './iframe-helper';
 import {dev} from './log';

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -187,7 +187,8 @@ export class IntersectionObserverApi {
  * The IntersectionObserver receives a callback function and an optional option
  * as params. Whenever the element intersection ratio cross a threshold value,
  * IntersectionObserverPolyfill will call the provided callback function with
- * the change entry.
+ * the change entry. Only Works with one document for now.
+ * TODO (@torch2424): Allow this to observe elements from multiple documents.
  * @visibleForTesting
  */
 export class IntersectionObserverPolyfill {

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -239,7 +239,7 @@ export class IntersectionObserverPolyfill {
 
     /**
      * Mutation observer to fire off on visibility changes
-     * @private {?Object}
+     * @private {?MutationObserver}
      */
     this.mutationObserver_ = null;
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -238,20 +238,18 @@ export class IntersectionObserverPolyfill {
 
     /**
      * Mutation observer to fire off on visibility changes
-     * @private {Object|undefined}
+     * @private {?Object}
      */
-    this.mutationObserver_ = undefined;
-    /** @private {./service/viewport/viewport-impl.Viewport|undefined} */
-    this.viewport_ = undefined;
+    this.mutationObserver_ = null;
+    /** @private {?./service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = null;
   }
 
   /**
    */
   disconnect() {
     this.observeEntries_.length = 0;
-    this.mutationObserver_.disconnect();
-    this.mutationObserver_ = undefined;
-    this.viewport_ = undefined;
+    this.disconnectMutationObserver_();
   }
 
   /**
@@ -313,7 +311,7 @@ export class IntersectionObserverPolyfill {
       if (this.observeEntries_[i].element === element) {
         this.observeEntries_.splice(i, 1);
         if (this.observeEntries_.length <= 0) {
-          this.disconnect();
+          this.disconnectMutationObserver_();
         }
         return;
       }
@@ -412,6 +410,18 @@ export class IntersectionObserverPolyfill {
   handleMutationObserverNotification_() {
     this.tick(this.viewport_.getRect());
   }
+
+  /**
+   * Clean up the mutation observer
+   * @private
+   */
+  disconnectMutationObserver_() {
+    if (this.mutationObserver_) {
+      this.mutationObserver_.disconnect();
+    }
+    this.mutationObserver_ = null;
+    this.viewport_ = null;
+  }
 }
 
 /**
@@ -426,11 +436,7 @@ export function intersectionRatio(smaller, larger) {
   const largerBoxArea = larger.width * larger.height;
 
   // Check for a divide by zero
-  if (largerBoxArea === 0) {
-    return 0;
-  } else {
-    return smallerBoxArea / largerBoxArea;
-  }
+  return largerBoxArea === 0 ? 0 : smallerBoxArea / largerBoxArea;
 }
 
 /**

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -70,11 +70,16 @@ describe('IntersectionObserverApi', () => {
     sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
       return mockViewport;
     });
+    sandbox.stub(Services, 'ampdoc').callsFake(() => {
+      return {
+        getRootNode: () => {return window.document},
+        win: window
+      };
+    });
     testEle = {
       isBuilt: () => {return true;},
       getOwner: () => {return null;},
       getLayoutBox: () => {return layoutRectLtwh(50, 100, 150, 200);},
-      ownerDocument: window.document,
       win: window,
     };
 
@@ -299,11 +304,16 @@ describe('IntersectionObserverPolyfill', () => {
           },
         };
       });
+      sandbox.stub(Services, 'ampdoc').callsFake(() => {
+        return {
+          getRootNode: () => {return window.document},
+          win: window
+        };
+      });
 
       element = {
         isBuilt: () => {return true;},
         getOwner: () => {return null;},
-        ownerDocument: window.document,
       };
     });
 

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -72,8 +72,8 @@ describe('IntersectionObserverApi', () => {
     });
     sandbox.stub(Services, 'ampdoc').callsFake(() => {
       return {
-        getRootNode: () => {return window.document},
-        win: window
+        getRootNode: () => {return window.document;},
+        win: window,
       };
     });
     testEle = {
@@ -306,8 +306,8 @@ describe('IntersectionObserverPolyfill', () => {
       });
       sandbox.stub(Services, 'ampdoc').callsFake(() => {
         return {
-          getRootNode: () => {return window.document},
-          win: window
+          getRootNode: () => {return window.document;},
+          win: window,
         };
       });
 

--- a/test/manual/amp-bind-intersection-observer-polyfill.html
+++ b/test/manual/amp-bind-intersection-observer-polyfill.html
@@ -17,11 +17,8 @@
         button {
           border: solid 1px black;
         }
-        #analytics-image {
-          display: none;
-        }
-        .show {
-          display: block !important;
+        [hidden="1"] {
+          display: block;
         }
       </style>
   </head>
@@ -62,11 +59,11 @@
     <p [class]="textClass">This text will have have a red background color</p>
     <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt" [aria-label]="'Image of a ' + imgAlt"></amp-img>
     <p>The image above will increase in size and change its src</p>
-    <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" id="analytics-image" [class]="analyticsImage" width="100" height="100" alt="Border Collie">
+    <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" id="analytics-image" hidden [hidden]="hide-analytics-image != false" width="100" height="100" alt="Border Collie">
     </amp-img>
     <p>The image above (currently hidden) will fire a visibility trigger for analytics</p>
     <div>
-      <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog', 'analyticsImage': 'show'})">Click me</button>
+      <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog', 'hide-analytics-image': false})">Click me</button>
     </div>
 
     <amp-state id="myState">

--- a/test/manual/amp-bind-intersection-observer-polyfill.html
+++ b/test/manual/amp-bind-intersection-observer-polyfill.html
@@ -17,9 +17,6 @@
         button {
           border: solid 1px black;
         }
-        [hidden="1"] {
-          display: block;
-        }
       </style>
   </head>
 

--- a/test/manual/amp-bind-intersection-observer-polyfill.html
+++ b/test/manual/amp-bind-intersection-observer-polyfill.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8">
+    <title>amp-bind: Basic</title>
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+      <script async src="https://cdn.ampproject.org/v0.js"></script>
+      <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+      <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+      <style amp-custom>
+        .redBackground {
+          background-color: red;
+        }
+        button {
+          border: solid 1px black;
+        }
+        #analytics-image {
+          display: none;
+        }
+        .show {
+          display: block !important;
+        }
+      </style>
+  </head>
+
+  <body>
+    
+    <amp-analytics>
+      <script type="application/json">
+        {
+          "requests": {
+            "pageview": "/analytics/pageview",
+            "imagevisible": "/analytics/imagevisible"
+          },
+          "triggers": {
+            "pageview": {
+              "on": "visible",
+              "request": "pageview"
+            },
+            "visibility": {
+              "on": "visible",
+              "request": "imagevisible",
+              "selector": "#analytics-image"
+            }
+          },
+          "transport": {
+            "referrerPolicy": "no-referrer"
+          }
+        }
+      </script>
+    </amp-analytics>
+    
+
+    <h2>Basic example</h2>
+    <p [text]="foo">After clicking the button below, this will read 'foo'<p>
+    <p id="foo" [text]="foo + 'bar'">And this will read 'foobar'<p>
+    <p [text]="myState.myStateKey1">This will read 'myStateValue1'<p>
+    <button [disabled]="isButtonDisabled">This button will be disabled</button>
+    <p [class]="textClass">This text will have have a red background color</p>
+    <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt" [aria-label]="'Image of a ' + imgAlt"></amp-img>
+    <p>The image above will increase in size and change its src</p>
+    <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" id="analytics-image" [class]="analyticsImage" width="100" height="100" alt="Border Collie">
+    </amp-img>
+    <p>The image above (currently hidden) will fire a visibility trigger for analytics</p>
+    <div>
+      <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog', 'analyticsImage': 'show'})">Click me</button>
+    </div>
+
+    <amp-state id="myState">
+      <script type="application/json">
+        {
+        "myStateKey1": "myStateValue1"
+      }
+      </script>
+    </amp-state>
+  </body>
+</html>


### PR DESCRIPTION
closes #18972

This does the following:

* Creates an example in `test/manual` to display the bug in safari.
* Fixes a bug with `intersectionRatio()` to check for a divide by zero.
* Adds a mutation observer to trigger events on `class` and `style` attribute changes.

# Example Screenshot

*Look for the `imagevisible` request in the network tab*

<img width="1440" alt="screen shot 2018-10-29 at 1 30 54 pm" src="https://user-images.githubusercontent.com/1448289/47678581-682e6280-db7f-11e8-85b8-e34069d8c766.png">
<img width="720" alt="screen shot 2018-10-29 at 1 31 00 pm" src="https://user-images.githubusercontent.com/1448289/47678582-682e6280-db7f-11e8-99d0-827335350d95.png">
