### PR TITLE
AMP-Consent: Introduce consentInfoDef

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import {CONSENT_ITEM_STATE, ConsentStateManager} from './consent-state-manager';
+import {CONSENT_ITEM_STATE} from './consent-info';
 import {CSS} from '../../../build/amp-consent-0.1.css';
 import {ConsentConfig, expandPolicyConfig} from './consent-config';
 import {ConsentPolicyManager} from './consent-policy-manager';
+import {ConsentStateManager} from './consent-state-manager';
 import {ConsentUI} from './consent-ui';
 import {Deferred} from '../../../src/utils/promise';
 import {

--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev} from '../../../src/log';
+
+/**
+ * @enum {number}
+ */
+export const CONSENT_ITEM_STATE = {
+  ACCEPTED: 1,
+  REJECTED: 2,
+  DISMISSED: 3,
+  NOT_REQUIRED: 4,
+  UNKNOWN: 5,
+  // TODO(@zhouyx): Seperate UI state from consent state. Add consent
+  // requirement state ui_state = {pending, active, complete} consent_state =
+  // {unknown, accepted, rejected}
+};
+
+/**
+ * @typedef {{
+ *  consentState: CONSENT_ITEM_STATE,
+ *  consentString: (string|undefined),
+ *  isDirty: (boolean|undefined),
+ * }}
+ */
+export let ConsentInfoDef;
+
+/**
+ * Convert the legacy storage value to Consent Info
+ * @param {boolean|undefined} value
+ * @return {ConsentInfoDef}
+ */
+export function getStoredConsentInfo(value) {
+  if (value === undefined) {
+    return constructConsentInfo(
+        CONSENT_ITEM_STATE.UNKNOWN, undefined, undefined);
+  }
+  if (typeof value === 'boolean') {
+    // legacy format
+    return getLegacyStoredConsentInfo(value);
+  }
+  throw dev().createError('Invalid stored consent value');
+}
+
+/**
+ * Convert the legacy boolean stored value to consentInfo object
+ * @param {boolean} value
+ * @return {!ConsentInfoDef}
+ */
+function getLegacyStoredConsentInfo(value) {
+  const state = value ? CONSENT_ITEM_STATE.ACCEPTED :
+    CONSENT_ITEM_STATE.REJECTED;
+  return constructConsentInfo(state, undefined, undefined);
+}
+
+/**
+ * Construct the consentInfo object from values
+ * @param {CONSENT_ITEM_STATE} consentState
+ * @param {string|undefined} consentString
+ * @param {boolean|undefined} isDirty
+ * @return {!ConsentInfoDef}
+ */
+function constructConsentInfo(consentState, consentString, isDirty) {
+  return {
+    'consentState': consentState,
+    'consentString': consentString,
+    'isDirty': isDirty,
+  };
+}

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -165,8 +165,8 @@ export class ConsentPolicyManager {
     if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, 'can not find defined policy %s, ' +
-          'only supported predefined policy supported now', policyId);
+        user().error(TAG, 'can not find policy %s, ' +
+          'only predefined policies are supported', policyId);
         return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
       }
     }
@@ -186,8 +186,8 @@ export class ConsentPolicyManager {
     if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, 'can not find defined policy %s, ' +
-          'only supported predefined policy supported now', policyId);
+        user().error(TAG, 'can not find policy %s, ' +
+          'only predefined policies are supported', policyId);
         return Promise.resolve(false);
       }
     }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CONSENT_ITEM_STATE} from './consent-state-manager';
+import {CONSENT_ITEM_STATE} from './consent-info';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
 import {dev, user} from '../../../src/log';
@@ -165,8 +165,8 @@ export class ConsentPolicyManager {
     if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, `can not find defined policy ${policyId}, ` +
-          'only supported predefined policy supported now');
+        user().error(TAG, 'can not find defined policy %s, ' +
+          'only supported predefined policy supported now', policyId);
         return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
       }
     }
@@ -186,8 +186,8 @@ export class ConsentPolicyManager {
     if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, `can not find defined policy ${policyId}, ` +
-          'only supported predefined policy supported now');
+        user().error(TAG, 'can not find defined policy %s, ' +
+          'only supported predefined policy supported now', policyId);
         return Promise.resolve(false);
       }
     }
