### PR TITLE
✨ Allow SVG 'focusable' attribute from SVG Tiny 1.2

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2456,6 +2456,7 @@ attr_lists: {
   attrs: { name: "filter" }
   attrs: { name: "flood-color" }
   attrs: { name: "flood-opacity" }
+  attrs: { name: "focusable" }
   attrs: { name: "font-family" }
   attrs: { name: "font-size" }
   attrs: { name: "font-size-adjust" }


### PR DESCRIPTION
In working on adding AMP compatibility to the next default WordPress theme Twenty Nineteen (https://github.com/Automattic/amp-wp/pull/1587), I found that it was [outputting](https://github.com/WordPress/twentynineteen/blob/4973d28fd0cea626ed3ca7c7c6d56229ca9612a7/classes/class-twentynineteen-svg-icons.php#L36) a `focusable` attribute in an `svg` element like so:

```xml
<svg class="svg-icon" width="24" height="24" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
    <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"></path>
    <path fill="none" d="M0 0h24v24H0V0z"></path>
</svg>
```

The `focusable` attribute is defined in SVG Tiny 1.2: https://www.w3.org/TR/SVGTiny12/interact.html#focusable-attr

Fixes https://github.com/ampproject/amphtml/issues/19107

/cc @Gregable 