### PR TITLE
add amp-story-tooltip anchor tags validation ✅

### DIFF
--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.html
@@ -1,0 +1,65 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-story-tooltip
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Roboto', sans-serif;
+    }
+    amp-story-page {
+      background: white;
+    }
+    .button {
+      font: bold 20px Arial;
+      text-decoration: none;
+      background-color: rgba(0, 240, 248, 0.63);
+      color: #333333;
+      padding: 2px 6px 2px 6px;
+      border-top: 1px solid #CCCCCC;
+      border-right: 1px solid #333333;
+      border-bottom: 1px solid #333333;
+      border-left: 1px solid #CCCCCC;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+    <amp-story-page id="fill-template-title">
+      <amp-story-grid-layer template="vertical">
+        <a href="google.com" role="link" data-tooltip-icon="javascript:alert('hello evil')" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+        <a href="javascript:alert('hello evil world')" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="">TOOLTIP</a>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="vertical">
+          <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_top">TOOLTIP</a>
+          <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_self">TOOLTIP</a>
+        </amp-story-grid-layer>
+    </amp-story-page>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.html
@@ -19,34 +19,12 @@
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <title>My Story</title>
   <meta name="description" content="Get started with amp-story">
+  <link rel="canonical" href="validator-amp-story-tooltip-error.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="grid-layer-templates.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    body {
-      font-family: 'Roboto', sans-serif;
-    }
-    amp-story-page {
-      background: white;
-    }
-    .button {
-      font: bold 20px Arial;
-      text-decoration: none;
-      background-color: rgba(0, 240, 248, 0.63);
-      color: #333333;
-      padding: 2px 6px 2px 6px;
-      border-top: 1px solid #CCCCCC;
-      border-right: 1px solid #333333;
-      border-bottom: 1px solid #333333;
-      border-left: 1px solid #CCCCCC;
-      width: 100%;
-      height: 100%;
-      position: absolute;
-    }
-  </style>
 </head>
 <body>
   <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.out
@@ -1,0 +1,78 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story-tooltip
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <title>My Story</title>
+|    <meta name="description" content="Get started with amp-story">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link rel="canonical" href="grid-layer-templates.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Roboto', sans-serif;
+|      }
+|      amp-story-page {
+|        background: white;
+|      }
+|      .button {
+|        font: bold 20px Arial;
+|        text-decoration: none;
+|        background-color: rgba(0, 240, 248, 0.63);
+|        color: #333333;
+|        padding: 2px 6px 2px 6px;
+|        border-top: 1px solid #CCCCCC;
+|        border-right: 1px solid #333333;
+|        border-bottom: 1px solid #333333;
+|        border-left: 1px solid #CCCCCC;
+|        width: 100%;
+|        height: 100%;
+|        position: absolute;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|      <amp-story-page id="fill-template-title">
+|        <amp-story-grid-layer template="vertical">
+|          <a href="google.com" role="link" data-tooltip-icon="javascript:alert('hello evil')" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:55:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+|          <a href="javascript:alert('hello evil world')" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="">TOOLTIP</a>
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 The attribute 'target' in tag 'a' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|        </amp-story-grid-layer>
+|        <amp-story-grid-layer template="vertical">
+|            <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_top">TOOLTIP</a>
+>>           ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:59:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+|            <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_self">TOOLTIP</a>
+>>           ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:60:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+|          </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip-error.out
@@ -20,34 +20,12 @@ FAIL
 |  <head>
 |    <meta charset="utf-8">
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
-|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 |    <title>My Story</title>
 |    <meta name="description" content="Get started with amp-story">
+|    <link rel="canonical" href="validator-amp-story-tooltip-error.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-|    <link rel="canonical" href="grid-layer-templates.html">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      body {
-|        font-family: 'Roboto', sans-serif;
-|      }
-|      amp-story-page {
-|        background: white;
-|      }
-|      .button {
-|        font: bold 20px Arial;
-|        text-decoration: none;
-|        background-color: rgba(0, 240, 248, 0.63);
-|        color: #333333;
-|        padding: 2px 6px 2px 6px;
-|        border-top: 1px solid #CCCCCC;
-|        border-right: 1px solid #333333;
-|        border-bottom: 1px solid #333333;
-|        border-left: 1px solid #CCCCCC;
-|        width: 100%;
-|        height: 100%;
-|        position: absolute;
-|      }
-|    </style>
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
@@ -55,22 +33,22 @@ FAIL
 |        <amp-story-grid-layer template="vertical">
 |          <a href="google.com" role="link" data-tooltip-icon="javascript:alert('hello evil')" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:55:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:33:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
 |          <a href="javascript:alert('hello evil world')" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="">TOOLTIP</a>
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:34:8 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:34:8 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:56:8 The attribute 'target' in tag 'a' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:34:8 The attribute 'target' in tag 'a' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
 |        </amp-story-grid-layer>
 |        <amp-story-grid-layer template="vertical">
 |            <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_top">TOOLTIP</a>
 >>           ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:59:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:37:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
 |            <a href="google.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_self">TOOLTIP</a>
 >>           ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-tooltip-error.html:60:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-tooltip-error.html:38:10 The tag 'a', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
 |          </amp-story-grid-layer>
 |      </amp-story-page>
 |    </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
