### PR TITLE
🐛  re-fetch entitlements on reset

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -133,7 +133,7 @@ export class GoogleSubscriptionsPlatform {
 
   /** @private */
   onLinkComplete_() {
-    this.serviceAdapter_.reAuthorizePlatform(this);
+    this.serviceAdapter_.resetPlatforms();
   }
 
   /** @private */
@@ -160,7 +160,7 @@ export class GoogleSubscriptionsPlatform {
    */
   onSubscribeResponse_(response) {
     response.complete().then(() => {
-      this.serviceAdapter_.reAuthorizePlatform(this);
+      this.serviceAdapter_.resetPlatforms();
     });
   }
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -224,15 +224,13 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should reauthorize on complete linking', () => {
-    serviceAdapterMock.expects('reAuthorizePlatform')
-        .withExactArgs(platform)
+    serviceAdapterMock.expects('resetPlatforms')
         .once();
     callback(callbacks.linkComplete)();
   });
 
   it('should reauthorize on canceled linking', () => {
-    serviceAdapterMock.expects('reAuthorizePlatform')
-        .withExactArgs(platform)
+    serviceAdapterMock.expects('resetPlatforms')
         .once();
     callback(callbacks.flowCanceled)({flow: 'linkAccount'});
   });
@@ -241,8 +239,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     const promise = Promise.resolve();
     const response = new SubscribeResponse(null, null, null, null,
         () => promise);
-    serviceAdapterMock.expects('reAuthorizePlatform')
-        .withExactArgs(platform)
+    serviceAdapterMock.expects('resetPlatforms')
         .once();
     callback(callbacks.subscribeResponse)(Promise.resolve(response));
     expect(methods.reset).to.not.be.called;

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -496,10 +496,12 @@ export class SubscriptionService {
     );
     this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED,
+        ''
     );
     // deprecated event fired for backward compatibility
     this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED_DEPRECATED,
