### PR TITLE
Introduce a method to update localstorage value 

### DIFF
--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -216,6 +216,9 @@ export class Store {
   }
 
   /**
+   * Set the storage value along with the current timestamp.
+   * When opt_isUpdated is true, timestamp will be the creation timestamp,
+   * the stored value will be updated w/o updating timestamp.
    * @param {string} name
    * @param {*} value
    * @param {boolean=} opt_isUpdate

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -86,11 +86,12 @@ export class Storage {
    * Returns the promise that's resolved when the operation completes.
    * @param {string} name
    * @param {*} value
+   * @param {boolean=} opt_isUpdate
    * @return {!Promise}
    */
-  set(name, value) {
+  set(name, value, opt_isUpdate) {
     dev().assert(typeof value == 'boolean', 'Only boolean values accepted');
-    return this.setNonBoolean(name, value);
+    return this.setNonBoolean(name, value, opt_isUpdate);
   }
 
   /**
@@ -99,10 +100,11 @@ export class Storage {
    * Note: More restrict privacy review is required to store non boolean value.
    * @param {string} name
    * @param {*} value
+   * @param {boolean=} opt_isUpdate
    * @return {!Promise}
    */
-  setNonBoolean(name, value) {
-    return this.saveStore_(store => store.set(name, value));
+  setNonBoolean(name, value, opt_isUpdate) {
+    return this.saveStore_(store => store.set(name, value, opt_isUpdate));
   }
 
   /**
@@ -216,15 +218,21 @@ export class Store {
   /**
    * @param {string} name
    * @param {*} value
+   * @param {boolean=} opt_isUpdate
    */
-  set(name, value) {
+  set(name, value, opt_isUpdate) {
     dev().assert(name != '__proto__' && name != 'prototype',
         'Name is not allowed: %s', name);
     // The structure is {key: {v: *, t: time}}
     if (this.values_[name] !== undefined) {
       const item = this.values_[name];
+      let timestamp = Date.now();
+      if (opt_isUpdate) {
+        // Update value w/o timestamp
+        timestamp = item['t'];
+      }
       item['v'] = value;
-      item['t'] = Date.now();
+      item['t'] = timestamp;
     } else {
       this.values_[name] = dict({
         'v': value,

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -368,6 +368,21 @@ describe('Store', () => {
     });
   });
 
+  it('should update a value w/o changing timestamp', () => {
+    store.set('key1', 'value1', true);
+    clock.tick(101);
+    store.set('key2', 'value2', true);
+    store.set('key1', 'value1b', true);
+    expect(store.get('key1')).to.equal('value1b');
+    expect(Object.keys(store.values_).length).to.equal(2);
+    expect(store.values_['key1']['t']).to.equal(0);
+    expect(store.values_['key2']['t']).to.equal(101);
+    expect(store.values_).to.deep.equal({
+      'key1': {v: 'value1b', t: 0},
+      'key2': {v: 'value2', t: 101},
+    });
+  });
+
   it('should remove a value', () => {
     store.set('key1', 'value1');
     store.set('key2', 'value2');


### PR DESCRIPTION
This is necessary for #17742 to support `forcePromptNext`. 

In order to support that I'll need to write a dirty bit to the localStorage in order to erase the value next time. I need to erase storage next time, because the current stored consent string will be required for UI the next time. 

However in order to be GDPR compliance, the current stored value need to be expired based on the last user consent timestamp. Which requires me to update the local stored value w/o changing the timestamp.