### PR TITLE
Create eslint rule to ban module.exports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,6 +17,7 @@ validator/node_modules
 validator/nodejs/node_modules
 validator/webui/node_modules
 eslint-rules
+babel.config.js
 karma.conf.js
 testing/local-amp-chrome-extension
 extensions/amp-a4a/0.1/test/testdata

--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
     "amphtml-internal/no-import-rename": 2,
     "amphtml-internal/no-is-amp-alt": 2,
     "amphtml-internal/no-mixed-operators": 2,
+    "amphtml-internal/no-module-exports": 2,
     "amphtml-internal/no-non-string-log-args": 1,
     "amphtml-internal/no-spread": 2,
     "amphtml-internal/no-style-display": 2,

--- a/ads/.eslintrc
+++ b/ads/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "amphtml-internal/no-style-display": 0,
+    "amphtml-internal/no-module-exports": 0,
     "amphtml-internal/query-selector": 0
   }
 }

--- a/build-system/.eslintrc
+++ b/build-system/.eslintrc
@@ -11,6 +11,7 @@
     "amphtml-internal/no-array-destructuring": 0,
     "amphtml-internal/no-for-of-statement": 0,
     "amphtml-internal/no-has-own-property-method": 0,
+    "amphtml-internal/no-module-exports": 0,
     "amphtml-internal/no-spread": 0,
     "require-jsdoc": 0
   }

--- a/build-system/eslint-rules/no-module-exports.js
+++ b/build-system/eslint-rules/no-module-exports.js
@@ -32,7 +32,7 @@ module.exports = {
   create(context) {
 
     function isModuleExports(node) {
-      return node.object.type === 'Identifier' && (/^(module|exports)$/).test(node.object.name)
+      return node.object.type === 'Identifier' && (/^(module.exports)$/).test(node.object.name)
     }
 
     return {

--- a/build-system/eslint-rules/no-module-exports.js
+++ b/build-system/eslint-rules/no-module-exports.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    schema: [],
+    messages: {
+      unexpected: "Unexpected use of `module.exports` statement."
+    }
+  },
+
+  create(context) {
+
+    function isModuleExports(node) {
+      return node.object.type === 'Identifier' && (/^(module|exports)$/).test(node.object.name)
+    }
+
+    return {
+      MemberExpression(node) {
+        if (isModuleExports(node)) {
+            context.report({ node, messageId: "unexpected"});
+        }
+      }
+    };
+  }
+};

--- a/testing/.eslintrc
+++ b/testing/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "amphtml-internal/no-export-side-effect": 0,
+    "amphtml-internal/no-module-exports": 0,
     "amphtml-internal/no-style-property-setting": 0
   }
 }

--- a/validator/.eslintrc
+++ b/validator/.eslintrc
@@ -20,6 +20,7 @@
     "fs": false
   },
   "rules": {
+    "amphtml-internal/no-module-exports": 0,
     "amphtml-internal/no-for-of-statement": 0,
     "amphtml-internal/no-has-own-property-method": 0,
     "chai-expect/missing-assertion": 1,


### PR DESCRIPTION
Bans `module.exports` from all directories except ads, build-system, testing, and validator

Fixes #19257