### PR TITLE
Subscriptions service public method to render the dialog with the current entitlement.

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -375,6 +375,19 @@ export class SubscriptionService {
   }
 
   /**
+   * Renders and opens the dialog using the cached entitlements.
+   */
+  renderDialogForSelectedPlatform() {
+    this.initialize_().then(() => {
+      if (this.doesViewerProvideAuth_ || this.platformConfig_['alwaysGrant']) {
+        return;
+      }
+
+      this.selectAndActivatePlatform_(false /** sendAnalyticsEvents */);
+    });
+  }
+
+  /**
    * Unblock document based on grant state and selected platform
    * @param {boolean=} doPlatformSelection
    * @private
@@ -390,8 +403,12 @@ export class SubscriptionService {
     }
   }
 
-  /** @private */
-  selectAndActivatePlatform_() {
+  /**
+   * @param {boolean=} sendAnalyticsEvents
+   * @return {!Promise}
+   * @private
+   */
+  selectAndActivatePlatform_(sendAnalyticsEvents = true) {
     const requireValuesPromise = Promise.all([
       this.platformStore_.getGrantStatus(),
       this.platformStore_.selectPlatform(),
@@ -403,6 +420,11 @@ export class SubscriptionService {
           selectedPlatform.getServiceId());
 
       selectedPlatform.activate(selectedEntitlement);
+
+      if (sendAnalyticsEvents === false) {
+        return;
+      }
+
       this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
           selectedPlatform.getServiceId());


### PR DESCRIPTION
To support the `amp-story` integration of `amp-subscriptions`, we need to be able to control what is displayed in the dialog, and when. `amp-story` has a soft (notification) paywall, and a hard (navigation blocking) paywall.
Soft: only visible on the cover page, can be dismissed, used for metering
Hard: only visible when trying to navigate to a protected page, used to login/subscribe

To support this, `amp-story` needs an additional method that re-renders the dialog, using the current entitlement, based on the subscriptions-dialog templates available in the DOM.

This method:
- Doesn’t send extra analytics events
- Uses cached entitlements to avoid extra unnecessary queries
- Doesn’t override viewer provided auth, or platform configuration (ie: alwaysGrant), so it does work with all the integrations