### PR TITLE
Fix CSS transitions on sidebar

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -59,10 +59,6 @@ amp-sidebar[side] {
   margin: 0;
 }
 
-.i-amphtml-sidebar-mask.amp-visible {
-  visibility: visible;
-}
-
 .i-amphtml-sidebar-mask {
   position: fixed !important;
   top: 0 !important;
@@ -74,5 +70,4 @@ amp-sidebar[side] {
   background-image: none !important;
   background-color: #000;
   z-index: 2147483646;
-  visibility: hidden;
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -59,6 +59,10 @@ amp-sidebar[side] {
   margin: 0;
 }
 
+.i-amphtml-sidebar-mask.amp-visible {
+  visibility: visible;
+}
+
 .i-amphtml-sidebar-mask {
   position: fixed !important;
   top: 0 !important;
@@ -70,4 +74,5 @@ amp-sidebar[side] {
   background-image: none !important;
   background-color: #000;
   z-index: 2147483646;
+  visibility: hidden;
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -373,7 +373,7 @@ export class AmpSidebar extends AMP.BaseElement {
       });
       this.maskElement_ = mask;
     }
-    this.maskElement_.classList.toggle('amp-visible', true);
+    this.maskElement_.classList.toggle('i-amphtml-ghost', false);
   }
 
   /**
@@ -381,7 +381,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   closeMask_() {
     if (this.maskElement_) {
-      this.maskElement_.classList.toggle('amp-visible', false);
+      this.maskElement_.classList.toggle('i-amphtml-ghost', true);
     }
   }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -373,7 +373,7 @@ export class AmpSidebar extends AMP.BaseElement {
       });
       this.maskElement_ = mask;
     }
-    toggle(this.maskElement_, /* display */true);
+    this.maskElement_.classList.toggle('amp-visible', true);
   }
 
   /**
@@ -381,7 +381,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   closeMask_() {
     if (this.maskElement_) {
-      toggle(this.maskElement_, /* display */false);
+      this.maskElement_.classList.toggle('amp-visible', false);
     }
   }
 


### PR DESCRIPTION
This PR fixes the problem where opening or closing the side bar does not respect the CSS transform property (closes https://github.com/ampproject/amphtml/issues/19777).

This bug was caused by https://github.com/ampproject/amphtml/pull/17988, which changed the toggle function to use the `display` property instead of the `visibility` property. Toggling display appears to interrupt the CSS `transition` property, whereas toggling `visibility` does not. The other solution proposed in the thread works but is dependent on the value of `ANIMATION_TIMEOUT` being greater than the time specified for the CSS transition property. This could potentially break if we try to overwrite the CSS transition property with a transition time greater than `ANIMATION_TIMEOUT`. Reverting the sidebar mask toggle back to using the visibility property is slightly more robust. There is one minor caveat though: since the sidebar is hidden after a constant delay (`ANIMATION_TIMEOUT = 350`), this means that the closing animation has to finish before that delay. But with the visibility toggle, at least this is not a problem for the opening animation. 
