### PR TITLE
Stop lightboxes from forwarding hotkeys to viewer

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -850,6 +850,7 @@ class AmpImageLightbox extends AMP.BaseElement {
    */
   closeOnEscape_(event) {
     if (event.key == Keys.ESCAPE) {
+      event.preventDefault();
       this.close();
     }
   }

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -190,7 +190,7 @@ describes.realWin('amp-image-lightbox component', {
       ampImage.setAttribute('width', '100');
       ampImage.setAttribute('height', '100');
       impl.activate({caller: ampImage});
-      impl.closeOnEscape_({key: Keys.ESCAPE});
+      impl.closeOnEscape_(new KeyboardEvent('keydown', {key: Keys.ESCAPE}));
       expect(setupCloseSpy).to.be.calledOnce;
 
       // Regression test: ensure escape event listener is bound properly

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -396,6 +396,7 @@ class AmpLightbox extends AMP.BaseElement {
    */
   closeOnEscape_(event) {
     if (event.key == Keys.ESCAPE) {
+      event.preventDefault();
       this.close();
     }
   }


### PR DESCRIPTION
The keyboard event handler in the AMP viewer extension stops forwarding
keyboard events to the viewer if the event is marked as "default
prevented". For hotkeys used by amp-lightbox and amp-image-lightbox
(i.e., the ESC key), since they are already consumed by the AMP
component they should not be forwarded to the viewer. This prevents
double-triggering a keyboard shortcut on the viewer side.

For more background, see #18437.

`b/117567983`