### PR TITLE
🐛 Replace CDN URLs in video testbench

### DIFF
--- a/build-system/app-utils.js
+++ b/build-system/app-utils.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {string} mode
+ * @param {string} file
+ * @param {string=} hostName
+ * @param {boolean=} inabox
+ * @param {boolean=} storyV1
+ */
+const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
+  hostName = hostName || '';
+  if (mode == 'default') {
+    // TODO:(ccordry) remove this when story 0.1 is deprecated
+    if (storyV1) {
+      file = file.replace(
+          /https:\/\/cdn\.ampproject\.org\/v0\/amp-story-0\.1\.js/g,
+          hostName + '/dist/v0/amp-story-1.0.max.js');
+    }
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
+        hostName + '/dist/amp.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
+        hostName + '/dist/amp-shadow.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
+        hostName + '/dist/amp-inabox.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
+        hostName + '/dist/v0/$1.max.js');
+    if (inabox) {
+      let filename;
+      if (inabox == '1') {
+        filename = '/dist/amp-inabox.js';
+      } else if (inabox == '2') {
+        filename = '/dist/amp-inabox-lite.js';
+      }
+      file = file.replace(/<html [^>]*>/, '<html amp4ads>');
+      file = file.replace(/\/dist\/amp\.js/g, filename);
+    }
+  } else if (mode == 'compiled') {
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
+        hostName + '/dist/v0.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
+        hostName + '/dist/shadow-v0.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
+        hostName + '/dist/amp4ads-v0.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
+        hostName + '/dist/v0/$1.js');
+    file = file.replace(
+        /\/dist.3p\/current\/(.*)\.max.html/g,
+        hostName + '/dist.3p/current-min/$1.html');
+    if (inabox) {
+      let filename;
+      if (inabox == '1') {
+        filename = '/dist/amp4ads-v0.js';
+      } else if (inabox == '2') {
+        filename = '/dist/amp4ads-lite-v0.js';
+      }
+      file = file.replace(/\/dist\/v0\.js/g, filename);
+    }
+  }
+  return file;
+};
+
+module.exports = {replaceUrls};

--- a/build-system/app-video-testbench.js
+++ b/build-system/app-video-testbench.js
@@ -19,6 +19,7 @@
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));
 const {JSDOM} = require('jsdom');
+const {replaceUrls} = require('./app-utils');
 
 const sourceFile = 'test/manual/amp-video.amp.html';
 
@@ -351,7 +352,8 @@ function isValidExtension(extension) {
 }
 
 
-function runVideoTestBench(req, res) {
+function runVideoTestBench(req, res, next) {
+  const mode = process.env.SERVE_MODE;
   fs.readFileAsync(sourceFile).then(contents => {
     const dom = new JSDOM(contents);
     const {window} = dom;
@@ -379,10 +381,9 @@ function runVideoTestBench(req, res) {
 
     appendClientScript(doc);
 
-    return res.end(dom.serialize());
+    return res.end(replaceUrls(mode, dom.serialize()));
   }).error(() => {
-    res.status(404);
-    res.end('Not found: ' + sourceFile);
+    next();
   });
 }
 

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -33,6 +33,7 @@ const request = require('request');
 const pc = process;
 const countries = require('../examples/countries.json');
 const runVideoTestBench = require('./app-video-testbench');
+const {replaceUrls} = require('./app-utils');
 
 app.use(bodyParser.text());
 app.use('/amp4test', require('./amp4test'));
@@ -1184,73 +1185,6 @@ app.get('/search/countries', function(req, res) {
   };
   res.send(results);
 });
-
-/**
- * @param {string} mode
- * @param {string} file
- * @param {string=} hostName
- * @param {boolean=} inabox
- * @param {boolean=} storyV1
- */
-function replaceUrls(mode, file, hostName, inabox, storyV1) {
-  hostName = hostName || '';
-  if (mode == 'default') {
-    // TODO:(ccordry) remove this when story 0.1 is deprecated
-    if (storyV1) {
-      file = file.replace(
-          /https:\/\/cdn\.ampproject\.org\/v0\/amp-story-0\.1\.js/g,
-          hostName + '/dist/v0/amp-story-1.0.max.js');
-    }
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
-        hostName + '/dist/amp.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
-        hostName + '/dist/amp-shadow.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
-        hostName + '/dist/amp-inabox.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
-        hostName + '/dist/v0/$1.max.js');
-    if (inabox) {
-      let filename;
-      if (inabox == '1') {
-        filename = '/dist/amp-inabox.js';
-      } else if (inabox == '2') {
-        filename = '/dist/amp-inabox-lite.js';
-      }
-      file = file.replace(/<html [^>]*>/, '<html amp4ads>');
-      file = file.replace(/\/dist\/amp\.js/g, filename);
-    }
-  } else if (mode == 'compiled') {
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
-        hostName + '/dist/v0.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
-        hostName + '/dist/shadow-v0.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
-        hostName + '/dist/amp4ads-v0.js');
-    file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
-        hostName + '/dist/v0/$1.js');
-    file = file.replace(
-        /\/dist.3p\/current\/(.*)\.max.html/g,
-        hostName + '/dist.3p/current-min/$1.html');
-    if (inabox) {
-      let filename;
-      if (inabox == '1') {
-        filename = '/dist/amp4ads-v0.js';
-      } else if (inabox == '2') {
-        filename = '/dist/amp4ads-lite-v0.js';
-      }
-      file = file.replace(/\/dist\/v0\.js/g, filename);
-    }
-  }
-  return file;
-}
 
 /**
  * @param {string} ampJsVersion


### PR DESCRIPTION
Previously, the video testbench would serve production binaries regardless of `SERVE_MODE`. Now replaces URLs properly like other `test/manual/*` files.