### PR TITLE
🏗 Move the bundle-size check upwards

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -643,6 +643,7 @@ function main() {
     }
     if (buildTargets.has('RUNTIME')) {
       command.buildRuntimeMinified(/* extensions */ false);
+      command.runBundleSizeCheck(/* action */ 'pr');
     } else {
       // Skip the bundle-size check to satisfy the required GitHub check.
       command.runBundleSizeCheck(/* action */ 'skipped');
@@ -660,9 +661,6 @@ function main() {
         buildTargets.has('FLAG_CONFIG') ||
         buildTargets.has('BUILD_SYSTEM')) {
       command.verifyVisualDiffTests();
-    }
-    if (buildTargets.has('RUNTIME')) {
-      command.runBundleSizeCheck(/* action */ 'pr');
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();


### PR DESCRIPTION
Semi-revert #19559, now that the bundle-size check doesn't fail if the master build hasn't produced a bundle-size file in `ampproject/amphtml-build-artifacts` yet. (see https://github.com/ampproject/amp-github-apps/pull/13)