+        ''
     );
     this.startAuthorizationFlow_();
   }

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -482,10 +482,7 @@ export class SubscriptionService {
    * external event (for example a login)
    */
   resetPlatforms() {
-    const serviceIds = this.platformConfig_['services'].map(service =>
-      service['serviceId'] || 'local');
-
-    this.initializePlatformStore_(serviceIds);
+    this.platformStore_ = this.platformStore_.resetPlatformStore();
     this.renderer_.toggleLoading(true);
 
     this.platformConfig_['services'].forEach(service => {

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -480,7 +480,6 @@ export class SubscriptionService {
   /**
    * Re authorizes a platform
    * @param {!SubscriptionPlatform} subscriptionPlatform
-   * @return {!Promise}
    */
   reAuthorizePlatform(subscriptionPlatform) {
     this.platformStore_.getAvailablePlatforms()
@@ -488,21 +487,20 @@ export class SubscriptionService {
           platform.reset();
           this.platformStore_.resetEntitlementFor(
               platform.getServiceId());
+          this.fetchEntitlements_(platform);
         });
     this.renderer_.toggleLoading(true);
-    return this.fetchEntitlements_(subscriptionPlatform).then(() => {
-      this.subscriptionAnalytics_.serviceEvent(
-          SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED,
-          subscriptionPlatform.getServiceId()
-      );
-      // deprecated event fired for backward compatibility
-      this.subscriptionAnalytics_.serviceEvent(
-          SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED_DEPRECATED,
-          subscriptionPlatform.getServiceId()
-      );
-      this.platformStore_.reset();
-      this.startAuthorizationFlow_();
-    });
+    this.subscriptionAnalytics_.serviceEvent(
+        SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED,
+        subscriptionPlatform.getServiceId()
+    );
+    // deprecated event fired for backward compatibility
+    this.subscriptionAnalytics_.serviceEvent(
+        SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED_DEPRECATED,
+        subscriptionPlatform.getServiceId()
+    );
+    this.platformStore_.reset();
+    this.startAuthorizationFlow_();
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -482,6 +482,7 @@ export class SubscriptionService {
    * @param {!SubscriptionPlatform} subscriptionPlatform
    */
   reAuthorizePlatform(subscriptionPlatform) {
+    this.platformStore_.reset();
     this.platformStore_.getAvailablePlatforms()
         .forEach(platform => {
           platform.reset();
@@ -499,7 +500,6 @@ export class SubscriptionService {
         SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED_DEPRECATED,
         subscriptionPlatform.getServiceId()
     );
-    this.platformStore_.reset();
     this.startAuthorizationFlow_();
   }
 

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -172,7 +172,7 @@ export class LocalSubscriptionPlatform {
     const actionExecution = this.actions_.execute(action);
     return actionExecution.then(result => {
       if (result) {
-        this.serviceAdapter_.reAuthorizePlatform(this);
+        this.serviceAdapter_.resetPlatforms();
       }
       return !!result;
     });

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -45,7 +45,8 @@ export class PlatformStore {
    * @param {!./entitlement.Entitlement} fallbackEntitlement
    * @param {JsonObject} optPlatforms
    */
-  constructor(expectedServiceIds, scoreConfig, fallbackEntitlement, optPlatforms) {
+  constructor(expectedServiceIds, scoreConfig,
+    fallbackEntitlement, optPlatforms) {
 
     /** @private @const {!Object<string, !./subscription-platform.SubscriptionPlatform>} */
     this.subscriptionPlatforms_ = optPlatforms || dict();

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -43,11 +43,12 @@ export class PlatformStore {
    * @param {!Array<string>} expectedServiceIds
    * @param {!JsonObject} scoreConfig
    * @param {!./entitlement.Entitlement} fallbackEntitlement
+   * @param {JsonObject} optPlatforms
    */
-  constructor(expectedServiceIds, scoreConfig, fallbackEntitlement) {
+  constructor(expectedServiceIds, scoreConfig, fallbackEntitlement, optPlatforms) {
 
     /** @private @const {!Object<string, !./subscription-platform.SubscriptionPlatform>} */
-    this.subscriptionPlatforms_ = dict();
+    this.subscriptionPlatforms_ = optPlatforms || dict();
 
     /** @private @const {!Array<string>} */
     this.serviceIds_ = expectedServiceIds;
@@ -105,6 +106,20 @@ export class PlatformStore {
     this.onPlatformResolvedCallbacks_.fire({
       serviceId,
     });
+  }
+
+  /**
+   * Reset the platformStore via a factory that returns a
+   * new PlatformStore with the same platforms as this one.
+   * @return {PlatformStore}
+   */
+  resetPlatformStore() {
+    return new PlatformStore(
+        this.serviceIds_,
+        this.scoreConfig_,
+        this.fallbackEntitlement_,
+        this.subscriptionPlatforms_,
+    );
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -41,15 +41,15 @@ let PlatformWeightDef;
 export class PlatformStore {
   /**
    * @param {!Array<string>} expectedServiceIds
-   * @param {!JsonObject} scoreConfig
+   * @param {!JsonObject|Object<string, number>} scoreConfig
    * @param {!./entitlement.Entitlement} fallbackEntitlement
-   * @param {JsonObject} optPlatforms
+   * @param {Object<string, !./subscription-platform.SubscriptionPlatform>=} opt_Platforms
    */
   constructor(expectedServiceIds, scoreConfig,
-    fallbackEntitlement, optPlatforms) {
+    fallbackEntitlement, opt_Platforms) {
 
     /** @private @const {!Object<string, !./subscription-platform.SubscriptionPlatform>} */
-    this.subscriptionPlatforms_ = optPlatforms || dict();
+    this.subscriptionPlatforms_ = opt_Platforms || dict();
 
     /** @private @const {!Array<string>} */
     this.serviceIds_ = expectedServiceIds;
@@ -119,7 +119,7 @@ export class PlatformStore {
         this.serviceIds_,
         this.scoreConfig_,
         this.fallbackEntitlement_,
-        this.subscriptionPlatforms_,
+        this.subscriptionPlatforms_
     );
   }
 

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -216,15 +216,6 @@ export class PlatformStore {
   }
 
   /**
-   * @param {string} serviceId
-   */
-  resetEntitlementFor(serviceId) {
-    dev().assert(this.entitlementDeferredMap_[serviceId],
-        `Platform ${serviceId} is not declared`);
-    this.entitlementDeferredMap_[serviceId] = new Deferred();
-  }
-
-  /**
    * @return {!Promise<boolean>}
    */
   getGrantStatus() {

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -75,10 +75,9 @@ export class ServiceAdapter {
 
   /**
    * Reauthorize platforms
-   * @param {!./subscription-platform.SubscriptionPlatform} subscriptionPlatform
    */
-  reAuthorizePlatform(subscriptionPlatform) {
-    this.subscriptionService_.reAuthorizePlatform(subscriptionPlatform);
+  resetPlatforms() {
+    this.subscriptionService_.resetPlatforms();
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -483,36 +483,21 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       });
     });
 
-    it('should reset entitlement on re-authorization', () => {
+    it('should reset platform on re-authorization', () => {
+      const service = serviceConfig.services[0];
+      subscriptionService.serviceAdapter_ =
+        new ServiceAdapter(subscriptionService);
+      subscriptionService.platformConfig_ = serviceConfig;
+      subscriptionService.pageConfig_ = pageConfig;
+      subscriptionService.platformStore_ = new PlatformStore(['local']);
+      subscriptionService.initializeLocalPlatforms_(service);
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      const resetEntitlementsStub = sandbox.stub(
-          subscriptionService.platformStore_,
-          'resetEntitlementFor');
+      const initPlatformsStub = sandbox.stub(
+          subscriptionService, 'initializePlatformStore_');
       sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
-      subscriptionService.reAuthorizePlatform(platform);
-      expect(resetEntitlementsStub).to.be.calledOnce.calledWith('local');
-    });
-
-    it('should reset UI in all platforms on re-authorization', () => {
-      const entitlement = Entitlement.empty('local');
-      sandbox.stub(platform, 'getEntitlements')
-          .callsFake(() => Promise.resolve(entitlement));
-      sandbox.stub(subscriptionService.platformStore_, 'resetEntitlementFor');
-      sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
-
-      const localResetStub = sandbox.stub(platform, 'reset');
-      subscriptionService.platformStore_.resolvePlatform('local', platform);
-
-      const otherPlatform = new LocalSubscriptionPlatform(ampdoc,
-          serviceConfig.services[0],
-          serviceAdapter);
-      const otherResetStub = sandbox.stub(otherPlatform, 'reset');
-      subscriptionService.platformStore_.resolvePlatform(
-          'other', otherPlatform);
-
-      subscriptionService.reAuthorizePlatform(platform);
-      expect(localResetStub).to.be.calledOnce;
-      expect(otherResetStub).to.be.calledOnce;
+      subscriptionService.resetPlatforms();
+      expect(initPlatformsStub).to.be.calledOnce
+          .calledWith(['local', 'google.subscription']);
     });
   });
 

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -492,12 +492,14 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.platformStore_ = new PlatformStore(['local']);
       subscriptionService.initializeLocalPlatforms_(service);
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      const initPlatformsStub = sandbox.stub(
-          subscriptionService, 'initializePlatformStore_');
+      const resetSubscriptionPlatformSpy = sandbox.spy(
+          subscriptionService.platformStore_, 'resetPlatformStore');
       sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
+      const origPlatforms = subscriptionService.platformStore_.serviceIds_;
       subscriptionService.resetPlatforms();
-      expect(initPlatformsStub).to.be.calledOnce
-          .calledWith(['local', 'google.subscription']);
+      expect(resetSubscriptionPlatformSpy).to.be.calledOnce;
+      expect(subscriptionService.platformStore_.serviceIds_)
+          .to.equal(origPlatforms);
     });
   });
 

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -485,17 +485,12 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
 
     it('should reset entitlement on re-authorization', () => {
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      const entitlement = new Entitlement({source: 'local', raw: 'raw',
-        granted: true, grantReason: GrantReason.SUBSCRIBER});
-      sandbox.stub(platform, 'getEntitlements')
-          .callsFake(() => Promise.resolve(entitlement));
       const resetEntitlementsStub = sandbox.stub(
           subscriptionService.platformStore_,
           'resetEntitlementFor');
       sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
-      return subscriptionService.reAuthorizePlatform(platform).then(() => {
-        expect(resetEntitlementsStub).to.be.calledOnce.calledWith('local');
-      });
+      subscriptionService.reAuthorizePlatform(platform);
+      expect(resetEntitlementsStub).to.be.calledOnce.calledWith('local');
     });
 
     it('should reset UI in all platforms on re-authorization', () => {
@@ -515,10 +510,9 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.platformStore_.resolvePlatform(
           'other', otherPlatform);
 
-      return subscriptionService.reAuthorizePlatform(platform).then(() => {
-        expect(localResetStub).to.be.calledOnce;
-        expect(otherResetStub).to.be.calledOnce;
-      });
+      subscriptionService.reAuthorizePlatform(platform);
+      expect(localResetStub).to.be.calledOnce;
+      expect(otherResetStub).to.be.calledOnce;
     });
   });
 

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -250,13 +250,12 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       const executeStub =
         sandbox.stub(localSubscriptionPlatform.actions_, 'execute')
             .callsFake(() => Promise.resolve(true));
-      const entitlementsStub = sandbox.stub(
-          localSubscriptionPlatform.serviceAdapter_,
-          'reAuthorizePlatform');
+      const resetStub = sandbox.stub(
+          serviceAdapter, 'resetPlatforms');
       localSubscriptionPlatform.executeAction(actionString);
       expect(executeStub).to.be.calledWith(actionString);
       return executeStub().then(() => {
-        expect(entitlementsStub).to.be.calledOnce;
+        expect(resetStub).to.be.calledOnce;
       });
     });
   });

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -79,22 +79,6 @@ describes.realWin('Platform store', {}, () => {
     return expect(p).to.eventually.equal(ent);
   });
 
-  it('should reset entitlement', () => {
-    // Request entitlement promise even before it's resolved.
-    const p = platformStore.getEntitlementPromiseFor('service2');
-
-    // Resolve once.
-    platformStore.resolveEntitlement('service2', new Entitlement({
-      service: 'service2',
-      granted: false,
-    }));
-    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
-
-    // Reset: new entitlement promise.
-    platformStore.resetEntitlementFor('service2');
-    expect(platformStore.getEntitlementPromiseFor('service2')).to.not.equal(p);
-  });
-
   it('should call onChange callbacks on every resolve', () => {
     const cb = sandbox.stub(platformStore.onEntitlementResolvedCallbacks_,
         'fire');

--- a/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
@@ -27,6 +27,17 @@ env => {
   let subscriptionService;
   let serviceAdapter;
   let pageConfig;
+  const serviceConfig = {
+    services: [
+      {
+        authorizationUrl: 'https://lipsum.com/authorize',
+        actions: {
+          subscribe: 'https://lipsum.com/subscribe',
+          login: 'https://lipsum.com/login',
+        },
+      },
+    ],
+  };
   beforeEach(() => {
     pageConfig = new PageConfig('example.org:basic', true);
     ampdoc = env.ampdoc;
@@ -35,7 +46,7 @@ env => {
     const element = win.document.createElement('script');
     element.id = 'amp-subscriptions';
     element.setAttribute('type', 'json');
-    element.innerHTML = JSON.stringify({});
+    element.innerHTML = JSON.stringify(serviceConfig);
     win.document.body.appendChild(element);
     subscriptionService = new SubscriptionService(ampdoc);
     serviceAdapter = new ServiceAdapter(subscriptionService);
@@ -72,10 +83,11 @@ env => {
     });
   });
 
-  describe('reAuthorizePlatform', () => {
-    it('should call reAuthorizePlatform of subscription service', () => {
-      const stub = sandbox.stub(subscriptionService, 'reAuthorizePlatform');
-      serviceAdapter.reAuthorizePlatform();
+  describe('resetPlatforms', () => {
+    it('should call initializePlatformStore_', () => {
+      const stub = sandbox.stub(
+          subscriptionService, 'resetPlatforms');
+      serviceAdapter.resetPlatforms();
       expect(stub).to.be.calledOnce;
     });
   });


### PR DESCRIPTION
re-fetch entitlements for all platforms in `reAuthorizePlatform`.  

Notable change: `reAuthorizePlatform`  is now `resetPlatforms` - calls `initializePlatformnStore_` to reset to starting condition.
