### PR TITLE
Save bookend state in window history

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -746,7 +746,8 @@ export class AmpStory extends AMP.BaseElement {
         this.element.querySelector('amp-story-page'),
         'Story must have at least one page.');
 
-    const initialPageId = this.getHistoryStatePageId_() || firstPageEl.id;
+    const initialPageId = this.getHistoryState_(HistoryStates.PAGE_ID) ||
+        firstPageEl.id;
 
     this.initializeSidebar_();
     this.setThemeColor_();
@@ -765,15 +766,17 @@ export class AmpStory extends AMP.BaseElement {
         })
         .then(() => this.initializeBookend_())
         .then(() => {
-          const bookendActive =
+          const bookendInHistory =
               !!this.getHistoryState_(HistoryStates.BOOKEND_ACTIVE);
-          return this.hasBookend_().then(hasBookend => {
-            if (hasBookend && bookendActive) {
-              // Ensure that when bookend is built in the switchTo_ call below,
-              // it will skip the opening animation.
-              this.openedBookend_ = true;
-            }
-          });
+          if (bookendInHistory) {
+            return this.hasBookend_().then(hasBookend => {
+              if (hasBookend) {
+                // Ensure that when bookend is built in the switchTo_ call
+                // below, it will skip the opening animation.
+                this.openedBookend_ = true;
+              }
+            });
+          }
         })
         .then(() => this.switchTo_(initialPageId))
         .then(() => {
@@ -1289,15 +1292,6 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    * */
   onCurrentPageIdUpdate_(pageId) {
-    this.setHistoryStatePageId_(pageId);
-  }
-
-  /**
-   * Save page id using history API.
-   * @param {string} pageId page id to be saved
-   * @private
-   */
-  setHistoryStatePageId_(pageId) {
     // Never save ad pages to history as they are unique to each visit.
     const page = this.getPageById(pageId);
     if (page.isAd()) {
@@ -1305,15 +1299,6 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     this.updateHistoryState_(HistoryStates.PAGE_ID, pageId);
-  }
-
-  /**
-   * @private
-   * @return {?string}
-   */
-  getHistoryStatePageId_() {
-    const state = getState(this.win.history);
-    return state ? state.ampStoryPageId : null;
   }
 
   /**
@@ -1663,18 +1648,8 @@ export class AmpStory extends AMP.BaseElement {
   onBookendStateUpdate_(isActive) {
     this.toggleElementsOnBookend_(/* display */ isActive);
     this.element.classList.toggle('i-amphtml-story-bookend-active', isActive);
-    this.setHistoryBookendState_(isActive);
-  }
-
-  /**
-   * Save bookend state using history API.
-   * @param {boolean} isActive state of the bookend
-   * @private
-   */
-  setHistoryBookendState_(isActive) {
     this.updateHistoryState_(HistoryStates.BOOKEND_ACTIVE, isActive);
   }
-
 
   /**
    * Updates the value for a given state in the window history.

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -312,9 +312,6 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {?MutationObserver} */
     this.sidebarObserver_ = null;
 
-    /** @private {?Array<string>} */
-    this.supportedOrientations_ = null;
-
     /** @private {?Element} */
     this.maskElement_ = null;
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -785,8 +785,9 @@ export class AmpStory extends AMP.BaseElement {
         .then(() => {
           this.hasBookend_().then(hasBookend => {
             if (hasBookend && bookendActive) {
-              this.showBookend_();
+              return this.showBookend_();
             }
+            return Promise.resolve();
           });
         });
 
@@ -1638,9 +1639,10 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Shows the bookend overlay.
    * @private
+   * @return {!Promise}
    */
   showBookend_() {
-    this.buildAndPreloadBookend_().then(() => {
+    return this.buildAndPreloadBookend_().then(() => {
       this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
     });
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1641,6 +1641,7 @@ export class AmpStory extends AMP.BaseElement {
    * Updates the value for a given state in the window history.
    * @param {string} stateName
    * @param {string|boolean} value
+   * @private
    */
   setHistoryState_(stateName, value) {
     const {history} = this.win;
@@ -1654,6 +1655,8 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Returns the value of a given state of the window history.
    * @param {string} stateName
+   * @return {?string}
+   * @private
    */
   getHistoryState_(stateName) {
     const {history} = this.win;
@@ -1662,7 +1665,6 @@ export class AmpStory extends AMP.BaseElement {
     }
     return null;
   }
-
 
   /**
    * Toggles content when bookend is opened/closed.

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1644,10 +1644,11 @@ export class AmpStory extends AMP.BaseElement {
    */
   setHistoryState_(stateName, value) {
     const {history} = this.win;
-    const newHistory = Object.assign({}, getState(history) || {},
+    const state = getState(history) || {};
+    const newHistory = Object.assign({}, /** @type {!Object} */ (state),
         {[stateName]: value});
 
-    history.replaceState(newHistory);
+    history.replaceState(newHistory, '');
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1615,10 +1615,9 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Shows the bookend overlay.
    * @private
-   * @return {!Promise}
    */
   showBookend_() {
-    return this.buildAndPreloadBookend_().then(() => {
+    this.buildAndPreloadBookend_().then(() => {
       this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
     });
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -748,7 +748,6 @@ export class AmpStory extends AMP.BaseElement {
 
     const initialPageId = this.getHistoryStatePageId_() || firstPageEl.id;
 
-    this.initializeBookend_();
     this.initializeSidebar_();
     this.setThemeColor_();
 
@@ -1305,14 +1304,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    const {history} = this.win;
-    if (history.replaceState && history.state &&
-        this.getHistoryStatePageId_() !== pageId) {
-      history.state.ampStoryPageId = pageId;
-      history.replaceState(history.state, '');
-    } else if (!history.state) {
-      history.replaceState({ampStoryPageId: pageId}, '');
-    }
+    this.updateHistoryState_(HistoryStates.PAGE_ID, pageId);
   }
 
   /**
@@ -1672,19 +1664,9 @@ export class AmpStory extends AMP.BaseElement {
     this.toggleElementsOnBookend_(/* display */ isActive);
     this.element.classList.toggle('i-amphtml-story-bookend-active', isActive);
     this.setHistoryBookendState_(isActive);
-
-    if (isActive) {
-      this.systemLayer_.hideDeveloperLog();
-      this.activePage_.setState(PageState.PAUSED);
-    }
-
-    if (!isActive) {
-      this.activePage_.setState(PageState.PLAYING);
-    }
   }
 
   /**
-   * Toggles content when bookend is opened/closed.
    * Save bookend state using history API.
    * @param {boolean} isActive state of the bookend
    * @private
@@ -1701,11 +1683,11 @@ export class AmpStory extends AMP.BaseElement {
    */
   updateHistoryState_(stateName, newValue) {
     const {history} = this.win;
-    if (history.replaceState && history.state &&
+    if (history.replaceState && getState(history) &&
         this.getHistoryState_(stateName) !== newValue) {
-      history.state[stateName] = newValue;
-      history.replaceState(history.state, '');
-    } else if (!history.state) {
+      getState(history)[stateName] = newValue;
+      history.replaceState(getState(history), '');
+    } else if (!getState(history)) {
       // First time writing to history state. Nothing to overwrite.
       history.replaceState({[stateName]: newValue}, '');
     }
@@ -1717,15 +1699,15 @@ export class AmpStory extends AMP.BaseElement {
    */
   getHistoryState_(stateName) {
     const {history} = this.win;
-    if (history && history.state) {
-      return history.state[stateName];
+    if (history && getState(history)) {
+      return getState(history)[stateName];
     }
     return null;
   }
 
 
   /**
-   * Toggle content when bookend is opened/closed.
+   * Toggles content when bookend is opened/closed.
    * @param {boolean} isActive
    * @private
    */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -747,7 +747,6 @@ export class AmpStory extends AMP.BaseElement {
         'Story must have at least one page.');
 
     const initialPageId = this.getHistoryStatePageId_() || firstPageEl.id;
-    const bookendActive = !!this.getHistoryState_(HistoryStates.BOOKEND_ACTIVE);
 
     this.initializeBookend_();
     this.initializeSidebar_();
@@ -766,7 +765,26 @@ export class AmpStory extends AMP.BaseElement {
           });
         })
         .then(() => this.initializeBookend_())
+        .then(() => {
+          const bookendActive =
+              !!this.getHistoryState_(HistoryStates.BOOKEND_ACTIVE);
+          return this.hasBookend_().then(hasBookend => {
+            if (hasBookend && bookendActive) {
+              // Ensure that when bookend is built in the switchTo_ call below,
+              // it will skip the opening animation.
+              this.openedBookend_ = true;
+            }
+          });
+        })
         .then(() => this.switchTo_(initialPageId))
+        .then(() => {
+          if (this.openedBookend_) {
+            // The bookend trigger must be done AFTER the swithTo_ call above
+            // to ensure the correct displaying of pagination buttons in
+            // desktop.
+            this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
+          }
+        })
         .then(() => this.updateViewportSizeStyles_())
         .then(() => {
           // Preloads and prerenders the share menu if mobile, where the share
@@ -780,9 +798,8 @@ export class AmpStory extends AMP.BaseElement {
             new InfoDialog(this.win, this.element) : null;
           if (infoDialog) {
             infoDialog.build();
-          }}
-        )
-        .then(() => this.checkForReturnToBookend_());
+          }
+        });
 
     // Do not block the layout callback on the completion of these promises, as
     // that prevents descendents from being laid out (and therefore loaded).
@@ -1305,7 +1322,6 @@ export class AmpStory extends AMP.BaseElement {
   getHistoryStatePageId_() {
     const state = getState(this.win.history);
     return state ? state.ampStoryPageId : null;
-    this.updateHistoryState_(HistoryStates.PAGE_ID, pageId);
   }
 
   /**
@@ -1630,22 +1646,6 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Checks if user returned from another page back to the bookend page and
-   * displays it.
-   * @return {!Promise}
-   * @private
-   */
-  checkForReturnToBookend_() {
-    const bookendActive = !!this.getHistoryState_(HistoryStates.BOOKEND_ACTIVE);
-
-    if (bookendActive) {
-      return this.showBookend_().then(() => bookendActive);
-    }
-    return Promise.resolve();
-  }
-
-
-  /**
    * Shows the bookend overlay.
    * @private
    * @return {!Promise}
@@ -1679,7 +1679,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     if (!isActive) {
-      this.activePage_.setState(PageState.ACTIVE);
+      this.activePage_.setState(PageState.PLAYING);
     }
   }
 
@@ -1897,7 +1897,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildAndPreloadBookend_() {
-    this.bookend_.build();
+    this.bookend_.build(this.openedBookend_);
     return this.bookend_.loadConfigAndMaybeRenderBookend();
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -771,22 +771,12 @@ export class AmpStory extends AMP.BaseElement {
           if (bookendInHistory) {
             return this.hasBookend_().then(hasBookend => {
               if (hasBookend) {
-                // Ensure that when bookend is built in the switchTo_ call
-                // below, it will skip the opening animation.
-                this.openedBookend_ = true;
+                this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
               }
             });
           }
         })
         .then(() => this.switchTo_(initialPageId))
-        .then(() => {
-          if (this.openedBookend_) {
-            // The bookend trigger must be done AFTER the swithTo_ call above
-            // to ensure the correct displaying of pagination buttons in
-            // desktop.
-            this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
-          }
-        })
         .then(() => this.updateViewportSizeStyles_())
         .then(() => {
           // Preloads and prerenders the share menu if mobile, where the share
@@ -1854,7 +1844,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildAndPreloadBookend_() {
-    this.bookend_.build(this.openedBookend_);
+    this.bookend_.build(!!this.getHistoryState_(HistoryStates.BOOKEND_ACTIVE));
     return this.bookend_.loadConfigAndMaybeRenderBookend();
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1288,7 +1288,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    this.updateHistoryState_(HistoryStates.PAGE_ID, pageId);
+    this.setHistoryState_(HistoryStates.PAGE_ID, pageId);
   }
 
   /**
@@ -1637,24 +1637,20 @@ export class AmpStory extends AMP.BaseElement {
   onBookendStateUpdate_(isActive) {
     this.toggleElementsOnBookend_(/* display */ isActive);
     this.element.classList.toggle('i-amphtml-story-bookend-active', isActive);
-    this.updateHistoryState_(HistoryStates.BOOKEND_ACTIVE, isActive);
+    this.setHistoryState_(HistoryStates.BOOKEND_ACTIVE, isActive);
   }
 
   /**
    * Updates the value for a given state in the window history.
    * @param {string} stateName
-   * @param {string|boolean} newValue
+   * @param {string|boolean} value
    */
-  updateHistoryState_(stateName, newValue) {
+  setHistoryState_(stateName, value) {
     const {history} = this.win;
-    if (history.replaceState && getState(history) &&
-        this.getHistoryState_(stateName) !== newValue) {
-      getState(history)[stateName] = newValue;
-      history.replaceState(getState(history), '');
-    } else if (!getState(history)) {
-      // First time writing to history state. Nothing to overwrite.
-      history.replaceState({[stateName]: newValue}, '');
-    }
+    const newHistory = Object.assign({}, getState(history) || {},
+        {[stateName]: value});
+
+    history.replaceState(newHistory);
   }
 
   /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -63,27 +63,32 @@ const BOOKEND_VERSION_KEY = 'bookendVersion';
  */
 const DEPRECATED_BOOKEND_VERSION_KEY = 'bookend-version';
 
-/** @private @const {!../simple-template.ElementDef} */
-const ROOT_TEMPLATE = {
-  tag: 'section',
-  attrs: dict({
-    'class': 'i-amphtml-story-bookend i-amphtml-story-system-reset ' +
-        HIDDEN_CLASSNAME}),
-  children: [
-    // Overflow container that gets pushed to the bottom when content height is
-    // smaller than viewport.
-    {
-      tag: 'div',
-      attrs: dict({'class': 'i-amphtml-story-bookend-overflow'}),
-      children: [
-        // Holds bookend content.
-        {
-          tag: 'div',
-          attrs: dict({'class': 'i-amphtml-story-bookend-inner'}),
-        },
-      ],
-    },
-  ],
+/**
+ * @param {string} hidden
+ * @return {!../simple-template.ElementDef}
+ */
+const buildRootTemplate = hidden => {
+  return /** @type {!../simple-template.ElementDef} */ ({
+    tag: 'section',
+    attrs: dict({
+      'class': 'i-amphtml-story-bookend i-amphtml-story-system-reset ' +
+          hidden}),
+    children: [
+      // Overflow container that gets pushed to the bottom when content height
+      // is smaller than viewport.
+      {
+        tag: 'div',
+        attrs: dict({'class': 'i-amphtml-story-bookend-overflow'}),
+        children: [
+          // Holds bookend content.
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-story-bookend-inner'}),
+          },
+        ],
+      },
+    ],
+  });
 };
 
 /** @private @const {!../simple-template.ElementDef} */
@@ -211,15 +216,18 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * Builds the bookend components and appends it to the provided story.
+   * @param {string} skipAnimation Skips opening animation of the bookend.
    */
-  build() {
+  build(skipAnimation = false) {
     if (this.isBuilt_) {
       return;
     }
 
     this.isBuilt_ = true;
 
-    this.bookendEl_ = renderAsElement(this.win.document, ROOT_TEMPLATE);
+    this.bookendEl_ =
+        renderAsElement(this.win.document, buildRootTemplate(skipAnimation ?
+          '' : HIDDEN_CLASSNAME));
 
     createShadowRootWithStyle(this.element, this.bookendEl_, CSS);
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -216,7 +216,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * Builds the bookend components and appends it to the provided story.
-   * @param {string} skipAnimation Skips opening animation of the bookend.
+   * @param {boolean} skipAnimation Skips opening animation of the bookend.
    */
   build(skipAnimation = false) {
     if (this.isBuilt_) {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -24,6 +24,7 @@ import {
 } from '../amp-story-store-service';
 import {ActionTrust} from '../../../../src/action-constants';
 import {AmpStory} from '../amp-story';
+import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryConsent} from '../amp-story-consent';
 import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../localization';
@@ -378,17 +379,21 @@ describes.realWin('amp-story', {
 
   it('should not block layoutCallback when bookend xhr fails', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
+
     sandbox.stub(story, 'getHistoryState_')
         .withArgs('ampStoryBookendActive')
         .returns(true);
+    sandbox.stub(AmpStoryBookend.prototype, 'build');
+    const bookendXhr = sandbox
+        .stub(AmpStoryBookend.prototype, 'loadConfigAndMaybeRenderBookend')
+        .returns(Promise.reject());
 
     story.buildCallback();
 
-    const bookendXhr =
-      sandbox.stub(story, 'showBookend_').returns(Promise.reject());
-
     return story.layoutCallback().then(() => {
       expect(bookendXhr).to.have.been.calledOnce;
+      expect(story.element.classList.contains('i-amphtml-story-loaded'))
+          .to.be.true;
     }).catch(error => {
       expect(error).to.be.undefined;
     });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -357,6 +357,25 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should update bookend status in browser history', () => {
+    const replaceStub = sandbox.stub(win.history, 'replaceState');
+    const pageCount = 1;
+    createPages(story.element, pageCount, ['last-page']);
+
+    sandbox.stub(story, 'buildAndPreloadBookend_');
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
+
+          return expect(replaceStub).to.have.been.calledWith(
+              {ampStoryBookendActive: true}, '',
+          );
+        });
+  });
+
   it('should NOT update page id in browser history if ad', () => {
     const firstPageId = 'i-amphtml-ad-page-1';
     const pageCount = 2;

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -362,7 +362,7 @@ describes.realWin('amp-story', {
     const pageCount = 1;
     createPages(story.element, pageCount, ['last-page']);
 
-    sandbox.stub(story, 'buildAndPreloadBookend_');
+    sandbox.stub(AmpStoryBookend.prototype, 'build');
 
     story.buildCallback();
 
@@ -378,12 +378,9 @@ describes.realWin('amp-story', {
 
 
   it('should not block layoutCallback when bookend xhr fails', () => {
-    createPages(story.element, 2, ['cover', 'page-1']);
-
-    sandbox.stub(story, 'getHistoryState_')
-        .withArgs('ampStoryBookendActive')
-        .returns(true);
+    createPages(story.element, 1, ['page-1']);
     sandbox.stub(AmpStoryBookend.prototype, 'build');
+
     const bookendXhr = sandbox
         .stub(AmpStoryBookend.prototype, 'loadConfigAndMaybeRenderBookend')
         .returns(Promise.reject());
@@ -392,8 +389,6 @@ describes.realWin('amp-story', {
 
     return story.layoutCallback().then(() => {
       expect(bookendXhr).to.have.been.calledOnce;
-      expect(story.element.classList.contains('i-amphtml-story-loaded'))
-          .to.be.true;
     }).catch(error => {
       expect(error).to.be.undefined;
     });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -358,7 +358,6 @@ describes.realWin('amp-story', {
   });
 
   it('should update bookend status in browser history', () => {
-    const replaceStub = sandbox.stub(win.history, 'replaceState');
     const pageCount = 1;
     createPages(story.element, pageCount, ['last-page']);
 
@@ -370,10 +369,29 @@ describes.realWin('amp-story', {
         .then(() => {
           story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
 
-          return expect(replaceStub).to.have.been.calledWith(
+          return expect(replaceStateStub).to.have.been.calledWith(
               {ampStoryBookendActive: true}, '',
           );
         });
+  });
+
+
+  it('should not block layoutCallback when bookend xhr fails', () => {
+    createPages(story.element, 2, ['cover', 'page-1']);
+    sandbox.stub(story, 'getHistoryState_')
+        .withArgs('ampStoryBookendActive')
+        .returns(true);
+
+    story.buildCallback();
+
+    const bookendXhr =
+      sandbox.stub(story, 'showBookend_').returns(Promise.reject());
+
+    return story.layoutCallback().then(() => {
+      expect(bookendXhr).to.have.been.calledOnce;
+    }).catch(error => {
+      expect(error).to.be.undefined;
+    });
   });
 
   it('should NOT update page id in browser history if ad', () => {


### PR DESCRIPTION
Re-do of #17041 

Fixes #15095.

When users navigate to another page from the bookend and come back, the bookend is closed, which might be confusing.

This PR saves the bookend state so when a user opens it, navigates to another page and comes back, it will still be open.