### PR TITLE
Removes code that forces fixed layout on multi-size slots.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -520,13 +520,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       : `${this.initialSize_.width}x${this.initialSize_.height}`;
     const multiSizeDataStr = this.element.getAttribute('data-multi-size');
     if (multiSizeDataStr) {
-      if (this.element.getAttribute('layout') == 'responsive') {
-        // TODO(levitzky) Define the behavior and remove this warning.
-        user().warn(TAG, 'Behavior of multi-size and responsive layout is ' +
-            'currently not well defined. Forcefully overriding layout to ' +
-            '`fixed`.');
-        this.element.setAttribute('layout', 'fixed');
-      }
       const multiSizeValidation = this.element
           .getAttribute('data-multi-size-validation') || 'true';
       // The following call will check all specified multi-size dimensions,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -520,6 +520,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       : `${this.initialSize_.width}x${this.initialSize_.height}`;
     const multiSizeDataStr = this.element.getAttribute('data-multi-size');
     if (multiSizeDataStr) {
+      if (this.element.getAttribute('layout') == 'responsive') {
+        // TODO(levitzky) Define the behavior and remove this warning.
+        user().warn(TAG, 'Behavior of multi-size and responsive layout is ' +
+            'currently not well defined. Forcefully overriding layout to ' +
+            '`fixed`.');
+        this.element.setAttribute('layout', 'fixed');
+      }
       const multiSizeValidation = this.element
           .getAttribute('data-multi-size-validation') || 'true';
       // The following call will check all specified multi-size dimensions,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1102,20 +1102,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         expect(impl.adUrl_.length).to.be.ok;
       });
     });
-
-    it('should force layout to `fixed` if `responsive`', () => {
-      impl.element.setAttribute('layout', 'responsive');
-      impl.element.setAttribute('data-multi-size', '320x50');
-      impl.populateAdUrlState();
-      expect(impl.element.getAttribute('layout')).to.equal('fixed');
-    });
-
-    it('should not change layout if not `responsive`', () => {
-      impl.element.setAttribute('layout', 'not-responsive');
-      impl.element.setAttribute('data-multi-size', '320x50');
-      impl.populateAdUrlState();
-      expect(impl.element.getAttribute('layout')).to.equal('not-responsive');
-    });
   });
 
   describe('Troubleshoot for AMP pages', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/multi-size.md
+++ b/extensions/amp-ad-network-doubleclick-impl/multi-size.md
@@ -25,6 +25,10 @@ set. Further, the secondary sizes must not be smaller than 2/3rds, in any of the
 two dimensions, of their primary size counterpart, unless 
 `data-multi-size-validation` is explicitly set to false. See below for some valid and invalid examples.
 
+<b>Note that multi-size slots may have unexpected interactions with
+`layout="responsive"`. For this reason it is strongly encouraged that multi-size
+slots use `layout="fixed"`.</b>
+
 #### Attributes
 Below the term `primary size` refers to the width and height pair specified by the `width` and `height` attributes of the tag.
 - `data-multi-size` A string of comma separated sizes, which if present, forces the tag to request an ad with all of the given sizes, including the primary size. Each individual size must be a number (the width) followed by a lowercase 'x' followed by a number (the height). Each dimension specified this way must not be larger than its counterpart in the primary size. Further, each dimension must be no less than 2/3rds of the corresponding primary dimension, unless `data-mutli-size-validation` is set to false.
@@ -34,6 +38,7 @@ Example - Valid multi-size request
 ```html
 <amp-ad width=728 height=90
     type="doubleclick"
+    layout="fixed"
     data-slot="/6355419/Travel"
     data-multi-size="700x90,700x60,500x60">
 </amp-ad>
@@ -43,6 +48,7 @@ Example - Invalid multi-size request (multi-size size is too small relative to o
 ```html
 <amp-ad width=320 height=50
     type="doubleclick"
+    layout="fixed"
     data-slot="/6355419/Travel"
     data-override-width=728
     data-override-height=90
@@ -54,6 +60,7 @@ Example - Invalid multi-size request (last multi-size size is too small)
 ```html
 <amp-ad width=728 height=90
     type="doubleclick"
+    layout="fixed"
     data-slot="/6355419/Travel"
     data-multi-size="700x90,700x60,300x25">
 </amp-ad>
@@ -63,6 +70,7 @@ Example - Valid multi-size request (ignores minimum size constraint)
 ```html
 <amp-ad width=728 height=90
     type="doubleclick"
+    layout="fixed"
     data-slot="/6355419/Travel"
     data-multi-size="700x90,700x60,300x25">
     data-multi-size-validation="false">

--- a/extensions/amp-ad-network-doubleclick-impl/multi-size.md
+++ b/extensions/amp-ad-network-doubleclick-impl/multi-size.md
@@ -22,7 +22,7 @@ by a lowercase 'x' followed by a height. Secondary sizes must not be larger than
 their corresponding dimensions specified by the `width` and `height` attributes,
 or the `data-override-width` and `data-override-height` attributes, if they are
 set. Further, the secondary sizes must not be smaller than 2/3rds, in any of the
-two dimensions, of their primary size counterpart, unless 
+two dimensions, of their primary size counterpart, unless
 `data-multi-size-validation` is explicitly set to false. See below for some valid and invalid examples.
 
 <b>Note that multi-size slots may have unexpected interactions with


### PR DESCRIPTION
Due to issue #16955, we introduced a change that forced `layout="fixed'` on multi-size ad slots. It now appears that forcing a change to the layout attribute causes the slot to be torn down (due to a call to unlayoutCallback), invalidating the promise ID on the slot, and causing no ad request to be issued.

The original issue (#16955) is no longer reproducible, so this PR removes the changes that force `layout="fixed"`. Moreover, it looks like the original assessment was wrong in that it's unclear wether the issue had anything to do with the slot being multi-sized. The issue seemed specific to a particular slot and occurred due to a repeating cycle of `empty ad response -> collapse -> relayout -> ad request`, which would occur regardless of the slot being multi-size.

Given that the initial "fix" didn't really address the problem, we should simply roll it back, and if it re-appears, we should address it correctly.

Fixes #19837