### PR TITLE
♻️ Add typedefs for pool-bound and placeholder elements

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -459,7 +459,8 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.pause();
       } else {
         return mediaPool.pause(
-            /** @type {!HTMLMediaElement} */ (mediaEl), rewindToBeginning);
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl),
+            rewindToBeginning);
       }
     });
   }
@@ -474,7 +475,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       if (this.isBotUserAgent_) {
         mediaEl.play();
       } else {
-        return mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
+        return mediaPool.play(
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }
@@ -489,7 +491,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       if (this.isBotUserAgent_) {
         // No-op.
       } else {
-        return mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
+        return mediaPool.preload(
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }
@@ -504,7 +507,8 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.muted = true;
         mediaEl.setAttribute('muted', '');
       } else {
-        return mediaPool.mute(/** @type {!HTMLMediaElement} */ (mediaEl));
+        return mediaPool.mute(
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }
@@ -519,7 +523,8 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.muted = false;
         mediaEl.removeAttribute('muted');
       } else {
-        return mediaPool.unmute(/** @type {!HTMLMediaElement} */ (mediaEl));
+        return mediaPool.unmute(
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }
@@ -534,7 +539,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       if (this.isBotUserAgent_) {
         // No-op.
       } else {
-        return mediaPool.register(/** @type {!HTMLMediaElement} */ (mediaEl));
+        return mediaPool.register(
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }
@@ -550,7 +556,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.currentTime = 0;
       } else {
         return mediaPool.rewindToBeginning(
-            /** @type {!HTMLMediaElement} */ (mediaEl));
+            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
       }
     });
   }


### PR DESCRIPTION
Currently, elements being replaced by `MediaPool` are all `HTMLMediaElement` instances, and the elements generated by the pool are also `HTMLMediaElement` instances.  This will change in the future, as we would like any element to be usable as the placeholder, and potentially could use `MediaPool` to manage things other than `HTMLMediaElement`.

This PR introduces typedefs to semantically represent "placeholder" elements (those that will be swapped out by the pool) and "pool-bound elements" (those generated by the pool to be inserted in place of a placeholder).  It currently defines them both as `HTMLMediaElement`, but this can be changed in future PRs.

This PR makes only type and documentation changes; as a result, this should be a no-op.