### PR TITLE
SwG release 0.1.22.41

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.40 */
+/** Version: 0.1.22.41 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *


### PR DESCRIPTION
Previous release: 0.1.22.40

Make CSS injection use Doc to correctly handle shadow dom case. (#495)
Force Edge into redirect mode (#494)
Fix pay.js to avoid calls to endsWith. Upstream fix is comming in parallel (#493)
Use default values in proto tests (#492)