### PR TITLE
Delay and delegate the subscriptions platform selection call.

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -37,6 +37,7 @@ import {getMode} from '../../../src/mode';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {getWinOrigin} from '../../../src/url';
 import {installStylesForDoc} from '../../../src/style-installer';
+import {isStoryDescendant} from '../../../src/dom';
 
 /** @const */
 const TAG = 'amp-subscriptions';
@@ -294,7 +295,11 @@ export class SubscriptionService {
             this.fetchEntitlements_(subscriptionPlatform);
           }
       );
-      this.startAuthorizationFlow_();
+
+      // Delegates the platform selection and activation call.
+      const doPlatformSelection = !isStoryDescendant(this.ampdoc_.win.document);
+
+      this.startAuthorizationFlow_(doPlatformSelection);
 
     });
     return this;
@@ -375,15 +380,15 @@ export class SubscriptionService {
   }
 
   /**
-   * Renders and opens the dialog using the cached entitlements.
+   * Selects and activates a platform.
    */
-  renderDialogForSelectedPlatform() {
+  maybeSelectAndActivatePlatform() {
     this.initialize_().then(() => {
       if (this.doesViewerProvideAuth_ || this.platformConfig_['alwaysGrant']) {
         return;
       }
 
-      this.selectAndActivatePlatform_(false /** sendAnalyticsEvents */);
+      this.selectAndActivatePlatform_();
     });
   }
 
@@ -404,11 +409,10 @@ export class SubscriptionService {
   }
 
   /**
-   * @param {boolean=} sendAnalyticsEvents
    * @return {!Promise}
    * @private
    */
-  selectAndActivatePlatform_(sendAnalyticsEvents = true) {
+  selectAndActivatePlatform_() {
     const requireValuesPromise = Promise.all([
       this.platformStore_.getGrantStatus(),
       this.platformStore_.selectPlatform(),
@@ -420,10 +424,6 @@ export class SubscriptionService {
           selectedPlatform.getServiceId());
 
       selectedPlatform.activate(selectedEntitlement);
-
-      if (sendAnalyticsEvents === false) {
-        return;
-      }
 
       this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -296,11 +296,10 @@ export class SubscriptionService {
           }
       );
 
-      // Delegates the platform selection and activation call.
-      const doPlatformSelection = !isStoryDocument(this.ampdoc_.win.document);
-
-      this.startAuthorizationFlow_(doPlatformSelection);
-
+      isStoryDocument(this.ampdoc_.win.document).then(isStory => {
+        // Delegates the platform selection and activation call if is story.
+        this.startAuthorizationFlow_(!isStory /** doPlatformSelection */);
+      });
     });
     return this;
   }

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -296,7 +296,7 @@ export class SubscriptionService {
           }
       );
 
-      isStoryDocument(this.ampdoc_.win.document).then(isStory => {
+      isStoryDocument(this.ampdoc_).then(isStory => {
         // Delegates the platform selection and activation call if is story.
         this.startAuthorizationFlow_(!isStory /** doPlatformSelection */);
       });

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -37,7 +37,7 @@ import {getMode} from '../../../src/mode';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {getWinOrigin} from '../../../src/url';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {isStoryDescendant} from '../../../src/dom';
+import {isStoryDocument} from '../../../src/utils/story';
 
 /** @const */
 const TAG = 'amp-subscriptions';
@@ -297,7 +297,7 @@ export class SubscriptionService {
       );
 
       // Delegates the platform selection and activation call.
-      const doPlatformSelection = !isStoryDescendant(this.ampdoc_.win.document);
+      const doPlatformSelection = !isStoryDocument(this.ampdoc_.win.document);
 
       this.startAuthorizationFlow_(doPlatformSelection);
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -936,3 +936,12 @@ export function domOrderComparator(element1, element2) {
   // if fe2 is following or contained by fe1, then fe1 is before fe2
   return -1;
 }
+
+/**
+ * Returns true if the document is an amp-story.
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isStoryDescendant(doc) {
+  return doc.body.firstElementChild.tagName === 'AMP-STORY';
+}

--- a/src/dom.js
+++ b/src/dom.js
@@ -936,12 +936,3 @@ export function domOrderComparator(element1, element2) {
   // if fe2 is following or contained by fe1, then fe1 is before fe2
   return -1;
 }
-
-/**
- * Returns true if the document is an amp-story.
- * @param {!Document} doc
- * @return {boolean}
- */
-export function isStoryDescendant(doc) {
-  return doc.body.firstElementChild.tagName === 'AMP-STORY';
-}

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -14,7 +14,7 @@
   * limitations under the License.
   */
 
-import {closestByTag} from '../dom';
+import {closestByTag, waitForChild} from '../dom';
 
 
 /**
@@ -32,8 +32,13 @@ export function descendsFromStory(element) {
 /**
  * Returns true if the document is an amp-story.
  * @param {!Document} doc
- * @return {boolean}
+ * @return {!Promise<boolean>}
  */
 export function isStoryDocument(doc) {
-  return doc.body.firstElementChild.tagName === 'AMP-STORY';
+  return new Promise(resolve => {
+    waitForChild(doc.documentElement,
+        () => !!(doc.body && doc.body.firstElementChild), () => {
+          resolve(doc.body.firstElementChild.tagName === 'AMP-STORY');
+        });
+  });
 }

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -31,14 +31,16 @@ export function descendsFromStory(element) {
 
 /**
  * Returns true if the document is an amp-story.
- * @param {!Document} doc
+ * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
  * @return {!Promise<boolean>}
  */
-export function isStoryDocument(doc) {
+export function isStoryDocument(ampdoc) {
   return new Promise(resolve => {
-    waitForChild(doc.documentElement,
-        () => !!(doc.body && doc.body.firstElementChild), () => {
-          resolve(doc.body.firstElementChild.tagName === 'AMP-STORY');
-        });
+    ampdoc.whenBodyAvailable().then(() => {
+      const body = ampdoc.getBody();
+      waitForChild(body, () => !!body.firstElementChild, () => {
+        resolve(body.firstElementChild.tagName === 'AMP-STORY');
+      });
+    });
   });
 }

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -28,3 +28,12 @@ import {closestByTag} from '../dom';
 export function descendsFromStory(element) {
   return !!closestByTag(element, 'amp-story-page');
 }
+
+/**
+ * Returns true if the document is an amp-story.
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isStoryDocument(doc) {
+  return doc.body.firstElementChild.tagName === 'AMP-STORY';
+}


### PR DESCRIPTION
As discussed offline and in the design doc, here's how `amp-subscriptions` will work in an `amp-story` context:

1. `amp-subscriptions` starts, processes the grant state, and delays the `selectAndActivatePlatform` if it detects that it is in an `amp-story` context
2. User navigates until they hit a non-free page, and amp-story calls a new method on the `SubscriptionsService` to trigger `selectAndActivatePlatform`, which could trigger the local platform (dialog), or the SwG UI, etc
3. `amp-story` waits for a document re-authorization, and resumes navigation

This PR delays and delegates the platform selection call when subscriptions is used in an `amp-story`.

Part of #12180