### PR TITLE
🐛Only add runtime classNames custom-elements not in templates

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -735,6 +735,13 @@ function createBaseCustomElementClass(win) {
      * @final @this {!Element}
      */
     connectedCallback() {
+      if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
+        this.isInTemplate_ = !!dom.closestByTag(this, 'template');
+      }
+      if (this.isInTemplate_) {
+        return;
+      }
+
       if (this.isConnected_ || !dom.isConnectedNode(this)) {
         return;
       }
@@ -746,12 +753,6 @@ function createBaseCustomElementClass(win) {
         this.classList.add('amp-notbuilt');
       }
 
-      if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
-        this.isInTemplate_ = !!dom.closestByTag(this, 'template');
-      }
-      if (this.isInTemplate_) {
-        return;
-      }
       if (!this.ampdoc_) {
         // Ampdoc can now be initialized.
         const win = toWin(this.ownerDocument.defaultView);


### PR DESCRIPTION
Fixes #18183 

In browsers that do not support `<template>` natively, AMP custom-elements in templates have runtime classNames added. I believe this is not the intended behavior. 

This caused problems when parent elements called `measureMutateElement`. `measureMutateElement` queries child elements with the  `i-amphtml-element` className and attempts to reference their `resources_` methods. The custom-elements inside the templates are assigned the runtime classNames, but don't reach the code path where their `resources_` get assigned, and so a `Reference Error` would occur.

This PR fixes that error from occurring by exiting from `connectedCallback` before the runtime classnames are added. This prevents `measureMutateElement` from querying custom-elements inside `<template>` tags.

Do you foresee any issues with this approach?

/to @jridgewell @choumx 
/cc @dvoytenko 