### PR TITLE
🐛 amp-subscriptions platform reset all platforms on reauthorise

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -483,10 +483,12 @@ export class SubscriptionService {
    * @return {!Promise}
    */
   reAuthorizePlatform(subscriptionPlatform) {
-    this.platformStore_.resetEntitlementFor(
-        subscriptionPlatform.getServiceId());
     this.platformStore_.getAvailablePlatforms()
-        .forEach(platform => platform.reset());
+        .forEach(platform => {
+          platform.reset();
+          this.platformStore_.resetEntitlementFor(
+              platform.getServiceId());
+        });
     this.renderer_.toggleLoading(true);
     return this.fetchEntitlements_(subscriptionPlatform).then(() => {
       this.subscriptionAnalytics_.serviceEvent(

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -484,6 +484,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should reset entitlement on re-authorization', () => {
+      subscriptionService.platformStore_.resolvePlatform('local', platform);
       const entitlement = new Entitlement({source: 'local', raw: 'raw',
         granted: true, grantReason: GrantReason.SUBSCRIBER});
       sandbox.stub(platform, 'getEntitlements')


### PR DESCRIPTION
We need to reset entitlements on all platforms when re-reauthorise.
