### PR TITLE
[amp-list] allow templating for load-more elements load-more-button and load-more-end

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1174,10 +1174,6 @@ app.get('/infinite-scroll', function(req, res) {
   const pagesLeft = query['left'] || 1;
   const latency = query['latency'] || 0;
 
-  if (pagesLeft == 0) {
-    res.json({items: []});
-  }
-
   for (let i = 0; i < numberOfItems; i++) {
     const imageUrl = 'http://picsum.photos/200?' +
         Math.floor(Math.random() * Math.floor(50));
@@ -1203,7 +1199,11 @@ app.get('/infinite-scroll', function(req, res) {
   };
 
   const next = pagesLeft == 0 ? randomFalsy() : nextUrl;
-  const results = next === false ? {items} : {items, next};
+  const results = next === false ? {items}
+    : {items, next,
+      'loadMoreButtonText': 'test',
+      'loadMoreEndText': 'end',
+    };
 
   if (latency) {
     setTimeout(() => res.json(results), latency);

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1186,7 +1186,7 @@ app.get('/infinite-scroll', function(req, res) {
   }
 
   const nextUrl = '/infinite-scroll?items=' +
-    numberOfItems + '&left=' + JSON.stringify(pagesLeft - 1) +
+    numberOfItems + '&left=' + (pagesLeft - 1) +
     '&latency=' + latency;
 
   const randomFalsy = () => {

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1186,7 +1186,8 @@ app.get('/infinite-scroll', function(req, res) {
   }
 
   const nextUrl = '/infinite-scroll?items=' +
-    numberOfItems + '&left=' + JSON.stringify(pagesLeft - 1);
+    numberOfItems + '&left=' + JSON.stringify(pagesLeft - 1) +
+    '&latency=' + latency;
 
   const randomFalsy = () => {
     const rand = Math.floor(Math.random() * Math.floor(3));

--- a/css/amp.css
+++ b/css/amp.css
@@ -635,13 +635,6 @@ amp-list[load-more] > [load-more-end] {
   bottom: 0;
 }
 
-amp-list[load-more] > [load-more-loading].amp-visible,
-amp-list[load-more] > [load-more-failed].amp-visible,
-amp-list[load-more] > [load-more-button].amp-visible,
-amp-list[load-more] > [load-more-end].amp-visible {
-  visibility: visible;
-}
-
 /* Polyfill for IE and any other browser that don't understand templates. */
 template {
   display: none !important;

--- a/css/amp.css
+++ b/css/amp.css
@@ -621,6 +621,27 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   visibility: visible;
 }
 
+amp-list[load-more] > [load-more-button] > .i-amphtml-loader {
+  visibility: hidden;
+}
+
+amp-list[load-more] > [load-more-loading],
+amp-list[load-more] > [load-more-failed],
+amp-list[load-more] > [load-more-button],
+amp-list[load-more] > [load-more-failed],
+amp-list[load-more] > [load-more-end] {
+  visibility: hidden;
+  position: absolute;
+  bottom: 0;
+}
+
+amp-list[load-more] > [load-more-loading].amp-visible,
+amp-list[load-more] > [load-more-failed].amp-visible,
+amp-list[load-more] > [load-more-button].amp-visible,
+amp-list[load-more] > [load-more-end].amp-visible {
+  visibility: visible;
+}
+
 /* Polyfill for IE and any other browser that don't understand templates. */
 template {
   display: none !important;

--- a/css/amp.css
+++ b/css/amp.css
@@ -621,20 +621,6 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   visibility: visible;
 }
 
-amp-list[load-more] > [load-more-button] > .i-amphtml-loader {
-  visibility: hidden;
-}
-
-amp-list[load-more] > [load-more-loading],
-amp-list[load-more] > [load-more-failed],
-amp-list[load-more] > [load-more-button],
-amp-list[load-more] > [load-more-failed],
-amp-list[load-more] > [load-more-end] {
-  visibility: hidden;
-  position: absolute;
-  bottom: 0;
-}
-
 /* Polyfill for IE and any other browser that don't understand templates. */
 template {
   display: none !important;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -433,11 +433,11 @@ export class AmpList extends AMP.BaseElement {
    * Schedules a fetch result to be rendered in the near future.
    * @param {!Array|?JsonObject|string|undefined} data
    * @param {boolean} append
-   * @param {JsonObject=} opt_other
+   * @param {JsonObject=} opt_payload
    * @return {!Promise}
    * @private
    */
-  scheduleRender_(data, append, opt_other) {
+  scheduleRender_(data, append, opt_payload) {
     dev().info(TAG, 'schedule:', data);
     const deferred = new Deferred();
     const {promise, resolve: resolver, reject: rejecter} = deferred;
@@ -447,11 +447,12 @@ export class AmpList extends AMP.BaseElement {
       this.renderPass_.schedule();
     }
 
-    this.renderItems_ = {data, append, resolver, rejecter, 'other': opt_other};
+    this.renderItems_ = {data, append, resolver, rejecter,
+      'payload': opt_payload};
 
     if (this.renderedItems_ && append) {
       this.renderItems_.data = this.renderedItems_.concat(data);
-      this.renderItems_.other = opt_other || {};
+      this.renderItems_.payload = opt_payload || {};
     }
 
     return promise;
@@ -490,11 +491,11 @@ export class AmpList extends AMP.BaseElement {
           .then(onFulfilledCallback, onRejectedCallback);
     } else {
       const array = /** @type {!Array} */ (current.data);
-      const templateData = /** @type {!JsonObject} */ (current.other);
+      const payload = /** @type {!JsonObject} */ (current.payload);
       this.templates_.findAndRenderTemplateArray(this.element, array)
           .then(results => this.updateBindings_(results))
           .then(elements => this.render_(elements, current.append))
-          .then(() => this.maybeRenderLoadMoreTemplates_(templateData))
+          .then(() => this.maybeRenderLoadMoreTemplates_(payload))
           .then(() => this.loadMoreEnabled_ && this.setLoadMore_())
           .then(onFulfilledCallback, onRejectedCallback);
     }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -376,7 +376,7 @@ export class AmpList extends AMP.BaseElement {
         if (maxLen < items.length) {
           items = items.slice(0, maxLen);
         }
-        return this.scheduleRender_(/** @type {!Array} */(items), !!opt_append);
+        return this.scheduleRender_(/** @type {!Array} */(items), !!opt_append, data);
       });
     }
 
@@ -433,10 +433,12 @@ export class AmpList extends AMP.BaseElement {
    * Schedules a fetch result to be rendered in the near future.
    * @param {!Array|?JsonObject|string|undefined} data
    * @param {boolean} append
+   * @param {JsonObject=} opt_other
    * @return {!Promise}
    * @private
    */
-  scheduleRender_(data, append) {
+  scheduleRender_(data, append, opt_other) {
+    console.log(opt_other);
     dev().info(TAG, 'schedule:', data);
     const deferred = new Deferred();
     const {promise, resolve: resolver, reject: rejecter} = deferred;
@@ -446,10 +448,11 @@ export class AmpList extends AMP.BaseElement {
       this.renderPass_.schedule();
     }
 
-    this.renderItems_ = {data, append, resolver, rejecter};
+    this.renderItems_ = {data, append, resolver, rejecter, 'other': opt_other};
 
     if (this.renderedItems_ && append) {
       this.renderItems_.data = this.renderedItems_.concat(data);
+      this.renderItems_.other = opt_other || {};
     }
 
     return promise;
@@ -488,12 +491,46 @@ export class AmpList extends AMP.BaseElement {
           .then(onFulfilledCallback, onRejectedCallback);
     } else {
       const array = /** @type {!Array} */ (current.data);
+      const templateData = /** @type {!JsonObject} */ (current.other);
       this.templates_.findAndRenderTemplateArray(this.element, array)
           .then(results => this.updateBindings_(results))
           .then(elements => this.render_(elements, current.append))
+          .then(() => this.maybeRenderLoadMoreTemplates_(templateData))
           .then(() => this.loadMoreEnabled_ && this.setLoadMore_())
           .then(onFulfilledCallback, onRejectedCallback);
     }
+  }
+
+  /**
+   * @param {!JsonObject} data
+   * @return {!Promise}
+   * @private
+   */
+  maybeRenderLoadMoreTemplates_(data) {
+    const promises = [];
+    promises.push(this.maybeRenderLoadMoreElement_(this.loadMoreButton_, data));
+    promises.push(this.maybeRenderLoadMoreElement_(
+        this.loadMoreEndElement_, data));
+    return Promise.all(promises);
+  }
+
+  /**
+   * @param {?Element} elem
+   * @param {!JsonObject} data
+   * @return {!Promise}
+   * @private
+   */
+  maybeRenderLoadMoreElement_(elem, data) {
+    if (elem && this.templates_.hasTemplate(elem)) {
+      return this.templates_.findAndRenderTemplate(elem, data)
+          .then(newContents => {
+            this.mutateElement(() => {
+              removeChildren(dev().assertElement(elem));
+              elem.appendChild(newContents);
+            });
+          });
+    }
+    return Promise.resolve();
   }
 
   /**
@@ -685,9 +722,10 @@ export class AmpList extends AMP.BaseElement {
   setLoadMore_() {
     // Done loading, nothing more to load.
     if (!this.loadMoreSrc_) {
-      this.loadMoreButton_.classList.toggle('amp-visible', false);
-      this.loadMoreEndElement_.classList.toggle('amp-visible', true);
-      return;
+      return this.mutateElement(() => {
+        this.loadMoreButton_.classList.toggle('amp-visible', false);
+        this.loadMoreEndElement_.classList.toggle('amp-visible', true);
+      });
     }
     const triggerOnScroll = this.element.getAttribute('load-more') === 'auto';
     if (triggerOnScroll) {
@@ -730,7 +768,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @return {!Element|null}
+   * @return {?Element}
    * @private
    */
   getLoadMoreLoadingElement_() {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -438,7 +438,6 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   scheduleRender_(data, append, opt_other) {
-    console.log(opt_other);
     dev().info(TAG, 'schedule:', data);
     const deferred = new Deferred();
     const {promise, resolve: resolver, reject: rejecter} = deferred;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -195,7 +195,7 @@ export class AmpList extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {!Element|null}
+   * @return {?Element}
    */
   getloadMoreButton_() {
     if (!this.loadMoreButton_) {
@@ -837,7 +837,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @return {!Element|null}
+   * @return {?Element}
    * @private
    */
   getLoadMoreFailedElement_() {
@@ -849,7 +849,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @return {!Element|null}
+   * @return {?Element}
    * @private
    */
   getLoadMoreEndElement_() {

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -299,7 +299,7 @@ This attribute specifies an attribute in the returned data that will give the ur
 `<amp-list>` with the `load-more` attribute expects the following additional child elements. All of these elements are templated. (Note that UX defaults for these are on the roadmap, thus it will not always be necessary to include these elements.)
 
 #### load-more-button (mandatory)
-An element containing the `load-more-button` attribute, usually a button. Clicking on this element will trigger a fetch to load more elements from the url contained in the field of the data returned corresponding to the `load-more-bookmark` attribute. This element can be templated via amp-mustache.
+An element containing the `load-more-button` attribute, usually a button. Clicking on this element will trigger a fetch to load more elements from the url contained in the field of the data returned corresponding to the `load-more-bookmark` attribute. This element can be templated via `amp-mustache`.
 
 #### load-more-loading (mandatory)
 An element containing the `load-more-loading` attribute. This element will be displayed if the user reaches the end of the list and the contents are still loading, or as a result of clicking on the `load-more-button` element (while the new children of the amp-list are still loading).
@@ -308,7 +308,7 @@ An element containing the `load-more-loading` attribute. This element will be di
 An element containing the `load-more-failed` attribute. This element will be displayed at the bottom of the `<amp-list>` if loading failed. Clicking on this element will trigger a reload of the url that failed.
 
 #### load-more-end (optional)
-An element containing the `load-more-end` attribute. This element will be displayed at the bottom of the `<amp-list>` if there are no more items. This element is optional. This element can be templated via amp-mustache.
+An element containing the `load-more-end` attribute. This element will be displayed at the bottom of the `<amp-list>` if there are no more items. This element is optional. This element can be templated via `amp-mustache`.
 
 ##### common attributes
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -299,7 +299,7 @@ This attribute specifies an attribute in the returned data that will give the ur
 `<amp-list>` with the `load-more` attribute expects the following additional child elements. All of these elements are templated. (Note that UX defaults for these are on the roadmap, thus it will not always be necessary to include these elements.)
 
 #### load-more-button (mandatory)
-An element containing the `load-more-button` attribute, usually a button. Clicking on this element will trigger a fetch to load more elements from the url contained in the field of the data returned corresponding to the `load-more-bookmark` attribute.
+An element containing the `load-more-button` attribute, usually a button. Clicking on this element will trigger a fetch to load more elements from the url contained in the field of the data returned corresponding to the `load-more-bookmark` attribute. This element can be templated via amp-mustache.
 
 #### load-more-loading (mandatory)
 An element containing the `load-more-loading` attribute. This element will be displayed if the user reaches the end of the list and the contents are still loading, or as a result of clicking on the `load-more-button` element (while the new children of the amp-list are still loading).
@@ -308,8 +308,7 @@ An element containing the `load-more-loading` attribute. This element will be di
 An element containing the `load-more-failed` attribute. This element will be displayed at the bottom of the `<amp-list>` if loading failed. Clicking on this element will trigger a reload of the url that failed.
 
 #### load-more-end (optional)
-An element containing the `load-more-end` attribute. This element will be displayed at the bottom of the `<amp-list>` if there are no more items. This element is optional.
-
+An element containing the `load-more-end` attribute. This element will be displayed at the bottom of the `<amp-list>` if there are no more items. This element is optional. This element can be templated via amp-mustache.
 
 ##### common attributes
 

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -66,7 +66,7 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=1"
+    src="/infinite-scroll?items=5&left=5&latency=3000"
     load-more
     load-more-bookmark="next">
     <template type="amp-mustache">

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -66,8 +66,8 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=3"
-    load-more="auto"
+    src="/infinite-scroll?items=5&left=1"
+    load-more
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="story-entry">
@@ -76,19 +76,23 @@
       </div>
     </template>
     <div load-more-button>
-      SEE MORE
+      <template type="amp-mustache">
+        {{loadMoreButtonText}}
+      </template>
     </div>
     <div load-more-failed>
-      LOAD FAILED
-    </div>
-    <div fallback>
-      FALLBACK
+      FAILED
     </div>
     <div load-more-loading>
       LOADING
     </div>
     <div load-more-end>
-      LOAD END
+      <template type="amp-mustache">
+        {{loadMoreEndText}}
+      </template>
+    </div>
+    <div fallback>
+        FALLBACK
     </div>
   </amp-list>
 


### PR DESCRIPTION
Allows templating for `load-more-button` and `load-more-end` elements within `amp-list-load-more`. We don't allow templating for `load-more-loading` and `load-more-failed` because the data will not be present when they should be displayed. 