@@ -312,15 +312,15 @@ export class ConsentPolicyInstance {
           fallbackState = CONSENT_ITEM_STATE.REJECTED;
         } else if (timeoutConfig['fallbackAction'] &&
             timeoutConfig['fallbackAction'] != 'dismiss') {
-          user().error(TAG,
-              `unsupported fallbackAction ${timeoutConfig['fallbackAction']}`);
+          user().error(TAG, 'unsupported fallbackAction %s',
+              timeoutConfig['fallbackAction']);
         }
         timeoutSecond = timeoutConfig['seconds'];
       } else {
         timeoutSecond = timeoutConfig;
       }
       user().assert(isFiniteNumber(timeoutSecond),
-          `invalid timeout value ${timeoutSecond}`);
+          'invalid timeout value %s', timeoutSecond);
     }
 
     if (timeoutSecond != null) {
@@ -340,7 +340,7 @@ export class ConsentPolicyInstance {
     // TODO: Keeping an array can have performance issue, change to using a map
     // if necessary.
     if (!hasOwn(this.itemToConsentState_, consentId)) {
-      dev().error(TAG, `cannot find ${consentId} in policy state`);
+      dev().error(TAG, 'cannot find %s in policy state', consentId);
       return;
     }
 

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -389,9 +389,9 @@ describes.realWin('amp-consent', {
       });
       it('handle postPromptUI', function* () {
         storageValue = {
-          'amp-consent:ABC': CONSENT_ITEM_STATE.ACCEPTED,
-          'amp-consent:DEF': CONSENT_ITEM_STATE.ACCEPTED,
-          'amp-consent:GH': CONSENT_ITEM_STATE.ACCEPTED,
+          'amp-consent:ABC': true,
+          'amp-consent:DEF': true,
+          'amp-consent:GH': true,
         };
         ampConsent.buildCallback();
         ampConsent.element.classList.remove('i-amphtml-notbuilt');
@@ -438,7 +438,7 @@ describes.realWin('amp-consent', {
 
         it('show postPromptUI', function* () {
           storageValue = {
-            'amp-consent:ABC': CONSENT_ITEM_STATE.ACCEPTED,
+            'amp-consent:ABC': true,
           };
           ampConsent.buildCallback();
           ampConsent.element.classList.remove('i-amphtml-notbuilt');

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -18,7 +18,7 @@ import {
   ACTION_TYPE,
   AmpConsent,
 } from '../amp-consent';
-import {CONSENT_ITEM_STATE} from '../consent-state-manager';
+import {CONSENT_ITEM_STATE} from '../consent-info';
 import {dict} from '../../../../src/utils/object';
 import {macroTask} from '../../../../testing/yield';
 import {

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CONSENT_ITEM_STATE,
+  getStoredConsentInfo,
+} from '../consent-info';
+import {dict} from '../../../../src/utils/object';
+
+
+describes.fakeWin('ConsentConfig', {}, () => {
+  describe('getStoredConsentInfo', () => {
+    it('construct consentInfo from undefined', () => {
+      expect(getStoredConsentInfo(undefined)).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.UNKNOWN,
+        'consentString': undefined,
+        'isDirty': undefined,
+      }));
+    });
+
+    it('construct consentInfo from legacy value', () => {
+      expect(getStoredConsentInfo(true)).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.ACCEPTED,
+        'consentString': undefined,
+        'isDirty': undefined,
+      }));
+      expect(getStoredConsentInfo(false)).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.REJECTED,
+        'consentString': undefined,
+        'isDirty': undefined,
+      }));
+    });
+
+    it('throw error with invalid value', () => {
+      expect(() => getStoredConsentInfo({})).to.throw(
+          'Invalid stored consent value');
+    });
+  });
+});

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -15,7 +15,7 @@
  */
 
 import * as lolex from 'lolex';
-import {CONSENT_ITEM_STATE} from '../consent-state-manager';
+import {CONSENT_ITEM_STATE} from '../consent-info';
 import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
 import {
   ConsentPolicyInstance,

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {CONSENT_ITEM_STATE} from '../consent-info';
 import {
-  CONSENT_ITEM_STATE,
   ConsentInstance,
   ConsentStateManager,
 } from '../consent-state-manager';


### PR DESCRIPTION
As mentioned, the `consentInfoDef` will be useful later to store more information. 