### PR TITLE
Message Extraction: while removing assert methods as a preprocess step, add back in the type

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -28,7 +28,7 @@ const typeMap = {
   'assertString': 'string',
   'assertNumber': 'number',
   'assertBoolean': 'boolean',
-}
+};
 
 const removableDevAsserts = [
   'assert',
@@ -83,12 +83,12 @@ module.exports = function(babel) {
           // If it has no type that we can cast to, then we also won't need to
           // do type annotation.
           } else if (!/^assert/.test(property.name) || !type) {
-              path.replaceWith(args);
+            path.replaceWith(args);
           } else {
             // Special case null value argument since it's mostly used for
             // interface methods with no implementation which will most likely
             // get DCE'd by Closure Compiler since they are unused code methods.
-            if (args.value === "null" || args.type === "NullLiteral") {
+            if (args.type === 'NullLiteral') {
               return;
             } else {
               path.replaceWith(t.parenthesizedExpression(args));

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -82,7 +82,7 @@ module.exports = function(babel) {
           // If is not an assert type, we won't need to do type annotation.
           // If it has no type that we can cast to, then we also won't need to
           // do type annotation.
-          } else if (!/^assert/.test(property.name) || !type) {
+          } else if (!property.name.startsWith('assert') || !type) {
             path.replaceWith(args);
           } else {
             // Special case null value argument since it's mostly used for

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -86,8 +86,9 @@ module.exports = function(babel) {
               path.replaceWith(args);
           } else {
             // Special case null value argument since it's mostly used for
-            // interface methods with no implementation.
-            if (args.raw === "null") {
+            // interface methods with no implementation which will most likely
+            // get DCE'd by Closure Compiler since they are unused code methods.
+            if (args.value === "null" || args.type === "NullLiteral") {
               return;
             } else {
               path.replaceWith(t.parenthesizedExpression(args));
@@ -97,7 +98,8 @@ module.exports = function(babel) {
           }
         } else {
           // This is to resolve right hand side usage of expression where
-          // no argument is passed in.
+          // no argument is passed in. This bare undefined value is eventually
+          // stripped by Closure Compiler.
           path.replaceWith(t.identifier('undefined'));
         }
       },

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/input.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const falsey = false;
+dev().assertBoolean(falsey);
 dev().assertBoolean(true);
 let result = dev().assertBoolean(false, 'hello', 'world');
 let result2 = dev().assertBoolean();

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const falsey = false;
+
+/** @type {boolean} */
+(falsey);
 
 /** @type {boolean} */
 (true);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-true;
-let result = false;
+
+/** @type {boolean} */
+(true);
+let result =
+/** @type {boolean} */
+(false);
 let result2 = undefined;

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-element/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-element/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-element;
-let result = element;
+
+/** @type {!Element} */
+(element);
+let result =
+/** @type {!Element} */
+(element);
 let result2 = undefined;

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/input.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+let num = 5;
+dev().assertNumber(num);
 dev().assertNumber(1 + 1);
 let result = dev().assertNumber(3, 'hello', 'world');
 let result2 = dev().assertNumber();

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-1 + 1;
-let result = 3;
+
+/** @type {number} */
+(1 + 1);
+let result =
+/** @type {number} */
+(3);
 let result2 = undefined;

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+let num = 5;
+
+/** @type {number} */
+(num);
 
 /** @type {number} */
 (1 + 1);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/input.js
@@ -16,3 +16,4 @@
 dev().assertString('hello');
 let result = dev().assertString('world');
 let result2 = dev().assertString();
+let result3 = dev().assertString(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/input.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+let str = 'foo';
+dev().assertString(str);
 dev().assertString('hello');
 let result = dev().assertString('world');
 let result2 = dev().assertString();

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
@@ -20,3 +20,4 @@ let result =
 /** @type {string} */
 ('world');
 let result2 = undefined;
+let result3 = null;

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+let str = 'foo';
+
+/** @type {string} */
+(str);
 
 /** @type {string} */
 ('hello');

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'hello';
-let result = 'world';
+
+/** @type {string} */
+('hello');
+let result =
+/** @type {string} */
+('world');
 let result2 = undefined;

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string/output.js
@@ -20,4 +20,4 @@ let result =
 /** @type {string} */
 ('world');
 let result2 = undefined;
-let result3 = null;
+let result3 = dev().assertString(null);

--- a/build-system/build.conf.js
+++ b/build-system/build.conf.js
@@ -16,6 +16,8 @@
 
 const defaultPlugins = [
   require.resolve(
+      './babel-plugins/babel-plugin-transform-amp-asserts'),
+  require.resolve(
       './babel-plugins/babel-plugin-transform-parenthesize-expression'),
 ];
 

--- a/extensions/amp-pinterest/0.1/pinit-button.js
+++ b/extensions/amp-pinterest/0.1/pinit-button.js
@@ -56,8 +56,11 @@ export class PinItButton {
     this.round = rootElement.getAttribute('data-round');
     this.tall = rootElement.getAttribute('data-tall');
     this.description = rootElement.getAttribute('data-description');
+    /** @type {?string} */
     this.media = null;
+    /** @type {?string} */
     this.url = null;
+    /** @type {?string} */
     this.href = null;
   }
 


### PR DESCRIPTION
when we remove assert methods as a preprocess step, this changes the type flow as `assert` methods do a type cast. We need to add the typecast annotation to replace the removed method.

we special case `null` literals passed into `assert` methods as they are sometimes used in abstract classes methods to enforce subclasses to implement.