### PR TITLE
🐛Expander: Don't double encode nested macros

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -62,7 +62,7 @@ export class Expander {
     this.whiteList_ = opt_whiteList;
 
     /**@const {boolean|undefined} */
-    this.noEncode_ = opt_noEncode;
+    this.encode_ = !opt_noEncode;
   }
 
 
@@ -237,7 +237,7 @@ export class Expander {
           });
     };
 
-    return evaluateNextLevel(/* encode */ !this.noEncode_);
+    return evaluateNextLevel(this.encode_);
   }
 
 

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -151,7 +151,7 @@ describes.realWin('Expander', {
       ASYNCFN: arg => Promise.resolve(arg),
       BROKEN: () => undefined,
       ANCESTOR_ORIGIN: () => Promise.resolve('https://www.google.com@foo'),
-      TITLE: 'hello world',
+      TITLE: 'hello world ',
     };
 
     const sharedTestCases = [
@@ -242,7 +242,7 @@ describes.realWin('Expander', {
       },
       {
         description: 'should not double encode nested macros',
-        input: 'title=TRIM(TITLE )',
+        input: 'title=TRIM(TITLE)',
         output: 'title=hello%20world',
       },
     ];

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -151,6 +151,7 @@ describes.realWin('Expander', {
       ASYNCFN: arg => Promise.resolve(arg),
       BROKEN: () => undefined,
       ANCESTOR_ORIGIN: () => Promise.resolve('https://www.google.com@foo'),
+      TITLE: 'hello world',
     };
 
     const sharedTestCases = [
@@ -238,6 +239,11 @@ describes.realWin('Expander', {
         description: 'passes undefined for omitted args',
         input: 'CONCAT(foo)',
         output: 'foo-undefined',
+      },
+      {
+        description: 'should not double encode nested macros',
+        input: 'title=TRIM(TITLE)',
+        output: 'title=hello%20world',
       },
     ];
 

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -242,7 +242,7 @@ describes.realWin('Expander', {
       },
       {
         description: 'should not double encode nested macros',
-        input: 'title=TRIM(TITLE)',
+        input: 'title=TRIM(TITLE )',
         output: 'title=hello%20world',
       },
     ];


### PR DESCRIPTION
Expander was encoding at every level of macro resolution. This changes it so that we only encode at the top level.