### PR TITLE
Fix gestures recognizers end up in broken state after additional unaccounted for touch

### DIFF
--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -285,7 +285,7 @@ class SwipeRecognizer extends GestureRecognizer {
       this.startX_ = touches[0].clientX;
       this.startY_ = touches[0].clientY;
       return true;
-    } else if (touches && touches.length > 1 && this.eventing_) {
+    } else if (this.eventing_ && touches && touches.length > 1) {
       return true;
     } else {
       return false;
@@ -295,7 +295,11 @@ class SwipeRecognizer extends GestureRecognizer {
   /** @override */
   onTouchMove(e) {
     const {touches} = e;
-    if (touches && touches.length >= 1) {
+    // If already eventing, ignore additional touches
+    if (this.eventing_ && touches && touches.length > 1) {
+      return true;
+    }
+    if (touches && touches.length == 1) {
       const {clientX: x, clientY: y} = touches[0] ;
       this.lastX_ = x;
       this.lastY_ = y;

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -280,12 +280,14 @@ class SwipeRecognizer extends GestureRecognizer {
   /** @override */
   onTouchStart(e) {
     const {touches} = e;
+    // If already eventing, ignore additional touches
+    if (this.eventing_ && touches && touches.length > 1) {
+      return true;
+    }
     if (touches && touches.length == 1) {
       this.startTime_ = Date.now();
       this.startX_ = touches[0].clientX;
       this.startY_ = touches[0].clientY;
-      return true;
-    } else if (this.eventing_ && touches && touches.length > 1) {
       return true;
     } else {
       return false;
@@ -761,9 +763,9 @@ export class PinchRecognizer extends GestureRecognizer {
       return true;
     }
     // If already in the middle of a pinch event, ignore additional touches.
-    // if (this.eventing_ && touches && touches.length > 2) {
-    //   return true;
-    // }
+    if (this.eventing_ && touches && touches.length > 2) {
+      return true;
+    }
     else if (touches && touches.length >= 2) {
       this.lastX1_ = touches[0].clientX;
       this.lastY1_ = touches[0].clientY;
@@ -789,7 +791,7 @@ export class PinchRecognizer extends GestureRecognizer {
           return false;
         }
       }
-      // Threshold not reached, continue listening but do not emit
+      // Pinch threshold not reached, continue listening but do not emit
       return true;
     } else {
       return false;

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -297,17 +297,15 @@ class SwipeRecognizer extends GestureRecognizer {
   /** @override */
   onTouchMove(e) {
     const {touches} = e;
-    // If already eventing, ignore additional touches
-    if (this.eventing_ && touches && touches.length > 1) {
-      return true;
-    }
-    if (touches && touches.length == 1) {
+    if (touches && touches.length >= 1) {
       const {clientX: x, clientY: y} = touches[0] ;
       this.lastX_ = x;
       this.lastY_ = y;
       if (this.eventing_) {
+        // If already eventing, always emit new coordinates
         this.emit_(false, false, e);
       } else {
+        // Figure out whether or not we should start eventing
         const dx = Math.abs(x - this.startX_);
         const dy = Math.abs(y - this.startY_);
         // Swipe is penalized slightly since it's one of the least demanding
@@ -762,18 +760,16 @@ export class PinchRecognizer extends GestureRecognizer {
     if (touches && touches.length == 1) {
       return true;
     }
-    // If already in the middle of a pinch event, ignore additional touches.
-    if (this.eventing_ && touches && touches.length > 2) {
-      return true;
-    }
     else if (touches && touches.length >= 2) {
       this.lastX1_ = touches[0].clientX;
       this.lastY1_ = touches[0].clientY;
       this.lastX2_ = touches[1].clientX;
       this.lastY2_ = touches[1].clientY;
       if (this.eventing_) {
+        // If eventing, always emit gesture with new coordinates
         this.emit_(false, false, e);
       } else {
+        // Figure out whether or not to start eventing
         const dx1 = this.lastX1_ - this.startX1_;
         const dy1 = this.lastY1_ - this.startY1_;
         const dx2 = this.lastX2_ - this.startX2_;

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -338,7 +338,11 @@ class SwipeRecognizer extends GestureRecognizer {
 
   /** @override */
   onTouchEnd(e) {
-    this.end_(e);
+    const {touches} = e;
+    // Number of current touches on the page
+    if (touches.length == 0) {
+      this.end_(e);
+    }
   }
 
   /** @override */
@@ -791,7 +795,11 @@ export class PinchRecognizer extends GestureRecognizer {
 
   /** @override */
   onTouchEnd(e) {
-    this.end_(e);
+    // Number of current touches on the page
+    const {touches} = e;
+    if (touches.length <= 1) {
+      this.end_(e);
+    }
   }
 
   /** @override */

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -778,11 +778,11 @@ export class PinchRecognizer extends GestureRecognizer {
     }
 
     // Gesture is 2+ touch but direction indicates not a pinch
-    if (this.pinchRejected_()) {
+    if (this.isPinchRejected_()) {
       return false;
     }
 
-    if (this.pinchReady_()) {
+    if (this.isPinchReady_()) {
       this.signalReady(0);
     }
     // Pinch gesture detected but threshold not reached, continue listening
@@ -793,7 +793,7 @@ export class PinchRecognizer extends GestureRecognizer {
    * @return {boolean}
    * @private
    */
-  pinchReady_() {
+  isPinchReady_() {
     const dx1 = this.lastX1_ - this.startX1_;
     const dy1 = this.lastY1_ - this.startY1_;
     const dx2 = this.lastX2_ - this.startX2_;
@@ -809,7 +809,7 @@ export class PinchRecognizer extends GestureRecognizer {
    * @return {boolean}
    * @private
    */
-  pinchRejected_() {
+  isPinchRejected_() {
     const dx1 = this.lastX1_ - this.startX1_;
     const dy1 = this.lastY1_ - this.startY1_;
     const dx2 = this.lastX2_ - this.startX2_;

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -199,7 +199,6 @@ export class DoubletapRecognizer extends GestureRecognizer {
   /** @override */
   acceptCancel() {
     this.tapCount_ = 0;
-    this.eventing_ = false;
   }
 }
 

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -318,18 +318,15 @@ class SwipeRecognizer extends GestureRecognizer {
           if (dx >= 8 && dx > dy) {
             this.signalReady(-10);
           } else if (dy >= 8) {
-            this.acceptCancel();
             return false;
           }
         } else if (this.vert_) {
           if (dy >= 8 && dy > dx) {
             this.signalReady(-10);
           } else if (dx >= 8) {
-            this.acceptCancel();
             return false;
           }
         } else {
-          this.acceptCancel();
           return false;
         }
       }

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -757,7 +757,7 @@ export class PinchRecognizer extends GestureRecognizer {
     if (touches && touches.length == 1) {
       return true;
     }
-    else if (touches && touches.length >= 2) {
+    if (touches && touches.length >= 2) {
       this.lastX1_ = touches[0].clientX;
       this.lastY1_ = touches[0].clientY;
       this.lastX2_ = touches[1].clientX;

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -297,11 +297,12 @@ export class Gestures {
         continue;
       }
 
+      this.recognizers_[i].onTouchEnd(event);
+
       const isReady = !this.pending_[i];
       const isExpired = this.pending_[i] < now;
       const isEventing = this.eventing_ == this.recognizers_[i];
 
-      this.recognizers_[i].onTouchEnd(event);
       if (!isEventing && (isReady || isExpired)) {
         this.stopTracking_(i);
       }

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -297,7 +297,8 @@ export class Gestures {
         continue;
       }
       this.recognizers_[i].onTouchEnd(event);
-      if (!this.pending_[i] || this.pending_[i] < now) {
+      if ((!this.pending_[i] || this.pending_[i] < now)
+        && this.eventing_ != this.recognizers_[i]) {
         this.stopTracking_(i);
       }
     }

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -296,9 +296,13 @@ export class Gestures {
         this.stopTracking_(i);
         continue;
       }
+
+      const isReady = !this.pending_[i];
+      const isExpired = this.pending_[i] < now;
+      const isEventing = this.eventing_ == this.recognizers_[i];
+
       this.recognizers_[i].onTouchEnd(event);
-      if ((!this.pending_[i] || this.pending_[i] < now)
-        && this.eventing_ != this.recognizers_[i]) {
+      if (!isEventing && (isReady || isExpired)) {
         this.stopTracking_(i);
       }
     }

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -878,14 +878,18 @@ describe('PinchRecognizer', () => {
 
   it('should ignore additional touches if eventing', () => {
     clock.tick(1);
-    recognizer.onTouchStart({touches:
+    let res = recognizer.onTouchStart({touches:
     [{clientX: 90, clientY: 80},
       {clientX: 110, clientY: 120}]});
-    recognizer.onTouchMove({touches:
+    expect(res).to.equal(true);
+
+    res = recognizer.onTouchMove({touches:
     [{clientX: 80, clientY: 70},
       {clientX: 120, clientY: 130}]});
-    // Once from touch move, once from acceptStart
-    gesturesMock.expects('signalEmit_').twice();
+    expect(res).to.equal(true);
+
+    gesturesMock.expects('signalEmit_').once();
+
     clock.tick(10);
     recognizer.acceptStart();
 
@@ -893,23 +897,26 @@ describe('PinchRecognizer', () => {
 
     // Trigger additional touch start; nothing should happen
     // for the additional touch
-    recognizer.onTouchStart({touches:
+    res = recognizer.onTouchStart({touches:
       [{clientX: 80, clientY: 70},
         {clientX: 120, clientY: 130},
         {clientX: 160, clientY: 160}]});
+    expect(res).to.equal(true);
 
     // Trigger additional touch move; nothing should happen since the
     // existing touches did not move.
-    recognizer.onTouchMove({touches:
+    res = recognizer.onTouchMove({touches:
       [{clientX: 80, clientY: 70},
         {clientX: 120, clientY: 130},
         {clientX: 160, clientY: 160}]});
+    expect(res).to.equal(true);
 
     // Trigger touch end; should not end since two touches are remaining
-    recognizer.onTouchEnd({touches:
+    res = recognizer.onTouchEnd({touches:
       [{clientX: 80, clientY: 70},
         {clientX: 120, clientY: 130}]});
 
+    clock.tick(50);
     // Additional touch start and touch move should not trigger a signal
     gesturesMock.expects('signalEnd_').never();
   });

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -888,9 +888,35 @@ describe('PinchRecognizer', () => {
       {clientX: 120, clientY: 130}]});
     expect(res).to.equal(true);
 
-    gesturesMock.expects('signalEmit_').twice();
+    // On acceptStart, we get a null event
+    gesturesMock.expects('signalEmit_').withExactArgs(recognizer,
+        sinon.match(data => {
+          return data.centerClientX == 100 &&
+            data.centerClientY == 100 &&
+            data.deltaX == 10 &&
+            data.deltaY == 10 &&
+            data.dir == 1 &&
+            data.first == true &&
+            data.last == false &&
+            data.time == 1;
+        }), null).once();
 
-    clock.tick(10);
+    // On onTouchMove, we didn't actually move the original touches
+    gesturesMock.expects('signalEmit_').withExactArgs(recognizer,
+        sinon.match(data => {
+          return data.centerClientX == 100 &&
+            data.centerClientY == 100 &&
+            data.deltaX == 10 &&
+            data.deltaY == 10 &&
+            data.dir == 1 &&
+            data.first == false &&
+            data.last == false;
+        }), {touches: [
+          {clientX: 80, clientY: 70},
+          {clientX: 120, clientY: 130},
+          {clientX: 160, clientY: 160},
+        ]}).once();
+
     recognizer.acceptStart();
 
     expect(recognizer.eventing_).to.equal(true);

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -403,6 +403,45 @@ describe('SwipeXYRecognizer', () => {
     recognizer.onTouchEnd(event);
     expect(recognizer.eventing_).to.equal(false);
   });
+
+  it('should ignore additional touches if eventing', () => {
+    const event = {touches: [{clientX: 111, clientY: 211}]};
+
+    recognizer.startX_ = recognizer.prevX_ = 101;
+    recognizer.startY_ = recognizer.prevY_ = 201;
+    recognizer.eventing_ = true;
+    gesturesMock.expects('signalEmit_').once();
+
+    clock.tick(10);
+    let res = recognizer.onTouchMove(event);
+    expect(res).to.equal(true);
+    expect(recognizer.lastX_).to.equal(111);
+    expect(recognizer.lastY_).to.equal(211);
+
+    res = recognizer.onTouchStart({touches: [
+      {clientX: 111, clientY: 211},
+      {clientX: 122, clientY: 254},
+    ]});
+
+    // Additional touch start should not have any effect
+    expect(res).to.equal(true);
+
+    res = recognizer.onTouchMove({touches: [
+      {clientX: 111, clientY: 211},
+      {clientX: 122, clientY: 234},
+    ]});
+
+    // Additional touch move should not have any effect
+    expect(res).to.equal(true);
+
+    clock.tick(50);
+
+    // If further touches are remaining, do not fire signal end.
+    recognizer.onTouchEnd({touches: [{clientX: 111, clientY: 211}]});
+    expect(recognizer.eventing_).to.equal(true);
+    gesturesMock.expects('signalEnd_').never();
+  });
+
 });
 
 
@@ -835,4 +874,5 @@ describe('PinchRecognizer', () => {
     recognizer.onTouchEnd(event);
     expect(recognizer.eventing_).to.equal(false);
   });
+
 });

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -410,7 +410,7 @@ describe('SwipeXYRecognizer', () => {
     recognizer.startX_ = recognizer.prevX_ = 101;
     recognizer.startY_ = recognizer.prevY_ = 201;
     recognizer.eventing_ = true;
-    gesturesMock.expects('signalEmit_').once();
+    gesturesMock.expects('signalEmit_').twice();
 
     clock.tick(10);
     let res = recognizer.onTouchMove(event);
@@ -888,7 +888,7 @@ describe('PinchRecognizer', () => {
       {clientX: 120, clientY: 130}]});
     expect(res).to.equal(true);
 
-    gesturesMock.expects('signalEmit_').once();
+    gesturesMock.expects('signalEmit_').twice();
 
     clock.tick(10);
     recognizer.acceptStart();

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -875,4 +875,43 @@ describe('PinchRecognizer', () => {
     expect(recognizer.eventing_).to.equal(false);
   });
 
+
+  it('should ignore additional touches if eventing', () => {
+    clock.tick(1);
+    recognizer.onTouchStart({touches:
+    [{clientX: 90, clientY: 80},
+      {clientX: 110, clientY: 120}]});
+    recognizer.onTouchMove({touches:
+    [{clientX: 80, clientY: 70},
+      {clientX: 120, clientY: 130}]});
+    // Once from touch move, once from acceptStart
+    gesturesMock.expects('signalEmit_').twice();
+    clock.tick(10);
+    recognizer.acceptStart();
+
+    expect(recognizer.eventing_).to.equal(true);
+
+    // Trigger additional touch start; nothing should happen
+    // for the additional touch
+    recognizer.onTouchStart({touches:
+      [{clientX: 80, clientY: 70},
+        {clientX: 120, clientY: 130},
+        {clientX: 160, clientY: 160}]});
+
+    // Trigger additional touch move; nothing should happen since the
+    // existing touches did not move.
+    recognizer.onTouchMove({touches:
+      [{clientX: 80, clientY: 70},
+        {clientX: 120, clientY: 130},
+        {clientX: 160, clientY: 160}]});
+
+    // Trigger touch end; should not end since two touches are remaining
+    recognizer.onTouchEnd({touches:
+      [{clientX: 80, clientY: 70},
+        {clientX: 120, clientY: 130}]});
+
+    // Additional touch start and touch move should not trigger a signal
+    gesturesMock.expects('signalEnd_').never();
+  });
+
 });

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -355,7 +355,7 @@ describe('SwipeXYRecognizer', () => {
   });
 
   it('should stop on touchend; velocity doesn\'t change', () => {
-    const event = {};
+    const event = {touches: []};
 
     recognizer.startX_ = recognizer.prevX_ = 101;
     recognizer.startY_ = recognizer.prevY_ = 201;
@@ -380,7 +380,7 @@ describe('SwipeXYRecognizer', () => {
   });
 
   it('should stop on touchend; velocity changes', () => {
-    const event = {};
+    const event = {touches: []};
 
     recognizer.startX_ = 101;
     recognizer.startY_ = 201;
@@ -789,7 +789,7 @@ describe('PinchRecognizer', () => {
     clock.tick(10);
     recognizer.acceptStart();
 
-    const event = {};
+    const event = {touches: []};
     gesturesMock.expects('signalEmit_').withExactArgs(recognizer,
         sinon.match(data => {
           return (data.first === false && data.last === true &&
@@ -819,7 +819,7 @@ describe('PinchRecognizer', () => {
     clock.tick(10);
     recognizer.acceptStart();
 
-    const event = {};
+    const event = {touches: []};
     gesturesMock.expects('signalEmit_').withExactArgs(recognizer,
         sinon.match(data => {
           return (data.first === false && data.last === true &&


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/17796. 
~1. Make sure that if a gesture returns false from `onTouchMove`, that we call `acceptCancel` to ensure that `this.eventing_` is set to false. This prevents the permanently broken state of `gestures`, where a recognizer is `eventing_` but not tracking anything and thus prevents subsequent gestures from being recognized. 
2. [Open to debate] Ignore all additional touches if a gesture is already eventing. I think this is correct behavior, but we can experiment with the UX.~

Update: 
We're going to go with the implementation here where if an additional touch is added while the recognizer is still eventing, it is ignored, and UX-wise the gesture will continue based on the first n touches that triggered the gesture. 

To recap, there were three possible solutions to this problem: 
1. Call `acceptCancel` on all return `false`. This would solve the problem where additional touches causes the eventing recognizer to stop listening to future gestures (and thus never stops eventing), but no future recognizers can trigger because there is already an eventing gesture. 
2. Early return true on additional touch (keep listening to subsequent events but ignore additional touches). This causes the gesture to pause while additional touches are present but to resume when the additional touches are gone. Results in slightly sub-optimal UX because users can unintentionally freeze the gesture due to a unnoticed extra touch. 
3. [Chosen approach] always emit on touch move even if there is an additional touch, but not to start the gesture if there are extra touches. UX-wise, it will ignore additional touch if a recognizer is already eventing, so if you put down or release a third finger while pinching or a second finger while swiping, the zoom / swipe continues as is based on your first 2 or 1 touch(es). 

Option 3 has the downside of this situation:  if you first move one finger to pan, then stop, then put second down, I can't pinch zoom. Similarly if you try to transition from a pinch zoom to a pan without lifting the finger, it doesn't register as a swipe. 



Demo link [here](https://amp-demo-project-1323a.firebaseapp.com/). 
Developed on Pixel 2 / Chrome, sanity checked on Safari. 