### PR TITLE
🐛Update cookie name from segment_amp_id to _ga

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/segment.js
+++ b/extensions/amp-analytics/0.1/vendors/segment.js
@@ -21,7 +21,7 @@ export const SEGMENT_CONFIG = /** @type {!JsonObject} */ ({
     'image': true,
   },
   'vars': {
-    'anonymousId': 'CLIENT_ID(_ga)',
+    'anonymousId': 'CLIENT_ID(AMP_ECID_GOOGLE,,_ga)',
   },
   'requests': {
     'host': 'https://api.segment.io/v1/pixel',

--- a/extensions/amp-analytics/0.1/vendors/segment.js
+++ b/extensions/amp-analytics/0.1/vendors/segment.js
@@ -21,7 +21,7 @@ export const SEGMENT_CONFIG = /** @type {!JsonObject} */ ({
     'image': true,
   },
   'vars': {
-    'anonymousId': 'CLIENT_ID(segment_amp_id)',
+    'anonymousId': 'CLIENT_ID(_ga)',
   },
   'requests': {
     'host': 'https://api.segment.io/v1/pixel',
@@ -53,7 +53,7 @@ export const SEGMENT_CONFIG = /** @type {!JsonObject} */ ({
     },
   },
   'cookies': {
-    'segment_amp_id': {
+    '_ga': {
       'value': 'LINKER_PARAM(segment, s_amp_id)',
     },
   },


### PR DESCRIPTION
Per discussion with Andre and Caleb, update Segment's cookie name from segment_amp_id to _ga so that Google Analytics will treat as a single session.