### PR TITLE
🐛 amp-analytics: allow intersectionRatio to be used on :root

### DIFF
--- a/examples/inabox.amp.html
+++ b/examples/inabox.amp.html
@@ -35,7 +35,7 @@
       {
         "transport": {"beacon": false, "xhrpost": false},
         "requests": {
-          "visibility": "/${type}?cid=CLIENT_ID(a)&elementX=${elementX}&elementY=${elementY}&elementWidth=${elementWidth}&elementHeight=${elementHeight}&totalTime=${totalTime}&totalVisibleTime=${totalVisibleTime}&maxContinuousVisibleTime=${maxContinuousVisibleTime}&loadTimeVisibility=${loadTimeVisibility}&backgrounded=${backgrounded}&backgroundedAtStart=${backgroundedAtStart}&firstSeenTime=${firstSeenTime}&lastSeenTime=${lastSeenTime}&firstVisibleTime=${firstVisibleTime}&lastVisibleTime=${lastVisibleTime}&minVisiblePercentage=${minVisiblePercentage}&maxVisiblePercentage=${maxVisiblePercentage}"
+          "visibility": "/${type}?cid=CLIENT_ID(a)&elementX=${elementX}&elementY=${elementY}&elementWidth=${elementWidth}&elementHeight=${elementHeight}&totalTime=${totalTime}&totalVisibleTime=${totalVisibleTime}&maxContinuousVisibleTime=${maxContinuousVisibleTime}&loadTimeVisibility=${loadTimeVisibility}&backgrounded=${backgrounded}&backgroundedAtStart=${backgroundedAtStart}&firstSeenTime=${firstSeenTime}&lastSeenTime=${lastSeenTime}&firstVisibleTime=${firstVisibleTime}&lastVisibleTime=${lastVisibleTime}&minVisiblePercentage=${minVisiblePercentage}&maxVisiblePercentage=${maxVisiblePercentage}&intersectionRatio=${intersectionRatio}"
         },
         "triggers": {
           "visible": {

--- a/examples/inabox.host.html
+++ b/examples/inabox.host.html
@@ -24,7 +24,7 @@
   </iframe>
   <div>
     <strong>Check Point 1: Above the fold visibility tracking</strong><br/>
-    Before any scrolling, you should see 3 failed network requests: <code>visible</code>, <code>rootVisible</code> and <code>img2Visible</code>. Also check their URL params.
+    Before any scrolling, you should see 3 failed network requests: <code>visible</code>, <code>rootVisible</code> and <code>img2Visible</code>. Also check their URL params including verifying that intersectionRatio is included on all three.
   </div>
   <hr>
   <h3>Inabox below the fold, and nested in friendly iframe </h3>

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -439,6 +439,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
       expect(state.elementY).to.equal(21);
       expect(state.elementWidth).to.equal(101);
       expect(state.elementHeight).to.equal(201);
+      expect(state.intersectionRatio).to.equal(1);
     });
   });
 
@@ -470,6 +471,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
       expect(state.backgrounded).to.equal(0);
       expect(state.backgroundedAtStart).to.equal(0);
       expect(state.totalTime).to.equal(22);
+      expect(state.intersectionRatio).to.equal(1);
     });
   });
 

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -363,6 +363,7 @@ export class VisibilityManager {
 
       } else {
         state['opacity'] = this.getRootMinOpacity();
+        state['intersectionRatio'] = this.getRootVisibility();
         layoutBox = this.getRootLayoutBox();
       }
       model.maybeDispose();


### PR DESCRIPTION
Currently, ${intersectionRatio} expands to "" when applied to :root.  This is a
problem for supporting GPT with AMP Inabox because we watch :root and need to
support publishers subscribing to changes in slot visibility. [1]  Expand
support to include :root.

[1] https://developers.google.com/doubleclick-gpt/reference#googletag.events.slotVisibilityChangedEvent