### PR TITLE
✨ amp-subscriptions: Add logging to analytics events

### DIFF
--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -18,6 +18,8 @@ import {dict} from '../../../src/utils/object';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 import {user} from '../../../src/log';
 
+const TAG = 'amp-subscriptions';
+
 /**
  * subscriptions-platform-* event names are deprecated in favor
  * of subscription-service-*  The DEPRECATED events are still triggered
@@ -66,7 +68,7 @@ export class SubscriptionAnalytics {
    * @param {!JsonObject=} opt_vars
    */
   event(eventType, opt_vars) {
-    user().info('Subscriptions', eventType, opt_vars || '');
+    user().info(TAG, eventType, opt_vars || '');
     triggerAnalyticsEvent(this.element_, eventType, opt_vars || dict({}));
   }
 }

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -16,6 +16,7 @@
 
 import {dict} from '../../../src/utils/object';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
+import {user} from '../../../src/log';
 
 /**
  * subscriptions-platform-* event names are deprecated in favor
@@ -65,6 +66,7 @@ export class SubscriptionAnalytics {
    * @param {!JsonObject=} opt_vars
    */
   event(eventType, opt_vars) {
+    user().info('Subscriptions', eventType, opt_vars || '');
     triggerAnalyticsEvent(this.element_, eventType, opt_vars || dict({}));
   }
 }


### PR DESCRIPTION


Adds a `user().info()` log message to all `amp-subscriptions` analytics events.  The resulting console messages are visible when the `#log=3` flag is appended to the amp url. 

Example:

`[Subscriptions] subscriptions-action-delegated {action: "subscribe", serviceId: "subscribe.google.com"}` 
