### PR TITLE
Always set theme color to background color ✅

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -424,8 +424,8 @@ export class AmpStory extends AMP.BaseElement {
     const styles = getComputedStyle(document.body);
     meta.name = "theme-color";
     // The theme color should be copied from the story's primary accent color
-    // if possible.
-    meta.content = styles.getPropertyValue('primary-color') || 'black';
+    // if possible, with the fall back being default light gray.
+    meta.content = styles.getPropertyValue('primary-color') || '#F1F3F4';
     document.getElementsByTagName('head')[0].appendChild(meta);
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -428,14 +428,19 @@ export class AmpStory extends AMP.BaseElement {
   * @private
   */
   setThemeColor_() {
+    // Don't override the publisher's tag.
+    if (this.win.document.querySelector('meta[name=theme-color]')) {
+      return;
+    }
     // The theme color should be copied from the story's primary accent color
     // if possible, with the fall back being default light gray.
-    let meta = document.createElement('meta');
-    const styles = computedStyle(this.win.document.body);
+    const meta = this.win.document.createElement('meta');
+    const ampStoryEl = this.win.document.getElementsByTagName('amp-story')[0];
+    const styles = computedStyle(this.win, ampStoryEl);
     meta.name = 'theme-color';
-    meta.content = styles.getPropertyValue('primary-color') ||
-                   DEFAULT_THEME_COLOR;
-    document.getElementsByTagName('head')[0].appendChild(meta);
+    meta.content = styles.getPropertyValue('--primary-color') ||
+        DEFAULT_THEME_COLOR;
+    this.win.document.getElementsByTagName('head')[0].appendChild(meta);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -422,7 +422,7 @@ export class AmpStory extends AMP.BaseElement {
   /**
   * @private
   */
-  setThemeColor_(){
+  setThemeColor_() {
     // The theme color should be copied from the story's primary accent color
     // if possible, with the fall back being default light gray.
     let meta = document.createElement('meta');

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -431,7 +431,7 @@ export class AmpStory extends AMP.BaseElement {
     // The theme color should be copied from the story's primary accent color
     // if possible, with the fall back being default light gray.
     let meta = document.createElement('meta');
-    const styles = getComputedStyle(this.win.document.body);
+    const styles = computedStyle(this.win.document.body);
     meta.name = 'theme-color';
     meta.content = styles.getPropertyValue('primary-color') ||
                    DEFAULT_THEME_COLOR;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -180,6 +180,11 @@ const TAG = 'amp-story';
 const HIDE_ON_BOOKEND_SELECTOR =
     'amp-story-page, .i-amphtml-story-system-layer';
 
+/**
+ * The default light gray for chrome supported theme color.
+ * @const {string}
+ */
+const DEFAULT_THEME_COLOR = '#F1F3F4';
 
 /**
  * @implements {./media-pool.MediaPoolRoot}
@@ -426,9 +431,10 @@ export class AmpStory extends AMP.BaseElement {
     // The theme color should be copied from the story's primary accent color
     // if possible, with the fall back being default light gray.
     let meta = document.createElement('meta');
-    const styles = getComputedStyle(document.body);
-    meta.name = "theme-color";
-    meta.content = styles.getPropertyValue('primary-color') || '#F1F3F4';
+    const styles = getComputedStyle(this.win.document.body);
+    meta.name = 'theme-color';
+    meta.content = styles.getPropertyValue('primary-color') ||
+                   DEFAULT_THEME_COLOR;
     document.getElementsByTagName('head')[0].appendChild(meta);
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -418,13 +418,16 @@ export class AmpStory extends AMP.BaseElement {
           .replace(/([\d.]+)vmax/gmi, 'calc($1 * var(--i-amphtml-story-vmax))');
     });
   }
-  /** TODO(Budnampet): add JSDoc describing this function */
+
+  /**
+  * @private
+  */
   setThemeColor_(){
+    // The theme color should be copied from the story's primary accent color
+    // if possible, with the fall back being default light gray.
     let meta = document.createElement('meta');
     const styles = getComputedStyle(document.body);
     meta.name = "theme-color";
-    // The theme color should be copied from the story's primary accent color
-    // if possible, with the fall back being default light gray.
     meta.content = styles.getPropertyValue('primary-color') || '#F1F3F4';
     document.getElementsByTagName('head')[0].appendChild(meta);
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -348,6 +348,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListeners_();
     this.initializeListenersForDev_();
 
+    this.setThemeColor_();
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
     this.navigationState_.observe(stateChangeEvent => {
@@ -416,6 +417,16 @@ export class AmpStory extends AMP.BaseElement {
           .replace(/([\d.]+)vmin/gmi, 'calc($1 * var(--i-amphtml-story-vmin))')
           .replace(/([\d.]+)vmax/gmi, 'calc($1 * var(--i-amphtml-story-vmax))');
     });
+  }
+  /** TODO(Budnampet): add JSDoc describing this function */
+  setThemeColor_(){
+    let meta = document.createElement('meta');
+    const styles = getComputedStyle(document.body);
+    meta.name = "theme-color";
+    // The theme color should be copied from the story's primary accent color
+    // if possible.
+    meta.content = styles.getPropertyValue('primary-color') || 'black';
+    document.getElementsByTagName('head')[0].appendChild(meta);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -399,10 +399,10 @@ describes.realWin('amp-story', {
   });
 
   it('should have a meta tag that sets the theme color', () => {
-    createPages(story.element, pageCount);
+    createPages(story.element, 2);
     story.buildCallback();
     const metaTags = story.element.getElementsByTagName('meta');
-    const metaTagNames = Array.from(pageElements).map(el => el.name);
+    const metaTagNames = Array.from(metTagNames).map(el => el.name);
     expect(metaTagNames.contains('theme-color')).to.be.true;
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -398,6 +398,14 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should have a meta tag that sets the theme color', () => {
+    createPages(story.element, pageCount);
+    story.buildCallback();
+    const metaTags = story.element.getElementsByTagName('meta');
+    const metaTagNames = Array.from(pageElements).map(el => el.name);
+    expect(metaTagNames.contains('theme-color')).to.be.true;
+  });
+
   describe('amp-story consent', () => {
     it('should pause the story if there is a consent', () => {
       sandbox.stub(Services, 'actionServiceForDoc')

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -401,9 +401,11 @@ describes.realWin('amp-story', {
   it('should have a meta tag that sets the theme color', () => {
     createPages(story.element, 2);
     story.buildCallback();
-    const metaTags = story.element.getElementsByTagName('meta');
-    const metaTagNames = Array.from(metTagNames).map(el => el.name);
-    expect(metaTagNames.contains('theme-color')).to.be.true;
+    return story.layoutCallback()
+        .then(() => {
+          const metaTag = win.document.querySelector('meta[name=theme-color]');
+          expect(metaTag).to.not.be.null;
+        });
   });
 
   describe('amp-story consent', () => {


### PR DESCRIPTION
Closes #19203

Added theme-color meta-tags based on the primary accent color of the story. Should the primary accent color not exist, the default theme-color is set to light gray with black text (which is the default for lighter theme colors).