### PR TITLE
🐛 Fix AMP cache viewer removing document element classes on iOS

### DIFF
--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -50,7 +50,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     const doc = this.win.document;
     const {documentElement} = doc;
     const topClasses = documentElement.className;
-    documentElement.className = 'i-amphtml-ios-embed';
+    documentElement.classList.add('i-amphtml-ios-embed');
 
     const wrapper = doc.createElement('html');
     /** @private @const {!Element} */

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -282,7 +282,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     expect(child.textContent).to.equal('test');
 
     // Top-level classes moved to the wrapper element.
-    expect(win.document.documentElement).to.not.have.class('top');
+    expect(win.document.documentElement).to.have.class('top');
     expect(binding.wrapper_).to.have.class('top');
   });
 


### PR DESCRIPTION
* Adds extra document element classes on iOS viewport binding instead of overwriting the existing ones.
* Adjusts a related test.

Fixes #19105 