### PR TITLE
Disallow passing node to more service getters

### DIFF
--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -140,8 +140,9 @@ export class GwdAnimation extends AMP.BaseElement {
 
       const setCurrentPageAction =
           `${this.element.id}.setCurrentPage(index=event.index)`;
-      const nodeOrDoc = this.fie_ ? this.element : this.getAmpDoc();
-      addAction(nodeOrDoc, gwdPageDeck, 'slideChange', setCurrentPageAction);
+      const elementOrAmpDoc = this.fie_ ? this.element : this.getAmpDoc();
+      addAction(elementOrAmpDoc, gwdPageDeck, 'slideChange',
+          setCurrentPageAction);
     }
 
     // Register handlers for supported actions.
@@ -247,21 +248,20 @@ export class GwdAnimation extends AMP.BaseElement {
 }
 
 /**
- * Adds an event action definition to a node.
- * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc The node
- *     or AmpDoc reference for retrieving the action service. The node rather
- *     than the doc is provided when in a FIE.
- * @param {!Element} element The target element whose actions to update.
+ * Adds an event action definition to an element.
+ * @param {!Element|!../../../src/service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+ * @param {!Element} target The target element whose actions to update.
  * @param {string} event The event name, e.g., 'slideChange'.
  * @param {string} actionStr e.g., `someDiv.hide`.
- * @private Visible for testing.
+ * @private
+ * @visibleForTesting
  */
-export function addAction(nodeOrDoc, element, event, actionStr) {
+export function addAction(elementOrAmpDoc, target, event, actionStr) {
   // Assemble the new actions string by splicing in the new action string
   // with any existing actions.
   let newActionsStr;
 
-  const currentActionsStr = element.getAttribute('on') || '';
+  const currentActionsStr = target.getAttribute('on') || '';
   const eventPrefix = `${event}:`;
   const eventActionsIndex = currentActionsStr.indexOf(eventPrefix);
 
@@ -284,7 +284,8 @@ export function addAction(nodeOrDoc, element, event, actionStr) {
   }
 
   // Reset the element's actions with the new actions string.
-  Services.actionServiceForDoc(nodeOrDoc).setActions(element, newActionsStr);
+  const actionService = Services.actionServiceForDoc(elementOrAmpDoc);
+  actionService.setActions(target, newActionsStr);
 }
 
 AMP.extension(TAG, '0.1', AMP => {

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -579,7 +579,10 @@ export class Navigation {
    */
   parseUrl_(url) {
     // Must use URL parsing scoped to this.rootNode_ for correct FIE behavior.
-    return Services.urlForDoc(this.rootNode_).parse(url);
+    const elementOrAmpDoc = (this.rootNode_.nodeType == Node.DOCUMENT_NODE)
+      ? this.rootNode_.documentElement
+      : this.ampdoc;
+    return Services.urlForDoc(elementOrAmpDoc).parse(url);
   }
 }
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -67,7 +67,8 @@ export class StandardActions {
 
   /** @override */
   adoptEmbedWindow(embedWin) {
-    this.installActions_(Services.actionServiceForDoc(embedWin.document));
+    const element = embedWin.document.documentElement;
+    this.installActions_(Services.actionServiceForDoc(element));
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -89,8 +89,7 @@ export class Services {
    */
   static actionServiceForDoc(elementOrAmpDoc) {
     return /** @type {!./service/action-impl.ActionService} */ (
-      getExistingServiceForDocInEmbedScope(
-          elementOrAmpDoc, 'action', /* opt_fallbackToTopWin */ true));
+      getExistingServiceForDocInEmbedScope(elementOrAmpDoc, 'action'));
   }
 
   /**
@@ -482,8 +481,7 @@ export class Services {
    */
   static urlReplacementsForDoc(elementOrAmpDoc) {
     return /** @type {!./service/url-replacements-impl.UrlReplacements} */ (
-      getExistingServiceForDocInEmbedScope(
-          elementOrAmpDoc, 'url-replace', /* opt_fallbackToTopWin */ true));
+      getExistingServiceForDocInEmbedScope(elementOrAmpDoc, 'url-replace'));
   }
 
   /**
@@ -526,8 +524,7 @@ export class Services {
    */
   static urlForDoc(elementOrAmpDoc) {
     return /** @type {!./service/url-impl.Url} */ (
-      getExistingServiceForDocInEmbedScope(
-          elementOrAmpDoc, 'url', /* opt_fallbackToTopWin */ true));
+      getExistingServiceForDocInEmbedScope(elementOrAmpDoc, 'url'));
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -84,15 +84,13 @@ export class Services {
   }
 
   /**
-   * Unlike most service getters, passing `Node` is necessary for some FIE-scope
-   * services since sometimes we only have the FIE Document for context.
-   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/action-impl.ActionService}
    */
-  static actionServiceForDoc(nodeOrDoc) {
+  static actionServiceForDoc(elementOrAmpDoc) {
     return /** @type {!./service/action-impl.ActionService} */ (
       getExistingServiceForDocInEmbedScope(
-          nodeOrDoc, 'action', /* opt_fallbackToTopWin */ true));
+          elementOrAmpDoc, 'action', /* opt_fallbackToTopWin */ true));
   }
 
   /**
@@ -479,15 +477,13 @@ export class Services {
   }
 
   /**
-   * Unlike most service getters, passing `Node` is necessary for some FIE-scope
-   * services since sometimes we only have the FIE Document for context.
-   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/url-replacements-impl.UrlReplacements}
    */
-  static urlReplacementsForDoc(nodeOrDoc) {
+  static urlReplacementsForDoc(elementOrAmpDoc) {
     return /** @type {!./service/url-replacements-impl.UrlReplacements} */ (
       getExistingServiceForDocInEmbedScope(
-          nodeOrDoc, 'url-replace', /* opt_fallbackToTopWin */ true));
+          elementOrAmpDoc, 'url-replace', /* opt_fallbackToTopWin */ true));
   }
 
   /**
@@ -525,15 +521,13 @@ export class Services {
   }
 
   /**
-   * Unlike most service getters, passing `Node` is necessary for some FIE-scope
-   * services since sometimes we only have the FIE Document for context.
-   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/url-impl.Url}
    */
-  static urlForDoc(nodeOrDoc) {
+  static urlForDoc(elementOrAmpDoc) {
     return /** @type {!./service/url-impl.Url} */ (
       getExistingServiceForDocInEmbedScope(
-          nodeOrDoc, 'url', /* opt_fallbackToTopWin */ true));
+          elementOrAmpDoc, 'url', /* opt_fallbackToTopWin */ true));
   }
 
   /**


### PR DESCRIPTION
Partial for #16322.

Also removes `opt_fallbackToTopWin`. URL/URL replacement/action services should definitely not be shared across FIE and parent. I originally configured them as such because fallback was the default behavior.