### PR TITLE
♻️ AMP-Consent: Move config related code to its own file

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -73,8 +73,8 @@ export class AmpConsent extends AMP.BaseElement {
     /** @private {?JsonObject} */
     this.consentConfig_ = null;
 
-    /** @private {!JsonObject} */
-    this.policyConfig_ = dict({});
+    /** @private {?JsonObject} */
+    this.policyConfig_ = null;
 
     /** @private {!Object} */
     this.consentRequired_ = map();
@@ -117,16 +117,16 @@ export class AmpConsent extends AMP.BaseElement {
     user().assert(this.element.getAttribute('id'),
         'amp-consent should have an id');
 
-    const config = new ConsentConfig(this.element).getConfig();
+    const config = new ConsentConfig(this.element);
 
-    if (config['postPromptUI']) {
+    if (config.getPostPromptUI()) {
       this.postPromptUI_ =
-          new ConsentUI(this, dict({}), config['postPromptUI']);
+          new ConsentUI(this, dict({}), config.getPostPromptUI());
     }
 
-    this.consentConfig_ = config['consents'];
+    this.consentConfig_ = config.getConsentConfig();
 
-    const policyConfig = config['policy'] || dict({});
+    const policyConfig = config.getPolicyConfig();
 
     this.policyConfig_ = expandPolicyConfig(policyConfig, this.consentConfig_);
 
@@ -143,7 +143,8 @@ export class AmpConsent extends AMP.BaseElement {
             .then(manager => {
               this.consentPolicyManager_ = /** @type {!ConsentPolicyManager} */ (
                 manager);
-              const policyKeys = Object.keys(this.policyConfig_);
+              const policyKeys =
+                  Object.keys(/** @type {!Object} */ (this.policyConfig_));
               for (let i = 0; i < policyKeys.length; i++) {
                 this.consentPolicyManager_.registerConsentPolicyInstance(
                     policyKeys[i], this.policyConfig_[policyKeys[i]]);
@@ -186,7 +187,8 @@ export class AmpConsent extends AMP.BaseElement {
       const {args} = invocation;
       let consentId = args && args['consent'];
       if (!this.isMultiSupported_) {
-        consentId = Object.keys(this.consentConfig_)[0];
+        consentId =
+            Object.keys(/** @type {!Object} */ (this.consentConfig_))[0];
       }
       this.handlePostPrompt_(consentId || '');
     });
@@ -335,7 +337,8 @@ export class AmpConsent extends AMP.BaseElement {
    * Init the amp-consent by registering and initiate consent instance.
    */
   init_() {
-    const instanceKeys = Object.keys(this.consentConfig_);
+    const instanceKeys =
+        Object.keys(/** @type {!Object} */ (this.consentConfig_));
     const initPromptPromises = [];
     for (let i = 0; i < instanceKeys.length; i++) {
       const instanceId = instanceKeys[i];

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {CMP_CONFIG} from './cmps';
 import {CONSENT_ITEM_STATE, ConsentStateManager} from './consent-state-manager';
-import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {CSS} from '../../../build/amp-consent-0.1.css';
+import {ConsentConfig, expandPolicyConfig} from './consent-config';
 import {ConsentPolicyManager} from './consent-policy-manager';
 import {ConsentUI} from './consent-ui';
 import {Deferred} from '../../../src/utils/promise';
@@ -31,14 +30,12 @@ import {
   getSourceUrl,
   resolveRelativeUrl,
 } from '../../../src/url';
-import {deepMerge, dict, hasOwn, map} from '../../../src/utils/object';
 import {dev, user} from '../../../src/log';
-import {getChildJsonConfig} from '../../../src/json';
+import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';
 
 import {isEnumValue} from '../../../src/types';
-import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -73,11 +70,11 @@ export class AmpConsent extends AMP.BaseElement {
     /** @private {!Object<string, !ConsentUI>} */
     this.consentUI_ = map();
 
-    /** @private {!JsonObject} */
-    this.consentConfig_ = dict();
+    /** @private {?JsonObject} */
+    this.consentConfig_ = null;
 
     /** @private {!JsonObject} */
-    this.policyConfig_ = dict();
+    this.policyConfig_ = dict({});
 
     /** @private {!Object} */
     this.consentRequired_ = map();
@@ -120,14 +117,18 @@ export class AmpConsent extends AMP.BaseElement {
     user().assert(this.element.getAttribute('id'),
         'amp-consent should have an id');
 
-    const inlineConfig = this.getInlineConfig_();
+    const config = new ConsentConfig(this.element).getConfig();
 
-    const cmpConfig = this.getCMPConfig_();
+    if (config['postPromptUI']) {
+      this.postPromptUI_ =
+          new ConsentUI(this, dict({}), config['postPromptUI']);
+    }
 
-    const config = deepMerge(cmpConfig || {}, inlineConfig || {}, 1);
+    this.consentConfig_ = config['consents'];
 
-    // TODO: Decide what to do with incorrect configuration.
-    this.validateAndParseConfig_(/** @type {!JsonObject} */ (config));
+    const policyConfig = config['policy'] || dict({});
+
+    this.policyConfig_ = expandPolicyConfig(policyConfig, this.consentConfig_);
 
     const children = this.getRealChildren();
     for (let i = 0; i < children.length; i++) {
@@ -142,7 +143,6 @@ export class AmpConsent extends AMP.BaseElement {
             .then(manager => {
               this.consentPolicyManager_ = /** @type {!ConsentPolicyManager} */ (
                 manager);
-              this.generateDefaultPolicy_();
               const policyKeys = Object.keys(this.policyConfig_);
               for (let i = 0; i < policyKeys.length; i++) {
                 this.consentPolicyManager_.registerConsentPolicyInstance(
@@ -257,7 +257,7 @@ export class AmpConsent extends AMP.BaseElement {
   show_(instanceId) {
     if (this.currentDisplayInstance_) {
       dev().error(TAG,
-          `other consent instance on display ${this.currentDisplayInstance_}`);
+          'other consent instance on display %s', this.currentDisplayInstance_);
     }
 
     this.vsync_.mutate(() => {
@@ -276,8 +276,8 @@ export class AmpConsent extends AMP.BaseElement {
   hide_() {
     if (!this.currentDisplayInstance_ ||
         !this.consentUI_[this.currentDisplayInstance_]) {
-      dev().error(TAG,
-          `${this.currentDisplayInstance_} no consent ui to hide`);
+      dev().error(TAG, '%s no consent ui to hide',
+          this.currentDisplayInstance_);
     }
 
     const uiToHide = this.consentUI_[this.currentDisplayInstance_];
@@ -343,7 +343,6 @@ export class AmpConsent extends AMP.BaseElement {
           instanceId, this.consentConfig_[instanceId]);
 
       this.passSharedData_(instanceId);
-
       const isConsentRequiredPromise = this.getConsentRequiredPromise_(
           instanceId, this.consentConfig_[instanceId]);
 
@@ -431,57 +430,6 @@ export class AmpConsent extends AMP.BaseElement {
   }
 
   /**
-   * Generate default consent policy if not defined
-   */
-  generateDefaultPolicy_() {
-    // Generate default policy
-    const instanceKeys = Object.keys(this.consentConfig_);
-    const defaultWaitForItems = {};
-    for (let i = 0; i < instanceKeys.length; i++) {
-      // TODO: Need to support an array.
-      defaultWaitForItems[instanceKeys[i]] = undefined;
-    }
-    const defaultPolicy = {
-      'waitFor': defaultWaitForItems,
-    };
-
-    // TODO(@zhouyx): unblockOn is internal now.
-    const unblockOnAll = [
-      CONSENT_POLICY_STATE.UNKNOWN,
-      CONSENT_POLICY_STATE.SUFFICIENT,
-      CONSENT_POLICY_STATE.INSUFFICIENT,
-      CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
-    ];
-
-    const predefinedNone = {
-      'waitFor': defaultWaitForItems,
-      // Experimental config, do not expose
-      'unblockOn': unblockOnAll,
-    };
-
-    const rejectAllOnZero = {
-      'waitFor': defaultWaitForItems,
-      'timeout': {
-        'seconds': 0,
-        'fallbackAction': 'reject',
-      },
-      'unblockOn': unblockOnAll,
-    };
-
-    this.policyConfig_['_till_responded'] = predefinedNone;
-
-    this.policyConfig_['_till_accepted'] = defaultPolicy;
-
-    this.policyConfig_['_auto_reject'] = rejectAllOnZero;
-
-    if (this.policyConfig_ && this.policyConfig_['default']) {
-      return;
-    }
-
-    this.policyConfig_['default'] = defaultPolicy;
-  }
-
-  /**
    * Get localStored consent info, and send request to get consent from endpoint
    * if there is checkConsentHref specified.
    * @param {string} instanceId
@@ -522,123 +470,15 @@ export class AmpConsent extends AMP.BaseElement {
   }
 
   /**
-   * Read and parse consent instance config
-   * An example valid config json looks like
-   * {
-   *   "consents": {
-   *     "consentABC": {
-   *       "checkConsentHref": "https://fake.com"
-   *     }
-   *   }
-   * }
-   * TODO: Add support for policy config
-   * @param {!JsonObject} config
-   */
-  validateAndParseConfig_(config) {
-    const consents = config['consents'];
-    user().assert(consents, `${TAG}: consents config is required`);
-    user().assert(Object.keys(consents).length != 0,
-        `${TAG}: can't find consent instance`);
-    if (!this.isMultiSupported_) {
-      // Assert single consent instance
-      user().assert(Object.keys(consents).length <= 1,
-          `${TAG}: only single consent instance is supported`);
-      if (config['policy']) {
-        // Only respect 'default' consent policy;
-        const keys = Object.keys(config['policy']);
-        for (let i = 0; i < keys.length; i++) {
-          if (keys[i] != 'default') {
-            user().warn(TAG, `policy ${keys[i]} is currently not supported` +
-              'and will be ignored');
-            delete config['policy'][keys[i]];
-          }
-        }
-      }
-    }
-
-    this.consentConfig_ = consents;
-    if (config['postPromptUI']) {
-      this.postPromptUI_ =
-          new ConsentUI(this, dict({}), config['postPromptUI']);
-    }
-    this.policyConfig_ = config['policy'] || this.policyConfig_;
-  }
-
-  /**
-   * Read the inline config from publisher
-   * @return {?JsonObject}
-   */
-  getInlineConfig_() {
-    // All consent config within the amp-consent component. There will be only
-    // one single amp-consent allowed in page.
-    try {
-      return getChildJsonConfig(this.element);
-    } catch (e) {
-      throw this.user().createError(TAG, e);
-    }
-  }
-
-  /**
-   * Read and format the CMP config
-   * The returned CMP config should looks like
-   * {
-   *   "consents": {
-   *     "foo": {
-   *       "checkConsentHref": "https://fake.com",
-   *       "promptUISrc": "https://fake.com/promptUI.html"
-   *     }
-   *   }
-   * }
-   * @return {?JsonObject}
-   */
-  getCMPConfig_() {
-    if (!isExperimentOn(this.win, 'amp-consent-v2')) {
-      return null;
-    }
-
-    const type = this.element.getAttribute('type');
-    if (!type) {
-      return null;
-    }
-    user().assert(CMP_CONFIG[type], `invalid CMP type ${type}`);
-    const importConfig = CMP_CONFIG[type];
-    this.validateCMPConfig_(importConfig);
-    const constentInstance = importConfig['consentInstanceId'];
-
-    const cmpConfig = dict({
-      'consents': dict({}),
-    });
-
-    const config = Object.assign({}, importConfig);
-    delete config['consentInstanceId'];
-
-    cmpConfig['consents'][constentInstance] = config;
-    return cmpConfig;
-  }
-
-  /**
    * Handles the revoke action.
    * Display consent UI.
    * @param {string} consentId
    */
   handlePostPrompt_(consentId) {
     user().assert(this.consentConfig_[consentId],
-        `consent with id ${consentId} not found`);
+        'consent with id %s not found', consentId);
     // toggle the UI for this consent
     this.scheduleDisplay_(consentId);
-  }
-
-  /**
-   * Check if the CMP config is valid
-   * @param {!JsonObject} config
-   */
-  validateCMPConfig_(config) {
-    const assertValues =
-        ['consentInstanceId', 'checkConsentHref', 'promptUISrc'];
-    for (let i = 0; i < assertValues.length; i++) {
-      const attribute = assertValues[i];
-      dev().assert(config[attribute], `CMP config must specify ${attribute}`);
-    }
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -110,7 +110,7 @@ export class ConsentConfig {
         const keys = Object.keys(config['policy']);
         for (let i = 0; i < keys.length; i++) {
           if (keys[i] != 'default') {
-            user().warn(TAG, 'policy %s is currently not supported' +
+            user().warn(TAG, 'policy %s is currently not supported ' +
               'and will be ignored', keys[i]);
             delete config['policy'][keys[i]];
           }

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -42,15 +42,40 @@ export class ConsentConfig {
   }
 
   /**
+   * Return the consents config
+   * @return {!JsonObject}
+   */
+  getConsentConfig() {
+    return this.getConfig_()['consents'];
+  }
+
+  /**
+   * Return the policy config
+   * @return {!JsonObject}
+   */
+  getPolicyConfig() {
+    return this.getConfig_()['policy'] || dict({});
+  }
+
+  /**
+   * Return the postPromptUI config
+   * @return {string|undefined}
+   */
+  getPostPromptUI() {
+    return this.getConfig_()['postPromptUI'];
+  }
+
+  /**
    * Read validate and return the config
    * @return {!JsonObject}
    */
-  getConfig() {
+  getConfig_() {
     if (!this.config_) {
       this.config_ = this.validateAndParseConfig_();
     }
     return this.config_;
   }
+
 
   /**
    * Read and parse consent config

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CMP_CONFIG} from './cmps';
+import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
+import {deepMerge, dict} from '../../../src/utils/object';
+import {dev, user} from '../../../src/log';
+import {getChildJsonConfig} from '../../../src/json';
+import {isExperimentOn} from '../../../src/experiments';
+import {toWin} from '../../../src/types';
+
+const TAG = 'amp-consent/consent-config';
+
+export class ConsentConfig {
+
+  /** @param {!Element} element */
+  constructor(element) {
+    /** @private {!Element} */
+    this.element_ = element;
+
+    /** @private {!Window} */
+    this.win_ = toWin(element.ownerDocument.defaultView);
+
+    /** @private {boolean} */
+    this.isMultiSupported_ = isExperimentOn(this.win_, 'multi-consent');
+
+    /** @private {?JsonObject} */
+    this.config_ = null;
+  }
+
+  /**
+   * Read validate and return the config
+   * @return {!JsonObject}
+   */
+  getConfig() {
+    if (!this.config_) {
+      this.config_ = this.validateAndParseConfig_();
+    }
+    return this.config_;
+  }
+
+  /**
+   * Read and parse consent config
+   * An example valid config json looks like
+   * {
+   *   "consents": {
+   *     "consentABC": {
+   *       "checkConsentHref": "https://fake.com"
+   *     }
+   *   }
+   * }
+   * @return {!JsonObject}
+   */
+  validateAndParseConfig_() {
+    const inlineConfig = this.getInlineConfig_();
+
+    const cmpConfig = this.getCMPConfig_();
+
+    const config = /** @type {!JsonObject} */
+        (deepMerge(cmpConfig || {}, inlineConfig || {}, 1));
+
+    const consents = config['consents'];
+    user().assert(consents, '%s: consents config is required', TAG);
+    user().assert(Object.keys(consents).length != 0,
+        '%s: can\'t find consent instance', TAG);
+    if (!this.isMultiSupported_) {
+      // Assert single consent instance
+      user().assert(Object.keys(consents).length <= 1,
+          '%s: only single consent instance is supported', TAG);
+      if (config['policy']) {
+        // Only respect 'default' consent policy;
+        const keys = Object.keys(config['policy']);
+        for (let i = 0; i < keys.length; i++) {
+          if (keys[i] != 'default') {
+            user().warn(TAG, 'policy %s is currently not supported' +
+              'and will be ignored', keys[i]);
+            delete config['policy'][keys[i]];
+          }
+        }
+      }
+    }
+
+    return config;
+  }
+
+  /**
+   * Read the inline config from publisher
+   * @return {?JsonObject}
+   */
+  getInlineConfig_() {
+    // All consent config within the amp-consent component. There will be only
+    // one single amp-consent allowed in page.
+    try {
+      return getChildJsonConfig(this.element_);
+    } catch (e) {
+      throw user(this.element_).createError('%s: %s', TAG, e);
+    }
+  }
+
+  /**
+   * Read and format the CMP config
+   * The returned CMP config should looks like
+   * {
+   *   "consents": {
+   *     "foo": {
+   *       "checkConsentHref": "https://fake.com",
+   *       "promptUISrc": "https://fake.com/promptUI.html"
+   *     }
+   *   }
+   * }
+   * @return {?JsonObject}
+   */
+  getCMPConfig_() {
+    if (!isExperimentOn(this.win_, 'amp-consent-v2')) {
+      return null;
+    }
+
+    const type = this.element_.getAttribute('type');
+    if (!type) {
+      return null;
+    }
+    user().assert(CMP_CONFIG[type], '%s: invalid CMP type %s', TAG, type);
+    const importConfig = CMP_CONFIG[type];
+    this.validateCMPConfig_(importConfig);
+    const constentInstance = importConfig['consentInstanceId'];
+
+    const cmpConfig = dict({
+      'consents': dict({}),
+    });
+
+    const config = Object.assign({}, importConfig);
+    delete config['consentInstanceId'];
+
+    cmpConfig['consents'][constentInstance] = config;
+    return cmpConfig;
+  }
+
+  /**
+   * Check if the CMP config is valid
+   * @param {!JsonObject} config
+   */
+  validateCMPConfig_(config) {
+    const assertValues =
+        ['consentInstanceId', 'checkConsentHref', 'promptUISrc'];
+    for (let i = 0; i < assertValues.length; i++) {
+      const attribute = assertValues[i];
+      dev().assert(config[attribute], 'CMP config must specify %s', attribute);
+    }
+  }
+}
+
+/**
+ * Expand the passed in policyConfig and generate predefined policy entires
+ * @param {!JsonObject} policyConfig
+ * @param {!JsonObject} consentConfig
+ * @return {!JsonObject}
+ */
+export function expandPolicyConfig(policyConfig, consentConfig) {
+  // Generate default policy
+  const instanceKeys = Object.keys(consentConfig);
+  const defaultWaitForItems = {};
+  for (let i = 0; i < instanceKeys.length; i++) {
+    // TODO: Need to support an array.
+    defaultWaitForItems[instanceKeys[i]] = undefined;
+  }
+  const defaultPolicy = {
+    'waitFor': defaultWaitForItems,
+  };
+
+  // TODO(@zhouyx): unblockOn is internal now.
+  const unblockOnAll = [
+    CONSENT_POLICY_STATE.UNKNOWN,
+    CONSENT_POLICY_STATE.SUFFICIENT,
+    CONSENT_POLICY_STATE.INSUFFICIENT,
+    CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+  ];
+
+  const predefinedNone = {
+    'waitFor': defaultWaitForItems,
+    // Experimental config, do not expose
+    'unblockOn': unblockOnAll,
+  };
+
+  const rejectAllOnZero = {
+    'waitFor': defaultWaitForItems,
+    'timeout': {
+      'seconds': 0,
+      'fallbackAction': 'reject',
+    },
+    'unblockOn': unblockOnAll,
+  };
+
+  policyConfig['_till_responded'] = predefinedNone;
+
+  policyConfig['_till_accepted'] = defaultPolicy;
+
+  policyConfig['_auto_reject'] = rejectAllOnZero;
+
+  if (policyConfig && policyConfig['default']) {
+    return policyConfig;
+  }
+
+  policyConfig['default'] = defaultPolicy;
+
+  return policyConfig;
+}

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -19,7 +19,6 @@ import {
   AmpConsent,
 } from '../amp-consent';
 import {CONSENT_ITEM_STATE} from '../consent-state-manager';
-import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
 import {dict} from '../../../../src/utils/object';
 import {macroTask} from '../../../../testing/yield';
 import {
@@ -97,54 +96,17 @@ describes.realWin('amp-consent', {
 
   describe('amp-consent', () => {
     describe('consent config', () => {
-      let defaultConfig;
       let consentElement;
-      beforeEach(() => {
-        defaultConfig = dict({
-          'consents': {
-            'ABC': {
-              'checkConsentHref': 'https://response1',
-            },
-            'DEF': {
-              'checkConsentHref': 'https://response1',
-            },
-          },
-        });
-      });
 
-      it('read inline config', () => {
-        consentElement = createConsentElement(doc, defaultConfig);
-        doc.body.appendChild(consentElement);
-        const ampConsent = new AmpConsent(consentElement);
-        ampConsent.buildCallback();
-        expect(ampConsent.consentConfig_).to.deep.equal(
-            defaultConfig['consents']);
-      });
-
-      it('read cmp config', () => {
-        consentElement = createConsentElement(doc, dict({}), '_ping_');
-        doc.body.appendChild(consentElement);
-        const ampConsent = new AmpConsent(consentElement);
-        ampConsent.buildCallback();
-        expect(ampConsent.consentConfig_).to.deep.equal(dict({
-          '_ping_': {
-            'checkConsentHref': 'http://localhost:8000/get-consent-v1',
-            'promptUISrc':
-                'http://ads.localhost:8000/test/manual/diy-consent.html',
-          },
-        }));
-      });
-
-      it('merge inline config w/ cmp config', () => {
+      it('get consent/policy/postPromptUI config', () => {
         consentElement = createConsentElement(doc, dict({
           'consents': {
-            '_ping_': {
-              'promptIfUnknownForGeoGroup': 'eea',
+            'test': {
               'checkConsentHref': '/override',
             },
           },
           'postPromptUI': 'test',
-        }), '_ping_');
+        }));
         const postPromptUI = document.createElement('div');
         postPromptUI.setAttribute('id', 'test');
         consentElement.appendChild(postPromptUI);
@@ -152,62 +114,19 @@ describes.realWin('amp-consent', {
         const ampConsent = new AmpConsent(consentElement);
         ampConsent.buildCallback();
 
+        expect(ampConsent.postPromptUI_).to.not.be.null;
+
         expect(ampConsent.consentConfig_).to.deep.equal(dict({
-          '_ping_': {
+          'test': {
             'checkConsentHref': '/override',
-            'promptUISrc':
-                'http://ads.localhost:8000/test/manual/diy-consent.html',
-            'promptIfUnknownForGeoGroup': 'eea',
           },
         }));
-        expect(ampConsent.postPromptUI_).to.not.be.null;
-      });
 
-      it('assert valid config', () => {
-        const scriptTypeError = 'amp-consent: <script> child ' +
-            'must have type="application/json"';
-        const consentExistError = 'amp-consent: consents config is required';
-        const multiScriptError =
-            'amp-consent: Found 2 <script> children. Expected 1';
-        const invalidJsonError = 'amp-consent: Failed to parse <script> ' +
-            'contents. Is it valid JSON?';
-        const invalidCMPError = 'invalid CMP type';
-        // Check script type equals to application/json
-        const consentElement = doc.createElement('amp-consent');
-        consentElement.setAttribute('id', 'test');
-        consentElement.setAttribute('layout', 'nodisplay');
-        const scriptElement = doc.createElement('script');
-        scriptElement.textContent = JSON.stringify(defaultConfig);
-        scriptElement.setAttribute('type', '');
-        consentElement.appendChild(scriptElement);
-
-        doc.body.appendChild(consentElement);
-        const ampConsent = new AmpConsent(consentElement);
-        expect(() => ampConsent.buildCallback()).to.throw(scriptTypeError);
-
-
-        // Check consent config exists
-        scriptElement.setAttribute('type', 'application/json');
-        scriptElement.textContent = JSON.stringify({});
-        allowConsoleError(() => {
-          expect(() => ampConsent.buildCallback()).to.throw(consentExistError);
-        });
-
-        // Check invalid CMP
-        consentElement.setAttribute('type', 'not_exist');
-        allowConsoleError(() => {
-          expect(() => ampConsent.buildCallback()).to.throw(invalidCMPError);
-        });
-
-        scriptElement.textContent = '"abc": {"a",}';
-        expect(() => ampConsent.buildCallback()).to.throw(invalidJsonError);
-
-
-        // Check there is only one script object
-        scriptElement.textContent = JSON.stringify(defaultConfig);
-        const script2 = doc.createElement('script');
-        consentElement.appendChild(script2);
-        expect(() => ampConsent.buildCallback()).to.throw(multiScriptError);
+        expect(Object.keys(ampConsent.policyConfig_)).to.have.length(4);
+        expect(ampConsent.policyConfig_['default']).to.be.ok;
+        expect(ampConsent.policyConfig_['_till_responded']).to.be.ok;
+        expect(ampConsent.policyConfig_['_till_accepted']).to.be.ok;
+        expect(ampConsent.policyConfig_['_auto_reject']).to.be.ok;
       });
 
       it('relative checkConsentHref is resolved', function* () {
@@ -315,122 +234,6 @@ describes.realWin('amp-consent', {
       ampConsent.buildCallback();
       yield macroTask();
       expect(ampConsent.consentRequired_['ABC']).to.equal(false);
-    });
-  });
-
-  describe('policy config', () => {
-    let defaultConfig;
-    let ampConsent;
-    let consentElement;
-    beforeEach(() => {
-      defaultConfig = dict({
-        'consents': {
-          'ABC': {
-            'checkConsentHref': 'https://response1',
-          },
-          'DEF': {
-            'checkConsentHref': 'https://response1',
-          },
-        },
-      });
-      consentElement = createConsentElement(doc, defaultConfig);
-      doc.body.appendChild(consentElement);
-      ampConsent = new AmpConsent(consentElement);
-    });
-
-    it('create default policy', function* () {
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.policyConfig_['default']).to.deep.equal({
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-      });
-    });
-
-    it('create predefined _till_responded policy', function* () {
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.policyConfig_['_till_responded']).to.deep.equal({
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-        'unblockOn': [
-          CONSENT_POLICY_STATE.UNKNOWN,
-          CONSENT_POLICY_STATE.SUFFICIENT,
-          CONSENT_POLICY_STATE.INSUFFICIENT,
-          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
-        ],
-      });
-    });
-
-    it('create predefined _till_accepted policy', function* () {
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.policyConfig_['_till_accepted']).to.deep.equal({
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-      });
-    });
-
-    it('create default _auto_reject policy', function* () {
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.policyConfig_['_auto_reject']).to.deep.equal({
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-        'timeout': {
-          'seconds': 0,
-          'fallbackAction': 'reject',
-        },
-        'unblockOn': [
-          CONSENT_POLICY_STATE.UNKNOWN,
-          CONSENT_POLICY_STATE.SUFFICIENT,
-          CONSENT_POLICY_STATE.INSUFFICIENT,
-          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
-        ],
-      });
-    });
-
-    it('override default policy', function* () {
-      consentElement = createConsentElement(doc, {
-        'consents': {
-          'ABC': {
-            'checkConsentHref': 'https://response1',
-          },
-          'DEF': {
-            'checkConsentHref': 'https://response1',
-          },
-        },
-        'policy': {
-          'default': {
-            'waitFor': {
-              'ABC': [],
-            },
-          },
-        },
-      });
-      doc.body.appendChild(consentElement);
-      ampConsent = new AmpConsent(consentElement);
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.policyConfig_['default']).to.deep.equal({
-        'waitFor': {
-          'ABC': [],
-        },
-      });
-      expect(ampConsent.policyConfig_['_till_accepted']).to.deep.equal({
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-      });
     });
   });
 
@@ -656,7 +459,7 @@ describes.realWin('amp-consent', {
  * @param {string=} opt_type
  * @return {Element}
  */
-function createConsentElement(doc, config, opt_type) {
+export function createConsentElement(doc, config, opt_type) {
   const consentElement = doc.createElement('amp-consent');
   consentElement.setAttribute('id', 'amp-consent');
   consentElement.setAttribute('layout', 'nodisplay');

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
+import {ConsentConfig, expandPolicyConfig} from '../consent-config';
+import {dict} from '../../../../src/utils/object';
+import {toggleExperiment} from '../../../../src/experiments';
+
+
+
+
+describes.realWin('ConsentConfig', {amp: 1}, env => {
+  let win;
+  let doc;
+  let element;
+  let defaultConfig;
+  beforeEach(() => {
+    win = env.win;
+    doc = env.win.document;
+    element = doc.createElement('div');
+    toggleExperiment(win, 'multi-consent', true);
+    toggleExperiment(win, 'amp-consent-v2', true);
+    defaultConfig = dict({
+      'consents': {
+        'ABC': {
+          'checkConsentHref': 'https://response1',
+        },
+        'DEF': {
+          'checkConsentHref': 'https://response1',
+        },
+      },
+    });
+  });
+
+  describe('read consent config', () => {
+    it('read inline config', () => {
+      appendConfigScriptElement(doc, element, defaultConfig);
+      const consentConfig = new ConsentConfig(element);
+      expect(consentConfig.getConfig()).to.deep.equal(
+          defaultConfig);
+    });
+
+    it('read cmp config', () => {
+      appendConfigScriptElement(doc, element, dict({}));
+      element.setAttribute('type', '_ping_');
+      const consentConfig = new ConsentConfig(element);
+      expect(consentConfig.getConfig()).to.deep.equal(dict({
+        'consents': {
+          '_ping_': {
+            'checkConsentHref': 'http://localhost:8000/get-consent-v1',
+            'promptUISrc':
+                'http://ads.localhost:8000/test/manual/diy-consent.html',
+          },
+        },
+      }));
+    });
+
+    it('merge inline config w/ cmp config', () => {
+      appendConfigScriptElement(doc, element, dict({
+        'consents': {
+          '_ping_': {
+            'promptIfUnknownForGeoGroup': 'eea',
+            'checkConsentHref': '/override',
+          },
+        },
+        'postPromptUI': 'test',
+      }));
+      element.setAttribute('type', '_ping_');
+      const consentConfig = new ConsentConfig(element);
+      expect(consentConfig.getConfig()).to.deep.equal(dict({
+        'consents': {
+          '_ping_': {
+            'checkConsentHref': '/override',
+            'promptUISrc':
+                'http://ads.localhost:8000/test/manual/diy-consent.html',
+            'promptIfUnknownForGeoGroup': 'eea',
+          },
+        },
+        'postPromptUI': 'test',
+      }));
+    });
+
+    it('assert valid config', () => {
+      const scriptTypeError = 'amp-consent/consent-config: <script> child ' +
+          'must have type="application/json"';
+      const consentExistError = 'amp-consent/consent-config: ' +
+          'consents config is required';
+      const multiScriptError =
+          'amp-consent/consent-config: Found 2 <script> children. Expected 1';
+      const invalidJsonError = 'amp-consent/consent-config: ' +
+          'Failed to parse <script> contents. Is it valid JSON?';
+      const invalidCMPError = 'amp-consent/consent-config: invalid CMP type';
+      // Check script type equals to application/json
+
+      const scriptElement = doc.createElement('script');
+      scriptElement.textContent = JSON.stringify(defaultConfig);
+      scriptElement.setAttribute('type', '');
+      element.appendChild(scriptElement);
+
+      expect(() => new ConsentConfig(element).getConfig())
+          .to.throw(scriptTypeError);
+
+      // Check consent config exists
+      scriptElement.setAttribute('type', 'application/json');
+      scriptElement.textContent = JSON.stringify({});
+      allowConsoleError(() => {
+        expect(() => new ConsentConfig(element).getConfig())
+            .to.throw(consentExistError);
+      });
+
+      // Check invalid CMP
+      element.setAttribute('type', 'not_exist');
+      allowConsoleError(() => {
+        expect(() => new ConsentConfig(element).getConfig())
+            .to.throw(invalidCMPError);
+      });
+
+      scriptElement.textContent = '"abc": {"a",}';
+      expect(() => new ConsentConfig(element).getConfig())
+          .to.throw(invalidJsonError);
+
+      // Check there is only one script object
+      scriptElement.textContent = JSON.stringify(defaultConfig);
+      const script2 = doc.createElement('script');
+      element.appendChild(script2);
+      expect(() => new ConsentConfig(element).getConfig())
+          .to.throw(multiScriptError);
+    });
+
+    it('remove not supported policy', () => {
+      toggleExperiment(win, 'multi-consent', false);
+      appendConfigScriptElement(doc, element, dict({
+        'consents': {
+          'ABC': 'r1',
+        },
+        'policy': {
+          'ABC': undefined,
+        },
+      }));
+      const consentConfig = new ConsentConfig(element);
+      expect(consentConfig.getConfig()['policy']).to.deep.equal({});
+    });
+  });
+
+  describe('expandPolicyConfig', () => {
+    it('create default policy', () => {
+      const policy = expandPolicyConfig(dict({}), defaultConfig['consents']);
+      expect(policy['default']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+      });
+    });
+
+    it('create predefined _till_responded policy', function* () {
+      const policy = expandPolicyConfig(dict({}), defaultConfig['consents']);
+      expect(policy['_till_responded']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+        'unblockOn': [
+          CONSENT_POLICY_STATE.UNKNOWN,
+          CONSENT_POLICY_STATE.SUFFICIENT,
+          CONSENT_POLICY_STATE.INSUFFICIENT,
+          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+        ],
+      });
+    });
+
+    it('create predefined _till_accepted policy', function* () {
+      const policy = expandPolicyConfig(dict({}), defaultConfig['consents']);
+      expect(policy['_till_accepted']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+      });
+    });
+
+    it('create default _auto_reject policy', function* () {
+      const policy = expandPolicyConfig(dict({}), defaultConfig['consents']);
+      expect(policy['_auto_reject']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+        'timeout': {
+          'seconds': 0,
+          'fallbackAction': 'reject',
+        },
+        'unblockOn': [
+          CONSENT_POLICY_STATE.UNKNOWN,
+          CONSENT_POLICY_STATE.SUFFICIENT,
+          CONSENT_POLICY_STATE.INSUFFICIENT,
+          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+        ],
+      });
+    });
+
+    it('override default policy', function* () {
+      const policy = expandPolicyConfig(dict({
+        'default': {
+          'waitFor': {
+            'ABC': [],
+          },
+        },
+      }), defaultConfig['consents']);
+      expect(policy['default']).to.deep.equal({
+        'waitFor': {
+          'ABC': [],
+        },
+      });
+      expect(policy['_till_accepted']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+      });
+    });
+  });
+});
+
+function appendConfigScriptElement(doc, element, config) {
+  const scriptElement = doc.createElement('script');
+  scriptElement.setAttribute('type', 'application/json');
+  scriptElement.textContent = JSON.stringify(config);
+  element.appendChild(scriptElement);
+}


### PR DESCRIPTION
Part of the AMP-Consent refactor effort. To reduce the number of lines of amp-consent.js

