### PR TITLE
Allow us to locally run tests on Chrome Canary.

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -60,6 +60,9 @@ function getConfig() {
   if (argv.ie) {
     return Object.assign({}, karmaDefault, {browsers: ['IE']});
   }
+  if (argv.chrome_canary) {
+    return Object.assign({}, karmaDefault, {browsers: ['ChromeCanary']});
+  }
   if (argv.headless) {
     return Object.assign({}, karmaDefault,
         {browsers: ['Chrome_no_extensions_headless']});
@@ -173,6 +176,7 @@ function printArgvMessages() {
         cyan(argv.grep) + '".',
     coverage: 'Running tests in code coverage mode.',
     headless: 'Running tests in a headless Chrome window.',
+    'chrome_canary': 'Running tests on Chrome Canary.',
     'local-changes': 'Running unit tests directly affected by the files' +
         ' changed in the local branch.',
   };
@@ -719,6 +723,7 @@ gulp.task('test', 'Runs tests', preTestTasks, function() {
     'a4a': '  Runs all A4A tests',
     'coverage': '  Run tests in code coverage mode',
     'headless': '  Run tests in a headless Chrome window',
+    'chrome_canary': 'Running tests on Chrome Canary.',
     'local-changes': '  Run unit tests directly affected by the files ' +
         'changed in the local branch',
   },

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -158,6 +158,7 @@ function printArgvMessages() {
     firefox: 'Running tests on Firefox.',
     ie: 'Running tests on IE.',
     edge: 'Running tests on Edge.',
+    'chrome_canary': 'Running tests on Chrome Canary.',
     saucelabs: 'Running integration tests on Sauce Labs browsers.',
     saucelabs_lite: 'Running tests on a subset of Sauce Labs browsers.', // eslint-disable-line google-camelcase/google-camelcase
     nobuild: 'Skipping build.',
@@ -176,7 +177,6 @@ function printArgvMessages() {
         cyan(argv.grep) + '".',
     coverage: 'Running tests in code coverage mode.',
     headless: 'Running tests in a headless Chrome window.',
-    'chrome_canary': 'Running tests on Chrome Canary.',
     'local-changes': 'Running unit tests directly affected by the files' +
         ' changed in the local branch.',
   };
@@ -711,6 +711,7 @@ gulp.task('test', 'Runs tests', preTestTasks, function() {
     'firefox': '  Runs tests on Firefox',
     'edge': '  Runs tests on Edge',
     'ie': '  Runs tests on IE',
+    'chrome_canary': 'Runs tests on Chrome Canary.',
     'unit': '  Run only unit tests.',
     'integration': '  Run only integration tests.',
     'dev_dashboard': ' Run only the dev dashboard tests. ' +
@@ -723,7 +724,6 @@ gulp.task('test', 'Runs tests', preTestTasks, function() {
     'a4a': '  Runs all A4A tests',
     'coverage': '  Run tests in code coverage mode',
     'headless': '  Run tests in a headless Chrome window',
-    'chrome_canary': 'Running tests on Chrome Canary.',
     'local-changes': '  Run unit tests directly affected by the files ' +
         'changed in the local branch',
   },


### PR DESCRIPTION
This is useful for testing more experimental work in Chrome. For e.g Houdini APIs like AnimationWorklet. 

Next PR will add support for specifying flags to pass to Chrome (if I can pull it off)