### PR TITLE
Fix off-by-one in freeze dates

### DIFF
--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -2,7 +2,7 @@
 
 **Our last scheduled release for 2018 will be created on Tuesday, December 11, 2018 (targeting full rollout on December 18).**
 
-After this the next scheduled release will be created on Wednesday, January 3, 2019 (targeting full rollout on January 9).
+After this the next scheduled release will be created on Wednesday, January 2, 2019 (targeting full rollout on January 8).
 
 If necessary, fixes for P0 issues may be cherry-picked into the production release and pushed during this time.
 ⚡⚡⚡


### PR DESCRIPTION
Also changed Wednesday 1/9 to Tuesday 1/8 to get back on track with our normal cadence.