### PR TITLE
amp-bind: Support alternative binding syntax with amp-list

### DIFF
--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -65,7 +65,7 @@
     <strong>Quantity:</strong>: {{quantity}}
     <strong>Unit Price</strong>: ${{unitPrice}}
     <strong>1+1:</strong>: <span [text]="1+1">?</span>
-    <strong>Foo</strong>: <span [text]="foo">?</span>
+    <strong>Foo</strong>: <span data-amp-bind-text="foo">?</span>
   </template>
 
   <h3>Default</h3>

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -44,7 +44,7 @@ const TAG = 'purifier';
 const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
 
 /** @private @const {string} */
-const BIND_PREFIX = 'data-amp-bind-';
+export const BIND_PREFIX = 'data-amp-bind-';
 
 /**
  * @const {!Object<string, boolean>}

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -22,9 +22,9 @@ import {
   resolveRelativeUrl,
 } from './url';
 import {dict} from './utils/object';
+import {endsWith, startsWith} from './string';
 import {parseSrcset} from './srcset';
 import {remove} from './utils/array';
-import {startsWith} from './string';
 import {urls} from './config';
 import {user} from './log';
 import purify from 'dompurify/dist/purify.es';
@@ -42,6 +42,9 @@ const TAG = 'purifier';
 
 /** @private @const {string} */
 const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
+
+/** @private @const {string} */
+const BIND_PREFIX = 'data-amp-bind-';
 
 /**
  * @const {!Object<string, boolean>}
@@ -391,14 +394,16 @@ export function addPurifyHooks(purifier, diffing) {
       }
     }
 
-    // Rewrite amp-bind attributes e.g. [foo]="bar" -> data-amp-bind-foo="bar".
+    const classicBinding = startsWith(attrName, '[') && endsWith(attrName, ']');
+    const alternativeBinding = startsWith(attrName, BIND_PREFIX);
+    // Rewrite classic bindings e.g. [foo]="bar" -> data-amp-bind-foo="bar".
     // This is because DOMPurify eagerly removes attributes and re-adds them
     // after sanitization, which fails because `[]` are not valid attr chars.
-    const isBinding = attrName[0] == '['
-        && attrName[attrName.length - 1] == ']';
-    if (isBinding) {
+    if (classicBinding) {
       const property = attrName.substring(1, attrName.length - 1);
-      node.setAttribute(`data-amp-bind-${property}`, attrValue);
+      node.setAttribute(`${BIND_PREFIX}${property}`, attrValue);
+    }
+    if (classicBinding || alternativeBinding) {
       // Set a custom attribute to mark this element as containing a binding.
       // This is an optimization that obviates the need for DOM scan later.
       node.setAttribute('i-amphtml-binding', '');

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -22,9 +22,9 @@ import {
   resolveRelativeUrl,
 } from './url';
 import {dict} from './utils/object';
-import {endsWith, startsWith} from './string';
 import {parseSrcset} from './srcset';
 import {remove} from './utils/array';
+import {startsWith} from './string';
 import {urls} from './config';
 import {user} from './log';
 import purify from 'dompurify/dist/purify.es';
@@ -394,7 +394,8 @@ export function addPurifyHooks(purifier, diffing) {
       }
     }
 
-    const classicBinding = startsWith(attrName, '[') && endsWith(attrName, ']');
+    const classicBinding = attrName[0] == '['
+        && attrName[attrName.length - 1] == ']';
     const alternativeBinding = startsWith(attrName, BIND_PREFIX);
     // Rewrite classic bindings e.g. [foo]="bar" -> data-amp-bind-foo="bar".
     // This is because DOMPurify eagerly removes attributes and re-adds them

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -15,6 +15,7 @@
  */
 
 import {
+  BIND_PREFIX,
   BLACKLISTED_TAGS,
   TRIPLE_MUSTACHE_WHITELISTED_TAGS,
   WHITELISTED_ATTRS,
@@ -114,7 +115,7 @@ export function sanitizeHtml(html, diffing) {
           continue;
         }
         const classicBinding = attr[0] == '[' && attr[attr.length - 1] == ']';
-        const alternativeBinding = startsWith(attr, 'data-amp-bind-');
+        const alternativeBinding = startsWith(attr, BIND_PREFIX);
         if (classicBinding) {
           attribs[i] = attr.slice(1, -1);
         }
@@ -210,7 +211,11 @@ export function sanitizeHtml(html, diffing) {
           continue;
         }
         emit(' ');
-        emit(bindingAttribs.includes(i) ? `[${attrName}]` : attrName);
+        if (bindingAttribs.includes(i) && !startsWith(attrName, BIND_PREFIX)) {
+          emit(`[${attrName}]`);
+        } else {
+          emit(attrName);
+        }
         emit('="');
         if (attrValue) {
           // Rewrite attribute values unless this attribute is a binding.

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -110,8 +110,15 @@ export function sanitizeHtml(html, diffing) {
       const bindingAttribs = [];
       for (let i = 0; i < attribs.length; i += 2) {
         const attr = attribs[i];
-        if (attr && attr[0] == '[' && attr[attr.length - 1] == ']') {
+        if (!attr) {
+          continue;
+        }
+        const classicBinding = attr[0] == '[' && attr[attr.length - 1] == ']';
+        const alternativeBinding = startsWith(attr, 'data-amp-bind-');
+        if (classicBinding) {
           attribs[i] = attr.slice(1, -1);
+        }
+        if (classicBinding || alternativeBinding) {
           bindingAttribs.push(i);
         }
       }

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -83,7 +83,7 @@ describe('DOMPurify-based', () => {
 
     it('should add "i-amphtml-binding" for data-amp-bind-*', () => {
       expect(purify('<p data-amp-bind-text="foo"></p>')).to.be
-          .equal('<p data-amp-bind-text="foo" i-amphtml-binding=""></p>');
+          .equal('<p i-amphtml-binding="" data-amp-bind-text="foo"></p>');
     });
 
     it('should NOT rewrite values of binding attributes', () => {

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -81,6 +81,11 @@ describe('DOMPurify-based', () => {
           .equal('<p data-amp-bind-class="bar" i-amphtml-binding=""></p>');
     });
 
+    it('should add "i-amphtml-binding" for data-amp-bind-*', () => {
+      expect(purify('<p data-amp-bind-text="foo"></p>')).to.be
+          .equal('<p data-amp-bind-text="foo" i-amphtml-binding=""></p>');
+    });
+
     it('should NOT rewrite values of binding attributes', () => {
       // Should not change "foo.bar".
       expect(purify('<a [href]="foo.bar">link</a>')).to.equal(

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -58,6 +58,11 @@ describe('Caja-based', () => {
           .equal('<p [text]="foo" [class]="bar" i-amphtml-binding=""></p>');
     });
 
+    it('should add "i-amphtml-binding" for data-amp-bind-*', () => {
+      expect(sanitizeHtml('<p data-amp-bind-text="foo"></p>')).to.be
+          .equal('<p data-amp-bind-text="foo" i-amphtml-binding=""></p>');
+    });
+
     it('should NOT rewrite values of binding attributes', () => {
       // Should not change "foo.bar". Adding `target` attribute is not necessary
       // (but harmless) since <amp-bind> will use rewriteAttributesForElement().


### PR DESCRIPTION
- Supports `data-amp-bind-*` bindings with amp-list's binding integration.