### PR TITLE
Update `gulp bundle-size` to work with the AMP bundle-size GitHub App

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -94,7 +94,9 @@ exports.gitBranchName = function() {
  * @return {string}
  */
 exports.gitCommitHash = function() {
-  return getStdout('git rev-parse --verify HEAD').trim();
+  return process.env.TRAVIS_PULL_REQUEST_SHA ?
+    process.env.TRAVIS_PULL_REQUEST_SHA :
+    getStdout('git rev-parse --verify HEAD').trim();
 };
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -336,12 +336,8 @@ const command = {
     }
     timedExecOrDie(cmd);
   },
-  runBundleSizeCheck: function(storeBundleSize = false) {
-    let cmd = 'gulp bundle-size';
-    if (storeBundleSize) {
-      cmd += ' --store';
-    }
-    timedExecOrDie(cmd);
+  runBundleSizeCheck: function(action) {
+    timedExecOrDie(`gulp bundle-size --${action}`);
   },
   runDepAndTypeChecks: function() {
     timedExecOrDie('gulp dep-check');
@@ -466,10 +462,7 @@ function runAllCommands() {
     command.updatePackages();
     command.cleanBuild();
     command.buildRuntimeMinified(/* extensions */ true);
-    // Disable bundle-size check on release branch builds.
-    if (process.env['TRAVIS_BRANCH'] === 'master') {
-      command.runBundleSizeCheck(/* storeBundleSize */ true);
-    }
+    command.runBundleSizeCheck('master');
     command.runPresubmitTests();
     command.runIntegrationTests(/* compiled */ true, /* coverage */ false);
     command.runSinglePassCompiledIntegrationTests();
@@ -489,7 +482,6 @@ function runAllCommandsLocally() {
     command.cleanBuild();
     command.buildRuntime();
     command.buildRuntimeMinified(/* extensions */ false);
-    command.runBundleSizeCheck();
   }
 
   // These tests need a build.
@@ -647,7 +639,9 @@ function main() {
       command.runVisualDiffTests();
       if (buildTargets.has('RUNTIME')) {
         command.buildRuntimeMinified(/* extensions */ false);
-        command.runBundleSizeCheck();
+        command.runBundleSizeCheck('report');
+      } else {
+        command.runBundleSizeCheck('skipped');
       }
     } else {
       // Generates a blank Percy build to satisfy the required Github check.

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -337,7 +337,7 @@ const command = {
     timedExecOrDie(cmd);
   },
   runBundleSizeCheck: function(action) {
-    timedExecOrDie(`gulp bundle-size --${action}`);
+    timedExecOrDie(`gulp bundle-size --on_${action}_build`);
   },
   runDepAndTypeChecks: function() {
     timedExecOrDie('gulp dep-check');
@@ -462,7 +462,7 @@ function runAllCommands() {
     command.updatePackages();
     command.cleanBuild();
     command.buildRuntimeMinified(/* extensions */ true);
-    command.runBundleSizeCheck('master');
+    command.runBundleSizeCheck('push');
     command.runPresubmitTests();
     command.runIntegrationTests(/* compiled */ true, /* coverage */ false);
     command.runSinglePassCompiledIntegrationTests();
@@ -639,7 +639,7 @@ function main() {
       command.runVisualDiffTests();
       if (buildTargets.has('RUNTIME')) {
         command.buildRuntimeMinified(/* extensions */ false);
-        command.runBundleSizeCheck('report');
+        command.runBundleSizeCheck('pr');
       } else {
         command.runBundleSizeCheck('skipped');
       }

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -211,7 +211,7 @@ function compareBundleSize(maxBundleSize) {
  * Checks gzipped size of existing v0.js (amp.js) against `maxSize`.
  * Does _not_ rebuild: run `gulp dist --fortesting --noextensions` first.
  */
-async function checkBundleSize() {
+async function legacyBundleSizeCheck() {
   if (!fs.existsSync(runtimeFile)) {
     log(yellow('Could not find'), cyan(runtimeFile) +
         yellow('. Skipping bundlesize check.'));
@@ -346,7 +346,9 @@ async function performBundleSize() {
     } else if (argv.report) {
       await reportBundleSize();
     }
-    return await checkBundleSize();
+    // TODO(danielrozenberg): remove the legacy check once the app has been
+    // activated and tested on the repository.
+    return await legacyBundleSizeCheck();
   }
 }
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -287,7 +287,7 @@ async function skipBundleSize() {
     try {
       const response = await requestPost(url.resolve(bundleSizeAppBaseUrl,
           path.join('commit', commitHash, 'skip')));
-      if (response.statusCode !== '200') {
+      if (response.statusCode !== 200) {
         throw new Error(
             `${response.statusCode} ${response.statusMessage}: ` +
             response.body);
@@ -320,7 +320,7 @@ async function reportBundleSize() {
           bundleSize,
         },
       });
-      if (response.statusCode !== '200') {
+      if (response.statusCode !== 200) {
         throw new Error(
             `${response.statusCode} ${response.statusMessage}: ` +
             response.body);

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -343,6 +343,7 @@ async function performBundleSize() {
   } else {
     if (argv.master) {
       await storeBundleSize();
+      await reportBundleSize();
     } else if (argv.report) {
       await reportBundleSize();
     }

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -337,7 +337,7 @@ async function reportBundleSize() {
   }
 }
 
-async function performBundleSize() {
+async function performBundleSizeCheck() {
   if (argv.on_skipped_build) {
     return await skipBundleSize();
   } else {
@@ -357,7 +357,7 @@ async function performBundleSize() {
 gulp.task(
     'bundle-size',
     'Checks if the minified AMP binary has exceeded its size cap',
-    performBundleSize,
+    performBundleSizeCheck,
     {
       options: {
         'on_push_build': '  Store bundle size in AMP build artifacts repo '

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -57,7 +57,7 @@ async function getMaxBundleSize() {
     });
   }
 
-  return await octokit.repos.getContent(
+  return await octokit.repos.getContents(
       Object.assign(buildArtifactsRepoOptions, {
         path: path.join('bundle-size', '.max_size'),
       })
@@ -101,7 +101,7 @@ async function getAncestorBundleSize() {
   const gitBranchPointSha = gitBranchPoint(/* fromMerge */ isPullRequest());
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
-  return await octokit.repos.getContent(
+  return await octokit.repos.getContents(
       Object.assign(buildArtifactsRepoOptions, {
         path: path.join('bundle-size', gitBranchPointSha),
       })
@@ -158,7 +158,7 @@ function storeBundleSize() {
     token: process.env.GITHUB_ARTIFACTS_RW_TOKEN,
   });
 
-  return octokit.repos.getContent(githubApiCallOptions).then(() => {
+  return octokit.repos.getContents(githubApiCallOptions).then(() => {
     log('The file', cyan(`bundle-size/${commitHash}`), 'already exists in the',
         'build artifacts repository on GitHub. Skipping...');
   }).catch(() => {

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -127,7 +127,7 @@ async function getAncestorBundleSize() {
  */
 function storeBundleSize() {
   if (!process.env.TRAVIS || process.env.TRAVIS_EVENT_TYPE !== 'push') {
-    log(yellow('Skipping'), cyan('--master') + ':',
+    log(yellow('Skipping'), cyan('--on_push_build') + ':',
         'this action can only be performed on `push` builds on Travis');
     return;
   }
@@ -338,13 +338,13 @@ async function reportBundleSize() {
 }
 
 async function performBundleSize() {
-  if (argv.skipped) {
+  if (argv.on_skipped_build) {
     return await skipBundleSize();
   } else {
-    if (argv.master) {
+    if (argv.on_push_build) {
       await storeBundleSize();
       await reportBundleSize();
-    } else if (argv.report) {
+    } else if (argv.on_pr_build) {
       await reportBundleSize();
     }
     // TODO(danielrozenberg): remove the legacy check once the app has been
@@ -360,10 +360,11 @@ gulp.task(
     performBundleSize,
     {
       options: {
-        'master': '  Store bundle size in AMP build artifacts repo (used only '
-            + 'for `master` builds)',
-        'skipped': '  Set the status of this pull request\'s bundle size in '
-            + 'GitHub to `skipped`',
-        'report': '  Report the bundle size of this pull request to GitHub',
+        'on_push_build': '  Store bundle size in AMP build artifacts repo '
+            + '(also implies --on_pr_build)',
+        'on_pr_build': '  Report the bundle size of this pull request to '
+            + 'GitHub',
+        'on_skipped_build': '  Set the status of this pull request\'s bundle '
+            + 'size check in GitHub to `skipped`',
       },
     });

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -108,7 +108,7 @@ async function getAncestorBundleSize() {
  */
 function storeBundleSize(bundleSize) {
   if (!process.env.TRAVIS || process.env.TRAVIS_EVENT_TYPE !== 'push') {
-    log(yellow('Skipping'), cyan('--store') + ':',
+    log(yellow('Skipping'), cyan('--master') + ':',
         'this action can only be performed on `push` builds on Travis');
     return;
   }
@@ -257,7 +257,7 @@ async function checkBundleSize() {
     }
   }
 
-  if (argv.store) {
+  if (argv.master) {
     return storeBundleSize(newBundleSize);
   }
 }
@@ -269,7 +269,7 @@ gulp.task(
     checkBundleSize,
     {
       options: {
-        'store': '  Store bundle size in AMP build artifacts repo (used only '
+        'master': '  Store bundle size in AMP build artifacts repo (used only '
             + 'for `master` builds)',
       },
     });


### PR DESCRIPTION
Fixes #19146
Fixes #16380

This PR updates the bundle-size check and pr-check to use the new AMP bundle-size GitHub App. It maintains the existing (legacy) behaviour in parallel for now, until such time that we are ready to remove that code.