### PR TITLE
Do not validate for #development=1 when on AMP Caches

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -101,7 +101,6 @@ const forbiddenTerms = {
       'build-system/pr-check.js',
       'build-system/app.js',
       'build-system/check-package-manager.js',
-      'validator/engine/validator-in-browser.js',
       'validator/nodejs/index.js', // NodeJs only.
       'validator/engine/parse-css.js',
       'validator/engine/validator-in-browser.js',
@@ -876,6 +875,7 @@ const forbiddenTermsSrcInclusive = {
       'src/config.js',
       'testing/local-amp-chrome-extension/background.js',
       'tools/errortracker/errortracker.go',
+      'validator/engine/validator-in-browser.js',
       'validator/nodejs/index.js',
       'validator/webui/serve-standalone.go',
       'build-system/app-video-testbench.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -101,6 +101,7 @@ const forbiddenTerms = {
       'build-system/pr-check.js',
       'build-system/app.js',
       'build-system/check-package-manager.js',
+      'validator/engine/validator-in-browser.js',
       'validator/nodejs/index.js', // NodeJs only.
       'validator/engine/parse-css.js',
       'validator/engine/validator-in-browser.js',

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -45,6 +45,15 @@ function getUrl(url) {
 }
 
 /**
+ * Checks if the given URL is an AMP Cache URL.
+ * @param {string} url
+ * @return {bool}
+ */
+amp.validator.isAmpCacheUrl = function(url) {
+  return (url.toLowerCase().indexOf('cdn.ampproject.org') !== -1);
+};
+
+/**
  * Validates doc in the browser by inspecting elements, attributes, etc. in
  * the DOM. This method is exported so it can be unittested.
  * @param {!Document} doc
@@ -66,8 +75,6 @@ amp.validator.validateInBrowser = function(doc) {
 /**
  * Validates a URL input, logging to the console the result.
  * Careful when modifying this; it's called from
- * https://github.com/ampproject/amphtml/blob/master/test/integration/test-example-validation.js
- * and
  * https://github.com/ampproject/amphtml/blob/master/src/validator-integration.js
  * @param {string} url
  * @param {!Document=} opt_doc
@@ -76,6 +83,12 @@ amp.validator.validateInBrowser = function(doc) {
  */
 amp.validator.validateUrlAndLog = function(
   url, opt_doc, opt_errorCategoryFilter) {
+  if (amp.validator.isAmpCacheUrl(url)) {
+    console.error(
+        'Attempting to validate an AMP Cache URL. Please use' +
+        '#development=1 on the origin URL instead.');
+    return;
+  }
   getUrl(url).then(
       function(html) { // Success
         const validationResult = amp.validator.validateString(html);

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -45,9 +45,9 @@ function getUrl(url) {
 }
 
 /**
- * Checks if the given URL is an AMP Cache URL.
+ * Checks if the given URL is an AMP cache URL.
  * @param {string} url
- * @return {bool}
+ * @return {boolean}
  */
 amp.validator.isAmpCacheUrl = function(url) {
   return (
@@ -87,7 +87,7 @@ amp.validator.validateUrlAndLog = function(
     url, opt_doc, opt_errorCategoryFilter) {
   if (amp.validator.isAmpCacheUrl(url)) {
     console.error(
-        'Attempting to validate an AMP Cache URL. Please use' +
+        'Attempting to validate an AMP cache URL. Please use ' +
         '#development=1 on the origin URL instead.');
     return;
   }

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -51,17 +51,17 @@ function getUrl(url) {
  */
 amp.validator.isAmpCacheUrl = function(url) {
   return (
-      url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 ||
-      url.toLowerCase().indexOf('amp.cloudflare.com') !== -1);
+    url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 ||
+    url.toLowerCase().indexOf('amp.cloudflare.com') !== -1);
 };
 
 /**
  * Validates doc in the browser by inspecting elements, attributes, etc. in
  * the DOM. This method is exported so it can be unittested.
- * @param {!Document} doc
+ * @param {!Document} opt_doc
  * @return {!amp.validator.ValidationResult}
  */
-amp.validator.validateInBrowser = function(doc) {
+amp.validator.validateInBrowser = function(opt_doc) {
   const result = new amp.validator.ValidationResult();
   result.status = amp.validator.ValidationResult.Status.UNKNOWN;
 
@@ -84,7 +84,7 @@ amp.validator.validateInBrowser = function(doc) {
  * @export
  */
 amp.validator.validateUrlAndLog = function(
-    url, opt_doc, opt_errorCategoryFilter) {
+  url, opt_doc, opt_errorCategoryFilter) {
   if (amp.validator.isAmpCacheUrl(url)) {
     console.error(
         'Attempting to validate an AMP cache URL. Please use ' +

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -50,7 +50,9 @@ function getUrl(url) {
  * @return {bool}
  */
 amp.validator.isAmpCacheUrl = function(url) {
-  return (url.toLowerCase().indexOf('cdn.ampproject.org') !== -1);
+  return (
+      url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 ||
+      url.toLowerCase().indexOf('amp.cloudflare.com') !== -1);
 };
 
 /**
@@ -82,7 +84,7 @@ amp.validator.validateInBrowser = function(doc) {
  * @export
  */
 amp.validator.validateUrlAndLog = function(
-  url, opt_doc, opt_errorCategoryFilter) {
+    url, opt_doc, opt_errorCategoryFilter) {
   if (amp.validator.isAmpCacheUrl(url)) {
     console.error(
         'Attempting to validate an AMP Cache URL. Please use' +


### PR DESCRIPTION
Fixes #19082
