### PR TITLE
Creates separate bug/feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Used to report bugs in AMP.
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+**Please only file reports about bugs in AMP here.**
+
+- If you have questions about how to use AMP or other general questions about AMP please ask them on Stack Overflow under the AMP HTML tag instead of filing an issue here: http://stackoverflow.com/questions/tagged/amp-html
+- If you have questions/issues related to Google Search please ask them in Google's AMP forum instead of filing an issue here: https://goo.gl/utQ1KZ
+
+If you have a bug for AMP please fill in the following template.  Delete everything except the headers (including this text).
+
+## What's the issue?
+
+Briefly describe the bug.
+
+## How do we reproduce the issue?
+
+Please provide a public URL and ideally a reduced test case (e.g. on jsbin.com) that exhibits only your issue and nothing else.  Provide step-by-step instructions for reproducing the issue:
+
+1. Step 1 to reproduce
+2. Step 2 to reproduce
+3. …
+
+## What browsers are affected?
+
+All browsers? Some specific browser? What device type?
+
+## Which AMP version is affected?
+
+Is this a new issue? Or was it always broken? Paste the version of AMP where you saw this issue.  (You can find the version printed in your browser's console.)

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,11 +1,13 @@
 ---
 name: Cherry pick template
 about: Used to request a cherry pick.  See bit.ly/amp-cherry-pick
-title: 🌸 Cherry pick request for <YOUR_ISSUE_NUMBER> into <RELEASE_ISSUE_NUMBER> (Pending)
+title: "\U0001F338 Cherry pick request for <YOUR_ISSUE_NUMBER> into <RELEASE_ISSUE_NUMBER>
+  (Pending)"
 labels: 'Type: Release'
 assignees: cramforce
+
 ---
- 
+
 **Replace *everything* in angle brackets in the title AND body of this issue.  If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).**
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Used to report a feature request for AMP.
+title: ''
+labels: 'Type: Feature Request'
+assignees: ''
+
+---
+
+## Describe the new feature or change to an existing feature you'd like to see
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+Provide a clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Creates a bug template and a feature request template using GitHub's newer template system.

We can now assign labels as part of this template, so these will automatically get the right label.

This also allows us to make the instructions more clear since the old template tried to combine both bugs and feature requests.