### PR TITLE
Story subscriptions navigation.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -128,8 +128,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @private
    */
   initializeListeners_() {
-    this.storeService_.subscribe(StateProperty.ACCESS_STATE, isAccess => {
-      this.onAccessStateChange_(isAccess);
+    this.storeService_.subscribe(StateProperty.PAYWALL_STATE, isPaywall => {
+      this.onPaywallStateChange_(isPaywall);
     });
 
     this.storeService_
@@ -142,12 +142,12 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
   /**
    * Reacts to access state updates, and shows/hides the UI accordingly.
-   * @param {boolean} isAccess
+   * @param {boolean} isPaywall
    * @private
    */
-  onAccessStateChange_(isAccess) {
+  onPaywallStateChange_(isPaywall) {
     if (this.getType_() === Type.BLOCKING) {
-      this.toggle_(isAccess);
+      this.toggle_(isPaywall);
     }
   }
 
@@ -179,7 +179,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
     // Closes the menu if click happened outside of the main container.
     if (!closest(el, el => el === this.containerEl_, this.element)) {
-      this.storeService_.dispatch(Action.TOGGLE_ACCESS, false);
+      this.storeService_.dispatch(Action.TOGGLE_PAYWALL, false);
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -919,4 +919,27 @@ export class AmpStoryPage extends AMP.BaseElement {
   isAd() {
     return this.element.hasAttribute(ADVERTISEMENT_ATTR_NAME);
   }
+
+  /**
+   * Whether the page is currently blocked by a paywall, either amp-access or
+   * amp-subscriptions.
+   * @return {boolean}
+   */
+  isPaywallProtected() {
+    return this.element.hasAttribute('amp-access-hide') ||
+        matches(
+            this.element,
+            '.i-amphtml-subs-grant-no [subscriptions-section="content"]');
+  }
+
+  /**
+   * Whether the page has amp-access or amp-subscriptions attributes that,
+   * depending on the user's authorizations, might block navigation to this
+   * page.
+   * @return {boolean}
+   */
+  hasPaywallAttributes() {
+    return this.element.hasAttribute('amp-access') ||
+        this.element.hasAttribute('subscriptions-section');
+  }
 }

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -64,7 +64,6 @@ export const UIType = {
  *    canShowPreviousPageHelp: boolean,
  *    canShowSharingUis: boolean,
  *    canShowSystemLayerButtons: boolean,
- *    accessState: boolean,
  *    adState: boolean,
  *    bookendState: boolean,
  *    desktopState: boolean,
@@ -74,6 +73,7 @@ export const UIType = {
  *    mutedState: boolean,
  *    pageAudioState: boolean,
  *    pausedState: boolean,
+ *    paywallState: boolean,
  *    rtlState: boolean,
  *    shareMenuState: boolean,
  *    sidebarState: boolean,
@@ -104,7 +104,6 @@ export const StateProperty = {
   CAN_SHOW_SYSTEM_LAYER_BUTTONS: 'canShowSystemLayerButtons',
 
   // App States.
-  ACCESS_STATE: 'accessState', // amp-access paywall.
   AD_STATE: 'adState',
   BOOKEND_STATE: 'bookendState',
   DESKTOP_STATE: 'desktopState',
@@ -114,6 +113,7 @@ export const StateProperty = {
   MUTED_STATE: 'mutedState',
   PAGE_HAS_AUDIO_STATE: 'pageAudioState',
   PAUSED_STATE: 'pausedState',
+  PAYWALL_STATE: 'paywallState', // amp-access and amp-subscriptions paywall.
   RTL_STATE: 'rtlState',
   SHARE_MENU_STATE: 'shareMenuState',
   SIDEBAR_STATE: 'sidebarState',
@@ -141,7 +141,6 @@ export const Action = {
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
   SET_PAGES_COUNT: 'setPagesCount',
-  TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_BOOKEND: 'toggleBookend',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
@@ -149,6 +148,7 @@ export const Action = {
   TOGGLE_MUTED: 'toggleMuted',
   TOGGLE_PAGE_HAS_AUDIO: 'togglePageHasAudio',
   TOGGLE_PAUSED: 'togglePaused',
+  TOGGLE_PAYWALL: 'togglePaywall',
   TOGGLE_RTL: 'toggleRtl',
   TOGGLE_SHARE_MENU: 'toggleShareMenu',
   TOGGLE_SIDEBAR: 'toggleSidebar',
@@ -186,18 +186,6 @@ const actions = (state, action, data) => {
           [].concat(state[StateProperty.ACTIONS_WHITELIST], data);
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.ACTIONS_WHITELIST]: newActionsWhitelist}));
-    // Triggers the amp-acess paywall.
-    case Action.TOGGLE_ACCESS:
-      // Don't change the PAUSED_STATE if ACCESS_STATE is not changed.
-      if (state[StateProperty.ACCESS_STATE] === data) {
-        return state;
-      }
-
-      return /** @type {!State} */ (Object.assign(
-          {}, state, {
-            [StateProperty.ACCESS_STATE]: !!data,
-            [StateProperty.PAUSED_STATE]: !!data,
-          }));
     // Triggers the ad UI.
     case Action.TOGGLE_AD:
       return /** @type {!State} */ (Object.assign(
@@ -239,6 +227,17 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_PAUSED:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.PAUSED_STATE]: !!data}));
+    case Action.TOGGLE_PAYWALL:
+      // Don't change the PAUSED_STATE if PAYWALL_STATE is not changed.
+      if (state[StateProperty.PAYWALL_STATE] === data) {
+        return state;
+      }
+
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {
+            [StateProperty.PAYWALL_STATE]: !!data,
+            [StateProperty.PAUSED_STATE]: !!data,
+          }));
     case Action.TOGGLE_RTL:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.RTL_STATE]: !!data}));
