### PR TITLE
🚀 Create definition element for pool-bound <amp-video>

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -294,6 +294,13 @@ class AmpVideo extends AMP.BaseElement {
     return !!closestByTag(this.element, 'amp-story-page');
   }
 
+  /**
+   * @return {!Element}
+   */
+  getMediaReference() {
+    return this.video_;
+  }
+
   /** @override */
   mutatedAttributesCallback(mutations) {
     if (!this.video_) {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -853,4 +853,33 @@ describes.realWin('amp-video', {
       });
     });
   });
+
+  describe('pool-bound', () => {
+    const getVideo = () => new Promise(resolve => {
+      getVideo({
+        'src': 'https://example-com.cdn.ampproject.org/m/s/video.mp4',
+        'class': 'i-amphtml-poolbound',
+        width: 160,
+        height: 90,
+      }, /* children */ null, resolve);
+    });
+
+    it('creates a definition element', () => {
+      getVideo().then(element => {
+        const defintionElement = element.implementation_.video_;
+
+        expect(defintionElement.tagName.toLowerCase())
+            .to.equal('i-amphtml-media-def');
+
+        expect(defintionElement.getAttribute('type')).to.equal('video');
+      });
+    });
+
+    it('does not append defintion element', () => {
+      getVideo().then(element => {
+        const defintionElement = element.implementation_.video_;
+        expect(defintionElement.parentNode).to.be.undefined;
+      });
+    });
+  });
 });

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -866,19 +866,26 @@ describes.realWin('amp-video', {
 
     it('creates a definition element', () => {
       getVideo().then(element => {
-        const defintionElement = element.implementation_.video_;
+        const definitionElement = element.implementation_.video_;
 
-        expect(defintionElement.tagName.toLowerCase())
+        expect(definitionElement.tagName.toLowerCase())
             .to.equal('i-amphtml-media-def');
 
-        expect(defintionElement.getAttribute('type')).to.equal('video');
+        expect(definitionElement.getAttribute('type')).to.equal('video');
       });
     });
 
     it('does not append defintion element', () => {
       getVideo().then(element => {
-        const defintionElement = element.implementation_.video_;
-        expect(defintionElement.parentNode).to.be.undefined;
+        const definitionElement = element.implementation_.video_;
+        expect(definitionElement.parentNode).to.be.undefined;
+      });
+    });
+
+    it('returns defintion element as media reference', () => {
+      getVideo().then(element => {
+        const definitionElement = element.implementation_.video_;
+        expect(element.getMediaReference()).to.equal(definitionElement);
       });
     });
   });


### PR DESCRIPTION
The current flow for media pool registry + insertion is as follows

This is problematic since the first step unnecessarily adds a media element to the DOM. Since the media pool limits the amount of media element per document, in cases where the media component count is greater than the media allowed by the media pool there will be performance issues.

1. A media element is created by the AMP media component. (**Performance hit**)
2. The media element is detached and kept as a reference element. (**Performance hit**)
3. A different media element is inserted, whose properties and children are copies of the reference element. (Real playable element is attached.)

This PR simplifies this flow and improves performance (steps 1 and 2) by directly providing reference elements to media pool that are detached from the DOM. 

**Work in progress.** Depends on mediapool understanding the concepts of media definition references and act accordingly (e.g. not detaching, keeping reference of parent `amp-video`, etc).
