### PR TITLE
Fix placeholder to display none in resizable children

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -664,6 +664,7 @@ export class AmpList extends AMP.BaseElement {
     if (overflowElement) {
       toggle(overflowElement, false);
     }
+    this.element.classList.add('i-amphtml-layout-container');
     this.element.setAttribute('layout', 'container');
   }
 

--- a/test/manual/amp-list-with-ads.amp.html
+++ b/test/manual/amp-list-with-ads.amp.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      font-family: 'Questrial', Arial;
+    }
+    article {
+      display: block;
+      margin: 8px;
+    }
+
+    amp-list {
+      border: 1px solid green;
+    }
+
+    [overflow] {
+      background: gray;
+      color: #fff;
+      cursor: pointer;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 2;
+      padding: 16px;
+    }
+
+    .story-entry {
+      padding: 40px;
+      border-bottom: 1px solid green;
+    }
+
+    .split {
+      height: 360px;
+    }
+
+    .list {
+      height: 120px;
+    }
+
+    .grid {
+      height: 40px;
+    }
+
+    .tall {
+      height: 50vh;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+
+    <amp-state id="listStyle">
+      <script type="application/json">
+        "list"
+      </script>
+    </amp-state>
+<article>
+  <h1>AMP List Resize Manual Test</h1>
+
+  <h2>AMP List Basic with Ads</h2>
+  <amp-list width="396" height="80" layout="responsive" resizable-children reset-on-refresh
+      src="/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      <div class="story-entry">
+        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
+        {{title}}
+        <amp-layout id='layout-container'>
+          <div>Advertisment</div>
+          <amp-ad width=300 height=250
+              type="_ping_"
+              data-url='not-exist'
+              data-valid='false'
+              data-ad-container-id='layout-container'
+              data-enable-io='true'>
+          </amp-ad>
+        </amp-layout>
+      </div>
+    </template>
+    <div overflow>
+      SEE MORE
+    </div>
+    <div placeholder>
+      <div class="tall">PLACEHOLDER</div>
+    </div>
+  </amp-list>
+
+</article>
+</body>
+</html>


### PR DESCRIPTION
Add the layout container to the CSS class, otherwise within `resizable-children`, the placeholder will still take up space. Made an additional example to test the amp-list with collapsing ads use case, and added it as well (but it doesn't have to go in this PR). 