### PR TITLE
🐛Amp-iframe: Only create one iframe

### DIFF
--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -174,6 +174,21 @@ describes.realWin('amp-iframe', {
       expect(ranJs).to.equal(0);
     });
 
+    it('should render iframe only once', function* () {
+      const ampIframe = createAmpIframe(env, {
+        src: iframeSrc,
+        width: 100,
+        height: 100,
+      });
+      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+      const impl = ampIframe.implementation_;
+      let iframe = ampIframe.querySelectorAll('iframe');
+      expect(iframe.length).to.equal(1);
+      impl.layoutCallback();
+      iframe = ampIframe.querySelectorAll('iframe');
+      expect(iframe.length).to.equal(1);
+    });
+
     it('should only propagate supported attributes', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,


### PR DESCRIPTION
Closes #19599 

Multiple iframes will be created if we call `schduleLayout` of `<amp-iframe>` multiple times. This is to prevent that from happening

cc @torch2424 