### PR TITLE
Various amp-selector clean up

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -129,8 +129,8 @@ export class AmpSelector extends AMP.BaseElement {
     this.registerAction('toggle', invocation => {
       const {args} = invocation;
       user().assert(args['index'] >= 0, '\'index\' must be greater than 0');
-      user().assert(args['index'] < this.elements_.length, '\'index\' must be ' +
-        'less than the length of options in the <amp-selector>');
+      user().assert(args['index'] < this.elements_.length, '\'index\' must ' +
+        'be less than the length of options in the <amp-selector>');
       if (args && args['index'] !== undefined) {
         this.toggle_(args['index'], args['value']);
       }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -570,6 +570,7 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
+   * @return {!Array<!Element>}
    * @visibleForTesting
    */
   getElementsForTesting() {
@@ -577,6 +578,7 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
+   * @return {!Array<!Element>}
    * @visibleForTesting
    */
   getSelectedElementsForTesting() {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -241,7 +241,7 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   maybeRefreshOnUpdate_(unusedEvent) {
-    const newElements = this.element.querySelectorAll('[option]');
+    const newElements = toArray(this.element.querySelectorAll('[option]'));
     if (areEqualOrdered(this.elements_, newElements)) {
       return;
     }
@@ -249,11 +249,11 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
-   * @param {Array<Element>=} opt_elements
+   * @param {!Array<!Element>=} opt_elements
    * @private
    */
   init_(opt_elements) {
-    this.selectedElements_ = [];
+    this.selectedElements_.length = 0;
 
     const elements = opt_elements
       ? opt_elements
@@ -273,6 +273,7 @@ export class AmpSelector extends AMP.BaseElement {
       el.tabIndex = 0;
     });
     this.elements_ = elements;
+
     this.updateFocus_();
     this.setInputs_();
   }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -168,14 +168,14 @@ export class AmpSelector extends AMP.BaseElement {
       this.clearAllSelections_();
       return;
     }
+    // Only use first value if multiple selection is disabled.
+    if (!this.isMultiple_) {
+      selected = selected.slice(0, 1);
+    }
     // If selection hasn't changed, early-out.
     const current = this.selectedOptions_();
     if (areEqualOrdered(current.sort(), selected.sort())) {
       return;
-    }
-    // Only use first value if multiple selection is disabled.
-    if (!this.isMultiple_) {
-      selected = selected.slice(0, 1);
     }
     // Convert array values to strings and create map for fast lookup.
     const isSelected = selected.reduce((map, value) => {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -568,6 +568,20 @@ export class AmpSelector extends AMP.BaseElement {
     element.setAttribute('aria-selected', 'true');
     this.selectedElements_.push(element);
   }
+
+  /**
+   * @visibleForTesting
+   */
+  getElementsForTesting() {
+    return this.elements_;
+  }
+
+  /**
+   * @visibleForTesting
+   */
+  getSelectedElementsForTesting() {
+    return this.selectedElements_;
+  }
 }
 
 AMP.extension(TAG, '0.1', AMP => {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -26,6 +26,7 @@ import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {mod} from '../../../src/utils/math';
 import {toArray} from '../../../src/types';
+
 const TAG = 'amp-selector';
 
 /**
@@ -39,9 +40,7 @@ const KEYBOARD_SELECT_MODES = {
   SELECT: 'select',
 };
 
-
 export class AmpSelector extends AMP.BaseElement {
-
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -50,10 +49,10 @@ export class AmpSelector extends AMP.BaseElement {
     this.isMultiple_ = false;
 
     /** @private {!Array<!Element>} */
-    this.selectedOptions_ = [];
+    this.selectedElements_ = [];
 
     /** @private {!Array<!Element>} */
-    this.options_ = [];
+    this.elements_ = [];
 
     /** @private {!Array<!Element>} */
     this.inputs_ = [];
@@ -130,7 +129,7 @@ export class AmpSelector extends AMP.BaseElement {
     this.registerAction('toggle', invocation => {
       const {args} = invocation;
       user().assert(args['index'] >= 0, '\'index\' must be greater than 0');
-      user().assert(args['index'] < this.options_.length, '\'index\' must be ' +
+      user().assert(args['index'] < this.elements_.length, '\'index\' must be ' +
         'less than the length of options in the <amp-selector>');
       if (args && args['index'] !== undefined) {
         this.toggle_(args['index'], args['value']);
@@ -164,32 +163,36 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   selectedAttributeMutated_(newValue) {
-    if (newValue === null) {
+    let selected = Array.isArray(newValue) ? newValue : [newValue];
+    if (newValue === null || selected.length == 0) {
       this.clearAllSelections_();
       return;
     }
-    let selectedArray = Array.isArray(newValue) ? newValue : [newValue];
+    // If selection hasn't changed, early-out.
+    const current = this.selectedOptions_();
+    if (areEqualOrdered(current.sort(), selected.sort())) {
+      return;
+    }
     // Only use first value if multiple selection is disabled.
     if (!this.isMultiple_) {
-      selectedArray = selectedArray.slice(0, 1);
+      selected = selected.slice(0, 1);
     }
     // Convert array values to strings and create map for fast lookup.
-    const selectedMap = selectedArray.reduce((map, value) => {
+    const isSelected = selected.reduce((map, value) => {
       map[value] = true;
       return map;
     }, Object.create(null));
     // Iterate through elements and toggle selection as necessary.
-    for (let i = 0; i < this.options_.length; i++) {
-      const element = this.options_[i];
+    for (let i = 0; i < this.elements_.length; i++) {
+      const element = this.elements_[i];
       const option = element.getAttribute('option');
-      if (selectedMap[option]) {
+      if (isSelected[option]) {
         this.setSelection_(element);
       } else {
         this.clearSelection_(element);
       }
     }
     this.updateFocus_();
-    // Update inputs.
     this.setInputs_();
   }
 
@@ -214,20 +217,20 @@ export class AmpSelector extends AMP.BaseElement {
       return;
     }
 
-    this.options_.forEach(option => {
+    this.elements_.forEach(option => {
       option.tabIndex = -1;
     });
 
     let focusElement = opt_focusEl;
     if (!focusElement) {
       if (this.isMultiple_) {
-        focusElement = this.options_[0];
+        focusElement = this.elements_[0];
       } else {
-        focusElement = this.selectedOptions_[0] || this.options_[0];
+        focusElement = this.selectedElements_[0] || this.elements_[0];
       }
     }
     if (focusElement) {
-      this.focusedIndex_ = this.options_.indexOf(focusElement);
+      this.focusedIndex_ = this.elements_.indexOf(focusElement);
       focusElement.tabIndex = 0;
     }
   }
@@ -238,40 +241,38 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   maybeRefreshOnUpdate_(unusedEvent) {
-    const newOptions = toArray(this.element.querySelectorAll('[option]'));
-    if (areEqualOrdered(this.options_, newOptions)) { // no updates
+    const newElements = this.element.querySelectorAll('[option]');
+    if (areEqualOrdered(this.elements_, newElements)) {
       return;
     }
-    // Clear prev states
-    this.options_ = [];
-    this.selectedOptions_ = [];
-    this.inputs_ = [];
-    this.init_(newOptions);
+    this.init_(newElements);
   }
 
   /**
-   * @param {Array<Element>=} opt_options
+   * @param {Array<Element>=} opt_elements
    * @private
    */
-  init_(opt_options) {
-    const options = opt_options ?
-      opt_options :
-      toArray(this.element.querySelectorAll('[option]'));
-    options.forEach(option => {
-      if (!option.hasAttribute('role')) {
-        option.setAttribute('role', 'option');
+  init_(opt_elements) {
+    this.selectedElements_ = [];
+
+    const elements = opt_elements
+      ? opt_elements
+      : toArray(this.element.querySelectorAll('[option]'));
+    elements.forEach(el => {
+      if (!el.hasAttribute('role')) {
+        el.setAttribute('role', 'option');
       }
-      if (option.hasAttribute('disabled')) {
-        option.setAttribute('aria-disabled', 'true');
+      if (el.hasAttribute('disabled')) {
+        el.setAttribute('aria-disabled', 'true');
       }
-      if (option.hasAttribute('selected')) {
-        this.setSelection_(option);
+      if (el.hasAttribute('selected')) {
+        this.setSelection_(el);
       } else {
-        this.clearSelection_(option);
+        this.clearSelection_(el);
       }
-      option.tabIndex = 0;
-      this.options_.push(option);
+      el.tabIndex = 0;
     });
+    this.elements_ = elements;
     this.updateFocus_();
     this.setInputs_();
   }
@@ -297,7 +298,7 @@ export class AmpSelector extends AMP.BaseElement {
     this.inputs_ = [];
     const doc = this.win.document;
     const fragment = doc.createDocumentFragment();
-    this.selectedOptions_.forEach(option => {
+    this.selectedElements_.forEach(option => {
       if (!option.hasAttribute('disabled')) {
         const hidden = doc.createElement('input');
         const value = option.getAttribute('option');
@@ -319,6 +320,7 @@ export class AmpSelector extends AMP.BaseElement {
   /**
    * Handles user selection on an option.
    * @param {!Element} el The element selected.
+   * @private
    */
   onOptionPicked_(el) {
     if (el.hasAttribute('disabled')) {
@@ -341,12 +343,10 @@ export class AmpSelector extends AMP.BaseElement {
       // 'targetOption' - option value of the selected or deselected element.
       // 'selectedOptions' - array of option values of selected elements.
       const name = 'select';
-      const selections =
-          this.selectedOptions_.map(el => el.getAttribute('option'));
       const selectEvent =
           createCustomEvent(this.win, `amp-selector.${name}`, dict({
             'targetOption': el.getAttribute('option'),
-            'selectedOptions': selections,
+            'selectedOptions': this.selectedOptions_(),
           }));
       this.action_.trigger(this.element, name, selectEvent,
           ActionTrust.HIGH);
@@ -354,8 +354,17 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
+   * @return {!Array<string>}
+   * @private
+   */
+  selectedOptions_() {
+    return this.selectedElements_.map(el => el.getAttribute('option'));
+  }
+
+  /**
    * Handles click events for the selectables.
    * @param {!Event} event
+   * @private
    */
   clickHandler_(event) {
     if (this.element.hasAttribute('disabled')) {
@@ -377,15 +386,16 @@ export class AmpSelector extends AMP.BaseElement {
    * Handles toggle action.
    * @param {number} index
    * @param {boolean=} opt_value
+   * @private
    */
   toggle_(index, opt_value) {
     // Change the selection to the next element in the specified direction.
     // The selection should loop around if the user attempts to go one
     // past the beginning or end.
-    const indexCurrentStatus = this.options_[index].hasAttribute('selected');
+    const indexCurrentStatus = this.elements_[index].hasAttribute('selected');
     const indexFinalStatus =
       opt_value !== undefined ? opt_value : !indexCurrentStatus;
-    const selectedIndex = this.options_.indexOf(this.selectedOptions_[0]);
+    const selectedIndex = this.elements_.indexOf(this.selectedElements_[0]);
 
     if (indexFinalStatus === indexCurrentStatus) {
       return;
@@ -393,33 +403,34 @@ export class AmpSelector extends AMP.BaseElement {
 
     // There is a change of the `selected` attribute for the element
     if (selectedIndex !== index) {
-      this.setSelection_(this.options_[index]);
-      this.clearSelection_(this.options_[selectedIndex]);
+      this.setSelection_(this.elements_[index]);
+      this.clearSelection_(this.elements_[selectedIndex]);
     } else {
-      this.clearSelection_(this.options_[index]);
+      this.clearSelection_(this.elements_[index]);
     }
   }
-
 
   /**
    * Handles selectUp events.
    * @param {number} delta
+   * @private
    */
   select_(delta) {
     // Change the selection to the next element in the specified direction.
     // The selection should loop around if the user attempts to go one
     // past the beginning or end.
-    const previousIndex = this.options_.indexOf(this.selectedOptions_[0]);
+    const previousIndex = this.elements_.indexOf(this.selectedElements_[0]);
     const index = previousIndex + delta;
-    const normalizedIndex = mod(index, this.options_.length);
+    const normalizedIndex = mod(index, this.elements_.length);
 
-    this.setSelection_(this.options_[normalizedIndex]);
-    this.clearSelection_(this.options_[previousIndex]);
+    this.setSelection_(this.elements_[normalizedIndex]);
+    this.clearSelection_(this.elements_[previousIndex]);
   }
 
   /**
    * Handles keyboard events.
    * @param {!Event} event
+   * @private
    */
   keyDownHandler_(event) {
     if (this.element.hasAttribute('disabled')) {
@@ -446,6 +457,7 @@ export class AmpSelector extends AMP.BaseElement {
    * Handles keyboard navigation events. Should not be called if
    * keyboard selection is disabled.
    * @param {!Event} event
+   * @private
    */
   navigationKeyDownHandler_(event) {
     const doc = this.win.document;
@@ -474,22 +486,22 @@ export class AmpSelector extends AMP.BaseElement {
     event.preventDefault();
 
     // Make currently selected option unfocusable
-    this.options_[this.focusedIndex_].tabIndex = -1;
+    this.elements_[this.focusedIndex_].tabIndex = -1;
 
     // Change the focus to the next element in the specified direction.
     // The selection should loop around if the user attempts to go one
     // past the beginning or end.
-    this.focusedIndex_ = (this.focusedIndex_ + dir) % this.options_.length;
+    this.focusedIndex_ = (this.focusedIndex_ + dir) % this.elements_.length;
     if (this.focusedIndex_ < 0) {
-      this.focusedIndex_ = this.focusedIndex_ + this.options_.length;
+      this.focusedIndex_ = this.focusedIndex_ + this.elements_.length;
     }
 
     // Focus newly selected option
-    const newSelectedOption = this.options_[this.focusedIndex_];
+    const newSelectedOption = this.elements_[this.focusedIndex_];
     newSelectedOption.tabIndex = 0;
     tryFocus(newSelectedOption);
 
-    const focusedOption = this.options_[this.focusedIndex_];
+    const focusedOption = this.elements_[this.focusedIndex_];
     if (this.kbSelectMode_ == KEYBOARD_SELECT_MODES.SELECT) {
       this.onOptionPicked_(focusedOption);
     }
@@ -498,11 +510,12 @@ export class AmpSelector extends AMP.BaseElement {
   /**
    * Handles keyboard selection events.
    * @param {!Event} event
+   * @private
    */
   selectionKeyDownHandler_(event) {
     const {key} = event;
     if (key == Keys.SPACE || key == Keys.ENTER) {
-      if (this.options_.includes(event.target)) {
+      if (this.elements_.includes(event.target)) {
         event.preventDefault();
         const el = dev().assertElement(event.target);
         this.onOptionPicked_(el);
@@ -518,9 +531,9 @@ export class AmpSelector extends AMP.BaseElement {
   clearSelection_(element) {
     element.removeAttribute('selected');
     element.setAttribute('aria-selected', 'false');
-    const selIndex = this.selectedOptions_.indexOf(element);
+    const selIndex = this.selectedElements_.indexOf(element);
     if (selIndex !== -1) {
-      this.selectedOptions_.splice(selIndex, 1);
+      this.selectedElements_.splice(selIndex, 1);
     }
   }
 
@@ -529,9 +542,9 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   clearAllSelections_() {
-    while (this.selectedOptions_.length > 0) {
+    while (this.selectedElements_.length > 0) {
       // Clear selected options for single select.
-      const el = this.selectedOptions_.pop();
+      const el = this.selectedElements_.pop();
       this.clearSelection_(el);
     }
     this.setInputs_();
@@ -544,7 +557,7 @@ export class AmpSelector extends AMP.BaseElement {
    */
   setSelection_(element) {
     // Exit if `element` is already selected.
-    if (this.selectedOptions_.includes(element)) {
+    if (this.selectedElements_.includes(element)) {
       return;
     }
     if (!this.isMultiple_) {
@@ -552,10 +565,9 @@ export class AmpSelector extends AMP.BaseElement {
     }
     element.setAttribute('selected', '');
     element.setAttribute('aria-selected', 'true');
-    this.selectedOptions_.push(element);
+    this.selectedElements_.push(element);
   }
 }
-
 
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerElement(TAG, AmpSelector, CSS);

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -152,11 +152,11 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       yield ampSelector.build();
       expect(impl.element.getAttribute('role')).to.equal('tablist');
-      expect(impl.options_[0].getAttribute('role')).to.equal('tab');
+      const options = impl.getElementsForTesting();
+      expect(options[0].getAttribute('role')).to.equal('tab');
     });
 
     it('should init properly for single select', function* () {
-
       let ampSelector = getSelector({});
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
@@ -165,7 +165,7 @@ describes.realWin('amp-selector', {
       yield ampSelector.build();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(0);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(0);
       expect(setInputsSpy).to.have.been.calledOnce;
 
 
@@ -181,10 +181,10 @@ describes.realWin('amp-selector', {
       yield ampSelector.build();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(1);
-      expect(impl.options_[1].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[1].getAttribute('aria-selected')).to.be.equal('true');
+      expect(impl.getSelectedElementsForTesting().length).to.equal(1);
+      const options = impl.getElementsForTesting();
+      expect(options[1].hasAttribute('selected')).to.be.true;
+      expect(options[1].getAttribute('aria-selected')).to.be.equal('true');
       expect(setInputsSpy).to.have.been.calledThrice; // once to set, twice to clear
     });
 
@@ -204,7 +204,7 @@ describes.realWin('amp-selector', {
       yield ampSelector.build();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(2);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(2);
       expect(setInputsSpy).to.have.been.calledOnce;
     });
 
@@ -226,8 +226,8 @@ describes.realWin('amp-selector', {
 
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.options_.length).to.equal(10);
-      expect(impl.selectedOptions_.length).to.equal(2);
+      expect(impl.getElementsForTesting().length).to.equal(10);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(2);
       expect(setInputsSpy).to.have.been.calledOnce;
     });
 
@@ -246,20 +246,19 @@ describes.realWin('amp-selector', {
       const clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       yield ampSelector.build();
 
+      const options = impl.getElementsForTesting();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(1);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(1);
       expect(setInputsSpy).to.have.been.calledThrice;
-      expect(impl.options_[1].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[1].getAttribute('aria-selected')).to.be.equal('true');
+      expect(options[1].hasAttribute('selected')).to.be.true;
+      expect(options[1].getAttribute('aria-selected')).to.be.equal('true');
 
-      impl.setSelection_(impl.options_[3]);
-      expect(impl.selectedOptions_.length).to.equal(1);
-      expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[1]);
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[3].getAttribute('aria-selected')).to.be.equal('true');
+      impl.setSelection_(options[3]);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(1);
+      expect(clearSelectionSpy).to.have.been.calledWith(options[1]);
+      expect(options[3].hasAttribute('selected')).to.be.true;
+      expect(options[3].getAttribute('aria-selected')).to.be.equal('true');
 
     });
 
@@ -279,22 +278,20 @@ describes.realWin('amp-selector', {
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
       yield ampSelector.build();
 
+      const options = impl.getElementsForTesting();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(2);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(2);
       expect(setInputsSpy).to.have.been.calledOnce;
-      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[0].getAttribute('aria-selected')).to.be.equal('true');
-      expect(impl.options_[1].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[1].getAttribute('aria-selected')).to.be.equal('true');
+      expect(options[0].hasAttribute('selected')).to.be.true;
+      expect(options[0].getAttribute('aria-selected')).to.be.equal('true');
+      expect(options[1].hasAttribute('selected')).to.be.true;
+      expect(options[1].getAttribute('aria-selected')).to.be.equal('true');
 
-      impl.setSelection_(impl.options_[3]);
-      expect(impl.selectedOptions_.length).to.equal(3);
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[3].getAttribute('aria-selected')).to.be.equal('true');
+      impl.setSelection_(options[3]);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(3);
+      expect(options[3].hasAttribute('selected')).to.be.true;
+      expect(options[3].getAttribute('aria-selected')).to.be.equal('true');
     });
 
 
@@ -314,22 +311,20 @@ describes.realWin('amp-selector', {
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
       yield ampSelector.build();
 
+      const options = impl.getElementsForTesting();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
-      expect(impl.selectedOptions_.length).to.equal(2);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(2);
       expect(setInputsSpy).to.have.been.calledOnce;
-      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[0].getAttribute('aria-selected')).to.be.equal('true');
-      expect(impl.options_[1].hasAttribute('selected')).to.be.true;
-      expect(
-          impl.options_[1].getAttribute('aria-selected')).to.be.equal('true');
+      expect(options[0].hasAttribute('selected')).to.be.true;
+      expect(options[0].getAttribute('aria-selected')).to.be.equal('true');
+      expect(options[1].hasAttribute('selected')).to.be.true;
+      expect(options[1].getAttribute('aria-selected')).to.be.equal('true');
 
-      impl.clearSelection_(impl.options_[1]);
-      expect(impl.selectedOptions_.length).to.equal(1);
-      expect(impl.options_[1].hasAttribute('selected')).to.be.false;
-      expect(
-          impl.options_[1].getAttribute('aria-selected')).to.be.equal('false');
+      impl.clearSelection_(options[1]);
+      expect(impl.getSelectedElementsForTesting().length).to.equal(1);
+      expect(options[1].hasAttribute('selected')).to.be.false;
+      expect(options[1].getAttribute('aria-selected')).to.be.equal('false');
 
     });
 
@@ -373,14 +368,17 @@ describes.realWin('amp-selector', {
       });
       impl = ampSelector.implementation_;
       yield ampSelector.build();
-      expect(impl.inputs_.length).to.equal(1);
-      expect(impl.selectedOptions_).to.include.members([impl.options_[1]]);
 
-      impl.setSelection_(impl.options_[3]);
+      let options = impl.getElementsForTesting();
+      expect(impl.inputs_.length).to.equal(1);
+      expect(impl.getSelectedElementsForTesting())
+          .to.include.members([options[1]]);
+
+      impl.setSelection_(options[3]);
       impl.setInputs_();
       expect(impl.inputs_.length).to.equal(1);
-      expect(impl.selectedOptions_).to.include.members([impl.options_[3]]);
-
+      expect(impl.getSelectedElementsForTesting())
+          .to.include.members([options[3]]);
 
       ampSelector = getSelector({
         attributes: {
@@ -393,20 +391,22 @@ describes.realWin('amp-selector', {
         },
       });
       impl = ampSelector.implementation_;
+
       yield ampSelector.build();
+      options = impl.getElementsForTesting();
       expect(impl.inputs_.length).to.equal(2);
-      expect(impl.selectedOptions_).to.include.members([
-        impl.options_[0],
-        impl.options_[1],
+      expect(impl.getSelectedElementsForTesting()).to.include.members([
+        options[0],
+        options[1],
       ]);
 
-      impl.setSelection_(impl.options_[2]);
+      impl.setSelection_(options[2]);
       impl.setInputs_();
       expect(impl.inputs_.length).to.equal(3);
-      expect(impl.selectedOptions_).to.include.members([
-        impl.options_[0],
-        impl.options_[1],
-        impl.options_[2],
+      expect(impl.getSelectedElementsForTesting()).to.include.members([
+        options[0],
+        options[1],
+        options[2],
       ]);
     });
 
@@ -424,9 +424,10 @@ describes.realWin('amp-selector', {
       });
       const impl = ampSelector.implementation_;
       yield ampSelector.build();
-      expect(impl.inputs_.length).to.equal(0);
 
-      impl.setSelection_(impl.options_[3]);
+      const options = impl.getElementsForTesting();
+      expect(impl.inputs_.length).to.equal(0);
+      impl.setSelection_(options[3]);
       impl.setInputs_();
       expect(impl.inputs_.length).to.equal(0);
     });
@@ -444,17 +445,18 @@ describes.realWin('amp-selector', {
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
       yield ampSelector.build();
+
+      let options = impl.getElementsForTesting();
       let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
-
       let e = {
-        target: impl.options_[3],
+        target: options[3],
       };
       impl.clickHandler_(e);
 
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[3]);
-      expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[1]);
+      expect(options[3].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[3]);
+      expect(clearSelectionSpy).to.have.been.calledWith(options[1]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
@@ -467,7 +469,7 @@ describes.realWin('amp-selector', {
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
       e = {
-        target: impl.options_[3],
+        target: options[3],
       };
       impl.clickHandler_(e);
       expect(setSelectionSpy).to.have.been.calledOnce;
@@ -487,31 +489,33 @@ describes.realWin('amp-selector', {
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
       yield ampSelector.build();
+
+      options = impl.getElementsForTesting();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
       e = {
-        target: impl.options_[4],
+        target: options[4],
       };
 
       impl.clickHandler_(e);
-      expect(impl.options_[4].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[4]);
+      expect(options[4].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.not.have.been.called;
 
       impl.clickHandler_(e);
-      expect(impl.options_[4].hasAttribute('selected')).to.be.false;
-      expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[4]);
+      expect(options[4].hasAttribute('selected')).to.be.false;
+      expect(clearSelectionSpy).to.have.been.calledWith(options[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
       e = {
-        target: impl.options_[2],
+        target: options[2],
       };
       impl.clickHandler_(e);
-      expect(impl.options_[2].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[2]);
+      expect(options[2].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[2]);
       expect(setSelectionSpy).to.have.been.calledTwice;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
@@ -555,16 +559,19 @@ describes.realWin('amp-selector', {
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
       yield ampSelector.build();
+
+      let options = impl.getElementsForTesting();
       let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
-      keyPress(ampSelector, Keys.ENTER, impl.options_[3]);
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[3]);
-      expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[1]);
+
+      keyPress(ampSelector, Keys.ENTER, options[3]);
+      expect(options[3].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[3]);
+      expect(clearSelectionSpy).to.have.been.calledWith(options[1]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
-      keyPress(ampSelector, Keys.ENTER, impl.options_[3]);
+      keyPress(ampSelector, Keys.ENTER, options[3]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
@@ -582,24 +589,26 @@ describes.realWin('amp-selector', {
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
       yield ampSelector.build();
+
+      options = impl.getElementsForTesting();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
-      keyPress(ampSelector, Keys.SPACE, impl.options_[4]);
-      expect(impl.options_[4].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[4]);
+      keyPress(ampSelector, Keys.SPACE, options[4]);
+      expect(options[4].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.not.have.been.called;
 
-      keyPress(ampSelector, Keys.SPACE, impl.options_[4]);
-      expect(impl.options_[4].hasAttribute('selected')).to.be.false;
-      expect(clearSelectionSpy).to.have.been.calledWith(impl.options_[4]);
+      keyPress(ampSelector, Keys.SPACE, options[4]);
+      expect(options[4].hasAttribute('selected')).to.be.false;
+      expect(clearSelectionSpy).to.have.been.calledWith(options[4]);
       expect(setSelectionSpy).to.have.been.calledOnce;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
-      keyPress(ampSelector, Keys.ENTER, impl.options_[2]);
-      expect(impl.options_[2].hasAttribute('selected')).to.be.true;
-      expect(setSelectionSpy).to.have.been.calledWith(impl.options_[2]);
+      keyPress(ampSelector, Keys.ENTER, options[2]);
+      expect(options[2].hasAttribute('selected')).to.be.true;
+      expect(setSelectionSpy).to.have.been.calledWith(options[2]);
       expect(setSelectionSpy).to.have.been.calledTwice;
       expect(clearSelectionSpy).to.have.been.calledOnce;
 
@@ -635,21 +644,23 @@ describes.realWin('amp-selector', {
 
       const impl = ampSelector.implementation_;
       ampSelector.build();
+
+      const options = impl.getElementsForTesting();
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
 
-      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.false;
+      expect(options[0].hasAttribute('selected')).to.be.true;
+      expect(options[3].hasAttribute('selected')).to.be.false;
 
       impl.mutatedAttributesCallback({selected: '3'});
 
-      expect(impl.options_[0].hasAttribute('selected')).to.be.false;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
+      expect(options[0].hasAttribute('selected')).to.be.false;
+      expect(options[3].hasAttribute('selected')).to.be.true;
 
       // Integers should be converted to strings.
       impl.mutatedAttributesCallback({selected: 0});
 
-      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.false;
+      expect(options[0].hasAttribute('selected')).to.be.true;
+      expect(options[3].hasAttribute('selected')).to.be.false;
 
       expect(setInputsSpy).to.have.callCount(4);
     });
@@ -666,14 +677,15 @@ describes.realWin('amp-selector', {
       impl.mutateElement = fn => fn();
       ampSelector.build();
 
-      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.false;
+      const options = impl.getElementsForTesting();
+      expect(options[0].hasAttribute('selected')).to.be.true;
+      expect(options[3].hasAttribute('selected')).to.be.false;
 
-      impl.clickHandler_({target: impl.options_[3]});
+      impl.clickHandler_({target: options[3]});
 
       // When not disabled, clicking an option should select it.
-      expect(impl.options_[0].hasAttribute('selected')).to.be.false;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
+      expect(options[0].hasAttribute('selected')).to.be.false;
+      expect(options[3].hasAttribute('selected')).to.be.true;
 
       expect(ampSelector.hasAttribute('aria-disabled')).to.be.false;
 
@@ -682,11 +694,11 @@ describes.realWin('amp-selector', {
 
       expect(ampSelector.getAttribute('aria-disabled')).to.equal('true');
 
-      impl.clickHandler_({target: impl.options_[0]});
+      impl.clickHandler_({target: options[0]});
 
       // When disabled, clicking an option should not select it.
-      expect(impl.options_[0].hasAttribute('selected')).to.be.false;
-      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
+      expect(options[0].hasAttribute('selected')).to.be.false;
+      expect(options[3].hasAttribute('selected')).to.be.true;
     });
 
     it('should trigger `toggle` action even when no `value` argument is' +
@@ -778,8 +790,9 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
 
+      const options = impl.getElementsForTesting();
       const triggerSpy = sandbox.spy(impl.action_, 'trigger');
-      impl.clickHandler_({target: impl.options_[3]});
+      impl.clickHandler_({target: options[3]});
 
       expect(triggerSpy).to.be.calledOnce;
       expect(triggerSpy).to.have.been.calledWith(ampSelector, 'select');
@@ -806,8 +819,9 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
 
+      const options = impl.getElementsForTesting();
       const triggerSpy = sandbox.spy(impl.action_, 'trigger');
-      impl.clickHandler_({target: impl.options_[2]});
+      impl.clickHandler_({target: options[2]});
 
       expect(triggerSpy).to.be.calledOnce;
       expect(triggerSpy).to.have.been.calledWith(ampSelector, 'select');

--- a/extensions/amp-selector/0.1/test/test-selector-list.js
+++ b/extensions/amp-selector/0.1/test/test-selector-list.js
@@ -120,26 +120,30 @@ describes.realWin('amp-selector amp-list interaction', {
   it('should load selector options correctly with template', function() {
     return layoutPromise.then(() => {
       return poll('wait for options to construct', () => {
-        return selector.options_.length > 0;
+        // TODO: Integration tests really should not be inspecting ivars, or
+        // anything other than DOM-observable properties and attributes.
+        return selector.getElementsForTesting().length > 0;
       }, () => {}, 1000);
-    })
-        .then(() => {
-          expect(selector.options_.length).to.equal(2);
-          expect(selector.options_[0].getAttribute('option')).to.equal('0');
-          expect(selector.options_[1].getAttribute('option')).to.equal('1');
-        });
+    }).then(() => {
+      const options = selector.getElementsForTesting();
+      expect(options.length).to.equal(2);
+      expect(options[0].getAttribute('option')).to.equal('0');
+      expect(options[1].getAttribute('option')).to.equal('1');
+    });
   });
 
   it('should not call init again if no actual option is changed', function() {
-    let opts;
+    let options;
     let initCount;
     return layoutPromise.then(() => {
       return poll('wait for options to construct', () => {
-        return selector.options_.length > 0;
+        // TODO: Integration tests really should not be inspecting ivars, or
+        // anything other than DOM-observable properties and attributes.
+        return selector.getElementsForTesting().length > 0;
       }, () => {}, 1000);
     })
         .then(() => {
-          opts = selector.options_;
+          options = selector.getElementsForTesting();
           initCount = AmpSelector.prototype.init_.callCount;
 
           refreshDeferred = new Deferred();
@@ -152,7 +156,7 @@ describes.realWin('amp-selector amp-list interaction', {
           return refreshDeferred.promise;
         })
         .then(() => {
-          expect(opts).to.equal(selector.options_);
+          expect(options).to.equal(selector.getElementsForTesting());
           expect(AmpSelector.prototype.init_.callCount).to.equal(initCount);
         });
   });

--- a/src/types.js
+++ b/src/types.js
@@ -42,14 +42,7 @@ export function isArray(value) {
  * @template T
  */
 export function toArray(arrayLike) {
-  if (!arrayLike) {
-    return [];
-  }
-  const array = new Array(arrayLike.length);
-  for (let i = 0; i < arrayLike.length; i++) {
-    array[i] = arrayLike[i];
-  }
-  return array;
+  return arrayLike ? Array.prototype.slice.call(arrayLike) : [];
 }
 
 /**

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -17,11 +17,10 @@
 
 /**
  * Compares if two arrays contains exactly same elements of same number
- * of same order.
- * Notice that it does NOT handle NaN case as expected
+ * of same order. Note that it does NOT handle NaN case as expected.
  *
- * @param {!Array<T>} arr1
- * @param {!Array<T>} arr2
+ * @param {!IArrayLike<T>} arr1
+ * @param {!IArrayLike<T>} arr2
  * @return {boolean}
  * @template T
  */
@@ -29,13 +28,11 @@ export function areEqualOrdered(arr1, arr2) {
   if (arr1.length !== arr2.length) {
     return false;
   }
-
   for (let i = 0; i < arr1.length; i++) {
     if (arr1[i] !== arr2[i]) {
       return false;
     }
   }
-
   return true;
 }
 

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -19,8 +19,8 @@
  * Compares if two arrays contains exactly same elements of same number
  * of same order. Note that it does NOT handle NaN case as expected.
  *
- * @param {!IArrayLike<T>} arr1
- * @param {!IArrayLike<T>} arr2
+ * @param {!Array<T>} arr1
+ * @param {!Array<T>} arr2
  * @return {boolean}
  * @template T
  */


### PR DESCRIPTION
- Rename ivars `options_` to `elements_` and `selectedOptions_` to `selectedElements_`.
- When `[selected]` is mutated, early-out if selections have not changed.
- More concise `toArray()` util.