### PR TITLE
✨♻️ Expander: Expose a new getter for macro names in url

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -85,6 +85,19 @@ export class Expander {
     return this.parseUrlRecursively_(url, matches);
   }
 
+  /**
+   * Return any macros that exist in the given url.
+   * @param {string} url
+   * @return {!Array}
+   */
+  getMacroNames(url) {
+    const expr = this.variableSource_.getExpr(this.bindings_, this.whiteList_);
+    const matches = url.match(expr);
+    if (matches) {
+      return matches;
+    }
+    return [];
+  }
 
   /**
    * Structures the regex matching into the desired format

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1053,21 +1053,13 @@ export class UrlReplacements {
    */
   collectUnwhitelistedVarsSync(element) {
     const url = element.getAttribute('src');
-    const vars = Object.create(null);
-    this.expandStringSync(url, /* opt_bindings */ undefined, vars);
-    const varNames = Object.keys(vars)
-        // Strip arguments from collect_vars to match whitelist api.
-        .map(key => {
-          const argsIndex = key.indexOf('(');
-          return argsIndex === -1 ? key : key.substring(0, argsIndex);
-        });
-
+    const macroNames = new Expander(this.variableSource_).getMacroNames(url);
     const whitelist = this.getWhitelistForElement_(element);
     if (whitelist) {
-      return varNames.filter(v => !whitelist[v]);
+      return macroNames.filter(v => !whitelist[v]);
     } else {
       // All vars are unwhitelisted if the element has no whitelist.
-      return varNames;
+      return macroNames;
     }
   }
 

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -465,4 +465,18 @@ describes.realWin('Expander', {
       });
     });
   });
+
+  describe('getMacroNames', () => {
+    it('should handle no names found', () => {
+      const url = 'https://www.example.com/foo/bar?a=1&b=hello';
+      expect(new Expander(variableSource).getMacroNames(url)).to
+          .eql([]);
+    });
+
+    it('should find the correct names', () => {
+      const url = 'https://www.example.com?a=1&t=TITLE&c=CLIENT_ID(foo)';
+      expect(new Expander(variableSource).getMacroNames(url)).to
+          .eql(['TITLE', 'CLIENT_ID']);
+    });
+  });
 });

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -478,5 +478,11 @@ describes.realWin('Expander', {
       expect(new Expander(variableSource).getMacroNames(url)).to
           .eql(['TITLE', 'CLIENT_ID']);
     });
+
+    it('should find the nested names', () => {
+      const url = 'https://www.example.com?a=1&t=TITLE&c=CLIENT_ID(QUERY_PARAM(foo))';
+      expect(new Expander(variableSource).getMacroNames(url)).to
+          .eql(['TITLE', 'CLIENT_ID', 'QUERY_PARAM']);
+    });
   });
 });


### PR DESCRIPTION
Follow up to #19061 & #19069.

Exposes a new method on expander to extract any macro names from a given url. Previously the only option was using `opt_collectVars` which would actually resolve any macros. This is now a simple regex match.