### PR TITLE
Teardown RequestBank after a test finish.

### DIFF
--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -26,7 +26,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${RequestBank.getUrl(1)}"
+            "endpoint": "${RequestBank.getUrl()}"
           },
           "triggers": {
             "pageview": {
@@ -47,7 +47,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/?a=2&b=AMP%20TEST');
         expect(req.headers.referer,
             'should keep referrer if no referrerpolicy specified').to.be.ok;
@@ -62,7 +62,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${RequestBank.getUrl(1)}",
+              "baseUrl": "${RequestBank.getUrl()}",
               "batchInterval": 1
             }
           },
@@ -94,7 +94,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request in batch', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/?a=1&b=AMP%20TEST&a=1&b=AMP%20TEST');
       });
     });
@@ -106,7 +106,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${RequestBank.getUrl(1)}"
+            "endpoint": "${RequestBank.getUrl()}"
           },
           "triggers": {
             "pageview": {
@@ -132,7 +132,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request use POST body payload', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/');
         expect(JSON.parse(req.body)).to.deep.equal({a: 2, b: 'AMP TEST'});
       });
@@ -146,7 +146,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${RequestBank.getUrl(1)}",
+              "baseUrl": "${RequestBank.getUrl()}",
               "batchInterval": 1
             }
           },
