### PR TITLE
Fixes a bug in infinite scroll where load-end does not hide after binding src

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -848,9 +848,12 @@ export class AmpList extends AMP.BaseElement {
    */
   toggleLoadMoreLoading_(state) {
     this.mutateElement(() => {
-      // If it's loading, then it's no longer failed
+      // If it's loading, then it's no longer failed or ended
       if (this.loadMoreFailedElement_) {
         this.loadMoreFailedElement_.classList.toggle('amp-visible', false);
+      }
+      if (this.loadMoreEndElement_) {
+        this.loadMoreEndElement_.classList.toggle('amp-visible', false);
       }
       if (this.loadMoreLoadingElement_) {
         this.loadMoreButton_.classList.toggle('amp-visible', !state);

--- a/test/manual/amp-list/infinite-scroll-2.amp.html
+++ b/test/manual/amp-list/infinite-scroll-2.amp.html
@@ -5,39 +5,52 @@
   <title>AMP #0</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel='stylesheet' type='text/css'>
   <style amp-custom>
     body {
       font-family: 'Questrial', Arial;
     }
+
     article {
       display: block;
       margin: 8px;
     }
-    amp-list {
-      border: 1px solid green;
-    }
-    [load-more-button], [load-more-failed] {
+
+    [load-more-button],
+    [load-more-failed],
+    [load-more-loading],
+    [load-more-end] {
       background: gray;
       color: #fff;
       cursor: pointer;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
       z-index: 2;
       padding: 16px;
     }
 
-    .amp-load-more-loading {
-      background: red;
-    }
-    .story-entry {
-      padding: 40px;
-      border: 1px solid gray;
-      text-align: center;
+    .pin-container {
       border-radius: 8px;
+      background-color: #fefefe;
+      padding: 8px;
+      margin: 5px;
+    }
 
+    .pin-container:hover {
+       background-color: #eeeeee;
+    }
+
+    amp-img {
+      border-radius: 8px;
+    }
+
+    .title {
+      font-family: Roboto, Sans;
+      margin: 2px;
+    }
+
+    .description {
+      max-width: 160px;
+      font-size: 12px;
+      margin: 2px;
     }
 
     div[role="list"] {
@@ -45,7 +58,7 @@
       flex-wrap: wrap;
       flex-direction: row;
       align-items: flex-start;
-      justify-content: center;
+      justify-content: flex-start;
     }
 
   </style>
@@ -53,21 +66,52 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+  <script async custom-template="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+
 </head>
 <body>
+
+
+  <amp-state id="data">
+    <script type="application/json">
+      {
+        "items": 1,
+        "left": 2,
+        "latency": 0,
+        "url": "/infinite-scroll?items=8&left=2"
+      }
+    </script>
+  </amp-state>
+
 <article>
   <h1>AMP List</h1>
-  <p>This is a flexbox amp-list with tiles, something like an infinite image gallery.</p>
+  <p>Infinite scroll with amp-bind.</p>
 
-  <amp-list width="auto" height="200"
+  <input type="text" id="items" placeholder="Items per page"
+         on="change:AMP.setState({data: {items: event.value}})">
+  <input type="text" id="left" placeholder="Pages left"
+         on="change:AMP.setState({data: {left: event.value}})">
+  <input type="text" id="latency" placeholder="Latency"
+         on="change:AMP.setState({data: {latency: event.value}})">
+  <button
+          on="tap:list.changeToLayoutContainer(),AMP.setState({data: {url: '/infinite-scroll?items=' + data.items + '&left=' + data.left + '&latency=' + data.latency}})">
+    Go
+  </button>
+
+  <amp-list width="auto" height="200" id="list"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=3"
-    load-more="auto"
+    src="/infinite-scroll?items=8&left=2"
+    [src]="data.url"
+    load-more
+    reset-on-refresh
     load-more-bookmark="next">
     <template type="amp-mustache">
-      <div class="story-entry">
+      <div class="pin-container">
         <amp-img src="{{imageUrl}}" width="160" height="160"></amp-img>
-        <div><a href="/link.html">{{title}}</a></div>
+        <div class="title">{{title}}</div>
+        <div class="description">
+          At vero eos et accusamus et iusto odio dignissimos ducimus...
+        </div>
       </div>
     </template>
     <div overflow>
@@ -75,6 +119,15 @@
     </div>
     <div load-more-button>
       SEE MORE
+    </div>
+    <div load-more-loading>
+      LOADING
+    </div>
+    <div load-more-failed>
+      LOAD FAILED
+    </div>
+    <div load-more-end>
+      LOAD ENDED
     </div>
     <div fallback>
       FALLBACK


### PR DESCRIPTION
... and adds an example with `amp-bind`. 