### PR TITLE
🏗✨ Configure Renovate to allow all active LTS versions of node in package.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,11 @@
   "extends": [
     "config:base"
   ],
+  "node": {
+    "supportPolicy": [
+      "lts_active"
+    ]
+  },
   "statusCheckVerify": true,
   "ignoreDeps": [
     "babel-polyfill",


### PR DESCRIPTION
Every time a new LTS version of node is released, our `package.json` breaks, because we currently specify just one acceptable version of node. This PR sets up Renovate to automatically update the `engines` section of `package.json` to allow all active LTS versions of node for development.

Note: Travis will continue to use the latest active LTS version of node for testing.

Partial fix for #19050
