### PR TITLE
Introduce an experiment that requires body to have a minimum height in iOS embed mode

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -176,6 +176,18 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
   overflow: hidden !important;
 }
 
+/**
+ * TODO(dvoytenko, #19004): if/when "scroll-height-minheight" launched, merge
+ * these styles into _both_: `#i-amphtml-wrapper > body` and
+ * `html.i-amphtml-ios-embed-sd > body` sections above.
+ */
+.i-amphtml-body-minheight > body {
+  /* A slightly overflowing height is necessary to avoid scrolling and
+     rendering bugs on iOS due to
+     https://bugs.webkit.org/show_bug.cgi?id=158342. */
+  min-height: calc(100vh + 1px);
+}
+
 
 .i-amphtml-element {
   display: inline-block;

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -109,6 +109,9 @@ export class ViewportBindingIosEmbedShadowRoot_ {
     const doc = this.win.document;
     const {documentElement} = doc;
     documentElement.classList.add('i-amphtml-ios-embed-sd');
+    if (isExperimentOn(win, 'scroll-height-minheight')) {
+      documentElement.classList.add('i-amphtml-body-minheight');
+    }
 
     const scroller = htmlFor(doc)`
       <div id="i-amphtml-scroller">

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -57,6 +57,9 @@ export class ViewportBindingIosEmbedWrapper_ {
     this.wrapper_ = wrapper;
     wrapper.id = 'i-amphtml-wrapper';
     wrapper.className = topClasses;
+    if (isExperimentOn(win, 'scroll-height-minheight')) {
+      wrapper.classList.add('i-amphtml-body-minheight');
+    }
 
     /** @private @const {!Observable} */
     this.scrollObservable_ = new Observable();

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -497,6 +497,7 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
       iframe.style.width = '100px';
       iframe.style.height = '100px';
       win = env.win;
+      toggleExperiment(win, 'scroll-height-minheight', false);
       win.document.documentElement.className = 'top i-amphtml-singledoc';
       child = win.document.createElement('div');
       child.style.width = '200px';

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -231,6 +231,22 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     binding.connect();
   });
 
+  it('should NOT setup body min-height w/o experiment', () => {
+    const style = win.getComputedStyle(win.document.body);
+    expect(style.minHeight).to.equal('0px');
+  });
+
+  it('should setup body min-height wwith experiment', () => {
+    toggleExperiment(win, 'scroll-height-minheight', true);
+    try {
+      binding = new ViewportBindingIosEmbedWrapper_(win);
+    } catch (e) {
+      // Ignore a double-init errors.
+    }
+    const style = win.getComputedStyle(win.document.body);
+    expect(style.minHeight).to.equal((win.innerHeight + 1) + 'px');
+  });
+
   it('should NOT require fixed layer transferring', () => {
     expect(binding.requiresFixedLayerTransfer()).to.be.true;
   });
@@ -503,6 +519,22 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
       vsync = Services.vsyncFor(win);
       binding = new ViewportBindingIosEmbedShadowRoot_(win);
       binding.connect();
+    });
+
+    it('should NOT setup body min-height w/o experiment', () => {
+      const style = win.getComputedStyle(win.document.body);
+      expect(style.minHeight).to.equal('0px');
+    });
+
+    it('should setup body min-height wwith experiment', () => {
+      toggleExperiment(win, 'scroll-height-minheight', true);
+      try {
+        new ViewportBindingIosEmbedShadowRoot_(win);
+      } catch (e) {
+        // Ignore a double-init errors.
+      }
+      const style = win.getComputedStyle(win.document.body);
+      expect(style.minHeight).to.equal((win.innerHeight + 1) + 'px');
     });
 
     it('should NOT require fixed layer transferring', () => {

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -218,6 +218,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     env.iframe.style.height = '100px';
     win = env.win;
     win.document.documentElement.className = 'top i-amphtml-singledoc';
+    toggleExperiment(win, 'scroll-height-minheight', false);
     child = win.document.createElement('div');
     child.style.width = '200px';
     child.style.height = '300px';

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -401,6 +401,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/18861',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/19004',
   },
+  {
+    id: 'scroll-height-minheight',
+    name: 'Forces min-height on body (fix for #18861 and #8798)',
+    spec: 'https://github.com/ampproject/amphtml/issues/18861',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/19004',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
An alternative solution for #18861: always require the body in iOS embed mode to be at least `1px` taller than the viewport to force scrolling stack on iOS. A failure to create a scrolling stack on iOS causes numerous scrolling and rendering bugs. See #18861 and https://bugs.webkit.org/show_bug.cgi?id=158342 for more details.