### PR TITLE
Adds a default title/label/assignee for the cherry pick request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,3 +1,11 @@
+---
+name: Cherry pick template
+about: Used to request a cherry pick.  See bit.ly/amp-cherry-pick
+title: 🌸 Cherry pick request for <YOUR_ISSUE_NUMBER> into <RELEASE_ISSUE_NUMBER> (Pending)
+labels: 'Type: Release'
+assignees: cramforce
+---
+ 
 **Replace *everything* in angle brackets in the title AND body of this issue.  If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).**
 
 


### PR DESCRIPTION
GitHub [recently added support](https://blog.github.com/changelog/2018-12-05-issue-template-automation-improvements/) for default titles/labels/assignees for issues filed with a template.

I'm not certain this will work with our templates since we use the older [manual template method](https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/), but I am copying the format that's generated for the new template style to see if it works.  (I think we chose to use the manual style since it allows us to expose the template through a link but not the main issue filing UI, which is preferable to avoid confusing people filing issues.)

/cc @adelinamart @rsimha 