### PR TITLE
🐛 Amp subscriptions reset fixes.

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -485,10 +485,6 @@ export class SubscriptionService {
     this.platformStore_ = this.platformStore_.resetPlatformStore();
     this.renderer_.toggleLoading(true);
 
-    this.platformConfig_['services'].forEach(service => {
-      this.initializeLocalPlatforms_(service);
-    });
-
     this.platformStore_.getAvailablePlatforms().forEach(
         subscriptionPlatform => {
           this.fetchEntitlements_(subscriptionPlatform);

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -115,6 +115,11 @@ export class PlatformStore {
    * @return {PlatformStore}
    */
   resetPlatformStore() {
+    // Reset individual platforms to ensure their UX clears.
+    for (const platformKey in this.subscriptionPlatforms_) {
+      this.subscriptionPlatforms_[platformKey].reset();
+    }
+    // Then create new platform store withe the newply reset platforms in it.
     return new PlatformStore(
         this.serviceIds_,
         this.scoreConfig_,

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -45,6 +45,8 @@ export class SubscriptionPlatform {
 
   /**
    * Reset the platform and renderer.
+   * This should clear dialogs and toasts originating
+   * from the platform.
    */
   reset() {}
 

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -82,7 +82,7 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     const content2 = createElementWithAttributes(doc, 'div', {
       style: 'height:21px',
     });
-    dialog.open(content, false)
+    dialog.open(content, false);
     return vsync.mutatePromise(() => {}).then(() => {
       expect(content.parentNode).to.equal(dialog.getRoot());
       return dialog.open(content2, false);

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -56,7 +56,6 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     expect(styles.position).to.equal('fixed');
   });
 
-  // (TODO, #19625): test is flakey
   it('should open content when invisible', () => {
     const promise = dialog.open(content, false);
     expect(dialog.getRoot()).to.have.display('none');
@@ -68,7 +67,7 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
       const styles = getComputedStyle(dialog.getRoot());
       expect(styles.transform).to.contain('17');
       return promise;
-    }).then(() => {
+    }).then(() => vsync.mutatePromise(() => {})).then(() => {
       expect(dialog.getRoot()).to.have.display('block');
       const styles = getComputedStyle(dialog.getRoot());
       expect(styles.transform).to.not.contain('17');
@@ -82,10 +81,10 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     const content2 = createElementWithAttributes(doc, 'div', {
       style: 'height:21px',
     });
-    dialog.open(content, false);
+    const promise = dialog.open(content2, false);
     return vsync.mutatePromise(() => {}).then(() => {
-      expect(content.parentNode).to.equal(dialog.getRoot());
-      return dialog.open(content2, false);
+      expect(content2.parentNode).to.equal(dialog.getRoot());
+      return promise;
     }).then(() => {
       expect(content2.parentNode).to.equal(dialog.getRoot());
       expect(content.parentNode).to.be.null;

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -57,7 +57,7 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
   });
 
   // (TODO, #19625): test is flakey
-  it.skip('should open content when invisible', () => {
+  it('should open content when invisible', () => {
     const promise = dialog.open(content, false);
     expect(dialog.getRoot()).to.have.display('none');
     return vsync.mutatePromise(() => {}).then(() => {
@@ -82,7 +82,8 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     const content2 = createElementWithAttributes(doc, 'div', {
       style: 'height:21px',
     });
-    return dialog.open(content, false).then(() => {
+    dialog.open(content, false)
+    return vsync.mutatePromise(() => {}).then(() => {
       expect(content.parentNode).to.equal(dialog.getRoot());
       return dialog.open(content2, false);
     }).then(() => {


### PR DESCRIPTION

This fixes issues #19684 and a related issue where the local platform UX was not being reset.  

It also fixes the test in #19625 