@@ -1,0 +1,61 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-story-tooltip
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Roboto', sans-serif;
+    }
+    amp-story-page {
+      background: white;
+    }
+    .button {
+      font: bold 20px Arial;
+      text-decoration: none;
+      background-color: rgba(0, 240, 248, 0.63);
+      color: #333333;
+      padding: 2px 6px 2px 6px;
+      border-top: 1px solid #CCCCCC;
+      border-right: 1px solid #333333;
+      border-bottom: 1px solid #333333;
+      border-left: 1px solid #CCCCCC;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+    <amp-story-page id="fill-template-title">
+      <amp-story-grid-layer template="vertical">
+        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">TOOLTIP</a>
+        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+      </amp-story-grid-layer>
+    </amp-story-page>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
@@ -19,34 +19,12 @@
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <title>My Story</title>
   <meta name="description" content="Get started with amp-story">
+  <link rel="canonical" href="validator-amp-story-tooltip.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="grid-layer-templates.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    body {
-      font-family: 'Roboto', sans-serif;
-    }
-    amp-story-page {
-      background: white;
-    }
-    .button {
-      font: bold 20px Arial;
-      text-decoration: none;
-      background-color: rgba(0, 240, 248, 0.63);
-      color: #333333;
-      padding: 2px 6px 2px 6px;
-      border-top: 1px solid #CCCCCC;
-      border-right: 1px solid #333333;
-      border-bottom: 1px solid #333333;
-      border-left: 1px solid #CCCCCC;
-      width: 100%;
-      height: 100%;
-      position: absolute;
-    }
-  </style>
 </head>
 <body>
   <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.html
@@ -30,8 +30,11 @@
   <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
     <amp-story-page id="fill-template-title">
       <amp-story-grid-layer template="vertical">
-        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">TOOLTIP</a>
-        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">Tooltip</a>
+        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">Tooltip</a>
+        <a href="googlex.com" role="link" data-tooltip-icon="/my-icon">Tooltip with no text</a>
+        <a href="googlex.com" role="link" data-tooltip-text="click me">Tooltip with no icon</a>
+        <a href="googlex.com" role="link">Tooltip with neither text nor icon</a>
       </amp-story-grid-layer>
     </amp-story-page>
   </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
@@ -31,8 +31,11 @@ PASS
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
 |      <amp-story-page id="fill-template-title">
 |        <amp-story-grid-layer template="vertical">
-|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">TOOLTIP</a>
-|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">Tooltip</a>
+|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">Tooltip</a>
+|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon">Tooltip with no text</a>
+|          <a href="googlex.com" role="link" data-tooltip-text="click me">Tooltip with no icon</a>
+|          <a href="googlex.com" role="link">Tooltip with neither text nor icon</a>
 |        </amp-story-grid-layer>
 |      </amp-story-page>
 |    </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
@@ -1,0 +1,62 @@
+PASS
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story-tooltip
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <title>My Story</title>
+|    <meta name="description" content="Get started with amp-story">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link rel="canonical" href="grid-layer-templates.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Roboto', sans-serif;
+|      }
+|      amp-story-page {
+|        background: white;
+|      }
+|      .button {
+|        font: bold 20px Arial;
+|        text-decoration: none;
+|        background-color: rgba(0, 240, 248, 0.63);
+|        color: #333333;
+|        padding: 2px 6px 2px 6px;
+|        border-top: 1px solid #CCCCCC;
+|        border-right: 1px solid #333333;
+|        border-bottom: 1px solid #333333;
+|        border-left: 1px solid #CCCCCC;
+|        width: 100%;
+|        height: 100%;
+|        position: absolute;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|      <amp-story-page id="fill-template-title">
+|        <amp-story-grid-layer template="vertical">
+|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me">TOOLTIP</a>
+|          <a href="googlex.com" role="link" data-tooltip-icon="/my-icon" data-tooltip-text="click me" target="_blank">TOOLTIP</a>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-tooltip.out
@@ -20,34 +20,12 @@ PASS
 |  <head>
 |    <meta charset="utf-8">
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
-|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 |    <title>My Story</title>
 |    <meta name="description" content="Get started with amp-story">
+|    <link rel="canonical" href="validator-amp-story-tooltip.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-|    <link rel="canonical" href="grid-layer-templates.html">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      body {
-|        font-family: 'Roboto', sans-serif;
-|      }
-|      amp-story-page {
-|        background: white;
-|      }
-|      .button {
-|        font: bold 20px Arial;
-|        text-decoration: none;
-|        background-color: rgba(0, 240, 248, 0.63);
-|        color: #333333;
-|        padding: 2px 6px 2px 6px;
-|        border-top: 1px solid #CCCCCC;
-|        border-right: 1px solid #333333;
-|        border-bottom: 1px solid #333333;
-|        border-left: 1px solid #CCCCCC;
-|        width: 100%;
-|        height: 100%;
-|        position: absolute;
-|      }
-|    </style>
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -213,6 +213,7 @@ tags: {
     value_url: {
       protocol: "http"
       protocol: "https"
+      protocol: "data"
     }
   }
   attrs: {
@@ -319,6 +320,7 @@ tags: {
     value_url: {
       protocol: "http"
       protocol: "https"
+      protocol: "data"
     }
   }
   attrs: { name: "animate-in-after" }

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -205,6 +205,17 @@ tags: {
     value: "stretch"
   }
   attrs: {
+    name: "target"
+    value: "_blank"
+  }
+  attrs: {
+    name: "data-tooltip-icon"
+    value_url: {
+      protocol: "http"
+      protocol: "https"
+    }
+  }
+  attrs: {
     name: "align-items"
     value: "center"
     value: "end"
@@ -298,6 +309,17 @@ tags: {
     value: "whoosh-in-right"
     value: "zoom-in"
     value: "zoom-out"
+  }
+  attrs: {
+    name: "target"
+    value: "_blank"
+  }
+  attrs: {
+    name: "data-tooltip-icon"
+    value_url: {
+      protocol: "http"
+      protocol: "https"
+    }
   }
   attrs: { name: "animate-in-after" }
   attrs: { name: "animate-in-delay" }
@@ -512,6 +534,7 @@ descendant_tag_list: {
 }
 descendant_tag_list: {
   name: "amp-story-grid-layer-allowed-descendants"
+  tag: "A"
   tag: "ABBR"
   tag: "ADDRESS"
   tag: "AMP-ANALYTICS"


### PR DESCRIPTION
Closes #19181

Add validation to allow <a> tags under `amp-story-grid-layer`. This will allow publishers to use clickable items in the grid layer, displaying the tooltip.

