### PR TITLE
FIE support for <amp-gwd-animation>

### DIFF
--- a/examples/gwd.amp.html
+++ b/examples/gwd.amp.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-gwd-animation</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-gwd-animation" src="https://cdn.ampproject.org/v0/amp-gwd-animation-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+    .amp-animate #page1.gwd-play-animation .gwd-gen-1234gwdanimation {
+      animation: gwd-gen-1234gwdanimation_gwd-keyframes 3s linear 0s infinite normal forwards;
+    }
+    .amp-animate #page1.foo .gwd-gen-1234gwdanimation {
+      animation: gwd-gen-1234gwdanimation_gwd-keyframes_foo 3s linear -2.5s infinite normal forwards;
+    }
+    .amp-animate .gwd-play-animation #child .gwd-gen-5678gwdanimation {
+      animation: gwd-gen-1234gwdanimation_gwd-keyframes 3s linear 0s infinite normal forwards;
+    }
+    #page1.nearend .gwd-gen-1l64gwdanimation {
+      animation: gwd-gen-1l64gwdanimation_gwd-keyframes_nearend 3s linear -1.3s infinite normal forwards;
+    }
+    .amp-animate #page1.gwd-pause-animation .gwd-gen-1234gwdanimation {
+      animation-play-state: paused;
+    }
+    .amp-animate #child.gwd-pause-animation .gwd-gen-5678gwdanimation {
+      animation-play-state: paused;
+    }
+    .amp-animate .gwd-play-animation .event-1-animation {
+      animation: gwd-empty-animation 1s linear 0s 1 normal forwards;
+    }
+    .amp-animate .gwd-play-animation .event-2-animation {
+      animation: gwd-empty-animation 2s linear 0s 1 normal forwards;
+    }
+    .amp-animate #page1.gwd-pause-animation .event-2-animation {
+      animation-play-state: paused;
+    }
+    #pagedeck {
+      border: 1px solid #ddd;
+    }
+    #child {
+      background: #ccffff;
+    }
+    #hideText {
+      background: purple;
+      color: #fff;
+      padding: 10px;
+      width: 100px;
+      text-align: center;
+      position: absolute;
+      z-index: 2;
+    }
+    .gwd-page-wrapper {
+      height: 300px;
+    }
+    #amp-carousel_1 {
+      background: #ccffff;
+    }
+  </style>
+</head>
+<body class="amp-animate">
+  <!-- Page deck carousel with one page. -->
+  <amp-carousel
+      id="pagedeck"
+      class="gwd-page-container"
+      layout="fixed"
+      width="400"
+      height="300"
+      type="slides">
+    <div id="page1" class="gwd-page-wrapper">
+      <p>Page 1</p>
+
+      <div id="hideText">This text hides after 1s</div>
+
+      <amp-img id="image1"
+          class="gwd-gen-1234gwdanimation"
+          src="img/sea@2x.jpg"
+          width=260 height=100>
+      </amp-img>
+
+      <div id="child">
+        <p>Child element</p>
+        <amp-img id="image2"
+            class="gwd-gen-5678gwdanimation"
+            src="img/sea@2x.jpg"
+            width=140 height=50>
+        </amp-img>
+      </div>
+
+      <!-- Timeline event elements which fire animationend events after 1s and 2s. -->
+      <div class="gwd-animation-event event-1-animation"
+          data-event-name="event-1" data-event-time="1000"></div>
+      <div class="gwd-animation-event event-2-animation"
+          data-event-name="event-2" data-event-time="2000"></div>
+    </div>
+  </amp-carousel>
+
+  <!-- Demo animation controls. -->
+  <p>
+    Page1 animations:
+    <button on="tap:gwd-animation.play(id=page1)" role="button" tabindex="0">Play</button>
+    <button on="tap:gwd-animation.pause(id=page1)" role="button" tabindex="0">Pause</button>
+    <button on="tap:gwd-animation.togglePlay(id=page1)" role="button" tabindex="0">Toggle</button>
+    <button on="tap:gwd-animation.gotoAndPlay(id=page1, label=foo)" role="button" tabindex="0">
+      Play page from label
+    </button>
+  </p>
+  <p>
+    Page1 child animations:
+    <button on="tap:gwd-animation.play(id=child)" role="button" tabindex="0">Play</button>
+    <button on="tap:gwd-animation.pause(id=child)" role="button" tabindex="0">Pause</button>
+    <button on="tap:gwd-animation.togglePlay(id=child)" role="button" tabindex="0">Toggle</button>
+  </p>
+
+  <!-- Configure the animation runtime with handlers for the two timeline events. -->
+  <amp-gwd-animation id="gwd-animation" layout="nodisplay" timeline-event-prefix="tl_"
+      on="tl_event-1:hideText.hide();tl_event-2:gwd-animation.pause(id=child)">
+  </amp-gwd-animation>
+
+  <style amp-keyframes>
+    @keyframes gwd-empty-animation {
+      0% {
+        opacity: 0.001;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+    @keyframes gwd-gen-1234gwdanimation_gwd-keyframes {
+      0% {
+        transform: translate3d(0px, 0px, 0px);
+        opacity: 1;
+        animation-timing-function: linear;
+      }
+      100% {
+        transform: translate3d(100px, 0px, 0px);
+        opacity: 0.25;
+        animation-timing-function: linear;
+      }
+    }
+    @keyframes gwd-gen-1234gwdanimation_gwd-keyframes_foo {
+      0% {
+        transform: translate3d(0px, 0px, 0px);
+        opacity: 1;
+        animation-timing-function: linear;
+      }
+      100% {
+        transform: translate3d(100px, 0px, 0px);
+        opacity: 0.25;
+        animation-timing-function: linear;
+      }
+    }
+  </style>
+</body>
+</html>

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -133,8 +133,8 @@ function setCounter(receiver, counterName, counterValue) {
 
 /**
  * AMP GWD animation runtime service.
- * @implements {../../../src/service.EmbeddableService}
  * @implements {../../../src/service.Disposable}
+ * @implements {../../../src/service.EmbeddableService}
  */
 export class AmpGwdRuntimeService {
   /**
@@ -181,7 +181,7 @@ export class AmpGwdRuntimeService {
           body,
           () => !!body.querySelector(
               `.${escapeCssSelectorIdent(GWD_PAGE_WRAPPER_CLASS)}`),
-          this.initialize.bind(this));
+          this.initialize_.bind(this));
     });
   }
 
@@ -196,8 +196,9 @@ export class AmpGwdRuntimeService {
   /**
    * Initializes the runtime. Attaches `animationend` event listeners for
    * handling timeline events, and activates animations on the first page.
+   * @private
    */
-  initialize() {
+  initialize_() {
     // TODO(#7846): The GWD animation runtime should start out disabled, but
     // leaving it enabled for now as the main runtime is not yet integrated to
     // enable it. When it does so, uncomment the below code (also see

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {createCustomEvent} from '../../../src/event-helper';
+import {dev, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {
   escapeCssSelectorIdent,
@@ -23,7 +24,6 @@ import {
 } from '../../../src/dom';
 import {installServiceInEmbedScope} from '../../../src/service';
 import {toArray} from '../../../src/types';
-import {user} from '../../../src/log';
 
 /**
  * CSS class used to deactivate animations.
@@ -176,7 +176,7 @@ export class AmpGwdRuntimeService {
       // avoids performing initialization on the top-level document, on which
       // the service is first (unnecessarily) installed when installing in a
       // FIE.
-      const body = /** @type {!Element} */ (this.doc_.body);
+      const body = dev().assertElement(this.doc_.body);
       waitForChild(
           body,
           () => !!body.querySelector(

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -171,11 +171,10 @@ export class AmpGwdRuntimeService {
       // If the page deck is not yet in the DOM, wait until it is. The page deck
       // must be present in the body before the runtime can be initialized, as
       // it must activate animations on the first page. It's not clear whether
-      // in production this is a realistic scenario (though this occurs in tests
-      // due to the sequence of `bodyAvailable` and `beforeEach`), but this also
-      // avoids performing initialization on the top-level document, on which
-      // the service is first (unnecessarily) installed when installing in a
-      // FIE.
+      // in production this is a realistic scenario (though this occurs in
+      // tests), but this also avoids performing initialization on the top-level
+      // document on which the service is first (unnecessarily) installed when
+      // in a FIE.
       const body = dev().assertElement(this.doc_.body);
       waitForChild(
           body,
@@ -411,7 +410,7 @@ export class AmpGwdRuntimeService {
    */
   gotoAndPlayNTimes(id, label, maxCount, eventName) {
     if (maxCount <= 0) {
-      user().error(LOG_ID, 'Invalid maxCount parameter: ' + maxCount);
+      user().error(LOG_ID, `Invalid maxCount parameter: ${maxCount}`);
       return;
     }
 
@@ -456,7 +455,7 @@ export class AmpGwdRuntimeService {
     if (receiver && receiver.classList) {
       return receiver;
     } else {
-      user().error(LOG_ID, 'Could not get receiver with id ' + id);
+      user().error(LOG_ID, `Could not get receiver with id ${id}.`);
       return null;
     }
   }

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -15,7 +15,13 @@
  */
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict, hasOwn} from '../../../src/utils/object';
-import {escapeCssSelectorIdent} from '../../../src/dom';
+import {
+  escapeCssSelectorIdent,
+  scopedQuerySelector,
+  waitForBodyPromise,
+  waitForChild,
+} from '../../../src/dom';
+import {installServiceInEmbedScope} from '../../../src/service';
 import {toArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
@@ -127,28 +133,71 @@ function setCounter(receiver, counterName, counterValue) {
 
 /**
  * AMP GWD animation runtime service.
+ * @implements {../../../src/service.EmbeddableService}
  * @implements {../../../src/service.Disposable}
  */
 export class AmpGwdRuntimeService {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc An AMP document
    *     with GWD content in which to install the animation runtime controller.
+   * @param {!Window=} opt_win If in a FIE, the FIE window in which to install
+   *     the service.
    */
-  constructor(ampdoc) {
-    /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+  constructor(ampdoc, opt_win) {
+    /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = ampdoc;
 
-    /** @private {!Function} */
+    /**
+     * The window containing the GWD ad document. This will differ from the
+     * provided AmpDoc's window when in FIE.
+     * @const @private {!Window}
+     */
+    this.win_ = opt_win || ampdoc.win;
+
+    /**
+     * The GWD ad document root. This will differ from the top-level AmpDoc's
+     * root when in FIE.
+     * @const @private {!Document}
+     */
+    this.doc_ = this.win_.document;
+
+    /** @const @private {!Function} */
     this.boundOnAnimationEndEvent_ = this.onAnimationEndEvent_.bind(this);
 
-    this.ampdoc_.whenBodyAvailable().then(() => { this.initialize_(); });
+    // Initialize once the body and DOM is ready.
+    const docReadyPromise =
+        opt_win ? waitForBodyPromise(this.doc_) : ampdoc.whenBodyAvailable();
+    docReadyPromise.then(() => {
+      // If the page deck is not yet in the DOM, wait until it is. The page deck
+      // must be present in the body before the runtime can be initialized, as
+      // it must activate animations on the first page. It's not clear whether
+      // in production this is a realistic scenario (though this occurs in tests
+      // due to the sequence of `bodyAvailable` and `beforeEach`), but this also
+      // avoids performing initialization on the top-level document, on which
+      // the service is first (unnecessarily) installed when installing in a
+      // FIE.
+      const body = /** @type {!Element} */ (this.doc_.body);
+      waitForChild(
+          body,
+          () => !!body.querySelector(
+              `.${escapeCssSelectorIdent(GWD_PAGE_WRAPPER_CLASS)}`),
+          this.initialize.bind(this));
+    });
+  }
+
+  /** @override */
+  adoptEmbedWindow(embedWin) {
+    installServiceInEmbedScope(
+        embedWin,
+        GWD_SERVICE_NAME,
+        new AmpGwdRuntimeService(this.ampdoc_, embedWin));
   }
 
   /**
-   * Performs setup tasks on body ready.
-   * @private
+   * Initializes the runtime. Attaches `animationend` event listeners for
+   * handling timeline events, and activates animations on the first page.
    */
-  initialize_() {
+  initialize() {
     // TODO(#7846): The GWD animation runtime should start out disabled, but
     // leaving it enabled for now as the main runtime is not yet integrated to
     // enable it. When it does so, uncomment the below code (also see
@@ -174,7 +223,7 @@ export class AmpGwdRuntimeService {
    * @param {boolean} enable True to enable, false to disable.
    */
   setEnabled(enable) {
-    this.ampdoc_.getBody().classList.toggle(ANIMATIONS_DISABLED_CLASS, !enable);
+    this.doc_.body.classList.toggle(ANIMATIONS_DISABLED_CLASS, !enable);
   }
 
   /**
@@ -184,19 +233,23 @@ export class AmpGwdRuntimeService {
    *     pagedeck amp-carousel).
    */
   setCurrentPage(index) {
-    const gwdPages = this.ampdoc_.getRootNode().querySelectorAll(
+    const gwdPages = this.doc_.body.querySelectorAll(
         `.${escapeCssSelectorIdent(GWD_PAGE_WRAPPER_CLASS)}`);
 
     if (gwdPages.length == 0) {
+      user().warn(LOG_ID,
+          'Could not set current page. No pages were found in the document.');
       return;
     }
 
     // Deactivate the outgoing current page, if there is one.
     // TODO(sklobovskaya): Decide if it's worth just storing the index.
-    const currentPageEl = this.ampdoc_.getRootNode().querySelector(
+    const activePageSelector =
         `.${escapeCssSelectorIdent(GWD_PAGE_WRAPPER_CLASS)}.${
           escapeCssSelectorIdent(PlaybackCssClass.PLAY)
-        }`);
+        }`;
+    const currentPageEl =
+        scopedQuerySelector(this.doc_.body, activePageSelector);
 
     if (currentPageEl) {
       this.deactivatePage_(currentPageEl);
@@ -341,7 +394,7 @@ export class AmpGwdRuntimeService {
 
     // Pause playback. The pause must be triggered after a delay as a workaround
     // for a Safari bug that prevents pausing animations from working.
-    this.ampdoc_.win.setTimeout(() => {
+    this.win_.setTimeout(() => {
       this.pause(id);
     }, GOTO_AND_PAUSE_DELAY);
   }
@@ -357,7 +410,7 @@ export class AmpGwdRuntimeService {
    */
   gotoAndPlayNTimes(id, label, maxCount, eventName) {
     if (maxCount <= 0) {
-      user().error(LOG_ID, `Invalid maxCount parameter: ${maxCount}`);
+      user().error(LOG_ID, 'Invalid maxCount parameter: ' + maxCount);
       return;
     }
 
@@ -390,19 +443,19 @@ export class AmpGwdRuntimeService {
    */
   getReceiver(id) {
     if (id == 'document.body') {
-      return this.ampdoc_.getBody();
+      return this.doc_.body;
     }
 
     // Try to locate the receiver by id in the DOM.
     // TODO(sklobovskaya): When support for groups is added, this lookup will
     // need to use GwdIds.
-    const receiver = this.ampdoc_.getRootNode().getElementById(id);
+    const receiver = this.doc_.getElementById(id);
 
     // Check that a valid element was found.
     if (receiver && receiver.classList) {
       return receiver;
     } else {
-      user().error(LOG_ID, `Could not get receiver with id ${id}.`);
+      user().error(LOG_ID, 'Could not get receiver with id ' + id);
       return null;
     }
   }
@@ -460,9 +513,9 @@ export class AmpGwdRuntimeService {
       'sourceEvent': event,
     });
     const timelineEvent =
-        createCustomEvent(this.ampdoc_.win, GWD_TIMELINE_EVENT, detail);
+        createCustomEvent(this.win_, GWD_TIMELINE_EVENT, detail);
 
-    this.ampdoc_.getRootNode().dispatchEvent(timelineEvent);
+    this.doc_.dispatchEvent(timelineEvent);
   }
 
   /**
@@ -470,7 +523,7 @@ export class AmpGwdRuntimeService {
    */
   listenForAnimationEnd_() {
     for (let i = 0; i < VENDOR_ANIMATIONEND_EVENTS.length; i++) {
-      this.ampdoc_.getBody().addEventListener(
+      this.doc_.body.addEventListener(
           VENDOR_ANIMATIONEND_EVENTS[i], this.boundOnAnimationEndEvent_, true);
     }
   }
@@ -480,7 +533,7 @@ export class AmpGwdRuntimeService {
    */
   unlistenForAnimationEnd_() {
     for (let i = 0; i < VENDOR_ANIMATIONEND_EVENTS.length; i++) {
-      this.ampdoc_.getBody().removeEventListener(
+      this.doc_.body.removeEventListener(
           VENDOR_ANIMATIONEND_EVENTS[i], this.boundOnAnimationEndEvent_, true);
     }
   }

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -22,7 +22,10 @@ import {
 import {CSS} from '../../../build/amp-gwd-animation-0.1.css';
 import {Services} from '../../../src/services';
 import {getDetail} from '../../../src/event-helper';
-import {getServiceForDoc} from '../../../src/service';
+import {getExistingServiceForDocInEmbedScope, getParentWindowFrameElement}
+  from '../../../src/service';
+import {getFriendlyIframeEmbedOptional}
+  from '../../../src/friendly-iframe-embed';
 import {user} from '../../../src/log';
 
 /**
@@ -96,18 +99,33 @@ export class GwdAnimation extends AMP.BaseElement {
      */
     this.timelineEventPrefix_ = '';
 
+    /** @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
+    this.fie_ = null;
+
     /** @private {!Function} */
     this.boundOnGwdTimelineEvent_ = this.onGwdTimelineEvent_.bind(this);
   }
 
   /** @override */
   buildCallback() {
+    // Record the timeline event prefix.
     this.timelineEventPrefix_ =
         this.element.getAttribute('timeline-event-prefix') || '';
 
+    // Record whether the extension is in a FIE.
+    const frameElement =
+        getParentWindowFrameElement(this.element, this.getAmpDoc().win);
+    if (frameElement) {
+      this.fie_ = getFriendlyIframeEmbedOptional(frameElement);
+    }
+
+    // Retrieve the local document root (either the top-level doc or the FIE
+    // doc). This must be done after a handle on the FIE has been retrieved.
+    const root = this.getRoot_();
+
     // Listen for GWD timeline events to re-broadcast them via the doc action
     // service.
-    this.getAmpDoc().getRootNode().addEventListener(
+    root.addEventListener(
         GWD_TIMELINE_EVENT, this.boundOnGwdTimelineEvent_, true);
 
     // If the document has a GWD pagedeck, automatically generate listeners for
@@ -115,12 +133,13 @@ export class GwdAnimation extends AMP.BaseElement {
     // switched from the old page to the new.
     const gwdPageDeck = this.getGwdPageDeck_();
     if (gwdPageDeck) {
-      user().assert(this.element.id, `The ${TAG} element must have an id.`);
+      user().assert(
+          this.element.id, 'The ' + TAG + ' element must have an id.');
 
       const setCurrentPageAction =
           `${this.element.id}.setCurrentPage(index=event.index)`;
-      addAction(
-          this.getAmpDoc(), gwdPageDeck, 'slideChange', setCurrentPageAction);
+      const nodeOrDoc = this.fie_ ? this.element : this.getAmpDoc();
+      addAction(nodeOrDoc, gwdPageDeck, 'slideChange', setCurrentPageAction);
     }
 
     // Register handlers for supported actions.
@@ -131,12 +150,25 @@ export class GwdAnimation extends AMP.BaseElement {
   }
 
   /**
+   * The local document node managed by the GWD runtime (either the top-level
+   * document for single AmpDocs or a FIE document). This function will only
+   * return the right value after `buildCallback` has executed.
+   * @return {!Document|!ShadowRoot}
+   * @private
+   */
+  getRoot_() {
+    return this.fie_ ?
+      this.fie_.win.document :
+      this.getAmpDoc().getRootNode();
+  }
+
+  /**
    * Returns the GWD pagedeck element if one exists in the document.
    * @return {?Element}
    * @private
    */
   getGwdPageDeck_() {
-    return this.getAmpDoc().getRootNode().getElementById(GWD_PAGEDECK_ID);
+    return this.getRoot_().getElementById(GWD_PAGEDECK_ID);
   }
 
   /**
@@ -175,8 +207,9 @@ export class GwdAnimation extends AMP.BaseElement {
    * @private
    */
   executeInvocation_(invocation) {
+    const nodeOrDoc = this.fie_ ? this.element : this.getAmpDoc();
     const service = user().assert(
-        getServiceForDoc(this.getAmpDoc(), GWD_SERVICE_NAME),
+        getExistingServiceForDocInEmbedScope(nodeOrDoc, GWD_SERVICE_NAME),
         'Cannot execute action because the GWD service is not registered.');
 
     const argPaths = ACTION_IMPL_ARGS[invocation.method];
@@ -194,16 +227,18 @@ export class GwdAnimation extends AMP.BaseElement {
    * @private
    */
   onGwdTimelineEvent_(event) {
-    Services.actionServiceForDoc(this.getAmpDoc()).trigger(
-        this.element,
-        `${this.timelineEventPrefix_}${getDetail(event)['eventName']}`,
-        event,
-        ActionTrust.HIGH);
+    const nodeOrDoc = this.fie_ ? this.element : this.getAmpDoc();
+    const actionService = Services.actionServiceForDoc(nodeOrDoc);
+    const eventName = getDetail(event)['eventName'];
+    const timelineEventName = `${this.timelineEventPrefix_}${eventName}`;
+
+    actionService.trigger(
+        this.element, timelineEventName, event, ActionTrust.HIGH);
   }
 
   /** @override */
   detachedCallback() {
-    this.getAmpDoc().getRootNode().removeEventListener(
+    this.getRoot_().removeEventListener(
         GWD_TIMELINE_EVENT, this.boundOnGwdTimelineEvent_, true);
     return true;
   }
@@ -211,13 +246,15 @@ export class GwdAnimation extends AMP.BaseElement {
 
 /**
  * Adds an event action definition to a node.
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc The node
+ *     or AmpDoc reference for retrieving the action service. The node is
+ *     provided when in an FIE.
  * @param {!Element} element The target element whose actions to update.
  * @param {string} event The event name, e.g., 'slideChange'.
  * @param {string} actionStr e.g., `someDiv.hide`.
  * @private Visible for testing.
  */
-export function addAction(ampdoc, element, event, actionStr) {
+export function addAction(nodeOrDoc, element, event, actionStr) {
   // Assemble the new actions string by splicing in the new action string
   // with any existing actions.
   let newActionsStr;
@@ -245,7 +282,7 @@ export function addAction(ampdoc, element, event, actionStr) {
   }
 
   // Reset the element's actions with the new actions string.
-  Services.actionServiceForDoc(ampdoc).setActions(element, newActionsStr);
+  Services.actionServiceForDoc(nodeOrDoc).setActions(element, newActionsStr);
 }
 
 AMP.extension(TAG, '0.1', AMP => {

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -123,7 +123,7 @@ export class GwdAnimation extends AMP.BaseElement {
     }
 
     // Retrieve the local document root (either the top-level doc or the FIE
-    // doc). This must be done after a handle on the FIE has been retrieved.
+    // doc). This must be done after the FIE has been retrieved above.
     const root = this.getRoot_();
 
     // Listen for GWD timeline events to re-broadcast them via the doc action
@@ -136,8 +136,7 @@ export class GwdAnimation extends AMP.BaseElement {
     // switched from the old page to the new.
     const gwdPageDeck = this.getGwdPageDeck_();
     if (gwdPageDeck) {
-      user().assert(
-          this.element.id, 'The ' + TAG + ' element must have an id.');
+      user().assert(this.element.id, `The ${TAG} element must have an id.`);
 
       const setCurrentPageAction =
           `${this.element.id}.setCurrentPage(index=event.index)`;
@@ -250,8 +249,8 @@ export class GwdAnimation extends AMP.BaseElement {
 /**
  * Adds an event action definition to a node.
  * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc The node
- *     or AmpDoc reference for retrieving the action service. The node is
- *     provided when in an FIE.
+ *     or AmpDoc reference for retrieving the action service. The node rather
+ *     than the doc is provided when in a FIE.
  * @param {!Element} element The target element whose actions to update.
  * @param {string} event The event name, e.g., 'slideChange'.
  * @param {string} actionStr e.g., `someDiv.hide`.

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -99,7 +99,10 @@ export class GwdAnimation extends AMP.BaseElement {
      */
     this.timelineEventPrefix_ = '';
 
-    /** @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
+    /**
+     * The friendly iframe embed, if within one.
+     * @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed}
+     */
     this.fie_ = null;
 
     /** @private {!Function} */

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -96,8 +96,6 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         doc = variant.ampdoc == 'fie' ?
           embed.win.document :
           ampdoc.getRootNode();
-        runtime = getExistingServiceForDocInEmbedScope(
-            variant.ampdoc == 'fie' ? element : ampdoc, GWD_SERVICE_NAME);
 
         // Create a test amp-carousel GWD page deck.
         doc.body.innerHTML =
@@ -123,6 +121,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         return createGwdAnimationElement(doc, config).then(el => {
           element = el;
           impl = element.implementation_;
+          runtime = getExistingServiceForDocInEmbedScope(
+              variant.ampdoc == 'fie' ? element : ampdoc, GWD_SERVICE_NAME);
           page1Elem = doc.getElementById('page1');
         });
       });
@@ -248,11 +248,11 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
       });
 
       it('should disable and re-enable', () => {
-        getLocalWinService().setEnabled(true);
+        runtime.setEnabled(true);
         expect(doc.body.classList.contains(ANIMATIONS_DISABLED_CLASS))
             .to.be.false;
 
-        getLocalWinService().setEnabled(false);
+        runtime.setEnabled(false);
         expect(doc.body.classList.contains(ANIMATIONS_DISABLED_CLASS))
             .to.be.true;
       });
@@ -479,8 +479,6 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
       });
 
       it('should get the receiver element by id if it exists', () => {
-        const runtime = getLocalWinService();
-
         expect(runtime.getReceiver('document.body')).to.equal(
             doc.body);
         expect(runtime.getReceiver('page1')).to.equal(page1Elem);

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -30,23 +30,22 @@ import {
 } from '../amp-gwd-animation';
 import {Services} from '../../../../src/services';
 import {createCustomEvent} from '../../../../src/event-helper';
-import {getServiceForDoc} from '../../../../src/service';
+import {getExistingServiceForDocInEmbedScope} from '../../../../src/service';
 
-describe('AMP GWD Animation', () => {
+describes.sandboxed('AMP GWD Animation', {}, () => {
   /**
    * Creates a test amp-gwd-animation element in the given document.
-   * @param {!../../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Document} root
    * @param {!Object} attrs Attributes to set on the element.
+   * @return {!Promise}
    */
-  function createGwdAnimationElement(ampdoc, attrs) {
-    const element =
-        ampdoc.getBody().ownerDocument.createElement(TAG);
+  function createGwdAnimationElement(root, attrs) {
+    const element = root.createElement(TAG);
     for (const attr in attrs) {
       element.setAttribute(attr, attrs[attr]);
     }
-    ampdoc.getBody().appendChild(element);
-    element.build();
-    return element;
+    root.body.appendChild(element);
+    return element.build().then(() => element);
   }
 
   /**
@@ -69,28 +68,39 @@ describe('AMP GWD Animation', () => {
     });
   }
 
-  describes.repeated('in single and shadow doc', {
-    'single ampdoc': {ampdoc: 'single'},
-    'shadow ampdoc': {ampdoc: 'shadow'},
+  describes.repeated('', {
+    'in top-level document': {ampdoc: 'single'},
+    'in FIE document': {ampdoc: 'fie'},
   }, (name, variant) => {
-
-    describes.realWin('in iframe', {
+    describes.realWin('', {
       amp: {
         ampdoc: variant.ampdoc,
         extensions: ['amp-gwd-animation'],
       },
     }, env => {
+      let sandbox;
       let ampdoc;
       let element;
       let impl;
       let page1Elem;
-      let sandbox;
+      let embed;
+      let win;
+      let doc;
+      let runtime;
 
       beforeEach(() => {
         sandbox = sinon.sandbox;
         ampdoc = env.ampdoc;
+        embed = env.embed;
+        win = variant.ampdoc == 'fie' ? embed.win : ampdoc.win;
+        doc = variant.ampdoc == 'fie' ?
+          embed.win.document :
+          ampdoc.getRootNode();
+        runtime = getExistingServiceForDocInEmbedScope(
+            variant.ampdoc == 'fie' ? element : ampdoc, GWD_SERVICE_NAME);
 
-        ampdoc.getBody().innerHTML =
+        // Create a test amp-carousel GWD page deck.
+        doc.body.innerHTML =
             `<amp-carousel id="pagedeck"
                 on="slideChange:node1.hide;event1:node1.show">
               <div id="page1" class="${GWD_PAGE_WRAPPER_CLASS}">
@@ -104,25 +114,21 @@ describe('AMP GWD Animation', () => {
               <div id="page2" class="${GWD_PAGE_WRAPPER_CLASS}"></div>
             </amp-carousel>`;
 
-        element = createGwdAnimationElement(ampdoc, {
+        // Create a test amp-gwd-animation element.
+        const config = {
           'id': 'gwdAnim',
           'timeline-event-prefix': 'tl_',
           'layout': 'nodisplay',
+        };
+        return createGwdAnimationElement(doc, config).then(el => {
+          element = el;
+          impl = element.implementation_;
+          page1Elem = doc.getElementById('page1');
         });
-
-        impl = element.implementation_;
-        page1Elem = ampdoc.getRootNode().getElementById('page1');
-
-        // Manually invoke initialize_(). This is normally done automatically on
-        // bodyAvailable, but bodyAvailable fires before beforeEach so it's
-        // necessary to call it a second time once the test DOM is actually
-        // ready so the initialization can perform setup on the DOM.
-        const runtime = getServiceForDoc(ampdoc, GWD_SERVICE_NAME);
-        runtime.initialize_();
       });
 
       afterEach(() => {
-        ampdoc.getBody().innerHTML = '';
+        doc.body.innerHTML = '';
       });
 
       // TODO(#7846): This test case verifies the GWD runtime disables itself
@@ -132,413 +138,406 @@ describe('AMP GWD Animation', () => {
       /*
       it('should immediately disable animations', () => {
         return ampdoc.whenBodyAvailable().then(() => {
-          expect(ampdoc.getBody().classList.contains(ANIMATIONS_DISABLED_CLASS))
-              .to.be.true;
+          expect(doc.body.classList.contains(ANIMATIONS_DISABLED_CLASS))
+            .to.be.true;
         });
       });
       */
 
       it('should initially enable animations on GWD page 1', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          // Page 1 should have been enabled.
-          const page1 = ampdoc.getRootNode().getElementById('page1');
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        // Page 1 should have been enabled.
+        const page1 = doc.getElementById('page1');
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
 
-          // Page 2 should remain unaffected.
-          const page2 = ampdoc.getRootNode().getElementById('page2');
-          expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
-        });
+        // Page 2 should remain unaffected.
+        const page2 = doc.getElementById('page2');
+        expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
       });
 
       it('should install slideChange listeners on the GWD pagedeck', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const pagedeck = ampdoc.getRootNode().getElementById(GWD_PAGEDECK_ID);
-          expect(pagedeck.getAttribute('on')).to.contain('setCurrentPage');
-          // @see addAction test case below.
-        });
+        const pagedeck = doc.getElementById(GWD_PAGEDECK_ID);
+        expect(pagedeck.getAttribute('on')).to.contain('setCurrentPage');
+        // @see addAction test case below.
       });
 
       it('should change the current page on pagedeck slideChange', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const pagedeck = ampdoc.getRootNode().getElementById(GWD_PAGEDECK_ID);
-          const page1 = ampdoc.getRootNode().getElementById('page1');
-          const page2 = ampdoc.getRootNode().getElementById('page2');
+        const pagedeck = doc.getElementById(GWD_PAGEDECK_ID);
+        const page1 = doc.getElementById('page1');
+        const page2 = doc.getElementById('page2');
 
-          // Verify the first page was activated on initialization.
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        // Verify the first page was activated on initialization.
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
 
-          // Trigger a setCurrentPage action as though it originated from a
-          // pagedeck slideChange event and verify that page 2 is activated.
-          const setCurrentPageInvocation = {
-            method: 'setCurrentPage',
-            args: {index: 1},
-            source: pagedeck,
-            caller: pagedeck,
-            satisfiesTrust: () => true,
-          };
-          impl.executeAction(setCurrentPageInvocation);
+        // Trigger a setCurrentPage action as though it originated from a
+        // pagedeck slideChange event and verify that page 2 is activated.
+        const setCurrentPageInvocation = {
+          method: 'setCurrentPage',
+          args: {index: 1},
+          source: pagedeck,
+          caller: pagedeck,
+          satisfiesTrust: () => true,
+        };
+        impl.executeAction(setCurrentPageInvocation);
 
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
-          expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
+        expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
 
-          // Simulate setCurrentPage from a slideChange event which originated
-          // from some other carousel. There should be no page change.
-          const otherSetCurrentPageInvocation = {
-            method: 'setCurrentPage',
-            args: {index: 0},
-            source: null,
-            caller: pagedeck,
-            satisfiesTrust: () => true,
-          };
-          impl.executeAction(otherSetCurrentPageInvocation);
+        // Simulate setCurrentPage from a slideChange event which originated
+        // from some other carousel. There should be no page change.
+        const otherSetCurrentPageInvocation = {
+          method: 'setCurrentPage',
+          args: {index: 0},
+          source: null,
+          caller: pagedeck,
+          satisfiesTrust: () => true,
+        };
+        impl.executeAction(otherSetCurrentPageInvocation);
 
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
-          expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
+        expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
 
-          // Remove the pagedeck element and verify that triggering
-          // setCurrentPage does not throw errors. Set a null source on the
-          // dummy invocation to test the comparison to a null pagedeck
-          // reference.
-          pagedeck.remove();
-          otherSetCurrentPageInvocation.source = null;
-          impl.executeAction(otherSetCurrentPageInvocation);
-        });
+        // Remove the pagedeck element and verify that triggering
+        // setCurrentPage does not throw errors. Set a null source on the
+        // dummy invocation to test the comparison to a null pagedeck
+        // reference.
+        pagedeck.remove();
+        otherSetCurrentPageInvocation.source = null;
+        impl.executeAction(otherSetCurrentPageInvocation);
       });
 
       it('should activate and deactivate pages', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const runtime = getServiceForDoc(ampdoc, GWD_SERVICE_NAME);
-          const page1 = ampdoc.getRootNode().getElementById('page1');
-          const grandchild = page1.querySelector('#grandchild');
-          const page2 = ampdoc.getRootNode().getElementById('page2');
+        const page1 = doc.getElementById('page1');
+        const grandchild = page1.querySelector('#grandchild');
+        const page2 = doc.getElementById('page2');
 
-          // Activate page 1.
-          runtime.setCurrentPage(0);
+        // Activate page 1.
+        runtime.setCurrentPage(0);
 
-          // Animations should be enabled on page1 only.
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
-          expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
+        // Animations should be enabled on page1 only.
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
 
-          // Set an active label animation, goto counters, and a pause on
-          // several descendant elements and the page element itself to test
-          // that this state is reset when the page is deactivated.
-          page1.classList.add(PlaybackCssClass.PAUSE);
-          grandchild.classList.add(PlaybackCssClass.PAUSE);
-          page1[GOTO_COUNTER_PROP] = {};
-          grandchild[GOTO_COUNTER_PROP] = {};
-          page1.setAttribute(CURRENT_LABEL_ANIMATION_ATTR, 'someLabel1');
-          grandchild.setAttribute(CURRENT_LABEL_ANIMATION_ATTR, 'someLabel2');
+        // Set an active label animation, goto counters, and a pause on
+        // several descendant elements and the page element itself to test
+        // that this state is reset when the page is deactivated.
+        page1.classList.add(PlaybackCssClass.PAUSE);
+        grandchild.classList.add(PlaybackCssClass.PAUSE);
+        page1[GOTO_COUNTER_PROP] = {};
+        grandchild[GOTO_COUNTER_PROP] = {};
+        page1.setAttribute(CURRENT_LABEL_ANIMATION_ATTR, 'someLabel1');
+        grandchild.setAttribute(CURRENT_LABEL_ANIMATION_ATTR, 'someLabel2');
 
-          // Change to page 2.
-          runtime.setCurrentPage(1);
+        // Change to page 2.
+        runtime.setCurrentPage(1);
 
-          // Animations should be enabled on page2 only.
-          expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
-          expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
+        // Animations should be enabled on page2 only.
+        expect(page1.classList.contains(PlaybackCssClass.PLAY)).to.be.false;
+        expect(page2.classList.contains(PlaybackCssClass.PLAY)).to.be.true;
 
-          // Pause, goto counters, and current label animation data should have
-          // been cleared from all elements under page1, including the page
-          // itself.
-          expect(page1.classList.contains(PlaybackCssClass.PAUSE)).to.be.false;
-          expect(grandchild.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.false;
-          expect(page1).to.not.have.property(GOTO_COUNTER_PROP);
-          expect(grandchild).to.not.have.property(GOTO_COUNTER_PROP);
-          expect(page1.hasAttribute(CURRENT_LABEL_ANIMATION_ATTR)).to.be.false;
-          expect(grandchild.hasAttribute(CURRENT_LABEL_ANIMATION_ATTR))
-              .to.be.false;
-        });
+        // Pause, goto counters, and current label animation data should have
+        // been cleared from all elements under page1, including the page
+        // itself.
+        expect(page1.classList.contains(PlaybackCssClass.PAUSE)).to.be.false;
+        expect(grandchild.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.false;
+        expect(page1).to.not.have.property(GOTO_COUNTER_PROP);
+        expect(grandchild).to.not.have.property(GOTO_COUNTER_PROP);
+        expect(page1.hasAttribute(CURRENT_LABEL_ANIMATION_ATTR)).to.be.false;
+        expect(grandchild.hasAttribute(CURRENT_LABEL_ANIMATION_ATTR))
+            .to.be.false;
       });
 
       it('should disable and re-enable', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          getServiceForDoc(ampdoc, GWD_SERVICE_NAME).setEnabled(true);
-          expect(ampdoc.getBody().classList.contains(ANIMATIONS_DISABLED_CLASS))
-              .to.be.false;
+        getLocalWinService().setEnabled(true);
+        expect(doc.body.classList.contains(ANIMATIONS_DISABLED_CLASS))
+            .to.be.false;
 
-          getServiceForDoc(ampdoc, GWD_SERVICE_NAME).setEnabled(false);
-          expect(ampdoc.getBody().classList.contains(ANIMATIONS_DISABLED_CLASS))
-              .to.be.true;
-        });
+        getLocalWinService().setEnabled(false);
+        expect(doc.body.classList.contains(ANIMATIONS_DISABLED_CLASS))
+            .to.be.true;
       });
 
       it('should execute play', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          // Pause an animation to test resuming it.
-          const pauseInvocation = {
-            method: 'pause',
-            args: {id: 'page1'},
-            satisfiesTrust: () => true,
-          };
-          impl.executeAction(pauseInvocation);
+        // Pause an animation to test resuming it.
+        const pauseInvocation = {
+          method: 'pause',
+          args: {id: 'page1'},
+          satisfiesTrust: () => true,
+        };
+        impl.executeAction(pauseInvocation);
 
-          const playInvocation = {
-            method: 'play',
-            args: {id: 'page1'},
-            satisfiesTrust: () => true,
-          };
-          impl.executeAction(playInvocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.false;
+        const playInvocation = {
+          method: 'play',
+          args: {id: 'page1'},
+          satisfiesTrust: () => true,
+        };
+        impl.executeAction(playInvocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.false;
 
-          // Repeated play invocations should have no change.
-          impl.executeAction(playInvocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.false;
+        // Repeated play invocations should have no change.
+        impl.executeAction(playInvocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.false;
 
-          // Test handling missing arguments.
-          invokeWithSomeArgsUndefined(impl, playInvocation);
-        });
+        // Test handling missing arguments.
+        invokeWithSomeArgsUndefined(impl, playInvocation);
       });
 
       it('should execute pause', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const invocation = {
-            method: 'pause',
-            args: {id: 'page1'},
-            satisfiesTrust: () => true,
-          };
+        const invocation = {
+          method: 'pause',
+          args: {id: 'page1'},
+          satisfiesTrust: () => true,
+        };
 
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.true;
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.true;
 
-          // Repeated pause invocations should have no change.
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.true;
+        // Repeated pause invocations should have no change.
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.true;
 
-          // Test handling missing arguments.
-          invokeWithSomeArgsUndefined(impl, invocation);
-        });
+        // Test handling missing arguments.
+        invokeWithSomeArgsUndefined(impl, invocation);
       });
 
       it('should execute togglePlay', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const invocation = {
-            method: 'togglePlay',
-            args: {id: 'page1'},
-            satisfiesTrust: () => true,
-          };
+        const invocation = {
+          method: 'togglePlay',
+          args: {id: 'page1'},
+          satisfiesTrust: () => true,
+        };
 
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.true;
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.true;
 
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.false;
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.false;
 
-          // Test handling missing arguments.
-          invokeWithSomeArgsUndefined(impl, invocation);
-        });
+        // Test handling missing arguments.
+        invokeWithSomeArgsUndefined(impl, invocation);
       });
 
       it('should execute gotoAndPlay', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const invocation = {
-            method: 'gotoAndPlay',
-            args: {id: 'page1', label: 'foo'},
-            satisfiesTrust: () => true,
-          };
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-          expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
-              .to.equal('foo');
+        const invocation = {
+          method: 'gotoAndPlay',
+          args: {id: 'page1', label: 'foo'},
+          satisfiesTrust: () => true,
+        };
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+        expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
+            .to.equal('foo');
 
-          // Repeated invocations should have no effect (animation will be
-          // restarted, however).
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-          expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
-              .to.equal('foo');
+        // Repeated invocations should have no effect (animation will be
+        // restarted, however).
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+        expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
+            .to.equal('foo');
 
-          // Change to a different label.
-          invocation.args.label = 'bar';
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.false;
-          expect(page1Elem.classList.contains('bar')).to.be.true;
-          expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
-              .to.equal('bar');
+        // Change to a different label.
+        invocation.args.label = 'bar';
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.false;
+        expect(page1Elem.classList.contains('bar')).to.be.true;
+        expect(page1Elem.getAttribute(CURRENT_LABEL_ANIMATION_ATTR))
+            .to.equal('bar');
 
-          // Test handling missing arguments.
-          invokeWithSomeArgsUndefined(impl, invocation);
-        });
+        // Test handling missing arguments.
+        invokeWithSomeArgsUndefined(impl, invocation);
       });
 
       it('should execute gotoAndPause', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          // Test handling missing arguments.
-          const invocation = {
-            method: 'gotoAndPause',
-            args: {id: 'page1', label: 'foo'},
-            satisfiesTrust: () => true,
-          };
-          invokeWithSomeArgsUndefined(impl, invocation);
+        // Test handling missing arguments.
+        const invocation = {
+          method: 'gotoAndPause',
+          args: {id: 'page1', label: 'foo'},
+          satisfiesTrust: () => true,
+        };
+        invokeWithSomeArgsUndefined(impl, invocation);
 
-          // gotoAndPause invokes a pause after a short delay, but waiting for
-          // this time to pass makes the test flaky. Stub setTimeout to
-          // execute the callback synchronously.
-          const origSetTimeout = ampdoc.win.setTimeout;
-          ampdoc.win.setTimeout = func => func();
+        // gotoAndPause invokes a pause after a short delay, but waiting for
+        // this time to pass makes the test flaky. Stub setTimeout to
+        // execute the callback synchronously.
+        const origSetTimeout = win.setTimeout;
+        win.setTimeout = func => func();
 
-          // Test a valid gotoAndPause invocation. Verify animation was
-          // switched to the label and has been paused.
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-          expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
-              .to.be.true;
+        // Test a valid gotoAndPause invocation. Verify animation was
+        // switched to the label and has been paused.
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+        expect(page1Elem.classList.contains(PlaybackCssClass.PAUSE))
+            .to.be.true;
 
-          ampdoc.win.setTimeout = origSetTimeout;
-        });
+        win.setTimeout = origSetTimeout;
       });
 
       it('should execute gotoAndPlayNTimes', () => {
-        return ampdoc.whenBodyAvailable().then(() => {
-          const testEvent = createCustomEvent(
-              ampdoc.win, GWD_TIMELINE_EVENT, {'eventName': 'event-1'});
+        const testEvent = createCustomEvent(
+            win, GWD_TIMELINE_EVENT, {'eventName': 'event-1'});
 
-          // Invoking gotoAndPlayNTimes with a negative N value is a no-op.
-          const invocationWithBadNValue = {
-            method: 'gotoAndPlayNTimes',
-            args: {id: 'page1', label: 'foo', N: -5},
-            event: testEvent,
-            satisfiesTrust: () => true,
-          };
+        // Invoking gotoAndPlayNTimes with a negative N value is a no-op.
+        const invocationWithBadNValue = {
+          method: 'gotoAndPlayNTimes',
+          args: {id: 'page1', label: 'foo', N: -5},
+          event: testEvent,
+          satisfiesTrust: () => true,
+        };
 
-          allowConsoleError(() => {
-            impl.executeAction(invocationWithBadNValue);
-          });
-          expect(page1Elem.classList.contains('foo')).to.be.false;
-
-
-          // Initialize a valid gotoAndPlayNTimes invocation from some event.
-          const invocation = {
-            method: 'gotoAndPlayNTimes',
-            args: {id: 'page1', label: 'foo', N: 2},
-            event: testEvent,
-            satisfiesTrust: () => true,
-          };
-
-          // gotoAndPlay call #1 from 'event-1'.
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-
-          page1Elem.classList.remove('foo');
-
-          // gotoAndPlay call #2 from 'event-1'.
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-
-          page1Elem.classList.remove('foo');
-
-          // gotoAndPlay call #3 from 'event-1'. The number of invocations
-          // from event 'event-1' is now past the specified max count, so this
-          // and subsequent gotoAndPlayNTimes invocations from this event should
-          // have no effect.
-          impl.executeAction(invocation);
-          impl.executeAction(invocation);
-          expect(page1Elem.classList.contains('foo')).to.be.false;
-
-          // gotoAndPlayNTimes invocations originating from a different timeline
-          // event begin their own counters.
-          const testEvent2 = createCustomEvent(
-              ampdoc.win, GWD_TIMELINE_EVENT, {'eventName': 'event-2'});
-          const invocationFromEvent2 = {
-            method: 'gotoAndPlayNTimes',
-            args: {id: 'page1', label: 'foo', N: 1},
-            event: testEvent2,
-            satisfiesTrust: () => true,
-          };
-
-          impl.executeAction(invocationFromEvent2);
-          expect(page1Elem.classList.contains('foo')).to.be.true;
-
-          page1Elem.classList.remove('foo');
-
-          // Counter for 'event-2' has now run out; no more gotoAndPlays may
-          // execute.
-          impl.executeAction(invocationFromEvent2);
-          expect(page1Elem.classList.contains('foo')).to.be.false;
-
-          // Test handling missing arguments.
-          invokeWithSomeArgsUndefined(impl, invocation);
+        allowConsoleError(() => {
+          impl.executeAction(invocationWithBadNValue);
         });
+        expect(page1Elem.classList.contains('foo')).to.be.false;
+
+        // Initialize a valid gotoAndPlayNTimes invocation from some event.
+        const invocation = {
+          method: 'gotoAndPlayNTimes',
+          args: {id: 'page1', label: 'foo', N: 2},
+          event: testEvent,
+          satisfiesTrust: () => true,
+        };
+
+        // gotoAndPlay call #1 from 'event-1'.
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+
+        page1Elem.classList.remove('foo');
+
+        // gotoAndPlay call #2 from 'event-1'.
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+
+        page1Elem.classList.remove('foo');
+
+        // gotoAndPlay call #3 from 'event-1'. The number of invocations
+        // from event 'event-1' is now past the specified max count, so this
+        // and subsequent gotoAndPlayNTimes invocations from this event should
+        // have no effect.
+        impl.executeAction(invocation);
+        impl.executeAction(invocation);
+        expect(page1Elem.classList.contains('foo')).to.be.false;
+
+        // gotoAndPlayNTimes invocations originating from a different timeline
+        // event begin their own counters.
+        const testEvent2 = createCustomEvent(
+            ampdoc.win, GWD_TIMELINE_EVENT, {'eventName': 'event-2'});
+        const invocationFromEvent2 = {
+          method: 'gotoAndPlayNTimes',
+          args: {id: 'page1', label: 'foo', N: 1},
+          event: testEvent2,
+          satisfiesTrust: () => true,
+        };
+
+        impl.executeAction(invocationFromEvent2);
+        expect(page1Elem.classList.contains('foo')).to.be.true;
+
+        page1Elem.classList.remove('foo');
+
+        // Counter for 'event-2' has now run out; no more gotoAndPlays may
+        // execute.
+        impl.executeAction(invocationFromEvent2);
+        expect(page1Elem.classList.contains('foo')).to.be.false;
+
+        // Test handling missing arguments.
+        invokeWithSomeArgsUndefined(impl, invocation);
       });
 
       it('should trigger timeline events', () => {
         const triggeredAmpEventNames = [];
         const triggeredEvents = [];
-        sandbox.stub(Services.actionServiceForDoc(ampdoc), 'trigger').callsFake(
+
+        const actionService = Services.actionServiceForDoc(
+            variant.ampdoc == 'fie' ? element : ampdoc);
+        sandbox.stub(actionService, 'trigger').callsFake(
             (target, name, event) => {
               triggeredAmpEventNames.push(name);
               triggeredEvents.push(event);
             });
 
-        return ampdoc.whenBodyAvailable().then(() => {
-          const animationendEvent =
-              new AnimationEvent('animationend', {bubbles: true});
+        const animationendEvent =
+            new AnimationEvent('animationend', {bubbles: true});
 
-          // Dispatch `animationend` events on GWD event elements and on a
-          // non-event element (to test it is ignored).
-          ampdoc.getRootNode().getElementById('event1').dispatchEvent(
-              animationendEvent);
-          ampdoc.getRootNode().getElementById('event2').dispatchEvent(
-              animationendEvent);
-          ampdoc.getRootNode().getElementById('not-an-event').dispatchEvent(
-              animationendEvent);
+        // Dispatch `animationend` events on GWD event elements and on a
+        // non-event element (to test it is ignored).
+        doc.getElementById('event1').dispatchEvent(
+            animationendEvent);
+        doc.getElementById('event2').dispatchEvent(
+            animationendEvent);
+        doc.getElementById('not-an-event').dispatchEvent(
+            animationendEvent);
 
-          expect(triggeredAmpEventNames)
-              .to.deep.equal(['tl_event-1', 'tl_event-2']);
-          expect(triggeredEvents.map(event => event.detail.eventName))
-              .to.deep.equal(['event-1', 'event-2']);
-        });
+        expect(triggeredAmpEventNames)
+            .to.deep.equal(['tl_event-1', 'tl_event-2']);
+        expect(triggeredEvents.map(event => event.detail.eventName))
+            .to.deep.equal(['event-1', 'event-2']);
+      });
 
-        it('should get the receiver element by id if it exists', () => {
-          const runtime = getServiceForDoc(ampdoc, GWD_SERVICE_NAME);
+      it('should get the receiver element by id if it exists', () => {
+        const runtime = getLocalWinService();
 
-          expect(runtime.getReceiver('document.body')).to.equal(
-              ampdoc.getBody());
-          expect(runtime.getReceiver('page1')).to.equal(page1Elem);
+        expect(runtime.getReceiver('document.body')).to.equal(
+            doc.body);
+        expect(runtime.getReceiver('page1')).to.equal(page1Elem);
+
+        allowConsoleError(() => {
           expect(runtime.getReceiver('nonexistentElement')).to.be.null;
         });
       });
     });
   });
-});
 
-describe('addAction', () => {
-  let ampdoc;
+  describe('addAction', () => {
+    let ampdoc;
 
-  beforeEach(() => {
-    ampdoc = new AmpDocSingle(window);
-  });
+    beforeEach(() => {
+      ampdoc = new AmpDocSingle(window);
+    });
 
-  it('should insert when no existing actions', () => {
-    const element = document.createElement('div');
+    it('should insert when no existing actions', () => {
+      const element = document.createElement('div');
 
-    addAction(ampdoc, element, 'event1', 'node1.foo()');
+      addAction(ampdoc, element, 'event1', 'node1.foo()');
 
-    expect(element.getAttribute('on')).to.equal('event1:node1.foo()');
-  });
+      expect(element.getAttribute('on')).to.equal('event1:node1.foo()');
+    });
 
-  it('should insert when actions defined for this event', () => {
-    const element = document.createElement('div');
-    element.setAttribute('on', 'event1:node2.hide;event2:node2.show');
+    it('should insert when actions defined for this event', () => {
+      const element = document.createElement('div');
+      element.setAttribute('on', 'event1:node2.hide;event2:node2.show');
 
-    addAction(ampdoc, element, 'event1', 'node1.foo()');
+      addAction(ampdoc, element, 'event1', 'node1.foo()');
 
-    expect(element.getAttribute('on')).to.equal(
-        'event1:node1.foo(),node2.hide;event2:node2.show');
-  });
+      expect(element.getAttribute('on')).to.equal(
+          'event1:node1.foo(),node2.hide;event2:node2.show');
+    });
 
-  it('should insert when actions defined for other events only', () => {
-    const element = document.createElement('div');
-    element.setAttribute('on', 'event2:node2.hide');
+    it('should insert when actions defined for other events only', () => {
+      const element = document.createElement('div');
+      element.setAttribute('on', 'event2:node2.hide');
 
-    addAction(ampdoc, element, 'event1', 'node1.foo()');
+      addAction(ampdoc, element, 'event1', 'node1.foo()');
 
-    expect(element.getAttribute('on')).to.equal(
-        'event2:node2.hide;event1:node1.foo()');
+      expect(element.getAttribute('on')).to.equal(
+          'event2:node2.hide;event1:node1.foo()');
+    });
+
+    it('should insert in FIE', () => {
+      const element = document.createElement('div');
+      ampdoc.getBody().appendChild(element);
+      element.setAttribute('on', 'event2:node2.hide');
+
+      // Provide the element for the `nodeOrDoc` parameter used to retrieve the
+      // owner window's action service.
+      addAction(element, element, 'event1', 'node1.foo()');
+
+      expect(element.getAttribute('on')).to.equal(
+          'event2:node2.hide;event1:node1.foo()');
+    });
   });
 });


### PR DESCRIPTION
Fixes #19295.

Changes:
- Convert `AmpGwdRuntimeService` to an `EmbeddableService`.
- Update document root and service references throughout the custom element code to be scoped to the correct root.
- Update tests for the single and FIE doc cases. I removed the shadow doc type from the list of variants to test.
- Add an initial demo page for basic manual testing in the a4a harness.

Tests:
Unit tests and manual testing using the a4a harness.