### PR TITLE
📖 amp-ima-video: Add documentation for data-ad-label

### DIFF
--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -77,7 +77,7 @@ The component HTML accepts the following types of HTML nodes as children:
 
 The URL for your VAST ad document. A relative URL or a URL that uses https protocol.
 
-##### data-src  
+##### data-src
 
 The URL of your video content. A relative URL or a URL that uses https protocol. This attribute is required if no `<source>` children are present.
 
@@ -86,9 +86,13 @@ The URL of your video content. A relative URL or a URL that uses https protocol.
 An image for the frame to be displayed before video playback has started. By
 default, the first frame is displayed.
 
-##### data-delay-ad-request
+##### data-delay-ad-request (optional)
 
 If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.
+
+##### data-ad-label (optional)
+
+A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3).  This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".
 
 ##### common attributes
 


### PR DESCRIPTION
Relates to https://github.com/ampproject/amphtml/issues/19393

## Changes

Add documentation for the `data-ad-label` attribute for the `<amp-ima-video>` element, including the default value.

## Screenshot

![docupdate](https://user-images.githubusercontent.com/4807680/49331663-8a444780-f566-11e8-881c-8b5c0e96610b.png)
