### PR TITLE
googleanalytics: add support for DocumentPath (dp) parameter

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/googleanalytics.js
+++ b/extensions/amp-analytics/0.1/vendors/googleanalytics.js
@@ -17,7 +17,7 @@
 export const GOOGLEANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'vars': {
     'eventValue': '0',
-    'documentPath: '${canonicalPath}',
+    'documentPath': '${canonicalPath}',
     'documentLocation': 'SOURCE_URL',
     'clientId': 'CLIENT_ID(AMP_ECID_GOOGLE,,_ga)',
     'dataSource': 'AMP',

--- a/extensions/amp-analytics/0.1/vendors/googleanalytics.js
+++ b/extensions/amp-analytics/0.1/vendors/googleanalytics.js
@@ -17,6 +17,7 @@
 export const GOOGLEANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'vars': {
     'eventValue': '0',
+    'documentPath: '${canonicalPath}',
     'documentLocation': 'SOURCE_URL',
     'clientId': 'CLIENT_ID(AMP_ECID_GOOGLE,,_ga)',
     'dataSource': 'AMP',
@@ -37,6 +38,7 @@ export const GOOGLEANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'tid=${account}&' +
         'dl=${documentLocation}&' +
         'dr=${externalReferrer}&' +
+        'dp=${documentPath}&' +
         'sd=${screenColorDepth}&' +
         'ul=${browserLanguage}&' +
         'de=${documentCharset}',


### PR DESCRIPTION
✨ New feature (`:sparkles:`)  

add support for providing custom DocumentPath.
we have some internal statistic tools and some GA dashboard that depend on a "custom" supplied documentPath.



https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dp