### PR TITLE
🐛🏗 Split gitBranchPoint to two function

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -25,11 +25,20 @@ const {getStdout} = require('./exec');
  * Returns the branch point of the current branch off of master.
  * @return {string}
  */
-exports.gitBranchPoint = function() {
+exports.gitBranchPointFromMaster = function() {
+  return getStdout('git merge-base master HEAD^').trim();
+};
+
+/**
+ * When running on Travis, this returns the branch point of the current branch
+ * off of master, as merged by Travis. When not running on Travis, falls back to
+ * gitBranchPointFromMaster.
+ */
+exports.gitTravisCommitRangeStart = function() {
   if (process.env.TRAVIS_COMMIT_RANGE) {
     return process.env.TRAVIS_COMMIT_RANGE.substr(0, 40);
   }
-  return getStdout('git merge-base master HEAD^').trim();
+  return exports.gitBranchPointFromMaster();
 };
 
 /**
@@ -38,7 +47,7 @@ exports.gitBranchPoint = function() {
  * @return {!Array<string>}
  */
 exports.gitDiffNameOnlyMaster = function() {
-  const branchPoint = exports.gitBranchPoint();
+  const branchPoint = exports.gitBranchPointFromMaster();
   return getStdout(`git diff --name-only ${branchPoint}`).trim().split('\n');
 };
 
@@ -48,7 +57,7 @@ exports.gitDiffNameOnlyMaster = function() {
  * @return {string}
  */
 exports.gitDiffStatMaster = function() {
-  const branchPoint = exports.gitBranchPoint();
+  const branchPoint = exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always diff --stat ${branchPoint}`);
 };
 
@@ -58,7 +67,7 @@ exports.gitDiffStatMaster = function() {
  * @return {!Array<string>}
  */
 exports.gitDiffAddedNameOnlyMaster = function() {
-  const branchPoint = exports.gitBranchPoint();
+  const branchPoint = exports.gitBranchPointFromMaster();
   return getStdout(`git diff --name-only --diff-filter=ARC ${branchPoint}`)
       .trim().split('\n');
 };

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitBranchPoint, gitCommitHash} = require('../git');
+const {gitCommitHash, gitTravisCommitRangeStart} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -108,7 +108,7 @@ function isPullRequest() {
  * @return {string} the `master` ancestor's bundle size.
  */
 async function getAncestorBundleSize() {
-  const gitBranchPointSha = gitBranchPoint();
+  const gitBranchPointSha = gitTravisCommitRangeStart();
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
   return await octokit.repos.getContents(

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -26,7 +26,7 @@ const request = BBPromise.promisify(require('request'));
 const sleep = require('sleep-promise');
 const tryConnect = require('try-net-connect');
 const {execOrDie, execScriptAsync} = require('../../exec');
-const {gitBranchName, gitBranchPoint, gitCommitterEmail} = require('../../git');
+const {gitBranchName, gitCommitterEmail, gitTravisCommitRangeStart} = require('../../git');
 const {log, verifyCssElements} = require('./helpers');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
 
@@ -97,7 +97,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitBranchPoint();
+    process.env['PERCY_TARGET_COMMIT'] = gitTravisCommitRangeStart();
   }
 }
 


### PR DESCRIPTION
This PR splits the `gitBranchPoint` to two functions - one to be used by processes expecting the pre-#19558 behaviour, and one for those expecting the post-#19558 behaviour

Fixed #19604