### PR TITLE
Fallback "Play video" message when the story video failed to play.

### DIFF
--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -54,6 +54,9 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LINK]: {
     string: 'More about AMP results',
   },
+  [LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO]: {
+    string: 'Play video',
+  },
   [LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT]: {
     string: ':(',
   },

--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -54,9 +54,6 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
   [LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LINK]: {
     string: 'More about AMP results',
   },
-  [LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO]: {
-    string: 'Play video',
-  },
   [LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT]: {
     string: ':(',
   },

--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -76,6 +76,10 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     description: 'Label for a link to documentation on how AMP links are ' +
         'handled.',
   },
+  [LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO]: {
+    string: 'Play video',
+    description: 'Label for a button to play the video visible on the page.',
+  },
   [LocalizedStringId.AMP_STORY_HINT_UI_NEXT_LABEL]: {
     string: 'Tap Next',
     description: 'Label indicating that users can navigate to the next ' +

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -95,7 +95,8 @@ const REWIND_TIMEOUT_MS = 350;
  */
 const buildPlayMessageElement = element =>
   htmlFor(element)`
-      <button role="button" class="i-amphtml-story-page-play-button">
+      <button role="button"
+          class="i-amphtml-story-page-play-button i-amphtml-story-system-reset">
         <span class="i-amphtml-story-page-play-label"></span>
         <span class='i-amphtml-story-page-play-icon'></span>
       </button>`;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -39,6 +39,7 @@ import {Deferred} from '../../../src/utils/promise';
 import {EventType, dispatch} from './events';
 import {Layout} from '../../../src/layout';
 import {LoadingSpinner} from './loading-spinner';
+import {LocalizedStringId} from './localization';
 import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
 import {VideoServiceSync} from '../../../src/service/video-service-sync-impl';
@@ -95,7 +96,7 @@ const REWIND_TIMEOUT_MS = 350;
 const buildPlayMessageElement = element =>
   htmlFor(element)`
       <button role="button" class="i-amphtml-story-page-play-button">
-        Play video
+        <span class="i-amphtml-story-page-play-label"></span>
         <span class='i-amphtml-story-page-play-icon'></span>
       </button>`;
 
@@ -871,7 +872,13 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   buildAndAppendPlayMessage_() {
+    const localizationService = Services.localizationService(this.win);
+
     this.playMessageEl_ = buildPlayMessageElement(this.element);
+    const labelEl =
+        this.playMessageEl_.querySelector('.i-amphtml-story-page-play-label');
+    labelEl.textContent = localizationService.getLocalizedString(
+        LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO);
 
     this.playMessageEl_.addEventListener('click', () => {
       this.togglePlayMessage_(false);
@@ -880,7 +887,7 @@ export class AmpStoryPage extends AMP.BaseElement {
           .then(() => this.playAllMedia_());
     });
 
-    this.element.appendChild(this.playMessageEl_);
+    this.mutateElement(() => this.element.appendChild(this.playMessageEl_));
   }
 
   /**
@@ -890,7 +897,9 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   togglePlayMessage_(isActive) {
     if (!isActive) {
-      this.playMessageEl_ && toggle(this.playMessageEl_, false);
+      this.playMessageEl_ &&
+          this.mutateElement(() =>
+            toggle(dev().assertElement(this.playMessageEl_), false));
       return;
     }
 
@@ -898,7 +907,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.buildAndAppendPlayMessage_();
     }
 
-    toggle(dev().assertElement(this.playMessageEl_), true);
+    this.mutateElement(() =>
+      toggle(dev().assertElement(this.playMessageEl_), true));
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -654,12 +654,24 @@ amp-story .amp-video-eq,
   border: 0 !important;
   margin: 8px 0 0 !important; /* Making the click target 48px.*/
   padding: 0 !important;
+  animation: play-button-fly-in 0.4s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
   background-color: transparent !important;
   color: #fff !important;
   font-family: 'Roboto', sans-serif !important;
   font-size: 14px !important;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
   z-index: 10000 !important;
+}
+
+@keyframes play-button-fly-in {
+  0% {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .i-amphtml-story-page-play-button[hidden] {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -652,14 +652,10 @@ amp-story .amp-video-eq,
   right: 0 !important;
   height: 40px !important;
   border: 0 !important;
-  margin: 8px 0 0 !important; /* Making the click target 48px.*/
+  margin: 8px 0 0 8px !important; /* Making the click target 48px.*/
   padding: 0 !important;
   animation: play-button-fly-in 0.4s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
   background-color: transparent !important;
-  color: #fff !important;
-  font-family: 'Roboto', sans-serif !important;
-  font-size: 14px !important;
-  text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
   z-index: 10000 !important;
 }
 
@@ -676,6 +672,13 @@ amp-story .amp-video-eq,
 
 .i-amphtml-story-page-play-button[hidden] {
   display: none !important;
+}
+
+.i-amphtml-story-page-play-label {
+  color: #fff !important;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 14px !important;
+  text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
 }
 
 .i-amphtml-story-page-play-icon {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -643,3 +643,35 @@ amp-story .amp-video-eq,
   50% { transform: rotate(5deg) }
   to { transform: rotate(-130deg) }
 }
+
+.i-amphtml-story-page-play-button {
+  display: flex !important;
+  align-items: center !important;
+  position: absolute !important;
+  bottom: 0 !important;
+  right: 0 !important;
+  height: 40px !important;
+  border: 0 !important;
+  margin: 8px 0 0 !important; /* Making the click target 48px.*/
+  padding: 0 !important;
+  background-color: transparent !important;
+  color: #fff !important;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 14px !important;
+  text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
+  z-index: 10000 !important;
+}
+
+.i-amphtml-story-page-play-button[hidden] {
+  display: none !important;
+}
+
+.i-amphtml-story-page-play-icon {
+  display: inline-block !important;
+  height: 24px !important;
+  width: 24px !important;
+  margin: 0 8px !important;
+  border-radius: 24px !important;
+  filter: drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.36)) !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 48 48" fill="#FFF"><path d="M0 0h48v48H0z" fill="none"/><path d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"/></svg>') !important;
+}

--- a/extensions/amp-story/1.0/localization.js
+++ b/extensions/amp-story/1.0/localization.js
@@ -25,7 +25,7 @@ import {parseJson} from '../../../src/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 34
+ * Next ID: 35
  *
  * @const @enum {string}
  */
@@ -44,6 +44,7 @@ export const LocalizedStringId = {
   AMP_STORY_DOMAIN_DIALOG_HEADING_LINK: '26',
   AMP_STORY_HINT_UI_NEXT_LABEL: '2',
   AMP_STORY_HINT_UI_PREVIOUS_LABEL: '3',
+  AMP_STORY_PAGE_PLAY_VIDEO: '34',
   AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT: '4',
   AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT: '5',
   AMP_STORY_SHARING_PROVIDER_NAME_EMAIL: '6',


### PR DESCRIPTION
Story videos might fail to auto play for various reasons (data saver mode, low battery mode, probably others...). This PR displays a "Play video" message to capture a user intent and bless / play the videos.

[Temporary demo](https://stamp-gmajoulet.firebaseapp.com/examples/s20/body-painting/index.html): it has a video on the first page, and it auto advances to another video. If you click the "Play video" message on the first page, the video on the second page should have been "blessed" and auto play too.

Fixes #12786