### PR TITLE
Support useBody config to send payload as POST body.

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -113,6 +113,7 @@ app.use('/request-bank/withdraw/', (req, res) => {
   const callback = function(result) {
     res.json({
       headers: result.headers,
+      body: result.body,
     });
     delete bank[key];
   };

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -34,7 +34,7 @@ const pc = process;
 const countries = require('../examples/countries.json');
 const runVideoTestBench = require('./app-video-testbench');
 
-app.use(bodyParser.json());
+app.use(bodyParser.text());
 app.use('/amp4test', require('./amp4test'));
 
 // Append ?csp=1 to the URL to turn on the CSP header.
@@ -171,7 +171,7 @@ app.use('/api/dont-show', (req, res) => {
 
 app.use('/api/echo/post', (req, res) => {
   res.setHeader('Content-Type', 'application/json');
-  res.end(JSON.stringify(req.body, null, 2));
+  res.end(req.body);
 });
 
 app.use('/analytics/:type', (req, res) => {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import {BatchSegmentDef, defaultSerializer} from './transport-serializer';
 import {
   ExpansionOptions,
   variableServiceFor,
 } from './variables';
 import {SANDBOX_AVAILABLE_VARS} from './sandbox-vars-whitelist';
 import {Services} from '../../../src/services';
-import {batchSegmentDef, defaultSerializer} from './transport-serializer';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getResourceTiming} from './resource-timing';
@@ -69,7 +69,7 @@ export class RequestHandler {
     /** @private {?Promise<string>} */
     this.baseUrlTemplatePromise_ = null;
 
-    /** @private {!Array<!Promise<!batchSegmentDef>>} */
+    /** @private {!Array<!Promise<!BatchSegmentDef>>} */
     this.batchSegmentPromises_ = [];
 
     /** @private {!../../../src/preconnect.Preconnect} */
@@ -211,7 +211,8 @@ export class RequestHandler {
               'iframePing is only available on page view requests.');
           this.transport_.sendRequestUsingIframe(baseUrl, batchSegments[0]);
         } else {
-          this.transport_.sendRequest(baseUrl, batchSegments);
+          this.transport_.sendRequest(
+              baseUrl, batchSegments, !!this.batchInterval_);
         }
       });
     });

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -15,11 +15,14 @@
  */
 
 import * as lolex from 'lolex';
+import {
+  ImagePixelVerifier,
+  mockWindowInterface,
+} from '../../../../testing/test-helper';
 import {Transport} from '../transport';
 import {getMode} from '../../../../src/mode';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {loadPromise} from '../../../../src/event-helper';
-import {mockWindowInterface} from '../../../../testing/test-helper';
 
 describes.realWin('amp-analytics.transport', {
   amp: false,
@@ -32,7 +35,7 @@ describes.realWin('amp-analytics.transport', {
   let openXhrStub;
   let sendXhrStub;
   let sendBeaconStub;
-  let imagePixel;
+  let imagePixelVerifier;
 
   beforeEach(() => {
     sandbox = env.sandbox;
@@ -41,7 +44,6 @@ describes.realWin('amp-analytics.transport', {
     openXhrStub = sandbox.stub();
     sendXhrStub = sandbox.stub();
     sendBeaconStub = sandbox.stub();
-    imagePixel = {};
   });
 
   it('prefers beacon over xhrpost and image', () => {
@@ -408,8 +410,7 @@ describes.realWin('amp-analytics.transport', {
     wi.getXMLHttpRequest.returns(xhr ? FakeXMLHttpRequest : undefined);
     sendBeaconStub.returns(beacon);
 
-    const FakeImage = () => imagePixel;
-    wi.getImage.returns(FakeImage);
+    imagePixelVerifier = new ImagePixelVerifier(wi);
   }
 
   function sendRequest(win, request, options) {
@@ -435,11 +436,10 @@ describes.realWin('amp-analytics.transport', {
   }
 
   function expectImagePixel(url, referrerPolicy) {
-    expect(imagePixel.src).to.equal(url);
-    expect(imagePixel.referrerPolicy).to.equal(referrerPolicy);
+    imagePixelVerifier.verifyRequest(url, referrerPolicy);
   }
 
   function expectNoImagePixel() {
-    expect(imagePixel.src).to.be.undefined;
+    expect(imagePixelVerifier.hasRequestSent()).to.be.false;
   }
 });

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -19,6 +19,7 @@ import {Transport} from '../transport';
 import {getMode} from '../../../../src/mode';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {loadPromise} from '../../../../src/event-helper';
+import {mockWindowInterface} from '../../../../testing/test-helper';
 
 describes.realWin('amp-analytics.transport', {
   amp: false,
@@ -28,39 +29,29 @@ describes.realWin('amp-analytics.transport', {
   let sandbox;
   let win;
   let doc;
+  let openXhrStub;
+  let sendXhrStub;
+  let sendBeaconStub;
+  let imagePixel;
 
   beforeEach(() => {
     sandbox = env.sandbox;
     win = env.win;
     doc = win.document;
+    openXhrStub = sandbox.stub();
+    sendXhrStub = sandbox.stub();
+    sendBeaconStub = sandbox.stub();
+    imagePixel = {};
   });
-
-  function setupStubs(beaconRetval, xhrRetval) {
-    sandbox.stub(Transport, 'sendRequestUsingImage');
-    sandbox.stub(Transport, 'sendRequestUsingBeacon').returns(beaconRetval);
-    sandbox.stub(Transport, 'sendRequestUsingXhr').returns(xhrRetval);
-  }
-
-  function sendRequest(win, request, options) {
-    new Transport(win, options).sendRequest(request, []);
-  }
-
-  function assertCallCounts(
-    expectedBeaconCalls, expectedXhrCalls, expectedImageCalls) {
-    expect(Transport.sendRequestUsingBeacon.callCount,
-        'sendRequestUsingBeacon call count').to.equal(expectedBeaconCalls);
-    expect(Transport.sendRequestUsingXhr.callCount,
-        'sendRequestUsingXhr call count').to.equal(expectedXhrCalls);
-    expect(Transport.sendRequestUsingImage.callCount,
-        'sendRequestUsingImage call count').to.equal(expectedImageCalls);
-  }
 
   it('prefers beacon over xhrpost and image', () => {
     setupStubs(true, true);
     sendRequest(win, 'https://example.com/test', {
       beacon: true, xhrpost: true, image: true,
     });
-    assertCallCounts(1, 0, 0);
+    expectBeacon('https://example.com/test', '');
+    expectNoXhr();
+    expectNoImagePixel();
   });
 
   it('prefers xhrpost over image', () => {
@@ -68,7 +59,9 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       beacon: false, xhrpost: true, image: true,
     });
-    assertCallCounts(0, 1, 0);
+    expectNoBeacon();
+    expectXhr('https://example.com/test', '');
+    expectNoImagePixel();
   });
 
   it('reluctantly uses image if nothing else is enabled', () => {
@@ -76,7 +69,9 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       image: true,
     });
-    assertCallCounts(0, 0, 1);
+    expectNoBeacon();
+    expectImagePixel('https://example.com/test');
+    expectNoXhr();
   });
 
   it('falls back to image setting suppressWarnings to true', () => {
@@ -84,7 +79,19 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       beacon: false, xhrpost: false, image: {suppressWarnings: true},
     });
-    assertCallCounts(0, 0, 1);
+    expectNoBeacon();
+    expectNoXhr();
+    expectImagePixel('https://example.com/test');
+  });
+
+  it('falls back to image setting referrerPolicy', () => {
+    setupStubs(true, true);
+    sendRequest(win, 'https://example.com/test', {
+      beacon: true, xhrpost: true, image: true, referrerPolicy: 'no-referrer',
+    });
+    expectNoBeacon();
+    expectNoXhr();
+    expectImagePixel('https://example.com/test', 'no-referrer');
   });
 
   it('falls back to xhrpost when enabled and beacon is not available', () => {
@@ -92,7 +99,9 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       beacon: true, xhrpost: true, image: true,
     });
-    assertCallCounts(1, 1, 0);
+    expectNoBeacon();
+    expectXhr('https://example.com/test', '');
+    expectNoImagePixel();
   });
 
   it('falls back to image when beacon not found and xhr disabled', () => {
@@ -100,7 +109,9 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       beacon: true, xhrpost: false, image: true,
     });
-    assertCallCounts(1, 0, 1);
+    expectNoBeacon();
+    expectNoXhr();
+    expectImagePixel('https://example.com/test');
   });
 
   it('falls back to image when beacon and xhr are not available', () => {
@@ -108,24 +119,142 @@ describes.realWin('amp-analytics.transport', {
     sendRequest(win, 'https://example.com/test', {
       beacon: true, xhrpost: true, image: true,
     });
-    assertCallCounts(1, 1, 1);
+    expectNoBeacon();
+    expectNoXhr();
+    expectImagePixel('https://example.com/test');
   });
 
   it('does not send a request when no transport methods are enabled', () => {
     setupStubs(true, true);
     sendRequest(win, 'https://example.com/test', {});
-    assertCallCounts(0, 0, 0);
+    expectNoBeacon();
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('does not send a request when URL is empty', () => {
+    setupStubs(true, true);
+    sendRequest(win, '', {beacon: true, xhrpost: true, image: true});
+    expectNoBeacon();
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send single segment request', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], false);
+    expectBeacon('https://e.com/test?a=1&b=hello', '');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send single segment request in batch', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], true);
+    expectBeacon('https://e.com/test?a=1&b=hello', '');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send single segment request useBody', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true, useBody: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], false);
+    expectBeacon('https://e.com/test', '{"a":1,"b":"hello"}');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send single segment request useBody in batch', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true, useBody: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], true);
+    expectBeacon('https://e.com/test', '[{"a":1,"b":"hello"}]');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send multi-segment request w/o batch (only 1st sent)', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }, {
+      extraUrlParams: {
+        a: 2,
+        b: 'world',
+      },
+    }], false);
+    expectBeacon('https://e.com/test?a=1&b=hello', '');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send multi-segment request in batch', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }, {
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], true);
+    expectBeacon('https://e.com/test?a=1&b=hello&a=1&b=hello', '');
+    expectNoXhr();
+    expectNoImagePixel();
+  });
+
+  it('send multi-segment request useBody in batch', () => {
+    setupStubs(true, true);
+    new Transport(win, {beacon: true, useBody: true}).sendRequest('https://e.com/test', [{
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }, {
+      extraUrlParams: {
+        a: 1,
+        b: 'hello',
+      },
+    }], true);
+    expectBeacon('https://e.com/test', '[{"a":1,"b":"hello"},{"a":1,"b":"hello"}]');
+    expectNoXhr();
+    expectNoImagePixel();
   });
 
   it('asserts that urls are https', () => {
     allowConsoleError(() => { expect(() => {
-      sendRequest(win, 'http://example.com/test');
+      sendRequest(win, 'http://example.com/test', {image: true});
     }).to.throw(/https/); });
   });
 
   it('should NOT allow __amp_source_origin', () => {
     allowConsoleError(() => { expect(() => {
-      sendRequest(win, 'https://twitter.com?__amp_source_origin=1');
+      sendRequest(win, 'https://twitter.com?__amp_source_origin=1', {image: true});
     }).to.throw(/Source origin is not allowed in/); });
   });
 
@@ -256,9 +385,61 @@ describes.realWin('amp-analytics.transport', {
       transport.iframeTransport_ = {
         sendRequest: iframeTransportSendRequestSpy,
       };
-      transport.sendRequest('test test', []);
-      assertCallCounts(0, 0, 0);
+      transport.sendRequest('test test', [{}], false);
+      expectNoBeacon();
+      expectNoXhr();
+      expectNoImagePixel();
       expect(iframeTransportSendRequestSpy).to.be.calledWith('test test');
     });
   });
+
+  function setupStubs(beacon, xhr) {
+    const wi = mockWindowInterface(sandbox);
+    wi.getSendBeacon.returns(beacon ? sendBeaconStub : undefined);
+
+    const FakeXMLHttpRequest = () => {
+      return {
+        withCredentials: false,
+        open: openXhrStub,
+        send: sendXhrStub,
+        setRequestHeader: () => {},
+      };
+    };
+    wi.getXMLHttpRequest.returns(xhr ? FakeXMLHttpRequest : undefined);
+    sendBeaconStub.returns(beacon);
+
+    const FakeImage = () => imagePixel;
+    wi.getImage.returns(FakeImage);
+  }
+
+  function sendRequest(win, request, options) {
+    new Transport(win, options).sendRequest(request, [{}], false);
+  }
+
+  function expectBeacon(url, payload) {
+    expect(sendBeaconStub).to.be.calledWith(url, payload);
+  }
+
+  function expectNoBeacon() {
+    expect(sendBeaconStub).to.not.be.called;
+  }
+
+  function expectXhr(url, payload) {
+    expect(openXhrStub).to.be.calledWith('POST', url, true);
+    expect(sendXhrStub).to.be.calledWith(payload);
+  }
+
+  function expectNoXhr() {
+    expect(openXhrStub).to.not.be.called;
+    expect(sendXhrStub).to.not.be.called;
+  }
+
+  function expectImagePixel(url, referrerPolicy) {
+    expect(imagePixel.src).to.equal(url);
+    expect(imagePixel.referrerPolicy).to.equal(referrerPolicy);
+  }
+
+  function expectNoImagePixel() {
+    expect(imagePixel.src).to.be.undefined;
+  }
 });

