### PR TITLE
🐛 [amp-analytics] Pass the canonical url on every Parse.ly Analytics pageview request

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -300,7 +300,7 @@
   "parsely": {
     "host": "https://srv.pixel.parsely.com",
     "basePrefix": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=!apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_",
-    "pageview": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=!apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_&action=pageview",
+    "pageview": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=!apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_&action=pageview&metadata={\"canonical_url\":\"_canonical_url_\"}",
     "heartbeat": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=!apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_&action=heartbeat&tt=_total_engaged_time_&inc=_incremental_engaged_time_"
   },
   "piStats": {

--- a/extensions/amp-analytics/0.1/vendors/parsely.js
+++ b/extensions/amp-analytics/0.1/vendors/parsely.js
@@ -29,7 +29,7 @@ export const PARSELY_CONFIG = /** @type {!JsonObject} */ ({
       'date=${timestamp}&' +
       'ampid=${clientId(_parsely_visitor)}',
     'pageview': '${basePrefix}&action=pageview&metadata=' +
-    '{\"canonical_url\":\"${canonicalUrl}\"}"',
+    '{\"canonical_url\":\"${canonicalUrl}\"}',
     'heartbeat': '${basePrefix}&action=heartbeat' +
     '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js)}',
   },

--- a/extensions/amp-analytics/0.1/vendors/parsely.js
+++ b/extensions/amp-analytics/0.1/vendors/parsely.js
@@ -28,7 +28,8 @@ export const PARSELY_CONFIG = /** @type {!JsonObject} */ ({
       'title=${title}&' +
       'date=${timestamp}&' +
       'ampid=${clientId(_parsely_visitor)}',
-    'pageview': '${basePrefix}&action=pageview',
+    'pageview': '${basePrefix}&action=pageview&metadata=' +
+    '{\"canonical_url\":\"${canonicalUrl}\"}"',
     'heartbeat': '${basePrefix}&action=heartbeat' +
     '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js)}',
   },


### PR DESCRIPTION
Passing the canonical url on pageview requests will allow us to properly associate self-hosted (non-CDN hosted) AMP traffic with the canonical URL of the content. We have had a customer manually add this change to their AMP configuration and verified that the traffic post-change was being correctly associated. I also tested this locally using `gulp default` and the `analytics-vendors.amp.html` page to confirm the HTTP request sent by the pageview event was correct.