### PR TITLE
🏗 Stop printing a console error summary at the end of full test runs

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -233,7 +233,7 @@ module.exports = {
       // Longer timeout on Travis; fail quickly at local.
       timeout: process.env.TRAVIS ? 10000 : 2000,
     },
-    captureConsole: true,
+    captureConsole: false,
     verboseLogging: false,
   },
 

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -35,7 +35,7 @@ const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
 const {exec, getStdout} = require('../exec');
 const {gitDiffNameOnlyMaster} = require('../git');
 
-const {green, yellow, cyan, red, bold} = colors;
+const {green, yellow, cyan, red} = colors;
 
 const preTestTasks = argv.nobuild ? [] : (
   (argv.unit || argv.a4a || argv['local-changes']) ? ['css'] : ['build']);
@@ -441,6 +441,7 @@ async function runTests() {
   c.files = argv.saucelabs ? [] : config.chaiAsPromised;
 
   if (argv.files) {
+    c.client.captureConsole = true;
     c.files = c.files.concat(config.commonIntegrationTestPaths, argv.files);
     if (!argv.saucelabs && !argv.saucelabs_lite) {
       c.reporters = ['mocha'];
@@ -457,6 +458,7 @@ async function runTests() {
         log(cyan(test));
       });
     }
+    c.client.captureConsole = true;
     c.files = c.files.concat(config.commonUnitTestPaths, testsToRun);
   } else if (argv.integration) {
     c.files = c.files.concat(
@@ -498,7 +500,6 @@ async function runTests() {
   }
 
   if (argv.coverage) {
-    c.client.captureConsole = false;
     c.browserify.transform = [
       ['babelify', {
         plugins: [
@@ -540,14 +541,6 @@ async function runTests() {
 
   // Avoid Karma startup errors
   refreshKarmaWdCache();
-
-  // On Travis, collapse the summary printed by the 'karmaSimpleReporter'
-  // reporter for full unit test runs, since it likely contains copious amounts
-  // of logs.
-  const shouldCollapseSummary = process.env.TRAVIS && c.client.captureConsole &&
-      c.reporters.includes('karmaSimpleReporter') && !argv['local-changes'];
-  const sectionMarker =
-      (argv.saucelabs || argv.saucelabs_lite) ? 'saucelabs' : 'local';
 
   // Run Sauce Labs tests in batches to avoid timeouts when connecting to the
   // Sauce Labs environment.
@@ -611,9 +604,6 @@ async function runTests() {
     let resolver;
     const deferred = new Promise(resolverIn => {resolver = resolverIn;});
     new Karma(configBatch, function(exitCode) {
-      if (shouldCollapseSummary) {
-        console./* OK*/log('travis_fold:end:console_errors_' + sectionMarker);
-      }
       if (argv.coverage) {
         if (process.env.TRAVIS) {
           const codecovCmd =
@@ -651,12 +641,6 @@ async function runTests() {
       if (!argv.saucelabs && !argv.saucelabs_lite) {
         log(green('Running tests locally...'));
       }
-    }).on('run_complete', function() {
-      if (shouldCollapseSummary) {
-        console./* OK*/log(bold(red('Console errors:')),
-            'Expand this section and fix all errors printed by your tests.');
-        console./* OK*/log('travis_fold:start:console_errors_' + sectionMarker);
-      }
     }).on('browser_complete', function(browser) {
       const result = browser.lastResult;
       // Prevent cases where Karma detects zero tests and still passes. #16851.
@@ -666,19 +650,18 @@ async function runTests() {
           process.exit(1);
         }
       }
-      if (shouldCollapseSummary) {
-        let message = browser.name + ': ';
-        message += 'Executed ' + (result.success + result.failed) +
-            ' of ' + result.total + ' (Skipped ' + result.skipped + ') ';
-        if (result.failed === 0) {
-          message += green('SUCCESS');
-        } else {
-          message += red(result.failed + ' FAILED');
-        }
-        message += '\n';
-        console./* OK*/log('\n');
-        log(message);
+      // Print a summary for each browser as soon as tests complete.
+      let message = browser.name + ': ';
+      message += 'Executed ' + (result.success + result.failed) +
+          ' of ' + result.total + ' (Skipped ' + result.skipped + ') ';
+      if (result.failed === 0) {
+        message += green('SUCCESS');
+      } else {
+        message += red(result.failed + ' FAILED');
       }
+      message += '\n';
+      console./* OK*/log('\n');
+      log(message);
     }).start();
     return deferred;
   }


### PR DESCRIPTION
This PR silences the long summary of `console.error` messages printed at the end of full unit and integration tests on Travis and during local development. It implements option 1 in https://github.com/ampproject/amphtml/issues/19654#issuecomment-445313808.

Note: Errors will still be printed when tests are run from an individual file with `--files`, or when tests are run via `--local-changes`. This is in keeping with the spirit of #7381.

Fixes #19654
