### PR TITLE
🐛Fix bug with fading in lightbox after image transition.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -50,7 +50,7 @@ import {
 import {
   prepareImageAnimation,
 } from '@ampproject/animations/dist/animations.mjs';
-import {setStyles, toggle} from '../../../src/style';
+import {setStyle, setStyles, toggle} from '../../../src/style';
 import {toArray} from '../../../src/types';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
@@ -937,6 +937,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   runImgTransition_(srcImg, targetImg, enter) {
     const carousel = dev().assertElement(this.carousel_);
+    const container = dev().assertElement(this.container_);
     const transLayer = this.element.ownerDocument.createElement('div');
     transLayer.classList.add('i-amphtml-lightbox-gallery-trans');
 
@@ -972,7 +973,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         opacity: 1,
       });
       // Fade in/out the background in sync with the motion.
-      setStyles(dev().assertElement(this.container_), {
+      setStyles(container, {
         animationName: enter ? 'fadeIn' : 'fadeOut',
         animationTimingFunction: 'cubic-bezier(0.8, 0, 0.2, 1)',
         animationDuration: `${motionDuration}ms`,
@@ -999,6 +1000,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         zIndex: '',
         opacity: '',
       });
+      setStyle(container, 'animationName', '');
+      setStyle(carousel, 'animationName', '');
       srcImg.classList.remove('i-amphtml-ghost');
       targetImg.classList.remove('i-amphtml-ghost');
       imageAnimation.cleanupAnimation();


### PR DESCRIPTION
Originally noticed this bug when due to the imageViewer's `getImageBoxWithOffset()` being zero-sized, which caused the lightbox to do a fade-in transition. This bug can also occur if lightboxing something other than an image.

Note that if `getImageBoxWithOffset()` has zero height/width, the image will not display, but at least the lightbox will show up. Needs more investigation.
