### PR TITLE
[ANIMATION WORKLET] Change position observer detection logic in `amp-animation.js`

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -291,7 +291,7 @@ export class AmpAnimation extends AMP.BaseElement {
     // The animation will be triggered (in paused state) and seek will happen
     // regardless of visibility
     this.triggered_ = true;
-    this.hasPositionObserver_ = invocation.caller &&
+    this.hasPositionObserver_ = !!invocation.caller &&
       invocation.caller.tagName === 'AMP-POSITION-OBSERVER';
     return this.createRunnerIfNeeded_().then(() => {
       this.pause_();

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -154,19 +154,6 @@ export class AmpAnimation extends AMP.BaseElement {
       });
     }
 
-    // See if page has a PositionObserver in it associated with this animation.
-    const positionObservers =
-    this.element.ownerDocument.querySelectorAll('amp-position-observer');
-    positionObservers.forEach(observer => {
-      const onAttr = observer.getAttribute('on');
-      // We are only concerned with positionObservers that are associated with
-      // this animation and are controlling it using the seekTo event.
-      if (onAttr.indexOf(this.element.id) !== -1 &&
-        onAttr.indexOf('seekTo') !== -1) {
-        this.hasPositionObserver_ = true;
-      }
-    });
-
     // Actions.
     this.registerAction('start',
         this.startAction_.bind(this), ActionTrust.LOW);
@@ -304,6 +291,8 @@ export class AmpAnimation extends AMP.BaseElement {
     // The animation will be triggered (in paused state) and seek will happen
     // regardless of visibility
     this.triggered_ = true;
+    this.hasPositionObserver_ = invocation.caller &&
+      invocation.caller.tagName === 'AMP-POSITION-OBSERVER';
     return this.createRunnerIfNeeded_().then(() => {
       this.pause_();
       this.pausedByAction_ = true;


### PR DESCRIPTION
This changes the logic to detecting that the `seekTo` action is being called by a position observer. This way we retain only using AnimationWorklet for scroll bound animations and don't have to crawl the page to detect an animation. 