### PR TITLE
🐛 Remove direct child combinator for fill layers

### DIFF
--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -23,10 +23,10 @@ amp-story-grid-layer * {
   margin: 0;
 }
 
-.i-amphtml-story-grid-template-fill > amp-anim img,
-.i-amphtml-story-grid-template-fill > amp-img img,
-.i-amphtml-story-grid-template-fill > amp-video video,
-.i-amphtml-story-grid-template-with-full-bleed-animation > amp-img img {
+.i-amphtml-story-grid-template-fill amp-anim img,
+.i-amphtml-story-grid-template-fill amp-img img,
+.i-amphtml-story-grid-template-fill amp-video video,
+.i-amphtml-story-grid-template-with-full-bleed-animation amp-img img {
   object-fit: cover;
 }
 


### PR DESCRIPTION
Sometimes, people wrap contents in `<div>`s or whatever, so this breaks the `fill` layers by stretching the images.

Re-implementation of #18893 