### PR TITLE
Add changeToLayoutContainer action and is-layout-container attribute to amp-list for resizing

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -279,8 +279,8 @@ export class Bind {
         case 'pushState':
           return this.pushStateWithExpression(expression, scope);
         default:
-          return Promise.reject(dev().createError('Unrecognized method: ' +
-              `"${tagOrTarget}.${method}"`));
+          return Promise.reject(dev().createError('Unrecognized method: %s.%s',
+              tagOrTarget, method));
       }
     } else {
       user().error('AMP-BIND', 'Please use the object-literal syntax, '
@@ -578,8 +578,8 @@ export class Bind {
   /** Emits console error stating that the binding limit was exceeded. */
   emitMaxBindingsExceededError_() {
     dev().expectedError(TAG, 'Maximum number of bindings reached ' +
-        `(${this.maxNumberOfBindings_}). Additional elements with ` +
-        'bindings will be ignored.');
+        '(%s). Additional elements with bindings will be ignored.',
+    this.maxNumberOfBindings_);
   }
 
   /**
@@ -796,7 +796,7 @@ export class Bind {
         return {property, expressionString: attribute.value};
       } else {
         const err = user().createError(
-            `${TAG}: Binding to [${property}] on <${tag}> is not allowed.`);
+            '%s: Binding to [%s] on <%s> is not allowed.', TAG, property, tag);
         this.reportError_(err, element);
       }
     }
@@ -841,8 +841,8 @@ export class Bind {
         if (elements.length > 0) {
           const evalError = errors[expressionString];
           const userError = user().createError(
-              `${TAG}: Expression evaluation error in "${expressionString}". `
-              + evalError.message);
+              '%s: Expression evaluation error in "%s". %s', TAG,
+              expressionString, evalError.message);
           userError.stack = evalError.stack;
           this.reportError_(userError, elements[0]);
         }
@@ -1032,8 +1032,8 @@ export class Bind {
         try {
           element.mutatedAttributesCallback(mutations);
         } catch (e) {
-          const error = user().createError(`${TAG}: Applying expression ` +
-              `results (${JSON.stringify(mutations)}) failed with error`, e);
+          const error = user().createError('%s: Applying expression results' +
+              ' (%s) failed with error,', TAG, JSON.stringify(mutations), e);
           this.reportError_(error, element);
         }
       }
@@ -1083,7 +1083,7 @@ export class Bind {
           element.setAttribute('class', ampClasses.join(' '));
         } else {
           const err = user().createError(
-              `${TAG}: "${newValue}" is not a valid result for [class].`);
+              '%s: "%s" is not a valid result for [class].', TAG, newValue);
           this.reportError_(err, element);
         }
         break;
@@ -1144,8 +1144,8 @@ export class Bind {
           updateProperty);
       return true;
     } catch (e) {
-      const error = user().createError(`${TAG}: "${value}" is not a ` +
-          `valid result for [${attrName}]`, e);
+      const error = user().createError('%s: "%s" is not a ' +
+          'valid result for [%]', TAG, value, attrName, e);
       this.reportError_(error, element);
     }
     return false;
@@ -1202,7 +1202,8 @@ export class Bind {
           }
         } else {
           const err = user().createError(
-              `${TAG}: "${expectedValue}" is not a valid result for [class].`);
+              '%s: "%s" is not a valid result for [class].',
+              TAG, expectedValue);
           this.reportError_(err, element);
         }
         match = this.compareStringArrays_(initialValue, classes);
@@ -1281,7 +1282,7 @@ export class Bind {
    * @private
    */
   reportWorkerError_(e, message, opt_element) {
-    const userError = user().createError(message + ' ' + e.message);
+    const userError = user().createError('%s %s', message, e.message);
     userError.stack = e.stack;
     this.reportError_(userError, opt_element);
     return userError;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -72,7 +72,7 @@ let BoundElementDef;
  */
 const BIND_ONLY_ATTRIBUTES = map({
   'AMP-CAROUSEL': ['slide'],
-  'AMP-LIST': ['state', 'is-container'],
+  'AMP-LIST': ['state', 'is-layout-container'],
   'AMP-SELECTOR': ['selected'],
 });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -72,7 +72,7 @@ let BoundElementDef;
  */
 const BIND_ONLY_ATTRIBUTES = map({
   'AMP-CAROUSEL': ['slide'],
-  'AMP-LIST': ['state', 'isContainer'],
+  'AMP-LIST': ['state', 'is-container'],
   'AMP-SELECTOR': ['selected'],
 });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -72,7 +72,7 @@ let BoundElementDef;
  */
 const BIND_ONLY_ATTRIBUTES = map({
   'AMP-CAROUSEL': ['slide'],
-  'AMP-LIST': ['state'],
+  'AMP-LIST': ['state', 'isContainer'],
   'AMP-SELECTOR': ['selected'],
 });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -72,6 +72,7 @@ let BoundElementDef;
  */
 const BIND_ONLY_ATTRIBUTES = map({
   'AMP-CAROUSEL': ['slide'],
+  // TODO (#18875): add is-layout-container to validator file for amp-list
   'AMP-LIST': ['state', 'is-layout-container'],
   'AMP-SELECTOR': ['selected'],
 });

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -257,7 +257,7 @@ function createElementRules_() {
         },
       },
       'state': null,
-      'is-container': null,
+      'is-layout-container': null,
     },
     'AMP-SELECTOR': {
       'disabled': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -257,6 +257,7 @@ function createElementRules_() {
         },
       },
       'state': null,
+      'isContainer': null,
     },
     'AMP-SELECTOR': {
       'disabled': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -257,7 +257,7 @@ function createElementRules_() {
         },
       },
       'state': null,
