### PR TITLE
🐛 Wait for AmpDoc to fully load before creating default lightbox gallery element.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1442,15 +1442,19 @@ export class AmpLightboxGallery extends AMP.BaseElement {
  * @return {!Promise<undefined>}
  */
 export function installLightboxGallery(ampdoc) {
-  return ampdoc.whenBodyAvailable().then(body => {
-    const existingGallery = elementByTag(ampdoc.getRootNode(), TAG);
-    if (!existingGallery) {
-      const gallery = ampdoc.win.document.createElement(TAG);
-      gallery.setAttribute('layout', 'nodisplay');
-      gallery.setAttribute('id', DEFAULT_GALLERY_ID);
-      body.appendChild(gallery);
-    }
-  });
+  // Make sure to wait for the ampdoc to finish loading, see:
+  // https://github.com/ampproject/amphtml/issues/19728#issuecomment-446033966
+  return ampdoc.whenReady()
+      .then(() => ampdoc.getBody())
+      .then(body => {
+        const existingGallery = elementByTag(ampdoc.getRootNode(), TAG);
+        if (!existingGallery) {
+          const gallery = ampdoc.win.document.createElement(TAG);
+          gallery.setAttribute('layout', 'nodisplay');
+          gallery.setAttribute('id', DEFAULT_GALLERY_ID);
+          body.appendChild(gallery);
+        }
+      });
 }
 
 /**


### PR DESCRIPTION
We need to wait for two reasons:

1. Appending an element to the end of the body causes other elements to upgrade too early (#19728)
2. There might be an `<amp-lightbox-gallery>` further down on the page

Fixes #19728
