### PR TITLE
amp-action-macro extension skeleton

### DIFF
--- a/extensions/amp-action-macro/0.1/amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/amp-action-macro.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LayoutPriority} from '../../../src/layout';
+/**
+* The <amp-action-macro> element is used to define a reusable action macro.
+*/
+export class AmpActionMacro extends AMP.BaseElement {
+ /** @override */
+ getLayoutPriority() {
+   // Loads after other content.
+   return LayoutPriority.METADATA;
+ }
+  /** @override */
+ isAlwaysFixed() {
+   return true;
+ }
+  /** @override */
+ isLayoutSupported(unusedLayout) {
+   return true;
+ }
+  /** @override */
+ renderOutsideViewport() {
+   // We want the macro to be available wherever it is in the document.
+   return true;
+ }
+}

--- a/extensions/amp-action-macro/0.1/amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/amp-action-macro.js
@@ -14,26 +14,31 @@
  * limitations under the License.
  */
 import {LayoutPriority} from '../../../src/layout';
+
 /**
 * The <amp-action-macro> element is used to define a reusable action macro.
 */
 export class AmpActionMacro extends AMP.BaseElement {
- /** @override */
- getLayoutPriority() {
-   // Loads after other content.
-   return LayoutPriority.METADATA;
- }
+
   /** @override */
- isAlwaysFixed() {
-   return true;
- }
+  getLayoutPriority() {
+    // Loads after other content.
+    return LayoutPriority.METADATA;
+  }
+
   /** @override */
- isLayoutSupported(unusedLayout) {
-   return true;
- }
+  isAlwaysFixed() {
+    return true;
+  }
+
   /** @override */
- renderOutsideViewport() {
-   // We want the macro to be available wherever it is in the document.
-   return true;
- }
+  isLayoutSupported(unusedLayout) {
+    return true;
+  }
+
+  /** @override */
+  renderOutsideViewport() {
+    // We want the macro to be available wherever it is in the document.
+    return true;
+  }
 }

--- a/extensions/amp-action-macro/0.1/amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/amp-action-macro.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 import {LayoutPriority} from '../../../src/layout';
+import {isExperimentOn} from '../../../src/experiments';
+import {user} from '../../../src/log';
+
+/** @const {string} */
+const TAG = 'amp-action-macro';
 
 /**
 * The <amp-action-macro> element is used to define a reusable action macro.
@@ -21,14 +26,15 @@ import {LayoutPriority} from '../../../src/layout';
 export class AmpActionMacro extends AMP.BaseElement {
 
   /** @override */
