### PR TITLE
:bug IFrame placeholder assertion fix

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -341,6 +341,11 @@ export class AmpIframe extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    this.placeholder_ = this.getPlaceholder();
+    this.isClickToPlay_ = !!this.placeholder_;
+
+    this.isResizable_ = this.element.hasAttribute('resizable');
+
     user().assert(!this.isDisallowedAsAd_, 'amp-iframe is not used for ' +
         'displaying fixed ad. Please use amp-sticky-ad and amp-ad instead.');
 


### PR DESCRIPTION
# Instructions:

- Placeholder is null on `layoutCallback`
  - Call to `updateLayoutBox` in custom-element causes the `layoutCallback` on the amp-iframe, however `this.placeholder_` is null - the context here seems to be different compared to when the IFrame was first rendered and the first `layoutCallback` was executed.

<img width="2471" alt="screen shot 2018-12-11 at 11 01 12 am" src="https://user-images.githubusercontent.com/5479907/49826789-a69d6c80-fd3c-11e8-8a2b-482e45ad973c.png">

`this.assertPosition` above fails because `this.placeholder_` is null

After adding the calls to `this.getPlaceholder()` on `layoutCallback`:

<img width="2450" alt="screen shot 2018-12-11 at 11 32 09 am" src="https://user-images.githubusercontent.com/5479907/49826899-dd738280-fd3c-11e8-8280-e51caec312b7.png">
