### PR TITLE
Remove text that is no longer needed

### DIFF
--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_html_attr.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_html_attr.html
@@ -10,14 +10,7 @@
     <meta name=viewport content=width=device-width,minimum-scale=1>
   </head>
   <body>
-    Before using this example page, please add the following to
-    extensions/amp-analytics/0.1/vendors.js:
-    <pre>
-      'example-3p-vendor': {
-        'transport': {'beacon': true, 'xhrpost': true, 'image': true},
-      },
-    </pre>
-    Then look at the network log, and see the requests including "imgData="
+    Look at the network log, and see the requests including "imgData="
     <amp-analytics type='example-3p-vendor'>
       <script type='application/json'>
         {


### PR DESCRIPTION
The removed instructions are no longer necessary to make the example work.