### PR TITLE
♻️ Fix string literal warnings in UI extensions

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -117,7 +117,8 @@ class AmpAccordion extends AMP.BaseElement {
           const sectionEl = this.getAmpDoc().getElementById(sectionId);
           user().assertElement(
               sectionEl,
-              'No element found with id:' + sectionId);
+              'No element found with id: %s',
+              sectionId);
           this.toggle_(dev().assertElement(sectionEl));
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
@@ -131,7 +132,8 @@ class AmpAccordion extends AMP.BaseElement {
           const sectionEl = this.getAmpDoc().getElementById(sectionId);
           user().assertElement(
               sectionEl,
-              'No element found with id:' + sectionId);
+              'No element found with id: %s',
+              sectionId);
           this.expand_(dev().assertElement(sectionEl));
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
@@ -145,7 +147,8 @@ class AmpAccordion extends AMP.BaseElement {
           const sectionEl = this.getAmpDoc().getElementById(sectionId);
           user().assertElement(
               sectionEl,
-              'No element found with id:' + sectionId);
+              'No element found with id: %s',
+              sectionId);
           this.collapse_(dev().assertElement(sectionEl));
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
@@ -211,7 +214,8 @@ class AmpAccordion extends AMP.BaseElement {
           dev().assert(parseJson(dev().assertString(sessionStr))))
         : dict();
     } catch (e) {
-      dev().fine('AMP-ACCORDION', e.message, e.stack);
+      dev().fine('AMP-ACCORDION',
+          'Error setting session state: %s, %s', e.message, e.stack);
       return dict();
     }
   }