@@ -179,7 +179,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send batch request use POST body payload', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/');
         expect(JSON.parse(req.body)).to.deep.equal([{
           a: 1, b: 'AMP TEST',
@@ -196,7 +196,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
           <script type="application/json">
           {
             "requests": {
-              "endpoint": "${RequestBank.getUrl(1)}"
+              "endpoint": "${RequestBank.getUrl()}"
             },
             "triggers": {
               "pageview": {
@@ -213,7 +213,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/');
         expect(req.headers.referer).to.not.be.ok;
       });

--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -16,14 +16,6 @@
 
 import {RequestBank} from '../../testing/test-helper';
 
-const RequestId = {
-  BASIC: 'analytics-basic',
-  BATCH: 'analytics-batch',
-  USE_BODY: 'analytics-use-body',
-  BATCH_BODY: 'analytics-batch-use-body',
-  NO_REFERRER: 'analytics-no-referrer',
-};
-
 describe.configure().skipIfPropertiesObfuscated().run('amp' +
     '-analytics', function() {
   this.timeout(15000);
@@ -34,7 +26,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${RequestBank.getUrl(RequestId.BASIC)}"
+            "endpoint": "${RequestBank.getUrl(1)}"
           },
           "triggers": {
             "pageview": {
@@ -55,7 +47,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request', () => {
-      return RequestBank.withdraw(RequestId.BASIC).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/?a=2&b=AMP%20TEST');
         expect(req.headers.referer,
             'should keep referrer if no referrerpolicy specified').to.be.ok;
@@ -70,7 +62,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${RequestBank.getUrl(RequestId.BATCH)}",
+              "baseUrl": "${RequestBank.getUrl(1)}",
               "batchInterval": 1
             }
           },
@@ -102,7 +94,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request in batch', () => {
-      return RequestBank.withdraw(RequestId.BATCH).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/?a=1&b=AMP%20TEST&a=1&b=AMP%20TEST');
       });
     });
@@ -114,7 +106,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         <script type="application/json">
         {
           "requests": {
-            "endpoint": "${RequestBank.getUrl(RequestId.USE_BODY)}"
+            "endpoint": "${RequestBank.getUrl(1)}"
           },
           "triggers": {
             "pageview": {
@@ -140,7 +132,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send request use POST body payload', () => {
-      return RequestBank.withdraw(RequestId.USE_BODY).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/');
         expect(JSON.parse(req.body)).to.deep.equal({a: 2, b: 'AMP TEST'});
       });
@@ -154,7 +146,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
         {
           "requests": {
             "endpoint": {
-              "baseUrl": "${RequestBank.getUrl(RequestId.BATCH_BODY)}",
+              "baseUrl": "${RequestBank.getUrl(1)}",
               "batchInterval": 1
             }
           },
@@ -187,7 +179,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should send batch request use POST body payload', () => {
-      return RequestBank.withdraw(RequestId.BATCH_BODY).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/');
         expect(JSON.parse(req.body)).to.deep.equal([{
           a: 1, b: 'AMP TEST',
@@ -204,7 +196,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
           <script type="application/json">
           {
             "requests": {
-              "endpoint": "${RequestBank.getUrl(RequestId.NO_REFERRER)}"
+              "endpoint": "${RequestBank.getUrl(1)}"
             },
             "triggers": {
               "pageview": {
@@ -221,7 +213,7 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return RequestBank.withdraw(RequestId.NO_REFERRER)
+      return RequestBank.withdraw(1)
           .then(req => {
             expect(req.url).to.equal('/');
             expect(req.headers.referer).to.not.be.ok;

--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -213,11 +213,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp' +
     extensions: ['amp-analytics'],
   }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return RequestBank.withdraw(1)
-          .then(req => {
-            expect(req.url).to.equal('/');
-            expect(req.headers.referer).to.not.be.ok;
-          });
+      return RequestBank.withdraw(1).then(req => {
+        expect(req.url).to.equal('/');
+        expect(req.headers.referer).to.not.be.ok;
+      });
     });
   });
 });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -19,24 +19,18 @@ import {RequestBank} from '../../testing/test-helper';
 import {Services} from '../../src/services';
 import {createElementWithAttributes} from '../../src/dom';
 
-const RequestId = {
-  MACRO: 'pixel-macro',
-  HAS_REFERRER: 'pixel-has-referrer',
-  NO_REFERRER: 'pixel-no-referrer',
-};
-
 describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
-  this.timeout(15000);
+  this.timeout(1000);
 
   describes.integration('amp-pixel macro integration test', {
     body: `<amp-pixel src="${RequestBank.getUrl(
-        RequestId.MACRO)}hello-world?title=TITLE&qp=QUERY_PARAM(a)">`,
+        1)}hello-world?title=TITLE&qp=QUERY_PARAM(a)">`,
     params: {
       a: 123,
     },
   }, () => {
     it('should expand the TITLE macro', () => {
-      return RequestBank.withdraw(RequestId.MACRO)
+      return RequestBank.withdraw(1)
           .then(req => {
             expect(req.url)
                 .to.equal('/hello-world?title=AMP%20TEST&qp=123');
@@ -46,10 +40,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   });
 
   describes.integration('amp-pixel referrer integration test', {
-    body: `<amp-pixel src="${RequestBank.getUrl(RequestId.HAS_REFERRER)}">`,
+    body: `<amp-pixel src="${RequestBank.getUrl(1)}">`,
   }, () => {
     it('should keep referrer if no referrerpolicy specified', () => {
-      return RequestBank.withdraw(RequestId.HAS_REFERRER).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/');
         expect(req.headers.referer).to.be.ok;
       });
@@ -57,11 +51,11 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   });
 
   describes.integration('amp-pixel no-referrer integration test', {
-    body: `<amp-pixel src="${RequestBank.getUrl(RequestId.NO_REFERRER)}"
+    body: `<amp-pixel src="${RequestBank.getUrl(1)}"
              referrerpolicy="no-referrer">`,
   }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return RequestBank.withdraw(RequestId.NO_REFERRER).then(req => {
+      return RequestBank.withdraw(1).then(req => {
         expect(req.url).to.equal('/');
         expect(req.headers.referer).to.not.be.ok;
       });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -23,14 +23,14 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   this.timeout(1000);
 
   describes.integration('amp-pixel macro integration test', {
-    body: `<amp-pixel src="${RequestBank.getUrl(
-        1)}hello-world?title=TITLE&qp=QUERY_PARAM(a)">`,
+    body: `<amp-pixel
+    src="${RequestBank.getUrl()}hello-world?title=TITLE&qp=QUERY_PARAM(a)">`,
     params: {
       a: 123,
     },
   }, () => {
     it('should expand the TITLE macro', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url)
             .to.equal('/hello-world?title=AMP%20TEST&qp=123');
         expect(req.headers.host).to.be.ok;
@@ -39,10 +39,10 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   });
 
   describes.integration('amp-pixel referrer integration test', {
-    body: `<amp-pixel src="${RequestBank.getUrl(1)}">`,
+    body: `<amp-pixel src="${RequestBank.getUrl()}">`,
   }, () => {
     it('should keep referrer if no referrerpolicy specified', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/');
         expect(req.headers.referer).to.be.ok;
       });
@@ -50,11 +50,11 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
   });
 
   describes.integration('amp-pixel no-referrer integration test', {
-    body: `<amp-pixel src="${RequestBank.getUrl(1)}"
+    body: `<amp-pixel src="${RequestBank.getUrl()}"
              referrerpolicy="no-referrer">`,
   }, () => {
     it('should remove referrer if referrerpolicy=no-referrer', () => {
-      return RequestBank.withdraw(1).then(req => {
+      return RequestBank.withdraw().then(req => {
         expect(req.url).to.equal('/');
         expect(req.headers.referer).to.not.be.ok;
       });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -30,12 +30,11 @@ describe.configure().skipIfPropertiesObfuscated().run('amp-pixel', function() {
     },
   }, () => {
     it('should expand the TITLE macro', () => {
-      return RequestBank.withdraw(1)
-          .then(req => {
-            expect(req.url)
-                .to.equal('/hello-world?title=AMP%20TEST&qp=123');
-            expect(req.headers.host).to.be.ok;
-          });
+      return RequestBank.withdraw(1).then(req => {
+        expect(req.url)
+            .to.equal('/hello-world?title=AMP%20TEST&qp=123');
+        expect(req.headers.host).to.be.ok;
+      });
     });
   });
 

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -16,12 +16,6 @@
 
 import {RequestBank} from '../../testing/test-helper';
 
-const RequestId = {
-  PIXEL: 'user-error-amp-pixel',
-  IMG: 'user-error-amp-img',
-  THIRD_PARTY: 'user-error-3p',
-};
-
 describe.configure().skipIfPropertiesObfuscated()
     .skipSafari().skipEdge().run('user-error', function() {
       //TODO(zhouyx, #11459): Unskip the test on safari.
@@ -35,7 +29,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(RequestId.PIXEL)}"
+                "error": "${RequestBank.getUrl(1)}"
               },
               "triggers": {
                 "userError": {
@@ -52,7 +46,7 @@ describe.configure().skipIfPropertiesObfuscated()
                `,
       }, () => {
         it('should ping correct host with amp-pixel user().assert err', () => {
-          return RequestBank.withdraw(RequestId.PIXEL);
+          return RequestBank.withdraw(1);
         });
       });
 
@@ -72,7 +66,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(RequestId.IMG)}"
+                "error": "${RequestBank.getUrl(1)}"
               },
               "triggers": {
                 "userError": {
@@ -85,7 +79,7 @@ describe.configure().skipIfPropertiesObfuscated()
         </amp-analytics>`,
       }, () => {
         it('should ping correct host with amp-img user().error err', () => {
-          return RequestBank.withdraw(RequestId.IMG);
+          return RequestBank.withdraw(1);
         });
       });
 
@@ -106,7 +100,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(RequestId.THIRD_PARTY)}"
+                "error": "${RequestBank.getUrl(1)}"
               },
               "triggers": {
                 "userError": {
@@ -119,7 +113,7 @@ describe.configure().skipIfPropertiesObfuscated()
         </amp-analytics>`,
       }, () => {
         it('should ping correct host with 3p error message', () => {
-          return RequestBank.withdraw(RequestId.THIRD_PARTY);
+          return RequestBank.withdraw(1);
         });
       });
     });

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -29,7 +29,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(1)}"
+                "error": "${RequestBank.getUrl()}"
               },
               "triggers": {
                 "userError": {
@@ -46,7 +46,7 @@ describe.configure().skipIfPropertiesObfuscated()
                `,
       }, () => {
         it('should ping correct host with amp-pixel user().assert err', () => {
-          return RequestBank.withdraw(1);
+          return RequestBank.withdraw();
         });
       });
 
@@ -66,7 +66,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(1)}"
+                "error": "${RequestBank.getUrl()}"
               },
               "triggers": {
                 "userError": {
@@ -79,7 +79,7 @@ describe.configure().skipIfPropertiesObfuscated()
         </amp-analytics>`,
       }, () => {
         it('should ping correct host with amp-img user().error err', () => {
-          return RequestBank.withdraw(1);
+          return RequestBank.withdraw();
         });
       });
 
