### PR TITLE
🐛 A4A: Improve google matched content responsive ad logic.

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -24,7 +24,6 @@
  *   consentHandlingOverride: (boolean|undefined),
  *   remoteHTMLDisabled: (boolean|undefined),
  *   fullWidthHeightRatio: (number|undefined),
- *   mcFullWidthHeightRatio: (number|undefined),
  * }}
  */
 let AdNetworkConfigDef;
@@ -60,12 +59,6 @@ let AdNetworkConfigDef;
  *   // If absent, it means the network does not support full width ad units.
  *   // Example value: 1.2
  *   fullWidthHeightRatio: number
- *
- *   // The width / height ratio for matched content full width ad units.
- *   // If absent, it means the network does not support matched content full
- *   // width ad unit.
- *   // Example value: 0.27
- *   mcFullWidthHeightRatio: number
  * }
  *
  * @const {!Object<string, !AdNetworkConfigDef>}}
@@ -173,7 +166,6 @@ export const adConfig = {
     remoteHTMLDisabled: true,
     masterFrameAccessibleType: 'google_network',
     fullWidthHeightRatio: 1.2,
-    mcFullWidthHeightRatio: 0.27,
     consentHandlingOverride: true,
   },
 

--- a/ads/google/test/test-utils.js
+++ b/ads/google/test/test-utils.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {getMultiSizeDimensions} from '../utils';
+import {
+  getMatchedContentResponsiveHeight,
+  getMultiSizeDimensions,
+} from '../utils';
 
 describe('#getMultiSizeDimensions', () => {
 
@@ -98,5 +101,24 @@ describe('#getMultiSizeDimensions', () => {
     expect(getMultiSizeDimensions(
         '300x300,fluid', 300, 300, /* useLowerBound */ false))
         .to.deep.equal([[300, 300], [320, 50]]);
+  });
+
+  it('should calculate responsive matched content height correctly', () => {
+    const testCases = [
+      [300, 1032],
+      [400, 1376],
+      [500, 350],
+      [600, 360],
+      [900, 450],
+      [1000, 500],
+      [1200, 600],
+      [1300, 600],
+    ];
+    testCases.forEach(testCase => {
+      const width = testCase[0];
+      const expectedHeight = testCase[1];
+      expect(getMatchedContentResponsiveHeight(width),
+          `width = ${width}`).to.equal(expectedHeight);
+    });
   });
 });

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -170,3 +170,24 @@ function validateDimensions(width, height, widthCond, heightCond, errorBuilder)
   }
   return !badParams.length;
 }
+
+/**
+ * Calculates height of responsive matched content slot based on its width.
+ * This logic should be kept as close to possible to the logic inside
+ * adsbygoogle.js.
+ *
+ * @param {number} width
+ * @return {number}
+ */
+export function getMatchedContentResponsiveHeight(width) {
+  if (width >= 1200) {
+    return 600;
+  } else if (width >= 850) {
+    return Math.floor(width * 0.5);
+  } else if (width >= 550) {
+    return Math.floor(width * 0.6);
+  } else if (width >= 468) {
+    return Math.floor(width * 0.7);
+  }
+  return Math.floor(width * 3.44);
+}

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -24,6 +24,7 @@ import {
   ADSENSE_MCRSPV_TAG,
   ADSENSE_RSPV_TAG,
   ADSENSE_RSPV_WHITELISTED_HEIGHT,
+  getMatchedContentResponsiveHeight,
 } from '../../../ads/google/utils';
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
@@ -581,7 +582,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         const idealHeight = Math.round(viewportSize.width / 1.2);
         return clamp(idealHeight, minHeight, maxHeight);
       case ADSENSE_MCRSPV_TAG:
-        return Math.floor((viewportSize.width * 3.4) + 112);
+        return getMatchedContentResponsiveHeight(viewportSize.width);
       default:
         return 0;
     }

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -851,7 +851,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       expect(promise).to.exist;
       yield promise;
 
-      expect(adsense.attemptChangeSize).to.be.calledWith(1387, VIEWPORT_WIDTH);
+      expect(adsense.attemptChangeSize).to.be.calledWith(1290, VIEWPORT_WIDTH);
     });
   });
 
@@ -982,14 +982,14 @@ describes.realWin('amp-ad-network-adsense-impl', {
       expect(
           AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
               'mcrspv', {width: 375, height: 320}))
-          .to.be.equal(1387);
+          .to.be.equal(1290);
     });
 
     it('get matched content responsive height for iPhone 5', () => {
       expect(
           AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
               'mcrspv', {width: 320, height: 320}))
-          .to.be.equal(1200);
+          .to.be.equal(1100);
     });
   });
 

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -16,6 +16,7 @@
 
 import {
   ADSENSE_MCRSPV_TAG,
+  getMatchedContentResponsiveHeight,
 } from '../../../ads/google/utils';
 import {AmpAdUIHandler} from './amp-ad-ui';
 import {AmpAdXOriginIframeHandler} from './amp-ad-xorigin-iframe-handler';
@@ -219,8 +220,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         'Ad units with data-full-width must have width="100vw".');
     user().assert(!!this.config.fullWidthHeightRatio,
         'Ad network does not support full width ads.');
-    user().assert(!!this.config.mcFullWidthHeightRatio,
-        'Ad network does not support matched content full width ads.');
     dev().info(TAG_3P_IMPL,
         '#${this.getResource().getId()} Full width requested');
     return true;
@@ -436,9 +435,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @private
    */
   getFullWidthHeight_(width, maxHeight) {
+    // TODO(google a4a eng): remove this once adsense switches fully to
+    // fast fetch.
     if (this.element.getAttribute('data-auto-format') == ADSENSE_MCRSPV_TAG) {
-      return Math.max(MIN_FULL_WIDTH_HEIGHT,
-          Math.round(width / this.config.mcFullWidthHeightRatio));
+      return getMatchedContentResponsiveHeight(width);
     }
     return clamp(Math.round(width / this.config.fullWidthHeightRatio),
         MIN_FULL_WIDTH_HEIGHT, maxHeight);

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -400,7 +400,6 @@ describes.realWin('amp-ad-3p-impl', {
 
     beforeEach(() => {
       adConfig['_ping_'].fullWidthHeightRatio = 1.2;
-      adConfig['_ping_'].mcFullWidthHeightRatio = 0.27;
       win.document.body.removeChild(ad3p.element);
     });
 
@@ -464,7 +463,7 @@ describes.realWin('amp-ad-3p-impl', {
             sandbox.stub(impl, 'attemptChangeSize').callsFake(
                 (height, width) => {
                   expect(width).to.equal(VIEWPORT_WIDTH);
-                  expect(height).to.equal(1111);
+                  expect(height).to.equal(1032);
                   return Promise.resolve();
                 });
 


### PR DESCRIPTION
Current logic doesn't work well on desktops: it creates 3k-4k px tall ad slots. Instead we use logic that uses shorter slots if screen is wide. This aligns with matched content logic in adsbygoogle.js tag.

Tested:
  unit tests
  manually