-      'isContainer': null,
+      'is-container': null,
     },
     'AMP-SELECTOR': {
       'disabled': null,

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -205,7 +205,7 @@ describe('BindValidator', () => {
     it('should support <amp-list>', () => {
       expect(val.canBind('AMP-LIST', 'src')).to.be.true;
       expect(val.canBind('AMP-LIST', 'state')).to.be.true;
-      expect(val.canBind('AMP-LIST', 'isContainer')).to.be.true;
+      expect(val.canBind('AMP-LIST', 'is-container')).to.be.true;
     });
 
     it('should support <amp-selector>', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -205,6 +205,7 @@ describe('BindValidator', () => {
     it('should support <amp-list>', () => {
       expect(val.canBind('AMP-LIST', 'src')).to.be.true;
       expect(val.canBind('AMP-LIST', 'state')).to.be.true;
+      expect(val.canBind('AMP-LIST', 'isContainer')).to.be.true;
     });
 
     it('should support <amp-selector>', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -205,7 +205,7 @@ describe('BindValidator', () => {
     it('should support <amp-list>', () => {
       expect(val.canBind('AMP-LIST', 'src')).to.be.true;
       expect(val.canBind('AMP-LIST', 'state')).to.be.true;
-      expect(val.canBind('AMP-LIST', 'is-container')).to.be.true;
+      expect(val.canBind('AMP-LIST', 'is-layout-container')).to.be.true;
     });
 
     it('should support <amp-selector>', () => {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -231,6 +231,7 @@ export class AmpList extends AMP.BaseElement {
     let promise;
     const src = mutations['src'];
     const state = /** @type {!JsonObject} */ (mutations)['state'];
+    const isContainer = mutations['isContainer'];
     if (src !== undefined) {
       if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
@@ -252,6 +253,9 @@ export class AmpList extends AMP.BaseElement {
       this.resetIfNecessary_(/* isFetch */ false);
       const data = isArray(state) ? state : [state];
       promise = this.scheduleRender_(data, /*append*/ false);
+    }
+    if (isContainer) {
+      this.changeToLayoutContainer_();
     }
     // Only return the promise for easier testing.
     if (getMode().test) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -17,7 +17,6 @@
 import * as setDOM from 'set-dom/src/index';
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
-import {CommonSignals} from '../../../src/common-signals';
 import {Deferred} from '../../../src/utils/promise';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Pass} from '../../../src/pass';

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -221,7 +221,7 @@ export class AmpList extends AMP.BaseElement {
     let promise;
     const src = mutations['src'];
     const state = /** @type {!JsonObject} */ (mutations)['state'];
-    const isContainer = mutations['is-layout-container'];
+    const isLayoutContainer = mutations['is-layout-container'];
     if (src !== undefined) {
       if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
@@ -244,7 +244,7 @@ export class AmpList extends AMP.BaseElement {
       const data = isArray(state) ? state : [state];
       promise = this.scheduleRender_(data, /*append*/ false);
     }
-    if (isContainer) {
+    if (isLayoutContainer) {
       this.changeToLayoutContainer_();
     }
     // Only return the promise for easier testing.

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -130,10 +130,11 @@ export class AmpList extends AMP.BaseElement {
       }
     }, ActionTrust.HIGH);
 
-    this.registerAction('containerize',
-        () => this.changeToLayoutContainer_(),
-        ActionTrust.HIGH);
-
+    if (isExperimentOn(this.win, 'amp-list-resizable-children')) {
+      this.registerAction('containerize',
+          () => this.changeToLayoutContainer_(),
+          ActionTrust.HIGH);
+    }
 
     /** @private {?../../../src/ssr-template-helper.SsrTemplateHelper} */
     this.ssrTemplateHelper_ = null;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -61,6 +61,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
   constructor(element) {
+
     super(element);
 
     /** @private {?Element} */
@@ -131,7 +132,7 @@ export class AmpList extends AMP.BaseElement {
     }, ActionTrust.HIGH);
 
     if (isExperimentOn(this.win, 'amp-list-resizable-children')) {
-      this.registerAction('containerize',
+      this.registerAction('changeToLayoutContainer',
           () => this.changeToLayoutContainer_(),
           ActionTrust.HIGH);
     }
@@ -220,7 +221,7 @@ export class AmpList extends AMP.BaseElement {
     let promise;
     const src = mutations['src'];
     const state = /** @type {!JsonObject} */ (mutations)['state'];
-    const isContainer = mutations['is-container'];
+    const isContainer = mutations['is-layout-container'];
     if (src !== undefined) {
       if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
@@ -631,6 +632,7 @@ export class AmpList extends AMP.BaseElement {
   /**
    * Converts the amp-list to de facto layout container. Called in mutate
    * context.
+   * @return {!Promise}
    * @private
    */
   changeToLayoutContainer_() {
@@ -644,7 +646,7 @@ export class AmpList extends AMP.BaseElement {
       return;
     }
 
-    this.mutateElement(() => {
+    return this.mutateElement(() => {
       this.undoPreviousLayout_(previousLayout);
       this.container_.classList.remove(
           'i-amphtml-fill-content',

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -629,8 +629,8 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * Converts the amp-list to de facto layout container. Must be called in
-   * mutation context.
+   * Converts the amp-list to de facto layout container. Called in mutate
+   * context.
    * @private
    */
   changeToLayoutContainer_() {
@@ -643,20 +643,23 @@ export class AmpList extends AMP.BaseElement {
     if (previousLayout == Layout.CONTAINER) {
       return;
     }
-    this.undoPreviousLayout_(previousLayout);
-    this.container_.classList.remove(
-        'i-amphtml-fill-content',
-        'i-amphtml-replaced-content'
-    );
-    // The overflow element is generally hidden with visibility hidden,
-    // but after changing to layout container, this causes an undesirable
-    // empty white space so we hide it with display none instead.
-    const overflowElement = this.getOverflowElement();
-    if (overflowElement) {
-      toggle(overflowElement, false);
-    }
-    this.element.classList.add('i-amphtml-layout-container');
-    this.element.setAttribute('layout', 'container');
+
+    this.mutateElement(() => {
+      this.undoPreviousLayout_(previousLayout);
+      this.container_.classList.remove(
+          'i-amphtml-fill-content',
+          'i-amphtml-replaced-content'
+      );
+      // The overflow element is generally hidden with visibility hidden,
+      // but after changing to layout container, this causes an undesirable
+      // empty white space so we hide it with display none instead.
+      const overflowElement = this.getOverflowElement();
+      if (overflowElement) {
+        toggle(overflowElement, false);
+      }
+      this.element.classList.add('i-amphtml-layout-container');
+      this.element.setAttribute('layout', 'container');
+    });
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -220,7 +220,7 @@ export class AmpList extends AMP.BaseElement {
     let promise;
     const src = mutations['src'];
     const state = /** @type {!JsonObject} */ (mutations)['state'];
-    const isContainer = mutations['isContainer'];
+    const isContainer = mutations['is-container'];
     if (src !== undefined) {
       if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -643,7 +643,7 @@ export class AmpList extends AMP.BaseElement {
     const previousLayout = this.element.getAttribute('layout');
     // If we have already changed to layout container, no need to run again.
     if (previousLayout == Layout.CONTAINER) {
-      return;
+      return Promise.resolve();
     }
 
     return this.mutateElement(() => {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -623,6 +623,8 @@ export class AmpList extends AMP.BaseElement {
       case Layout.INTRINSIC:
         this.element.classList.remove('i-amphtml-layout-intrinsic');
         break;
+      default:
+        // fall through, always remove sizer and size-defined class
     }
     // The changeSize() call removes the sizer element.
     this.element./*OK*/changeSize();

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -134,6 +134,10 @@ export class AmpList extends AMP.BaseElement {
       }
     }, ActionTrust.HIGH);
 
+    this.registerAction('containerize',
+        () => this.changeToLayoutContainer_(),
+        ActionTrust.LOW);
+
     /** @private {?../../../src/ssr-template-helper.SsrTemplateHelper} */
     this.ssrTemplateHelper_ = null;
   }

--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -25,7 +25,7 @@ const body =
       '</template>' +
     '</amp-list>';
 
-const extensions = ['amp-list', 'amp-mustache'];
+const extensions = ['amp-list', 'amp-mustache', 'amp-bind'];
 
 describe('amp-list', function() {
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
@@ -89,14 +89,14 @@ describe('amp-list', function() {
   });
 
   const body3 =
-  '<amp-state id="containerState">' +
+  '<amp-state id="state">' +
     '<script type="application/json">' +
       'false' +
     '</script>' +
   '</amp-state>' +
     '<button id="button" on="tap:AMP.setState({state: true})">+</button>' +
     '<amp-list id="list" width=300 height=100 ' +
-      '[is-layout-container]="containerState" ' +
+      '[is-layout-container]="state" ' +
       'src="http://localhost:9876/list/fruit-data/get?cors=0">' +
       '<template type="amp-mustache">' +
         '{{name}} : {{quantity}} @ ${{unitPrice}}' +
@@ -115,7 +115,7 @@ describe('amp-list', function() {
       doc = win.document;
     });
 
-    it('should change to layout container as action', function*() {
+    it('should change to layout container as on bind', function*() {
       expect(isExperimentOn(win, 'amp-list-resizable-children')).to.be.true;
 
       const button = doc.getElementById('button');
@@ -130,5 +130,4 @@ describe('amp-list', function() {
       expect(list.classList.contains('i-amphtml-layout-container')).to.be.true;
     });
   });
-
 });

--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {isExperimentOn} from '../../../../../src/experiments';
 import {poll} from '../../../../../testing/iframe';
 
 const body =
@@ -24,12 +25,14 @@ const body =
       '</template>' +
     '</amp-list>';
 
+const extensions = ['amp-list', 'amp-mustache'];
+
 describe('amp-list', function() {
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);
 
   describes.integration('(integration)', {
-    body, extensions: ['amp-list', 'amp-mustache'],
+    body, extensions,
   }, env => {
     it('should render items', function*() {
       const list = env.win.document.getElementById('list');
@@ -47,4 +50,85 @@ describe('amp-list', function() {
       expect(children[2].textContent.trim()).to.equal('tomato : 0 @ $0.23');
     });
   });
+
+  const body2 =
+  '<button id="button" on="tap:list.changeToLayoutContainer()">+</button>' +
+  '<amp-list id="list" width=300 height=100 ' +
+      'src="http://localhost:9876/list/fruit-data/get?cors=0">' +
+    '<template type="amp-mustache">' +
+      '{{name}} : {{quantity}} @ ${{unitPrice}}' +
+    '</template>' +
+  '</amp-list>';
+
+  describes.integration('with changeToLayoutContainer', {
+    body: body2, extensions,
+    experiments: ['amp-list-resizable-children']},
+  env => {
+
+    let win, doc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+    });
+
+    it('should change to layout container as action', function*() {
+      expect(isExperimentOn(win, 'amp-list-resizable-children')).to.be.true;
+
+      const button = doc.getElementById('button');
+      const list = doc.getElementById('list');
+      button.click();
+
+      yield poll('changes to layout container', () => {
+        const layout = list.getAttribute('layout');
+        return layout == 'container';
+      }, undefined, /* opt_timeout */ TIMEOUT);
+
+      expect(list.classList.contains('i-amphtml-layout-container')).to.be.true;
+    });
+  });
+
+  const body3 =
+  '<amp-state id="containerState">' +
+    '<script type="application/json">' +
+      'false' +
+    '</script>' +
+  '</amp-state>' +
+    '<button id="button" on="tap:AMP.setState({state: true})">+</button>' +
+    '<amp-list id="list" width=300 height=100 ' +
+      '[is-layout-container]="containerState" ' +
+      'src="http://localhost:9876/list/fruit-data/get?cors=0">' +
+      '<template type="amp-mustache">' +
+        '{{name}} : {{quantity}} @ ${{unitPrice}}' +
+      '</template>' +
+    '</amp-list>';
+
+  describes.integration('with bindable is-layout-container', {
+    body: body3, extensions,
+    experiments: ['amp-list-resizable-children']},
+  env => {
+
+    let win, doc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+    });
+
+    it('should change to layout container as action', function*() {
+      expect(isExperimentOn(win, 'amp-list-resizable-children')).to.be.true;
+
+      const button = doc.getElementById('button');
+      const list = doc.getElementById('list');
+      button.click();
+
+      yield poll('changes to layout container', () => {
+        const layout = list.getAttribute('layout');
+        return layout == 'container';
+      }, undefined, /* opt_timeout */ TIMEOUT);
+
+      expect(list.classList.contains('i-amphtml-layout-container')).to.be.true;
+    });
+  });
+
 });

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -266,7 +266,7 @@ Displays a loading indicator and placeholder again when the list's source is ref
 
 By default, this will only trigger on refreshes that cause a network fetch. To reset on all refreshes, use `reset-on-refresh="always"`.
 
-#### is-layout-container (experimental, optional)
+#### [is-layout-container] (experimental, optional)
 This is a bindable attribute that should always be false by default. When set to true via `bind`, it changes the layout of the amp-list to layout `CONTAINER`. This attribute is useful for handling dynamic resizing for amp-list. This attribute cannot be true by default for the same reason why `<amp-list>` does not support layout `CONTAINER`--it potentially causes content jumping on first load. This attribute is experimentally available under `amp-list-resizable-children`. Alternatively, one may also use the `changeToLayoutContainer` action.
 
 #### binding (optional)

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -267,7 +267,7 @@ Displays a loading indicator and placeholder again when the list's source is ref
 By default, this will only trigger on refreshes that cause a network fetch. To reset on all refreshes, use `reset-on-refresh="always"`.
 
 #### is-layout-container (experimental, optional)
-This is a bindable attribute that should always be false by default. When set to true via `bind`, it changes the layout of the amp-list to layout `CONTAINER`. This attribute is useful for handling dynamic resizing for amp-list. This attribute is experimentally available under `amp-list-resizable-children`.
+This is a bindable attribute that should always be false by default. When set to true via `bind`, it changes the layout of the amp-list to layout `CONTAINER`. This attribute is useful for handling dynamic resizing for amp-list. This attribute cannot be true by default for the same reason why `<amp-list>` does not support layout `CONTAINER`--it potentially causes content jumping on first load. This attribute is experimentally available under `amp-list-resizable-children`. Alternatively, one may also use the `changeToLayoutContainer` action.
 
 #### binding (optional)
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -99,9 +99,9 @@ Here is how we styled the content fetched:
     amp-list div[role="list"] {
       display: grid;
       grid-gap: 0.5em;
-    } 
+    }
 ```
-    
+
 ## Behavior
 
 The request is always made from the client, even if the document was served from the AMP Cache. Loading is triggered using normal AMP rules depending on how far the element is from
@@ -183,6 +183,23 @@ The `amp-list` element exposes a `refresh` action that other elements can refere
 </amp-list>
 ```
 
+### Dynamic Resizing
+##### Experimental: amp-list-resizable-children
+In several cases, we may need the amp-list to resize on user interaction. For example, when the amp-list contains an amp-accordion that a user may tap on, when the contents of the amp-list change size due to bound CSS classes, or when the number of items inside an amp-list changes due to a bound `[src]` attribute. The `changeToLayoutContainer` action handles this by changing the amp list to `layout="CONTAINER"` when triggering this action. See the following example:
+
+```html
+  <button on="list.changeToLayoutContainer()">Show Grid</button>
+  <amp-list id="list"
+    width="396" height="80" layout="responsive"
+    src="/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      {{title}}
+    </template>
+  </amp-list>
+```
+
+This action is experimentally available under `amp-list-resizable-children`.
+
 ## Attributes
 
 ##### src (required)
@@ -248,6 +265,9 @@ Causes `amp-list` to treat the returned result as if it were a single element ar
 Displays a loading indicator and placeholder again when the list's source is refreshed via `amp-bind` or the `refresh()` action.
 
 By default, this will only trigger on refreshes that cause a network fetch. To reset on all refreshes, use `reset-on-refresh="always"`.
+
+#### is-layout-container (experimental, optional)
+This is a bindable attribute that should always be false by default. When set to true via `bind`, it changes the layout of the amp-list to layout `CONTAINER`. This attribute is useful for handling dynamic resizing for amp-list. This attribute is experimentally available under `amp-list-resizable-children`.
 
 #### binding (optional)
 

--- a/test/manual/amp-list-resize.amp.html
+++ b/test/manual/amp-list-resize.amp.html
@@ -71,7 +71,7 @@
   <h1>AMP List Resize Manual Test</h1>
 
   <h2>AMP List Resize with Accordion</h2>
-  <amp-list id="accordion-list" width="396" height="180" layout=responsive reset-on-refresh resizable-children
+  <amp-list id="accordion-list" width="396" height="180" layout=responsive reset-on-refresh
       src="/test/manual/amp-list-data.json">
     <template type="amp-mustache">
       <div class="story-entry">
@@ -96,8 +96,14 @@
   </amp-list>
 
   <h2>AMP List Basic</h2>
+  <amp-state id="containerState">
+    <script type="application/json">
+      false
+    </script>
+  </amp-state>
   <p>This contains an incorrectly sized container where the contents exceed the list height. It should show an overflow button. </p>
-  <amp-list width="396" height="80" layout="fixed" resizable-children reset-on-refresh
+  <button on="tap:AMP.setState({containerState: true})">Change to Container</button>
+  <amp-list width="396" height="80" layout="fixed" reset-on-refresh [is-container]="containerState"
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">
       <div class="story-entry">
@@ -113,25 +119,10 @@
     </div>
   </amp-list>
 
-  <h2>AMP List Basic Below fold</h2>
-  <p>This contains an incorrectly sized container where the contents exceed the list height. It should be changed to layout container. </p>
-  <amp-list width="396" height="80" layout="responsive" resizable-children reset-on-refresh
-      src="/test/manual/amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
-      <div class="story-entry">
-        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
-        {{title}}
-      </div>
-    </template>
-    <div overflow>
-      SEE MORE
-    </div>
-  </amp-list>
-
   <h2>AMP List Resize After Toggling Class</h2>
-  <button on="tap:AMP.setState({listStyle: 'grid'})">Show Grid</button>
+  <button on="tap:AMP.setState({listStyle: 'grid'}),toggleList.containerize()">Show Grid</button>
   <button on="tap:AMP.setState({listStyle: 'list'})">Show List</button>
-  <amp-list width="396" height="80" layout="responsive" resizable-children
+  <amp-list id="toggleList" width="396" height="80" layout="responsive"
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">
       <div class="story-entry" [class]="'story-entry ' + listStyle">
@@ -159,17 +150,17 @@
       });
       input-debounced:AMP.setState({
         query: event.value
-      });
+      }),typeahead.containerize();
     " value="" [value]="query"
     list="locations">
 
   <amp-list
+    id="typeahead"
     width="396"
     height="80"
     layout=responsive
     src="/search/countries"
     reset-on-refresh
-    resizable-children
     [src]="'/search/countries?q=' + query">
     <template type="amp-mustache">
       {{#results}}
@@ -183,7 +174,7 @@
       SEE MORE
     </div>
     <div placeholder>
-      <div class="tall">PACEHOLDER</div>
+      <div class="tall">PLACEHOLDER</div>
     </div>
   </amp-list>
 

--- a/test/manual/amp-list-resize.amp.html
+++ b/test/manual/amp-list-resize.amp.html
@@ -75,7 +75,7 @@
       src="/test/manual/amp-list-data.json">
     <template type="amp-mustache">
       <div class="story-entry">
-        <amp-accordion on="expand:accordion-list.containerize;collapse:accordion-list.containerize">
+        <amp-accordion on="expand:accordion-list.changeToLayoutContainer;collapse:accordion-list.changeToLayoutContainer">
           <section>
             <h1>{{title}}</h1>
             <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
@@ -103,7 +103,7 @@
   </amp-state>
   <p>This contains an incorrectly sized container where the contents exceed the list height. It should show an overflow button. </p>
   <button on="tap:AMP.setState({containerState: true})">Change to Container</button>
-  <amp-list width="396" height="80" layout="fixed" reset-on-refresh [is-container]="containerState"
+  <amp-list width="396" height="80" layout="fixed" reset-on-refresh [is-layout-container]="containerState"
       src="/test/manual/amp-list-data.json?RANDOM">
     <template type="amp-mustache">
       <div class="story-entry">
@@ -120,7 +120,7 @@
   </amp-list>
 
   <h2>AMP List Resize After Toggling Class</h2>
-  <button on="tap:AMP.setState({listStyle: 'grid'}),toggleList.containerize()">Show Grid</button>
+  <button on="tap:AMP.setState({listStyle: 'grid'}),toggleList.changeToLayoutContainer()">Show Grid</button>
   <button on="tap:AMP.setState({listStyle: 'list'})">Show List</button>
   <amp-list id="toggleList" width="396" height="80" layout="responsive"
       src="/test/manual/amp-list-data.json?RANDOM">
@@ -150,7 +150,7 @@
       });
       input-debounced:AMP.setState({
         query: event.value
-      }),typeahead.containerize();
+      }),typeahead.changeToLayoutContainer();
     " value="" [value]="query"
     list="locations">
 

--- a/test/manual/amp-list-resize.amp.html
+++ b/test/manual/amp-list-resize.amp.html
@@ -70,47 +70,12 @@
 <article>
   <h1>AMP List Resize Manual Test</h1>
 
-  <h2>AMP List Basic</h2>
-  <p>This contains an incorrectly sized container where the contents exceed the list height. It should show an overflow button. </p>
-  <amp-list width="396" height="80" layout="responsive" resizable-children reset-on-refresh
-      src="/test/manual/amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
-      <div class="story-entry">
-        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
-        {{title}}
-      </div>
-    </template>
-    <div overflow>
-      SEE MORE
-    </div>
-    <div placeholder>
-      <div class="tall">PACEHOLDER</div>
-    </div>
-  </amp-list>
-
-  <div class="split"></div>
-
-  <h2>AMP List Basic Below fold</h2>
-  <p>This contains an incorrectly sized container where the contents exceed the list height. It should be changed to layout container. </p>
-  <amp-list width="396" height="80" layout="responsive" resizable-children reset-on-refresh
-      src="/test/manual/amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
-      <div class="story-entry">
-        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
-        {{title}}
-      </div>
-    </template>
-    <div overflow>
-      SEE MORE
-    </div>
-  </amp-list>
-
   <h2>AMP List Resize with Accordion</h2>
-  <amp-list width="396" height="80" layout=responsive reset-on-refresh resizable-children
+  <amp-list id="accordion-list" width="396" height="180" layout=responsive reset-on-refresh resizable-children
       src="/test/manual/amp-list-data.json">
     <template type="amp-mustache">
       <div class="story-entry">
-        <amp-accordion>
+        <amp-accordion on="expand:accordion-list.containerize;collapse:accordion-list.containerize">
           <section>
             <h1>{{title}}</h1>
             <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
@@ -127,6 +92,39 @@
     </div>
     <div placeholder>
       <div class="tall">PACEHOLDER</div>
+    </div>
+  </amp-list>
+
+  <h2>AMP List Basic</h2>
+  <p>This contains an incorrectly sized container where the contents exceed the list height. It should show an overflow button. </p>
+  <amp-list width="396" height="80" layout="fixed" resizable-children reset-on-refresh
+      src="/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      <div class="story-entry">
+        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
+        {{title}}
+      </div>
+    </template>
+    <div overflow>
+      SEE MORE
+    </div>
+    <div placeholder>
+      <div class="tall">PLACEHOLDER</div>
+    </div>
+  </amp-list>
+
+  <h2>AMP List Basic Below fold</h2>
+  <p>This contains an incorrectly sized container where the contents exceed the list height. It should be changed to layout container. </p>
+  <amp-list width="396" height="80" layout="responsive" resizable-children reset-on-refresh
+      src="/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      <div class="story-entry">
+        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
+        {{title}}
+      </div>
+    </template>
+    <div overflow>
+      SEE MORE
     </div>
   </amp-list>
 


### PR DESCRIPTION
Experimentally addresses #10230. 

This addresses the resizable-children issue of giving developers a way to trigger `changeToLayoutContainer_` on an event or on bind, currently via the `changeToLayoutContainer` action and `is-layout-container` bindable attribute. As is, it will directly call `changeToLayoutContainer`, which undos the original layout with caveats (e.g. preserves fixed width for layout fixed), and apply layout container to the amp-list. This will allow the amp-list to automatically resize based on the size of its children after the layout container change. Repeated calls of the `changeToLayoutContainer` action will have no effect. 

If `changeToLayoutContainer` is called while the overflow element is visible and present, it will change to layout container and cause the overflow element to disappear. 


- [x] Testing on more devices and browsers
- [x] Action and attribute naming discussion
- [x] ~Unit tests~
- [x] Integration tests