### PR TITLE
Update Sauce Connect to 4.5.2

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -20,7 +20,7 @@
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 
-SC_VERSION="sc-4.5.1-linux"
+SC_VERSION="sc-4.5.2-linux"
 DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"
 DOWNLOAD_DIR="sauce_connect"
 TAR_FILE="$DOWNLOAD_DIR/$SC_VERSION.tar.gz"


### PR DESCRIPTION
```
5 Dec 17:20:02 - ***********************************************************
5 Dec 17:20:02 - A newer version of Sauce Connect (build 4485) is available!
5 Dec 17:20:02 - Download it here:
5 Dec 17:20:02 - https://saucelabs.com/downloads/sc-4.5.2-linux.tar.gz
5 Dec 17:20:02 - ***********************************************************
```
https://travis-ci.org/ampproject/amphtml/jobs/463938112