### PR TITLE
🐛inabox: workaround to keep compiler from removing cross-domain check

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -364,7 +364,9 @@ function canInspectWindow_(win) {
   // but since we're not using the closure library I'm not sure how to do this.
   // See https://github.com/google/closure-compiler/issues/3156
   try {
-    return !!win.location.href && win['test'];
+    // win['test'] could be truthy but not true the compiler shouldn't be able
+    // to optimize this check away.
+    return !!win.location.href && (win['test'] || true);
   } catch (unusedErr) { // eslint-disable-line no-unused-vars
     return false;
   }

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -359,9 +359,12 @@ export class InaboxMessagingHost {
  * @private
  */
 function canInspectWindow_(win) {
+  // TODO: this is not reliable.  The compiler assumes that property reads are
+  // side-effect free.  The recommended fix is to use goog.reflect.sinkValue
+  // but since we're not using the closure library I'm not sure how to do this.
+  // See https://github.com/google/closure-compiler/issues/3156
   try {
-    const unused = !!win.location.href && win['test']; // eslint-disable-line no-unused-vars
-    return true;
+    return !!win.location.href && win['test'];
   } catch (unusedErr) { // eslint-disable-line no-unused-vars
     return false;
   }


### PR DESCRIPTION
The compiler assumes that property reads are side-effect free, and so is removing our check for whether a window is cross domain.  As a workaround, rewrite the function to confuse the compiler into keeping our code.  This could easily get broken again, though, if the compiler got smarter.

Fixes #19653 