### PR TITLE
Allow decoding on img tag.

### DIFF
--- a/validator/testdata/feature_tests/noscript.html
+++ b/validator/testdata/feature_tests/noscript.html
@@ -32,7 +32,7 @@
     <audio controls>
       <source src="https://example.com/howl-of-the-lemur.mp3" type="audio/mpeg">
     </audio>
-    <img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80">
+    <img alt="Iconic Lemurs" decoding="auto" height="200" src="https://example.com/lemurs.png" width="80">
     <video controls height="480" width="640">
       <source src="https://example.com/island-of-lemurs.mp4" type="video/mp4">
     </video>

--- a/validator/testdata/feature_tests/noscript.out
+++ b/validator/testdata/feature_tests/noscript.out
@@ -33,7 +33,7 @@ FAIL
 |      <audio controls>
 |        <source src="https://example.com/howl-of-the-lemur.mp3" type="audio/mpeg">
 |      </audio>
-|      <img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80">
+|      <img alt="Iconic Lemurs" decoding="auto" height="200" src="https://example.com/lemurs.png" width="80">
 |      <video controls height="480" width="640">
 |        <source src="https://example.com/island-of-lemurs.mp4" type="video/mp4">
 |      </video>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1976,6 +1976,12 @@ tags: {
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-img"
   attrs: { name: "alt" }
   attrs: { name: "border" }  # Not valid html5 but commonly used and supported.
+  attrs: {
+    name: "decoding"
+    value: "async"
+    value: "auto"
+    value: "sync"
+  }
   attrs: { name: "height" }  # Not valid html5 but commonly used and supported.
   attrs: { name: "ismap" }
   attrs: {


### PR DESCRIPTION
Fixes #19121 by allowing `decoding` with values of `async`, `auto` or `sync` on `img`  tags that have `noscript` as an ancestor.