-  getLayoutPriority() {
-    // Loads after other content.
-    return LayoutPriority.METADATA;
+  buildCallback() {
+    user().assert(isExperimentOn(this.win, 'amp-action-macro'),
+        'Experiment is off');
   }
 
   /** @override */
-  isAlwaysFixed() {
-    return true;
+  getLayoutPriority() {
+    // Loads after other content.
+    return LayoutPriority.METADATA;
   }
 
   /** @override */
@@ -42,3 +48,8 @@ export class AmpActionMacro extends AMP.BaseElement {
     return true;
   }
 }
+
+
+AMP.extension(TAG, '0.1', AMP => {
+  AMP.registerElement(TAG, AmpActionMacro);
+});

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -36,7 +36,7 @@ describes.realWin('amp-action-macro', {
     toggleExperiment(win, 'amp-action-macro', true);
   });
 
-  function newActionMacro(type) {
+  function newActionMacro() {
     const actionMacro = doc.createElement('amp-action-macro');
     doc.body.appendChild(actionMacro);
     return actionMacro.build().then(() => {
@@ -47,9 +47,9 @@ describes.realWin('amp-action-macro', {
   it('should  build if experiment is on', done => {
     newActionMacro().then(() => {
       done();
-    }, err => {
+    }, unused => {
       done(new Error('component should have built'));
-    })
+    });
   });
 
   it('should not build if experiment is off', () => {

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -44,7 +44,7 @@ describes.realWin('amp-action-macro', {
     });
   }
 
-  it('should  build if experiment is on', done => {
+  it('should build if experiment is on', done => {
     newActionMacro().then(() => {
       done();
     }, unused => {

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-action-macro';
+import {
+  toggleExperiment,
+} from '../../../../src/experiments';
+
+describes.realWin('amp-action-macro', {
+  amp: {
+    runtimeOn: true,
+    extensions: ['amp-action-macro'],
+  },
+}, env => {
+
+  let win;
+  let doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+
+    toggleExperiment(win, 'amp-action-macro', true);
+  });
+
+  function newActionMacro(type) {
+    const actionMacro = doc.createElement('amp-action-macro');
+    doc.body.appendChild(actionMacro);
+    return actionMacro.build().then(() => {
+      return actionMacro.layoutCallback();
+    });
+  }
+
+  it('should  build if experiment is on', done => {
+    newActionMacro().then(() => {
+      done();
+    }, err => {
+      done(new Error('component should have built'));
+    })
+  });
+
+  it('should not build if experiment is off', () => {
+    return allowConsoleError(() => {
+      toggleExperiment(env.win, 'amp-action-macro', false);
+      return newActionMacro().catch(err => {
+        expect(err.message).to.include('Experiment is off');
+      });
+    });
+  });
+
+});

--- a/extensions/amp-action-macro/OWNERS.yaml
+++ b/extensions/amp-action-macro/OWNERS.yaml
@@ -1,0 +1,1 @@
+- alabiaga

--- a/extensions/amp-action-macro/amp-action-macro.md
+++ b/extensions/amp-action-macro/amp-action-macro.md
@@ -1,0 +1,59 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+ # <a name="amp-action-macro"></a> `amp-action-macro`
+ <table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Creates reusable actions.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-viz-vega" src="https://cdn.ampproject.org/v0/amp-action-macro-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/amp-action-macro.amp.html">amp-action-macro.amp.html</a></td>
+  </tr>
+</table>
+ [TOC]
+ ## Overview?
+The amp-action-macro component allows for the creation of reusable actions.
+ ## Example
+ ```html
+<amp-action-macro
+    id="closeNavigations"
+    action="AMP.setState({nav1: 'close', nav2: 'close})"></amp-action-macro>
+```
+ ```html
+ <button on="tap:closeNavigations">Close all</button>
+ <div on="tap:closeNavigations">Close all</div>
+```
+ ## Attributes
+ ##### id
+ Used to uniquely identify the action. This is referenced in an action invokation.
+ ##### action
+ The action to invoke. Any valid amp action is allowed here. <a href="https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events">See Actions and events in AMP.</a>
+ ```html
+ e.g.
+ <amp-action-macro
+    id="action1"
+    action="AMP.navigateTo('http://www.ampproject.org')"></amp-action-macro>
+ <amp-action-macro
+    id="action1"
+    action="ampList.refresh()"></amp-action-macro>
+ <amp-list id="ampList" src="...">...</amp-list>
+ ```

--- a/extensions/amp-action-macro/amp-action-macro.md
+++ b/extensions/amp-action-macro/amp-action-macro.md
@@ -22,7 +22,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-viz-vega" src="https://cdn.ampproject.org/v0/amp-action-macro-0.1.js">&lt;/script></code></td>
+    <td><code>&lt;script async custom-element="amp-action-macro" src="https://cdn.ampproject.org/v0/amp-action-macro-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
@@ -31,7 +31,7 @@ limitations under the License.
 </table>
  [TOC]
  ## Overview?
-The amp-action-macro component allows for the creation of reusable actions.
+The `amp-action-macro` component allows for the creation of reusable actions.
  ## Example
  ```html
 <amp-action-macro

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -148,6 +148,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/pull/6351',
   },
   {
+    id: 'amp-action-micro',
+    name: 'AMP extension for defining action macros',
+    spec: 'https://github.com/ampproject/amphtml/issues/19494',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/19495',
+  },
+  {
     id: 'ios-embed-sd',
     name: 'A new iOS embedded viewport model that wraps the body into' +
       ' shadow root',


### PR DESCRIPTION
Add the directory structure, experiment, and minimal viable changes for amp-action-macro component. This PR excludes the actual implementation to reduce the size of the PR and improve ease of reviewing.

Please see #19494 