### PR TITLE
🏗 Allow all active LTS versions of node in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Fastish HTML",
   "main": "index.js",
   "engines": {
-    "node": "^8.0.0",
+    "node": "^8.0.0 || ^10.0.0",
     "yarn": "^1.10.1"
   },
   "author": "The AMP HTML Authors",


### PR DESCRIPTION
#19218 enabled updates for node versions via Renovate. However, I don't see an incoming PR to change the `engines` section of `package.json`. If there's no incoming PR over the next day, I'll merge this PR, which manually updates the allowed versions.

Fixes #19050
