### PR TITLE
convert some `dev().assert` calls to `user().assert` calls

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -630,7 +630,7 @@ export class AmpSlideScroll extends BaseSlides {
     if (this.slideIndex_ !== null) {
       this.updateInViewport(this.slides_[
           user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')],
-              false);
+      false);
     }
     const newSlideInView = this.slides_[newIndex];
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -20,7 +20,7 @@ import {BaseSlides} from './base-slides';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
 import {createCustomEvent} from '../../../src/event-helper';
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getStyle, setStyle} from '../../../src/style';
 import {isExperimentOn} from '../../../src/experiments';
@@ -282,7 +282,8 @@ export class AmpSlideScroll extends BaseSlides {
     if (this.slideIndex_ !== null) {
       // Reset scrollLeft on orientationChange.
       this.slidesContainer_./*OK*/scrollLeft =
-          this.getScrollLeftForIndex_(dev().assertNumber(this.slideIndex_));
+          this.getScrollLeftForIndex_(user().assertNumber(this.slideIndex_,
+            `E#19457 this.slideIndex_:"${this.slideIndex_}"`));
       this.previousScrollLeft_ = this.slidesContainer_./*OK*/scrollLeft;
     }
   }
@@ -296,7 +297,8 @@ export class AmpSlideScroll extends BaseSlides {
       // it will need to be re-laid-out. This is only needed when the slide
       // does not change (example when browser window size changes,
       // or orientation changes)
-      this.scheduleLayout(this.slides_[dev().assertNumber(this.slideIndex_)]);
+      this.scheduleLayout(this.slides_[user().assertNumber(this.slideIndex_,
+        `E#19457 this.slideIndex_:"${this.slideIndex_}"`)]);
     }
     return Promise.resolve();
   }
@@ -311,7 +313,8 @@ export class AmpSlideScroll extends BaseSlides {
   updateViewportState(inViewport) {
     if (this.slideIndex_ !== null) {
       this.updateInViewport(
-          this.slides_[dev().assertNumber(this.slideIndex_)], inViewport);
+          this.slides_[user().assertNumber(this.slideIndex_,
+            `E#19457 this.slideIndex_:"${this.slideIndex_}"`)], inViewport);
     }
   }
 
@@ -626,7 +629,8 @@ export class AmpSlideScroll extends BaseSlides {
     }
     if (this.slideIndex_ !== null) {
       this.updateInViewport(this.slides_[
-          dev().assertNumber(this.slideIndex_)], false);
+          user().assertNumber(this.slideIndex_,
+            `E#19457 this.slideIndex_:"${this.slideIndex_}"`)], false);
     }
     const newSlideInView = this.slides_[newIndex];
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -283,7 +283,7 @@ export class AmpSlideScroll extends BaseSlides {
       // Reset scrollLeft on orientationChange.
       this.slidesContainer_./*OK*/scrollLeft =
           this.getScrollLeftForIndex_(user().assertNumber(this.slideIndex_,
-            `E#19457 this.slideIndex_:"${this.slideIndex_}"`));
+              'E#19457 this.slideIndex_'));
       this.previousScrollLeft_ = this.slidesContainer_./*OK*/scrollLeft;
     }
   }
@@ -298,7 +298,7 @@ export class AmpSlideScroll extends BaseSlides {
       // does not change (example when browser window size changes,
       // or orientation changes)
       this.scheduleLayout(this.slides_[user().assertNumber(this.slideIndex_,
-        `E#19457 this.slideIndex_:"${this.slideIndex_}"`)]);
+          'E#19457 this.slideIndex_')]);
     }
     return Promise.resolve();
   }
@@ -314,7 +314,7 @@ export class AmpSlideScroll extends BaseSlides {
     if (this.slideIndex_ !== null) {
       this.updateInViewport(
           this.slides_[user().assertNumber(this.slideIndex_,
-            `E#19457 this.slideIndex_:"${this.slideIndex_}"`)], inViewport);
+              'E#19457 this.slideIndex_')], inViewport);
     }
   }
 
