### PR TITLE
🐛 Fix thirds and fill layer in Safari

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -298,7 +298,6 @@ amp-story-grid-layer > * {
   width: 100% !important;
   display: block !important;
   position: absolute !important;
-  width: auto !important;
 }
 
 .i-amphtml-story-grid-template-vertical {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -292,12 +292,14 @@ amp-story-grid-layer > * {
 }
 
 .i-amphtml-story-grid-template-fill > :first-child {
-  top: 0 !important;
-  left: 0 !important;
-  height: 100% !important;
-  width: 100% !important;
+  bottom: 0 !important;
   display: block !important;
+  height: auto !important;
+  left: 0 !important;
   position: absolute !important;
+  right: 0 !important;
+  top: 0 !important;
+  width: auto !important;
 }
 
 .i-amphtml-story-grid-template-vertical {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -260,6 +260,7 @@ amp-story-cta-layer {
 
 /** Grid level */
 amp-story-grid-layer {
+  box-sizing: border-box !important;
   display: grid !important;
   position: absolute !important;
   top: 0 !important;
@@ -291,14 +292,12 @@ amp-story-grid-layer > * {
 }
 
 .i-amphtml-story-grid-template-fill > :first-child {
-  height: 100% !important;
-  bottom: 0 !important;
-  display: block !important;
-  height: auto !important;
-  left: 0 !important;
-  position: absolute !important;
-  right: 0 !important;
   top: 0 !important;
+  left: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  display: block !important;
+  position: absolute !important;
   width: auto !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -291,6 +291,7 @@ amp-story-grid-layer > * {
 }
 
 .i-amphtml-story-grid-template-fill > :first-child {
+  height: 100% !important;
   bottom: 0 !important;
   display: block !important;
   height: auto !important;
@@ -312,6 +313,7 @@ amp-story-grid-layer > * {
 }
 
 .i-amphtml-story-grid-template-thirds {
+  height: 100% !important;
   grid-template-rows: 33% 33% 33% !important; /* `fr` is broken in Safari. */
   grid-template-areas: "upper-third"
                        "middle-third"


### PR DESCRIPTION
Fixes #13433

Even though the layer has position: absolute; bottom: 0; top: 0;, Safari collapses the height as [this comment points out](https://github.com/ampproject/amphtml/issues/13433#issuecomment-422072646). Setting it explicitly prevents this.