### PR TITLE
Render AMP fluid creatives when iframe fires load event

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -227,7 +227,7 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?string} */
     this.adUrl_ = null;
 
-    /** @protected {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
+    /** @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
     this.friendlyIframeEmbed_ = null;
 
     /** @type {?AMP.AmpAdUIHandler} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1217,7 +1217,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @param {?CreativeMetaDataDef} creativeMetaData metadata if AMP creative,
    *    null otherwise.
    * @param {!Promise=} opt_onLoadPromise Promise that resolves when the FIE's
-   *    child window fires on the `onload` event.
+   *    child window fires the `onload` event.
    */
   onCreativeRender(creativeMetaData, opt_onLoadPromise) {
     this.maybeTriggerAnalyticsEvent_(

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1216,8 +1216,10 @@ export class AmpA4A extends AMP.BaseElement {
    *
    * @param {?CreativeMetaDataDef} creativeMetaData metadata if AMP creative,
    *    null otherwise.
+   * @param {!Promise=} opt_onLoadPromise Promise that resolves when the FIE's
+   *    child window fires on the `onload` event.
    */
-  onCreativeRender(creativeMetaData) {
+  onCreativeRender(creativeMetaData, opt_onLoadPromise) {
     this.maybeTriggerAnalyticsEvent_(
         creativeMetaData ? 'renderFriendlyEnd' : 'renderCrossDomainEnd');
   }
@@ -1405,7 +1407,7 @@ export class AmpA4A extends AMP.BaseElement {
       protectFunctionWrapper(this.onCreativeRender, this, err => {
         dev().error(TAG, this.element.getAttribute('type'),
             'Error executing onCreativeRender', err);
-      })(creativeMetaData);
+      })(creativeMetaData, friendlyIframeEmbed.whenWindowLoaded());
       // It's enough to wait for "ini-load" signal because in a FIE case
       // we know that the embed no longer consumes significant resources
       // after the initial load.
@@ -1767,17 +1769,6 @@ export class AmpA4A extends AMP.BaseElement {
    */
   isVerifiedAmpCreative() {
     return this.isVerifiedAmpCreative_;
-  }
-
-  /**
-   * Returns a promise that will resolve when the friendly iframe's window's
-   * `onload` event has been emitted.
-   * @return {!Promise}
-   */
-  onFriendlyIframeEmbedLoaded() {
-    return this.friendlyIframeEmbed_ ?
-      this.friendlyIframeEmbed_.whenWindowLoaded() :
-      Promise.reject('Friendly Iframe Embed is not available');
   }
 }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -228,7 +228,7 @@ export class AmpA4A extends AMP.BaseElement {
     this.adUrl_ = null;
 
     /** @protected {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
-    this.friendlyIframeEmbed = null;
+    this.friendlyIframeEmbed_ = null;
 
     /** @type {?AMP.AmpAdUIHandler} */
     this.uiHandler = null;
@@ -493,7 +493,7 @@ export class AmpA4A extends AMP.BaseElement {
   resumeCallback() {
     // FIE that was not destroyed on unlayoutCallback does not require a new
     // ad request.
-    if (this.friendlyIframeEmbed) {
+    if (this.friendlyIframeEmbed_) {
       return;
     }
     this.fromResumeCallback = true;
@@ -1104,9 +1104,9 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     // Allow embed to release its resources.
-    if (this.friendlyIframeEmbed) {
-      this.friendlyIframeEmbed.destroy();
-      this.friendlyIframeEmbed = null;
+    if (this.friendlyIframeEmbed_) {
+      this.friendlyIframeEmbed_.destroy();
+      this.friendlyIframeEmbed_ = null;
     }
     if (this.iframe && this.iframe.parentElement) {
       this.iframe.parentElement.removeChild(this.iframe);
@@ -1120,8 +1120,8 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   viewportCallback(inViewport) {
-    if (this.friendlyIframeEmbed) {
-      setFriendlyIframeEmbedVisible(this.friendlyIframeEmbed, inViewport);
+    if (this.friendlyIframeEmbed_) {
+      setFriendlyIframeEmbedVisible(this.friendlyIframeEmbed_, inViewport);
     }
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.viewportCallback(inViewport);
@@ -1395,7 +1395,7 @@ export class AmpA4A extends AMP.BaseElement {
               new A4AVariableSource(this.getAmpDoc(), embedWin));
         }).then(friendlyIframeEmbed => {
       checkStillCurrent();
-      this.friendlyIframeEmbed = friendlyIframeEmbed;
+      this.friendlyIframeEmbed_ = friendlyIframeEmbed;
       setFriendlyIframeEmbedVisible(
           friendlyIframeEmbed, this.isInViewport());
       // Ensure visibility hidden has been removed (set by boilerplate).
@@ -1767,6 +1767,17 @@ export class AmpA4A extends AMP.BaseElement {
    */
   isVerifiedAmpCreative() {
     return this.isVerifiedAmpCreative_;
+  }
+
+  /**
+   * Returns a promise that will resolve when the friendly iframe's window's
+   * `onload` event has been emitted.
+   * @return {!Promise}
+   */
+  onFriendlyIframeEmbedLoaded() {
+    return this.friendlyIframeEmbed_ ?
+      this.friendlyIframeEmbed_.whenWindowLoaded() :
+      Promise.reject('Friendly Iframe Embed is not available');
   }
 }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -227,8 +227,8 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?string} */
     this.adUrl_ = null;
 
-    /** @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
-    this.friendlyIframeEmbed_ = null;
+    /** @protected {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
+    this.friendlyIframeEmbed = null;
 
     /** @type {?AMP.AmpAdUIHandler} */
     this.uiHandler = null;
@@ -493,7 +493,7 @@ export class AmpA4A extends AMP.BaseElement {
   resumeCallback() {
     // FIE that was not destroyed on unlayoutCallback does not require a new
     // ad request.
-    if (this.friendlyIframeEmbed_) {
+    if (this.friendlyIframeEmbed) {
       return;
     }
     this.fromResumeCallback = true;
@@ -1104,9 +1104,9 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     // Allow embed to release its resources.
-    if (this.friendlyIframeEmbed_) {
-      this.friendlyIframeEmbed_.destroy();
-      this.friendlyIframeEmbed_ = null;
+    if (this.friendlyIframeEmbed) {
+      this.friendlyIframeEmbed.destroy();
+      this.friendlyIframeEmbed = null;
     }
     if (this.iframe && this.iframe.parentElement) {
       this.iframe.parentElement.removeChild(this.iframe);
@@ -1120,8 +1120,8 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   viewportCallback(inViewport) {
-    if (this.friendlyIframeEmbed_) {
-      setFriendlyIframeEmbedVisible(this.friendlyIframeEmbed_, inViewport);
+    if (this.friendlyIframeEmbed) {
+      setFriendlyIframeEmbedVisible(this.friendlyIframeEmbed, inViewport);
     }
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.viewportCallback(inViewport);
@@ -1395,7 +1395,7 @@ export class AmpA4A extends AMP.BaseElement {
               new A4AVariableSource(this.getAmpDoc(), embedWin));
         }).then(friendlyIframeEmbed => {
       checkStillCurrent();
-      this.friendlyIframeEmbed_ = friendlyIframeEmbed;
+      this.friendlyIframeEmbed = friendlyIframeEmbed;
       setFriendlyIframeEmbedVisible(
           friendlyIframeEmbed, this.isInViewport());
       // Ensure visibility hidden has been removed (set by boilerplate).

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -396,7 +396,7 @@ describe('amp-a4a', () => {
     });
 
     it('for A4A friendly iframe rendering case', () => {
-      expect(a4a.friendlyIframeEmbed).to.not.exist;
+      expect(a4a.friendlyIframeEmbed_).to.not.exist;
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -406,7 +406,7 @@ describe('amp-a4a', () => {
         const a4aBody = child.contentDocument.body;
         expect(a4aBody).to.be.ok;
         expect(a4aBody).to.be.visible;
-        expect(a4a.friendlyIframeEmbed).to.exist;
+        expect(a4a.friendlyIframeEmbed_).to.exist;
       });
     });
 
@@ -441,8 +441,8 @@ describe('amp-a4a', () => {
         iniLoadResolver();
         return layoutPromise;
       }).then(() => {
-        expect(a4a.friendlyIframeEmbed).to.exist;
-        expect(a4a.friendlyIframeEmbed.host).to.equal(a4a.element);
+        expect(a4a.friendlyIframeEmbed_).to.exist;
+        expect(a4a.friendlyIframeEmbed_.host).to.equal(a4a.element);
         expect(whenIniLoadedStub).to.be.calledOnce;
         expect(lifecycleEventStub).to.be.calledWith('friendlyIframeIniLoad');
       });
@@ -474,17 +474,17 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
-        expect(a4a.friendlyIframeEmbed).to.exist;
-        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.false;
+        expect(a4a.friendlyIframeEmbed_).to.exist;
+        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.false;
 
         a4a.viewportCallback(true);
-        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.true;
+        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.true;
 
         a4a.viewportCallback(false);
-        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.false;
+        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.false;
 
         a4a.viewportCallback(true);
-        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.true;
+        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.true;
       });
     });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -396,7 +396,7 @@ describe('amp-a4a', () => {
     });
 
     it('for A4A friendly iframe rendering case', () => {
-      expect(a4a.friendlyIframeEmbed_).to.not.exist;
+      expect(a4a.friendlyIframeEmbed).to.not.exist;
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -406,7 +406,7 @@ describe('amp-a4a', () => {
         const a4aBody = child.contentDocument.body;
         expect(a4aBody).to.be.ok;
         expect(a4aBody).to.be.visible;
-        expect(a4a.friendlyIframeEmbed_).to.exist;
+        expect(a4a.friendlyIframeEmbed).to.exist;
       });
     });
 
@@ -441,8 +441,8 @@ describe('amp-a4a', () => {
         iniLoadResolver();
         return layoutPromise;
       }).then(() => {
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        expect(a4a.friendlyIframeEmbed_.host).to.equal(a4a.element);
+        expect(a4a.friendlyIframeEmbed).to.exist;
+        expect(a4a.friendlyIframeEmbed.host).to.equal(a4a.element);
         expect(whenIniLoadedStub).to.be.calledOnce;
         expect(lifecycleEventStub).to.be.calledWith('friendlyIframeIniLoad');
       });
@@ -474,17 +474,17 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.false;
+        expect(a4a.friendlyIframeEmbed).to.exist;
+        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.false;
 
         a4a.viewportCallback(true);
-        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.true;
+        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.true;
 
         a4a.viewportCallback(false);
-        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.false;
+        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.false;
 
         a4a.viewportCallback(true);
-        expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.true;
+        expect(a4a.friendlyIframeEmbed.isVisible()).to.be.true;
       });
     });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -857,16 +857,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  layoutCallback() {
-    return super.layoutCallback().then(superReturn => {
-      // We expand fluid here because we must first wait for the iframe to fire
-      // onload.
-      this.expandFluidCreative_();
-      return superReturn;
-    });
-  }
-
-  /** @override */
   viewportCallback(inViewport) {
     super.viewportCallback(inViewport);
     if (this.reattemptToExpandFluidCreative_ && !inViewport) {
@@ -969,6 +959,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       setStyles(this.element, {width: `${size.width}px`});
     }
 
+    if (this.friendlyIframeEmbed) {
+      this.friendlyIframeEmbed.whenWindowLoaded().then(() => {
+        this.expandFluidCreative_();
+      });
+    }
+
     this.refreshManager_ = this.refreshManager_ ||
         getRefreshManager(this, () => {
           if (this.useSra) {
@@ -1016,7 +1012,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         return Promise.reject('Cannot access body of friendly frame');
       }
       return this.attemptChangeHeight(
-          this.iframe.contentWindow.document.body./*OK*/scrollHeight)
+          this.iframe.contentWindow.document.body./*OK*/clientHeight)
           .then(() => {
             this.fireFluidDelayedImpression();
             this.reattemptToExpandFluidCreative_ = false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -901,7 +901,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  onCreativeRender(creativeMetaData) {
+  onCreativeRender(creativeMetaData, opt_onLoadPromise) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
     if (creativeMetaData &&
@@ -959,9 +959,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       setStyles(this.element, {width: `${size.width}px`});
     }
 
-    this.onFriendlyIframeEmbedLoaded().then(() => {
-      this.expandFluidCreative_();
-    });
+    if (opt_onLoadPromise) {
+      opt_onLoadPromise.then(() => {
+        this.expandFluidCreative_();
+      });
+    }
 
     this.refreshManager_ = this.refreshManager_ ||
         getRefreshManager(this, () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -959,11 +959,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       setStyles(this.element, {width: `${size.width}px`});
     }
 
-    if (this.friendlyIframeEmbed) {
-      this.friendlyIframeEmbed.whenWindowLoaded().then(() => {
-        this.expandFluidCreative_();
-      });
-    }
+    this.onFriendlyIframeEmbedLoaded().then(() => {
+      this.expandFluidCreative_();
+    });
 
     this.refreshManager_ = this.refreshManager_ ||
         getRefreshManager(this, () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -53,7 +53,14 @@ const rawCreative = `
       })), '*');
   </script>`;
 
-const mockPromise = {then: callback => callback()};
+const mockPromise = {
+  then: callback => {
+    callback();
+    return {
+      catch: () => {},
+    };
+  },
+};
 
 /**
  * Sets up the necessary mocks and stubs to render a fake fluid creative in unit
@@ -246,9 +253,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.win.document.body.appendChild(impl.iframe);
     sandbox.stub(impl, 'attemptChangeHeight').returns(mockPromise);
     sandbox.stub(impl, 'attemptToRenderCreative').returns(mockPromise);
+    sandbox.stub(impl, 'onFriendlyIframeEmbedLoaded').returns(mockPromise);
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
     impl.buildCallback();
-    impl.friendlyIframeEmbed = {whenWindowLoaded: () => mockPromise};
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -252,14 +252,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     sandbox.stub(impl, 'attemptChangeHeight').returns(mockPromise);
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(mockPromise);
-    sandbox.stub(impl, 'onFriendlyIframeEmbedLoaded').returns(mockPromise);
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
-    impl.onCreativeRender();
+    impl.onCreativeRender(null, mockPromise);
     expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk'))
         .to.be.calledOnce;
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -53,6 +53,8 @@ const rawCreative = `
       })), '*');
   </script>`;
 
+const mockPromise = {then: callback => callback()};
+
 /**
  * Sets up the necessary mocks and stubs to render a fake fluid creative in unit
  * tests.
@@ -239,20 +241,20 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     });
   });
 
-  it('should resize slot and fire impression for AMP fluid creative', () => {
+  it('should fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
+    sandbox.stub(impl, 'attemptChangeHeight').returns(mockPromise);
+    sandbox.stub(impl, 'attemptToRenderCreative').returns(mockPromise);
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
     impl.buildCallback();
+    impl.friendlyIframeEmbed = {whenWindowLoaded: () => mockPromise};
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
-    return impl.layoutCallback().then(() => {
-      expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk'))
-          .to.be.calledOnce;
-    });
+    impl.onCreativeRender();
+    expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk'))
+        .to.be.calledOnce;
   });
 
   it('should set expansion re-attempt flag after initial failure', () => {


### PR DESCRIPTION
Currently, a fluid-enabled slot will not expand until the ini-load event fires. However, if not all elements within the FIE load, the ini-load event will never fire, and thus the creative will never show.

If we listen to the underlying iframe's load event instead, we are guaranteed to show the creative whenever the document of the iframe element has finished loading.