### PR TITLE
Improve RequestBank test infra

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -96,9 +96,8 @@ const bank = {};
  * Deposit a request. An ID has to be specified. Will override previous request
  * if the same ID already exists.
  */
-app.use('/request-bank/deposit/', (req, res) => {
-  // req.url is relative to the path specified in app.use
-  const key = req.url;
+app.use('/request-bank/deposit/:id/', (req, res) => {
+  const key = req.params.id;
   log('SERVER-LOG [DEPOSIT]: ', key);
   if (typeof bank[key] === 'function') {
     bank[key](req);
@@ -113,9 +112,8 @@ app.use('/request-bank/deposit/', (req, res) => {
  * return it immediately. Otherwise wait until it gets deposited
  * The same request cannot be withdrawn twice at the same time.
  */
-app.use('/request-bank/withdraw/', (req, res) => {
-  // req.url is relative to the path specified in app.use
-  const key = req.url;
+app.use('/request-bank/withdraw/:id/', (req, res) => {
+  const key = req.params.id;
   log('SERVER-LOG [WITHDRAW]: ' + key);
   const result = bank[key];
   if (typeof result === 'function') {
@@ -125,6 +123,7 @@ app.use('/request-bank/withdraw/', (req, res) => {
     res.json({
       headers: result.headers,
       body: result.body,
+      url: result.url,
     });
     delete bank[key];
   };

--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -19,6 +19,14 @@ import {
   withdrawRequest,
 } from '../../testing/test-helper';
 
+const RequestId = {
+  BASIC: 'analytics-basic',
+  BATCH: 'analytics-batch',
+  USE_BODY: 'analytics-useBody',
+  BATCH_BODY: 'analytics-batch-useBody',
+  NO_REFERRER: 'analytics-no-referrer',
+};
+
 describe.configure().skipIfPropertiesObfuscated().run('amp' +
     '-analytics', function() {
   this.timeout(15000);
@@ -29,7 +37,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${depositRequestUrl('analytics-basic')}"
+            "endpoint": "${depositRequestUrl(RequestId.BASIC)}"
           },
           "triggers": {
             "pageview": {
@@ -48,10 +56,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         </script>
       </amp-analytics>`,
     extensions: ['amp-analytics'],
-  }, env => {
+  }, () => {
     it('should send request', () => {
-      return withdrawRequest(
-          env.win, 'analytics-basic?a=2&b=AMP%20TEST').then(request => {
+      return withdrawRequest(RequestId.BASIC).then(request => {
+        expect(request.url).to.equal('/?a=2&b=AMP%20TEST');
         expect(request.headers.referer,
             'should keep referrer if no referrerpolicy specified').to.be.ok;
       });
@@ -65,7 +73,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${depositRequestUrl('analytics-batch')}",
+              "baseUrl": "${depositRequestUrl(RequestId.BATCH)}",
               "batchInterval": 1
             }
           },
@@ -95,10 +103,11 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         </script>
       </amp-analytics>`,
     extensions: ['amp-analytics'],
-  }, env => {
+  }, () => {
     it('should send request in batch', () => {
-      return withdrawRequest(env.win,
-          'analytics-batch?a=1&b=AMP%20TEST&a=1&b=AMP%20TEST');
+      return withdrawRequest(RequestId.BATCH).then(req => {
+        expect(req.url).to.equal('/?a=1&b=AMP%20TEST&a=1&b=AMP%20TEST');
+      });
     });
   });
 
@@ -108,7 +117,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${depositRequestUrl('analytics-useBody')}"
+            "endpoint": "${depositRequestUrl(RequestId.USE_BODY)}"
           },
           "triggers": {
             "pageview": {
@@ -132,10 +141,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         </script>
       </amp-analytics>`,
     extensions: ['amp-analytics'],
-  }, env => {
+  }, () => {
     it('should send request use POST body payload', () => {
-      return withdrawRequest(
-          env.win, 'analytics-useBody').then(request => {
+      return withdrawRequest(RequestId.USE_BODY).then(request => {
+        expect(request.url).to.equal('/');
         expect(request.body).to.equal('{"a":2,"b":"AMP TEST"}');
       });
     });
@@ -148,7 +157,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${depositRequestUrl('analytics-batch-useBody')}",
+              "baseUrl": "${depositRequestUrl(RequestId.BATCH_BODY)}",
               "batchInterval": 1
             }
           },
@@ -179,10 +188,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         </script>
       </amp-analytics>`,
     extensions: ['amp-analytics'],
-  }, env => {
+  }, () => {
     it('should send batch request use POST body payload', () => {
-      return withdrawRequest(
-          env.win, 'analytics-batch-useBody').then(request => {
+      return withdrawRequest(RequestId.BATCH_BODY).then(request => {
+        expect(request.url).to.equal('/');
         expect(request.body).to
             .equal('[{"a":1,"b":"AMP TEST"},{"a":1,"b":"AMP TEST"}]');
       });
@@ -195,7 +204,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
           <script type="application/json">
           {
             "requests": {
-              "endpoint": "${depositRequestUrl('analytics-no-referrer')}"
+              "endpoint": "${depositRequestUrl(RequestId.NO_REFERRER)}"
             },
             "triggers": {
               "pageview": {
@@ -210,10 +219,11 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
           </script>
       </amp-analytics>`,
     extensions: ['amp-analytics'],
-  }, env => {
+  }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return withdrawRequest(env.win, 'analytics-no-referrer')
+      return withdrawRequest(RequestId.NO_REFERRER)
           .then(request => {
+            expect(request.url).to.equal('/');
             expect(request.headers.referer).to.not.be.ok;
           });
     });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -22,40 +22,50 @@ import {
   withdrawRequest,
 } from '../../testing/test-helper';
 
+const RequestId = {
+  MACRO: 'pixel-macro',
+  HAS_REFERRER: 'pixel-has-referrer',
+  NO_REFERRER: 'pixel-no-referrer',
+};
+
 describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   this.timeout(15000);
 
-  describes.integration('amp-pixel referrer integration test', {
-    body: `<amp-pixel src="${depositRequestUrl('has-referrer')}">`,
-  }, env => {
-    it('should keep referrer if no referrerpolicy specified', () => {
-      return withdrawRequest(env.win, 'has-referrer').then(request => {
-        expect(request.headers.referer).to.be.ok;
-      });
-    });
-  });
-
   describes.integration('amp-pixel macro integration test', {
     body: `<amp-pixel src="${depositRequestUrl(
-        'hello-world&title=TITLE&qp=QUERY_PARAM(a)')}">`,
+        RequestId.MACRO)}hello-world?title=TITLE&qp=QUERY_PARAM(a)">`,
     params: {
       a: 123,
     },
-  }, env => {
+  }, () => {
     it('should expand the TITLE macro', () => {
-      return withdrawRequest(env.win, 'hello-world&title=AMP%20TEST&qp=123')
+      return withdrawRequest(RequestId.MACRO)
           .then(request => {
+            expect(request.url)
+                .to.equal('/hello-world?title=AMP%20TEST&qp=123');
             expect(request.headers.host).to.be.ok;
           });
     });
   });
 
+  describes.integration('amp-pixel referrer integration test', {
+    body: `<amp-pixel src="${depositRequestUrl(RequestId.HAS_REFERRER)}">`,
+  }, () => {
+    it('should keep referrer if no referrerpolicy specified', () => {
+      return withdrawRequest(RequestId.HAS_REFERRER).then(request => {
+        expect(request.url).to.equal('/');
+        expect(request.headers.referer).to.be.ok;
+      });
+    });
+  });
+
   describes.integration('amp-pixel no-referrer integration test', {
-    body: `<amp-pixel src="${depositRequestUrl('no-referrer')}"
+    body: `<amp-pixel src="${depositRequestUrl(RequestId.NO_REFERRER)}"
              referrerpolicy="no-referrer">`,
-  }, env => {
+  }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return withdrawRequest(env.win, 'no-referrer').then(request => {
+      return withdrawRequest(RequestId.NO_REFERRER).then(request => {
+        expect(request.url).to.equal('/');
         expect(request.headers.referer).to.not.be.ok;
       });
     });

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -19,38 +19,43 @@ import {
   withdrawRequest,
 } from '../../testing/test-helper';
 
+const RequestId = {
+  PIXEL: 'user-error-amp-pixel',
+  IMG: 'user-error-amp-img',
+  THIRD_PARTY: 'user-error-3p',
+};
+
 describe.configure().skipIfPropertiesObfuscated()
     .skipSafari().skipEdge().run('user-error', function() {
       //TODO(zhouyx, #11459): Unskip the test on safari.
-      let randomId;
-      beforeEach(() => {
-        randomId = Math.random();
-      });
 
       describes.integration('user-error integration test', {
         extensions: ['amp-analytics'],
         hash: 'log=0',
         experiments: ['user-error-reporting'],
-        body: () => `
-    <amp-analytics><script type="application/json">
-          {
+        body: `
+        <amp-analytics>
+          <script type="application/json">
+            {
               "requests": {
-                  "error": "${depositRequestUrl(randomId)}"
+                "error": "${depositRequestUrl(RequestId.PIXEL)}"
               },
               "triggers": {
-                  "userError": {
-                      "on": "user-error",
-                      "request": "error"
-                  }
+                "userError": {
+                  "on": "user-error",
+                  "request": "error"
+                }
               }
-          }
-    </script></amp-analytics>
+            }
+          </script>
+        </amp-analytics>
 
-    <amp-pixel src="https://foo.com/tracker/foo"
-               referrerpolicy="fail-referrer">`,
-      }, env => {
+        <amp-pixel src="https://foo.com/tracker/foo"
+               referrerpolicy="fail-referrer">
+               `,
+      }, () => {
         it('should ping correct host with amp-pixel user().assert err', () => {
-          return withdrawRequest(env.win, randomId);
+          return withdrawRequest(RequestId.PIXEL);
         });
       });
 
@@ -59,29 +64,31 @@ describe.configure().skipIfPropertiesObfuscated()
         hash: 'log=0',
         experiments: ['user-error-reporting'],
 
-        body: () => `
-    <amp-img
-      src="../../examples/img/sea@1x.jpg"
-      width="360" height="216" layout="responsive"
-      role='img'>
-    </amp-img>
+        body: `
+        <amp-img
+          src="../../examples/img/sea@1x.jpg"
+          width="360" height="216" layout="responsive"
+          role='img'>
+        </amp-img>
 
-    <amp-analytics><script type="application/json">
-          {
+        <amp-analytics>
+          <script type="application/json">
+            {
               "requests": {
-                  "error": "${depositRequestUrl(randomId)}"
+                "error": "${depositRequestUrl(RequestId.IMG)}"
               },
               "triggers": {
-                  "userError": {
-                      "on": "user-error",
-                      "request": "error"
-                  }
+                "userError": {
+                  "on": "user-error",
+                  "request": "error"
+                }
               }
-          }
-    </script></amp-analytics>`,
-      }, env => {
+            }
+          </script>
+        </amp-analytics>`,
+      }, () => {
         it('should ping correct host with amp-img user().error err', () => {
-          return withdrawRequest(env.win, randomId);
+          return withdrawRequest(RequestId.IMG);
         });
       });
 
@@ -90,30 +97,32 @@ describe.configure().skipIfPropertiesObfuscated()
         hash: 'log=0',
         experiments: ['user-error-reporting'],
 
-        body: () => `
-    <amp-ad width=300 height=250
-        type="_ping_"
-        data-url='not-exist'
-        data-valid='false'
-        data-error='true'>
-    </amp-ad>
+        body: `
+        <amp-ad width=300 height=250
+            type="_ping_"
+            data-url='not-exist'
+            data-valid='false'
+            data-error='true'>
+        </amp-ad>
 
-    <amp-analytics><script type="application/json">
-    {
-      "requests": {
-        "error": "${depositRequestUrl(randomId)}"
-      },
-      "triggers": {
-        "userError": {
-          "on": "user-error",
-          "request": "error"
-        }
-      }
-    }
-    </script></amp-analytics>`,
-      }, env => {
+        <amp-analytics>
+          <script type="application/json">
+            {
+              "requests": {
+                "error": "${depositRequestUrl(RequestId.THIRD_PARTY)}"
+              },
+              "triggers": {
+                "userError": {
+                  "on": "user-error",
+                  "request": "error"
+                }
+              }
+            }
+          </script>
+        </amp-analytics>`,
+      }, () => {
         it('should ping correct host with 3p error message', () => {
-          return withdrawRequest(env.win, randomId);
+          return withdrawRequest(RequestId.THIRD_PARTY);
         });
       });
     });

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -152,12 +152,12 @@ const REQUEST_URL = '//localhost:9876/amp4test/request-bank/';
 const userAgent = encodeURIComponent(window.navigator.userAgent);
 
 export function depositRequestUrl(path) {
-  return `${REQUEST_URL}deposit/${userAgent}/${path}`;
+  return `${REQUEST_URL}deposit/${userAgent}-${path}/`;
 }
 
-export function withdrawRequest(win, path) {
-  const url = `${REQUEST_URL}withdraw/${userAgent}/${path}`;
-  return xhrServiceForTesting(win).fetchJson(url, {
+export function withdrawRequest(path) {
+  const url = `${REQUEST_URL}withdraw/${userAgent}-${path}/`;
+  return xhrServiceForTesting(window).fetchJson(url, {
     method: 'GET',
     ampCors: false,
     credentials: 'omit',


### PR DESCRIPTION
We wait for pre-assigned request ID instead of the exact request URL, so that test failures would tell you about the diff between actual and expect URL, instead of just failing on timeout.

This is a preparation for #9526