### PR TITLE
📖🐛 Use VideoJS APIs for listeners, add VideoJS example, use CDN URLs

### DIFF
--- a/build-system/app-utils.js
+++ b/build-system/app-utils.js
@@ -40,6 +40,9 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
         /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
         hostName + '/dist/amp-inabox.js');
     file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.js/g,
+        hostName + '/dist/video-iframe-integration.js');
+    file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
         hostName + '/dist/v0/$1.max.js');
     if (inabox) {
@@ -62,6 +65,9 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
     file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
         hostName + '/dist/amp4ads-v0.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.js/g,
+        hostName + '/dist/video-iframe-integration-v0.js');
     file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
         hostName + '/dist/v0/$1.js');

--- a/examples/amp-video-iframe-videojs.html
+++ b/examples/amp-video-iframe-videojs.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-video-iframe</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-video-iframe" src="https://cdn.ampproject.org/v0/amp-video-iframe-0.1.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+    [fallback] {
+      display: block;
+      /* @alternative */ display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+      background: rgba(0, 0, 0, 0.5);
+      color: #fff;
+    }
+    .spacer {
+      height: 100vh;
+    }
+    p, h1, h2, h3 {
+      padding: 10px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-video-iframe
+      id="myVideo"
+      src="./amp-video-iframe/frame-videojs.html"
+      width="720"
+      height="405"
+      layout="responsive"
+      autoplay>
+    <div placeholder style="background: black; color: white">
+      This is a placeholder
+    </div>
+    <div fallback>
+      This is a fallback
+    </div>
+  </amp-video-iframe>
+</body>
+</html>

--- a/examples/amp-video-iframe/frame-es2015.html
+++ b/examples/amp-video-iframe/frame-es2015.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <script async src="/dist/video-iframe-integration.js"></script>
+  <script async src="https://cdn.ampproject.org/video-iframe-integration-v0.js"></script>
 </head>
 <body style="margin: 0; padding: 0">
   <video

--- a/examples/amp-video-iframe/frame-videojs.html
+++ b/examples/amp-video-iframe/frame-videojs.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <link href="https://vjs.zencdn.net/7.3.0/video-js.css" rel="stylesheet">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <script async src="https://cdn.ampproject.org/video-iframe-integration-v0.js"></script>
+  <style type="text/css">
+  /* Hide big play button for a smoother autoplay experience. */
+  .video-js .vjs-big-play-button {
+    display: none;
+  }
+  </style>
+</head>
+<body style="margin: 0; padding: 0">
+  <video
+      id="my-video"
+      playsinline
+      controls
+      style="width: 100vw; height: 100vh;"
+      preload="auto"
+      class="video-js"
+      data-setup="{}">
+    <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+        type="video/mp4">
+    <p class="vjs-no-js">
+      To view this video please enable JavaScript, and consider upgrading to a web browser that
+      <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
+    </p>
+  </video>
+
+  <script src="https://vjs.zencdn.net/7.3.0/video.js"></script>
+
+  <!-- Integration script -->
+  <script>
+    // Wait for API to initialize
+    (window.AmpVideoIframe = window.AmpVideoIframe || [])
+        .push(function(ampIntegration) {
+          var myVideo = document.querySelector('#my-video');
+          ampIntegration.listenTo('videojs', myVideo);
+        });
+  </script>
+</body>
+</html>

--- a/examples/amp-video-iframe/frame.html
+++ b/examples/amp-video-iframe/frame.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <script async src="/dist/video-iframe-integration.js"></script>
+  <script async src="https://cdn.ampproject.org/video-iframe-integration-v0.js"></script>
 </head>
 <body style="margin: 0; padding: 0">
   <video

--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -78,6 +78,19 @@ const validEvents = [
   'unmuted',
 ];
 
+/**
+ * @param {function()} win
+ * @param {*} opt_initializer
+ * @return {function()}
+ * @visibleForTesting
+ */
+export function getVideoJs(win, opt_initializer) {
+  return userAssert(
+      opt_initializer || /** @type (function()) */ (win.videojs),
+      'Video.JS not imported or initializer undefined.');
+}
+
+
 /** @visibleForTesting */
 export class AmpVideoIntegration {
 
@@ -182,14 +195,19 @@ export class AmpVideoIntegration {
   /**
    * @param {string} type
    * @param {*} obj
+   * @param {function()=} opt_initializer For VideoJS, this optionally takes a
+   *    reference to the `videojs` function. If not provided, this reference
+   *    will be taken from the `window` object.
    */
-  listenTo(type, obj) {
+  listenTo(type, obj, opt_initializer) {
     switch (type.toLowerCase()) {
       case 'jwplayer':
+        userAssert(!opt_initializer,
+            'jwplayer integration does not take an initializer');
         this.listenToJwPlayer_(obj);
         break;
       case 'videojs':
-        this.listenToVideoJs_(obj);
+        this.listenToVideoJs_(obj, opt_initializer);
         break;
       default:
         userAssert(false, `Invalid listener type ${type}.`);
@@ -238,30 +256,39 @@ export class AmpVideoIntegration {
 
   /**
    * @param {!Element} element
+   * @param {function()=} opt_initializer
    * @private
    */
-  listenToVideoJs_(element) {
-    userAssert(this.win_.videojs, 'Video.JS not imported.');
+  listenToVideoJs_(element, opt_initializer) {
+    const initializer = getVideoJs(this.win_, opt_initializer);
+    const player = initializer(element);
 
-    // Retrieve lazily.
-    const player = once(() =>
-      this.win_.videojs.getPlayer(element));
+    player.ready(() => {
+      const canplay = 'canplay';
 
-    ['canplay', 'playing', 'pause', 'ended'].forEach(e => {
-      listen(element, e, () => this.postEvent(e));
+      ['playing', 'pause', 'ended'].forEach(e => {
+        player.on(e, () => this.postEvent(e));
+      });
+
+      // in case `canplay` fires before this script loads
+      if (player.readyState() >= /* HAVE_FUTURE_DATA */ 3) {
+        this.postEvent(canplay);
+      } else {
+        player.on(canplay, () => this.postEvent(canplay));
+      }
+
+      listen(element, 'volumechange', () =>
+        this.onVolumeChange_(player.volume()));
+
+      this.method('play', () => player.play());
+      this.method('pause', () => player.pause());
+      this.method('mute', () => player.muted(true));
+      this.method('unmute', () => player.muted(false));
+      this.method('showcontrols', () => player.controls(true));
+      this.method('hidecontrols', () => player.controls(false));
+      this.method('fullscreenenter', () => player.requestFullscreen());
+      this.method('fullscreenexit', () => player.exitFullscreen());
     });
-
-    listen(element, 'volumechange', () =>
-      this.onVolumeChange_(player().volume()));
-
-    this.method('play', () => player().play());
-    this.method('pause', () => player().pause());
-    this.method('mute', () => player().muted(true));
-    this.method('unmute', () => player().muted(false));
-    this.method('showcontrols', () => player().controls(true));
-    this.method('hidecontrols', () => player().controls(false));
-    this.method('fullscreenenter', () => player().requestFullscreen());
-    this.method('fullscreenexit', () => player().exitFullscreen());
   }
 
   /**


### PR DESCRIPTION
I was adding the Video JS example and then I realized:

1. All examples point to `/dist/`. So I fixed that to use CDN URLs and...
2. ...the CDN URLs didn't get replaced. So I fixed that and...
2. ...for some reason, when using the `default` mode script VideoJS events won't bubble up properly, so I fixed the VideoJS integration so that it uses its sanctioned API instead of relying on HTML5 events.