### PR TITLE
🐛 Fixed typo in onInfoDialogStateUpdated_ method JSDoc.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -142,8 +142,8 @@ export class InfoDialog {
   }
 
   /**
-   * Reacts to menu state updates and decides whether to show either the native
-   * system sharing, or the fallback UI.
+   * Reacts to dialog state updates and decides whether to show either the
+   * native system sharing, or the fallback UI.
    * @param {boolean} isOpen
    * @private
    */


### PR DESCRIPTION
The method's JSDoc incorrectly described the method as _menu_ state changes. The comment was also wrapped to prevent going over the 80 character limit.

