### PR TITLE
🐛Run an initial render in buildCallback

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -470,6 +470,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       this.element.classList.toggle(FULLSCREEN_CSS, this.fullscreen_);
       this.element.appendChild(this.container_);
       this.state_ = this.getInitialState_();
+      this.render(this.state_);
     });
   }
 


### PR DESCRIPTION
This fixes a regression that caused #19109.

The date picker renders the info-area and that timing needs to be preserved. The render call was removed in #18691 as a performance optimization. However, removing the render call in `buildCallback` broke the implicit contract that a static date picker would be rendered when opened within a lightbox.