### PR TITLE
🐛Disable Linker decoration for same domains

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -156,8 +156,8 @@ export class LinkerManager {
           Object.assign({}, defaultConfig, config[name]);
 
       if (mergedConfig['enabled'] !== true) {
-        user().info(TAG, `linker config for ${name} is not enabled and ` +
-            'will be ignored.');
+        user().info(TAG, 'linker config for %s is not enabled and ' +
+            'will be ignored.', name);
         return;
       }
 
@@ -279,6 +279,13 @@ export class LinkerManager {
 
     // See if any domains match.
     if (domains && !domains.includes(hostname)) {
+      return false;
+    }
+
+    // Don't append linker for exact domain match, relative urls, or
+    // fragments.
+    const winHostname = WindowInterface.getHostname(this.ampdoc_.win);
+    if (winHostname === hostname) {
       return false;
     }
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -64,6 +64,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     windowInterface.getLocation.returns({
       origin: 'https://amp-source-com.cdn.ampproject.org',
     });
+    windowInterface.getHostname.returns('amp-source-com.cdn.ampproject.org');
     installVariableService(win);
   });
 
@@ -256,7 +257,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       expect(canonicalDomainUrl).to.contain('testLinker1=');
       expect(canonicalDomainUrl).to.not.contain('testLinker2=');
 
-      const sourceDomainUrl = clickAnchor('https://amp.source.com/path');
+      const sourceDomainUrl = clickAnchor('https://www.source.com/path');
       expect(sourceDomainUrl).to.contain('testLinker1=');
       expect(sourceDomainUrl).to.not.contain('testLinker2=');
 
@@ -383,6 +384,64 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       const a = clickAnchor('https://www.source.com');
       expect(a).to.not.contain('testLinker1=');
       expect(a).to.contain('testLinker2=');
+    });
+  });
+
+  describe('same domain matching', () => {
+    let config;
+
+    beforeEach(() => {
+      windowInterface.getLocation.returns({
+        origin: 'https://amp.source.com',
+      });
+      windowInterface.getHostname.returns('amp.source.com');
+      config = {
+        linkers: {
+          testLinker: {
+            enabled: true,
+            proxyOnly: false,
+            ids: {
+              foo: 'bar',
+            },
+          },
+        },
+      };
+    });
+
+    it('should not add linker if same domain', () => {
+      return new LinkerManager(ampdoc, config, null).init().then(() => {
+        const url = clickAnchor('https://amp.source.com/');
+        expect(url).to.not.contain('testLinker');
+      });
+    });
+
+    it('should add linker if subdomain is different but friendly', () => {
+      return new LinkerManager(ampdoc, config, null).init().then(() => {
+        const url = clickAnchor('https://m.source.com/');
+        expect(url).to.contain('testLinker');
+      });
+    });
+
+    it('should not add linker if href is fragment', () => {
+      return new LinkerManager(ampdoc, config, null).init().then(() => {
+        const a = {
+          href: '#hello',
+          hostname: 'amp.source.com',
+        };
+        handlers.forEach(handler => handler(a, {type: 'click'}));
+        expect(a.href).to.not.contain('testLinker');
+      });
+    });
+
+    it('should not add linker if href is relative', () => {
+      return new LinkerManager(ampdoc, config, null).init().then(() => {
+        const a = {
+          href: '/foo',
+          hostname: 'amp.source.com',
+        };
+        handlers.forEach(handler => handler(a, {type: 'click'}));
+        expect(a.href).to.not.contain('testLinker');
+      });
     });
   });
 


### PR DESCRIPTION
Linker was decorating all links on the same domain. This was causing problems where pages would refresh on fragment links. Also it was unnecessarily polluting urls on things like relative links.

This disables linker params on exact same hostname match.

Closes #19456