### PR TITLE
Exclude build-system directory from the LGTM analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,6 +8,8 @@ path_classifiers:
     - "third_party/**/*.*"
   externs:
     - "**/*.extern.js"
+  build-system:
+    - "build-system/**/*.*"
 extraction:
   javascript:
     index:


### PR DESCRIPTION
Hi,
(Disclosure: I am a member of the team behind LGTM.com)

Looking at some of the recent issues on LGTM.com, I discovered some security vulnerabilities in your project (Cross-site scripting). But they are all in `build-system`, which I think is not a security-sensitive component. 
I am proposing this change to exclude the `build-system` directory from the LGTM analysis, and avoid this unnecessary noise for your developers. 

🏗 

Cheers