@@ -389,7 +388,6 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
       [StateProperty.CAN_SHOW_SHARING_UIS]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
-      [StateProperty.ACCESS_STATE]: false,
       [StateProperty.AD_STATE]: false,
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
@@ -399,6 +397,7 @@ export class AmpStoryStoreService {
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.PAGE_HAS_AUDIO_STATE]: false,
       [StateProperty.PAUSED_STATE]: false,
+      [StateProperty.PAYWALL_STATE]: false,
       [StateProperty.RTL_STATE]: false,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SIDEBAR_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -274,10 +274,10 @@ export class AmpStory extends AMP.BaseElement {
     this.mediaPool_ = MediaPool.for(this);
 
     /** @private {boolean} */
-    this.areAccessAuthorizationsCompleted_ = false;
+    this.arePaywallAuthorizationsCompleted_ = false;
 
     /** @private */
-    this.navigateToPageAfterAccess_ = null;
+    this.navigateToPageAfterPaywall_ = null;
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win);
@@ -610,7 +610,7 @@ export class AmpStory extends AMP.BaseElement {
       // TODO(enriqe): Move to a separate file if this keeps growing.
       if (this.storeService_.get(StateProperty.BOOKEND_STATE) ||
           this.storeService_.get(StateProperty.TOOLTIP_ELEMENT) ||
-          this.storeService_.get(StateProperty.ACCESS_STATE) ||
+          this.storeService_.get(StateProperty.PAYWALL_STATE) ||
           !this.storeService_.get(StateProperty.SYSTEM_UI_IS_VISIBLE_STATE) ||
           !this.storeService_
               .get(StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT)) {
@@ -734,6 +734,7 @@ export class AmpStory extends AMP.BaseElement {
 
           this.handleConsentExtension_();
           this.initializeStoryAccess_();
+          this.initializeStorySubscriptions_();
 
           this.pages_.forEach((page, index) => {
             page.setState(PageState.NOT_ACTIVE);
@@ -858,7 +859,7 @@ export class AmpStory extends AMP.BaseElement {
         return;
       }
 
-      this.areAccessAuthorizationsCompleted_ =
+      this.arePaywallAuthorizationsCompleted_ =
           accessService.areFirstAuthorizationsCompleted();
       accessService.onApplyAuthorizations(
           () => this.onAccessApplyAuthorizations_());
@@ -883,21 +884,64 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   onAccessApplyAuthorizations_() {
-    this.areAccessAuthorizationsCompleted_ = true;
+    this.arePaywallAuthorizationsCompleted_ = true;
 
-    const nextPage = this.navigateToPageAfterAccess_;
+    const nextPage = this.navigateToPageAfterPaywall_;
 
     // Step out if the next page is still hidden by the access extension.
-    if (nextPage && nextPage.element.hasAttribute('amp-access-hide')) {
+    if (nextPage && !nextPage.isPaywallProtected()) {
+      this.navigateToPageAfterPaywall_ = null;
+      this.switchTo_(nextPage.element.id);
+      this.storeService_.dispatch(Action.TOGGLE_PAYWALL, false);
+    }
+  }
+
+  /**
+   * @private
+   */
+  initializeStorySubscriptions_() {
+    Services.subscriptionsServiceForDocOrNull(this.getAmpDoc()).then(
+        subscriptionsService => {
+          if (!subscriptionsService) {
+            return;
+          }
+
+          const bodyEl = this.win.document.body;
+
+          this.arePaywallAuthorizationsCompleted_ =
+              bodyEl.classList.contains('i-amphtml-subs-grant-no') ||
+              bodyEl.classList.contains('i-amphtml-subs-grant-yes');
+
+          const bodyObserver =
+              new this.win.MutationObserver(
+                  () => this.onBodyAttributesChanged_());
+          bodyObserver.observe(bodyEl, {attributes: true});
+        });
+  }
+
+  /**
+   * @private
+   */
+  onBodyAttributesChanged_() {
+    const bodyClassList = this.win.document.body.classList;
+
+    this.arePaywallAuthorizationsCompleted_ =
+        bodyClassList.contains('i-amphtml-subs-grant-no') ||
+        bodyClassList.contains('i-amphtml-subs-grant-yes');
+
+    // Dont try to navigate again if the document is not authorized yet.
+    if (!this.arePaywallAuthorizationsCompleted_) {
       return;
     }
 
-    if (nextPage) {
-      this.navigateToPageAfterAccess_ = null;
-      this.switchTo_(nextPage.element.id);
-    }
+    const nextPage = this.navigateToPageAfterPaywall_;
 
-    this.storeService_.dispatch(Action.TOGGLE_ACCESS, false);
+    // Navigate to the next page if it's no longer paywall protected.
+    if (nextPage && !nextPage.isPaywallProtected()) {
+      this.navigateToPageAfterPaywall_ = null;
+      this.switchTo_(nextPage.element.id);
+      this.storeService_.dispatch(Action.TOGGLE_PAYWALL, false);
+    }
   }
 
   /** @override */
@@ -986,20 +1030,20 @@ export class AmpStory extends AMP.BaseElement {
       return Promise.resolve();
     }
 
-    // If the next page might be paywall protected, and the access
+    // If the next page might be paywall protected, and the paywall
     // authorizations did not resolve yet, wait before navigating.
     // TODO(gmajoulet): implement a loading state.
-    if (targetPage.element.hasAttribute('amp-access') &&
-        !this.areAccessAuthorizationsCompleted_) {
-      this.navigateToPageAfterAccess_ = targetPage;
+    if (!this.arePaywallAuthorizationsCompleted_ &&
+        targetPage.hasPaywallAttributes()) {
+      this.navigateToPageAfterPaywall_ = targetPage;
       return Promise.resolve();
     }
 
-    // If the next page is paywall protected, display the access UI and wait for
-    // the document to be reauthorized.
-    if (targetPage.element.hasAttribute('amp-access-hide')) {
-      this.storeService_.dispatch(Action.TOGGLE_ACCESS, true);
-      this.navigateToPageAfterAccess_ = targetPage;
+    // If the next page is paywall protected, display the paywall UI and wait
+    // for the document to be reauthorized.
+    if (targetPage.isPaywallProtected()) {
+      this.storeService_.dispatch(Action.TOGGLE_PAYWALL, true);
+      this.navigateToPageAfterPaywall_ = targetPage;
       return Promise.resolve();
     }
 

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -79,7 +79,7 @@ describes.realWin('amp-story-access', {amp: true}, env => {
   it('should display the access blocking paywall on state update', done => {
     storyAccess.buildCallback();
 
-    storeService.dispatch(Action.TOGGLE_ACCESS, true);
+    storeService.dispatch(Action.TOGGLE_PAYWALL, true);
 
     win.requestAnimationFrame(() => {
       expect(storyAccess.element)

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -25,6 +25,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   let win;
   let element;
   let page;
+  let story;
 
   beforeEach(() => {
     win = env.win;
@@ -40,7 +41,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
 
-    const story = win.document.createElement('amp-story');
+    story = win.document.createElement('amp-story');
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
 
     element = win.document.createElement('amp-story-page');
@@ -248,5 +249,47 @@ describes.realWin('amp-story-page', {amp: true}, env => {
             done();
           });
         });
+  });
+
+  describe('Paywall public API', () => {
+    it('should be protected by the subscriptions paywall', () => {
+      story.classList.add('i-amphtml-subs-grant-no');
+      page.element.setAttribute('subscriptions-section', 'content');
+
+      expect(page.isPaywallProtected()).to.be.true;
+    });
+
+    it('should not be protected by the subscriptions paywall', () => {
+      story.classList.add('i-amphtml-subs-grant-yes');
+      page.element.setAttribute('subscriptions-section', 'content');
+
+      expect(page.isPaywallProtected()).to.be.false;
+    });
+
+    it('should be protected by the access paywall', () => {
+      page.element.setAttribute('amp-access-hide', '');
+
+      expect(page.isPaywallProtected()).to.be.true;
+    });
+
+    it('should not be protected', () => {
+      expect(page.isPaywallProtected()).to.be.false;
+    });
+
+    it('should have paywall attributes (subscriptions)', () => {
+      page.element.setAttribute('amp-access', 'someRule');
+
+      expect(page.hasPaywallAttributes()).to.be.true;
+    });
+
+    it('should have paywall attributes (subscriptions)', () => {
+      page.element.setAttribute('subscriptions-section', 'content');
+
+      expect(page.hasPaywallAttributes()).to.be.true;
+    });
+
+    it('should not have paywall attributes', () => {
+      expect(page.hasPaywallAttributes()).to.be.false;
+    });
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -221,13 +221,13 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(pausedListenerSpy).to.have.been.calledWith(false);
   });
 
-  it('should not update PAUSED_STATE if ACCESS_STATE is unchanged', () => {
+  it('should not update PAUSED_STATE if PAYWALL_STATE is unchanged', () => {
     // Story is paused.
     storeService.dispatch(Action.TOGGLE_PAUSED, true);
 
-    // ACCESS_STATE was already false but is set to false again.
-    expect(storeService.get(StateProperty.ACCESS_STATE)).to.be.false;
-    storeService.dispatch(Action.TOGGLE_ACCESS, false);
+    // PAYWALL_STATE was already false but is set to false again.
+    expect(storeService.get(StateProperty.PAYWALL_STATE)).to.be.false;
+    storeService.dispatch(Action.TOGGLE_PAYWALL, false);
 
     // PAUSED_STATE did not get affected.
     expect(storeService.get(StateProperty.PAUSED_STATE)).to.be.true;


### PR DESCRIPTION
Rewriting some amp-story navigation code to support both `amp-access` and `amp-subscriptions`.

Part of #12180