### PR TITLE
🐛Fix amp-form caching submit service reference before it's registered

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1210,6 +1210,6 @@ export class AmpFormService {
 
 
 AMP.extension(TAG, '0.1', AMP => {
-  AMP.registerServiceForDoc(TAG, AmpFormService);
   AMP.registerServiceForDoc('form-submit-service', FormSubmitService);
+  AMP.registerServiceForDoc(TAG, AmpFormService);
 });


### PR DESCRIPTION
This was causing some test failures.

@estherkim @alanorozco 
