### PR TITLE
✅amp-facebook: tests for sandboxing and remove exception for `amp-embedly-card`

### DIFF
--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -18,7 +18,7 @@ import '../amp-facebook';
 import {facebook} from '../../../../3p/facebook';
 import {resetServiceForTesting} from '../../../../src/service';
 import {setDefaultBootstrapBaseUrlForTesting} from '../../../../src/3p-frame';
-
+import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-facebook', {
   amp: {
@@ -63,6 +63,19 @@ describes.realWin('amp-facebook', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    });
+  });
+
+  it('ensures iframe is not sandboxed in amp-facebook', () => {
+    // We sandbox all 3P iframes however facebook embeds completely break in
+    // sandbox mode since they need access to document.domain, so we
+    // exclude facebook.
+    toggleExperiment(win, 'sandbox-ads', true);
+    return getAmpFacebook(fbPostHref).then(ampFB => {
+      const iframe = ampFB.firstChild;
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.hasAttribute('sandbox')).to.be.false;
     });
   });
 

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -135,7 +135,7 @@ export function getIframe(
     // request completes.
     iframe.setAttribute('allow', 'sync-xhr \'none\';');
   }
-  const excludeFromSandbox = ['facebook', 'embedly'];
+  const excludeFromSandbox = ['facebook'];
   if (isExperimentOn(parentWindow, 'sandbox-ads')
       && !excludeFromSandbox.includes(opt_type)) {
     applySandbox(iframe);


### PR DESCRIPTION
Related to #19822 

1- Tests for `amp-facebook` to ensure `sandbox` does not come back
2- Did more testing with `amp-embedly-card` and given usage is low and it only breaks if the embed itself doesn't work with sandbox (e.g. `facebook` embedded via  `amp-embedly-card` instead of `amp-facebook` ). I think we should remove for exception for it. (Actually given embedly can embed many things, having the `sandbox` is even more important here)