### PR TITLE
🏗 `gulp visual-diff` refactor and stability fixes

### DIFF
--- a/build-system/.eslintrc
+++ b/build-system/.eslintrc
@@ -11,6 +11,7 @@
     "amphtml-internal/no-array-destructuring": 0,
     "amphtml-internal/no-for-of-statement": 0,
     "amphtml-internal/no-has-own-property-method": 0,
+    "amphtml-internal/no-spread": 0,
     "require-jsdoc": 0
   }
 }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -573,6 +573,7 @@ const forbiddenTerms = {
       'build-system/tasks/firebase.js',
       'build-system/tasks/prepend-global/index.js',
       'build-system/tasks/prepend-global/test.js',
+      'build-system/tasks/visual-diff/index.js',
       'dist.3p/current/integration.js',
       'src/config.js',
       'src/experiments.js',

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -36,30 +36,25 @@ function log(mode, ...messages) {
       if (process.env.TRAVIS) {
         return;
       }
-      messages.unshift(colors.green('VERBOSE:'));
+      fancyLog.info(colors.green('VERBOSE:'), ...messages);
       break;
     case 'info':
-      messages.unshift(colors.green('INFO:'));
+      fancyLog.info(colors.green('INFO:'), ...messages);
       break;
     case 'warning':
-      messages.unshift(colors.yellow('WARNING:'));
+      fancyLog.warn(colors.yellow('WARNING:'), ...messages);
       break;
     case 'error':
-      messages.unshift(colors.red('ERROR:'));
+      fancyLog.error(colors.red('ERROR:'), ...messages);
       break;
     case 'fatal':
-      messages.unshift(colors.red('FATAL:'));
-      break;
+      fancyLog.error(colors.red('FATAL:'), ...messages);
+      throw new Error(messages.join(' '));
     case 'travis':
       if (process.env['TRAVIS']) {
         messages.forEach(message => process.stdout.write(message));
       }
-      return;
-  }
-  // eslint-disable-next-line amphtml-internal/no-spread
-  fancyLog(...messages);
-  if (mode == 'fatal') {
-    process.exit(1);
+      break;
   }
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -571,7 +571,7 @@ function preVisualDiffTasks() {
     const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":true\b/.test(
         fs.readFileSync('dist/amp.js', 'utf8'));
     if (!isInTestMode) {
-      log('fatal', 'AMP was not build in test mode. Run',
+      log('fatal', 'The AMP runtime was not built in test mode. Run',
           colors.cyan('gulp build --fortesting'), 'or remove the',
           colors.cyan('--nobuild'), 'option from this command');
     }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -240,6 +240,12 @@ async function launchBrowser() {
   browser_ = await puppeteer.launch(browserOptions)
       .catch(err => log('fatal', err));
 
+  // Every action on the browser or its pages adds a listener to the
+  // Puppeteer.Connection.Events.Disconnected event. This is a temporary
+  // workaround for the Node runtime warning that is emitted once 11 listeners
+  // are added to the same object.
+  browser_._connection.setMaxListeners(9999);
+
   return browser_;
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -120,9 +120,8 @@ async function launchWebServer() {
   webServerProcess_.on('close', code => {
     code = code || 0;
     if (code != 0) {
-      log('error', colors.cyan("'serve'"),
+      log('fatal', colors.cyan("'serve'"),
           `errored with code ${code}. Cannot continue with visual diff tests`);
-      process.exit(code);
     }
   });
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -584,6 +584,7 @@ function setupCleanup_() {
   process.on('exit', cleanup_);
   process.on('SIGINT', cleanup_);
   process.on('uncaughtException', cleanup_);
+  process.on('unhandledRejection', cleanup_);
 }
 
 async function cleanup_() {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -591,7 +591,7 @@ async function cleanup_() {
   if (browser_) {
     await browser_.close();
   }
-  if (!webServerProcess_.killed) {
+  if (webServerProcess_ && !webServerProcess_.killed) {
     // Explicitly exit the webserver.
     webServerProcess_.kill();
     // The child node process has an asynchronous stdout. See #10409.

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -516,6 +516,7 @@ async function createEmptyBuild(page) {
  * Runs the AMP visual diff tests.
  */
 async function visualDiff() {
+  ensureOrBuildAmpRuntimeInTestMode_();
   setupCleanup_();
   maybeOverridePercyEnvironmentVariables();
   setPercyBranch();
@@ -562,7 +563,7 @@ async function visualDiff() {
   process.exit(0);
 }
 
-function preVisualDiffTasks() {
+async function ensureOrBuildAmpRuntimeInTestMode_() {
   if (argv.verify_status) {
     return;
   }
@@ -600,7 +601,6 @@ async function cleanup_() {
 gulp.task(
     'visual-diff',
     'Runs the AMP visual diff tests.',
-    preVisualDiffTasks,
     visualDiff,
     {
       options: {


### PR DESCRIPTION
Fixes:
* Ensure that the `webServerProcess_` is defined before checking whether the process was killed, in the cleanup step
* Added a workaround to the `MaxListenersExceededWarning` that gets thrown by Node due to Puppeteer adding too many `Disconnect` listeners

Minor changes:
* Fatal log errors will throw an exception (that will be caught by task runner) instead of explicitly calling `process.exit`
* Call `cleanup_` on unhandled Promise rejections as well
* Refactored steps into smaller functions

New stuff:
* Ensure that AMP was build with `--fortesting` when running visual diff tests