### PR TITLE
Remove wait for ini-load when layout a4a

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1420,7 +1420,6 @@ export class AmpA4A extends AMP.BaseElement {
 
       // There's no need to wait for all resources to load.
       // StartRender is enough
-      return;
     });
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1408,13 +1408,19 @@ export class AmpA4A extends AMP.BaseElement {
         dev().error(TAG, this.element.getAttribute('type'),
             'Error executing onCreativeRender', err);
       })(creativeMetaData, friendlyIframeEmbed.whenWindowLoaded());
-      // There's no need to wait for all resources to load.
-      // StartRender is enough
-      friendlyIframeEmbed.whenIniLoaded().then(() => {
+      const iniLoadPromise = friendlyIframeEmbed.whenIniLoaded().then(() => {
         checkStillCurrent();
-        // Capture ini-load ping.
         this.maybeTriggerAnalyticsEvent_('friendlyIframeIniLoad');
       });
+      const isIniLoadFixExpr = !!frameDoc.querySelector(
+          'meta[name="amp-experiments-opt-in"][content*="fie_ini_load_fix"]');
+      if (!isIniLoadFixExpr) {
+        return iniLoadPromise;
+      }
+
+      // There's no need to wait for all resources to load.
+      // StartRender is enough
+      return;
     });
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1408,14 +1408,13 @@ export class AmpA4A extends AMP.BaseElement {
         dev().error(TAG, this.element.getAttribute('type'),
             'Error executing onCreativeRender', err);
       })(creativeMetaData, friendlyIframeEmbed.whenWindowLoaded());
-      // It's enough to wait for "ini-load" signal because in a FIE case
-      // we know that the embed no longer consumes significant resources
-      // after the initial load.
-      return friendlyIframeEmbed.whenIniLoaded();
-    }).then(() => {
-      checkStillCurrent();
-      // Capture ini-load ping.
-      this.maybeTriggerAnalyticsEvent_('friendlyIframeIniLoad');
+      // There's no need to wait for all resources to load.
+      // StartRender is enough
+      friendlyIframeEmbed.whenIniLoaded().then(() => {
+        checkStillCurrent();
+        // Capture ini-load ping.
+        this.maybeTriggerAnalyticsEvent_('friendlyIframeIniLoad');
+      });
     });
   }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -460,7 +460,7 @@ describe('amp-a4a', () => {
       // TODO: Remove after launch fie_ini_load_fix to 100%
       creativeString = creativeString.replace('<body>',
           '<body>' +
-          '<meta name="amp-experiments-opt-in" content="fie_ini_load_fix">');
+          '<meta name=amp-experiments-opt-in content=a,fie_ini_load_fix,b>');
       const metaData = a4a.getAmpAdMetadata(creativeString);
       return a4a.renderAmpCreative_(metaData).then(() => {
         expect(a4a.friendlyIframeEmbed_).to.exist;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -506,6 +506,8 @@ describe('amp-a4a', () => {
           sandbox.spy(analytics, 'triggerAnalyticsEvent');
       a4a.buildCallback();
       a4a.onLayoutMeasure();
+      sandbox.stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded').callsFake(
+          () => Promise.resolve());
       return a4a.layoutCallback().then(() => {
         verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
       });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -454,8 +454,8 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
 
       // Never resolve
-      sandbox.stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded').callsFake(
-          () => {return new Promise(() => {});});
+      sandbox.stub/*OK*/(FriendlyIframeEmbed.prototype,'whenIniLoaded')
+          .callsFake(() => {return new Promise(() => {});});
       let creativeString = buildCreativeString();
       // TODO: Remove after launch fie_ini_load_fix to 100%
       creativeString = creativeString.replace('<body>',
@@ -526,8 +526,8 @@ describe('amp-a4a', () => {
           sandbox.spy(analytics, 'triggerAnalyticsEvent');
       a4a.buildCallback();
       a4a.onLayoutMeasure();
-      sandbox.stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded').callsFake(
-          () => Promise.resolve());
+      sandbox.stub/*OK*/(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
+          .callsFake(() => Promise.resolve());
       return a4a.layoutCallback().then(() => {
         verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
       });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -422,6 +422,7 @@ describe('amp-a4a', () => {
       });
     });
 
+    // TODO: Remove after launch fie_ini_load_fix to 100%
     it('for A4A FIE should wait for initial layout', () => {
       let iniLoadResolver;
       const iniLoadPromise = new Promise(resolve => {
@@ -445,6 +446,25 @@ describe('amp-a4a', () => {
         expect(a4a.friendlyIframeEmbed_.host).to.equal(a4a.element);
         expect(whenIniLoadedStub).to.be.calledOnce;
         expect(lifecycleEventStub).to.be.calledWith('friendlyIframeIniLoad');
+      });
+    });
+
+    it('for A4A layout should resolve once FIE is created', () => {
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+
+      // Never resolve
+      sandbox.stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded').callsFake(
+          () => {return new Promise(() => {});});
+      let creativeString = buildCreativeString();
+      // TODO: Remove after launch fie_ini_load_fix to 100%
+      creativeString = creativeString.replace('<body>',
+          '<body>' +
+          '<meta name="amp-experiments-opt-in" content="fie_ini_load_fix">');
+      const metaData = a4a.getAmpAdMetadata(creativeString);
+      return a4a.renderAmpCreative_(metaData).then(() => {
+        expect(a4a.friendlyIframeEmbed_).to.exist;
+        expect(a4a.friendlyIframeEmbed_.host).to.equal(a4a.element);
       });
     });
 


### PR DESCRIPTION
This is to fix the issue that Ad start layout on idle early but layout never finish because it is waiting for FIE ini-load. 
This PR removes the wait for FIE ini-load, and change it render-start. Ad LayoutCallback should be completed once FIE start to render. 
 
The change could help with the case if there are multiple ads on the page. It will also lead to loading indicator behavior change. But I think it's should be safe. 

Please let me know if there's any concern. And if we want to run an experiment with it. 