### PR TITLE
Render the bookend in its own <amp-story-bookend> tag.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -325,12 +325,12 @@
   white-space: nowrap !important;
 }
 
-.i-amphtml-story-share-widget {
+.i-amphtml-story-bookend  .i-amphtml-story-share-widget {
   margin-left: 0 !important;
   margin-right: 0 !important;
 }
 
-.i-amphtml-story-share-list {
+.i-amphtml-story-bookend  .i-amphtml-story-share-list {
   padding-left: 16px !important;
   padding-right: 16px !important;
 }

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -41,6 +41,7 @@ import {getJsonLd} from '../jsonld';
 import {getRequestService} from '../amp-story-request-service';
 import {isArray} from '../../../../src/types';
 import {renderAsElement} from '../simple-template';
+import {toggle} from '../../../../src/style';
 
 
 /** @private @const {string} */
@@ -92,7 +93,7 @@ const REPLAY_ICON_TEMPLATE = {
 };
 
 /** @type {string} */
-const TAG = 'amp-story';
+const TAG = 'amp-story-bookend';
 
 /**
  * @param {string} title
@@ -192,12 +193,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
     this.replayButton_ = null;
 
     /**
-     * Root element containing a shadow DOM root.
-     * @private {?Element}
-     */
-    this.root_ = null;
-
-    /**
      * Actual bookend.
      * @private {?Element}
      */
@@ -222,10 +217,9 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
     this.isBuilt_ = true;
 
-    this.root_ = this.win.document.createElement('div');
     this.bookendEl_ = renderAsElement(this.win.document, ROOT_TEMPLATE);
 
-    createShadowRootWithStyle(this.root_, this.bookendEl_, CSS);
+    createShadowRootWithStyle(this.element, this.bookendEl_, CSS);
 
     this.replayButton_ = this.buildReplayButton_();
 
@@ -249,9 +243,9 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
     this.initializeListeners_();
 
-    this.mutateElement(() => {
-      this.element.parentElement.appendChild(this.getRoot());
-    });
+    // Removes the [hidden] attribute the runtime sets because of the
+    // [layout="nodisplay"].
+    toggle(this.element, true);
   }
 
   /**
@@ -305,7 +299,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
    */
   onReplayButtonClick_(event) {
     event.stopPropagation();
-    dispatch(this.win, this.getRoot(), EventType.REPLAY,
+    dispatch(this.win, this.element, EventType.REPLAY,
     /* payload */ undefined, {bubbles: true});
   }
 
@@ -529,12 +523,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
           user().error(TAG, 'Unable to fetch localization service.', e.message);
           return null;
         });
-  }
-
-  /** @return {!Element} */
-  getRoot() {
-    this.assertBuilt_();
-    return dev().assertElement(this.root_);
   }
 
   /** @return {!Element} */


### PR DESCRIPTION
Render the bookend in its own `<amp-story-bookend>` tag.

Fixes #17658