### PR TITLE
✅ Restore tests disabled on SauceLabs before #19832

### DIFF
--- a/extensions/amp-accordion/0.1/test/integration/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/integration/test-amp-accordion.js
@@ -40,7 +40,6 @@ describe('amp-accordion', function() {
       iframe.width = 300;
     });
 
-    // TODO(#19799): Fix test that broke on Chrome 71.
     it('should respect the media attribute', () => {
       const accordion = doc.getElementById('media-accordion');
       expect(iframe.clientWidth).to.equal(300);

--- a/extensions/amp-accordion/0.1/test/integration/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/integration/test-amp-accordion.js
@@ -41,17 +41,16 @@ describe('amp-accordion', function() {
     });
 
     // TODO(#19799): Fix test that broke on Chrome 71.
-    it.configure().skipChrome().run('should respect the media attribute',
-        () => {
-          const accordion = doc.getElementById('media-accordion');
-          expect(iframe.clientWidth).to.equal(300);
-          expect(accordion.className).to.match(/i-amphtml-hidden-by-media-query/);
-          iframe.width = 600;
-          expect(iframe.clientWidth).to.equal(600);
-          return timeout(200).then(() => {
-            expect(accordion.className).to.not.match(/i-amphtml-hidden-by-media-query/);
-          });
-        });
+    it('should respect the media attribute', () => {
+      const accordion = doc.getElementById('media-accordion');
+      expect(iframe.clientWidth).to.equal(300);
+      expect(accordion.className).to.match(/i-amphtml-hidden-by-media-query/);
+      iframe.width = 600;
+      expect(iframe.clientWidth).to.equal(600);
+      return timeout(200).then(() => {
+        expect(accordion.className).to.not.match(/i-amphtml-hidden-by-media-query/);
+      });
+    });
   });
 });
 

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -135,8 +135,7 @@ describes.realWin('AmpForm Integration', {
           .skipFirefox().skipSafari().skipEdge();
 
   describeChrome.run('on=submit:form.submit', () => {
-    // TODO(cvializ, #19788): fix this test for Chrome 71.
-    it.skip('should be protected from recursive-submission', () => {
+    it('should be protected from recursive-submission', () => {
       const form = getForm({
         id: 'sameform',
         actionXhr: baseUrl + '/form/post',

--- a/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in-scroll.js
+++ b/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in-scroll.js
@@ -54,34 +54,32 @@ config.run('amp-fx-collection', function() {
       win = env.win;
     });
 
-    // TODO(#19800): Fix test that broke on Chrome 71.
-    it.configure().skipChrome()
-        .run('runs fade-in-scroll animation with default parameters', () => {
-          expect(getOpacity(win)).to.equal(0);
-          win.scrollTo(0, 0.1 * getViewportHeight(win));
-          return Promise.resolve().then(timeout(2000))
-              .then(() => {
-              // Since the animation is spread over 50% of the viewport,
-              // scrolling 10% of the viewport should change the opacity by 20%
-                expect(getOpacity(win)).to.equal(0.2);
-                win.scrollTo(0, 0.4 * getViewportHeight(win));
-              }).then(timeout(2000))
-              .then(() => {
-                expect(getOpacity(win)).to.equal(0.8);
-                win.scrollTo(0, 0.5 * getViewportHeight(win));
-              }).then(timeout(2000))
-              .then(() => {
-                expect(getOpacity(win)).to.equal(1);
-                win.scrollTo(0, 0.7 * getViewportHeight(win));
-              }).then(timeout(2000))
-              .then(() => {
-                expect(getOpacity(win)).to.equal(1);
-                win.scrollTo(0, 0.4 * getViewportHeight(win));
-              }).then(timeout(2000))
-              .then(() => {
-                expect(getOpacity(win)).to.equal(1);
-              });
-        });
+    it('runs fade-in-scroll animation with default parameters', () => {
+      expect(getOpacity(win)).to.equal(0);
+      win.scrollTo(0, 0.1 * getViewportHeight(win));
+      return Promise.resolve().then(timeout(2000))
+          .then(() => {
+          // Since the animation is spread over 50% of the viewport,
+          // scrolling 10% of the viewport should change the opacity by 20%
+            expect(getOpacity(win)).to.equal(0.2);
+            win.scrollTo(0, 0.4 * getViewportHeight(win));
+          }).then(timeout(2000))
+          .then(() => {
+            expect(getOpacity(win)).to.equal(0.8);
+            win.scrollTo(0, 0.5 * getViewportHeight(win));
+          }).then(timeout(2000))
+          .then(() => {
+            expect(getOpacity(win)).to.equal(1);
+            win.scrollTo(0, 0.7 * getViewportHeight(win));
+          }).then(timeout(2000))
+          .then(() => {
+            expect(getOpacity(win)).to.equal(1);
+            win.scrollTo(0, 0.4 * getViewportHeight(win));
+          }).then(timeout(2000))
+          .then(() => {
+            expect(getOpacity(win)).to.equal(1);
+          });
+    });
   });
 
   const marginSpecifiedBody = `

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1013,7 +1013,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
     });
 
 
-    it('should apply media condition', () => {
+    // TODO(alabiaga, 19752): flaky on Chrome 71
+    it.skip('should apply media condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('media', '(min-width: 1px)');
       element1.applySizesAndMediaQuery();
@@ -1025,7 +1026,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2).to.have.class('i-amphtml-hidden-by-media-query');
     });
 
-    it('should apply sizes condition', () => {
+    // TODO(alabiaga, 19752): flaky on Chrome 71
+    it.skip('should apply sizes condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('sizes', '(min-width: 1px) 200px, 50vw');
       element1.applySizesAndMediaQuery();
@@ -1037,7 +1039,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2.style.width).to.equal('50vw');
     });
 
-    it('should apply heights condition', () => {
+    // TODO(alabiaga, 19752): flaky on Chrome 71
+    it.skip('should apply heights condition', () => {
       const element1 = new ElementClass();
       element1.sizerElement = doc.createElement('div');
       element1.setAttribute('layout', 'responsive');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1013,8 +1013,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
     });
 
 
-    // TODO(alabiaga, 19752): flaky on Chrome 71
-    it.skip('should apply media condition', () => {
+    it('should apply media condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('media', '(min-width: 1px)');
       element1.applySizesAndMediaQuery();
@@ -1026,8 +1025,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2).to.have.class('i-amphtml-hidden-by-media-query');
     });
 
-    // TODO(alabiaga, 19752): flaky on Chrome 71
-    it.skip('should apply sizes condition', () => {
+    it('should apply sizes condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('sizes', '(min-width: 1px) 200px, 50vw');
       element1.applySizesAndMediaQuery();
@@ -1039,8 +1037,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2.style.width).to.equal('50vw');
     });
 
-    // TODO(alabiaga, 19752): flaky on Chrome 71
-    it.skip('should apply heights condition', () => {
+    it('should apply heights condition', () => {
       const element1 = new ElementClass();
       element1.sizerElement = doc.createElement('div');
       element1.setAttribute('layout', 'responsive');

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -20,7 +20,7 @@ import {Services} from '../../src/services';
 import {createFixtureIframe, poll} from '../../testing/iframe';
 
 // TODO(#19647): Unskip tests
-describe.configure().skipChrome().run('amp-bind', function() {
+describe.skip('amp-bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -184,8 +184,7 @@ config.run('amp-carousel', function() {
       expect(document.querySelectorAll('amp-carousel')).to.have.length.above(0);
     });
 
-    // TODO(#19801): Fix test that broke on Chrome 71.
-    it.configure().skipChrome().run('should not have the buttons visible ' +
+    it('should not have the buttons visible ' +
         'when amp-mode-mouse class is not on body', () => {
       document.body.classList.remove('amp-mode-mouse');
       const amp = document.querySelector('#carousel-1');

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -52,8 +52,7 @@ t.run('error page', function() {
   });
 
   it.configure().skipFirefox().skipEdge()
-      // TODO(#19790): fix this test on SuaceLabs.
-      .skip('should show the body in error test', () => {
+      .run('should show the body in error test', () => {
         return expectBodyToBecomeVisible(fixture.win, TIMEOUT);
       });
 

--- a/test/integration/test-toggle-display.js
+++ b/test/integration/test-toggle-display.js
@@ -56,8 +56,7 @@ describe.configure().retryOnSaucelabs().run('toggle display helper', () => {
       fixture.doc.head.appendChild(s);
     },
   }, (name, setup) => {
-    // TODO(jridgewell, #19791): fix this test for Chrome 71.
-    it.skip('toggle display', () => {
+    it('toggle display', () => {
       setup(img);
 
       toggle(img, false);

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -112,8 +112,7 @@ describe.configure().skipIfPropertiesObfuscated()
           </script>
         </amp-analytics>`,
       }, () => {
-        // TODO(lannka, #19791): fix this test.
-        it.skip('should ping correct host with 3p error message', () => {
+        it('should ping correct host with 3p error message', () => {
           return RequestBank.withdraw();
         });
       });

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -21,8 +21,7 @@ import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 
 describe.configure().skipIfPropertiesObfuscated()
-    // TODO(jridgewell, #19793): fix this test for Chrome 71.
-    .skip('Viewer Visibility State', () => {
+    .ifChrome().run('Viewer Visibility State', () => {
 
       function noop() {}
 


### PR DESCRIPTION
Fixes #19788
Fixes #19790
Fixes #19791
Fixes #19792
Fixes #19793
Fixes #19799
Fixes #19800
Fixes #19801

Note this this PR also completely disabled `<amp-bind>` tests (which continue to be flaky, see #19647)