### PR TITLE
🏗 Modify `git.js` commands to be Travis-aware

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -92,9 +92,10 @@ exports.gitBranchName = function() {
  * @return {string}
  */
 exports.gitCommitHash = function() {
-  return process.env.TRAVIS_PULL_REQUEST_SHA ?
-    process.env.TRAVIS_PULL_REQUEST_SHA :
-    getStdout('git rev-parse --verify HEAD').trim();
+  if (process.env.TRAVIS_PULL_REQUEST_SHA) {
+    return process.env.TRAVIS_PULL_REQUEST_SHA;
+  }
+  return getStdout('git rev-parse --verify HEAD').trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -23,15 +23,13 @@ const {getStdout} = require('./exec');
 
 /**
  * Returns the branch point of the current branch off of master.
- * @param {boolean} fromMerge true if this is a merge commit.
  * @return {string}
  */
-exports.gitBranchPoint = function(fromMerge = false) {
-  if (fromMerge) {
-    return getStdout('git merge-base HEAD^1 HEAD^2').trim();
-  } else {
-    return getStdout('git merge-base master HEAD^').trim();
+exports.gitBranchPoint = function() {
+  if (process.env.TRAVIS_COMMIT_RANGE) {
+    return process.env.TRAVIS_COMMIT_RANGE.substr(0, 40);
   }
+  return getStdout('git merge-base master HEAD^').trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -72,14 +72,6 @@ exports.gitDiffColor = function() {
 };
 
 /**
- * Returns the URL of the origin (upstream) repository.
- * @return {string}
- */
-exports.gitOriginUrl = function() {
-  return getStdout('git remote get-url origin').trim();
-};
-
-/**
  * Returns the name of the local branch.
  * @return {string}
  */

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitBranchPoint, gitCommitHash, gitOriginUrl} = require('../git');
+const {gitBranchPoint, gitCommitHash} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -34,7 +34,7 @@ const buildArtifactsRepoOptions = {
   owner: 'ampproject',
   repo: 'amphtml-build-artifacts',
 };
-const expectedGitHubProject = 'ampproject/amphtml';
+const expectedGitHubRepoSlug = 'ampproject/amphtml';
 const bundleSizeAppBaseUrl = 'https://amp-bundle-size-bot.appspot.com/v0/';
 
 const {green, red, cyan, yellow} = colors;
@@ -142,11 +142,10 @@ function storeBundleSize() {
     return;
   }
 
-  const gitOriginUrlValue = gitOriginUrl();
-  if (!gitOriginUrlValue.includes(expectedGitHubProject)) {
-    log('Git origin URL is', cyan(gitOriginUrlValue));
-    log('Skipping storing the bundle size in the artifacts repository on',
-        'GitHub...');
+  if (process.env.TRAVIS_REPO_SLUG !== expectedGitHubRepoSlug) {
+    log(yellow('Skipping'), cyan('--on_push_build') + ':',
+        'this action can only be performed on Travis builds on the',
+        cyan(expectedGitHubRepoSlug), 'repository');
     return;
   }
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -108,7 +108,7 @@ function isPullRequest() {
  * @return {string} the `master` ancestor's bundle size.
  */
 async function getAncestorBundleSize() {
-  const gitBranchPointSha = gitBranchPoint(/* fromMerge */ isPullRequest());
+  const gitBranchPointSha = gitBranchPoint();
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
   return await octokit.repos.getContents(

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -97,7 +97,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint(/* fromMerge */ true);
+    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint();
   }
 }
 


### PR DESCRIPTION
This should fix issues where certain gulp commands (`bundle-size` and `visual-diff`) choose the wrong base commit