--- a/extensions/amp-analytics/0.1/transport-serializer.js
+++ b/extensions/amp-analytics/0.1/transport-serializer.js
@@ -19,46 +19,100 @@ import {
   serializeQueryString,
 } from '../../../src/url';
 
-/**
- * "trigger": string
- * "timestamp": null,
- *  "extraUrlParams": !JsonObject
- */
-/** @typedef {!JsonObject} */
-export let batchSegmentDef;
+const EXTRA_URL_PARAM_VAR = '${extraUrlParams}';
 
 /**
- * Please register your batch plugin function below.
+ * @typedef {{
+ *   trigger: (string|undefined),
+ *   timestamp: (number|undefined),
+ *   extraUrlParams: (!JsonObject|undefined)
+ * }}
+ */
+export let BatchSegmentDef;
+
+/**
+ * @typedef {{
+ *   url: (string),
+ *   payload: (string|undefined),
+ * }}
+ */
+export let RequestDef;
+
+/**
+ * @interface
+ */
+export class TransportSerializerDef {
+
+  /**
+   * @param {string} unusedBaseUrl
+   * @param {!BatchSegmentDef} unusedSegment
+   * @param {boolean} unusedWithPayload
+   * @return {!RequestDef}
+   */
+  generateRequest(unusedBaseUrl, unusedSegment, unusedWithPayload) {}
+
+  /**
+   * @param {string} unusedBaseUrl
+   * @param {!Array<!BatchSegmentDef>} unusedSegments
+   * @param {boolean} unusedWithPayload
+   * @return {!RequestDef}
+   */
+  generateBatchRequest(unusedBaseUrl, unusedSegments, unusedWithPayload) {}
+}
+
+/**
+ * The default serializer. All new serializer should consider
+ * extend this.
+ *
+ * @implements {TransportSerializerDef}
+ */
+class DefaultTransportSerializer {
+
+  /** @override */
+  generateRequest(baseUrl, segment, withPayload = false) {
+    if (withPayload) {
+      return {
+        url: baseUrl.replace(EXTRA_URL_PARAM_VAR, ''),
+        payload: JSON.stringify(segment.extraUrlParams),
+      };
+    } else {
+      return {
+        url: defaultSerializer(baseUrl, [segment]),
+      };
+    }
+  }
+
+  /** @override */
+  generateBatchRequest(baseUrl, segments, withPayload = false) {
+    if (withPayload) {
+      return {
+        url: baseUrl.replace(EXTRA_URL_PARAM_VAR, ''),
+        payload: JSON.stringify(
+            segments.map(segment => segment.extraUrlParams)),
+      };
+    } else {
+      return {
+        url: defaultSerializer(baseUrl, segments),
+      };
+    }
+  }
+}
+
+/**
+ * Please register your serializer below.
  * Please keep the object in alphabetic order.
- * Note: extraUrlParams passed in are not encoded. Please make sure to proper
- * encode segments and make sure the final output url is valid.
+ *
+ * @const {Object<string, DefaultTransportSerializer>}
  */
 export const TransportSerializers = {
-  'default': defaultSerializer,
+  'default': new DefaultTransportSerializer(),
 };
