### PR TITLE
Update docs to replace doubleclick with Google Ad Manager

### DIFF
--- a/ads/google/a4a/docs/Network-Impl-Guide.md
+++ b/ads/google/a4a/docs/Network-Impl-Guide.md
@@ -211,8 +211,7 @@ Usage of `getAdUrl` can be seen within the `this.adPromise_ promise` chain in
     });
     ```
 
-Example configs: [Google Ad Manager](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js#L80)
-and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js#L68).
+Example configs: [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js#L68).
 Usage of Google Ad Manager and AdSense configs can be seen in [_a4a-config.js](https://github.com/ampproject/amphtml/blob/master/ads/_a4a-config.js).
 
 #### Create documentation

--- a/ads/google/a4a/docs/Network-Impl-Guide.md
+++ b/ads/google/a4a/docs/Network-Impl-Guide.md
@@ -51,7 +51,7 @@ To support Fast Fetch, ad networks are required to implement the following:
 2. The JavaScript to build the ad request, which must be located within the AMP
 HTML GitHub repository (example implementations:
 [AdSense](https://github.com/ampproject/amphtml/tree/master/extensions/amp-ad-network-adsense-impl)
-& [DoubleClick](https://github.com/ampproject/amphtml/tree/master/extensions/amp-ad-network-doubleclick-impl)).
+& [Google Ad Manager](https://github.com/ampproject/amphtml/tree/master/extensions/amp-ad-network-doubleclick-impl)).
 
 ## Detailed design
 
@@ -129,7 +129,7 @@ is allowed by including the following headers in the response:
 
 The [`<amp-ad>`](https://www.ampproject.org/docs/reference/components/amp-ad)
 element differentiates between different ad network implementations via the
-`type` attribute. For example, the following amp-ad tag utilizes the DoubleClick
+`type` attribute. For example, the following amp-ad tag utilizes the Google Ad Manager
 ad network:
 
 ```html
@@ -175,7 +175,7 @@ To create an ad network implementation, you must perform the following:
       // @return {string} - the ad url
     ```
 
-Examples of network implementations can be seen for [DoubleClick](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js) and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js).
+Examples of network implementations can be seen for [Google Ad Manager](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js) and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js).
 Usage of `getAdUrl` can be seen within the `this.adPromise_ promise` chain in
 [amp-a4a.js](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/amp-a4a.js).
 
@@ -211,16 +211,16 @@ Usage of `getAdUrl` can be seen within the `this.adPromise_ promise` chain in
     });
     ```
 
