### PR TITLE
Fix button positioning for load-more elements as not to partially cover last item in amp-list

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -801,13 +801,13 @@ amp-accordion > section[expanded] > :last-child {
 }
 
 /* load-more elements should be hidden by default */
-amp-list[load-more] > [load-more-loading],
-amp-list[load-more] > [load-more-failed],
-amp-list[load-more] > [load-more-button],
-amp-list[load-more] > [load-more-end],
-amp-list[load-more] > [load-more-button] > .i-amphtml-loader
+amp-list[load-more] [load-more-loading],
+amp-list[load-more] [load-more-failed],
+amp-list[load-more] [load-more-button],
+amp-list[load-more] [load-more-end],
+amp-list[load-more] [load-more-button] > .i-amphtml-loader
 {
-  visibility: hidden;
+  display: none;
 }
 
 /**

--- a/extensions/amp-list/0.1/amp-list.css
+++ b/extensions/amp-list/0.1/amp-list.css
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-amp-list[load-more] > [load-more-loading].amp-visible,
-amp-list[load-more] > [load-more-failed].amp-visible,
-amp-list[load-more] > [load-more-button].amp-visible,
-amp-list[load-more] > [load-more-end].amp-visible {
-  visibility: visible;
+amp-list[load-more] [load-more-loading].amp-visible,
+amp-list[load-more] [load-more-failed].amp-visible,
+amp-list[load-more] [load-more-button].amp-visible,
+amp-list[load-more] [load-more-end].amp-visible {
+  display: block;
+  width: 100%;
 }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -775,7 +775,9 @@ export class AmpList extends AMP.BaseElement {
     this.toggleLoadMoreLoading_(true);
     return this.fetchList_(/* opt_append */ true)
         .then(() => {
-          this.toggleLoadMoreLoading_(false);
+          if (this.loadMoreSrc_) {
+            this.toggleLoadMoreLoading_(false);
+          }
           if (this.unlistenLoadMore_) {
             this.unlistenLoadMore_();
             this.unlistenLoadMore_ = null;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -727,7 +727,9 @@ export class AmpList extends AMP.BaseElement {
     // Done loading, nothing more to load.
     if (!this.loadMoreSrc_) {
       return this.mutateElement(() => {
-        this.loadMoreEndElement_.classList.toggle('amp-visible', true);
+        if (this.loadMoreEndElement_) {
+          this.loadMoreEndElement_.classList.toggle('amp-visible', true);
+        }
         this.loadMoreButton_.classList.toggle('amp-visible', false);
       });
     }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -726,12 +726,7 @@ export class AmpList extends AMP.BaseElement {
   setLoadMore_() {
     // Done loading, nothing more to load.
     if (!this.loadMoreSrc_) {
-      return this.mutateElement(() => {
-        if (this.loadMoreEndElement_) {
-          this.loadMoreEndElement_.classList.toggle('amp-visible', true);
-        }
-        this.loadMoreButton_.classList.toggle('amp-visible', false);
-      });
+      return;
     }
     const triggerOnScroll = this.element.getAttribute('load-more') === 'auto';
     if (triggerOnScroll) {
@@ -791,6 +786,8 @@ export class AmpList extends AMP.BaseElement {
         .then(() => {
           if (this.loadMoreSrc_) {
             this.toggleLoadMoreLoading_(false);
+          } else {
+            this.setLoadMoreEnded_();
           }
           if (this.unlistenLoadMore_) {
             this.unlistenLoadMore_();
@@ -825,6 +822,17 @@ export class AmpList extends AMP.BaseElement {
     return this.loadMoreLoadingOverlay_;
   }
 
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  setLoadMoreEnded_() {
+    return this.mutateElement(() => {
+      this.loadMoreFailedElement_.classList.toggle('amp-visible', false);
+      this.loadMoreButton_.classList.toggle('amp-visible', false);
+      this.loadMoreLoadingElement_.classList.toggle('amp-visible', false);
+    });
+  }
   /**
    * Toggles the visibility of the load-more-loading element, the
    * amp-load-more-loading CSS class, and the active state of the loader.

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -602,7 +602,7 @@ export class AmpList extends AMP.BaseElement {
           removeChildren(container);
         }
         this.addElementsToContainer_(elements, container);
-        if (opt_append) {
+        if (this.loadMoreEnabled_) {
           this.moveButtonsToBottom_(container);
         }
       }
@@ -740,6 +740,7 @@ export class AmpList extends AMP.BaseElement {
         this.loadMoreButton_.classList.toggle('amp-visible', true);
         this.unlistenLoadMore_ = listen(this.loadMoreButton_, 'click',
             () => this.loadMoreCallback_());
+        // Guarantees that the height accounts for the newly visible button
         this.attemptToFit_(dev().assertElement(this.container_));
       });
     }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -602,19 +602,8 @@ export class AmpList extends AMP.BaseElement {
           removeChildren(container);
         }
         this.addElementsToContainer_(elements, container);
-
-        // Move all buttons to the bottom of the list
-        if (this.loadMoreButton_) {
-          container.appendChild(this.loadMoreButton_);
-        }
-        if (this.loadMoreEndElement_) {
-          container.appendChild(this.loadMoreEndElement_);
-        }
-        if (this.loadMoreFailedElement_) {
-          container.appendChild(this.loadMoreFailedElement_);
-        }
-        if (this.loadMoreLoadingElement_) {
-          container.appendChild(this.loadMoreLoadingElement_);
+        if (opt_append) {
+          this.moveButtonsToBottom_(container);
         }
       }
 
@@ -758,6 +747,28 @@ export class AmpList extends AMP.BaseElement {
       user().error(TAG,
           'load-more is specified but no means of paging (overflow or ' +
           'load-more=auto) is available', this);
+    }
+  }
+
+
+  /**
+   * Moves all the load-more visual elements to the bottom of the list
+   * after newly appended items.
+   * @param {!Element} container
+   * @private
+   */
+  moveButtonsToBottom_(container) {
+    if (this.loadMoreButton_) {
+      container.appendChild(this.loadMoreButton_);
+    }
+    if (this.loadMoreEndElement_) {
+      container.appendChild(this.loadMoreEndElement_);
+    }
+    if (this.loadMoreFailedElement_) {
+      container.appendChild(this.loadMoreFailedElement_);
+    }
+    if (this.loadMoreLoadingElement_) {
+      container.appendChild(this.loadMoreLoadingElement_);
     }
   }
 

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -67,7 +67,7 @@
   <amp-list width="auto" height="200"
     layout="fixed-height"
     src="/infinite-scroll?items=5&left=3&latency=100"
-    load-more
+    load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="story-entry">

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -21,12 +21,12 @@
       background: gray;
       color: #fff;
       cursor: pointer;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
       z-index: 2;
       padding: 16px;
+    }
+
+    [load-more-failed] {
+      background: purple;
     }
 
     .amp-load-more-loading, [load-more-loading] {
@@ -66,7 +66,7 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=5&latency=3000"
+    src="/infinite-scroll?items=5&left=1&latency=100"
     load-more
     load-more-bookmark="next">
     <template type="amp-mustache">
@@ -75,10 +75,8 @@
         <div><a href="/link.html">{{title}}</a></div>
       </div>
     </template>
-    <div load-more-button>
-      <template type="amp-mustache">
-        {{loadMoreButtonText}}
-      </template>
+    <div load-more-button id="button">
+      SEE MORE
     </div>
     <div load-more-failed>
       FAILED
@@ -88,7 +86,7 @@
     </div>
     <div load-more-end>
       <template type="amp-mustache">
-        {{loadMoreEndText}}
+        <div>{{loadMoreEndText}}</div>
       </template>
     </div>
     <div fallback>

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -66,7 +66,7 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=1&latency=100"
+    src="/infinite-scroll?items=5&left=3&latency=100"
     load-more
     load-more-bookmark="next">
     <template type="amp-mustache">

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -7,17 +7,17 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <style amp-custom>
+
     body {
-      font-family: 'Questrial', Arial;
+      font-family: Roboto, Sans;
     }
+
     article {
       display: block;
       margin: 8px;
     }
-    amp-list {
-      border: 1px solid green;
-    }
-    [load-more-button], [load-more-failed], [load-more-loading], [load-more-end] {
+
+    [load-more-button], [load-more-failed], [load-more-loading] {
       background: gray;
       color: #fff;
       cursor: pointer;
@@ -25,24 +25,30 @@
       padding: 16px;
     }
 
-    [load-more-failed] {
-      background: purple;
-    }
-
-    .amp-load-more-loading, [load-more-loading] {
-      background: blue;
-    }
-
-    [load-more-end] {
-      background: red;
-    }
-
-    .story-entry {
-      padding: 40px;
-      border: 1px solid gray;
-      text-align: center;
+    .pin-container {
       border-radius: 8px;
+      background-color: #fefefe;
+      padding: 8px;
+      margin: 5px;
+    }
 
+    .pin-container:hover {
+       background-color: #eeeeee;
+    }
+
+    amp-img {
+      border-radius: 8px;
+    }
+
+    .title {
+      font-family: Roboto, Sans;
+      margin: 2px;
+    }
+
+    .description {
+      max-width: 160px;
+      font-size: 12px;
+      margin: 2px;
     }
 
     div[role="list"] {
@@ -50,7 +56,7 @@
       flex-wrap: wrap;
       flex-direction: row;
       align-items: flex-start;
-      justify-content: center;
+      justify-content: flex-start;
     }
 
   </style>
@@ -70,29 +76,31 @@
     load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
-      <div class="story-entry">
+      <div class="pin-container">
         <amp-img src="{{imageUrl}}" width="160" height="160"></amp-img>
-        <div><a href="/link.html">{{title}}</a></div>
+        <div class="title">{{title}}</div>
+        <div class="description">
+          At vero eos et accusamus et iusto odio dignissimos ducimus...
+        </div>
       </div>
     </template>
-    <div load-more-button id="button">
-      SEE MORE
+    <div overflow>
+      OVERFLOW
     </div>
-    <div load-more-failed>
-      FAILED
+    <div load-more-button>
+      SEE MORE
     </div>
     <div load-more-loading>
       LOADING
     </div>
-    <div load-more-end>
-      <template type="amp-mustache">
-        <div>{{loadMoreEndText}}</div>
-      </template>
+    <div load-more-failed>
+      LOAD FAILED
     </div>
     <div fallback>
-        FALLBACK
+      FALLBACK
     </div>
   </amp-list>
+
 
 </article>
 </body>

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -96,6 +96,9 @@
     <div load-more-failed>
       LOAD FAILED
     </div>
+    <div load-more-end>
+      LOAD ENDED
+    </div>
     <div fallback>
       FALLBACK
     </div>


### PR DESCRIPTION
Part of https://github.com/ampproject/amphtml/issues/14060. 
Demo: https://amp-infinite-scroll.glitch.me/
~Still need to fix a small bug regarding `classList.toggle` not working in the last `setLoadMore` call to hide the see more button.~
Fixed. 