### PR TITLE
♻️amp-consent: Refactored consent ui api to match consent response

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -326,12 +326,14 @@ export class ConsentUI {
    *
    * Required message from iframe to hide placeholder and display iframe
    * {
-   *   type: 'consent-ui-ready'
+   *   type: 'consent-ui',
+   *   action: 'ready'
    * }
    *
    * Enter Fullscreen
    * {
-   *   type: 'consent-ui-enter-fullscreen'
+   *   type: 'consent-ui',
+   *   action: 'enter-fullscreen'
    * }
    *
    * @param {!Event} event
@@ -343,15 +345,15 @@ export class ConsentUI {
     }
 
     const data = getData(event);
-    if (!data || !data['type']) {
+    if (!data || data['type'] != 'consent-ui') {
       return;
     }
 
-    if (data['type'] === 'consent-ui-ready') {
+    if (data['action'] === 'ready') {
       this.iframeReady_.resolve();
     }
 
-    if (data['type'] === 'consent-ui-enter-fullscreen') {
+    if (data['action'] === 'enter-fullscreen') {
 
       // TODO (@torch2424) Send response back if enter fullscreen was succesful
       if (!this.isIframeVisible_) {

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -185,7 +185,8 @@ describes.realWin('consent-ui', {
         consentUI.handleIframeMessages_({
           source: 'mock-src',
           data: {
-            type: 'consent-ui-enter-fullscreen',
+            type: 'consent-ui',
+            action: 'enter-fullscreen',
           },
         });
 
@@ -206,7 +207,8 @@ describes.realWin('consent-ui', {
         consentUI.handleIframeMessages_({
           source: 'mock-src',
           data: {
-            type: 'consent-ui-enter-fullscreen',
+            type: 'consent-ui',
+            action: 'enter-fullscreen',
           },
         });
 

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -42,7 +42,8 @@ if (hashMatch) {
 
 setTimeout(() => {
   parent.postMessage({
-    type: 'consent-ui-ready',
+    type: 'consent-ui',
+    action: 'ready'
   }, '*');
 }, 500);
 
@@ -108,7 +109,8 @@ const consentObjects = [
   },
   {
     querySelector: '#f',
-    type: 'consent-ui-enter-fullscreen',
+    type: 'consent-ui',
+    action: 'enter-fullscreen'
     onclick: () => {
       showLearnMoreState();
     }

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -110,7 +110,7 @@ const consentObjects = [
   {
     querySelector: '#f',
     type: 'consent-ui',
-    action: 'enter-fullscreen'
+    action: 'enter-fullscreen',
     onclick: () => {
       showLearnMoreState();
     }


### PR DESCRIPTION
relates to #18828

Mentioned in the comments, and discussed offline, changes the `consent-ui` postMessage API to match the same schema as `consent-response`.

**Gif of everything still working:**

![apirefacotrampconsent](https://user-images.githubusercontent.com/1448289/49907509-46392880-fe2b-11e8-9045-408774c9bf19.gif)
