### PR TITLE
✨ Remove minimum-scale from required meta viewport properties

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -102,7 +102,7 @@ AMP HTML documents MUST
 - <a name="crps"></a>contain `<head>` and `<body>` tags (They are optional in HTML). [🔗](#crps)
 - <a name="canon"></a>contain a `<link rel="canonical" href="$SOME_URL">` tag inside their head that points to the regular HTML version of the AMP HTML document or to itself if no such HTML version exists. [🔗](#canon)
 - <a name="chrs"></a>contain a `<meta charset="utf-8">` tag as the first child of their head tag. [🔗](#chrs)
-- <a name="vprt"></a>contain a `<meta name="viewport" content="width=device-width,minimum-scale=1">` tag inside their head tag. It's also recommended to include `initial-scale=1`. [🔗](#vprt)
+- <a name="vprt"></a>contain a `<meta name="viewport" content="width=device-width">` tag inside their head tag. It's also recommended to include `minimum-scale=1` and `initial-scale=1`. [🔗](#vprt)
 - <a name="scrpt"></a>contain a `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag inside their head tag. [🔗](#scrpt)
 - <a name="boilerplate"></a>contain the [AMP boilerplate code](amp-boilerplate.md) (`head > style[amp-boilerplate]` and `noscript > style[amp-boilerplate]`) in their head tag. [🔗](#boilerplate)
 

--- a/validator/testdata/feature_tests/bad_viewport.html
+++ b/validator/testdata/feature_tests/bad_viewport.html
@@ -22,7 +22,7 @@
     Test Description:
     Tests what happens when bad viewport properties are specified.
   -->
-  <meta name="viewport" content="minimum-scale=not-a-number,foo=bar">
+  <meta name="viewport" content="foo=bar">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/validator/testdata/feature_tests/bad_viewport.out
+++ b/validator/testdata/feature_tests/bad_viewport.out
@@ -23,11 +23,9 @@ FAIL
 |      Test Description:
 |      Tests what happens when bad viewport properties are specified.
 |    -->
-|    <meta name="viewport" content="minimum-scale=not-a-number,foo=bar">
+|    <meta name="viewport" content="foo=bar">
 >>   ^~~~~~~~~
 feature_tests/bad_viewport.html:25:2 The property 'foo' in attribute 'content' in tag 'meta name=viewport' is disallowed. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>   ^~~~~~~~~
-feature_tests/bad_viewport.html:25:2 The property 'minimum-scale' in attribute 'content' in tag 'meta name=viewport' is set to 'not-a-number', which is invalid. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 >>   ^~~~~~~~~
 feature_tests/bad_viewport.html:25:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/validator/testdata/feature_tests/link_meta_values.out
+++ b/validator/testdata/feature_tests/link_meta_values.out
@@ -41,8 +41,6 @@ feature_tests/link_meta_values.html:30:2 The attribute 'rel' in tag 'link rel=' 
 feature_tests/link_meta_values.html:36:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
 |    <meta name=viewport content=invalid>
 >>   ^~~~~~~~~
-feature_tests/link_meta_values.html:37:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>   ^~~~~~~~~
 feature_tests/link_meta_values.html:37:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    <link rel="unknown" href="foo">
 |

--- a/validator/testdata/feature_tests/minimum_valid_amp.html
+++ b/validator/testdata/feature_tests/minimum_valid_amp.html
@@ -23,7 +23,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">
-  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <meta name="viewport" content="width=device-width">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/validator/testdata/feature_tests/minimum_valid_amp.out
+++ b/validator/testdata/feature_tests/minimum_valid_amp.out
@@ -24,7 +24,7 @@ PASS
 |  <head>
 |    <meta charset="utf-8">
 |    <link rel="canonical" href="./regular-html-version.html">
-|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <meta name="viewport" content="width=device-width">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -386,7 +386,7 @@ tags: {
       properties: { name: "width" mandatory: true value: "device-width" }
       properties: { name: "height" }
       properties: { name: "initial-scale" }
-      properties: { name: "minimum-scale" mandatory: true value_double: 1.0 }
+      properties: { name: "minimum-scale" }
       properties: { name: "maximum-scale" }
       properties: { name: "shrink-to-fit" }
       properties: { name: "user-scalable" }


### PR DESCRIPTION
Fixes #18896.

* Update `validator/validator-main.protoascii` to remove mandatory value for the `minimum-scale` property of the meta viewport.
* Update `spec/amp-html-format.md` to similarly remove `minimum-scale` from being required, but leave it as recommended.
* Update `validator/testdata/feature_tests/minimum_valid_amp.html` to remove `minimum-scale`.