@@ -629,8 +629,8 @@ export class AmpSlideScroll extends BaseSlides {
     }
     if (this.slideIndex_ !== null) {
       this.updateInViewport(this.slides_[
-          user().assertNumber(this.slideIndex_,
-            `E#19457 this.slideIndex_:"${this.slideIndex_}"`)], false);
+          user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')],
+              false);
     }
     const newSlideInView = this.slides_[newIndex];
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -482,8 +482,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       if (isInStandardMode && descriptionOverflows) {
         this.descriptionBox_.classList.remove('i-amphtml-lbg-standard');
         this.descriptionBox_.classList.add('i-amphtml-lbg-overflow');
-        toggle(dev().assertElement(this.navControls_), false);
-        toggle(dev().assertElement(this.topBar_), false);
+        toggle(user().assertElement(this.navControls_,
+            `E#19457 this.navControls_:"${this.navControls_}"`), false);
+        toggle(user().assertElement(this.topBar_,
+            `E#19457 this.topBar_:"${this.topBar_}"`), false);
       } else if (isInOverflowMode) {
         this.clearDescOverflowState_();
       }
@@ -499,8 +501,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.descriptionBox_./*OK*/scrollTop = 0;
     this.descriptionBox_.classList.remove('i-amphtml-lbg-overflow');
     this.descriptionBox_.classList.add('i-amphtml-lbg-standard');
-    toggle(dev().assertElement(this.navControls_), true);
-    toggle(dev().assertElement(this.topBar_), true);
+    toggle(user().assertElement(this.navControls_,
+        `E#19457 this.navControls_:"${this.navControls_}"`), true);
+    toggle(user().assertElement(this.topBar_,
+        `E#19457 this.topBar_:"${this.topBar_}"`), true);
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -483,9 +483,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         this.descriptionBox_.classList.remove('i-amphtml-lbg-standard');
         this.descriptionBox_.classList.add('i-amphtml-lbg-overflow');
         toggle(user().assertElement(this.navControls_,
-            `E#19457 this.navControls_:"${this.navControls_}"`), false);
-        toggle(user().assertElement(this.topBar_,
-            `E#19457 this.topBar_:"${this.topBar_}"`), false);
+            'E#19457 this.navControls_'), false);
+        toggle(user().assertElement(this.topBar_, 'E#19457 this.topBar_'),
+            false);
       } else if (isInOverflowMode) {
         this.clearDescOverflowState_();
       }
@@ -502,9 +502,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.descriptionBox_.classList.remove('i-amphtml-lbg-overflow');
     this.descriptionBox_.classList.add('i-amphtml-lbg-standard');
     toggle(user().assertElement(this.navControls_,
-        `E#19457 this.navControls_:"${this.navControls_}"`), true);
+        'E#19457 this.navControls_'), true);
     toggle(user().assertElement(this.topBar_,
-        `E#19457 this.topBar_:"${this.topBar_}"`), true);
+        'E#19457 this.topBar_'), true);
   }
 
   /**

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -152,7 +152,8 @@ class AmpLightbox extends AMP.BaseElement {
 
     /** @const {function()} */
     this.boundReschedule_ = debounce(this.win, () => {
-      const container = dev().assertElement(this.container_);
+      const container = user().assertElement(this.container_,
+          `E#19457 this.container_:"${this.container_}"`);
       this.scheduleLayout(container);
       this.scheduleResume(container);
     }, 500);

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -153,7 +153,7 @@ class AmpLightbox extends AMP.BaseElement {
     /** @const {function()} */
     this.boundReschedule_ = debounce(this.win, () => {
       const container = user().assertElement(this.container_,
-          `E#19457 this.container_:"${this.container_}"`);
+          'E#19457 this.container_');
       this.scheduleLayout(container);
       this.scheduleResume(container);
     }, 500);

--- a/src/impression.js
+++ b/src/impression.js
@@ -57,7 +57,8 @@ const TRUSTED_REFERRER_HOSTS = [
  * @return {!Promise}
  */
 export function getTrackImpressionPromise() {
-  return dev().assert(trackImpressionPromise);
+  return user().assert(trackImpressionPromise,
+      `E#19457 trackImpressionPromise:"${trackImpressionPromise}"`);
 }
 
 /**

--- a/src/impression.js
+++ b/src/impression.js
@@ -58,7 +58,7 @@ const TRUSTED_REFERRER_HOSTS = [
  */
 export function getTrackImpressionPromise() {
   return user().assert(trackImpressionPromise,
-      `E#19457 trackImpressionPromise:"${trackImpressionPromise}"`);
+      'E#19457 trackImpressionPromise');
 }
 
 /**


### PR DESCRIPTION
When we remove the method calls (assert method of any type) and add a
straight type cast annotation, closure seems to infer that the values
for these instances are not of that exact type (meaning they could be
null). To prove this, I am switching the calls over to `user` type calls
so that we don't remove the method call and add an error message that I
can trace better.
