### PR TITLE
Remove legacy CSS for resizable-children

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -520,15 +520,6 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   visibility: hidden;
 }
 
-/**
- * The default amp-hidden changes visibility, which takes up space. In the case
- * where amp-list becomes a container via the resizable-children attribute, the
- * loader should be fully hidden and not take up space.
- */
-amp-list[resizable-children] > .i-amphtml-loading-container.amp-hidden {
-  display: none !important;
-}
-
 .i-amphtml-loader-line {
   position: absolute;
   top:0;


### PR DESCRIPTION
Related to https://github.com/ampproject/amphtml/issues/10230. This CSS is no longer relevant because we removed the `resizable-children` attribute and adopted the `changeToLayoutContainer` approach instead. Tested with layout container demos, and `reset-on-refresh`. Despite being `visibility: hidden` instead of `display: none`, the loading container shows a size of width x 0, and does not increase the size of the amp-list on Safari and Chrome. 