### PR TITLE
Synchronous Custom Elements Polyfill

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -457,13 +457,14 @@ class Registry {
     // The first registered name starts the mutation observer.
     const observer = new this.win_.MutationObserver(records => {
       if (records) {
-        this.handleRecords_(records);
+        this.handleRecords(records);
       }
     });
     observer.observe(this.doc_, {
       childList: true,
       subtree: true,
     });
+    installPatches(this.win_, this, observer);
   }
 
   /**
@@ -474,7 +475,7 @@ class Registry {
    *
    * @param {!Array<!MutationRecord>} records
    */
-  handleRecords_(records) {
+  handleRecords(records) {
     for (let i = 0; i < records.length; i++) {
       const record = records[i];
       if (!record) {
@@ -504,12 +505,102 @@ class Registry {
 }
 
 /**
+ * Patches the DOM APIs to support synchronous Custom Elements.
+ * @param {!Window} win
+ * @param {!Registry} registry
+ * @param {!MutationObserver} observer
+ */
+function installPatches(win, registry, observer) {
+  const {Document, Element, Node, Object} = win;
+  const docProto = Document.prototype;
+  const elProto = Element.prototype;
+  const nodeProto = Node.prototype;
+  const {createElement, importNode} = docProto;
+  const {
+    appendChild,
+    cloneNode,
+    insertBefore,
+    removeChild,
+    replaceChild,
+  } = nodeProto;
+
+  // Patch createElement to immediately upgrade the custom element.
+  // This has the added benefit that it avoids the "already created but needs
+  // constructor code run" chicken-and-egg problem.
+  docProto.createElement = function createElementPatch(name) {
+    const def = registry.getByName(name);
+    if (def) {
+      return new def.ctor();
+    }
+    return createElement.apply(this, arguments);
+  };
+
+  // Patch importNode to immediately upgrade custom elements.
+  // TODO(jridgewell): Can fire adoptedCallback for cross doc imports.
+  docProto.importNode = function importNodePatch() {
+    const imported = importNode.apply(this, arguments);
+    if (imported) {
+      registry.upgradeSelf(imported);
+      registry.upgrade(imported);
+    }
+    return imported;
+  };
+
+  // Patch appendChild to upgrade custom elements before returning.
+  nodeProto.appendChild = function appendChildPatch() {
+    const appended = appendChild.apply(this, arguments);
+    registry.handleRecords(observer.takeRecords());
+    return appended;
+  };
+
+  // Patch insertBefore to upgrade custom elements before returning.
+  nodeProto.insertBefore = function insertBeforePatch() {
+    const inserted = insertBefore.apply(this, arguments);
+    registry.handleRecords(observer.takeRecords());
+    return inserted;
+  };
+
+  // Patch removeChild to upgrade custom elements before returning.
+  nodeProto.removeChild = function removeChildPatch() {
+    const removed = removeChild.apply(this, arguments);
+    registry.handleRecords(observer.takeRecords());
+    return removed;
+  };
+
+  // Patch replaceChild to upgrade and detach custom elements before returning.
+  nodeProto.replaceChild = function replaceChildPatch() {
+    const replaced = replaceChild.apply(this, arguments);
+    registry.handleRecords(observer.takeRecords());
+    return replaced;
+  };
+
+  // Patch cloneNode to immediately upgrade custom elements.
+  nodeProto.cloneNode = function cloneNodePatch() {
+    const cloned = cloneNode.apply(this, arguments);
+    registry.upgradeSelf(cloned);
+    registry.upgrade(cloned);
+    return cloned;
+  };
+
+  // Patch the innerHTML setter to immediately upgrade custom elements.
+  // Note, this could technically fire connectedCallbacks if this node was
+  // connected, but we leave that to the Mutation Observer.
+  const innerHTMLDesc = Object.getOwnPropertyDescriptor(elProto, 'innerHTML');
+  const innerHTMLSetter = innerHTMLDesc.set;
+  innerHTMLDesc.set = function innerHtmlPatch(html) {
+    innerHTMLSetter.call(this, html);
+    registry.upgrade(this);
+  };
+  Object.defineProperty(elProto, 'innerHTML', innerHTMLDesc);
+}
+
+/**
  * Does the polyfilling.
  * @param {!Window} win
  */
 function polyfill(win) {
-  const {HTMLElement, Element, Node, Document, Object, document} = win;
-  const {createElement, cloneNode, importNode} = document;
+  const {HTMLElement, Object, document} = win;
+  const {createElement} = document;
 
   const registry = new Registry(win);
   const customElements = new CustomElementRegistry(win, registry);
@@ -523,48 +614,6 @@ function polyfill(win) {
     // writable: false,
     value: customElements,
   });
-
-  // Patch createElement to immediately upgrade the custom element.
-  // This has the added benefit that it avoids the "already created but needs
-  // constructor code run" chicken-and-egg problem.
-  Document.prototype.createElement = function createElementPolyfill(name) {
-    const def = registry.getByName(name);
-    if (def) {
-      return new def.ctor();
-    }
-    return createElement.apply(this, arguments);
-  };
-
-  // Patch importNode to immediately upgrade custom elements.
-  // TODO(jridgewell): Can fire adoptedCallback for cross doc imports.
-  Document.prototype.importNode = function importNodePolyfill() {
-    const imported = importNode.apply(this, arguments);
-    if (imported) {
-      registry.upgradeSelf(imported);
-      registry.upgrade(imported);
-    }
-    return imported;
-  };
-
-  // Patch cloneNode to immediately upgrade custom elements.
-  Node.prototype.cloneNode = function cloneNodePolyfill() {
-    const cloned = cloneNode.apply(this, arguments);
-    registry.upgradeSelf(cloned);
-    registry.upgrade(cloned);
-    return cloned;
-  };
-
-  // Patch the innerHTML setter to immediately upgrade custom elements.
-  // Note, this could technically fire connectedCallbacks if this node was
-  // connected, but we leave that to the Mutation Observer.
-  const innerHTMLDesc = Object.getOwnPropertyDescriptor(Element.prototype,
-      'innerHTML');
-  const innerHTMLSetter = innerHTMLDesc.set;
-  innerHTMLDesc.set = function(html) {
-    innerHTMLSetter.call(this, html);
-    registry.upgrade(this);
-  };
-  Object.defineProperty(Element.prototype, 'innerHTML', innerHTMLDesc);
 
   /**
    * You can't use the real HTMLElement constructor, because you can't subclass


### PR DESCRIPTION
`appendChild` and friends behave in a weird psuedo-synchronous way:

```js
class XDiv extends HTMLElement {
  connectedCallback() {
    console.log('connected');
  }
  disconnectedCallback() {
    console.log('disconnected');
  }
}
customElements.define('x-div', XDiv);

console.log('before append');
document.body.appendChild(document.createElement('x-div'));
console.log('after append');

console.log('before remove');
document.body.removeChild(document.body.lastElementChild);
console.log('after remove');
```

This logs:

1. 'before append'
2. 'connected'
3. 'after append'
4. 'before remove'
5. 'disconnected'
6. 'after remove'

This means that upgrade/`connectedCallback` happens before `appendChild` completes, and the similar for `removeChild`/etc. So, we need to support that in our polyfill.