### PR TITLE
✨ Add consentString support

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -858,6 +858,7 @@ const forbiddenTermsSrcInclusive = {
     message: requiresReviewPrivacy,
     whitelist: [
       'src/service/storage-impl.js',
+      'extensions/amp-consent/0.1/consent-state-manager.js',
     ],
   },
   '(cdn|3p)\\.ampproject\\.': {

--- a/examples/amp-consent-iframe.amp.html
+++ b/examples/amp-consent-iframe.amp.html
@@ -154,6 +154,35 @@
     </div>
   </header>
   <main role="main">
+     <h3>Image that is blocked by '_till_responded' consent</h3>
+    <amp-img
+        data-block-on-consent='_till_responded'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is blocked by '_till_accepted' consent</h3>
+    <amp-img
+        data-block-on-consent='_till_accepted'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is blocked by '_auto_reject' consent</h3>
+    <amp-img
+        data-block-on-consent='_auto_reject'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is blocked by 'default' consent</h3>
+    <amp-img
+        data-block-on-consent='default'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is blocked by default (not specified) consent</h3>
+    <amp-img
+        data-block-on-consent
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is NOT blocked by consent</h3>
+    <amp-img
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
     <h3>Image that is blocked by consent</h3>
     <amp-img
         data-block-on-consent

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -219,14 +219,13 @@ export class AmpConsent extends AMP.BaseElement {
         user().error(TAG, 'consent-response message missing required info');
         return;
       }
-      if (isExperimentOn(this.win, 'amp-consent-v2')) {
-        if (data['info'] !== undefined) {
-          if (typeof data['info'] != 'string') {
-            user().error(TAG, 'consent-response info only supports string, ' +
-                '%s, treated as undefined', data['info']);
-          }
-          consentString = data['info'];
+      if (isExperimentOn(this.win, 'amp-consent-v2') &&
+          data['info'] !== undefined) {
+        if (typeof data['info'] != 'string') {
+          user().error(TAG, 'consent-response info only supports string, ' +
+              '%s, treated as undefined', data['info']);
         }
+        consentString = data['info'];
       }
 
       const iframes = this.element.querySelectorAll('iframe');
@@ -311,9 +310,9 @@ export class AmpConsent extends AMP.BaseElement {
   /**
    * Handler User action
    * @param {string} action
-   * @param {string=} str
+   * @param {string=} consentString
    */
-  handleAction_(action, str) {
+  handleAction_(action, consentString) {
     if (!isEnumValue(ACTION_TYPE, action)) {
       // Unrecognized action
       return;
@@ -332,15 +331,21 @@ export class AmpConsent extends AMP.BaseElement {
     if (action == ACTION_TYPE.ACCEPT) {
       //accept
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.ACCEPTED, str);
+          this.currentDisplayInstance_,
+          CONSENT_ITEM_STATE.ACCEPTED,
+          consentString);
     } else if (action == ACTION_TYPE.REJECT) {
       // reject
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.REJECTED, str);
+          this.currentDisplayInstance_,
+          CONSENT_ITEM_STATE.REJECTED,
+          consentString);
     } else if (action == ACTION_TYPE.DISMISS) {
       // dismiss
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.DISMISSED, str);
+          this.currentDisplayInstance_,
+          CONSENT_ITEM_STATE.DISMISSED,
+          consentString);
     }
 
     // Hide current dialog

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -35,8 +35,8 @@ import {dev, user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';
-
 import {isEnumValue} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -208,6 +208,7 @@ export class AmpConsent extends AMP.BaseElement {
         return;
       }
 
+      let consentString;
       const data = getData(event);
 
       if (!data || data['type'] != 'consent-response') {
@@ -218,13 +219,22 @@ export class AmpConsent extends AMP.BaseElement {
         user().error(TAG, 'consent-response message missing required info');
         return;
       }
+      if (isExperimentOn(this.win, 'amp-consent-v2')) {
+        if (data['info'] !== undefined) {
+          if (typeof data['info'] != 'string') {
+            user().error(TAG, 'consent-response info only supports string, ' +
+                '%s, treated as undefined', data['info']);
+          }
+          consentString = data['info'];
+        }
+      }
 
       const iframes = this.element.querySelectorAll('iframe');
 
       for (let i = 0; i < iframes.length; i++) {
         if (iframes[i].contentWindow === event.source) {
           const action = data['action'];
-          this.handleAction_(action);
+          this.handleAction_(action, consentString);
           return;
         }
       }
@@ -301,8 +311,9 @@ export class AmpConsent extends AMP.BaseElement {
   /**
    * Handler User action
    * @param {string} action
+   * @param {string=} str
    */
-  handleAction_(action) {
+  handleAction_(action, str) {
     if (!isEnumValue(ACTION_TYPE, action)) {
       // Unrecognized action
       return;
@@ -321,15 +332,15 @@ export class AmpConsent extends AMP.BaseElement {
     if (action == ACTION_TYPE.ACCEPT) {
       //accept
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.ACCEPTED);
+          this.currentDisplayInstance_, CONSENT_ITEM_STATE.ACCEPTED, str);
     } else if (action == ACTION_TYPE.REJECT) {
       // reject
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.REJECTED);
+          this.currentDisplayInstance_, CONSENT_ITEM_STATE.REJECTED, str);
     } else if (action == ACTION_TYPE.DISMISS) {
       // dismiss
       this.consentStateManager_.updateConsentInstanceState(
-          this.currentDisplayInstance_, CONSENT_ITEM_STATE.DISMISSED);
+          this.currentDisplayInstance_, CONSENT_ITEM_STATE.DISMISSED, str);
     }
 
     // Hide current dialog
@@ -509,8 +520,9 @@ export class AmpConsent extends AMP.BaseElement {
         new ConsentUI(this, config);
 
     // Get current consent state
-    return this.consentStateManager_.getConsentInstanceState(instanceId)
-        .then(state => {
+    return this.consentStateManager_.getConsentInstanceInfo(instanceId)
+        .then(info => {
+          const state = info['consentState'];
           if (state == CONSENT_ITEM_STATE.ACCEPTED ||
               state == CONSENT_ITEM_STATE.REJECTED) {
             // Need to display post prompt ui if user previous made a decision

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -179,12 +179,17 @@ export class AmpConsent extends AMP.BaseElement {
    * Register a list of user action functions
    */
   enableInteractions_() {
-    this.registerAction('accept',
-        this.handleAction_.bind(this, ACTION_TYPE.ACCEPT));
-    this.registerAction('reject',
-        this.handleAction_.bind(this, ACTION_TYPE.REJECT));
-    this.registerAction('dismiss',
-        this.handleAction_.bind(this, ACTION_TYPE.DISMISS));
+    this.registerAction('accept', () => {
+      this.handleAction_(ACTION_TYPE.ACCEPT);
+    });
+
+    this.registerAction('reject', () => {
+      this.handleAction_(ACTION_TYPE.REJECT);
+    });
+
+    this.registerAction('dismiss', () => {
+      this.handleAction_(ACTION_TYPE.DISMISS);
+    });
 
     this.registerAction('prompt', invocation => {
       const {args} = invocation;

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -17,14 +17,19 @@
 import {
   CONSENT_ITEM_STATE,
   ConsentInfoDef,
+  calculateLegacyStateValue,
+  composeStoreValue,
+  consentInfoEquals,
+  constructConsentInfo,
   getStoredConsentInfo,
+  normalizeConsentStateValue,
 } from './consent-info';
 import {Deferred} from '../../../src/utils/promise';
 import {Observable} from '../../../src/observable';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {dev} from '../../../src/log';
-import {isEnumValue} from '../../../src/types';
+
 
 const TAG = 'CONSENT-STATE-MANAGER';
 const CID_SCOPE = 'AMP-CONSENT';
@@ -75,23 +80,24 @@ export class ConsentStateManager {
    * Update consent instance state
    * @param {string} instanceId
    * @param {CONSENT_ITEM_STATE} state
+   * @param {string=} consentStr
    */
-  updateConsentInstanceState(instanceId, state) {
+  updateConsentInstanceState(instanceId, state, consentStr) {
     if (!this.instances_[instanceId] ||
         !this.consentChangeObservables_[instanceId]) {
       dev().error(TAG, 'instance %s not registered', instanceId);
       return;
     }
     this.consentChangeObservables_[instanceId].fire(state);
-    this.instances_[instanceId].update(state);
+    this.instances_[instanceId].update(state, consentStr);
   }
 
   /**
    * Get local consent instance state
    * @param {string} instanceId
-   * @return {Promise<CONSENT_ITEM_STATE>}
+   * @return {Promise<!ConsentInfoDef>}
    */
-  getConsentInstanceState(instanceId) {
+  getConsentInstanceInfo(instanceId) {
     dev().assert(this.instances_[instanceId],
         '%s: cannot find this instance', TAG);
     return this.instances_[instanceId].get();
@@ -108,8 +114,8 @@ export class ConsentStateManager {
 
     const unlistener = this.consentChangeObservables_[instanceId].add(handler);
     // Fire first consent instance state.
-    this.getConsentInstanceState(instanceId).then(state => {
-      handler(state);
+    this.getConsentInstanceInfo(instanceId).then(info => {
+      handler(info['consentState']);
     });
 
     return unlistener;
@@ -182,8 +188,8 @@ export class ConsentInstance {
     /** @private {Promise<!../../../src/service/storage-impl.Storage>} */
     this.storagePromise_ = Services.storageForDoc(ampdoc);
 
-    /** @private {?CONSENT_ITEM_STATE} */
-    this.localValue_ = null;
+    /** @private {?ConsentInfoDef}*/
+    this.localConsentInfo_ = null;
 
     /** @private {string} */
     this.storageKey_ = 'amp-consent:' + id;
@@ -198,80 +204,86 @@ export class ConsentInstance {
   /**
    * Update the local consent state list
    * @param {!CONSENT_ITEM_STATE} state
+   * @param {string=} consentStr
    */
-  update(state) {
-    if (!isEnumValue(CONSENT_ITEM_STATE, state)) {
-      state = CONSENT_ITEM_STATE.UNKNOWN;
+  update(state, consentStr) {
+    const localStateValue =
+        this.localConsentInfo_ && this.localConsentInfo_['consentState'];
+    const localConsentStr =
+        this.localConsentInfo_ && this.localConsentInfo_['consentString'];
+    const normalizedState = normalizeConsentStateValue(state, localStateValue);
+    if (consentStr === undefined && localConsentStr) {
+      consentStr = localConsentStr;
     }
+    const newConsentInfo = constructConsentInfo(normalizedState, consentStr);
+    const oldConsentInfo = this.localConsentInfo_;
+    this.localConsentInfo_ = newConsentInfo;
 
-    if (state == CONSENT_ITEM_STATE.DISMISSED) {
-      this.localValue_ = this.localValue_ || CONSENT_ITEM_STATE.UNKNOWN;
-      return;
+    if (!consentInfoEquals(newConsentInfo, oldConsentInfo)) {
+      this.updateStoredValue_(newConsentInfo);
+      // TODO(@zhouyx): Need force update to update timestamp
     }
+  }
 
-    if (state == CONSENT_ITEM_STATE.NOT_REQUIRED) {
-      if (!this.localValue_ || this.localValue_ == CONSENT_ITEM_STATE.UNKNOWN) {
-        this.localValue_ = CONSENT_ITEM_STATE.NOT_REQUIRED;
-      }
-      return;
-    }
-
-    if (state === this.localValue_) {
-      return;
-    }
-
-    this.localValue_ = state;
-
-    if (state == CONSENT_ITEM_STATE.UNKNOWN) {
-      return;
-    }
-
-    const value = (state == CONSENT_ITEM_STATE.ACCEPTED);
+  /**
+   * Write the new value to localStorage and send updateHrefRequest
+   * @param {!ConsentInfoDef} consentInfo
+   */
+  updateStoredValue_(consentInfo) {
     this.storagePromise_.then(storage => {
-      if (state != this.localValue_) {
-        // If state has changed. do not store.
+      if (!consentInfoEquals(consentInfo, this.localConsentInfo_)) {
+        // If state has changed. do not store outdated value.
         return;
       }
-      storage.set(this.storageKey_, value);
-      this.sendUpdateHrefRequest_(value);
+      const value = composeStoreValue(consentInfo);
+      if (value == null) {
+        // Value can be false, do not use !value check
+        // Nothing to store to localStorage
+        return;
+      }
+      storage.setNonBoolean(this.storageKey_, value);
+      this.sendUpdateHrefRequest_(consentInfo);
     });
   }
 
   /**
    * Get the local consent state list
-   * @return {!Promise<CONSENT_ITEM_STATE>}
+   * @return {!Promise<!ConsentInfoDef>}
    */
   get() {
-    if (this.localValue_) {
-      return Promise.resolve(
-          /** @type {CONSENT_ITEM_STATE} */ (this.localValue_));
+    if (this.localConsentInfo_) {
+      // Return the local value if it has been processed before
+      return Promise.resolve(this.localConsentInfo_);
     }
 
     return this.storagePromise_.then(storage => {
       return storage.get(this.storageKey_);
     }).then(storedValue => {
-      if (this.localValue_) {
-        // If value has been updated. return most updated value;
-        return this.localValue_;
+      if (this.localConsentInfo_) {
+        // If local value has been updated, return most updated value;
+        return this.localConsentInfo_;
       }
+
       const consentInfo = getStoredConsentInfo(storedValue);
-      this.localValue_ = consentInfo['consentState'];
-      return this.localValue_;
+      this.localConsentInfo_ = consentInfo;
+      return this.localConsentInfo_;
     }).catch(e => {
       dev().error(TAG, 'Failed to read storage', e);
-      return CONSENT_ITEM_STATE.UNKNOWN;
+      return constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN);
     });
   }
 
   /**
    * send a POST request to the updateHref with userId with fixed scope
-   * and consentInstanceId
-   * @param {boolean} state
+   * and consentInstanceIds
+   * @param {!ConsentInfoDef} consentInfo
    */
-  sendUpdateHrefRequest_(state) {
+  sendUpdateHrefRequest_(consentInfo) {
     if (!this.onUpdateHref_) {
       return;
     }
+    const consentState =
+        calculateLegacyStateValue(consentInfo['consentState']);
     const cidPromise = Services.cidForDoc(this.ampdoc_).then(cid => {
       return cid.get({scope: CID_SCOPE, createCookieIfNotPresent: true},
           Promise.resolve());
@@ -280,8 +292,13 @@ export class ConsentInstance {
       const request = /** @type {!JsonObject} */ ({
         'consentInstanceId': this.id_,
         'ampUserId': userId,
-        'consentState': state,
       });
+      if (consentState != null) {
+        request['consentState'] = consentState;
+      }
+      if (consentInfo['consentString']) {
+        request['consentString'] = consentInfo['consentString'];
+      }
       const init = {
         credentials: 'include',
         method: 'POST',

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -270,10 +270,26 @@ describes.realWin('amp-consent', {
       event.data = {
         'type': 'consent-response',
         'action': 'accept',
+        'info': 'accept-string',
       };
       event.source = iframe.contentWindow;
       win.dispatchEvent(event);
-      expect(actionSpy).to.be.calledWith(ACTION_TYPE.ACCEPT);
+      expect(actionSpy).to.be.calledWith(ACTION_TYPE.ACCEPT,
+          'accept-string');
+    });
+
+    it('ignore info w/o amp-consent-v2 flag', () => {
+      // TODO(@zhouyx): Remove with amp-consent-v2 flag
+      toggleExperiment(win, 'amp-consent-v2', false);
+      event.data = {
+        'type': 'consent-response',
+        'action': 'accept',
+        'info': 'accept-string',
+      };
+      event.source = iframe.contentWindow;
+      win.dispatchEvent(event);
+      expect(actionSpy).to.be.calledWith(ACTION_TYPE.ACCEPT,
+          undefined);
     });
 
     it('ignore msg from incorrect source', () => {

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -16,12 +16,16 @@
 
 import {
   CONSENT_ITEM_STATE,
+  composeStoreValue,
+  consentInfoEquals,
+  constructConsentInfo,
   getStoredConsentInfo,
+  normalizeConsentStateValue,
 } from '../consent-info';
 import {dict} from '../../../../src/utils/object';
 
 
-describes.fakeWin('ConsentConfig', {}, () => {
+describes.fakeWin('ConsentInfo', {}, () => {
   describe('getStoredConsentInfo', () => {
     it('construct consentInfo from undefined', () => {
       expect(getStoredConsentInfo(undefined)).to.deep.equal(dict({
@@ -44,9 +48,156 @@ describes.fakeWin('ConsentConfig', {}, () => {
       }));
     });
 
+    it('construct consentInfo from stored value', () => {
+      expect(getStoredConsentInfo({
+        's': 1,
+      })).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.ACCEPTED,
+        'consentString': undefined,
+        'isDirty': undefined,
+      }));
+      expect(getStoredConsentInfo({
+        's': 0,
+        'r': 'test',
+      })).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.REJECTED,
+        'consentString': 'test',
+        'isDirty': undefined,
+      }));
+      expect(getStoredConsentInfo({
+        's': -1,
+        'r': 'test',
+        'd': 1,
+      })).to.deep.equal(dict({
+        'consentState': CONSENT_ITEM_STATE.UNKNOWN,
+        'consentString': 'test',
+        'isDirty': true,
+      }));
+    });
+
     it('throw error with invalid value', () => {
-      expect(() => getStoredConsentInfo({})).to.throw(
+      expect(() => getStoredConsentInfo('invalid')).to.throw(
           'Invalid stored consent value');
     });
+  });
+
+  it('composeStoreValue/getStoredConsentInfo', () => {
+    let consentInfo = constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED);
+    expect(getStoredConsentInfo(composeStoreValue(consentInfo)))
+        .to.deep.equal(consentInfo);
+
+    consentInfo =
+        constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test');
+    expect(getStoredConsentInfo(composeStoreValue(consentInfo)))
+        .to.deep.equal(consentInfo);
+
+    consentInfo =
+        constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test', true);
+    expect(getStoredConsentInfo(composeStoreValue(consentInfo)))
+        .to.deep.equal(consentInfo);
+  });
+
+  describe('composeStoreValue', () => {
+    let consentInfo;
+    beforeEach(() => {
+      consentInfo = {
+        'consentState': CONSENT_ITEM_STATE.UNKNOWN,
+      };
+    });
+
+    it('legacy stored value', () => {
+      expect(composeStoreValue(consentInfo)).to.be.null;
+      consentInfo['consentState'] = CONSENT_ITEM_STATE.ACCEPTED;
+      expect(composeStoreValue(consentInfo)).to.equal(true);
+    });
+
+    it('add field only when defined', () => {
+      consentInfo['consentString'] = 'test';
+      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        'r': 'test',
+      });
+      consentInfo['idDirty'] = false;
+      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        'r': 'test',
+      });
+      consentInfo['isDirty'] = true;
+      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        'r': 'test',
+        'd': 1,
+      });
+      consentInfo['consentState'] = CONSENT_ITEM_STATE.REJECTED;
+      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        's': 0,
+        'r': 'test',
+        'd': 1,
+      });
+    });
+  });
+
+  it('normalizeConsentStateValue', () => {
+    // Always respect reject/accept
+
+    let newState, previousState;
+    newState = CONSENT_ITEM_STATE.ACCEPTED;
+    previousState = CONSENT_ITEM_STATE.REJECTED;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(newState);
+
+    // UNKNOWN/DISMISS/NOT_REQUIRED cannot override reject/accept
+    newState = CONSENT_ITEM_STATE.UNKNOWN;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(previousState);
+    newState = CONSENT_ITEM_STATE.DISMISSED;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(previousState);
+    newState = CONSENT_ITEM_STATE.NOT_REQUIRED;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(previousState);
+
+    // UNKNOWN/DISMISS cannot override NOT_REQUIRED
+    previousState = CONSENT_ITEM_STATE.NOT_REQUIRED;
+    newState = CONSENT_ITEM_STATE.UNKNOWN;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(previousState);
+    newState = CONSENT_ITEM_STATE.DISMISSED;
+    expect(normalizeConsentStateValue(newState, previousState))
+        .to.equal(previousState);
+
+    // DISMISS is converted to UNKNOWN
+    expect(normalizeConsentStateValue(
+        CONSENT_ITEM_STATE.DISMISSED, CONSENT_ITEM_STATE.UNKNOWN))
+        .to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+  });
+
+  it('consentInfoEquals', () => {
+    expect(consentInfoEquals(null, null)).to.be.true;
+    expect(consentInfoEquals({}, null)).to.be.false;
+
+    // consentInfo equals when stored value is same
+    const infoA = {
+      'consentState': CONSENT_ITEM_STATE.UNKNOWN,
+    };
+    const infoB = {
+      'consentState': CONSENT_ITEM_STATE.NOT_REQUIRED,
+    };
+    expect(consentInfoEquals(infoA, infoB)).to.be.true;
+
+    infoA['consentString'] = '';
+    expect(consentInfoEquals(infoA, infoB)).to.be.true;
+
+    infoB['isDirty'] = false;
+    expect(consentInfoEquals(infoA, infoB)).to.be.true;
+
+    // consentInfo not equal
+    infoA['consentState'] = CONSENT_ITEM_STATE.ACCEPTED;
+    expect(consentInfoEquals(infoA, infoB)).to.be.false;
+
+    infoB['consentState'] = CONSENT_ITEM_STATE.ACCEPTED;
+    infoB['consentString'] = 'test';
+    expect(consentInfoEquals(infoA, infoB)).to.be.false;
+
+    infoA['consentString'] = 'test';
+    infoB['isDirty'] = true;
+    expect(consentInfoEquals(infoA, infoB)).to.be.false;
   });
 });

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -17,9 +17,9 @@
 import {
   CONSENT_ITEM_STATE,
   composeStoreValue,
-  isConsentInfoStoredValueChanged,
   constructConsentInfo,
   getStoredConsentInfo,
+  isConsentInfoStoredValueChanged,
   recalculateConsentStateValue,
 } from '../consent-info';
 import {dict} from '../../../../src/utils/object';

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {CONSENT_ITEM_STATE} from '../consent-info';
+import {
+  CONSENT_ITEM_STATE,
+  composeStoreValue,
+  constructConsentInfo,
+} from '../consent-info';
 import {
   ConsentInstance,
   ConsentStateManager,
@@ -24,6 +28,7 @@ import {
   registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
+
 
 
 describes.realWin('ConsentStateManager', {amp: 1}, env => {
@@ -46,7 +51,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
           storageGetSpy(name);
           return Promise.resolve(storageValue[name]);
         },
-        set: (name, value) => {
+        setNonBoolean: (name, value) => {
           storageSetSpy(name, value);
           storageValue[name] = value;
           return Promise.resolve();
@@ -78,21 +83,39 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
     });
 
-    it('get consent state', function* () {
-      manager.registerConsentInstance('test', {});
-      let value;
-      const p = manager.getConsentInstanceState('test').then(v => value = v);
-      yield p;
-      expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+    describe('update/get consentInfo', () => {
+      it('get initial default consentInfo value', function* () {
+        manager.registerConsentInstance('test', {});
+        let value;
+        const p = manager.getConsentInstanceInfo('test').then(v => value = v);
+        yield p;
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
+      });
 
-      let value1;
-      manager.updateConsentInstanceState('test', CONSENT_ITEM_STATE.ACCEPTED);
-      const p1 = manager.getConsentInstanceState('test').then(v => value1 = v);
-      yield p1;
-      expect(value1).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+      it('update/get consent state', function* () {
+        manager.registerConsentInstance('test', {});
+        manager.updateConsentInstanceState('test', CONSENT_ITEM_STATE.ACCEPTED);
+        let value;
+        const p = manager.getConsentInstanceInfo('test').then(v => value = v);
+        yield p;
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
+      });
+
+      it('update/get consent string', function* () {
+        manager.registerConsentInstance('test', {});
+        manager.updateConsentInstanceState('test',
+            CONSENT_ITEM_STATE.ACCEPTED, 'test-string');
+        let value;
+        const p = manager.getConsentInstanceInfo('test').then(v => value = v);
+        yield p;
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test-string'));
+      });
     });
 
-    describe('update consent', () => {
+    describe('onConsentStateChange', () => {
       let spy;
 
       beforeEach(() => {
@@ -126,6 +149,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         expect(spy).to.be.calledOnce;
         expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.REJECTED);
         yield macroTask();
+        // Called with updated state value REJECT instead of UNKNOWN
         expect(spy).to.be.calledTwice;
         expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.REJECTED);
       });
@@ -140,29 +164,114 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     describe('update', () => {
-      it('should be able to update local value', function* () {
-        instance.update(CONSENT_ITEM_STATE.UNKNOWN);
-        yield macroTask();
-        expect(storageSetSpy).to.not.be.called;
-        instance.update(CONSENT_ITEM_STATE.DISMISSED);
-        yield macroTask();
-        expect(storageSetSpy).to.not.be.called;
-        instance.update(CONSENT_ITEM_STATE.NOT_REQUIRED);
-        yield macroTask();
-        expect(storageSetSpy).to.not.be.called;
-        instance.update(CONSENT_ITEM_STATE.ACCEPTED);
-        yield macroTask();
-        expect(storageSetSpy).to.be.calledOnce;
-        expect(storageSetSpy).to.be.calledWith('amp-consent:test', true);
-        storageSetSpy.resetHistory();
-        instance.update(CONSENT_ITEM_STATE.REJECTED);
-        yield macroTask();
-        expect(storageSetSpy).to.be.calledOnce;
-        expect(storageSetSpy).to.be.calledWith('amp-consent:test', false);
-        storageSetSpy.resetHistory();
-        instance.update(-1);
-        yield macroTask();
-        expect(storageSetSpy).to.not.be.called;
+      describe('update value', () => {
+        it('invalid consent state', function* () {
+          instance.update(-1);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+
+          instance.update(-1, 'test');
+          yield macroTask();
+          expect(storageSetSpy).to.be.calledOnce;
+          const consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN, 'test');
+          const value = composeStoreValue(consentInfo);
+          expect(storageSetSpy).to.be.calledWith('amp-consent:test', value);
+        });
+
+        it('single consent state value', function* () {
+          instance.update(CONSENT_ITEM_STATE.UNKNOWN);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          instance.update(CONSENT_ITEM_STATE.DISMISSED);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          instance.update(CONSENT_ITEM_STATE.NOT_REQUIRED);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED);
+          yield macroTask();
+          expect(storageSetSpy).to.be.calledOnce;
+
+          // legacy boolean consent state value
+          expect(storageSetSpy).to.be.calledWith('amp-consent:test', true);
+          storageSetSpy.resetHistory();
+          instance.update(CONSENT_ITEM_STATE.REJECTED);
+          yield macroTask();
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith('amp-consent:test', false);
+        });
+
+        it('update consent info with consent string', function* () {
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'accept');
+          yield macroTask();
+          let consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'accept');
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith(
+              'amp-consent:test', composeStoreValue(consentInfo));
+          storageSetSpy.resetHistory();
+
+          instance.update(CONSENT_ITEM_STATE.REJECTED, 'reject');
+          yield macroTask();
+          consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.REJECTED, 'reject');
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith(
+              'amp-consent:test', composeStoreValue(consentInfo));
+        });
+      });
+
+      describe('should override stored value correctly', () => {
+        it('other state cannot override accept/reject', function* () {
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED);
+          yield macroTask();
+          storageSetSpy.resetHistory();
+          instance.update(CONSENT_ITEM_STATE.UNKNOWN);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          instance.update(CONSENT_ITEM_STATE.DISMISSED);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          instance.update(CONSENT_ITEM_STATE.NOT_REQUIRED);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+        });
+
+        it('undefined consent string cannot override old one', function* () {
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'old');
+          yield macroTask();
+          storageSetSpy.resetHistory();
+          instance.update(CONSENT_ITEM_STATE.REJECTED);
+          yield macroTask();
+          const consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.REJECTED, 'old');
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith(
+              'amp-consent:test', composeStoreValue(consentInfo));
+        });
+
+        it('new consent string always override old one', function* () {
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'old');
+          yield macroTask();
+          storageSetSpy.resetHistory();
+          instance.update(CONSENT_ITEM_STATE.DISMISSED, 'new');
+          yield macroTask();
+          let consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'new');
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith(
+              'amp-consent:test', composeStoreValue(consentInfo));
+
+          // empty consent string
+          storageSetSpy.resetHistory();
+          yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, '');
+          consentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, '');
+          expect(storageSetSpy).to.be.calledOnce;
+          expect(storageSetSpy).to.be.calledWith(
+              'amp-consent:test', composeStoreValue(consentInfo));
+        });
       });
 
       it('should not write localStorage with same value', function* () {
@@ -172,6 +281,12 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance.update(CONSENT_ITEM_STATE.ACCEPTED);
         yield macroTask();
         expect(storageSetSpy).to.be.calledOnce;
+        instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'test');
+        yield macroTask();
+        expect(storageSetSpy).to.be.calledTwice;
+        instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'test');
+        yield macroTask();
+        expect(storageSetSpy).to.be.calledTwice;
       });
 
       it('should handle race condition store latest value', function* () {
@@ -204,17 +319,32 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
 
       it('send update request on reject/accept', function* () {
-        instance.update(CONSENT_ITEM_STATE.ACCEPTED);
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED);
         yield macroTask();
         expect(requestSpy).to.be.calledOnce;
         expect(requestSpy).to.be.calledWith('//updateHref');
         expect(requestBody.consentInstanceId).to.equal('test');
         expect(requestBody.consentState).to.equal(true);
-        instance.update(CONSENT_ITEM_STATE.REJECTED);
+        expect(requestBody.consentString).to.be.undefined;
+        yield instance.update(CONSENT_ITEM_STATE.REJECTED);
         yield macroTask();
         expect(requestSpy).to.be.calledTwice;
         expect(requestSpy).to.be.calledWith('//updateHref');
         expect(requestBody.consentState).to.equal(false);
+        expect(requestBody.consentString).to.be.undefined;
+      });
+
+      it('send update request on consentString change', function* () {
+        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'old');
+        yield macroTask();
+        expect(requestSpy).to.be.calledOnce;
+        expect(requestBody.consentState).to.be.undefined;
+        expect(requestBody.consentString).to.equal('old');
+        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'new');
+        yield macroTask();
+        expect(requestSpy).to.be.calledTwice;
+        expect(requestBody.consentState).to.be.undefined;
+        expect(requestBody.consentString).to.equal('new');
       });
 
       it('do not send update request on dismiss/notRequied', function* () {
@@ -224,6 +354,15 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance.update(CONSENT_ITEM_STATE.NOT_REQUIRED);
         yield macroTask();
         expect(requestSpy).to.not.be.called;
+      });
+
+      it('do not send update request when no change', function* () {
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'abc');
+        yield macroTask();
+        expect(requestSpy).to.calledOnce;
+        yield instance.update(CONSENT_ITEM_STATE.UNKNOWN);
+        yield macroTask();
+        expect(requestSpy).to.calledOnce;
       });
 
       it('send update request on local storage state change', function* () {
@@ -241,29 +380,81 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     describe('get', () => {
-      it('should be able to get stored value', () => {
-        storageValue['amp-consent:test'] = true;
-        return instance.get().then(value => {
-          expect(value).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+      describe('should be able to read from stored value', () => {
+        it('legacy boolean value', function* () {
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(
+                constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
+          });
+          instance.localConsentInfo_ = null;
+          storageValue['amp-consent:test'] = true;
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(
+                constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
+          });
+          instance.localConsentInfo_ = null;
+          storageValue['amp-consent:test'] = false;
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(
+                constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
+          });
+        });
+
+        it('consentInfo value', function* () {
+          let testConsentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN, 'test');
+          storageValue['amp-consent:test'] = composeStoreValue(testConsentInfo);
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(testConsentInfo);
+          });
+          instance.localConsentInfo_ = null;
+          testConsentInfo =
+              constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test');
+          storageValue['amp-consent:test'] = composeStoreValue(testConsentInfo);
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(testConsentInfo);
+          });
+        });
+
+        it('unsupporte stored value', function* () {
+          expectAsyncConsoleError(/Invalid stored consent value/);
+          storageValue['amp-consent:test'] = 'invalid';
+          yield instance.get().then(value => {
+            expect(value).to.deep.equal(
+                constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
+          });
         });
       });
 
       it('should be able to get local value', function* () {
         let value;
         yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         yield instance.update(CONSENT_ITEM_STATE.DISMISSED);
         yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         yield instance.update(CONSENT_ITEM_STATE.ACCEPTED);
         yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
-        yield instance.update(CONSENT_ITEM_STATE.DISMISSED);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
+        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'test');
         yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
-        yield instance.update(CONSENT_ITEM_STATE.REJECTED);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test'));
+        yield instance.update(CONSENT_ITEM_STATE.REJECTED, 'test1');
         yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.REJECTED);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED, 'test1'));
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED);
+        yield instance.get().then(v => value = v);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test1'));
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, '');
+        yield instance.get().then(v => value = v);
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, ''));
       });
 
       it('should return unknown value with error', () => {
@@ -274,7 +465,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         sandbox.stub(dev(), 'error');
         storageValue['amp-consent:test'] = true;
         return instance.get().then(value => {
-          expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+          expect(value).to.deep.equal(
+              constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         });
       });
 
@@ -285,8 +477,10 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance.update(CONSENT_ITEM_STATE.REJECTED);
         instance.get().then(v => value2 = v);
         yield macroTask();
-        expect(value1).to.equal(CONSENT_ITEM_STATE.REJECTED);
-        expect(value2).to.equal(CONSENT_ITEM_STATE.REJECTED);
+        expect(value1).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
+        expect(value2).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
       });
     });
   });

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -46,12 +46,13 @@ setTimeout(() => {
   }, '*');
 }, 500);
 
-function registerClickConsentMessage(querySelector, type, action) {
+function registerClickConsentMessage(querySelector, type, action, info) {
   document.querySelector(querySelector).onclick = function () {
     // parent.postMessage("message to be sent", "http://the-website-that-will-receive-the-msg.com")
     parent.postMessage({
       type,
-      action
+      action,
+      info
     }, '*');
   };
 }
@@ -91,6 +92,7 @@ const consentObjects = [
     querySelector: '#r',
     type: 'consent-response',
     action: 'reject',
+    info: '',
     onclick: () => {
       showConfirmation();
     }
@@ -116,7 +118,8 @@ consentObjects.forEach(consentObject => {
   registerClickConsentMessage(
     consentObject.querySelector,
     consentObject.type,
-    consentObject.action
+    consentObject.action,
+    consentObject.info
   );
 
   if (consentObject.onclick) {

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -1,7 +1,7 @@
 <html>
   <div id="consent-wrapper">
     <div id="decision-state">
-      <h1>Hello! I am a consent Iframe.</h1> 
+      <h1>Hello! I am a consent Iframe.</h1>
       <h3>I am in `test/manual/diy-consent.html`</h3>
       <button id='f'>Learn More</button>
     </div>
@@ -82,6 +82,7 @@ const consentObjects = [
     querySelector: '#a',
     type: 'consent-response',
     action: 'accept',
+    info: 'accept-str',
     onclick: () => {
       showConfirmation();
     }
@@ -98,6 +99,7 @@ const consentObjects = [
     querySelector: '#d',
     type: 'consent-response',
     action: 'dismiss',
+    info: 'dismiss-str',
     onclick: () => {
       showConfirmation();
     }


### PR DESCRIPTION
This PR adds consentString support. 

Some decisions:
1. undefinedConsentString cannot override exist one
2. consentString (includes empty string) can always override previous stored consent string
3. localStorage format supports: legacy boolean value, new object value that looks like
```
{
  's': 1/0,
  'r': string, (optional)
  'd': true, (optional)
}
```
when 'r' and 'd' value don't exist, the stored value will fall back to boolean value today. I am open to  migrating to new format to all. 
4. When state is unknown, and string, dirtyBit don't exist no value will be stored to localStorage.

Since new format is introduced, the PR could break existing usage. Please help with a closer look.