### PR TITLE
Opt in into the desktop full bleed experience.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -52,7 +52,7 @@ export const getStoreService = win => {
 export const UIType = {
   MOBILE: 'mobile',
   DESKTOP: 'desktop',
-  FULLBLEED: 'fullbleed',
+  DESKTOP_FULLBLEED: 'fullbleed',
 };
 
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -47,11 +47,12 @@ export const getStoreService = win => {
 
 /**
  * Different UI experiences to display the story.
- * @const @enum {number}
+ * @const @enum {string}
  */
 export const UIType = {
-  MOBILE: 0,
-  DESKTOP: 1,
+  MOBILE: 'mobile',
+  DESKTOP: 'desktop',
+  FULLBLEED: 'fullbleed',
 };
 
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1331,7 +1331,7 @@ export class AmpStory extends AMP.BaseElement {
           this.updateBackground_(this.activePage_.element, /* initial */ true);
         }
         break;
-      case UIType.FULLBLEED:
+      case UIType.DESKTOP_FULLBLEED:
         this.shareMenu_.build();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop-fullbleed', '');
@@ -1352,8 +1352,9 @@ export class AmpStory extends AMP.BaseElement {
       return UIType.MOBILE;
     }
 
-    if (this.element.getAttribute('desktop-mode') === UIType.FULLBLEED) {
-      return UIType.FULLBLEED;
+    if (this.element.getAttribute('desktop-mode') ===
+        UIType.DESKTOP_FULLBLEED) {
+      return UIType.DESKTOP_FULLBLEED;
     }
 
     // Three panels desktop UI (default).

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -348,9 +348,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListeners_();
     this.initializeListenersForDev_();
 
-    if (this.isDesktop_()) {
-      this.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
-    }
+    this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
     this.navigationState_.observe(stateChangeEvent => {
       this.variableService_.onNavigationStateChange(stateChangeEvent);
@@ -750,9 +748,10 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   whenPagesLoaded_(timeoutMs = 0) {
-    const pagesToWaitFor = this.isDesktop_() ?
-      [this.pages_[0], this.pages_[1]] :
-      [this.pages_[0]];
+    const pagesToWaitFor =
+        this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP ?
+          [this.pages_[0], this.pages_[1]] :
+          [this.pages_[0]];
 
     const storyLoadPromise = Promise.all(
         pagesToWaitFor.filter(page => !!page).map(page => page.whenLoaded()));
@@ -937,7 +936,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   performTapNavigation_(direction) {
-    if (this.isDesktop_()) {
+    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
       this.next_();
       return;
     }
@@ -1172,7 +1171,7 @@ export class AmpStory extends AMP.BaseElement {
     if (!this.platform_.isSafari() && !this.platform_.isIos()) {
       return;
     }
-    if (this.isDesktop_()) {
+    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
       // Force repaint is only needed when transitioning from invisible to
       // visible
       return;
@@ -1258,8 +1257,7 @@ export class AmpStory extends AMP.BaseElement {
   onResize() {
     this.updateViewportSizeStyles_();
 
-    const uiState = this.isDesktop_() ? UIType.DESKTOP : UIType.MOBILE;
-
+    const uiState = this.getUIType_();
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
     if (uiState !== UIType.MOBILE) {
@@ -1316,12 +1314,14 @@ export class AmpStory extends AMP.BaseElement {
         this.shareMenu_.build();
         this.vsync_.mutate(() => {
           this.element.removeAttribute('desktop');
+          this.element.removeAttribute('desktop-fullbleed');
         });
         break;
       case UIType.DESKTOP:
         this.setDesktopPositionAttributes_(this.activePage_);
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
+          this.element.removeAttribute('desktop-fullbleed');
         });
         if (!this.background_) {
           this.background_ = new AmpStoryBackground(this.win, this.element);
@@ -1331,20 +1331,47 @@ export class AmpStory extends AMP.BaseElement {
           this.updateBackground_(this.activePage_.element, /* initial */ true);
         }
         break;
+      case UIType.FULLBLEED:
+        this.shareMenu_.build();
+        this.vsync_.mutate(() => {
+          this.element.setAttribute('desktop-fullbleed', '');
+          this.element.removeAttribute('desktop');
+        });
+        break;
     }
   }
 
   /**
+   * Retrieves the UI type that should be used to view the story.
+   * @return {!UIType}
+   * @private
+   */
+  getUIType_() {
+    if (!this.isDesktop_() ||
+        isExperimentOn(this.win, 'disable-amp-story-desktop')) {
+      return UIType.MOBILE;
+    }
+
+    if (this.element.getAttribute('desktop-mode') === UIType.FULLBLEED) {
+      return UIType.FULLBLEED;
+    }
+
+    // Three panels desktop UI (default).
+    return UIType.DESKTOP;
+  }
+
+  /**
    * @return {boolean} True if the screen size matches the desktop media query.
+   * @private
    */
   isDesktop_() {
-    return this.desktopMedia_.matches && !this.platform_.isBot() &&
-        !isExperimentOn(this.win, 'disable-amp-story-desktop');
+    return this.desktopMedia_.matches && !this.platform_.isBot();
   }
 
   /**
    * @return {boolean} true if this is a standalone story (i.e. this story is
    *     the only content of the document).
+   * @private
    */
   isStandalone_() {
     return this.element.hasAttribute(Attributes.STANDALONE);
@@ -1516,14 +1543,12 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Toggle content when bookend is opened/closed.
-   * TODO(gmajoulet): these elements should get hidden by listening to bookend
-   *                  state events.
+   * Toggles content when bookend is opened/closed.
    * @param {boolean} isActive
    * @private
    */
   toggleElementsOnBookend_(isActive) {
-    if (!this.isDesktop_()) {
+    if (this.storeService_.get(StateProperty.UI_STATE) !== UIType.DESKTOP) {
       return;
     }
 
@@ -1704,7 +1729,7 @@ export class AmpStory extends AMP.BaseElement {
     // TODO(newmuis): Change this comment.
     // On mobile there is always a bookend. On desktop, the bookend will only
     // be shown if related articles have been configured.
-    if (!this.isDesktop_()) {
+    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE) {
       return Promise.resolve(true);
     }
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -383,7 +383,7 @@ describes.realWin('amp-story', {
   });
 
   it('should detect fullbleed desktop mode', () => {
-    const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
+    createPages(story.element, 4, ['cover', '1', '2', '3']);
     story.element.setAttribute('desktop-mode', 'fullbleed');
 
     // Don't do this at home. :(
@@ -394,7 +394,7 @@ describes.realWin('amp-story', {
     return story.layoutCallback()
         .then(() => {
           expect(story.storeService_.get(StateProperty.UI_STATE))
-              .to.equals(UIType.FULLBLEED);
+              .to.equals(UIType.DESKTOP_FULLBLEED);
         });
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -382,6 +382,22 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should detect fullbleed desktop mode', () => {
+    const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
+    story.element.setAttribute('desktop-mode', 'fullbleed');
+
+    // Don't do this at home. :(
+    story.desktopMedia_ = {matches: true};
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.storeService_.get(StateProperty.UI_STATE))
+              .to.equals(UIType.FULLBLEED);
+        });
+  });
+
   describe('amp-story consent', () => {
     it('should pause the story if there is a consent', () => {
       sandbox.stub(Services, 'actionServiceForDoc')
@@ -690,9 +706,9 @@ describes.realWin('amp-story', {
       const desktopAttribute = 'i-amphtml-desktop-position';
       const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
 
-      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
-
       story.buildCallback();
+
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
 
       return story.layoutCallback()
           .then(() => {
@@ -707,9 +723,9 @@ describes.realWin('amp-story', {
       const desktopAttribute = 'i-amphtml-desktop-position';
       const pages = createPages(story.element, 4, ['cover', '1', '2', '3']);
 
-      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
-
       story.buildCallback();
+
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
 
       return story.layoutCallback()
           .then(() => story.switchTo_('2'))


### PR DESCRIPTION
Providing a way to opt in into the full bleed desktop experience, through a `<amp-story desktop-mode="fullbleed">` parameter.

This PR doesn't change anything to the current MOBILE and DESKTOP modes, nor to the `disable-amp-story-desktop` experiment.

[Demo](https://stamp-desktop-fullbleed.firebaseapp.com/examples/s20/body-painting/index.html)

#19270