@@ -100,7 +100,7 @@ describe.configure().skipIfPropertiesObfuscated()
           <script type="application/json">
             {
               "requests": {
-                "error": "${RequestBank.getUrl(1)}"
+                "error": "${RequestBank.getUrl()}"
               },
               "triggers": {
                 "userError": {
@@ -113,7 +113,7 @@ describe.configure().skipIfPropertiesObfuscated()
         </amp-analytics>`,
       }, () => {
         it('should ping correct host with 3p error message', () => {
-          return RequestBank.withdraw(1);
+          return RequestBank.withdraw();
         });
       });
     });

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -87,6 +87,7 @@ import {
   FakeWindow,
   interceptEventListeners,
 } from './fake-dom';
+import {RequestBank, stubService} from './test-helper';
 import {Services} from '../src/services';
 import {addParamsToUrl} from '../src/url';
 import {
@@ -113,7 +114,6 @@ import {
   resetScheduledElementForTesting,
 } from '../src/service/custom-element-registry';
 import {setStyles} from '../src/style';
-import {stubService} from './test-helper';
 import fetchMock from 'fetch-mock';
 
 /** Should have something in the name, otherwise nothing is shown. */
@@ -518,6 +518,7 @@ class FakeWinFixture {
     if (this.spec.mockFetch !== false) {
       fetchMock./*OK*/restore();
     }
+    RequestBank.tearDown();
   }
 }
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -344,14 +344,17 @@ function describeEnv(factory) {
 
       afterEach(() => {
         // Tear down all fixtures.
+        let teardown = Promise.resolve();
         fixtures.slice(0).reverse().forEach(fixture => {
-          fixture.teardown(env);
+          teardown = teardown.then(() => fixture.teardown(env));
         });
 
-        // Delete all other keys.
-        for (const key in env) {
-          delete env[key];
-        }
+        return teardown.then(() => {
+          // Delete all other keys.
+          for (const key in env) {
+            delete env[key];
+          }
+        });
       });
 
       describe(SUB, function() {
@@ -483,6 +486,7 @@ class IntegrationFixture {
     if (env.iframe.parentNode) {
       env.iframe.parentNode.removeChild(env.iframe);
     }
+    return RequestBank.tearDown();
   }
 }
 
@@ -518,7 +522,6 @@ class FakeWinFixture {
     if (this.spec.mockFetch !== false) {
       fetchMock./*OK*/restore();
     }
-    RequestBank.tearDown();
   }
 }
 

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -152,13 +152,10 @@ export class RequestBank {
   /**
    * Returns the URL for depositing a request.
    *
-   * @param id an unique identifier of the request.
+   * @param {number} id an unique identifier of the request in a test case.
    * @returns {string}
    */
   static getUrl(id) {
-    if (id.indexOf('/') >= 0) {
-      throw new Error('ID "' + id + '" should not contain "/"');
-    }
     return `${REQUEST_URL}/deposit/${id}/`;
   }
 
@@ -170,13 +167,10 @@ export class RequestBank {
    *   headers: JsonObject
    *   body: string
    * }
-   * @param id
+   * @param {number} id
    * @returns {Promise<JsonObject>}
    */
   static withdraw(id) {
-    if (id.indexOf('/') >= 0) {
-      throw new Error('ID "' + id + '" should not contain "/"');
-    }
     const url = `${REQUEST_URL}/withdraw/${id}/`;
     return xhrServiceForTesting(window).fetchJson(url, {
       method: 'GET',

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -152,11 +152,11 @@ export class RequestBank {
   /**
    * Returns the URL for depositing a request.
    *
-   * @param {number} id an unique identifier of the request in a test case.
+   * @param {number|string|undefined} requestId
    * @returns {string}
    */
-  static getUrl(id) {
-    return `${REQUEST_URL}/deposit/${id}/`;
+  static getUrl(requestId) {
+    return `${REQUEST_URL}/deposit/${requestId}/`;
   }
 
   /**
@@ -167,11 +167,11 @@ export class RequestBank {
    *   headers: JsonObject
    *   body: string
    * }
-   * @param {number} id
+   * @param {number|string|undefined} requestId
    * @returns {Promise<JsonObject>}
    */
-  static withdraw(id) {
-    const url = `${REQUEST_URL}/withdraw/${id}/`;
+  static withdraw(requestId) {
+    const url = `${REQUEST_URL}/withdraw/${requestId}/`;
     return xhrServiceForTesting(window).fetchJson(url, {
       method: 'GET',
       ampCors: false,


### PR DESCRIPTION
This fixes the `--watch` flag. Because RequestBank is not clean up between tests, bad state leak to the test run of test when `--watch` flag is used.

It also simplify the API a bit as the unique ID strings are not needed as we always clean up between tests.
