### PR TITLE
🐛Fix `data-amp-replace` comparison logic

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1051,8 +1051,10 @@ export class UrlReplacements {
     this.expandStringSync(url, /* opt_bindings */ undefined, vars);
     const varNames = Object.keys(vars)
         // Strip arguments from collect_vars to match whitelist api.
-        .map(key => key.includes('(') ?
-          key.substring(0, key.indexOf('(')) : key);
+        .map(key => {
+          const argsIndex = key.indexOf('(');
+          return argsIndex === -1 ? key : key.substring(0, argsIndex);
+        });
 
     const whitelist = this.getWhitelistForElement_(element);
     if (whitelist) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1049,7 +1049,9 @@ export class UrlReplacements {
     const url = element.getAttribute('src');
     const vars = Object.create(null);
     this.expandStringSync(url, /* opt_bindings */ undefined, vars);
-    const varNames = Object.keys(vars);
+    const varNames = Object.keys(vars)
+        // Strip arguments from collect_vars to match whitelist api.
+        .map(key => key.substring(0, key.indexOf('(')));
 
     const whitelist = this.getWhitelistForElement_(element);
     if (whitelist) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1051,7 +1051,8 @@ export class UrlReplacements {
     this.expandStringSync(url, /* opt_bindings */ undefined, vars);
     const varNames = Object.keys(vars)
         // Strip arguments from collect_vars to match whitelist api.
-        .map(key => key.substring(0, key.indexOf('(')));
+        .map(key => key.includes('(') ?
+          key.substring(0, key.indexOf('(')) : key);
 
     const whitelist = this.getWhitelistForElement_(element);
     if (whitelist) {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1307,12 +1307,13 @@ describes.sandboxed('UrlReplacements', {}, () => {
         });
   });
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should collect unwhitelisted vars', () => {
+  it('should collect unwhitelisted vars', () => {
     const win = getFakeWindow();
+    win.location =
+      parseUrlDeprecated('https://example.com/base?foo=bar&bar=abc&gclid=123');
     const element = document.createElement('amp-foo');
     element.setAttribute('src', '?SOURCE_HOST&QUERY_PARAM(p1)&COUNTER');
-    element.setAttribute('data-amp-replace', 'QUERY_PARAM(p1)');
+    element.setAttribute('data-amp-replace', 'QUERY_PARAM');
     const urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);
     const unwhitelisted = urlReplacements.collectUnwhitelistedVarsSync(element);
     expect(unwhitelisted).to.deep.equal(['SOURCE_HOST', 'COUNTER']);


### PR DESCRIPTION
Fixes #19061 

The new expander had inadvertently introduced a new API that `UrlReplacements.collectUnwhitelistedVarsSync_` had become dependent on. When the API was changed back in #18554 it broke the intended functionality of this method.

This removes the arguments collected by the `collectVars` object before comparing them to the given `data-amp-replace` options.