### PR TITLE
typo in amp-subscriptions.md

### DIFF
--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -309,7 +309,7 @@ The premium content is marked up using `subscriptions-section="content"` attribu
 </section>
 ```
 
-*Important*: Do not apply `subscriptions-section="content"` to the whole page. Doing so may cause a visible flash when content is later displayed, and may prevent your page from being indexed by search engines. We recommend that the content is the first viewport be allowed to render regardless of subscription state.
+*Important*: Do not apply `subscriptions-section="content"` to the whole page. Doing so may cause a visible flash when content is later displayed, and may prevent your page from being indexed by search engines. We recommend that the content in the first viewport be allowed to render regardless of subscription state.
 
 The fallback content is marked up using `subscriptions-section="content-not-granted"` attribute. For instance:
 


### PR DESCRIPTION
is -> in


