### PR TITLE
Skip some flaky tests in test-friendly-iframe-embed.

### DIFF
--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -31,7 +31,6 @@ import {isAnimationNone} from '../../testing/test-helper';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {loadPromise} from '../../src/event-helper';
 
-
 describe('friendly-iframe-embed', () => {
 
   let sandbox;
@@ -66,7 +65,8 @@ describe('friendly-iframe-embed', () => {
     });
   }
 
-  it('should follow main install steps', () => {
+  // TODO: fix tests. #19650
+  it.skip('should follow main install steps', () => {
 
     // Resources are not involved.
     extensionsMock.expects('preloadExtension').never();
@@ -115,7 +115,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  it('should write doc if srcdoc is not available', () => {
+  it.skip('should write doc if srcdoc is not available', () => {
     setSrcdocSupportedForTesting(false);
 
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
@@ -195,7 +195,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  it('should install and dispose services', () => {
+  it.skip('should install and dispose services', () => {
     const disposeSpy = sandbox.spy();
     const embedService = {
       dispose: disposeSpy,
@@ -237,7 +237,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  it('should support host', () => {
+  it.skip('should support host', () => {
     const host = document.createElement('amp-host');
     const hostSignals = new Signals();
     host.signals = () => hostSignals;
@@ -255,7 +255,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  it('should await initial load', () => {
+  it.skip('should await initial load', () => {
     resourcesMock
         .expects('getResourcesInRect')
         .withExactArgs(
@@ -281,7 +281,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  it('should await initial with host', () => {
+  it.skip('should await initial with host', () => {
     const rect = layoutRectLtwh(10, 10, 100, 200);
     const host = document.createElement('amp-host');
     const hostSignals = new Signals();
@@ -470,7 +470,7 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
-  describe('child document ready and loaded states', () => {
+  describe.skip('child document ready and loaded states', () => {
 
     it('should wait until ready', () => {
       const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {


### PR DESCRIPTION
Tracked at #19650

Those tests are blocking other PRs who accidentally triggered them. For example: https://travis-ci.org/ampproject/amphtml/jobs/463581530