### PR TITLE
♻️ Add DomElement type for media pool

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -459,7 +459,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.pause();
       } else {
         return mediaPool.pause(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl),
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl),
             rewindToBeginning);
       }
     });
@@ -476,7 +476,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.play();
       } else {
         return mediaPool.play(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }
@@ -492,7 +492,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         // No-op.
       } else {
         return mediaPool.preload(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }
@@ -508,7 +508,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.setAttribute('muted', '');
       } else {
         return mediaPool.mute(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }
@@ -524,7 +524,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.removeAttribute('muted');
       } else {
         return mediaPool.unmute(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }
@@ -540,7 +540,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         // No-op.
       } else {
         return mediaPool.register(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }
@@ -556,7 +556,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.currentTime = 0;
       } else {
         return mediaPool.rewindToBeginning(
-            /** @type {!./media-pool.PlaceholderElementDef} */ (mediaEl));
+            /** @type {!./media-pool.DomElementDef} */ (mediaEl));
       }
     });
   }

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -62,11 +62,17 @@ export let PlaceholderElementDef;
 let PoolBoundElementDef;
 
 /**
+ * An element pulled from the DOM.  It is yet to be resolved into a
+ * PlaceholderElement or a PoolBoundElement.
+ * @typedef {!PlaceholderElementDef|!PoolBoundElementDef}
+ */
+export let DomElementDef;
+
+/**
  * Represents the distance of an element from the current place in the document.
- * @typedef {function(!PoolBoundElementDef): number}
+ * @typedef {function(!DomElementDef): number}
  */
 export let ElementDistanceFnDef;
-
 
 /**
  * Represents a task to be executed on a media element.
@@ -78,7 +84,7 @@ let ElementTaskDef;
 /**
  * @const {string}
  */
-const DOM_MEDIA_ELEMENT_ID_PREFIX = 'i-amphtml-media-';
+const PLACEHOLDER_ELEMENT_ID_PREFIX = 'i-amphtml-media-';
 
 
 /**
@@ -169,7 +175,7 @@ export class MediaPool {
      * are kept in memory when they are swapped out of the DOM.
      * @private @const {!Object<string, !PlaceholderElementDef>}
      */
-    this.domMediaEls_ = {};
+    this.placeholderEls_ = {};
 
     /**
      * Counter used to produce unique IDs for media elements.
@@ -307,8 +313,8 @@ export class MediaPool {
    * @return {string} A unique ID.
    * @private
    */
