### PR TITLE
Remove i-amphtml-element class on forced disconnect

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -902,6 +902,15 @@ function createBaseCustomElementClass(win) {
       if (!pretendDisconnected && dom.isConnectedNode(this)) {
         return;
       }
+
+      // This path only comes from Resource#disconnect, which deletes the
+      // Resource instance tied to this element. Therefore, it is no longer
+      // an AMP Element. But, DOM queries for i-amphtml-element assume that
+      // the element is tied to a Resource.
+      if (pretendDisconnected) {
+        this.classList.remove('i-amphtml-element');
+      }
+
       this.isConnected_ = false;
       this.getResources().remove(this);
       if (isExperimentOn(this.ampdoc_.win, 'layers')) {


### PR DESCRIPTION
When an FIE is being removed, it calls `Resource.p.disconnect` on all contained child resources. This [deletes](https://github.com/ampproject/amphtml/blob/master/src/service/resource.js#L1023) the `Resource` association.

But some elements (ownership elements), during disconnect, ferry signals down to children. This is usually done by querying the DOM for `.i-amphtml-element`. Elements with this class are supposed to have a `Resource` instance, and we usually attempt to get the `Resource` from the element.

But we just deleted it. Hence, bugs.

Fixes #18207
Fixes #18483
Fixes #16032