### PR TITLE
🏗🐛 Modify the error handling of visual diff tests to be more robust

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -150,10 +150,11 @@ async function launchWebServer() {
  */
 async function getBuildStatus(buildId) {
   const statusUri = `${BUILD_STATUS_URL}?build_id=${buildId}`;
-  const {body} = await request(statusUri, {json: true}).catch(error => {
+  try {
+    return (await request(statusUri, {json: true})).body;
+  } catch (error) {
     log('fatal', 'Failed to query Percy build status:', error);
-  });
-  return body;
+  }
 }
 
 /**
@@ -239,8 +240,11 @@ async function launchBrowser() {
     headless: true,
   };
 
-  browser_ = await puppeteer.launch(browserOptions)
-      .catch(err => log('fatal', err));
+  try {
+    browser_ = await puppeteer.launch(browserOptions);
+  } catch (error) {
+    log('fatal', error);
+  }
 
   // Every action on the browser or its pages adds a listener to the
   // Puppeteer.Connection.Events.Disconnected event. This is a temporary
@@ -287,12 +291,15 @@ async function runVisualTests(assetGlobs, webpages) {
         colors.cyan(process.env['PERCY_TARGET_COMMIT']));
   }
 
-  // Take the snapshots.
-  await generateSnapshots(percy, webpages);
+  try {
+    // Take the snapshots.
+    await generateSnapshots(percy, webpages);
+  } finally {
+    // Tell Percy we're finished taking snapshots.
+    await percy.finalizeBuild();
+  }
 
-  // Tell Percy we're finished taking snapshots and check if the build failed
-  // early.
-  await percy.finalizeBuild();
+  // check if the build failed early.
   const status = await getBuildStatus(buildId);
   if (status.state == 'failed') {
     log('fatal', 'Build', colors.cyan(buildId), 'failed!');
@@ -362,7 +369,6 @@ async function generateSnapshots(percy, webpages) {
       (numTests, webpage) => numTests + Object.keys(webpage.tests_).length, 0);
   if (!totalTests) {
     log('fatal', 'No pages left to test!');
-    return;
   } else {
     log('info', 'Executing', colors.cyan(totalTests), 'visual diff tests on',
         colors.cyan(webpages.length), 'pages');
@@ -377,7 +383,9 @@ async function generateSnapshots(percy, webpages) {
   }
 
   log('verbose', 'Generating snapshots...');
-  await snapshotWebpages(percy, browser, webpages);
+  if (!(await snapshotWebpages(percy, browser, webpages))) {
+    log('fatal', 'Some tests have failed locally.');
+  }
 }
 
 /**
@@ -387,9 +395,12 @@ async function generateSnapshots(percy, webpages) {
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
  * @param {!Array<!JsonObject>} webpages an array of JSON objects containing
  *     details about the webpages to snapshot.
+ * @return {boolean} true if all tests passed locally (does not indicate whether
+ *     the tests passed on Percy).
  */
 async function snapshotWebpages(percy, browser, webpages) {
   const pagePromises = {};
+  const testErrors = [];
   for (const webpage of webpages) {
     const {viewport, name: pageName} = webpage;
     const fullUrl = `${BASE_URL}/${webpage.url}`;
@@ -467,10 +478,19 @@ async function snapshotWebpages(percy, browser, webpages) {
             }
 
             await percy.snapshot(name, page, snapshotOptions);
-            await page.close();
             log('travis', colors.cyan('●'));
           })
-          .then(() => delete pagePromises[name]);
+          .catch(testError => {
+            log('travis', colors.red('○'));
+            if (!process.env['TRAVIS']) {
+              log('error', testError);
+            }
+            testErrors.push(testError);
+          })
+          .then(async() => {
+            await page.close();
+            delete pagePromises[name];
+          });
       pagePromises[name] = pagePromise;
     }
   }
@@ -479,6 +499,12 @@ async function snapshotWebpages(percy, browser, webpages) {
     await sleep(WAIT_FOR_TABS_MS);
   }
   log('travis', '\n');
+  if (process.env['TRAVIS']) {
+    testErrors.forEach(testError => {
+      log('error', testError);
+    });
+  }
+  return testErrors.length == 0;
 }
 
 /**
@@ -537,13 +563,15 @@ async function visualDiff() {
     argv.grep = RegExp(argv.grep);
   }
 
-  if (argv.verify_status) {
-    await performVerifyStatus();
-  } else {
-    await performVisualTests();
+  try {
+    if (argv.verify_status) {
+      await performVerifyStatus();
+    } else {
+      await performVisualTests();
+    }
+  } finally {
+    return await cleanup_();
   }
-
-  return await cleanup_();
 }
 
 async function performVerifyStatus() {
@@ -564,9 +592,11 @@ async function performVisualTests() {
   setDebuggingLevel();
 
   // Launch a local web server.
-  await launchWebServer().catch(reason => {
+  try {
+    await launchWebServer();
+  } catch (reason) {
     log('fatal', `Failed to start a web server: ${reason}`);
-  });
+  }
 
   if (argv.empty) {
     await createEmptyBuild();
@@ -619,7 +649,7 @@ async function cleanup_() {
   }
   if (webServerProcess_ && !webServerProcess_.killed) {
     // Explicitly exit the webserver.
-    webServerProcess_.kill();
+    webServerProcess_.kill('SIGKILL');
     // The child node process has an asynchronous stdout. See #10409.
     await sleep(100);
   }


### PR DESCRIPTION
The follow changes are included:
* Calls to `log('fatal', …)` set the exit code to 1
* Failures in `verifyCssElements` now throw an error instead of calling `log('fatal', …)`, and that exception gets handled explicitly in the test runner code
* The `cleanup_()` function kills the server with `SIGKILL` instead of `SIGTERM`. The latter (default kill signal) did nothing for some reason
* Do not call `log('fatal', …)` from within `Promise#catch(…)` clauses because then the log's exception is thrown in a separate thread
* Continue running other tests even if one of the tests succeeds, so that we can find out if more than one test fails at the same time
* Always finalize Percy builds, even if they tests didn't succeed



Fixed #19366