-
-
-/**
- * Please add your batch plugin function below in alphabetic order. All batch
- * plugin function should accept input of a string, an array of batchSegment
- * Then return a string. Note: extraUrlParams passed in are not encoded. Please
- * make sure to proper encode segments and make sure the final output url is
- * valid.
- */
-
-// Below is a function prototype for easy copy
-// /**
-//  * @param {string} baseUrl
-//  * @param {Array<!batchSegmentDef>} batchSegments
-//  * @return {string}
-//  */
-// function ping(baseUrl, batchSegments) {}
 
 /**
  * The default way for merging batch segments
  *
  * @param {string} baseUrl
- * @param {!Array<!batchSegmentDef>} batchSegments
+ * @param {!Array<!BatchSegmentDef>} batchSegments
  * @return {string}
  */
 export function defaultSerializer(baseUrl, batchSegments) {
@@ -67,8 +121,8 @@ export function defaultSerializer(baseUrl, batchSegments) {
       .filter(queryString => !!queryString)
       .join('&');
   let requestUrl;
-  if (baseUrl.indexOf('${extraUrlParams}') >= 0) {
-    requestUrl = baseUrl.replace('${extraUrlParams}', extraUrlParamsStr);
+  if (baseUrl.indexOf(EXTRA_URL_PARAM_VAR) >= 0) {
+    requestUrl = baseUrl.replace(EXTRA_URL_PARAM_VAR, extraUrlParamsStr);
   } else {
     requestUrl = appendEncodedParamStringToUrl(baseUrl, extraUrlParamsStr);
   }

--- a/extensions/amp-analytics/0.1/transport-serializer.js
+++ b/extensions/amp-analytics/0.1/transport-serializer.js
@@ -32,13 +32,14 @@ export let BatchSegmentDef;
 
 /**
  * @typedef {{
- *   url: (string),
+ *   url: string,
  *   payload: (string|undefined),
  * }}
  */
 export let RequestDef;
 
 /**
+ * The interface for all TransportSerializer to implement.
  * @interface
  */
 export class TransportSerializerDef {
@@ -61,8 +62,7 @@ export class TransportSerializerDef {
 }
 
 /**
- * The default serializer. All new serializer should consider
- * extend this.
+ * The default serializer.
  *
  * @implements {TransportSerializerDef}
  */
@@ -75,11 +75,10 @@ class DefaultTransportSerializer {
         url: baseUrl.replace(EXTRA_URL_PARAM_VAR, ''),
         payload: JSON.stringify(segment.extraUrlParams),
       };
-    } else {
-      return {
-        url: defaultSerializer(baseUrl, [segment]),
-      };
     }
+    return {
+      url: defaultSerializer(baseUrl, [segment]),
+    };
   }
 
   /** @override */
@@ -90,11 +89,10 @@ class DefaultTransportSerializer {
         payload: JSON.stringify(
             segments.map(segment => segment.extraUrlParams)),
       };
-    } else {
-      return {
-        url: defaultSerializer(baseUrl, segments),
-      };
     }
+    return {
+      url: defaultSerializer(baseUrl, segments),
+    };
   }
 }
 
