### PR TITLE
Disallow __amp_source_origin in dynamic URLs

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -170,7 +170,7 @@ export class BindValidator {
         const match = re.exec(url);
         if (match !== null) {
           const protocol = match[1].toLowerCase().trim();
-          // hasOwnProperty() needed since nested objects are not prototype-less.
+          // hasOwn() needed since nested objects are not prototype-less.
           if (!hasOwn(allowedProtocols, protocol)) {
             return false;
           }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -159,16 +159,21 @@ export class BindValidator {
    * @private
    */
   isUrlValid_(url, rules) {
-    // @see validator/engine/validator.ParsedUrlSpec.validateUrlAndProtocol()
-    const {allowedProtocols} = rules;
-    if (allowedProtocols && url) {
-      const re = /^([^:\/?#.]+):[\s\S]*$/;
-      const match = re.exec(url);
-      if (match !== null) {
-        const protocol = match[1].toLowerCase().trim();
-        // hasOwnProperty() needed since nested objects are not prototype-less.
-        if (!hasOwn(allowedProtocols, protocol)) {
-          return false;
+    // @see validator/engine/validator.js#validateUrlAndProtocol()
+    if (url) {
+      if (/__amp_source_origin/.test(url)) {
+        return false;
+      }
+      const {allowedProtocols} = rules;
+      if (allowedProtocols) {
+        const re = /^([^:\/?#.]+):[\s\S]*$/;
+        const match = re.exec(url);
+        if (match !== null) {
+          const protocol = match[1].toLowerCase().trim();
+          // hasOwnProperty() needed since nested objects are not prototype-less.
+          if (!hasOwn(allowedProtocols, protocol)) {
+            return false;
+          }
         }
       }
     }

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -188,6 +188,8 @@ describe('BindValidator (allowUrlProperties=true)', () => {
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
       expect(val.isResultValid('AMP-IMG', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-IMG', 'src', '?__amp_source_origin=foo')).to.be.false;
 
       expect(val.isResultValid(
           'AMP-IMG',
@@ -197,6 +199,10 @@ describe('BindValidator (allowUrlProperties=true)', () => {
           'AMP-IMG',
           'srcset',
           /* eslint no-script-url: 0 */ 'javascript:alert(1);')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-IMG',
+          'src',
+          'http://a.com/b.jpg 1x, ?__amp_source_origin=foo 2x')).to.be.false;
     });
 
     it('should support <amp-carousel>', () => {

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -218,10 +218,13 @@ const BLACKLISTED_TAG_SPECIFIC_ATTRS = dict({
 });
 
 /**
- * Test for invalid `style` attribute values. `!important` is a general AMP
- * rule, while `position:fixed|sticky` is a current runtime limitation since
- * FixedLayer only scans the amp-custom stylesheet for potential fixed/sticky
- * elements.
+ * Test for invalid `style` attribute values.
+ *
+ * !important avoids overriding AMP styles, while `position:fixed|sticky` is a
+ * FixedLayer limitation (it only scans the style[amp-custom] stylesheet
+ * for potential fixed/sticky elements). Note that the latter can be
+ * circumvented with CSS comments -- not a big deal.
+ *
  * @const {!RegExp}
  */
 const INVALID_INLINE_STYLE_REGEX =
@@ -533,14 +536,18 @@ export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
     }
   }
 
-  // Inline styles are not allowed.
+  // Don't allow certain inline style values.
   if (attrName == 'style') {
     return !INVALID_INLINE_STYLE_REGEX.test(attrValue);
   }
 
   // Don't allow CSS class names with internal AMP prefix.
-  // See https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii
   if (attrName == 'class' && attrValue && /(^|\W)i-amphtml-/i.test(attrValue)) {
+    return false;
+  }
+
+  // Don't allow '__amp_source_origin' in URLs.
+  if (isUrlAttribute(attrName) && /__amp_source_origin/.test(attrValue)) {
     return false;
   }
 
@@ -612,20 +619,27 @@ export function rewriteAttributesForElement(
 /**
  * If (tagName, attrName) is a CDN-rewritable URL attribute, returns the
  * rewritten URL value. Otherwise, returns the unchanged `attrValue`.
- * @see resolveUrlAttr for rewriting rules.
- * @param {string} tagName
- * @param {string} attrName
+ * See resolveUrlAttr() for rewriting rules.
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
  * @return {string}
- * @private Visible for testing.
+ * @private
+ * @visibleForTesting
  */
 export function rewriteAttributeValue(tagName, attrName, attrValue) {
-  const tag = tagName.toLowerCase();
-  const attr = attrName.toLowerCase();
-  if (attr == 'src' || attr == 'href' || attr == 'srcset') {
-    return resolveUrlAttr(tag, attr, attrValue, self.location);
+  if (isUrlAttribute(attrName)) {
+    return resolveUrlAttr(tagName, attrName, attrValue, self.location);
   }
   return attrValue;
+}
+
+/**
+ * @param {string} attrName Lowercase attribute name.
+ * @return {boolean}
+ */
+function isUrlAttribute(attrName) {
+  return (attrName == 'src' || attrName == 'href' || attrName == 'srcset');
 }
 
 /**
@@ -635,12 +649,13 @@ export function rewriteAttributeValue(tagName, attrName, attrValue) {
  * - If resulting URL is a `http:` URL and it's for image, the URL is rewritten
  *   again to be served with AMP Cache (cdn.ampproject.org).
  *
- * @param {string} tagName
- * @param {string} attrName
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
  * @param {!Location} windowLocation
  * @return {string}
- * @private Visible for testing.
+ * @private
+ * @visibleForTesting
  */
 export function resolveUrlAttr(tagName, attrName, attrValue, windowLocation) {
   checkCorsUrl(attrValue);

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -511,8 +511,8 @@ export function purifyTagsForTripleMustache(html, doc = self.document) {
 
 /**
  * Whether the attribute/value is valid.
- * @param {string} tagName
- * @param {string} attrName
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
  * @param {boolean} opt_purify Is true, skips some attribute sanitizations
  *     that are already covered by DOMPurify.

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -222,7 +222,8 @@ export function sanitizeHtml(html, diffing) {
           // Bindings contain expressions and shouldn't be rewritten.
           const rewrite = (bindingAttribs.includes(i))
             ? attrValue
-            : rewriteAttributeValue(tagName, attrName, attrValue);
+            : rewriteAttributeValue(
+                tagName.toLowerCase(), attrName.toLowerCase(), attrValue);
           emit(htmlSanitizer.escapeAttrib(rewrite));
         }
         emit('"');

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -222,8 +222,7 @@ export function sanitizeHtml(html, diffing) {
           // Bindings contain expressions and shouldn't be rewritten.
           const rewrite = (bindingAttribs.includes(i))
             ? attrValue
-            : rewriteAttributeValue(
-                tagName.toLowerCase(), attrName.toLowerCase(), attrValue);
+            : rewriteAttributeValue(tagName, attrName, attrValue);
           emit(htmlSanitizer.escapeAttrib(rewrite));
         }
         emit('"');

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -18,7 +18,6 @@ import {
   purifyHtml,
   purifyTagsForTripleMustache,
   resolveUrlAttr,
-  rewriteAttributeValue,
   rewriteAttributesForElement,
 } from '../../src/purifier';
 

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -324,6 +324,8 @@ function runSanitizerTests() {
           'a<a target="_top">b</a>');
       expect(purify('a<a href="DATA:alert">b</a>')).to.be.equal(
           'a<a target="_top">b</a>');
+      expect(purify('a<a href="?__amp_source_origin=foo">b</a>')).to.be.equal(
+          'a<a target="_top">b</a>');
     });
 
     it('should NOT output blacklisted values for class attributes', () => {

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -549,18 +549,6 @@ describe('rewriteAttributesForElement', () => {
   });
 });
 
-describe('rewriteAttributeValue', () => {
-  it('should be case-insensitive to tag and attribute name', () => {
-    expect(rewriteAttributeValue('a', 'href', '/doc2'))
-        .to.equal(rewriteAttributeValue('A', 'HREF', '/doc2'));
-    expect(rewriteAttributeValue('amp-img', 'src', '/jpeg1'))
-        .to.equal(rewriteAttributeValue('AMP-IMG', 'SRC', '/jpeg1'));
-    expect(rewriteAttributeValue('amp-img', 'srcset', '/jpeg2 2x, /jpeg1 1x'))
-        .to.equal(rewriteAttributeValue(
-            'AMP-IMG', 'SRCSET', '/jpeg2 2x, /jpeg1 1x'));
-  });
-});
-
 describe('resolveUrlAttr', () => {
   it('should throw if __amp_source_origin is set', () => {
     allowConsoleError(() => {


### PR DESCRIPTION
For consistency with validator. `b/68714728`

Also minor fix to avoid unnecessary lowercasing in `rewriteAttributeValue()`.