### PR TITLE
📖 fix documentation mistakes of amp-fx-collection

### DIFF
--- a/extensions/amp-fx-collection/amp-fx-collection.md
+++ b/extensions/amp-fx-collection/amp-fx-collection.md
@@ -136,7 +136,7 @@ This parameter determines when to stop the animation. The value specified in `<p
 In the below example, the `<div>` is fully visible by the time it has crossed 80% of the viewport from the bottom. 
 
 ```html
-  <div amp-fx="fade-in" data-margin-end="80%">
+  <div amp-fx="fade-in-scroll" data-margin-end="80%">
     <amp-img width="1600" height="900" layout="responsive" src="https://picsum.photos/1600/900?image=1069"></amp-img>
   </div>
 ```
@@ -173,7 +173,7 @@ If the user overrides this default value of `data-duration` to `Xms`, the same d
 
 ##### data-easing (optional)
 
-This parameter lets you vary the animation's speed over the course of its duration. The default is `ease-in` which is `cubic-bezier(0.40, 0.00, 0.40, 1.00)`. You can choose from one of the presets available:
+This parameter lets you vary the animation's speed over the course of its duration. The default is `ease-out` which is `cubic-bezier(0.40, 0.00, 0.40, 1.00)`. You can choose from one of the presets available:
 * “linear” - cubic-bezier(0.00, 0.00, 1.00, 1.00)
 * “ease-in-out” - cubic-bezier(0.80, 0.00, 0.20, 1.00)
 * “ease-in” - cubic-bezier(0.80, 0.00, 0.60, 1.00)


### PR DESCRIPTION
Fix two documentation mistakes of `amp-fx-collection`.

Sorry, I messed up the commits history, so I've closed the previous PR.

1. `fade-in` => `fade-in-scroll`
  It should be `fade-in-scroll`. This example shows how to use `data-margin-end` which only works for `fade-in-scroll`.
2. `ease-in` => `ease-out`
  The default value of `data-easing` of `fly-in` fxs should be `ease-out` according to the [code](https://github.com/ampproject/amphtml/blob/master/extensions/amp-fx-collection/0.1/providers/amp-fx-presets-utils.js#L197).