@@ -102,7 +100,7 @@ class DefaultTransportSerializer {
  * Please register your serializer below.
  * Please keep the object in alphabetic order.
  *
- * @const {Object<string, DefaultTransportSerializer>}
+ * @const {Object<string, TransportSerializerDef>}
  */
 export const TransportSerializers = {
   'default': new DefaultTransportSerializer(),

--- a/src/pixel.js
+++ b/src/pixel.js
@@ -30,7 +30,7 @@ const TAG = 'pixel';
  */
 export function createPixel(win, src, referrerPolicy) {
   if (referrerPolicy && referrerPolicy !== 'no-referrer') {
-    user().error(TAG, 'Unsupported referrerPolicy: ' + referrerPolicy);
+    user().error(TAG, 'Unsupported referrerPolicy: %s', referrerPolicy);
   }
 
   return referrerPolicy === 'no-referrer'

--- a/src/pixel.js
+++ b/src/pixel.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {WindowInterface} from '../src/window-interface';
 import {createElementWithAttributes} from '../src/dom';
 import {dict} from '../src/utils/object';
 import {user} from '../src/log';
@@ -66,7 +67,8 @@ function createNoReferrerPixel(win, src) {
  * @return {!Image}
  */
 function createImagePixel(win, src, noReferrer = false) {
-  const image = new win.Image();
+  const Image = WindowInterface.getImage(win);
+  const image = new Image();
   if (noReferrer) {
     image.referrerPolicy = 'no-referrer';
   }

--- a/src/window-interface.js
+++ b/src/window-interface.js
@@ -65,4 +65,31 @@ export class WindowInterface {
   static getUserLanguage(win) {
     return win.navigator.userLanguage || win.navigator.language;
   }
+
+  /**
+   * @static
+   * @param {!Window} win
+   * @return {!Function}
+   */
+  static getSendBeacon(win) {
+    return win.navigator.sendBeacon;
+  }
+
+  /**
+   * @static
+   * @param {!Window} win
+   * @return {!XMLHttpRequest}
+   */
+  static getXMLHttpRequest(win) {
+    return win.XMLHttpRequest;
+  }
+
+  /**
+   * @static
+   * @param {!Window} win
+   * @return {!Image}
+   */
+  static getImage(win) {
+    return win.Image;
+  }
 }

--- a/src/window-interface.js
+++ b/src/window-interface.js
@@ -69,7 +69,7 @@ export class WindowInterface {
   /**
    * @static
    * @param {!Window} win
-   * @return {!Function}
+   * @return {function(string,(ArrayBufferView|Blob|FormData|null|string)=):boolean}
    */
   static getSendBeacon(win) {
     return win.navigator.sendBeacon;
@@ -78,7 +78,7 @@ export class WindowInterface {
   /**
    * @static
    * @param {!Window} win
-   * @return {!XMLHttpRequest}
+   * @return {function(new:XMLHttpRequest)}
    */
   static getXMLHttpRequest(win) {
     return win.XMLHttpRequest;
@@ -87,7 +87,7 @@ export class WindowInterface {
   /**
    * @static
    * @param {!Window} win
-   * @return {!Image}
+   * @return {function(new:Image)}
    */
   static getImage(win) {
     return win.Image;

--- a/src/window-interface.js
+++ b/src/window-interface.js
@@ -69,10 +69,13 @@ export class WindowInterface {
   /**
    * @static
    * @param {!Window} win
-   * @return {function(string,(ArrayBufferView|Blob|FormData|null|string)=):boolean}
+   * @return {function(string,(ArrayBufferView|Blob|FormData|null|string)=):boolean|undefined}
    */
   static getSendBeacon(win) {
-    return win.navigator.sendBeacon;
+    if (!win.navigator.sendBeacon) {
+      return undefined;
+    }
+    return win.navigator.sendBeacon.bind(win.navigator);
   }
 
   /**

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -204,4 +204,11 @@ export class ImagePixelVerifier {
     const pixel = this.imagePixels_.shift();
     expect(pixel.src).to.match(regex);
   }
+
+  getLastRequestUrl() {
+    if (!this.hasRequestSent()) {
+      return null;
+    }
+    return this.imagePixels_[this.imagePixels_.length - 1].src;
+  }
 }

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -178,3 +178,30 @@ export function createPointerEvent(type, x, y) {
   }];
   return event;
 }
+
+export class ImagePixelVerifier {
+  constructor(windowInterface) {
+    this.imagePixels_ = [];
+    const FakeImage = () => {
+      const pixel = {};
+      this.imagePixels_.push(pixel);
+      return pixel;
+    };
+    windowInterface.getImage.returns(FakeImage);
+  }
+
+  hasRequestSent() {
+    return this.imagePixels_.length > 0;
+  }
+
+  verifyRequest(url, referrerPolicy) {
+    const pixel = this.imagePixels_.shift();
+    expect(pixel.src).to.equal(url);
+    expect(pixel.referrerPolicy).to.equal(referrerPolicy);
+  }
+
+  verifyRequestMatch(regex) {
+    const pixel = this.imagePixels_.shift();
+    expect(pixel.src).to.match(regex);
+  }
+}


### PR DESCRIPTION
Introduces new `useBody` config in amp-analytics transport:

```
transport: {
  xhrpost: true,
  useBody: true
}
```

when `useBody` set to true, if `beacon` or `xhrpost` is in use, the `extraUrlParams` are sent as POST body payload instead of appended as URL params.

see test cases for detailed behaviors

Closes #6031