### PR TITLE
✨ anchor mutators on contextmenu event (navigation.js)

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -227,10 +227,11 @@ export class LinkerManager {
    * Called on click on any anchor element. Adds linker param if a match for
    * given linker configuration.
    * @param {!Element} element
+   * @param {!Event} event
    * @private
    */
-  handleAnchorMutation_(element) {
-    if (!element.href) {
+  handleAnchorMutation_(element, event) {
+    if (!element.href || event.type !== 'click') {
       return;
     }
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -483,9 +483,12 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   function clickAnchor(url) {
     const a = doc.createElement('a');
+    const event = {
+      type: 'click',
+    };
     a.href = url;
     doc.body.appendChild(a);
-    handlers.forEach(handler => handler(a));
+    handlers.forEach(handler => handler(a, event));
     return a.href;
   }
 

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
@@ -129,19 +129,23 @@ export class LinkRewriterManager {
    * on an anchor has happened. This should mostly be used to send click
    * tracking requests, handlers of this events should not
    * mutate the anchor!
-   * @param {!HTMLElement} anchor
-   * @param {string} clickType - 'click' or 'contextmenu'
+   * @param {!Element} anchor
+   * @param {!Event} event - 'click' or 'contextmenu'
    * @public
    */
-  maybeRewriteLink(anchor, clickType = 'click') {
-    const suitableLinkRewriters = this.getSuitableLinkRewritersForLink_(anchor);
+  maybeRewriteLink(anchor, event) {
+    const suitableLinkRewriters = this.getSuitableLinkRewritersForLink_(
+        /** @type {!HTMLElement} */(anchor)
+    );
     if (suitableLinkRewriters.length) {
       let chosenLinkRewriter = null;
 
       // Iterate by order of priority until one of the linkRewriter
       // replaces the link.
       for (let i = 0; i < suitableLinkRewriters.length; i++) {
-        const hasReplaced = suitableLinkRewriters[i].rewriteAnchorUrl(anchor);
+        const hasReplaced = suitableLinkRewriters[i].rewriteAnchorUrl(
+            /** @type {!HTMLElement} */(anchor)
+        );
         if (hasReplaced) {
           chosenLinkRewriter = suitableLinkRewriters[i];
           break;
@@ -154,7 +158,7 @@ export class LinkRewriterManager {
       const eventData = {
         linkRewriterId,
         anchor,
-        clickType,
+        clickType: event.type,
       };
 
       suitableLinkRewriters.forEach(linkRewriter => {

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
@@ -130,7 +130,7 @@ export class LinkRewriterManager {
    * tracking requests, handlers of this events should not
    * mutate the anchor!
    * @param {!Element} anchor
-   * @param {!Event} event - 'click' or 'contextmenu'
+   * @param {!Event} event - 'click' or 'contextmenu' event.
    * @public
    */
   maybeRewriteLink(anchor, event) {

--- a/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
@@ -28,6 +28,11 @@ import {Services} from '../../../../src/services';
 import {TwoStepsResponse} from '../link-rewriter/two-steps-response';
 import {createCustomEvent} from '../../../../src/event-helper';
 
+
+const CLICK_EVENT = {
+  type: 'click',
+};
+
 describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
   let rootDocument, linkRewriterManager, win;
   let sendEventHelper, registerLinkRewriterHelper, addPriorityMetaTagHelper;
@@ -233,7 +238,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
       });
 
       it('Should only send click event to suitable link rewriters', () => {
-        linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+        linkRewriterManager.maybeRewriteLink(
+            rootDocument.createElement('a'),
+            CLICK_EVENT
+        );
 
         expect(linkRewriterVendor1.events.fire.calledOnce).to.be.true;
         expect(linkRewriterVendor2.events.fire.called).to.be.false;
@@ -245,7 +253,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
         env.sandbox.stub(linkRewriterVendor2, 'rewriteAnchorUrl').returns(true);
         env.sandbox.stub(linkRewriterVendor3, 'rewriteAnchorUrl').returns(true);
 
-        linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+        linkRewriterManager.maybeRewriteLink(
+            rootDocument.createElement('a'),
+            CLICK_EVENT
+        );
 
         expect(getEventData(linkRewriterVendor1).linkRewriterId).to.equal(
             'vendor1'
@@ -262,7 +273,7 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
         env.sandbox.stub(linkRewriterVendor1, 'rewriteAnchorUrl').returns(true);
         const anchor = rootDocument.createElement('a');
 
-        linkRewriterManager.maybeRewriteLink(anchor);
+        linkRewriterManager.maybeRewriteLink(anchor, CLICK_EVENT);
 
         expect(getEventData(linkRewriterVendor1).anchor).to.equal(anchor);
       });
@@ -276,7 +287,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
             .stub(linkRewriterVendor3, 'rewriteAnchorUrl')
             .returns(false);
 
-        linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+        linkRewriterManager.maybeRewriteLink(
+            rootDocument.createElement('a'),
+            CLICK_EVENT
+        );
 
         expect(getEventData(linkRewriterVendor1).linkRewriterId).to.be.null;
         // vendor2 has isWatchingLink to false therefore can not replace.
@@ -285,9 +299,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
       });
 
       it('Should set the clickType', () => {
+        const contextMenuEvent = {type: 'contextmenu'};
         linkRewriterManager.maybeRewriteLink(
             rootDocument.createElement('a'),
-            'contextmenu'
+            contextMenuEvent
         );
         expect(getEventData(linkRewriterVendor1).clickType).to.equal(
             'contextmenu'
@@ -328,7 +343,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
               .stub(linkRewriterVendor2, 'rewriteAnchorUrl')
               .returns(false);
 
-          linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+          linkRewriterManager.maybeRewriteLink(
+              rootDocument.createElement('a'),
+              CLICK_EVENT
+          );
 
           expect(linkRewriterVendor1.rewriteAnchorUrl.calledOnce).to.be.true;
           expect(linkRewriterVendor2.rewriteAnchorUrl.called).to.be.false;
@@ -345,7 +363,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
               .stub(linkRewriterVendor3, 'rewriteAnchorUrl')
               .returns(true);
 
-          linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+          linkRewriterManager.maybeRewriteLink(
+              rootDocument.createElement('a'),
+              CLICK_EVENT
+          );
 
           expect(linkRewriterVendor1.rewriteAnchorUrl.calledOnce).to.be.true;
           expect(linkRewriterVendor2.rewriteAnchorUrl.called).to.be.false;
@@ -377,7 +398,10 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
               .stub(linkRewriterVendor3, 'rewriteAnchorUrl')
               .returns(true);
 
-          linkRewriterManager.maybeRewriteLink(rootDocument.createElement('a'));
+          linkRewriterManager.maybeRewriteLink(
+              rootDocument.createElement('a'),
+              CLICK_EVENT
+          );
 
           expect(linkRewriterVendor1.rewriteAnchorUrl.called).to.be.false;
           expect(linkRewriterVendor2.rewriteAnchorUrl.called).to.be.false;
@@ -399,7 +423,7 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
           // Overwrite global priority
           anchor.setAttribute('data-link-rewriters', 'vendor1 vendor3');
 
-          linkRewriterManager.maybeRewriteLink(anchor);
+          linkRewriterManager.maybeRewriteLink(anchor, CLICK_EVENT);
 
           expect(linkRewriterVendor1.rewriteAnchorUrl.calledOnce).to.be.true;
           expect(linkRewriterVendor2.rewriteAnchorUrl.called).to.be.false;

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -141,7 +141,7 @@ export class Navigation {
     this.a2aFeatures_ = null;
 
     /**
-     * @type {!PriorityQueue<function(!Element)>}
+     * @type {!PriorityQueue<function(!Element, !Event)>}
      * @private
      * @const
      */
@@ -317,6 +317,7 @@ export class Navigation {
       // TODO(alabiaga): investigate fix for handling A2A and custom link
       // protocols.
       this.expandVarsForAnchor_(target);
+      this.anchorMutatorHandlers_(target, e);
     }
   }
 
@@ -340,14 +341,22 @@ export class Navigation {
       return;
     }
 
-    // Handle anchor transformations.
-    this.anchorMutators_.forEach(anchorMutator => {
-      anchorMutator(target);
-    });
+    this.anchorMutatorHandlers_(target, e);
     location = this.parseUrl_(target.href);
 
     // Finally, handle normal click-navigation behavior.
     this.handleNavClick_(e, target, location);
+  }
+
+  /**
+   * Handle anchor transformations.
+   * @param {!Element} target
+   * @param {!Event} e
+   */
+  anchorMutatorHandlers_(target, e) {
+    this.anchorMutators_.forEach(anchorMutator => {
+      anchorMutator(target, e);
+    });
   }
 
   /**
@@ -521,7 +530,7 @@ export class Navigation {
   }
 
   /**
-   * @param {!Function} callback
+   * @param {function(!Element, !Event)} callback
    * @param {number} priority
    */
   registerAnchorMutator(callback, priority) {

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -309,15 +309,7 @@ export class Navigation {
     if (e.type == EVENT_TYPE_CLICK) {
       this.handleClick_(target, e);
     } else if (e.type == EVENT_TYPE_CONTEXT_MENU) {
-      // Handles contextmenu click. Note that currently this only deals
-      // with url variable substitution and expansion, as there is
-      // straightforward way of determining what the user clicked in the
-      // context menu, required for A2A navigation and custom link protocol
-      // handling.
-      // TODO(alabiaga): investigate fix for handling A2A and custom link
-      // protocols.
-      this.expandVarsForAnchor_(target);
-      this.anchorMutatorHandlers_(target, e);
+      this.handleContextMenuClick_(target, e);
     }
   }
 
@@ -346,6 +338,23 @@ export class Navigation {
 
     // Finally, handle normal click-navigation behavior.
     this.handleNavClick_(e, target, location);
+  }
+
+  /**
+   * @param {!Element} target
+   * @param {!Event} e
+   * @private
+   */
+  handleContextMenuClick_(target, e) {
+    // Handles contextmenu click. Note that currently this only deals
+    // with url variable substitution and expansion, as there is
+    // straightforward way of determining what the user clicked in the
+    // context menu, required for A2A navigation and custom link protocol
+    // handling.
+    // TODO(alabiaga): investigate fix for handling A2A and custom link
+    // protocols.
+    this.expandVarsForAnchor_(target);
+    this.anchorMutatorHandlers_(target, e);
   }
 
   /**


### PR DESCRIPTION
In navigation.js, registered anchor mutators are allowed to replace the link when a `click` event happens on it. This PR is an attempt to bring the same behavior for `contextmenu` events. 
Replacing the link when receiving the `contextmenu` event allows to use "copy link address" or "open in a new tab" from the context menu with the link already updated. 

One of the use cases is `amp-skimlinks` which wants to monetize links opened or copied from the context menu. 

Note: Replacing the link on `contextmenu` does not work on Safari. For Safari the replacement needs to happen on `touchstart` which brings more complexity and would require bigger changes in the way we handle clicks if we wanted to support it later.

@alabiaga 
