### PR TITLE
🐛 Fix non-inclusive between check for min and max

### DIFF
--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -298,6 +298,20 @@
 <label>max: <input on="change:AMP.setState({max: event.value})" value="2018-10-10"></label>
 <amp-date-picker mode="static" layout="fixed-height" height="360" max="2018-10-10" [max]="max"></amp-date-picker>
 
+<h3>range min/max</h3>
+<h3>min</h3>
+<amp-state id="rangeMin"><script type="application/json">"2018-12-10"</script></amp-state>
+<amp-state id="rangeMax"><script type="application/json">"2018-12-20"</script></amp-state>
+<div>Min: <span [text]="rangeMin">2018-12-10</span></div>
+<div>Max: <span [text]="rangeMax">2018-12-20</span></div>
+<label>min: <input on="change:AMP.setState({rangeMin: event.value})" value="2018-12-10"></label>
+<label>max: <input on="change:AMP.setState({rangeMax: event.value})" value="2018-12-20"></label>
+<amp-date-picker
+    mode="static" type="range" layout="fixed-height" height="360"
+    min="2018-12-10" [min]="rangeMin" max="2018-12-20" [max]="rangeMax"
+></amp-date-picker>
+
+
 <div class="spacer"></div>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/date-picker-common.js
+++ b/extensions/amp-date-picker/0.1/date-picker-common.js
@@ -50,6 +50,18 @@ export function withDatePickerCommon(WrappedComponent) {
   }
 
   /**
+   * Check if the given date is between or equal to the two bounds.
+   * @param {!moment} date
+   * @param {!moment} min
+   * @param {!moment} max
+   * @return {boolean}
+   */
+  function isInclusivelyBetween(date, min, max) {
+    return isInclusivelyAfterDay(date, min) &&
+        isInclusivelyBeforeDay(date, max);
+  }
+
+  /**
    * @param {string} min
    * @param {string} max
    * @param {!moment} date
@@ -65,7 +77,7 @@ export function withDatePickerCommon(WrappedComponent) {
     } else if (!maxInclusive) {
       return !isInclusivelyAfterDay(date, minInclusive);
     } else {
-      return !date.isBetween(minInclusive, maxInclusive);
+      return !isInclusivelyBetween(date, minInclusive, maxInclusive);
     }
   }
 


### PR DESCRIPTION
Fixes #19744. It looks the the `moment.isBetween` is not inclusive causing an off-by-one error, so this fixes the bug by using inclusive logic instead.
