### PR TITLE
Update no-module-exports eslint rule

### DIFF
--- a/build-system/eslint-rules/no-module-exports.js
+++ b/build-system/eslint-rules/no-module-exports.js
@@ -30,18 +30,10 @@ module.exports = {
   },
 
   create(context) {
-
-    function isModuleExports(node) {
-      return node.object.type === 'Identifier' && (/^(module)$/).test(node.object.name) &&
-        node.property.type === 'Identifier' && (/^(exports)$/).test(node.property.name)
-    }
-
     return {
-      MemberExpression(node) {
-        if (isModuleExports(node)) {
-            context.report({ node, messageId: "unexpected"});
-        }
-      }
+      "MemberExpression[object.name=module][property.name=exports]": function(node) {
+        context.report({ node, messageId: "unexpected"});
+      }      
     };
   }
 };

--- a/build-system/eslint-rules/no-module-exports.js
+++ b/build-system/eslint-rules/no-module-exports.js
@@ -32,7 +32,8 @@ module.exports = {
   create(context) {
 
     function isModuleExports(node) {
-      return node.object.type === 'Identifier' && (/^(module.exports)$/).test(node.object.name)
+      return node.object.type === 'Identifier' && (/^(module)$/).test(node.object.name) &&
+        node.property.type === 'Identifier' && (/^(exports)$/).test(node.property.name)
     }
 
     return {


### PR DESCRIPTION
Updates no-module-exports eslint rule to correctly identify `module.exports`.

Follow up to PR #19503.