### PR TITLE
🐛 Patch web-animations-js polyfill to avoid writing to readonly property

### DIFF
--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -79,6 +79,12 @@ function patchWebAnimations() {
   // See https://github.com/ampproject/amphtml/issues/18612 and
   // https://github.com/web-animations/web-animations-js/issues/46
   file = file.replace(/b.true=a/g, 'b?b.true=a:true');
+
+  // Fix web-animations-js code that attempts to write a read-only property.
+  // https://github.com/ampproject/amphtml/issues/19783 and
+  // https://github.com/web-animations/web-animations-js/issues/160
+  file = file.replace(/this\._isFinished\s*=\s*!0,/g, '');
+
   // Wrap the contents inside the install function.
   file = 'export function installWebAnimations(window) {\n' +
       'var document = window.document;\n' +

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -81,9 +81,9 @@ function patchWebAnimations() {
   file = file.replace(/b.true=a/g, 'b?b.true=a:true');
 
   // Fix web-animations-js code that attempts to write a read-only property.
-  // https://github.com/ampproject/amphtml/issues/19783 and
+  // See https://github.com/ampproject/amphtml/issues/19783 and
   // https://github.com/web-animations/web-animations-js/issues/160
-  file = file.replace(/this\._isFinished\s*=\s*!0,/g, '');
+  file = file.replace(/this\._isFinished\s*=\s*\!0,/, '');
 
   // Wrap the contents inside the install function.
   file = 'export function installWebAnimations(window) {\n' +


### PR DESCRIPTION
Fixes #19783