### PR TITLE
🏗 Move the bundle-size check downwards

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -462,7 +462,7 @@ function runAllCommands() {
     command.updatePackages();
     command.cleanBuild();
     command.buildRuntimeMinified(/* extensions */ true);
-    command.runBundleSizeCheck('push');
+    command.runBundleSizeCheck(/* action */ 'push');
     command.runPresubmitTests();
     command.runIntegrationTests(/* compiled */ true, /* coverage */ false);
     command.runSinglePassCompiledIntegrationTests();
@@ -639,13 +639,12 @@ function main() {
       command.runVisualDiffTests();
       if (buildTargets.has('RUNTIME')) {
         command.buildRuntimeMinified(/* extensions */ false);
-        command.runBundleSizeCheck('pr');
-      } else {
-        command.runBundleSizeCheck('skipped');
       }
     } else {
-      // Generates a blank Percy build to satisfy the required Github check.
+      // Generates a blank Percy build and skip the bundle-size check to satisfy
+      // the required Github checks.
       command.runVisualDiffTests(/* opt_mode */ 'empty');
+      command.runBundleSizeCheck(/* action */ 'skipped');
     }
     command.runPresubmitTests();
     if (buildTargets.has('INTEGRATION_TEST') ||
@@ -660,6 +659,9 @@ function main() {
         buildTargets.has('FLAG_CONFIG') ||
         buildTargets.has('BUILD_SYSTEM')) {
       command.verifyVisualDiffTests();
+    }
+    if (buildTargets.has('RUNTIME')) {
+      command.runBundleSizeCheck(/* action */ 'pr');
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -637,13 +637,14 @@ function main() {
       command.cleanBuild();
       command.buildRuntime();
       command.runVisualDiffTests();
+    } else {
+      // Generate a blank Percy build to satisfy the required GitHub check.
+      command.runVisualDiffTests(/* opt_mode */ 'empty');
     }
     if (buildTargets.has('RUNTIME')) {
       command.buildRuntimeMinified(/* extensions */ false);
     } else {
-      // Generates a blank Percy build and skip the bundle-size check to satisfy
-      // the required Github checks.
-      command.runVisualDiffTests(/* opt_mode */ 'empty');
+      // Skip the bundle-size check to satisfy the required GitHub check.
       command.runBundleSizeCheck(/* action */ 'skipped');
     }
     command.runPresubmitTests();

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -637,9 +637,9 @@ function main() {
       command.cleanBuild();
       command.buildRuntime();
       command.runVisualDiffTests();
-      if (buildTargets.has('RUNTIME')) {
-        command.buildRuntimeMinified(/* extensions */ false);
-      }
+    }
+    if (buildTargets.has('RUNTIME')) {
+      command.buildRuntimeMinified(/* extensions */ false);
     } else {
       // Generates a blank Percy build and skip the bundle-size check to satisfy
       // the required Github checks.


### PR DESCRIPTION
This PR will hopefully help us avoid the case where other PRs attempt to run their bundle-size check before the `master` commit that they are based on has finished generating its bundle-size file in the build artifacts repository