### PR TITLE
Story supports-landscape attribute.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -139,7 +139,7 @@ const Attributes = {
   DESKTOP_POSITION: 'i-amphtml-desktop-position',
   VISITED: 'i-amphtml-visited', // stacked offscreen to left
   AUTO_ADVANCE_AFTER: 'auto-advance-after',
-  SUPPORTED_ORIENTATIONS: 'supported-orientations',
+  SUPPORTS_LANDSCAPE: 'supports-landscape',
 };
 
 /**
@@ -186,12 +186,6 @@ const HIDE_ON_BOOKEND_SELECTOR =
  * @const {string}
  */
 const DEFAULT_THEME_COLOR = '#F1F3F4';
-
-/** @enum {string} */
-const ScreenOrientations = {
-  PORTRAIT: 'portrait',
-  LANDSCAPE: 'landscape',
-};
 
 /**
  * @implements {./media-pool.MediaPoolRoot}
@@ -1298,9 +1292,9 @@ export class AmpStory extends AMP.BaseElement {
     const uiState = this.getUIType_();
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
-    if (uiState !== UIType.MOBILE ||
-        this.getSupportedOrientations_()
-            .includes(ScreenOrientations.LANDSCAPE)) {
+    if (uiState !== UIType.MOBILE || this.isLandscapeSupported_()) {
+      // TODO: Rename the TOGGLE_LANDSCAPE action. (#19670)
+      // Hides the UI that prevents users from using the LANDSCAPE orientation.
       this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, false);
       return;
     }
@@ -1397,9 +1391,7 @@ export class AmpStory extends AMP.BaseElement {
       return UIType.MOBILE;
     }
 
-    const supportedOrientations = this.getSupportedOrientations_();
-
-    if (supportedOrientations.includes(ScreenOrientations.LANDSCAPE)) {
+    if (this.isLandscapeSupported_()) {
       return UIType.DESKTOP_FULLBLEED;
     }
 
@@ -1425,29 +1417,13 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Returns an array of the supported orientations configured by the publisher.
-   * Defaults to ['portrait'].
-   * @return {!Array<string>}
+   * Whether the story should support landscape orientation: landscape mobile,
+   * or full bleed desktop UI.
+   * @return {boolean}
    * @private
    */
-  getSupportedOrientations_() {
-    if (this.supportedOrientations_) {
-      return this.supportedOrientations_;
-    }
-
-    const supportedOrientationsAttribute =
-        this.element.getAttribute(Attributes.SUPPORTED_ORIENTATIONS);
-
-    if (!supportedOrientationsAttribute) {
-      return [ScreenOrientations.PORTRAIT];
-    }
-
-    this.supportedOrientations_ =
-        supportedOrientationsAttribute
-            .split(',')
-            .map(orientation => orientation.trim().toLowerCase());
-
-    return this.supportedOrientations_;
+  isLandscapeSupported_() {
+    return this.element.hasAttribute(Attributes.SUPPORTS_LANDSCAPE);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -383,9 +383,24 @@ describes.realWin('amp-story', {
         });
   });
 
-  it('should detect fullbleed desktop mode', () => {
+  it('should default to the three panels UI desktop experience', () => {
     createPages(story.element, 4, ['cover', '1', '2', '3']);
-    story.element.setAttribute('supported-orientations', 'portrait, laNdsCApe');
+
+    // Don't do this at home. :(
+    story.desktopMedia_ = {matches: true};
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.storeService_.get(StateProperty.UI_STATE))
+              .to.equals(UIType.DESKTOP_PANELS);
+        });
+  });
+
+  it('should detect landscape opt in', () => {
+    createPages(story.element, 4, ['cover', '1', '2', '3']);
+    story.element.setAttribute('supports-landscape', '');
 
     // Don't do this at home. :(
     story.desktopMedia_ = {matches: true};


### PR DESCRIPTION
Story `supports-landscape` attribute opt in and validation.
Even though the `supports-portrait` attribute doesn't do anything since we don't want publishers to be able to disallow portrait for now, I added it for consistency.

#19270