### PR TITLE
Fix element services and AMP.setState in FIE

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -465,7 +465,9 @@ export class Extensions {
         // To fix this, make sure the extension is installed in the AmpDoc.
         // Ideally, we'd be able to install a service in the FIE _without_
         // installing it in the AmpDoc. See #19344.
-        const ampdoc = getAmpdoc(childWin.frameElement);
+        const frameElement = /** @type {!Node} */ (dev().assert(
+            childWin.frameElement, 'frameElement not found for embed'));
+        const ampdoc = getAmpdoc(frameElement);
         this.installExtensionInDoc_(ampdoc, extensionId);
         return extension;
       }).then(extension => {

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -464,7 +464,7 @@ export class Extensions {
         // the embed window.
         // To fix this, make sure the extension is installed in the AmpDoc.
         // Ideally, we'd be able to install a service in the FIE _without_
-        // installing it in the AmpDoc. See #TODO.
+        // installing it in the AmpDoc. See #19344.
         const ampdoc = getAmpdoc(childWin.frameElement);
         this.installExtensionInDoc_(ampdoc, extensionId);
         return extension;

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -19,6 +19,7 @@ import {Services} from '../services';
 import {
   adoptServiceForEmbed,
   adoptServiceForEmbedIfEmbeddable,
+  getAmpdoc,
   registerServiceBuilder,
   registerServiceBuilderForDoc,
   setParentWindow,
@@ -366,6 +367,8 @@ export class Extensions {
         this.ampdocService_.hasAmpDocShell())) {
       const ampdoc = this.ampdocService_.getAmpDoc(this.win.document);
       const extensionId = dev().assertString(this.currentExtensionId_);
+      // Note that this won't trigger for FIE extensions that are not present
+      // in the parent doc.
       if (ampdoc.declaresExtension(extensionId) || holder.auto) {
         factory(ampdoc);
       }
@@ -454,6 +457,18 @@ export class Extensions {
 
       // Install CSS.
       const promise = this.preloadExtension(extensionId).then(extension => {
+        // An extension element/service that's declared in an FIE but _not_
+        // in the parent is not immediately installed. See addDocFactory().
+        // This is a problem for adoptServiceForEmbedIfEmbeddable(), which
+        // requires a service to be registered on an AmpDoc before adoption by
+        // the embed window.
+        // To fix this, make sure the extension is installed in the AmpDoc.
+        // Ideally, we'd be able to install a service in the FIE _without_
+        // installing it in the AmpDoc. See #TODO.
+        const ampdoc = getAmpdoc(childWin.frameElement);
+        this.installExtensionInDoc_(ampdoc, extensionId);
+        return extension;
+      }).then(extension => {
         // Adopt embeddable extension services.
         extension.services.forEach(service => {
           adoptServiceForEmbedIfEmbeddable(childWin, service);

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -106,8 +106,9 @@ export class StandardActions {
     switch (method) {
       case 'pushState':
       case 'setState':
-        const ampdoc = getAmpdoc(node);
-        return Services.bindForDocOrNull(ampdoc).then(bind => {
+        const element = (node.nodeType === Node.DOCUMENT_NODE)
+          ? node.documentElement : node;
+        return Services.bindForDocOrNull(element).then(bind => {
           user().assert(bind, 'AMP-BIND is not installed.');
           return bind.invoke(invocation);
         });

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -962,7 +962,9 @@ describes.sandboxed('Extensions', {}, () => {
       }, parentWin.AMP);
       return promise.then(() => {
         // Main extension.
-        expect(parentWin.ampExtendedElements['amp-test']).to.be.undefined;
+        // TODO(choumx, #19344): Registering in parent window is a temporary
+        // workaround to fix FIE element services.
+        expect(parentWin.ampExtendedElements['amp-test']).to.equal(AmpTest);
         expect(iframeWin.ampExtendedElements['amp-test']).to.equal(AmpTest);
         expect(iframeWin.document
             .querySelector('style[amp-extension=amp-test]')).to.exist;
@@ -971,7 +973,10 @@ describes.sandboxed('Extensions', {}, () => {
             .to.be.instanceOf(AmpTest);
 
         // Secondary extension.
-        expect(parentWin.ampExtendedElements['amp-test-sub']).to.be.undefined;
+        // TODO(choumx, #19344): Registering in parent window is a temporary
+        // workaround to fix FIE element services.
+        expect(parentWin.ampExtendedElements['amp-test-sub'])
+            .to.equal(AmpTestSub);
         expect(iframeWin.ampExtendedElements['amp-test-sub'])
             .to.equal(AmpTestSub);
         expect(iframeWin.document


### PR DESCRIPTION
- Minimal fix to get element services (e.g. amp-bind, amp-gwd-animation) working in FIE (broken in #10992 I think).
- Fixes `AMP.setState` in FIE (broken in #16328).

QA=Tested amp-bind page in local A4A harness.

Follow-ups:
- [ ] Ideally we can install an element service in FIE without installing it on the parent. Proposal: add `static function installServiceInEmbedWin()` to `EmbeddableService` interface.
- [ ] Add integration tests for amp-bind/amp-gwd-animation in FIE to prevent future regressions.
- [ ] #16322