-  createDomMediaElementId_() {
-    return DOM_MEDIA_ELEMENT_ID_PREFIX + this.idCounter_++;
+  createPlaceholderElementId_() {
+    return PLACEHOLDER_ELEMENT_ID_PREFIX + this.idCounter_++;
   }
 
   /**
@@ -347,14 +353,15 @@ export class MediaPool {
    * Retrieves the media element from the pool that matches the specified
    * element, if one exists.
    * @param {!MediaType} mediaType The type of media element to get.
-   * @param {!PlaceholderElementDef} domMediaEl The element whose matching media
+   * @param {!DomElementDef} domMediaEl The element whose matching media
    *     element should be retrieved.
    * @return {?PoolBoundElementDef} The media element in the pool that
    *     represents the specified media element
    */
   getMatchingMediaElementFromPool_(mediaType, domMediaEl) {
     if (this.isAllocatedMediaElement_(mediaType, domMediaEl)) {
-      return domMediaEl;
+      // The media element in the DOM was already from the pool.
+      return /** @type {!PoolBoundElementDef} */ (domMediaEl);
     }
 
     const allocatedEls = this.allocated[mediaType];
@@ -465,21 +472,25 @@ export class MediaPool {
 
   /**
    * @param {!MediaType} mediaType The media type to check.
-   * @param {!PlaceholderElementDef} el The element to check.
+   * @param {!DomElementDef} domMediaEl The element to check.
    * @return {boolean} true, if the specified element has already been allocated
    *     as the specified type of media element.
    * @private
    */
-  isAllocatedMediaElement_(mediaType, el) {
-    return this.allocated[mediaType].indexOf(el) >= 0;
+  isAllocatedMediaElement_(mediaType, domMediaEl) {
+    // Since we don't know whether or not the specified domMediaEl is a
+    // placeholder or originated from the pool, we coerce it to a pool-bound
+    // element, to check against the allocated list of pool-bound elements.
+    const poolMediaEl = /** @type {!PoolBoundElementDef} */ (domMediaEl);
+    return this.allocated[mediaType].indexOf(poolMediaEl) >= 0;
   }
 
 
   /**
    * Replaces a media element that was originally in the DOM with a media
    * element from the pool.
-   * @param {!PlaceholderElementDef} domMediaEl The media element originating
-   *     from the DOM.
+   * @param {!PlaceholderElementDef} placeholderEl The placeholder element
+   *     originating from the DOM.
    * @param {!PoolBoundElementDef} poolMediaEl The media element originating
    *     from the pool.
    * @param {!Sources} sources The sources for the media element.
@@ -487,13 +498,13 @@ export class MediaPool {
    *     been successfully swapped into the DOM.
    * @private
    */
-  swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources) {
+  swapPoolMediaElementIntoDom_(placeholderEl, poolMediaEl, sources) {
     const ampMediaForPoolEl = ampMediaElementFor(poolMediaEl);
-    const ampMediaForDomEl = ampMediaElementFor(domMediaEl);
-    poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = domMediaEl.id;
+    const ampMediaForDomEl = ampMediaElementFor(placeholderEl);
+    poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = placeholderEl.id;
 
     return this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapIntoDomTask(domMediaEl))
+        new SwapIntoDomTask(placeholderEl))
         .then(() => {
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
@@ -553,13 +564,13 @@ export class MediaPool {
    * @private
    */
   swapPoolMediaElementOutOfDom_(poolMediaEl) {
-    const oldDomMediaElId = poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME];
-    const oldDomMediaEl = /** @type {!PlaceholderElementDef} */ (
-      dev().assertElement(this.domMediaEls_[oldDomMediaElId],
+    const placeholderElId = poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME];
+    const placeholderEl = /** @type {!PlaceholderElementDef} */ (
+      dev().assertElement(this.placeholderEls_[placeholderElId],
           'No media element to put back into DOM after eviction.'));
 
     const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapOutOfDomTask(oldDomMediaEl))
+        new SwapOutOfDomTask(placeholderEl))
         .then(() => {
           poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
         });
@@ -599,7 +610,7 @@ export class MediaPool {
   /**
    * Preloads the content of the specified media element in the DOM and returns
    * a media element that can be used in its stead for playback.
-   * @param {!PlaceholderElementDef} domMediaEl The media element, found in the
+   * @param {!DomElementDef} domMediaEl The media element, found in the
    *     DOM, whose content should be loaded.
    * @return {Promise<!PoolBoundElementDef>} A media element from the pool that
    *     can be used to replace the specified element.
@@ -615,15 +626,20 @@ export class MediaPool {
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
     if (existingPoolMediaEl) {
       // The element being loaded already has an allocated media element.
-      return Promise.resolve(existingPoolMediaEl);
+      return Promise.resolve(
+          /** @type {!PoolBoundElementDef} */ (existingPoolMediaEl));
     }
 
-    const sources = this.sources_[domMediaEl.id];
+    // Since this is not an existing pool media element, we can be certain that
+    // it is a placeholder element.
+    const placeholderEl = /** @type {!PlaceholderElementDef} */ (domMediaEl);
+
+    const sources = this.sources_[placeholderEl.id];
     dev().assert(sources instanceof Sources,
         'Cannot play unregistered element.');
 
     const poolMediaEl = this.reserveUnallocatedMediaElement_(mediaType) ||
-        this.evictMediaElement_(mediaType, domMediaEl);
+        this.evictMediaElement_(mediaType, placeholderEl);
 
     if (!poolMediaEl) {
       // If there is no space in the pool to allocate a new element, and no
@@ -633,7 +649,8 @@ export class MediaPool {
 
     this.allocateMediaElement_(mediaType, poolMediaEl);
 
-    return this.swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources)
+    return this
+        .swapPoolMediaElementIntoDom_(placeholderEl, poolMediaEl, sources)
         .then(() => poolMediaEl);
   }
 
@@ -661,7 +678,7 @@ export class MediaPool {
    * being played while not managed by the media pool.  If the media element is
    * already registered, this is a no-op.  Registering elements from within the
    * pool is not allowed, and will also be a no-op.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be
+   * @param {!DomElementDef} domMediaEl The media element to be
    *     registered.
    * @return {!Promise} A promise that is resolved when the element has been
    *     successfully registered, or rejected otherwise.
@@ -679,21 +696,27 @@ export class MediaPool {
       return Promise.resolve();
     }
 
-    const id = domMediaEl.id || this.createDomMediaElementId_();
-    if (this.sources_[id] && this.domMediaEls_[id]) {
+    // Since this is not an existing pool media element, we can be certain that
+    // it is a placeholder element.
+    const placeholderEl = /** @type {!PlaceholderElementDef} */ (domMediaEl);
+
+    const id = placeholderEl.id || this.createPlaceholderElementId_();
+    if (this.sources_[id] && this.placeholderEls_[id]) {
       // This media element is already registered.
       return Promise.resolve();
     }
 
     // This media element has not yet been registered.
-    domMediaEl.id = id;
-    const sources = Sources.removeFrom(domMediaEl);
+    placeholderEl.id = id;
+    const sources = Sources.removeFrom(placeholderEl);
     this.sources_[id] = sources;
-    this.domMediaEls_[id] = domMediaEl;
+    this.placeholderEls_[id] = placeholderEl;
 
-    domMediaEl.muted = true;
-    domMediaEl.setAttribute('muted', '');
-    domMediaEl.pause();
+    if (placeholderEl instanceof HTMLMediaElement) {
+      placeholderEl.muted = true;
+      placeholderEl.setAttribute('muted', '');
+      placeholderEl.pause();
+    }
 
     return Promise.resolve();
   }
@@ -710,7 +733,7 @@ export class MediaPool {
 
   /**
    * Preloads the content of the specified media element in the DOM.
-   * @param {!PlaceholderElementDef} domMediaEl The media element, found in the
+   * @param {!DomElementDef} domMediaEl The media element, found in the
    *     DOM, whose content should be loaded.
    * @return {!Promise} A promise that is resolved when the specified media
    *     element has successfully started preloading.
@@ -726,7 +749,7 @@ export class MediaPool {
   /**
    * Plays the specified media element in the DOM by replacing it with a media
    * element from the pool and playing that.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be played.
+   * @param {!DomElementDef} domMediaEl The media element to be played.
    * @return {!Promise} A promise that is resolved when the specified media
    *     element has been successfully played.
    */
@@ -744,7 +767,7 @@ export class MediaPool {
 
   /**
    * Pauses the specified media element in the DOM.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be paused.
+   * @param {!DomElementDef} domMediaEl The media element to be paused.
    * @param {boolean=} rewindToBeginning Whether to rewind the currentTime
    *     of media items to the beginning.
    * @return {!Promise} A promise that is resolved when the specified media
@@ -772,7 +795,7 @@ export class MediaPool {
 
   /**
    * Rewinds a specified media element in the DOM to 0.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be rewound.
+   * @param {!DomElementDef} domMediaEl The media element to be rewound.
    * @return {!Promise} A promise that is resolved when the
    *     specified media element has been successfully rewound.
    */
@@ -791,7 +814,7 @@ export class MediaPool {
 
   /**
    * Mutes the specified media element in the DOM.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be muted.
+   * @param {!DomElementDef} domMediaEl The media element to be muted.
    * @return {!Promise} A promise that is resolved when the specified media
    *     element has been successfully muted.
    */
@@ -810,7 +833,7 @@ export class MediaPool {
 
   /**
    * Unmutes the specified media element in the DOM.
-   * @param {!PlaceholderElementDef} domMediaEl The media element to be unmuted.
+   * @param {!DomElementDef} domMediaEl The media element to be unmuted.
    * @return {!Promise} A promise that is resolved when the specified media
    *     element has been successfully paused.
    */

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -712,11 +712,9 @@ export class MediaPool {
     this.sources_[id] = sources;
     this.placeholderEls_[id] = placeholderEl;
 
-    if (placeholderEl instanceof HTMLMediaElement) {
-      placeholderEl.muted = true;
-      placeholderEl.setAttribute('muted', '');
-      placeholderEl.pause();
-    }
+    placeholderEl.muted = true;
+    placeholderEl.setAttribute('muted', '');
+    placeholderEl.pause();
 
     return Promise.resolve();
   }

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -82,9 +82,9 @@ function isProtectedAttributeName(attributeName) {
 
 /**
  * Copies all unprotected CSS classes from fromEl to toEl.
- * @param {!HTMLMediaElement} fromEl The element from which CSS classes should
+ * @param {!Element} fromEl The element from which CSS classes should
  *     be copied.
- * @param {!HTMLMediaElement} toEl The element to which CSS classes should be
+ * @param {!Element} toEl The element to which CSS classes should be
  *     copied.
  * @private
  */
@@ -109,9 +109,9 @@ function copyCssClasses(fromEl, toEl) {
 
 /**
  * Copies all unprotected attributes from fromEl to toEl.
- * @param {!HTMLMediaElement} fromEl The element from which attributes should
+ * @param {!Element} fromEl The element from which attributes should
  *     be copied.
- * @param {!HTMLMediaElement} toEl The element to which attributes should be
+ * @param {!Element} toEl The element to which attributes should be
  *     copied.
  * @private
  */
@@ -136,6 +136,16 @@ function copyAttributes(fromEl, toEl) {
   }
 }
 
+
+/**
+ * Determines whether the specified element is a media element.
+ * @param {!Element} el The element to check.
+ * @return {boolean} true, if the specified element is a media element.
+ * @private
+ */
+function isMediaElement(el) {
+  return el instanceof HTMLMediaElement;
+}
 
 
 /**
@@ -162,6 +172,21 @@ export class MediaTask {
   }
 
   /**
+   * @param {!Element} targetEl The element that should be checked to see
+   *     whether it is a media element.
+   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved if the
+   *     specified target element is a media element, and rejected otherwise.
+   */
+  assertMediaElement(targetEl) {
+    if (!isMediaElement(targetEl)) {
+      this.failTask(`${this.name_} can only be executed on media elements.`);
+      return Promise.reject();
+    }
+
+    return Promise.resolve(/** @type {!HTMLMediaElement} */ (targetEl));
+  }
+
+  /**
    * @return {string} The name of this task.
    */
   getName() {
@@ -177,8 +202,8 @@ export class MediaTask {
   }
 
   /**
-   * @param {!HTMLMediaElement} mediaEl The media element on which this task
-   *     should be executed.
+   * @param {!HTMLMediaElement} mediaEl The element on which this task should be
+   *     executed.
    * @return {!Promise} A promise that is resolved when the task has completed
    *     execution.
    */
@@ -188,8 +213,8 @@ export class MediaTask {
   }
 
   /**
-   * @param {!HTMLMediaElement} unusedMediaEl The media element on which this
-   *     task should be executed.
+   * @param {!HTMLMediaElement} unusedMediaEl The element on which this task
+   *     should be executed.
    * @protected
    */
   executeInternal(unusedMediaEl) {
@@ -393,57 +418,56 @@ export class UpdateSourcesTask extends MediaTask {
 
 
 /**
- * Swaps a media element into the DOM, in the place of another media element.
+ * Swaps a media element into the DOM, in the place of a placeholder element.
  */
 export class SwapIntoDomTask extends MediaTask {
   /**
-   * @param {!HTMLMediaElement} replacedMediaEl The element to be replaced by
-   *     the media element on which this task is executed.
+   * @param {!Element} placeholderEl The element to be replaced by the media
+   *     element on which this task is executed.
    */
-  constructor(replacedMediaEl) {
+  constructor(placeholderEl) {
     super('swap-into-dom');
 
-    /** @private @const {!HTMLMediaElement} */
-    this.replacedMediaEl_ = replacedMediaEl;
+    /** @private @const {!Element} */
+    this.placeholderEl_ = placeholderEl;
   }
 
   /** @override */
   executeInternal(mediaEl) {
-    if (!isConnectedNode(this.replacedMediaEl_)) {
+    if (!isConnectedNode(this.placeholderEl_)) {
       this.failTask('Cannot swap media for element that is not in DOM.');
       return Promise.resolve();
     }
 
-    copyCssClasses(this.replacedMediaEl_, mediaEl);
-    copyAttributes(this.replacedMediaEl_, mediaEl);
-    this.replacedMediaEl_.parentElement
-        .replaceChild(mediaEl, this.replacedMediaEl_);
+    copyCssClasses(this.placeholderEl_, mediaEl);
+    copyAttributes(this.placeholderEl_, mediaEl);
+    this.placeholderEl_.parentElement
+        .replaceChild(mediaEl, this.placeholderEl_);
     return Promise.resolve();
   }
 }
 
 
 /**
- * Swaps a media element out the DOM, in the place of a placeholder media
- * element.
+ * Swaps a media element out the DOM, replacing it with a placeholder element.
  */
 export class SwapOutOfDomTask extends MediaTask {
   /**
-   * @param {!HTMLMediaElement} placeholderMediaEl The element to be replaced by
-   *     the media element on which this task is executed.
+   * @param {!Element} placeholderEl The element to replace the media element on
+   *     which this task is executed.
    */
-  constructor(placeholderMediaEl) {
+  constructor(placeholderEl) {
     super('swap-out-of-dom');
 
-    /** @private @const {!HTMLMediaElement} */
-    this.placeholderMediaEl_ = placeholderMediaEl;
+    /** @private @const {!Element} */
+    this.placeholderEl_ = placeholderEl;
   }
 
   /** @override */
   executeInternal(mediaEl) {
-    copyCssClasses(mediaEl, this.placeholderMediaEl_);
-    copyAttributes(mediaEl, this.placeholderMediaEl_);
-    mediaEl.parentElement.replaceChild(this.placeholderMediaEl_, mediaEl);
+    copyCssClasses(mediaEl, this.placeholderEl_);
+    copyAttributes(mediaEl, this.placeholderEl_);
+    mediaEl.parentElement.replaceChild(this.placeholderEl_, mediaEl);
     return Promise.resolve();
   }
 }

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -138,17 +138,6 @@ function copyAttributes(fromEl, toEl) {
 
 
 /**
- * Determines whether the specified element is a media element.
- * @param {!Element} el The element to check.
- * @return {boolean} true, if the specified element is a media element.
- * @private
- */
-function isMediaElement(el) {
-  return el instanceof HTMLMediaElement;
-}
-
-
-/**
  * Base class for tasks executed in order on HTMLMediaElements.
  */
 export class MediaTask {
@@ -169,21 +158,6 @@ export class MediaTask {
 
     /** @private {?function(*)} */
     this.reject_ = deferred.reject;
-  }
-
-  /**
-   * @param {!Element} targetEl The element that should be checked to see
-   *     whether it is a media element.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved if the
-   *     specified target element is a media element, and rejected otherwise.
-   */
-  assertMediaElement(targetEl) {
-    if (!isMediaElement(targetEl)) {
-      this.failTask(`${this.name_} can only be executed on media elements.`);
-      return Promise.reject();
-    }
-
-    return Promise.resolve(/** @type {!HTMLMediaElement} */ (targetEl));
   }
 
   /**


### PR DESCRIPTION
Adds a third typedef for media pool: `DomElementDef`.  The three types are now:

1. `PlaceholderElementDef`: This element is a placeholder for media elements.  If there is space in the pool, media elements can be swapped into the DOM in place of placeholder elements.  If not, the placeholder element remains in the DOM.
2. `PoolBoundElementDef`: This element is allocated by the media pool.  It is swapped in place of placeholder elements, and is the media element that gets played in the UI.
3. `DomElementDef`: A union of `PlaceholderElementDef` and `PoolBoundElementDef`.  Essentially, "we're not sure yet; we'll need to check which type this is, but it's definitely one of the two."

This PR should be just type and documentation changes.