### PR TITLE
Publisher opt in into a story landscape fullbleed desktop + mobile experience.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -342,62 +342,49 @@
   color: #FFF !important;
 }
 
-[desktop].i-amphtml-story-bookend,
-[desktop-fullbleed].i-amphtml-story-bookend {
+[desktop].i-amphtml-story-bookend {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
   transform: translateY(0) !important;
   opacity: 1 !important;
 }
 
-[desktop].i-amphtml-story-bookend.i-amphtml-hidden,
-[desktop-fullbleed].i-amphtml-story-bookend.i-amphtml-hidden {
+[desktop].i-amphtml-story-bookend.i-amphtml-hidden {
   transition: opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
   transform: translateY(100vh) !important;
   opacity: 0 !important;
 }
 
-[desktop].i-amphtml-story-bookend .i-amphtml-story-share-widget,
-[desktop-fullbleed].i-amphtml-story-bookend .i-amphtml-story-share-widget {
+[desktop].i-amphtml-story-bookend .i-amphtml-story-share-widget {
   /* TODO(alanorozco): Don't render at all when on desktop */
   display: none !important;
 }
 
-[desktop] .i-amphtml-story-bookend-inner,
-[desktop-fullbleed] .i-amphtml-story-bookend-inner {
+[desktop] .i-amphtml-story-bookend-inner {
   box-sizing: border-box !important;
   min-height: 100vh !important;
   padding: 104px 156px 64px !important;
   margin: 0 !important;
 }
 
-[desktop] .i-amphtml-story-bookend-inner::before.
-[desktop-fullbleed] .i-amphtml-story-bookend-inner::before {
-  display: none !important;
-}
-
-[desktop] .i-amphtml-story-bookend-replay,
-[desktop-fullbleed] .i-amphtml-story-bookend-replay {
+[desktop] .i-amphtml-story-bookend-replay {
   /* This is replaced with the forward button on desktop. */
   display: none !important;
 }
 
-[desktop] .i-amphtml-story-bookend-overflow,
-[desktop-fullbleed] .i-amphtml-story-bookend-overflow {
+[desktop] .i-amphtml-story-bookend-overflow {
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }
 
 @media (min-width: 952px) {
-  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading),
-  [desktop-fullbleed] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
+  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /* 12px to match 24px margin-bottom with margin between 2 elements. */
     width: calc(50% - 12px) !important;
   }
 }
 
 @media (min-width: 1272px) {
-  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading),
-  [desktop-fullbleed] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
+  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /**
      * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
      * 16px = (24px * 2) / 3

--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -17,13 +17,13 @@
 @import './amp-story-desktop-user-overridable.css';
 
 
-amp-story[standalone][desktop] {
+amp-story[standalone].i-amphtml-story-desktop-panels {
  max-width: none!important;
  max-height: none!important;
  width: 100vw!important;
 }
 
-[desktop] .i-amphtml-story-logo {
+.i-amphtml-story-desktop-panels .i-amphtml-story-logo {
  display: block!important;
 }
 
@@ -88,7 +88,7 @@ amp-story[standalone][desktop] {
  * Page positions and animations.
  */
 
-[desktop] amp-story-page.i-amphtml-element {
+.i-amphtml-story-desktop-panels amp-story-page.i-amphtml-element {
   /* Pages are stacked to the right side of the screen and then animated in. */
   transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
   opacity: 0.05 !important;
@@ -96,58 +96,58 @@ amp-story[standalone][desktop] {
   border-radius: 16px !important;
 }
 
-[dir=rtl] [desktop] amp-story-page.i-amphtml-element {
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page.i-amphtml-element {
   transform: scale(0.9) translateX(calc(-350% - 192px)) translateY(0%) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-visited] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-visited] {
   transform: scale(0.9) translateX(calc(-350% - 192px)) translateY(0%) !important;
 }
 
-[dir=rtl] [desktop] amp-story-page[i-amphtml-visited] {
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-visited] {
   transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="-2"],
-[desktop] amp-story-page[i-amphtml-desktop-position="-1"],
-[desktop] amp-story-page[i-amphtml-desktop-position="1"],
-[desktop] amp-story-page[i-amphtml-desktop-position="2"] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"],
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"] {
   transition: opacity 350ms ease-out, transform 350ms cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="0"] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"] {
   transition: opacity 350ms cubic-bezier(0.0, 0.0, 0.2, 1), transform 350ms cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="-2"],
-[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="2"] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"],
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"] {
   transform: scale(0.9) translateX(calc(-250% - 128px)) translateY(0%) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="-1"],
-[desktop] .prev-container > .i-amphtml-story-page-sentinel,
-[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="1"],
-[dir=rtl] [desktop] .next-container > .i-amphtml-story-page-sentinel {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
+.i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel,
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
+[dir=rtl] .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel {
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
 }
 
-[desktop] amp-story-page[active],
-[dir=rtl] [desktop] amp-story-page[active],
-[desktop] amp-story-page[i-amphtml-desktop-position="0"],
-[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="0"] {
+.i-amphtml-story-desktop-panels amp-story-page[active],
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[active],
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"],
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"] {
   transform: scale(1.0) translateX(-50%) translateY(0%) !important;
   opacity: 1 !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="1"],
-[desktop] .next-container > .i-amphtml-story-page-sentinel,
-[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="-1"],
-[dir=rtl] [desktop] .prev-container > .i-amphtml-story-page-sentinel {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
+.i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel,
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
+[dir=rtl] .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel {
   transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="2"],
-[dir=rtl] [desktop] amp-story-page[i-amphtml-desktop-position="-2"] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"],
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"] {
   transform: scale(0.9) translate(calc(150% + 128px), 0%) !important;
 }
 
@@ -163,7 +163,7 @@ amp-story[standalone][desktop] {
  * If the next page is protected behind a paywall, blur its content and display
  * a lock icon on top of it.
  */
-[desktop] amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before {
   content: '' !important;
   position: absolute !important;
   top: 50% !important;
@@ -175,12 +175,12 @@ amp-story[standalone][desktop] {
   z-index: 4 !important; /** Above amp-story-cta-layer and amp-story-grid-layer. */
 }
 
-[desktop] amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide] > * {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide] > * {
   filter: blur(8px) !important;
 }
 
-[desktop] > amp-story-page,
-[desktop] .i-amphtml-story-page-sentinel {
+.i-amphtml-story-desktop-panels > amp-story-page,
+.i-amphtml-story-desktop-panels .i-amphtml-story-page-sentinel {
   left: 50%!important;
   right: auto !important;
   margin: auto !important;
@@ -190,6 +190,6 @@ amp-story[standalone][desktop] {
   min-height: 533px !important;
 }
 
-[desktop] > amp-story-page {
+.i-amphtml-story-desktop-panels > amp-story-page {
   box-shadow: 0 0 15px rgba(0, 0, 0, .4)!important;
 }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -298,7 +298,9 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     this.stopListeningToVideoEvents_();
     this.togglePlayMessage_(false);
-    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
+
+    if (this.storeService_.get(StateProperty.UI_STATE) ===
+        UIType.DESKTOP_PANELS) {
       // The rewinding is delayed on desktop so that it happens at a lower
       // opacity instead of immediately jumping to the first frame. See #17985.
       this.pauseAllMedia_(false /** rewindToBeginning */);

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -47,12 +47,12 @@ export const getStoreService = win => {
 
 /**
  * Different UI experiences to display the story.
- * @const @enum {string}
+ * @const @enum {number}
  */
 export const UIType = {
-  MOBILE: 'mobile',
-  DESKTOP: 'desktop',
-  DESKTOP_FULLBLEED: 'fullbleed',
+  MOBILE: 0,
+  DESKTOP_PANELS: 1, // Default desktop UI.
+  DESKTOP_FULLBLEED: 2, // Desktop UI if landscape mode is enabled.
 };
 
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -277,7 +277,7 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ (Object.assign(
           {}, state, {
             // Keep DESKTOP_STATE for compatiblity with v0.1.
-            [StateProperty.DESKTOP_STATE]: data === UIType.DESKTOP,
+            [StateProperty.DESKTOP_STATE]: data === UIType.DESKTOP_PANELS,
             [StateProperty.UI_STATE]: data,
           }));
     case Action.SET_CONSENT_ID:

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -42,7 +42,7 @@
   transition: opacity 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
-[desktop].i-amphtml-story-bookend-active.i-amphtml-story-system-layer {
+.i-amphtml-story-desktop-panels.i-amphtml-story-bookend-active.i-amphtml-story-system-layer {
   opacity: 0 !important;
 }
 
@@ -248,7 +248,7 @@
   display: none !important;
 }
 
-[desktop].i-amphtml-story-system-layer {
+.i-amphtml-story-desktop-panels.i-amphtml-story-system-layer {
   background: linear-gradient(to bottom, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
   top: auto !important;
   bottom: 0 !important;
@@ -259,18 +259,18 @@
   flex-direction: row-reverse !important;
 }
 
-[desktop] .i-amphtml-story-progress-bar {
+.i-amphtml-story-desktop-panels .i-amphtml-story-progress-bar {
   position: relative !important;
   height: 3px !important;
   width: calc(100vw / 3) !important;
   margin: 0 24px !important;
 }
 
-[desktop] .i-amphtml-story-page-progress-bar {
+.i-amphtml-story-desktop-panels .i-amphtml-story-page-progress-bar {
   border-radius: 100px !important;
 }
 
-[desktop].i-amphtml-story-system-layer .i-amphtml-story-system-layer-buttons {
+.i-amphtml-story-desktop-panels.i-amphtml-story-system-layer .i-amphtml-story-system-layer-buttons {
   display: flex !important;
   height: 40px !important;
   align-items: center !important;
@@ -278,7 +278,7 @@
   margin-top: 0px !important;
 }
 
-[desktop] .i-amphtml-story-share-control {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-control {
   display: none !important;
 }
 
@@ -294,7 +294,7 @@ div.i-amphtml-story-share-pill-container {
   background: linear-gradient(to bottom, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
 }
 
-[desktop] div.i-amphtml-story-share-pill-container {
+.i-amphtml-story-desktop-panels div.i-amphtml-story-share-pill-container {
   display: block !important;
 }
 
@@ -426,39 +426,39 @@ span.i-amphtml-story-share-pill-label {
   padding: 0;
 }
 
-[desktop] .i-amphtml-story-share-icon {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-icon {
   font-size: 0px!important;
   background-size: 24px 24px !important;
   background-position: center center !important;
   padding: 0 !important;
 }
 
-[desktop] .i-amphtml-story-share-icon.amp-social-share-facebook {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-icon.amp-social-share-facebook {
   /* SVG icon has inner padding, so the glyph renders visually smaller than
    * other icons, so we work around it by setting a higher background size. */
   background-size: 28px 28px !important;
   background-position: center center !important;
 }
 
-[desktop] .i-amphtml-story-share-pill .i-amphtml-story-share-icon {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-pill .i-amphtml-story-share-icon {
   background-color: transparent !important;
 }
 
-[desktop] .i-amphtml-story-share-pill .i-amphtml-story-share-label {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-pill .i-amphtml-story-share-label {
   display: none !important;
 }
 
-[desktop] .i-amphtml-story-share-list {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-list {
   margin-right: 72px !important;
 }
 
-[dir=rtl][desktop] .i-amphtml-story-share-list {
+[dir=rtl].i-amphtml-story-desktop-panels .i-amphtml-story-share-list {
   margin-right: 0 !important;
   margin-left: 72px !important;
 }
 
 /* system layer changes */
 
-[desktop] .i-amphtml-story-share-pill-container {
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-pill-container {
   z-index: 100002 !important; /* 1 higher than bookend */
 }

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -521,12 +521,12 @@ export class SystemLayer {
    * @private
    */
   onUIStateUpdate_(uiState) {
-    if (uiState === UIType.DESKTOP) {
+    if (uiState === UIType.DESKTOP_PANELS) {
       this.buildSharePill_();
     }
 
     this.vsync_.mutate(() => {
-      uiState === UIType.DESKTOP ?
+      uiState === UIType.DESKTOP_PANELS ?
         this.getShadowRoot().setAttribute('desktop', '') :
         this.getShadowRoot().removeAttribute('desktop');
     });

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -354,8 +354,8 @@ export class SystemLayer {
       this.onMutedStateUpdate_(isMuted);
     }, true /** callToInitialize */);
 
-    this.storeService_.subscribe(StateProperty.UI_STATE, isDesktop => {
-      this.onUIStateUpdate_(isDesktop);
+    this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
+      this.onUIStateUpdate_(uiState);
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.CURRENT_PAGE_INDEX, index => {
@@ -527,8 +527,8 @@ export class SystemLayer {
 
     this.vsync_.mutate(() => {
       uiState === UIType.DESKTOP_PANELS ?
-        this.getShadowRoot().setAttribute('desktop', '') :
-        this.getShadowRoot().removeAttribute('desktop');
+        this.getShadowRoot().classList.add('i-amphtml-story-desktop-panels') :
+        this.getShadowRoot().classList.remove('i-amphtml-story-desktop-panels');
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-tooltip.js
+++ b/extensions/amp-story/1.0/amp-story-tooltip.js
@@ -195,7 +195,7 @@ export class AmpStoryTooltip {
   onUIStateUpdate_(uiState) {
     this.resources_.mutateElement(dev().assertElement(this.tooltipOverlayEl_),
         () => {
-          uiState === UIType.DESKTOP_PANELS ?
+          [UIType.DESKTOP_FULLBLEED, UIType.DESKTOP_PANELS].includes(uiState) ?
             this.tooltipOverlayEl_.setAttribute('desktop', '') :
             this.tooltipOverlayEl_.removeAttribute('desktop');
         });

--- a/extensions/amp-story/1.0/amp-story-tooltip.js
+++ b/extensions/amp-story/1.0/amp-story-tooltip.js
@@ -195,7 +195,7 @@ export class AmpStoryTooltip {
   onUIStateUpdate_(uiState) {
     this.resources_.mutateElement(dev().assertElement(this.tooltipOverlayEl_),
         () => {
-          uiState === UIType.DESKTOP ?
+          uiState === UIType.DESKTOP_PANELS ?
             this.tooltipOverlayEl_.setAttribute('desktop', '') :
             this.tooltipOverlayEl_.removeAttribute('desktop');
         });

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -215,7 +215,7 @@ export class ViewportWarningLayer {
     }
 
     this.vsync_.mutate(() => {
-      uiState === UIType.DESKTOP ?
+      uiState === UIType.DESKTOP_PANELS ?
         this.overlayEl_.setAttribute('desktop', '') :
         this.overlayEl_.removeAttribute('desktop');
     });

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -15,7 +15,7 @@
  */
 
 @import './amp-story-access.css';
-@import './amp-story-desktop.css';
+@import './amp-story-desktop-panels.css';
 @import './amp-story-user-overridable.css';
 @import './pagination-buttons.css';
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1295,7 +1295,8 @@ export class AmpStory extends AMP.BaseElement {
     const uiState = this.getUIType_();
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
-    if (uiState !== UIType.MOBILE) {
+    if (uiState !== UIType.MOBILE ||
+        this.getSupportedOrientations_().includes('landscape')) {
       this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, false);
       return;
     }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -139,6 +139,7 @@ const Attributes = {
   DESKTOP_POSITION: 'i-amphtml-desktop-position',
   VISITED: 'i-amphtml-visited', // stacked offscreen to left
   AUTO_ADVANCE_AFTER: 'auto-advance-after',
+  SUPPORTED_ORIENTATIONS: 'supported-orientations',
 };
 
 /**
@@ -774,7 +775,8 @@ export class AmpStory extends AMP.BaseElement {
    */
   whenPagesLoaded_(timeoutMs = 0) {
     const pagesToWaitFor =
-        this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP ?
+        this.storeService_.get(StateProperty.UI_STATE) ===
+            UIType.DESKTOP_PANELS ?
           [this.pages_[0], this.pages_[1]] :
           [this.pages_[0]];
 
@@ -960,7 +962,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   performTapNavigation_(direction) {
-    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
+    if (this.storeService_.get(StateProperty.UI_STATE) ===
+        UIType.DESKTOP_PANELS) {
       this.next_();
       return;
     }
@@ -1014,7 +1017,8 @@ export class AmpStory extends AMP.BaseElement {
       () => {
         oldPage && oldPage.element.removeAttribute('active');
 
-        if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
+        if (this.storeService_.get(StateProperty.UI_STATE) ===
+            UIType.DESKTOP_PANELS) {
           this.setDesktopPositionAttributes_(targetPage);
         }
 
@@ -1195,7 +1199,8 @@ export class AmpStory extends AMP.BaseElement {
     if (!this.platform_.isSafari() && !this.platform_.isIos()) {
       return;
     }
-    if (this.storeService_.get(StateProperty.UI_STATE) === UIType.DESKTOP) {
+    if (this.storeService_.get(StateProperty.UI_STATE) ===
+        UIType.DESKTOP_PANELS) {
       // Force repaint is only needed when transitioning from invisible to
       // visible
       return;
@@ -1341,7 +1346,7 @@ export class AmpStory extends AMP.BaseElement {
           this.element.removeAttribute('desktop-fullbleed');
         });
         break;
-      case UIType.DESKTOP:
+      case UIType.DESKTOP_PANELS:
         this.setDesktopPositionAttributes_(this.activePage_);
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
@@ -1384,7 +1389,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     // Three panels desktop UI (default).
-    return UIType.DESKTOP;
+    return UIType.DESKTOP_PANELS;
   }
 
   /**
@@ -1575,7 +1580,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   toggleElementsOnBookend_(isActive) {
-    if (this.storeService_.get(StateProperty.UI_STATE) !== UIType.DESKTOP) {
+    if (this.storeService_.get(StateProperty.UI_STATE) !==
+        UIType.DESKTOP_PANELS) {
       return;
     }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -187,8 +187,11 @@ const HIDE_ON_BOOKEND_SELECTOR =
  */
 const DEFAULT_THEME_COLOR = '#F1F3F4';
 
-/** @const {!Array<string>} */
-const VALID_ORIENTATIONS = ['portrait', 'landscape'];
+/** @enum {string} */
+const ScreenOrientations = {
+  PORTRAIT: 'portrait',
+  LANDSCAPE: 'landscape',
+};
 
 /**
  * @implements {./media-pool.MediaPoolRoot}
@@ -1296,7 +1299,8 @@ export class AmpStory extends AMP.BaseElement {
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
     if (uiState !== UIType.MOBILE ||
-        this.getSupportedOrientations_().includes('landscape')) {
+        this.getSupportedOrientations_()
+            .includes(ScreenOrientations.LANDSCAPE)) {
       this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, false);
       return;
     }
@@ -1395,7 +1399,7 @@ export class AmpStory extends AMP.BaseElement {
 
     const supportedOrientations = this.getSupportedOrientations_();
 
-    if (supportedOrientations.includes('landscape')) {
+    if (supportedOrientations.includes(ScreenOrientations.LANDSCAPE)) {
       return UIType.DESKTOP_FULLBLEED;
     }
 
@@ -1435,14 +1439,13 @@ export class AmpStory extends AMP.BaseElement {
         this.element.getAttribute(Attributes.SUPPORTED_ORIENTATIONS);
 
     if (!supportedOrientationsAttribute) {
-      return ['portrait'];
+      return [ScreenOrientations.PORTRAIT];
     }
 
     this.supportedOrientations_ =
         supportedOrientationsAttribute
             .split(',')
-            .map(orientation => orientation.trim().toLowerCase())
-            .filter(orientation => VALID_ORIENTATIONS.includes(orientation));
+            .map(orientation => orientation.trim().toLowerCase());
 
     return this.supportedOrientations_;
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1343,7 +1343,8 @@ export class AmpStory extends AMP.BaseElement {
         this.shareMenu_.build();
         this.vsync_.mutate(() => {
           this.element.removeAttribute('desktop');
-          this.element.removeAttribute('desktop-fullbleed');
+          this.element.classList.remove('i-amphtml-story-desktop-panels');
+          this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
         break;
       case UIType.DESKTOP_PANELS:
@@ -1351,7 +1352,8 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
-          this.element.removeAttribute('desktop-fullbleed');
+          this.element.classList.add('i-amphtml-story-desktop-panels');
+          this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
         if (!this.background_) {
           this.background_ = new AmpStoryBackground(this.win, this.element);
@@ -1365,8 +1367,9 @@ export class AmpStory extends AMP.BaseElement {
         this.shareMenu_.build();
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
-          this.element.setAttribute('desktop-fullbleed', '');
-          this.element.removeAttribute('desktop');
+          this.element.setAttribute('desktop', '');
+          this.element.classList.add('i-amphtml-story-desktop-fullbleed');
+          this.element.classList.remove('i-amphtml-story-desktop-panels');
         });
         break;
     }
@@ -1383,8 +1386,11 @@ export class AmpStory extends AMP.BaseElement {
       return UIType.MOBILE;
     }
 
-    if (this.element.getAttribute('desktop-mode') ===
-        UIType.DESKTOP_FULLBLEED) {
+    const supportedOrientations =
+        this.element.getAttribute(Attributes.SUPPORTED_ORIENTATIONS)
+            .split(',').map(orientation => orientation.trim().toLowerCase());
+
+    if (supportedOrientations.includes('landscape')) {
       return UIType.DESKTOP_FULLBLEED;
     }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -187,6 +187,9 @@ const HIDE_ON_BOOKEND_SELECTOR =
  */
 const DEFAULT_THEME_COLOR = '#F1F3F4';
 
+/** @const {!Array<string>} */
+const VALID_ORIENTATIONS = ['portrait', 'landscape'];
+
 /**
  * @implements {./media-pool.MediaPoolRoot}
  */
@@ -298,6 +301,9 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private {?MutationObserver} */
     this.sidebarObserver_ = null;
+
+    /** @private {?Array<string>} */
+    this.supportedOrientations_ = null;
 
     /** @private @const {!LocalizationService} */
     this.localizationService_ = new LocalizationService(this.win);
@@ -1386,9 +1392,7 @@ export class AmpStory extends AMP.BaseElement {
       return UIType.MOBILE;
     }
 
-    const supportedOrientations =
-        this.element.getAttribute(Attributes.SUPPORTED_ORIENTATIONS)
-            .split(',').map(orientation => orientation.trim().toLowerCase());
+    const supportedOrientations = this.getSupportedOrientations_();
 
     if (supportedOrientations.includes('landscape')) {
       return UIType.DESKTOP_FULLBLEED;
@@ -1413,6 +1417,33 @@ export class AmpStory extends AMP.BaseElement {
    */
   isStandalone_() {
     return this.element.hasAttribute(Attributes.STANDALONE);
+  }
+
+  /**
+   * Returns an array of the supported orientations configured by the publisher.
+   * Defaults to ['portrait'].
+   * @return {!Array<string>}
+   * @private
+   */
+  getSupportedOrientations_() {
+    if (this.supportedOrientations_) {
+      return this.supportedOrientations_;
+    }
+
+    const supportedOrientationsAttribute =
+        this.element.getAttribute(Attributes.SUPPORTED_ORIENTATIONS);
+
+    if (!supportedOrientationsAttribute) {
+      return ['portrait'];
+    }
+
+    this.supportedOrientations_ =
+        supportedOrientationsAttribute
+            .split(',')
+            .map(orientation => orientation.trim().toLowerCase())
+            .filter(orientation => VALID_ORIENTATIONS.includes(orientation));
+
+    return this.supportedOrientations_;
   }
 
   /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -334,17 +334,9 @@ export class AmpStoryBookend extends AMP.BaseElement {
    */
   onUIStateUpdate_(uiState) {
     this.mutateElement(() => {
-      this.getShadowRoot().removeAttribute('desktop');
-      this.getShadowRoot().removeAttribute('desktop-fullbleed');
-
-      switch (uiState) {
-        case UIType.DESKTOP_PANELS:
-          this.getShadowRoot().setAttribute('desktop', '');
-          break;
-        case UIType.DESKTOP_FULLBLEED:
-          this.getShadowRoot().setAttribute('desktop-fullbleed', '');
-          break;
-      }
+      [UIType.DESKTOP_FULLBLEED, UIType.DESKTOP_PANELS].includes(uiState) ?
+          this.getShadowRoot().setAttribute('desktop', '') :
+          this.getShadowRoot().removeAttribute('desktop');
     });
   }
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -335,8 +335,8 @@ export class AmpStoryBookend extends AMP.BaseElement {
   onUIStateUpdate_(uiState) {
     this.mutateElement(() => {
       [UIType.DESKTOP_FULLBLEED, UIType.DESKTOP_PANELS].includes(uiState) ?
-          this.getShadowRoot().setAttribute('desktop', '') :
-          this.getShadowRoot().removeAttribute('desktop');
+        this.getShadowRoot().setAttribute('desktop', '') :
+        this.getShadowRoot().removeAttribute('desktop');
     });
   }
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -338,7 +338,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
       this.getShadowRoot().removeAttribute('desktop-fullbleed');
 
       switch (uiState) {
-        case UIType.DESKTOP:
+        case UIType.DESKTOP_PANELS:
           this.getShadowRoot().setAttribute('desktop', '');
           break;
         case UIType.DESKTOP_FULLBLEED:

--- a/extensions/amp-story/1.0/pagination-buttons.css
+++ b/extensions/amp-story/1.0/pagination-buttons.css
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-[desktop-fullbleed] .i-amphtml-story-button-container,
-[desktop] .i-amphtml-story-button-container {
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container,
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container {
   position: absolute !important;
   top: 0 !important;
   bottom: 0 !important;
@@ -26,7 +26,7 @@
   display: block !important;
 }
 
-[desktop] .i-amphtml-story-button-container::before {
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container::before {
   content: '';
   position: absolute !important;
   top: 0 !important;
@@ -35,15 +35,15 @@
   width: calc(50vw - 23vh - 32px) !important;
 }
 
-[desktop] .i-amphtml-story-button-container.next-container::before,
-[dir=rtl] [desktop] .i-amphtml-story-button-container.prev-container::before {
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container.next-container::before,
+[dir=rtl] .i-amphtml-story-desktop-panels .i-amphtml-story-button-container.prev-container::before {
   right: 0 !important;
   left: auto !important;
   background: linear-gradient(to right, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
 }
 
-[desktop] .i-amphtml-story-button-container.prev-container::before,
-[dir=rtl] [desktop] .i-amphtml-story-button-container.next-container::before {
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container.prev-container::before,
+[dir=rtl] .i-amphtml-story-desktop-panels .i-amphtml-story-button-container.next-container::before {
   left: 0 !important;
   right: auto !important;
   background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
@@ -77,7 +77,7 @@
   cursor: pointer;
 }
 
-[desktop-fullbleed] .i-amphtml-story-page-sentinel {
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-page-sentinel {
   display: none !important;
 }
 
@@ -104,7 +104,7 @@
   outline: none!important;
 }
 
-[desktop-fullbleed] .i-amphtml-story-button-move {
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-move {
   opacity: 0.8 !important;
 }
 
@@ -156,16 +156,16 @@
 }
 
 /* On forward (next) button mouseover */
-[desktop].i-amphtml-story-next-hover > .i-amphtml-story-fwd-next >
+.i-amphtml-story-desktop-panels.i-amphtml-story-next-hover > .i-amphtml-story-fwd-next >
     .i-amphtml-story-button-move {
   transform: translateX(8px)!important;
   opacity: 1!important;
 }
 
 /* On back button mouseover */
-[desktop].i-amphtml-story-prev-hover > .i-amphtml-story-back-prev >
+.i-amphtml-story-desktop-panels.i-amphtml-story-prev-hover > .i-amphtml-story-back-prev >
     .i-amphtml-story-button-move,
-[desktop].i-amphtml-story-prev-hover > .i-amphtml-story-back-close-bookend  >
+.i-amphtml-story-desktop-panels.i-amphtml-story-prev-hover > .i-amphtml-story-back-close-bookend  >
     .i-amphtml-story-button-move {
   transform: translateX(-8px)!important;
   opacity: 1!important;

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -113,7 +113,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   it('should toggle the desktop state when setting a UI State', () => {
     const listenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.DESKTOP_STATE, listenerSpy);
-    storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+    storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -183,7 +183,7 @@ describes.realWin('amp-story', {
   it('should not prerender/load the share menu on desktop', () => {
     createPages(story.element, 2);
 
-    story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+    story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
 
     const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
 
@@ -719,7 +719,7 @@ describes.realWin('amp-story', {
 
       story.buildCallback();
 
-      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
 
       return story.layoutCallback()
           .then(() => {
@@ -736,7 +736,7 @@ describes.realWin('amp-story', {
 
       story.buildCallback();
 
-      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
+      story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
 
       return story.layoutCallback()
           .then(() => story.switchTo_('2'))

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -385,7 +385,7 @@ describes.realWin('amp-story', {
 
   it('should detect fullbleed desktop mode', () => {
     createPages(story.element, 4, ['cover', '1', '2', '3']);
-    story.element.setAttribute('desktop-mode', 'fullbleed');
+    story.element.setAttribute('supported-orientations', 'portrait, laNdsCApe');
 
     // Don't do this at home. :(
     story.desktopMedia_ = {matches: true};


### PR DESCRIPTION
- Publishers can enable the landscape experience using `supported-orientations="portrait,landscape"` on the `<amp-story>` tag (pending validation)
- Other valid values would be`supported-orientations="portrait"` (which is the default), or no `supported-orientations` attribute at all
- This `landscape` optin also allows mobile landscape
- Renaming `UIType.DESKTOP` into `UIType.DESKTOP_PANELS`
- `[desktop]` now means "Viewport size should trigger a desktop UI", which could be PANELS or FULLBLEED depending on the configuration
- New private CSS classes `i-amphtml-story-desktop-panels` and `i-amphtml-story-desktop-fullbleed` to tweak the CSS
- Renaming `amp-story-desktop.css` into `amp-story-desktop-panels.css`

[Demo](https://stamp-supported-orientations.firebaseapp.com/examples/s20/body-painting/index.html)

#19270