### PR TITLE
Rollback #18871

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -261,9 +261,7 @@ amp-story-cta-layer {
 
 /** Grid level */
 amp-story-grid-layer {
-  box-sizing: border-box !important;
   display: grid !important;
-  height: 100% !important;
   position: absolute !important;
   top: 0 !important;
   right: 0 !important;


### PR DESCRIPTION
Rollback #18871

Due to breakages to existing publisher stories because grid layers with template="vertical" don't necessarily have to be 100% height