### PR TITLE
🐛Linker: check for empty param values

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -262,7 +262,9 @@ export class LinkerManager {
     if (this.isDomainMatch_(hostname, domains)) {
       const linkerValue = createLinker(/* version */ '1',
           this.resolvedIds_[name]);
-      el.href = addParamToUrl(href, name, linkerValue);
+      if (linkerValue) {
+        el.href = addParamToUrl(href, name, linkerValue);
+      }
     }
   }
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -187,6 +187,27 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
   });
 
+  it('should not add params where linker value is empty', () => {
+    const config = {
+      linkers: {
+        enabled: true,
+        proxyOnly: false,
+        testLinker1: {
+          ids: {
+            gclid: '',
+          },
+        },
+      },
+    };
+
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
+      expect(handlers.length).to.equal(1);
+      expect(clickAnchor('https://www.source.com/dest?a=1')).to.equal(
+          'https://www.source.com/dest?a=1'
+      );
+    });
+  });
+
   it('should generate a param valid for ingestion 5 min later', () => {
     const clock = sandbox.useFakeTimers(1533329483292);
     sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);


### PR DESCRIPTION
Currently if a pub/vendor is using a config that looks something like this: 
```      
linkers: {
  testLinker1: {
    ids: {
      cid: 'QUERY_PARAM(cid)',
    }
  }
}
```
It is possible that the `QUERY_PARAM` macro resolves to an empty string, and therefore the linker value will resolve to an empty string. In this case we send a param like `testLinker1=`. This changes this behavior so that if a param value is empty it will not be appended.