### PR TITLE
Fix margins in amp-consent bookend component 🐛

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -78,11 +78,11 @@
 }
 
 .i-amphtml-story-bookend-consent {
-  margin: 0 32px !important;
+  margin: 0 24px !important;
 }
 
 .i-amphtml-story-bookend-consent:last-child {
-  margin-bottom: 32px !important;
+  margin-bottom: 24px !important;
 }
 
 .i-amphtml-story-bookend-consent .i-amphtml-story-bookend-heading {

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -77,7 +77,7 @@
   overflow: hidden !important;
 }
 
-.i-amphtml-story-bookend-inner > div {
+.i-amphtml-story-bookend-top-level {
   margin-left: 24px !important;
   margin-right: 24px !important;
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -78,7 +78,8 @@
 }
 
 .i-amphtml-story-bookend-inner > div {
-  margin: 0 24px !important;
+  margin-left: 24px !important;
+  margin-right: 24px !important;
 }
 
 .i-amphtml-story-bookend-consent:last-child {

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -77,7 +77,7 @@
   overflow: hidden !important;
 }
 
-.i-amphtml-story-bookend-consent {
+.i-amphtml-story-bookend-inner > div {
   margin: 0 24px !important;
 }
 
@@ -248,7 +248,6 @@
 }
 
 .i-amphtml-story-bookend-replay {
-  margin: 0 24px !important;
   overflow: hidden !important;
   display: flex !important;
   max-height: 120px !important;
@@ -279,7 +278,6 @@
 }
 
 .i-amphtml-story-bookend-component-set {
-  margin: 0 24px !important;
   margin-bottom: 24px !important;
 }
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -104,7 +104,8 @@ const TAG = 'amp-story-bookend';
 const buildReplayButtonTemplate = (title, domainName, imageUrl = undefined) => {
   return /** @type {!../simple-template.ElementDef} */ ({
     tag: 'div',
-    attrs: dict({'class': 'i-amphtml-story-bookend-replay'}),
+    attrs: dict({'class': 'i-amphtml-story-bookend-replay ' +
+      'i-amphtml-story-bookend-top-level'}),
     children: [
       {
         tag: 'div',
@@ -141,7 +142,8 @@ const buildReplayButtonTemplate = (title, domainName, imageUrl = undefined) => {
 const buildPromptConsentTemplate = consentId => {
   return /** @type {!../simple-template.ElementDef} */ ({
     tag: 'div',
-    attrs: dict({'class': 'i-amphtml-story-bookend-consent'}),
+    attrs: dict({'class': 'i-amphtml-story-bookend-consent ' +
+        'i-amphtml-story-bookend-top-level'}),
     children: [
       {
         tag: 'h3',

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -180,7 +180,8 @@ export class BookendComponent {
   static buildContainer(element, doc) {
     const html = htmlFor(doc);
     const containerTemplate =
-      html`<div class="i-amphtml-story-bookend-component-set"></div>`;
+      html`<div class="i-amphtml-story-bookend-component-set
+          i-amphtml-story-bookend-top-level"></div>`;
     element.appendChild(containerTemplate);
     return element.lastElementChild;
   }


### PR DESCRIPTION
Fixes #19557

amp-consent has inconsistent margins compared to the `.i-amphtml-story-bookend-component-set ` class inside the bookend.

Before:
![image](https://user-images.githubusercontent.com/5449100/49386849-76c3e880-f6ee-11e8-9b84-a4a964700858.png)

After:
![image](https://user-images.githubusercontent.com/5449100/49386858-7af00600-f6ee-11e8-9659-76bf6b8decb4.png)