-Example configs: [DoubleClick](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js#L80)
+Example configs: [Google Ad Manager](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js#L80)
 and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js#L68).
-Usage of DoubleClick and AdSense configs can be seen in [_a4a-config.js](https://github.com/ampproject/amphtml/blob/master/ads/_a4a-config.js).
+Usage of Google Ad Manager and AdSense configs can be seen in [_a4a-config.js](https://github.com/ampproject/amphtml/blob/master/ads/_a4a-config.js).
 
 #### Create documentation
 
 Create a file named `amp-ad-network-<TYPE>-impl-internal.md`, and within this
 file provide thorough documentation for the use of your implementation.
 
-Examples: See [DoubleClick](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md)
+Examples: See [Google Ad Manager](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md)
 and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md).
 
 #### Create tests

--- a/ads/google/doubleclick.md
+++ b/ads/google/doubleclick.md
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Doubleclick
+# Google Ad Manager
 
-Support for DoubleClick Delayed Fetch has been deprecated as of March 29, 2018. Please upgrade to Fast Fetch. Visit the <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md">DoubleClick Fast Fetch documentation page</a> for more details.
+Support for Google Ad Manager Delayed Fetch has been deprecated as of March 29, 2018. Please upgrade to Fast Fetch. Visit the <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md">Google Ad Manager Fast Fetch documentation page</a> for more details.

--- a/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# DoubleClick
+# Google Ad Manager
 
 ### <a name="amp-ad-network-doubleclick-impl"></a> `amp-ad-network-doubleclick-impl`
 
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>DoubleClick implementation of the AMP Ad tag.  Click <a href="/ads/google/a4a/docs/Network-Impl-Guide.md">here</a>
+    <td>Google Ad Manager implementation of the AMP Ad tag.  Click <a href="/ads/google/a4a/docs/Network-Impl-Guide.md">here</a>
     for Fast Fetch details, and <a href="/extensions/amp-a4a/amp-a4a-format.md">here</a>
     for AMPHTML ad format details. This tag should
     not be directly referenced by pages and instead is dynamically loaded
@@ -97,7 +97,7 @@ limitations under the License.
 </table>
 
 #### Examples
-Example - DoubleClick Ad
+Example - Google Ad Manager Ad
 ```html
 <amp-ad width=728 height=90
     type="doubleclick"

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -22,4 +22,4 @@ If the user has responded negatively to the amp-consent component (user rejects 
 If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests or RTC call-outs are sent.  
 If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
 
-See [Doubleclick Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.
+See [Google Ad Manager Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.

--- a/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
+++ b/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
@@ -1,16 +1,16 @@
-# AMP Real Time Config with DoubleClick (DFP)
+# AMP Real Time Config with Google Ad Manager
 
 
 ## Introduction
 
-This implementation guide is intended for publishers who wish to use Real Time Config with DoubleClick Fast Fetch in AMP. Any publishers using remote.html with DoubleClick will need to implement this, as Delayed Fetch (and therefore remote.html support) will be deprecated March 29, 2018. See [Intent to Implement: Delayed Fetch Deprecation.](https://github.com/ampproject/amphtml/issues/11834)
+This implementation guide is intended for publishers who wish to use Real Time Config with Google Ad Manager Fast Fetch in AMP. Any publishers using remote.html with Google Ad Manager will need to implement this, as Delayed Fetch (and therefore remote.html support) will be deprecated March 29, 2018. See [Intent to Implement: Delayed Fetch Deprecation.](https://github.com/ampproject/amphtml/issues/11834)
 
 
 ## Background
 
-For full details and background, please refer to the [RTC Documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md) and the generic [RTC Publisher Implementation Guide](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md). This guide is intended to highlight some of the details of DoubleClick's implementation of RTC.
+For full details and background, please refer to the [RTC Documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md) and the generic [RTC Publisher Implementation Guide](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md). This guide is intended to highlight some of the details of Google Ad Manager's implementation of RTC.
 
-AMP Real Time Config (RTC) is a feature of Fast Fetch that allows Publishers to augment ad requests with targeting information that is retrieved at runtime. This dynamic targeting data can be applied in addition to any existing statically-defined data on each amp-ad element. RTC allows 5 callouts to targeting servers for each individual ad slot, the results of which can be added to the ad request. To use RTC with DoubleClick, you must simply setup the rtc-config on each amp-ad element.
+AMP Real Time Config (RTC) is a feature of Fast Fetch that allows Publishers to augment ad requests with targeting information that is retrieved at runtime. This dynamic targeting data can be applied in addition to any existing statically-defined data on each amp-ad element. RTC allows 5 callouts to targeting servers for each individual ad slot, the results of which can be added to the ad request. To use RTC with Google Ad Manager, you must simply setup the rtc-config on each amp-ad element.
 
 
 ## Setting Up RTC-Config
@@ -18,7 +18,7 @@ AMP Real Time Config (RTC) is a feature of Fast Fetch that allows Publishers to 
 For instructions on how to set the rtc-config attribute on the amp-ad, refer to [Setting Up RTC-Config](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md#setting-up-rtc-config) in the Publisher Implementation Guide.
 
 ## Available URL Macros
-Doubleclick's RTC implementation has made many macros available for RTC url expansion. Please note that the time to expand the URL is counted against the RTC timeout. Additionally, note that all RTC URLs are truncated at 16384 characters, so keep possible truncation in mind when determining which macros to include, and which order to include them in your URL. Currently available macros are as follows:
+Google Ad Manager's RTC implementation has made many macros available for RTC url expansion. Please note that the time to expand the URL is counted against the RTC timeout. Additionally, note that all RTC URLs are truncated at 16384 characters, so keep possible truncation in mind when determining which macros to include, and which order to include them in your URL. Currently available macros are as follows:
 
 - **PAGEVIEWID** - pageViewId
 - **HREF** - equivalent to window.context.location.href
@@ -40,7 +40,7 @@ Doubleclick's RTC implementation has made many macros available for RTC url expa
 
 To use their own first-party data, publishers will need to build a RTC-compatible endpoint that returns this targeting data. For those only retrieving data from 3rd-party vendors, this section is not applicable.
 
-The requirements for an RTC endpoint to be used with DoubleClick are the same as what is specified in the Publisher Implementation Guide. In summary:
+The requirements for an RTC endpoint to be used with Google Ad Manager are the same as what is specified in the Publisher Implementation Guide. In summary:
 
 The RTC Response to a GET must meet the following requirements:
 
@@ -48,7 +48,7 @@ The RTC Response to a GET must meet the following requirements:
 *   See [here for Required Headers](https://github.com/ampproject/amphtml/blob/master/spec/amp-cors-requests.md#ensuring-secure-responses) and note that Access-Control-Allow-Credentials: true must be present for cookies to be included in the request.
 *   Body of response is a JSON object of targeting information such as:
     *   **<code>{"targeting": {"sport":["rugby","cricket"]}}</code>**</strong>
-    *   The response body must be JSON, but the actual structure of that data need not match the structure here. Refer to Fast Fetch Network specific documentation for the required spec. (for example, if using DoubleClick, refer to DoubleClick docs).
+    *   The response body must be JSON, but the actual structure of that data need not match the structure here. Refer to Fast Fetch Network specific documentation for the required spec. (for example, if using Google Ad Manager, refer to Google Ad Manager docs).
 
 
 
@@ -166,7 +166,7 @@ And let the response from VendorB be:
 ```
 
 
-The DoubleClick Fast Fetch implementation automatically converts both of these responses to:
+The Google Ad Manager Fast Fetch implementation automatically converts both of these responses to:
 
 Rewritten VendorA Response
 
@@ -318,6 +318,6 @@ https://securepubads.g.doubleclick.net/...scp=loc%3Dusa%26gender%3Df%26r%3Dh%26e
 
 ## Using RTC In DFP
 
-The results of the RTC Callouts will be added to the DoubleClick Ad Request, allowing you to use the key/value pairs in DFP as you would for any other non-AMP ad request. Please refer to generic key/value targeting documentation for DoubleClick.
+The results of the RTC Callouts will be added to the Google Ad Manager Ad Request, allowing you to use the key/value pairs in DFP as you would for any other non-AMP ad request. Please refer to generic key/value targeting documentation for Google Ad Manager.
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/fluid.md
+++ b/extensions/amp-ad-network-doubleclick-impl/fluid.md
@@ -33,4 +33,4 @@ An example slot might look like:
 
 Note also that the width attribute is optional, and can be specified. When specified, the fluid creative will always occupy that width (unless used in conjunction with multi-size). Further, fluid creatives are fully compatible with multi-size creatives. When both features are turned on, either a fluid creative, or one matching one of the specified multi-size sizes may be given.
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/multi-size.md
+++ b/extensions/amp-ad-network-doubleclick-impl/multi-size.md
@@ -69,4 +69,4 @@ Example - Valid multi-size request (ignores minimum size constraint)
 </amp-ad>
 ```
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/refresh.md
+++ b/extensions/amp-ad-network-doubleclick-impl/refresh.md
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 # AMP Ad Refresh
-AMP Ad Refresh provides a mechanism for DoubleClick slots to periodically refresh, that is to fetch and render a new creative. Slots will only issue refresh requests once the current creative has been viewed (i.e., has had 50% of its pixels on screen for a continuous second).
+AMP Ad Refresh provides a mechanism for Google Ad Manager slots to periodically refresh, that is to fetch and render a new creative. Slots will only issue refresh requests once the current creative has been viewed (i.e., has had 50% of its pixels on screen for a continuous second).
 
 For a network implementation guide, please click <a href="../../extensions/amp-a4a/refresh.md">here</a>.
 
@@ -48,4 +48,4 @@ Refresh is currently not supported for SRA enabled slots. If a slot is enabled f
 
 The only AMP ad containers in which refresh is currently supported are amp-sticky-ad and amp-carousel container types.
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/render-on-idle.md
+++ b/extensions/amp-ad-network-doubleclick-impl/render-on-idle.md
@@ -21,4 +21,4 @@ viewable impressions and clicks.  Publishers sensitive to viewability rate shoul
 set data-loading-strategy=3 to keep the current viewport offset and disable idle render.  Publishers using data-loading-strategy=prefer-viewability-over-views will
 use current 1.25 viewport offset with idle render disabled.
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/safeframe.md
+++ b/extensions/amp-ad-network-doubleclick-impl/safeframe.md
@@ -1,13 +1,13 @@
-# Doubleclick Fast Fetch SafeFrame API
+# Google Ad Manager Fast Fetch SafeFrame API
 
-Doubleclick's Fast Fetch implementation supports some aspects of the [GPT SafeFrame API](https://support.google.com/dfp_premium/answer/6023110) for non-AMP creatives that are rendered within a SafeFrame. Please refer to the [IAB specification](https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf) of SafeFrame and the [GPT implementation details](https://support.google.com/dfp_premium/answer/6023110) for a comprehensive explanation of SafeFrame. This document is primarily aimed to explain the AMP-specific differences.
+Google Ad Manager's Fast Fetch implementation supports some aspects of the [GPT SafeFrame API](https://support.google.com/dfp_premium/answer/6023110) for non-AMP creatives that are rendered within a SafeFrame. Please refer to the [IAB specification](https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf) of SafeFrame and the [GPT implementation details](https://support.google.com/dfp_premium/answer/6023110) for a comprehensive explanation of SafeFrame. This document is primarily aimed to explain the AMP-specific differences.
 
 SafeFrame support (including ext.js library injection) can be forced client-side by setting `data-force-safeframe=true` attribute on amp-ad type=doubleclick elements.
 
 
 # Supported Methods
 
-The following methods all work for creatives rendered in SafeFrames via Doubleclick Fast Fetch, but have AMP-specific key differences that should be noted:
+The following methods all work for creatives rendered in SafeFrames via Google Ad Manager Fast Fetch, but have AMP-specific key differences that should be noted:
 
 ## \$sf.ext.resize({t, b, l, r})
 

--- a/extensions/amp-ad-network-doubleclick-impl/single-page-ad.md
+++ b/extensions/amp-ad-network-doubleclick-impl/single-page-ad.md
@@ -20,7 +20,7 @@ A single page ad allows an ad creative to appear as a full page, dynamically int
 
 ## Adding a Single Page Ad to Your Story
 
-Single page ads are similar to regular DoubleClick ads, but must be tagged as script elements within an `<amp-story-auto-ads>` element as follows:
+Single page ads are similar to regular Google Ad Manager ads, but must be tagged as script elements within an `<amp-story-auto-ads>` element as follows:
 
 ```html
 <amp-story-auto-ads>
@@ -56,6 +56,6 @@ See the above link for allowed call-to-action buttons. By design, these will be 
 ## Example
 You can find a fully working example hosted on [ampbyexample.com](https://ampbyexample.com/stories/monetization/doubleclick/).
 
-DoubleClick trafficking instructions can be found in the [DFP Help Center](https://support.google.com/dfp_premium/answer/9038178). 
+Google Ad Manager trafficking instructions can be found in the [DFP Help Center](https://support.google.com/dfp_premium/answer/9038178).
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>

--- a/extensions/amp-ad-network-doubleclick-impl/sra.md
+++ b/extensions/amp-ad-network-doubleclick-impl/sra.md
@@ -28,4 +28,4 @@ Note that SRA is only available if:
 Note also that <a href="refresh.md">Refresh</a> is not compatible with SRA. If both SRA and Refresh are enabled on the same slot, Refresh will be disabled in favor of SRA.
 
 
-#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to DoubleClick</a>
+#### <a href="amp-ad-network-doubleclick-impl-internal.md">Back to Google Ad Manager</a>


### PR DESCRIPTION
The term "doubleclick" is now deprecated. Begin moving over all usages of "Doubleclick" to "Google Ad Manager" 