@@ -229,7 +233,8 @@ class AmpAccordion extends AMP.BaseElement {
       this.win./*OK*/sessionStorage.setItem(
           dev().assertString(this.sessionId_), sessionStr);
     } catch (e) {
-      dev().fine('AMP-ACCORDION', e.message, e.stack);
+      dev().fine('AMP-ACCORDION',
+          'Error setting session state: %s, %s', e.message, e.stack);
     }
   }
 

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -114,12 +114,10 @@ class AmpAccordion extends AMP.BaseElement {
       this.registerAction('toggle', invocation => {
         if (invocation.args) {
           const sectionId = invocation.args['section'];
-          const sectionEl = this.getAmpDoc().getElementById(sectionId);
-          user().assertElement(
-              sectionEl,
-              'No element found with id: %s',
-              sectionId);
-          this.toggle_(dev().assertElement(sectionEl));
+          let sectionEl = this.getAmpDoc().getElementById(sectionId);
+          sectionEl = user().assertElement(sectionEl);
+          user().assert(sectionEl, 'No element found with id: %s', sectionId);
+          this.toggle_(sectionEl);
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
             this.toggle_(this.sections_[i]);
@@ -129,12 +127,10 @@ class AmpAccordion extends AMP.BaseElement {
       this.registerAction('expand', invocation => {
         if (invocation.args) {
           const sectionId = invocation.args['section'];
-          const sectionEl = this.getAmpDoc().getElementById(sectionId);
-          user().assertElement(
-              sectionEl,
-              'No element found with id: %s',
-              sectionId);
-          this.expand_(dev().assertElement(sectionEl));
+          let sectionEl = this.getAmpDoc().getElementById(sectionId);
+          sectionEl = user().assertElement(sectionEl);
+          user().assert(sectionEl, 'No element found with id: %s', sectionId);
+          this.expand_(sectionEl);
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
             this.expand_(this.sections_[i]);
@@ -144,12 +140,10 @@ class AmpAccordion extends AMP.BaseElement {
       this.registerAction('collapse', invocation => {
         if (invocation.args) {
           const sectionId = invocation.args['section'];
-          const sectionEl = this.getAmpDoc().getElementById(sectionId);
-          user().assertElement(
-              sectionEl,
-              'No element found with id: %s',
-              sectionId);
-          this.collapse_(dev().assertElement(sectionEl));
+          let sectionEl = this.getAmpDoc().getElementById(sectionId);
+          sectionEl = user().assertElement(sectionEl);
+          user().assert(sectionEl, 'No element found with id: %s', sectionId);
+          this.collapse_(sectionEl);
         } else {
           for (let i = 0; i < this.sections_.length; i++) {
             this.collapse_(this.sections_[i]);

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -90,9 +90,8 @@ export class AmpAnimation extends AMP.BaseElement {
       user().assert(
           this.element.parentNode == this.element.ownerDocument.body ||
           this.element.parentNode == ampdoc.getBody(),
-          `${TAG} is only allowed as a direct child of <body> element` +
-          ' when trigger is visibility.' +
-          ' This restriction will be removed soon.');
+          '%s is only allowed as a direct child of <body> element when trigger'
+          + ' is visibility. This restriction will be removed soon.', TAG);
     }
 
     // Parse config.

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -205,13 +205,13 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.scrollTimerId_ = Services.timerFor(this.win).delay(() => {
       // TODO(yuxichen): test out the threshold for identifying fast scrolling
       if (Math.abs(startingScrollLeft - this.pos_) < 30) {
-        dev().fine(TAG, 'slow scrolling: ' + startingScrollLeft + ' - '
-            + this.pos_);
+        dev().fine(TAG, 'slow scrolling: %s - %s',
+            startingScrollLeft, this.pos_);
         this.scrollTimerId_ = null;
         this.commitSwitch_(this.pos_);
       } else {
-        dev().fine(TAG, 'fast scrolling: ' + startingScrollLeft + ' - '
-            + this.pos_);
+        dev().fine(TAG, 'fast scrolling: %s - %s',
+            startingScrollLeft, this.pos_);
         this.waitForScroll_(this.pos_);
       }
     }, 100);

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -631,10 +631,8 @@ export class AmpSlideScroll extends BaseSlides {
     const newSlideInView = this.slides_[newIndex];
 
     if (newSlideInView === undefined) {
-      const error = new Error(
-          `Attempting to access a non-existant slide ${newIndex}/${noOfSlides_}`
-      );
-      dev().error(TAG, error);
+      dev().error(TAG, 'Attempting to access a non-existant slide %s / %s',
+          newIndex, noOfSlides_);
       return false;
     }
     this.updateInViewport(newSlideInView, true);

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -248,7 +248,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
         'seconds': localeWordList[5],
       };
     } else {
-      user().error(TAG, `Invalid locale '${locale}', return empty locale word`);
+      user().error(TAG, 'Invalid locale %s, return empty locale word', locale);
       return {};
     }
   }

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -856,8 +856,10 @@ export class AmpDatePicker extends AMP.BaseElement {
       return alternativeName;
     }
 
-    user().error(TAG, `Multiple date-pickers with implicit ${name} fields ` +
-        'need to have IDs');
+    user().error(
+        TAG,
+        'Multiple date-pickers with implicit %s fields need to have IDs',
+        name);
     return '';
   }
 
@@ -1689,15 +1691,16 @@ export class AmpDatePicker extends AMP.BaseElement {
       const {minHeight} = computedStyle(this.win, container);
       if (minHeight === DEFAULT_TRANSITION_CONTAINER_MIN_HEIGHT) {
         user().warn(TAG,
+            '%s\n The "day-size" attribute is changed from the default value '
+            + '%s. You must specify a new "min-height" `for the %s element in '
+            + 'your AMP CSS.\n This is necessary due to a bug in the '
+            + 'date-picker library. When the bug is fixed, the %s CSS class '
+            + 'will be removed.'
+            + 'See https://github.com/ampproject/amphtml/issues/13897',
             this.element,
-            'The "day-size" attribute is changed from the default value ' +
-            `"${DEFAULT_DAY_SIZE}". You must specify a new "min-height" ` +
-            `for the "${TRANSITION_CONTAINER_SELECTOR}" element in your ` +
-            'AMP CSS.\n' +
-            'This is necessary due to a bug in the date-picker library. ' +
-            `When the bug is fixed, the "${RESIZE_BUG_CSS}" CSS class ` +
-            'will be removed.\n' +
-            'See https://github.com/ampproject/amphtml/issues/13897');
+            DEFAULT_DAY_SIZE,
+            TRANSITION_CONTAINER_SELECTOR,
+            RESIZE_BUG_CSS);
       }
     }
   }

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -1695,7 +1695,7 @@ export class AmpDatePicker extends AMP.BaseElement {
             + '%s. You must specify a new "min-height" `for the %s element in '
             + 'your AMP CSS.\n This is necessary due to a bug in the '
             + 'date-picker library. When the bug is fixed, the %s CSS class '
-            + 'will be removed.'
+            + 'will be removed. '
             + 'See https://github.com/ampproject/amphtml/issues/13897',
             this.element,
             DEFAULT_DAY_SIZE,

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -51,9 +51,6 @@ const ELIGIBLE_TAGS = {
   'amp-anim': true,
 };
 
-const SUPPORT_VALIDATION_MSG = `amp-image-viewer should have its target element
-   as the one and only child`;
-
 export class AmpImageViewer extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
@@ -127,10 +124,15 @@ export class AmpImageViewer extends AMP.BaseElement {
     this.element.classList.add('i-amphtml-image-viewer');
     const children = this.getRealChildren();
 
-    user().assert(children.length == 1, SUPPORT_VALIDATION_MSG);
+    user().assert(
+        children.length == 1,
+        '%s should have its target element as its one and only child',
+        TAG);
     user().assert(
         this.elementIsSupported_(children[0]),
-        children[0].tagName + ' is not supported by <amp-image-viewer>'
+        '%s is not supported by %s',
+        children[0].tagName,
+        TAG
     );
 
     this.sourceAmpImage_ = children[0];

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -244,7 +244,7 @@ export class LightboxManager {
     }
 
     user().assert(this.baseElementIsSupported_(element),
-        `The element ${element.tagName} isn't supported in lightbox yet.`);
+        'The element %s isn\'t supported in lightbox yet.', element.tagName);
 
     if (!this.lightboxGroups_[lightboxGroupId]) {
       this.lightboxGroups_[lightboxGroupId] = [];

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -492,13 +492,13 @@ class AmpLightbox extends AMP.BaseElement {
   waitForScroll_(startingScrollTop) {
     this.scrollTimerId_ = Services.timerFor(this.win).delay(() => {
       if (Math.abs(startingScrollTop - this.pos_) < 30) {
-        dev().fine(TAG, 'slow scrolling: ' + startingScrollTop + ' - '
-            + this.pos_);
+        dev().fine(TAG, 'slow scrolling: %s - %s',
+            startingScrollTop, this.pos_);
         this.scrollTimerId_ = null;
         this.update_(this.pos_);
       } else {
-        dev().fine(TAG, 'fast scrolling: ' + startingScrollTop + ' - '
-            + this.pos_);
+        dev().fine(TAG, 'fast scrolling: %s - %s',
+            startingScrollTop, this.pos_);
         this.waitForScroll_(this.pos_);
       }
     }, 100);

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -206,9 +206,11 @@ export class AmpLiveList extends AMP.BaseElement {
 
     const maxItems = this.element.getAttribute('data-max-items-per-page');
     user().assert(Number(maxItems) > 0,
-        `amp-live-list#${this.liveListId_} must have ` +
-        'data-max-items-per-page attribute with numeric value. ' +
-        `Found ${maxItems}`);
+        'amp-live-list # %s must have data-max-items-per-page attribute with'
+        + ' numeric value. Found %s.',
+        this.liveListId_,
+        maxItems
+    );
 
     const actualCount = ([].slice.call(this.itemsSlot_.children)
         .filter(child => !child.hasAttribute('data-tombstone'))).length;
@@ -808,9 +810,10 @@ export class AmpLiveList extends AMP.BaseElement {
       numItems++;
     });
     user().assert(!foundInvalid,
-        `All amp-live-list-items under amp-live-list#${this.liveListId_} ` +
-        'children must have id and data-sort-time attributes. ' +
-        'data-sort-time must be a Number greater than 0.');
+        'All amp-live-list-items under amp-live-list# %s children must '
+        + 'have id and data-sort-time attributes. data-sort-time must be a '
+        + 'Number greater than 0.',
+        this.liveListId_);
     return numItems;
   }
 
@@ -900,9 +903,10 @@ export class AmpLiveList extends AMP.BaseElement {
     // we can't for data-update-time since we always have to evaluate if it
     // changed or not if it exists.
     const time = Number(elem.getAttribute(attr));
-    user().assert(time > 0, `"${attr}" attribute must exist and value ` +
-        `must be a number greater than 0. Found ${time} on ` +
-        `${elem.getAttribute('id')} instead.`);
+    user().assert(time > 0,
+        '%s attribute must exist and value must be a number greater than 0.'
+        + ' Found %s on %s instead.',
+        attr, time, elem.getAttribute('id'));
     return time;
   }
 

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -810,7 +810,7 @@ export class AmpLiveList extends AMP.BaseElement {
       numItems++;
     });
     user().assert(!foundInvalid,
-        'All amp-live-list-items under amp-live-list# %s children must '
+        'All amp-live-list-items under amp-live-list#%s children must '
         + 'have id and data-sort-time attributes. data-sort-time must be a '
         + 'Number greater than 0.',
         this.liveListId_);

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -168,7 +168,7 @@ export class LiveListManager {
     const id = liveList.getAttribute('id');
     user().assert(id, 'amp-live-list must have an id.');
     user().assert(id in this.liveLists_,
-        'amp-live-list# %s found but did not exist on original page load.', id);
+        'amp-live-list#%s found but did not exist on original page load.', id);
     const inClientDomLiveList = this.liveLists_[id];
     inClientDomLiveList.toggle(!liveList.hasAttribute('disabled'));
 

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -167,8 +167,8 @@ export class LiveListManager {
   updateLiveList_(liveList) {
     const id = liveList.getAttribute('id');
     user().assert(id, 'amp-live-list must have an id.');
-    user().assert(id in this.liveLists_, `amp-live-list#${id} found but did ` +
-        'not exist on original page load.');
+    user().assert(id in this.liveLists_,
+        'amp-live-list# %s found but did not exist on original page load.', id);
     const inClientDomLiveList = this.liveLists_[id];
     inClientDomLiveList.toggle(!liveList.hasAttribute('disabled'));
 

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -51,7 +51,7 @@ export class AmpNextPage extends AMP.BaseElement {
 
     const separatorElements = childElementsByAttr(this.element, 'separator');
     user().assert(separatorElements.length <= 1,
-        `${TAG} should contain at most one <div separator> child`);
+        '%s should contain at most one <div separator> child', TAG);
 
     let separator = null;
     if (separatorElements.length === 1) {
@@ -75,12 +75,12 @@ export class AmpNextPage extends AMP.BaseElement {
       } else {
         const scriptElements = childElementsByTag(element, 'SCRIPT');
         user().assert(scriptElements.length === 1,
-            `${TAG} should contain only one <script> child, or a URL specified `
-            + 'in [src]');
+            '%s should contain only one <script> child, or a URL specified '
+            + 'in [src]', TAG);
         const scriptElement = scriptElements[0];
         user().assert(isJsonScriptTag(scriptElement),
-            `${TAG} config should ` +
-            'be inside a <script> tag with type="application/json"');
+            '%s config should be inside a <script> tag with '
+            + 'type="application/json"', TAG);
         const configJson = tryParseJson(scriptElement.textContent, error => {
           user().error(TAG, 'failed to parse config', error);
         });

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -84,7 +84,7 @@ function assertSelectors(selectors) {
   selectors.forEach(selector => {
     BANNED_SELECTOR_PATTERNS.forEach(pattern => {
       user().assertString(selector,
-          'amp-next-page hideSelector value should be a string: ');
+          'amp-next-page hideSelector value should be a string');
       user().assert(!pattern.test(selector),
           'amp-next-page hideSelector %s not allowed', selector);
     });

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -84,9 +84,9 @@ function assertSelectors(selectors) {
   selectors.forEach(selector => {
     BANNED_SELECTOR_PATTERNS.forEach(pattern => {
       user().assertString(selector,
-          `amp-next-page hideSelector value ${selector} is not a string`);
+          'amp-next-page hideSelector value %s is not a string', selector);
       user().assert(!pattern.test(selector),
-          `amp-next-page hideSelector '${selector}' not allowed`);
+          'amp-next-page hideSelector %s not allowed', selector);
     });
   });
 }

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -84,7 +84,7 @@ function assertSelectors(selectors) {
   selectors.forEach(selector => {
     BANNED_SELECTOR_PATTERNS.forEach(pattern => {
       user().assertString(selector,
-          'amp-next-page hideSelector value %s is not a string', selector);
+          'amp-next-page hideSelector value should be a string: ');
       user().assert(!pattern.test(selector),
           'amp-next-page hideSelector %s not allowed', selector);
     });

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -277,9 +277,9 @@ export class NextPageService {
               }
             });
           }),
-          e => dev().error(TAG, `failed to fetch ${next.ampUrl}`, e))
+          e => dev().error(TAG, 'failed to fetch %s', next.ampUrl, e))
           .catch(e => dev().error(TAG,
-              `failed to attach shadow document for ${next.ampUrl}`, e))
+              'failed to attach shadow document for %s', next.ampUrl, e))
           // The new page may be short and the next may already need fetching.
           .then(() => this.scrollHandler_());
     }

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -281,7 +281,7 @@ describe('amp-next-page config', () => {
       };
       allowConsoleError(() => {
         expect(() => assertConfig(/*ctx*/ null, config, documentUrl))
-            .to.throw('amp-next-page hideSelector value 2 is not a string');
+            .to.throw('amp-next-page hideSelector value should be a string: 2');
       });
     });
 

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -52,9 +52,6 @@ const ELIGIBLE_TAGS = {
   'AMP-SELECTOR': true,
 };
 
-const SUPPORT_VALIDATION_MSG = `${TAG} should
-  have its target element as the one and only child`;
-
 /**
  * @extends {AMP.BaseElement}
  */
@@ -168,10 +165,16 @@ export class AmpPanZoom extends AMP.BaseElement {
     this.action_ = Services.actionServiceForDoc(this.element);
     const children = this.getRealChildren();
 
-    user().assert(children.length == 1, SUPPORT_VALIDATION_MSG);
+    user().assert(
+        children.length == 1,
+        '%s should have its target element as its one and only child',
+        TAG
+    );
     user().assert(
         this.elementIsSupported_(children[0]),
-        children[0].tagName + ` is not supported by ${TAG}`
+        '%s is not supported by %s',
+        children[0].tagName,
+        TAG
     );
     this.element.classList.add('i-amphtml-pan-zoom');
     this.content_ = children[0];

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -89,7 +89,7 @@ class AmpPinterest extends AMP.BaseElement {
       case 'buttonFollow':
         return new FollowButton(this.element).render();
     }
-    return Promise.reject(user().createError('Invalid selector: ' + selector));
+    return Promise.reject(user().createError('Invalid selector: %s', selector));
   }
 }
 

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -257,7 +257,7 @@ export class PinWidget {
       this.pinId = this.pinUrl.split('/pin/')[1].split('/')[0];
     } catch (err) {
       return Promise.reject(
-          user().createError('Invalid pinterest url: ' + this.pinUrl)
+          user().createError('Invalid pinterest url: %s', this.pinUrl)
       );
     }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -43,7 +43,7 @@ export class AmpScript extends AMP.BaseElement {
   layoutCallback() {
     if (!isExperimentOn(this.win, 'amp-script')) {
       const error = 'Experiment "amp-script" is not enabled.';
-      user().error(TAG, error);
+      user().error(TAG, 'Experiment "amp-script" is not enabled.');
       return Promise.reject(error);
     }
     // Configure worker-dom's sanitizer with AMP-specific config and hooks.

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -42,9 +42,8 @@ export class AmpScript extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (!isExperimentOn(this.win, 'amp-script')) {
-      const error = 'Experiment "amp-script" is not enabled.';
       user().error(TAG, 'Experiment "amp-script" is not enabled.');
-      return Promise.reject(error);
+      return Promise.reject('Experiment "amp-script" is not enabled.');
     }
     // Configure worker-dom's sanitizer with AMP-specific config and hooks.
     const config = purifyConfig();

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -63,9 +63,9 @@ export class AmpShareTracking extends AMP.BaseElement {
   buildCallback() {
     if (!this.isExperimentOn_()) {
       registerServiceBuilder(this.win, 'share-tracking', function() {
-        return Promise.reject(user().createError(TAG + ' disabled'));
+        return Promise.reject(user().createError('%s disabled', TAG));
       });
-      user().assert(false, `${TAG} experiment is disabled`);
+      user().assert(false, '%s experiment is disabled', TAG);
     }
 
     this.vendorHref_ = this.element.getAttribute('data-href');

--- a/extensions/amp-video-service/0.1/amp-video-service.js
+++ b/extensions/amp-video-service/0.1/amp-video-service.js
@@ -322,7 +322,7 @@ export class VideoEntry {
  * @private
  */
 function warnUnimplemented(feature) {
-  dev().warn(TAG, `${feature} unimplemented.`);
+  dev().warn(TAG, '%s unimplemented.', feature);
 }
 
 


### PR DESCRIPTION
There are a bunch of trivial string literal warnings in these various amp-extensions, so I've fixed these (primarily in components I own and some neighbors) to make the results of `gulp lint` more readable. =) Requesting review from owners: @cvializ @nainar @sparhami and @erwinmombay whom I guess owns the lint rule? 