### PR TITLE
Keep the highlighted text color consistent with Android Chrome.

### DIFF
--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -203,9 +203,11 @@ export class HighlightHandler {
 
     for (let i = 0; i < this.highlightedNodes_.length; i++) {
       const n = this.highlightedNodes_[i];
+      // The background color is same as Android Chrome text finding.
+      // https://cs.chromium.org/chromium/src/chrome/android/java/res/values/colors.xml?l=158&rcl=8b461e376e824c72fec1d6d91cd6633ba344dd55&q=ff9632
       setStyles(n, {
-        backgroundColor: '#fc9741',
-        color: '#333',
+        backgroundColor: '#ff9632',
+        color: '#000',
       });
     }
 

--- a/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
@@ -142,10 +142,10 @@ describes.realWin('HighlightHandler', {
         {state: 'auto_scroll'});
 
     expect(root.innerHTML).to.equal(
-        '<div>text in <span style="background-color: rgb(252, 151, 65); ' +
-          'color: rgb(51, 51, 51);">amp</span> doc</div><div>' +
-          '<span style="background-color: rgb(252, 151, 65); color: ' +
-          'rgb(51, 51, 51);">highlight</span>ed text</div>');
+        '<div>text in <span style="background-color: rgb(255, 150, 50); ' +
+          'color: rgb(0, 0, 0);">amp</span> doc</div><div>' +
+          '<span style="background-color: rgb(255, 150, 50); color: ' +
+          'rgb(0, 0, 0);">highlight</span>ed text</div>');
 
     const viewerOrigin = 'http://localhost:9876';
     const port = new WindowPortEmulator(


### PR DESCRIPTION
The background color of the active highlighted text in Android Chrome:
https://cs.chromium.org/chromium/src/chrome/android/java/res/values/colors.xml?l=158&rcl=8b461e376e824c72fec1d6d91cd6633ba344dd55&q=ff9632
