### PR TITLE
Fix <amp-fx="fly-in-{left|right}"> for IE/Edge.

### DIFF
--- a/examples/test-fly-in.amp.html
+++ b/examples/test-fly-in.amp.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "headline": "Open-source framework for publishing content",
+        "datePublished": "2015-10-07T12:02:41Z",
+        "image": [
+          "logo.jpg"
+        ]
+      }
+    </script>
+    <script async custom-element="amp-fx-collection" src="https://cdn.ampproject.org/v0/amp-fx-collection-0.1.js"></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+  <body>
+    <h1>Welcome to the mobile web</h1>
+    <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <div amp-fx="fly-in-left" data-duration="2000ms" style="border: 2px red solid">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </div>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores impedit commodi facilis doloribus architecto perferendis eaque rem minima unde est libero nisi blanditiis vero, voluptatum mollitia alias quasi saepe odio?
+      </p>
+    
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel voluptate commodi consectetur dolorem et in consequatur debitis earum iure id deserunt dignissimos, quaerat modi, odio culpa quia? Earum, officiis error.</p>
+    
+      <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Labore sapiente nisi fuga, totam illum, est repellat impedit suscipit possimus aliquam consectetur nesciunt corporis atque obcaecati? Quos, repudiandae recusandae? Vitae, dolore?</p>
+    
+  </body>
+</html>

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -95,7 +95,8 @@ export const Presets = {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
               setStyles(fxElement.getElement(), {
-                'top': `calc(${style.top} + ${fxElement.getFlyInDistance()}vh)`,
+                'top': `calc(${style.top == 'auto' ? '0px' : style.top} +
+                  ${fxElement.getFlyInDistance()}vh)`,
                 'visibility': 'visible',
               });
               fxElement.initialTrigger = true;
@@ -255,7 +256,8 @@ export const Presets = {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
               setStyles(fxElement.getElement(), {
-                'top': `calc(${style.top} - ${fxElement.getFlyInDistance()}vh)`,
+                'top': `calc(${style.top == 'auto' ? '0px' : style.top} -
+                  ${fxElement.getFlyInDistance()}vh)`,
                 'visibility': 'visible',
               });
               fxElement.initialTrigger = true;

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -94,8 +94,9 @@ export const Presets = {
             fxElement.getElement(), function() {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
+              const topAsLength = style.top == 'auto' ? '0px' : style.top;
               setStyles(fxElement.getElement(), {
-                'top': `calc(${style.top == 'auto' ? '0px' : style.top} +
+                'top': `calc(${topAsLength} +
                   ${fxElement.getFlyInDistance()}vh)`,
                 'visibility': 'visible',
               });
@@ -147,9 +148,10 @@ export const Presets = {
             fxElement.getElement(), function() {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
+              const leftAsLength = style.left == 'auto' ? '0px' : style.left;
               setStyles(fxElement.getElement(), {
                 'left':
-                  `calc(${style.left} - ${fxElement.getFlyInDistance()}vw)`,
+                  `calc(${leftAsLength} - ${fxElement.getFlyInDistance()}vw)`,
                 'visibility': 'visible',
               });
               fxElement.initialTrigger = true;
@@ -200,9 +202,10 @@ export const Presets = {
             fxElement.getElement(), function() {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
+              const leftAsLength = style.left == 'auto' ? '0px' : style.left;
               setStyles(fxElement.getElement(), {
                 'left':
-                  `calc(${style.left} + ${fxElement.getFlyInDistance()}vw)`,
+                  `calc(${leftAsLength} + ${fxElement.getFlyInDistance()}vw)`,
                 'visibility': 'visible',
               });
               fxElement.initialTrigger = true;
@@ -255,8 +258,9 @@ export const Presets = {
             fxElement.getElement(), function() {
               const style = computedStyle(fxElement.getAmpDoc().win,
                   fxElement.getElement());
+              const topAsLength = style.top == 'auto' ? '0px' : style.top;
               setStyles(fxElement.getElement(), {
-                'top': `calc(${style.top == 'auto' ? '0px' : style.top} -
+                'top': `calc(${topAsLength} -
                   ${fxElement.getFlyInDistance()}vh)`,
                 'visibility': 'visible',
               });

--- a/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fly-in.js
+++ b/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fly-in.js
@@ -16,7 +16,7 @@
 
 import {isExperimentOn, toggleExperiment} from '../../../../../src/experiments';
 
-describe.run('amp-fx-collection', function() {
+describe.configure().run('amp-fx-collection', function() {
   this.timeout(100000);
 
   const css = `

--- a/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fly-in.js
+++ b/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fly-in.js
@@ -16,8 +16,7 @@
 
 import {isExperimentOn, toggleExperiment} from '../../../../../src/experiments';
 
-const config = describe.configure().ifNewChrome();
-config.run('amp-fx-collection', function() {
+describe.run('amp-fx-collection', function() {
   this.timeout(100000);
 
   const css = `


### PR DESCRIPTION
Spec says the computed value for `elem.style.top` defaults to `auto`. Edge and IE respect that behaviour. Chrome and other Webkit browsers return `0px` which is what we want. This forces Edge and IE's correct values to something we can use. 

Also enabled the tests which would have caught this on all browsers. 

Fixes #19191