### PR TITLE
🐛🏗 Fix mask appearing on hover. Use patch pattern

### DIFF
--- a/third_party/inputmask/README.amp
+++ b/third_party/inputmask/README.amp
@@ -1,12 +1,18 @@
-URL: https://github.com/RobinHerbots/Inputmask/tree/4.x
+URL: https://github.com/RobinHerbots/Inputmask/tree/3.x
 License: MIT
-License File: https://github.com/RobinHerbots/Inputmask/blob/4.x/LICENSE.txt
+License File: https://github.com/RobinHerbots/Inputmask/blob/3.x/LICENSE.txt
 
 Description:
-Copy of inputmask library and dependency library from release 4.x
-https://github.com/vega/vega/tree/4.x
+Copy of inputmask library and dependency library from release 3.x
+https://github.com/RobinHerbots/Inputmask/tree/3.x
 
 Local Modifications:
-Replace the universal module definition with a factory wrapper.
-Changed initial unmask behavior when value patching is disabled.
-Altered trigger implementation to not use CustomElement for triggering events
+- Patch 0000: Replace the universal module definition with a factory wrapper.
+- Patch 0001: Reference Element from the global object dependency-injected into
+  the factory. This fixes behavior across iframe boundaries, like in tests.
+- Patch 0002: Changed initial unmask behavior when value patching is disabled.
+- Patch 0003: In `trigger` implementation, only use CustomEvent for custom
+  events, and use native Events for code-initiated user events like "click".
+- Patch 0004: Check for showMaskOnHover in the mouseenter handler.
+- Patch 0005: Remove extraneous whitespace.
+- Patch 0006: Add support for the "?" mask character as a wildcard character.

--- a/third_party/inputmask/compile.sh
+++ b/third_party/inputmask/compile.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run this file with bash to add AMP-specific changes to the
+# inputmask library.
+
+# Apply all the patches in third_party/inputmask/patches/
+for patchfile in patches/*.patch
+do
+  echo "Applying patch $patchfile"
+  patch < $patchfile
+done

--- a/third_party/inputmask/inputmask.dependencyLib.js
+++ b/third_party/inputmask/inputmask.dependencyLib.js
@@ -6,9 +6,6 @@
 * Version: 3.3.11
 */
 
-// !function(factory) {
-//     "function" == typeof define && define.amd ? define([ "../global/window", "../global/document" ], factory) : "object" == typeof exports ? module.exports = factory(require("../global/window"), require("../global/document")) : window.dependencyLib = factory(window, document);
-// }(function(window, document) {
 export function factory(window, document) {
     function indexOf(list, elem) {
         for (var i = 0, len = list.length; i < len; i++) if (list[i] === elem) return i;
@@ -83,7 +80,6 @@ export function factory(window, document) {
                     };
                     if (document.createEvent) {
                         try {
-                            // evnt = new CustomEvent(ev, params);
                             evnt = ["change","input","click"].indexOf(ev) > -1 ? new Event(ev, params) : new CustomEvent(ev, params);
                         } catch (e) {
                             (evnt = document.createEvent("CustomEvent")).initCustomEvent(ev, params.bubbles, params.cancelable, params.detail);
@@ -133,4 +129,3 @@ export function factory(window, document) {
         evt;
     }, DependencyLib.Event.prototype = window.Event.prototype), DependencyLib;
 }
-// });

--- a/third_party/inputmask/inputmask.js
+++ b/third_party/inputmask/inputmask.js
@@ -6,9 +6,6 @@
 * Version: 3.3.11
 */
 
-// !function(factory) {
-//     "function" == typeof define && define.amd ? define([ "./dependencyLibs/inputmask.dependencyLib", "./global/window", "./global/document" ], factory) : "object" == typeof exports ? module.exports = factory(require("./dependencyLibs/inputmask.dependencyLib"), require("./global/window"), require("./global/document")) : window.Inputmask = factory(window.dependencyLib || jQuery, window, document);
-// }(function($, window, document, undefined) {
 export function factory($, window, document, undefined) {
     function Inputmask(alias, options, internal) {
         if (!(this instanceof Inputmask)) return new Inputmask(alias, options, internal);
@@ -1128,7 +1125,7 @@ export function factory($, window, document, undefined) {
                             }(npt.type), function(npt) {
                                 EventRuler.on(npt, "mouseenter", function(event) {
                                     var $input = $(this);
-                                    this.inputmask._valueGet() !== getBuffer().join("") && $input.trigger("setvalue");
+                                    opts.showMaskOnHover == !0 && this.inputmask._valueGet() !== getBuffer().join("") && $input.trigger("setvalue");
                                 });
                             }(npt));
                         }
@@ -1290,7 +1287,7 @@ export function factory($, window, document, undefined) {
             "*": {
                 validator: "[0-9１-９A-Za-zА-яЁёÀ-ÿµ]",
                 cardinality: 1
-            },
+            }
         },
         aliases: {},
         masksCache: {},
@@ -1332,7 +1329,6 @@ export function factory($, window, document, undefined) {
                 var scopedOpts = $.extend(!0, {}, that.opts);
                 importAttributeOptions(el, scopedOpts, $.extend(!0, {}, that.userOptions), that.dataAttribute);
                 var maskset = generateMaskSet(scopedOpts, that.noMasksCache);
-                // maskset !== undefined && (el.inputmask !== undefined && (el.inputmask.opts.autoUnmask = !0,
                 maskset !== undefined && (el.inputmask !== undefined && (el.inputmask.opts.autoUnmask = el.inputmask.opts.autoUnmask,
                 el.inputmask.remove()), el.inputmask = new Inputmask(undefined, undefined, !0),
                 el.inputmask.opts = scopedOpts, el.inputmask.noMasksCache = that.noMasksCache, el.inputmask.userOptions = $.extend(!0, {}, that.userOptions),
@@ -1630,4 +1626,3 @@ export function factory($, window, document, undefined) {
         X: 88
     }, Inputmask;
 }
-// });

--- a/third_party/inputmask/patches/0000-remove-umd-wrapper.patch
+++ b/third_party/inputmask/patches/0000-remove-umd-wrapper.patch
@@ -1,0 +1,44 @@
+diff --git a/third_party/inputmask/inputmask.dependencyLib.js b/third_party/inputmask/inputmask.dependencyLib.js
+index 3916874f1..dabe6c770 100755
+--- a/third_party/inputmask/inputmask.dependencyLib.js
++++ b/third_party/inputmask/inputmask.dependencyLib.js
+@@ -6,9 +6,7 @@
+ * Version: 3.3.11
+ */
+ 
+-!function(factory) {
+-    "function" == typeof define && define.amd ? define([ "../global/window", "../global/document" ], factory) : "object" == typeof exports ? module.exports = factory(require("../global/window"), require("../global/document")) : window.dependencyLib = factory(window, document);
+-}(function(window, document) {
++export function factory(window, document) {
+     function indexOf(list, elem) {
+         for (var i = 0, len = list.length; i < len; i++) if (list[i] === elem) return i;
+         return -1;
+@@ -130,4 +128,4 @@
+         return evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail), 
+         evt;
+     }, DependencyLib.Event.prototype = window.Event.prototype), DependencyLib;
+-});
+\ No newline at end of file
++}
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index c6836be84..71f7b99b6 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -6,9 +6,7 @@
+ * Version: 3.3.11
+ */
+ 
+-!function(factory) {
+-    "function" == typeof define && define.amd ? define([ "./dependencyLibs/inputmask.dependencyLib", "./global/window", "./global/document" ], factory) : "object" == typeof exports ? module.exports = factory(require("./dependencyLibs/inputmask.dependencyLib"), require("./global/window"), require("./global/document")) : window.Inputmask = factory(window.dependencyLib || jQuery, window, document);
+-}(function($, window, document, undefined) {
++export function factory($, window, document, undefined) {
+     function Inputmask(alias, options, internal) {
+         if (!(this instanceof Inputmask)) return new Inputmask(alias, options, internal);
+         this.el = undefined, this.events = {}, this.maskset = undefined, this.refreshValue = !1, 
+@@ -1622,4 +1620,4 @@
+         WINDOWS: 91,
+         X: 88
+     }, Inputmask;
+-});
+\ No newline at end of file
++}

--- a/third_party/inputmask/patches/0001-window-element.patch
+++ b/third_party/inputmask/patches/0001-window-element.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/inputmask/inputmask.dependencyLib.js b/third_party/inputmask/inputmask.dependencyLib.js
+index dabe6c770..aff110fc5 100755
+--- a/third_party/inputmask/inputmask.dependencyLib.js
++++ b/third_party/inputmask/inputmask.dependencyLib.js
+@@ -22,7 +22,7 @@ export function factory(window, document) {
+         return "function" !== ltype && !isWindow(obj) && (!(1 !== obj.nodeType || !length) || ("array" === ltype || 0 === length || "number" == typeof length && length > 0 && length - 1 in obj));
+     }
+     function isValidElement(elem) {
+-        return elem instanceof Element;
++        return elem instanceof window.Element;
+     }
+     function DependencyLib(elem) {
+         return elem instanceof DependencyLib ? elem : this instanceof DependencyLib ? void (void 0 !== elem && null !== elem && elem !== window && (this[0] = elem.nodeName ? elem : void 0 !== elem[0] && elem[0].nodeName ? elem[0] : document.querySelector(elem), 

--- a/third_party/inputmask/patches/0002-use-real-event.patch
+++ b/third_party/inputmask/patches/0002-use-real-event.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/inputmask/inputmask.dependencyLib.js b/third_party/inputmask/inputmask.dependencyLib.js
+index dabe6c770..509e91dd2 100755
+--- a/third_party/inputmask/inputmask.dependencyLib.js
++++ b/third_party/inputmask/inputmask.dependencyLib.js
+@@ -80,7 +80,7 @@ export function factory(window, document) {
+                     };
+                     if (document.createEvent) {
+                         try {
+-                            evnt = new CustomEvent(ev, params);
++                            evnt = ["change","input","click"].indexOf(ev) > -1 ? new Event(ev, params) : new CustomEvent(ev, params);
+                         } catch (e) {
+                             (evnt = document.createEvent("CustomEvent")).initCustomEvent(ev, params.bubbles, params.cancelable, params.detail);
+                         }

--- a/third_party/inputmask/patches/0003-fix-unpatched-unmask.patch
+++ b/third_party/inputmask/patches/0003-fix-unpatched-unmask.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index 71f7b99b6..215e86839 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -1324,7 +1324,7 @@ export function factory($, window, document, undefined) {
+                 var scopedOpts = $.extend(!0, {}, that.opts);
+                 importAttributeOptions(el, scopedOpts, $.extend(!0, {}, that.userOptions), that.dataAttribute);
+                 var maskset = generateMaskSet(scopedOpts, that.noMasksCache);
+-                maskset !== undefined && (el.inputmask !== undefined && (el.inputmask.opts.autoUnmask = !0, 
++                maskset !== undefined && (el.inputmask !== undefined && (el.inputmask.opts.autoUnmask = el.inputmask.opts.autoUnmask,
+                 el.inputmask.remove()), el.inputmask = new Inputmask(undefined, undefined, !0), 
+                 el.inputmask.opts = scopedOpts, el.inputmask.noMasksCache = that.noMasksCache, el.inputmask.userOptions = $.extend(!0, {}, that.userOptions), 
+                 el.inputmask.isRTL = scopedOpts.isRTL || scopedOpts.numericInput, el.inputmask.el = el, 

--- a/third_party/inputmask/patches/0004-fix-unpatched-hover.patch
+++ b/third_party/inputmask/patches/0004-fix-unpatched-hover.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index c6836be84..ac471bcf3 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -1127,7 +1127,7 @@
+                             }(npt.type), function(npt) {
+                                 EventRuler.on(npt, "mouseenter", function(event) {
+                                     var $input = $(this);
+-                                    this.inputmask._valueGet() !== getBuffer().join("") && $input.trigger("setvalue");
++                                    opts.showMaskOnHover == !0 && this.inputmask._valueGet() !== getBuffer().join("") && $input.trigger("setvalue");
+                                 });
+                             }(npt));
+                         }

--- a/third_party/inputmask/patches/0005-cleanup-whitespace.patch
+++ b/third_party/inputmask/patches/0005-cleanup-whitespace.patch
@@ -1,0 +1,1098 @@
+diff --git a/third_party/inputmask/inputmask.dependencyLib.js b/third_party/inputmask/inputmask.dependencyLib.js
+index 3f6f85702..a3e7a4df1 100755
+--- a/third_party/inputmask/inputmask.dependencyLib.js
++++ b/third_party/inputmask/inputmask.dependencyLib.js
+@@ -25,7 +25,7 @@ export function factory(window, document) {
+         return elem instanceof window.Element;
+     }
+     function DependencyLib(elem) {
+-        return elem instanceof DependencyLib ? elem : this instanceof DependencyLib ? void (void 0 !== elem && null !== elem && elem !== window && (this[0] = elem.nodeName ? elem : void 0 !== elem[0] && elem[0].nodeName ? elem[0] : document.querySelector(elem), 
++        return elem instanceof DependencyLib ? elem : this instanceof DependencyLib ? void (void 0 !== elem && null !== elem && elem !== window && (this[0] = elem.nodeName ? elem : void 0 !== elem[0] && elem[0].nodeName ? elem[0] : document.querySelector(elem),
+         void 0 !== this[0] && null !== this[0] && (this[0].eventRegistry = this[0].eventRegistry || {}))) : new DependencyLib(elem);
+     }
+     for (var class2type = {}, classTypes = "Boolean Number String Function Array Date RegExp Object Error".split(" "), nameNdx = 0; nameNdx < classTypes.length; nameNdx++) class2type["[object " + classTypes[nameNdx] + "]"] = classTypes[nameNdx].toLowerCase();
+@@ -34,8 +34,8 @@ export function factory(window, document) {
+             if (isValidElement(this[0])) for (var eventRegistry = this[0].eventRegistry, elem = this[0], _events = events.split(" "), endx = 0; endx < _events.length; endx++) {
+                 var nsEvent = _events[endx].split(".");
+                 !function(ev, namespace) {
+-                    elem.addEventListener ? elem.addEventListener(ev, handler, !1) : elem.attachEvent && elem.attachEvent("on" + ev, handler), 
+-                    eventRegistry[ev] = eventRegistry[ev] || {}, eventRegistry[ev][namespace] = eventRegistry[ev][namespace] || [], 
++                    elem.addEventListener ? elem.addEventListener(ev, handler, !1) : elem.attachEvent && elem.attachEvent("on" + ev, handler),
++                    eventRegistry[ev] = eventRegistry[ev] || {}, eventRegistry[ev][namespace] = eventRegistry[ev][namespace] || [],
+                     eventRegistry[ev][namespace].push(handler);
+                 }(nsEvent[0], nsEvent[1] || "global");
+             }
+@@ -52,7 +52,7 @@ export function factory(window, document) {
+                     ev: ev,
+                     namespace: namespace && namespace.length > 0 ? namespace : "global",
+                     handler: handler
+-                }); else if (namespace.length > 0) for (var evNdx in eventRegistry) for (var nmsp in eventRegistry[evNdx]) if (nmsp === namespace) if (void 0 === handler) for (hndx = 0, 
++                }); else if (namespace.length > 0) for (var evNdx in eventRegistry) for (var nmsp in eventRegistry[evNdx]) if (nmsp === namespace) if (void 0 === handler) for (hndx = 0,
+                 hndL = eventRegistry[evNdx][nmsp].length; hndx < hndL; hndx++) evts.push({
+                     ev: evNdx,
+                     namespace: nmsp,
+@@ -64,7 +64,7 @@ export function factory(window, document) {
+                 });
+                 return evts;
+             }(nsEvent[0], nsEvent[1]), i = 0, offEventsL = offEvents.length; i < offEventsL; i++) !function(ev, namespace, handler) {
+-                if (ev in eventRegistry == 1) if (elem.removeEventListener ? elem.removeEventListener(ev, handler, !1) : elem.detachEvent && elem.detachEvent("on" + ev, handler), 
++                if (ev in eventRegistry == 1) if (elem.removeEventListener ? elem.removeEventListener(ev, handler, !1) : elem.detachEvent && elem.detachEvent("on" + ev, handler),
+                 "global" === namespace) for (var nmsp in eventRegistry[ev]) eventRegistry[ev][nmsp].splice(eventRegistry[ev][nmsp].indexOf(handler), 1); else eventRegistry[ev][namespace].splice(eventRegistry[ev][namespace].indexOf(handler), 1);
+             }(offEvents[i].ev, offEvents[i].namespace, offEvents[i].handler);
+             return this;
+@@ -85,9 +85,9 @@ export function factory(window, document) {
+                             (evnt = document.createEvent("CustomEvent")).initCustomEvent(ev, params.bubbles, params.cancelable, params.detail);
+                         }
+                         events.type && DependencyLib.extend(evnt, events), elem.dispatchEvent(evnt);
+-                    } else (evnt = document.createEventObject()).eventType = ev, events.type && DependencyLib.extend(evnt, events), 
++                    } else (evnt = document.createEventObject()).eventType = ev, events.type && DependencyLib.extend(evnt, events),
+                     elem.fireEvent("on" + evnt.eventType, evnt);
+-                } else if (void 0 !== eventRegistry[ev]) if (arguments[0] = arguments[0].type ? arguments[0] : DependencyLib.Event(arguments[0]), 
++                } else if (void 0 !== eventRegistry[ev]) if (arguments[0] = arguments[0].type ? arguments[0] : DependencyLib.Event(arguments[0]),
+                 "global" === namespace) for (var nmsp in eventRegistry[ev]) for (i = 0; i < eventRegistry[ev][nmsp].length; i++) eventRegistry[ev][nmsp][i].apply(elem, arguments); else for (i = 0; i < eventRegistry[ev][namespace].length; i++) eventRegistry[ev][namespace][i].apply(elem, arguments);
+             }
+             return this;
+@@ -100,11 +100,11 @@ export function factory(window, document) {
+         return "object" === type(obj) && !obj.nodeType && !isWindow(obj) && !(obj.constructor && !class2type.hasOwnProperty.call(obj.constructor.prototype, "isPrototypeOf"));
+     }, DependencyLib.extend = function() {
+         var options, name, src, copy, copyIsArray, clone, target = arguments[0] || {}, i = 1, length = arguments.length, deep = !1;
+-        for ("boolean" == typeof target && (deep = target, target = arguments[i] || {}, 
+-        i++), "object" == typeof target || DependencyLib.isFunction(target) || (target = {}), 
+-        i === length && (target = this, i--); i < length; i++) if (null != (options = arguments[i])) for (name in options) src = target[name], 
+-        target !== (copy = options[name]) && (deep && copy && (DependencyLib.isPlainObject(copy) || (copyIsArray = DependencyLib.isArray(copy))) ? (copyIsArray ? (copyIsArray = !1, 
+-        clone = src && DependencyLib.isArray(src) ? src : []) : clone = src && DependencyLib.isPlainObject(src) ? src : {}, 
++        for ("boolean" == typeof target && (deep = target, target = arguments[i] || {},
++        i++), "object" == typeof target || DependencyLib.isFunction(target) || (target = {}),
++        i === length && (target = this, i--); i < length; i++) if (null != (options = arguments[i])) for (name in options) src = target[name],
++        target !== (copy = options[name]) && (deep && copy && (DependencyLib.isPlainObject(copy) || (copyIsArray = DependencyLib.isArray(copy))) ? (copyIsArray ? (copyIsArray = !1,
++        clone = src && DependencyLib.isArray(src) ? src : []) : clone = src && DependencyLib.isPlainObject(src) ? src : {},
+         target[name] = DependencyLib.extend(deep, clone, copy)) : void 0 !== copy && (target[name] = copy));
+         return target;
+     }, DependencyLib.each = function(obj, callback) {
+@@ -125,7 +125,7 @@ export function factory(window, document) {
+             detail: void 0
+         };
+         var evt = document.createEvent("CustomEvent");
+-        return evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail), 
++        return evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail),
+         evt;
+     }, DependencyLib.Event.prototype = window.Event.prototype), DependencyLib;
+ }
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index 09c3be9f5..bb29f20ff 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -9,22 +9,22 @@
+ export function factory($, window, document, undefined) {
+     function Inputmask(alias, options, internal) {
+         if (!(this instanceof Inputmask)) return new Inputmask(alias, options, internal);
+-        this.el = undefined, this.events = {}, this.maskset = undefined, this.refreshValue = !1, 
+-        !0 !== internal && ($.isPlainObject(alias) ? options = alias : (options = options || {}).alias = alias, 
+-        this.opts = $.extend(!0, {}, this.defaults, options), this.noMasksCache = options && options.definitions !== undefined, 
++        this.el = undefined, this.events = {}, this.maskset = undefined, this.refreshValue = !1,
++        !0 !== internal && ($.isPlainObject(alias) ? options = alias : (options = options || {}).alias = alias,
++        this.opts = $.extend(!0, {}, this.defaults, options), this.noMasksCache = options && options.definitions !== undefined,
+         this.userOptions = options || {}, this.isRTL = this.opts.numericInput, resolveAlias(this.opts.alias, options, this.opts));
+     }
+     function resolveAlias(aliasStr, options, opts) {
+         var aliasDefinition = Inputmask.prototype.aliases[aliasStr];
+-        return aliasDefinition ? (aliasDefinition.alias && resolveAlias(aliasDefinition.alias, undefined, opts), 
+-        $.extend(!0, opts, aliasDefinition), $.extend(!0, opts, options), !0) : (null === opts.mask && (opts.mask = aliasStr), 
++        return aliasDefinition ? (aliasDefinition.alias && resolveAlias(aliasDefinition.alias, undefined, opts),
++        $.extend(!0, opts, aliasDefinition), $.extend(!0, opts, options), !0) : (null === opts.mask && (opts.mask = aliasStr),
+         !1);
+     }
+     function generateMaskSet(opts, nocache) {
+         function generateMask(mask, metadata, opts) {
+             var regexMask = !1;
+-            if (null !== mask && "" !== mask || ((regexMask = null !== opts.regex) ? mask = (mask = opts.regex).replace(/^(\^)(.*)(\$)$/, "$2") : (regexMask = !0, 
+-            mask = ".*")), 1 === mask.length && !1 === opts.greedy && 0 !== opts.repeat && (opts.placeholder = ""), 
++            if (null !== mask && "" !== mask || ((regexMask = null !== opts.regex) ? mask = (mask = opts.regex).replace(/^(\^)(.*)(\$)$/, "$2") : (regexMask = !0,
++            mask = ".*")), 1 === mask.length && !1 === opts.greedy && 0 !== opts.repeat && (opts.placeholder = ""),
+             opts.repeat > 0 || "*" === opts.repeat || "+" === opts.repeat) {
+                 var repeatStart = "*" === opts.repeat ? 0 : "+" === opts.repeat ? 1 : opts.repeat;
+                 mask = opts.groupmarker.start + mask + opts.groupmarker.end + opts.quantifiermarker.start + repeatStart + "," + opts.repeat + opts.quantifiermarker.end;
+@@ -39,8 +39,8 @@ export function factory($, window, document, undefined) {
+                 tests: {},
+                 metadata: metadata,
+                 maskLength: undefined
+-            }, !0 !== nocache && (Inputmask.prototype.masksCache[maskdefKey] = masksetDefinition, 
+-            masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]), 
++            }, !0 !== nocache && (Inputmask.prototype.masksCache[maskdefKey] = masksetDefinition,
++            masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
+             masksetDefinition;
+         }
+         if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), $.isArray(opts.mask)) {
+@@ -48,7 +48,7 @@ export function factory($, window, document, undefined) {
+                 opts.keepStatic = null === opts.keepStatic || opts.keepStatic;
+                 var altMask = opts.groupmarker.start;
+                 return $.each(opts.numericInput ? opts.mask.reverse() : opts.mask, function(ndx, msk) {
+-                    altMask.length > 1 && (altMask += opts.groupmarker.end + opts.alternatormarker + opts.groupmarker.start), 
++                    altMask.length > 1 && (altMask += opts.groupmarker.end + opts.alternatormarker + opts.groupmarker.start),
+                     msk.mask === undefined || $.isFunction(msk.mask) ? altMask += msk : altMask += msk.mask;
+                 }), altMask += opts.groupmarker.end, generateMask(altMask, opts.mask, opts);
+             }
+@@ -61,12 +61,12 @@ export function factory($, window, document, undefined) {
+             minimalPos = minimalPos || 0;
+             var ndxIntlzr, test, testPos, maskTemplate = [], pos = 0, lvp = getLastValidPosition();
+             do {
+-                !0 === baseOnInput && getMaskSet().validPositions[pos] ? (test = (testPos = getMaskSet().validPositions[pos]).match, 
+-                ndxIntlzr = testPos.locator.slice(), maskTemplate.push(!0 === includeMode ? testPos.input : !1 === includeMode ? test.nativeDef : getPlaceholder(pos, test))) : (test = (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1)).match, 
+-                ndxIntlzr = testPos.locator.slice(), (!1 === opts.jitMasking || pos < lvp || "number" == typeof opts.jitMasking && isFinite(opts.jitMasking) && opts.jitMasking > pos) && maskTemplate.push(!1 === includeMode ? test.nativeDef : getPlaceholder(pos, test))), 
++                !0 === baseOnInput && getMaskSet().validPositions[pos] ? (test = (testPos = getMaskSet().validPositions[pos]).match,
++                ndxIntlzr = testPos.locator.slice(), maskTemplate.push(!0 === includeMode ? testPos.input : !1 === includeMode ? test.nativeDef : getPlaceholder(pos, test))) : (test = (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1)).match,
++                ndxIntlzr = testPos.locator.slice(), (!1 === opts.jitMasking || pos < lvp || "number" == typeof opts.jitMasking && isFinite(opts.jitMasking) && opts.jitMasking > pos) && maskTemplate.push(!1 === includeMode ? test.nativeDef : getPlaceholder(pos, test))),
+                 pos++;
+             } while ((maxLength === undefined || pos < maxLength) && (null !== test.fn || "" !== test.def) || minimalPos > pos);
+-            return "" === maskTemplate[maskTemplate.length - 1] && maskTemplate.pop(), getMaskSet().maskLength = pos + 1, 
++            return "" === maskTemplate[maskTemplate.length - 1] && maskTemplate.pop(), getMaskSet().maskLength = pos + 1,
+             maskTemplate;
+         }
+         function getMaskSet() {
+@@ -81,7 +81,7 @@ export function factory($, window, document, undefined) {
+             closestTo === undefined && (closestTo = -1);
+             for (var posNdx in valids) {
+                 var psNdx = parseInt(posNdx);
+-                valids[psNdx] && (strict || !0 !== valids[psNdx].generatedInput) && (psNdx <= closestTo && (before = psNdx), 
++                valids[psNdx] && (strict || !0 !== valids[psNdx].generatedInput) && (psNdx <= closestTo && (before = psNdx),
+                 psNdx >= closestTo && (after = psNdx));
+             }
+             return -1 !== before && closestTo - before > 1 || after < closestTo ? before : after;
+@@ -100,9 +100,9 @@ export function factory($, window, document, undefined) {
+                 for (;getMaskSet().validPositions[startPos] !== undefined; ) startPos++;
+                 if (i < startPos && (i = startPos + 1), getMaskSet().validPositions[i] === undefined && isMask(i)) i++; else {
+                     var t = getTestTemplate(i);
+-                    !1 === needsValidation && positionsClone[startPos] && positionsClone[startPos].match.def === t.match.def ? (getMaskSet().validPositions[startPos] = $.extend(!0, {}, positionsClone[startPos]), 
+-                    getMaskSet().validPositions[startPos].input = t.input, delete getMaskSet().validPositions[i], 
+-                    i++) : positionCanMatchDefinition(startPos, t.match.def) ? !1 !== isValid(startPos, t.input || getPlaceholder(i), !0) && (delete getMaskSet().validPositions[i], 
++                    !1 === needsValidation && positionsClone[startPos] && positionsClone[startPos].match.def === t.match.def ? (getMaskSet().validPositions[startPos] = $.extend(!0, {}, positionsClone[startPos]),
++                    getMaskSet().validPositions[startPos].input = t.input, delete getMaskSet().validPositions[i],
++                    i++) : positionCanMatchDefinition(startPos, t.match.def) ? !1 !== isValid(startPos, t.input || getPlaceholder(i), !0) && (delete getMaskSet().validPositions[i],
+                     i++, needsValidation = !0) : isMask(i) || (i++, startPos--), startPos++;
+                 }
+             }
+@@ -139,7 +139,7 @@ export function factory($, window, document, undefined) {
+                         if (getMaskSet().validPositions[pos - 1] && targetAlternation && getMaskSet().tests[pos]) for (var vpAlternation = getMaskSet().validPositions[pos - 1].locator, tpAlternation = getMaskSet().tests[pos][0].locator, i = 0; i < targetAlternation; i++) if (vpAlternation[i] !== tpAlternation[i]) return vpAlternation.slice(targetAlternation + 1);
+                         return (getMaskSet().tests[pos] || getMaskSet().validPositions[pos]) && $.each(getMaskSet().tests[pos] || [ getMaskSet().validPositions[pos] ], function(ndx, lmnt) {
+                             var alternation = targetAlternation !== undefined ? targetAlternation : lmnt.alternation, ndxPos = lmnt.locator[alternation] !== undefined ? lmnt.locator[alternation].toString().indexOf(alternateNdx) : -1;
+-                            (indexPos === undefined || ndxPos < indexPos) && -1 !== ndxPos && (bestMatch = lmnt, 
++                            (indexPos === undefined || ndxPos < indexPos) && -1 !== ndxPos && (bestMatch = lmnt,
+                             indexPos = ndxPos);
+                         }), bestMatch ? bestMatch.locator.slice((targetAlternation !== undefined ? targetAlternation : bestMatch.alternation) + 1) : targetAlternation !== undefined ? resolveNdxInitializer(pos, alternateNdx) : undefined;
+                     }
+@@ -164,10 +164,10 @@ export function factory($, window, document, undefined) {
+                                 var amndx, currentPos = testPos, ndxInitializerClone = ndxInitializer.slice(), altIndexArr = [];
+                                 if ("string" == typeof altIndex) altIndexArr = altIndex.split(","); else for (amndx = 0; amndx < alternateToken.matches.length; amndx++) altIndexArr.push(amndx);
+                                 for (var ndx = 0; ndx < altIndexArr.length; ndx++) {
+-                                    if (amndx = parseInt(altIndexArr[ndx]), matches = [], ndxInitializer = resolveNdxInitializer(testPos, amndx, loopNdxCnt) || ndxInitializerClone.slice(), 
++                                    if (amndx = parseInt(altIndexArr[ndx]), matches = [], ndxInitializer = resolveNdxInitializer(testPos, amndx, loopNdxCnt) || ndxInitializerClone.slice(),
+                                     !0 !== (match = handleMatch(alternateToken.matches[amndx] || maskToken.matches[amndx], [ amndx ].concat(loopNdx), quantifierRecurse) || match) && match !== undefined && altIndexArr[altIndexArr.length - 1] < alternateToken.matches.length) {
+                                         var ntndx = $.inArray(match, maskToken.matches) + 1;
+-                                        maskToken.matches.length > ntndx && (match = handleMatch(maskToken.matches[ntndx], [ ntndx ].concat(loopNdx.slice(1, loopNdx.length)), quantifierRecurse)) && (altIndexArr.push(ntndx.toString()), 
++                                        maskToken.matches.length > ntndx && (match = handleMatch(maskToken.matches[ntndx], [ ntndx ].concat(loopNdx.slice(1, loopNdx.length)), quantifierRecurse)) && (altIndexArr.push(ntndx.toString()),
+                                         $.each(matches, function(ndx, lmnt) {
+                                             lmnt.alternation = loopNdx.length - 1;
+                                         }));
+@@ -182,8 +182,8 @@ export function factory($, window, document, undefined) {
+                                                 if (function(source, target) {
+                                                     return source.match.nativeDef === target.match.nativeDef || source.match.def === target.match.nativeDef || source.match.nativeDef === target.match.def;
+                                                 }(altMatch, altMatch2)) {
+-                                                    dropMatch = !0, altMatch.alternation === altMatch2.alternation && -1 === altMatch2.locator[altMatch2.alternation].toString().indexOf(altMatch.locator[altMatch.alternation]) && (altMatch2.locator[altMatch2.alternation] = altMatch2.locator[altMatch2.alternation] + "," + altMatch.locator[altMatch.alternation], 
+-                                                    altMatch2.alternation = altMatch.alternation), altMatch.match.nativeDef === altMatch2.match.def && (altMatch.locator[altMatch.alternation] = altMatch2.locator[altMatch2.alternation], 
++                                                    dropMatch = !0, altMatch.alternation === altMatch2.alternation && -1 === altMatch2.locator[altMatch2.alternation].toString().indexOf(altMatch.locator[altMatch.alternation]) && (altMatch2.locator[altMatch2.alternation] = altMatch2.locator[altMatch2.alternation] + "," + altMatch.locator[altMatch.alternation],
++                                                    altMatch2.alternation = altMatch.alternation), altMatch.match.nativeDef === altMatch2.match.def && (altMatch.locator[altMatch.alternation] = altMatch2.locator[altMatch2.alternation],
+                                                     malternateMatches.splice(malternateMatches.indexOf(altMatch2), 1, altMatch));
+                                                     break;
+                                                 }
+@@ -196,9 +196,9 @@ export function factory($, window, document, undefined) {
+                                                 }(altMatch, altMatch2) || function(source, target) {
+                                                     return null !== source.match.fn && null !== target.match.fn && target.match.fn.test(source.match.def.replace(/[\[\]]/g, ""), getMaskSet(), pos, !1, opts, !1);
+                                                 }(altMatch, altMatch2)) {
+-                                                    altMatch.alternation === altMatch2.alternation && -1 === altMatch.locator[altMatch.alternation].toString().indexOf(altMatch2.locator[altMatch2.alternation].toString().split("")[0]) && (altMatch.na = altMatch.na || altMatch.locator[altMatch.alternation].toString(), 
+-                                                    -1 === altMatch.na.indexOf(altMatch.locator[altMatch.alternation].toString().split("")[0]) && (altMatch.na = altMatch.na + "," + altMatch.locator[altMatch2.alternation].toString().split("")[0]), 
+-                                                    dropMatch = !0, altMatch.locator[altMatch.alternation] = altMatch2.locator[altMatch2.alternation].toString().split("")[0] + "," + altMatch.locator[altMatch.alternation], 
++                                                    altMatch.alternation === altMatch2.alternation && -1 === altMatch.locator[altMatch.alternation].toString().indexOf(altMatch2.locator[altMatch2.alternation].toString().split("")[0]) && (altMatch.na = altMatch.na || altMatch.locator[altMatch.alternation].toString(),
++                                                    -1 === altMatch.na.indexOf(altMatch.locator[altMatch.alternation].toString().split("")[0]) && (altMatch.na = altMatch.na + "," + altMatch.locator[altMatch2.alternation].toString().split("")[0]),
++                                                    dropMatch = !0, altMatch.locator[altMatch.alternation] = altMatch2.locator[altMatch2.alternation].toString().split("")[0] + "," + altMatch.locator[altMatch.alternation],
+                                                     malternateMatches.splice(malternateMatches.indexOf(altMatch2), 0, altMatch));
+                                                     break;
+                                                 }
+@@ -211,19 +211,19 @@ export function factory($, window, document, undefined) {
+                                     if (isFinite(ndx)) {
+                                         var alternation = lmnt.alternation, altLocArr = lmnt.locator[alternation].toString().split(",");
+                                         lmnt.locator[alternation] = undefined, lmnt.alternation = undefined;
+-                                        for (var alndx = 0; alndx < altLocArr.length; alndx++) -1 !== $.inArray(altLocArr[alndx], altIndexArr) && (lmnt.locator[alternation] !== undefined ? (lmnt.locator[alternation] += ",", 
+-                                        lmnt.locator[alternation] += altLocArr[alndx]) : lmnt.locator[alternation] = parseInt(altLocArr[alndx]), 
++                                        for (var alndx = 0; alndx < altLocArr.length; alndx++) -1 !== $.inArray(altLocArr[alndx], altIndexArr) && (lmnt.locator[alternation] !== undefined ? (lmnt.locator[alternation] += ",",
++                                        lmnt.locator[alternation] += altLocArr[alndx]) : lmnt.locator[alternation] = parseInt(altLocArr[alndx]),
+                                         lmnt.alternation = alternation);
+                                         if (lmnt.locator[alternation] !== undefined) return lmnt;
+                                     }
+-                                })), matches = currentMatches.concat(malternateMatches), testPos = pos, insertStop = matches.length > 0, 
++                                })), matches = currentMatches.concat(malternateMatches), testPos = pos, insertStop = matches.length > 0,
+                                 match = malternateMatches.length > 0, ndxInitializer = ndxInitializerClone.slice();
+                             } else match = handleMatch(alternateToken.matches[altIndex] || maskToken.matches[altIndex], [ altIndex ].concat(loopNdx), quantifierRecurse);
+                             if (match) return !0;
+                         } else if (match.isQuantifier && quantifierRecurse !== maskToken.matches[$.inArray(match, maskToken.matches) - 1]) for (var qt = match, qndx = ndxInitializer.length > 0 ? ndxInitializer.shift() : 0; qndx < (isNaN(qt.quantifier.max) ? qndx + 1 : qt.quantifier.max) && testPos <= pos; qndx++) {
+                             var tokenGroup = maskToken.matches[$.inArray(qt, maskToken.matches) - 1];
+                             if (match = handleMatch(tokenGroup, [ qndx ].concat(loopNdx), tokenGroup)) {
+-                                if (latestMatch = matches[matches.length - 1].match, latestMatch.optionalQuantifier = qndx > qt.quantifier.min - 1, 
++                                if (latestMatch = matches[matches.length - 1].match, latestMatch.optionalQuantifier = qndx > qt.quantifier.min - 1,
+                                 isFirstMatch(latestMatch, tokenGroup)) {
+                                     if (qndx > qt.quantifier.min - 1) {
+                                         insertStop = !0, testPos = pos;
+@@ -275,16 +275,16 @@ export function factory($, window, document, undefined) {
+                 },
+                 locator: [],
+                 cd: cacheDependency
+-            }), ndxIntlzr !== undefined && getMaskSet().tests[pos] ? filterTests($.extend(!0, [], matches)) : (getMaskSet().tests[pos] = $.extend(!0, [], matches), 
++            }), ndxIntlzr !== undefined && getMaskSet().tests[pos] ? filterTests($.extend(!0, [], matches)) : (getMaskSet().tests[pos] = $.extend(!0, [], matches),
+             filterTests(getMaskSet().tests[pos]));
+         }
+         function getBufferTemplate() {
+-            return getMaskSet()._buffer === undefined && (getMaskSet()._buffer = getMaskTemplate(!1, 1), 
+-            getMaskSet().buffer === undefined && (getMaskSet().buffer = getMaskSet()._buffer.slice())), 
++            return getMaskSet()._buffer === undefined && (getMaskSet()._buffer = getMaskTemplate(!1, 1),
++            getMaskSet().buffer === undefined && (getMaskSet().buffer = getMaskSet()._buffer.slice())),
+             getMaskSet()._buffer;
+         }
+         function getBuffer(noCache) {
+-            return getMaskSet().buffer !== undefined && !0 !== noCache || (getMaskSet().buffer = getMaskTemplate(!0, getLastValidPosition(), !0)), 
++            return getMaskSet().buffer !== undefined && !0 !== noCache || (getMaskSet().buffer = getMaskTemplate(!0, getLastValidPosition(), !0)),
+             getMaskSet().buffer;
+         }
+         function refreshFromBuffer(start, end, buffer) {
+@@ -342,27 +342,27 @@ export function factory($, window, document, undefined) {
+                         var elem = rslt.c !== undefined ? rslt.c : c;
+                         elem = elem === opts.skipOptionalPartCharacter && null === test.fn ? getPlaceholder(position, test, !0) || test.def : elem;
+                         var validatedPos = position, possibleModifiedBuffer = getBuffer();
+-                        if (rslt.remove !== undefined && ($.isArray(rslt.remove) || (rslt.remove = [ rslt.remove ]), 
++                        if (rslt.remove !== undefined && ($.isArray(rslt.remove) || (rslt.remove = [ rslt.remove ]),
+                         $.each(rslt.remove.sort(function(a, b) {
+                             return b - a;
+                         }), function(ndx, lmnt) {
+                             stripValidPositions(lmnt, lmnt + 1, !0);
+-                        })), rslt.insert !== undefined && ($.isArray(rslt.insert) || (rslt.insert = [ rslt.insert ]), 
++                        })), rslt.insert !== undefined && ($.isArray(rslt.insert) || (rslt.insert = [ rslt.insert ]),
+                         $.each(rslt.insert.sort(function(a, b) {
+                             return a - b;
+                         }), function(ndx, lmnt) {
+                             isValid(lmnt.pos, lmnt.c, !0, fromSetValid);
+                         })), rslt.refreshFromBuffer) {
+                             var refresh = rslt.refreshFromBuffer;
+-                            if (refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, possibleModifiedBuffer), 
+-                            rslt.pos === undefined && rslt.c === undefined) return rslt.pos = getLastValidPosition(), 
++                            if (refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, possibleModifiedBuffer),
++                            rslt.pos === undefined && rslt.c === undefined) return rslt.pos = getLastValidPosition(),
+                             !1;
+-                            if ((validatedPos = rslt.pos !== undefined ? rslt.pos : position) !== position) return rslt = $.extend(rslt, isValid(validatedPos, elem, !0, fromSetValid)), 
++                            if ((validatedPos = rslt.pos !== undefined ? rslt.pos : position) !== position) return rslt = $.extend(rslt, isValid(validatedPos, elem, !0, fromSetValid)),
+                             !1;
+-                        } else if (!0 !== rslt && rslt.pos !== undefined && rslt.pos !== position && (validatedPos = rslt.pos, 
+-                        refreshFromBuffer(position, validatedPos, getBuffer().slice()), validatedPos !== position)) return rslt = $.extend(rslt, isValid(validatedPos, elem, !0)), 
++                        } else if (!0 !== rslt && rslt.pos !== undefined && rslt.pos !== position && (validatedPos = rslt.pos,
++                        refreshFromBuffer(position, validatedPos, getBuffer().slice()), validatedPos !== position)) return rslt = $.extend(rslt, isValid(validatedPos, elem, !0)),
+                         !1;
+-                        return (!0 === rslt || rslt.pos !== undefined || rslt.c !== undefined) && (ndx > 0 && resetMaskSet(!0), 
++                        return (!0 === rslt || rslt.pos !== undefined || rslt.c !== undefined) && (ndx > 0 && resetMaskSet(!0),
+                         setValidPosition(validatedPos, $.extend({}, tst, {
+                             input: casing(elem, test, validatedPos)
+                         }), fromSetValid, isSelection(pos)) || (rslt = !1), !1);
+@@ -378,19 +378,19 @@ export function factory($, window, document, undefined) {
+                     for (i = j = pos; i <= lvp; i++) {
+                         var t = positionsClone[i];
+                         if (t !== undefined) for (var posMatch = j; posMatch < getMaskSet().maskLength && (null === t.match.fn && vps[i] && (!0 === vps[i].match.optionalQuantifier || !0 === vps[i].match.optionality) || null != t.match.fn); ) {
+-                            if (posMatch++, !1 === needsValidation && positionsClone[posMatch] && positionsClone[posMatch].match.def === t.match.def) getMaskSet().validPositions[posMatch] = $.extend(!0, {}, positionsClone[posMatch]), 
+-                            getMaskSet().validPositions[posMatch].input = t.input, fillMissingNonMask(posMatch), 
++                            if (posMatch++, !1 === needsValidation && positionsClone[posMatch] && positionsClone[posMatch].match.def === t.match.def) getMaskSet().validPositions[posMatch] = $.extend(!0, {}, positionsClone[posMatch]),
++                            getMaskSet().validPositions[posMatch].input = t.input, fillMissingNonMask(posMatch),
+                             j = posMatch, valid = !0; else if (positionCanMatchDefinition(posMatch, t.match.def)) {
+                                 var result = isValid(posMatch, t.input, !0, !0);
+-                                valid = !1 !== result, j = result.caret || result.insert ? getLastValidPosition() : posMatch, 
++                                valid = !1 !== result, j = result.caret || result.insert ? getLastValidPosition() : posMatch,
+                                 needsValidation = !0;
+                             } else if (!(valid = !0 === t.generatedInput) && posMatch >= getMaskSet().maskLength - 1) break;
+-                            if (getMaskSet().maskLength < initialLength && (getMaskSet().maskLength = initialLength), 
++                            if (getMaskSet().maskLength < initialLength && (getMaskSet().maskLength = initialLength),
+                             valid) break;
+                         }
+                         if (!valid) break;
+                     }
+-                    if (!valid) return getMaskSet().validPositions = $.extend(!0, {}, positionsClone), 
++                    if (!valid) return getMaskSet().validPositions = $.extend(!0, {}, positionsClone),
+                     resetMaskSet(!0), !1;
+                 } else getMaskSet().validPositions[pos] = $.extend(!0, {}, validTest);
+                 return resetMaskSet(!0), !0;
+@@ -398,17 +398,17 @@ export function factory($, window, document, undefined) {
+             function fillMissingNonMask(maskPos) {
+                 for (var pndx = maskPos - 1; pndx > -1 && !getMaskSet().validPositions[pndx]; pndx--) ;
+                 var testTemplate, testsFromPos;
+-                for (pndx++; pndx < maskPos; pndx++) getMaskSet().validPositions[pndx] === undefined && (!1 === opts.jitMasking || opts.jitMasking > pndx) && ("" === (testsFromPos = getTests(pndx, getTestTemplate(pndx - 1).locator, pndx - 1).slice())[testsFromPos.length - 1].match.def && testsFromPos.pop(), 
++                for (pndx++; pndx < maskPos; pndx++) getMaskSet().validPositions[pndx] === undefined && (!1 === opts.jitMasking || opts.jitMasking > pndx) && ("" === (testsFromPos = getTests(pndx, getTestTemplate(pndx - 1).locator, pndx - 1).slice())[testsFromPos.length - 1].match.def && testsFromPos.pop(),
+                 (testTemplate = determineTestTemplate(testsFromPos)) && (testTemplate.match.def === opts.radixPointDefinitionSymbol || !isMask(pndx, !0) || $.inArray(opts.radixPoint, getBuffer()) < pndx && testTemplate.match.fn && testTemplate.match.fn.test(getPlaceholder(pndx), getMaskSet(), pndx, !1, opts)) && !1 !== (result = _isValid(pndx, getPlaceholder(pndx, testTemplate.match, !0) || (null == testTemplate.match.fn ? testTemplate.match.def : "" !== getPlaceholder(pndx) ? getPlaceholder(pndx) : getBuffer()[pndx]), !0)) && (getMaskSet().validPositions[result.pos || pndx].generatedInput = !0));
+             }
+             strict = !0 === strict;
+             var maskPos = pos;
+             pos.begin !== undefined && (maskPos = isRTL && !isSelection(pos) ? pos.end : pos.begin);
+             var result = !0, positionsClone = $.extend(!0, {}, getMaskSet().validPositions);
+-            if ($.isFunction(opts.preValidation) && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts)), 
++            if ($.isFunction(opts.preValidation) && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts)),
+             !0 === result) {
+-                if (fillMissingNonMask(maskPos), isSelection(pos) && (handleRemove(undefined, Inputmask.keyCode.DELETE, pos, !0, !0), 
+-                maskPos = getMaskSet().p), maskPos < getMaskSet().maskLength && (maxLength === undefined || maskPos < maxLength) && (result = _isValid(maskPos, c, strict), 
++                if (fillMissingNonMask(maskPos), isSelection(pos) && (handleRemove(undefined, Inputmask.keyCode.DELETE, pos, !0, !0),
++                maskPos = getMaskSet().p), maskPos < getMaskSet().maskLength && (maxLength === undefined || maskPos < maxLength) && (result = _isValid(maskPos, c, strict),
+                 (!strict || !0 === fromSetValid) && !1 === result && !0 !== validateOnly)) {
+                     var currentPosValid = getMaskSet().validPositions[maskPos];
+                     if (!currentPosValid || null !== currentPosValid.match.fn || currentPosValid.match.def !== c && c !== opts.skipOptionalPartCharacter) {
+@@ -428,7 +428,7 @@ export function factory($, window, document, undefined) {
+                                         }
+                                     }), (bestMatch = $.extend({}, bestMatch, {
+                                         input: getPlaceholder(ps, bestMatch.match, !0) || bestMatch.match.def
+-                                    })).generatedInput = !0, setValidPosition(ps, bestMatch, !0), getMaskSet().validPositions[newPos] = undefined, 
++                                    })).generatedInput = !0, setValidPosition(ps, bestMatch, !0), getMaskSet().validPositions[newPos] = undefined,
+                                     _isValid(newPos, vp.input, !0);
+                                 }
+                             }(maskPos, result.pos !== undefined ? result.pos : nPos), maskPos = nPos;
+@@ -441,7 +441,7 @@ export function factory($, window, document, undefined) {
+                 !1 === result && opts.keepStatic && !strict && !0 !== fromAlternate && (result = function(pos, c, strict) {
+                     var lastAlt, alternation, altPos, prevAltPos, i, validPos, altNdxs, decisionPos, validPsClone = $.extend(!0, {}, getMaskSet().validPositions), isValidRslt = !1, lAltPos = getLastValidPosition();
+                     for (prevAltPos = getMaskSet().validPositions[lAltPos]; lAltPos >= 0; lAltPos--) if ((altPos = getMaskSet().validPositions[lAltPos]) && altPos.alternation !== undefined) {
+-                        if (lastAlt = lAltPos, alternation = getMaskSet().validPositions[lastAlt].alternation, 
++                        if (lastAlt = lAltPos, alternation = getMaskSet().validPositions[lastAlt].alternation,
+                         prevAltPos.locator[altPos.alternation] !== altPos.locator[altPos.alternation]) break;
+                         prevAltPos = altPos;
+                     }
+@@ -457,14 +457,14 @@ export function factory($, window, document, undefined) {
+                                 if (decisionTaker < altNdxs[mndx] && (test.na === undefined || -1 === $.inArray(altNdxs[mndx], test.na.split(",")) || -1 === $.inArray(decisionTaker.toString(), altNdxs))) {
+                                     getMaskSet().validPositions[decisionPos] = $.extend(!0, {}, test);
+                                     var possibilities = getMaskSet().validPositions[decisionPos].locator;
+-                                    for (getMaskSet().validPositions[decisionPos].locator[alternation] = parseInt(altNdxs[mndx]), 
+-                                    null == test.match.fn ? (possibilityPos.input !== test.match.def && (verifyValidInput = !0, 
+-                                    !0 !== possibilityPos.generatedInput && validInputs.push(possibilityPos.input)), 
+-                                    staticInputsBeforePosAlternate++, getMaskSet().validPositions[decisionPos].generatedInput = !/[0-9a-bA-Z]/.test(test.match.def), 
+-                                    getMaskSet().validPositions[decisionPos].input = test.match.def) : getMaskSet().validPositions[decisionPos].input = possibilityPos.input, 
+-                                    i = decisionPos + 1; i < getLastValidPosition(undefined, !0) + 1; i++) (validPos = getMaskSet().validPositions[i]) && !0 !== validPos.generatedInput && /[0-9a-bA-Z]/.test(validPos.input) ? validInputs.push(validPos.input) : i < pos && staticInputsBeforePos++, 
++                                    for (getMaskSet().validPositions[decisionPos].locator[alternation] = parseInt(altNdxs[mndx]),
++                                    null == test.match.fn ? (possibilityPos.input !== test.match.def && (verifyValidInput = !0,
++                                    !0 !== possibilityPos.generatedInput && validInputs.push(possibilityPos.input)),
++                                    staticInputsBeforePosAlternate++, getMaskSet().validPositions[decisionPos].generatedInput = !/[0-9a-bA-Z]/.test(test.match.def),
++                                    getMaskSet().validPositions[decisionPos].input = test.match.def) : getMaskSet().validPositions[decisionPos].input = possibilityPos.input,
++                                    i = decisionPos + 1; i < getLastValidPosition(undefined, !0) + 1; i++) (validPos = getMaskSet().validPositions[i]) && !0 !== validPos.generatedInput && /[0-9a-bA-Z]/.test(validPos.input) ? validInputs.push(validPos.input) : i < pos && staticInputsBeforePos++,
+                                     delete getMaskSet().validPositions[i];
+-                                    for (verifyValidInput && validInputs[0] === test.match.def && validInputs.shift(), 
++                                    for (verifyValidInput && validInputs[0] === test.match.def && validInputs.shift(),
+                                     resetMaskSet(!0), isValidRslt = !0; validInputs.length > 0; ) {
+                                         var input = validInputs.shift();
+                                         if (input !== opts.skipOptionalPartCharacter && !(isValidRslt = isValid(getLastValidPosition(undefined, !0) + 1, input, !1, fromSetValid, !0))) break;
+@@ -494,7 +494,7 @@ export function factory($, window, document, undefined) {
+                 }
+                 result = !0 === postResult ? result : postResult;
+             }
+-            return result && result.pos === undefined && (result.pos = maskPos), !1 !== result && !0 !== validateOnly || (resetMaskSet(!0), 
++            return result && result.pos === undefined && (result.pos = maskPos), !1 !== result && !0 !== validateOnly || (resetMaskSet(!0),
+             getMaskSet().validPositions = $.extend(!0, {}, positionsClone)), result;
+         }
+         function isMask(pos, strict) {
+@@ -528,7 +528,7 @@ export function factory($, window, document, undefined) {
+                 if (result) {
+                     if (result.refreshFromBuffer) {
+                         var refresh = result.refreshFromBuffer;
+-                        refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, result.buffer || buffer), 
++                        refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, result.buffer || buffer),
+                         buffer = getBuffer(!0);
+                     }
+                     caretPos !== undefined && (caretPos = result.caret !== undefined ? result.caret : caretPos);
+@@ -536,7 +536,7 @@ export function factory($, window, document, undefined) {
+             }
+             input !== undefined && (input.inputmask._valueSet(buffer.join("")), caretPos === undefined || event !== undefined && "blur" === event.type ? renderColorMask(input, caretPos, 0 === buffer.length) : android && event && "input" === event.type ? setTimeout(function() {
+                 caret(input, caretPos);
+-            }, 0) : caret(input, caretPos), !0 === triggerInputEvent && (skipInputEvent = !0, 
++            }, 0) : caret(input, caretPos), !0 === triggerInputEvent && (skipInputEvent = !0,
+             $(input).trigger("input")));
+         }
+         function getPlaceholder(pos, test, returnPL) {
+@@ -544,7 +544,7 @@ export function factory($, window, document, undefined) {
+             if (null === test.fn) {
+                 if (pos > -1 && getMaskSet().validPositions[pos] === undefined) {
+                     var prevTest, tests = getTests(pos), staticAlternations = [];
+-                    if (tests.length > 1 + ("" === tests[tests.length - 1].match.def ? 1 : 0)) for (var i = 0; i < tests.length; i++) if (!0 !== tests[i].match.optionality && !0 !== tests[i].match.optionalQuantifier && (null === tests[i].match.fn || prevTest === undefined || !1 !== tests[i].match.fn.test(prevTest.match.def, getMaskSet(), pos, !0, opts)) && (staticAlternations.push(tests[i]), 
++                    if (tests.length > 1 + ("" === tests[tests.length - 1].match.def ? 1 : 0)) for (var i = 0; i < tests.length; i++) if (!0 !== tests[i].match.optionality && !0 !== tests[i].match.optionalQuantifier && (null === tests[i].match.fn || prevTest === undefined || !1 !== tests[i].match.fn.test(prevTest.match.def, getMaskSet(), pos, !0, opts)) && (staticAlternations.push(tests[i]),
+                     null === tests[i].match.fn && (prevTest = tests[i]), staticAlternations.length > 1 && /[0-9a-bA-Z]/.test(staticAlternations[0].match.def))) return opts.placeholder.charAt(pos % opts.placeholder.length);
+                 }
+                 return test.def;
+@@ -558,10 +558,10 @@ export function factory($, window, document, undefined) {
+             var inputValue = nptvl.slice(), charCodes = "", initialNdx = -1, result = undefined;
+             if (resetMaskSet(), strict || !0 === opts.autoUnmask) initialNdx = seekNext(initialNdx); else {
+                 var staticInput = getBufferTemplate().slice(0, seekNext(-1)).join(""), matches = inputValue.join("").match(new RegExp("^" + Inputmask.escapeRegex(staticInput), "g"));
+-                matches && matches.length > 0 && (inputValue.splice(0, matches.length * staticInput.length), 
++                matches && matches.length > 0 && (inputValue.splice(0, matches.length * staticInput.length),
+                 initialNdx = seekNext(initialNdx));
+             }
+-            if (-1 === initialNdx ? (getMaskSet().p = seekNext(initialNdx), initialNdx = 0) : getMaskSet().p = initialNdx, 
++            if (-1 === initialNdx ? (getMaskSet().p = seekNext(initialNdx), initialNdx = 0) : getMaskSet().p = initialNdx,
+             $.each(inputValue, function(ndx, charCode) {
+                 if (charCode !== undefined) if (getMaskSet().validPositions[ndx] === undefined && inputValue[ndx] === getPlaceholder(ndx) && isMask(ndx, !0) && !1 === isValid(ndx, inputValue[ndx], !0, undefined, undefined, !0)) getMaskSet().p++; else {
+                     var keypress = new $.Event("_checkval");
+@@ -569,22 +569,22 @@ export function factory($, window, document, undefined) {
+                     var lvp = getLastValidPosition(undefined, !0), lvTest = getMaskSet().validPositions[lvp], nextTest = getTestTemplate(lvp + 1, lvTest ? lvTest.locator.slice() : undefined, lvp);
+                     if (!isTemplateMatch(initialNdx, charCodes) || strict || opts.autoUnmask) {
+                         var pos = strict ? ndx : null == nextTest.match.fn && nextTest.match.optionality && lvp + 1 < getMaskSet().p ? lvp + 1 : getMaskSet().p;
+-                        result = EventHandlers.keypressEvent.call(input, keypress, !0, !1, strict, pos), 
++                        result = EventHandlers.keypressEvent.call(input, keypress, !0, !1, strict, pos),
+                         initialNdx = pos + 1, charCodes = "";
+                     } else result = EventHandlers.keypressEvent.call(input, keypress, !0, !1, !0, lvp + 1);
+                     if (!1 !== result && !strict && $.isFunction(opts.onBeforeWrite)) {
+                         var origResult = result;
+-                        if (result = opts.onBeforeWrite.call(inputmask, keypress, getBuffer(), result.forwardPosition, opts), 
++                        if (result = opts.onBeforeWrite.call(inputmask, keypress, getBuffer(), result.forwardPosition, opts),
+                         (result = $.extend(origResult, result)) && result.refreshFromBuffer) {
+                             var refresh = result.refreshFromBuffer;
+-                            refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, result.buffer), 
++                            refreshFromBuffer(!0 === refresh ? refresh : refresh.start, refresh.end, result.buffer),
+                             resetMaskSet(!0), result.caret && (getMaskSet().p = result.caret, result.forwardPosition = result.caret);
+                         }
+                     }
+                 }
+             }), writeOut) {
+                 var caretPos = undefined;
+-                document.activeElement === input && result && (caretPos = opts.numericInput ? seekPrevious(result.forwardPosition) : result.forwardPosition), 
++                document.activeElement === input && result && (caretPos = opts.numericInput ? seekPrevious(result.forwardPosition) : result.forwardPosition),
+                 writeBuffer(input, getBuffer(), caretPos, initiatingEvent || new $.Event("checkval"), initiatingEvent && "input" === initiatingEvent.type);
+             }
+         }
+@@ -604,13 +604,13 @@ export function factory($, window, document, undefined) {
+         }
+         function caret(input, begin, end, notranslate) {
+             function translatePosition(pos) {
+-                return !0 === notranslate || !isRTL || "number" != typeof pos || opts.greedy && "" === opts.placeholder || (pos = getBuffer().join("").length - pos), 
++                return !0 === notranslate || !isRTL || "number" != typeof pos || opts.greedy && "" === opts.placeholder || (pos = getBuffer().join("").length - pos),
+                 pos;
+             }
+             var range;
+-            if (begin === undefined) return input.setSelectionRange ? (begin = input.selectionStart, 
+-            end = input.selectionEnd) : window.getSelection ? (range = window.getSelection().getRangeAt(0)).commonAncestorContainer.parentNode !== input && range.commonAncestorContainer !== input || (begin = range.startOffset, 
+-            end = range.endOffset) : document.selection && document.selection.createRange && (end = (begin = 0 - (range = document.selection.createRange()).duplicate().moveStart("character", -input.inputmask._valueGet().length)) + range.text.length), 
++            if (begin === undefined) return input.setSelectionRange ? (begin = input.selectionStart,
++            end = input.selectionEnd) : window.getSelection ? (range = window.getSelection().getRangeAt(0)).commonAncestorContainer.parentNode !== input && range.commonAncestorContainer !== input || (begin = range.startOffset,
++            end = range.endOffset) : document.selection && document.selection.createRange && (end = (begin = 0 - (range = document.selection.createRange()).duplicate().moveStart("character", -input.inputmask._valueGet().length)) + range.text.length),
+             {
+                 begin: translatePosition(begin),
+                 end: translatePosition(end)
+@@ -618,18 +618,18 @@ export function factory($, window, document, undefined) {
+             if (begin.begin !== undefined && (end = begin.end, begin = begin.begin), "number" == typeof begin) {
+                 begin = translatePosition(begin), end = "number" == typeof (end = translatePosition(end)) ? end : begin;
+                 var scrollCalc = parseInt(((input.ownerDocument.defaultView || window).getComputedStyle ? (input.ownerDocument.defaultView || window).getComputedStyle(input, null) : input.currentStyle).fontSize) * end;
+-                if (input.scrollLeft = scrollCalc > input.scrollWidth ? scrollCalc : 0, mobile || !1 !== opts.insertMode || begin !== end || end++, 
++                if (input.scrollLeft = scrollCalc > input.scrollWidth ? scrollCalc : 0, mobile || !1 !== opts.insertMode || begin !== end || end++,
+                 input.setSelectionRange) input.selectionStart = begin, input.selectionEnd = end; else if (window.getSelection) {
+                     if (range = document.createRange(), input.firstChild === undefined || null === input.firstChild) {
+                         var textNode = document.createTextNode("");
+                         input.appendChild(textNode);
+                     }
+-                    range.setStart(input.firstChild, begin < input.inputmask._valueGet().length ? begin : input.inputmask._valueGet().length), 
+-                    range.setEnd(input.firstChild, end < input.inputmask._valueGet().length ? end : input.inputmask._valueGet().length), 
++                    range.setStart(input.firstChild, begin < input.inputmask._valueGet().length ? begin : input.inputmask._valueGet().length),
++                    range.setEnd(input.firstChild, end < input.inputmask._valueGet().length ? end : input.inputmask._valueGet().length),
+                     range.collapse(!0);
+                     var sel = window.getSelection();
+                     sel.removeAllRanges(), sel.addRange(range);
+-                } else input.createTextRange && ((range = input.createTextRange()).collapse(!0), 
++                } else input.createTextRange && ((range = input.createTextRange()).collapse(!0),
+                 range.moveEnd("character", end), range.moveStart("character", begin), range.select());
+                 renderColorMask(input, {
+                     begin: begin,
+@@ -639,7 +639,7 @@ export function factory($, window, document, undefined) {
+         }
+         function determineLastRequiredPosition(returnDefinition) {
+             var pos, testPos, buffer = getBuffer(), bl = buffer.length, lvp = getLastValidPosition(), positions = {}, lvTest = getMaskSet().validPositions[lvp], ndxIntlzr = lvTest !== undefined ? lvTest.locator.slice() : undefined;
+-            for (pos = lvp + 1; pos < buffer.length; pos++) ndxIntlzr = (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1)).locator.slice(), 
++            for (pos = lvp + 1; pos < buffer.length; pos++) ndxIntlzr = (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1)).locator.slice(),
+             positions[pos] = $.extend(!0, {}, testPos);
+             var lvTestAlt = lvTest && lvTest.alternation !== undefined ? lvTest.locator[lvTest.alternation] : undefined;
+             for (pos = bl - 1; pos > lvp && (((testPos = positions[pos]).match.optionality || testPos.match.optionalQuantifier && testPos.match.newBlockMarker || lvTestAlt && (lvTestAlt !== positions[pos].locator[lvTest.alternation] && null != testPos.match.fn || null === testPos.match.fn && testPos.locator[lvTest.alternation] && checkAlternationMatch(testPos.locator[lvTest.alternation].toString().split(","), lvTestAlt.toString().split(",")) && "" !== getTests(pos)[0].def)) && buffer[pos] === getPlaceholder(pos, testPos.match)); pos--) bl--;
+@@ -670,20 +670,20 @@ export function factory($, window, document, undefined) {
+             return complete;
+         }
+         function handleRemove(input, k, pos, strict, fromIsValid) {
+-            if ((opts.numericInput || isRTL) && (k === Inputmask.keyCode.BACKSPACE ? k = Inputmask.keyCode.DELETE : k === Inputmask.keyCode.DELETE && (k = Inputmask.keyCode.BACKSPACE), 
++            if ((opts.numericInput || isRTL) && (k === Inputmask.keyCode.BACKSPACE ? k = Inputmask.keyCode.DELETE : k === Inputmask.keyCode.DELETE && (k = Inputmask.keyCode.BACKSPACE),
+             isRTL)) {
+                 var pend = pos.end;
+                 pos.end = pos.begin, pos.begin = pend;
+             }
+-            k === Inputmask.keyCode.BACKSPACE && (pos.end - pos.begin < 1 || !1 === opts.insertMode) ? (pos.begin = seekPrevious(pos.begin), 
+-            getMaskSet().validPositions[pos.begin] !== undefined && getMaskSet().validPositions[pos.begin].input === opts.groupSeparator && pos.begin--) : k === Inputmask.keyCode.DELETE && pos.begin === pos.end && (pos.end = isMask(pos.end, !0) && getMaskSet().validPositions[pos.end] && getMaskSet().validPositions[pos.end].input !== opts.radixPoint ? pos.end + 1 : seekNext(pos.end) + 1, 
+-            getMaskSet().validPositions[pos.begin] !== undefined && getMaskSet().validPositions[pos.begin].input === opts.groupSeparator && pos.end++), 
++            k === Inputmask.keyCode.BACKSPACE && (pos.end - pos.begin < 1 || !1 === opts.insertMode) ? (pos.begin = seekPrevious(pos.begin),
++            getMaskSet().validPositions[pos.begin] !== undefined && getMaskSet().validPositions[pos.begin].input === opts.groupSeparator && pos.begin--) : k === Inputmask.keyCode.DELETE && pos.begin === pos.end && (pos.end = isMask(pos.end, !0) && getMaskSet().validPositions[pos.end] && getMaskSet().validPositions[pos.end].input !== opts.radixPoint ? pos.end + 1 : seekNext(pos.end) + 1,
++            getMaskSet().validPositions[pos.begin] !== undefined && getMaskSet().validPositions[pos.begin].input === opts.groupSeparator && pos.end++),
+             stripValidPositions(pos.begin, pos.end, !1, strict), !0 !== strict && function() {
+                 if (opts.keepStatic) {
+                     for (var validInputs = [], lastAlt = getLastValidPosition(-1, !0), positionsClone = $.extend(!0, {}, getMaskSet().validPositions), prevAltPos = getMaskSet().validPositions[lastAlt]; lastAlt >= 0; lastAlt--) {
+                         var altPos = getMaskSet().validPositions[lastAlt];
+                         if (altPos) {
+-                            if (!0 !== altPos.generatedInput && /[0-9a-bA-Z]/.test(altPos.input) && validInputs.push(altPos.input), 
++                            if (!0 !== altPos.generatedInput && /[0-9a-bA-Z]/.test(altPos.input) && validInputs.push(altPos.input),
+                             delete getMaskSet().validPositions[lastAlt], altPos.alternation !== undefined && altPos.locator[altPos.alternation] !== prevAltPos.locator[altPos.alternation]) break;
+                             prevAltPos = altPos;
+                         }
+@@ -695,15 +695,15 @@ export function factory($, window, document, undefined) {
+                 }
+             }();
+             var lvp = getLastValidPosition(pos.begin, !0);
+-            if (lvp < pos.begin) getMaskSet().p = seekNext(lvp); else if (!0 !== strict && (getMaskSet().p = pos.begin, 
++            if (lvp < pos.begin) getMaskSet().p = seekNext(lvp); else if (!0 !== strict && (getMaskSet().p = pos.begin,
+             !0 !== fromIsValid)) for (;getMaskSet().p < lvp && getMaskSet().validPositions[getMaskSet().p] === undefined; ) getMaskSet().p++;
+         }
+         function initializeColorMask(input) {
+             function findCaretPos(clientx) {
+                 var caretPos, e = document.createElement("span");
+                 for (var style in computedStyle) isNaN(style) && -1 !== style.indexOf("font") && (e.style[style] = computedStyle[style]);
+-                e.style.textTransform = computedStyle.textTransform, e.style.letterSpacing = computedStyle.letterSpacing, 
+-                e.style.position = "absolute", e.style.height = "auto", e.style.width = "auto", 
++                e.style.textTransform = computedStyle.textTransform, e.style.letterSpacing = computedStyle.letterSpacing,
++                e.style.position = "absolute", e.style.height = "auto", e.style.width = "auto",
+                 e.style.visibility = "hidden", e.style.whiteSpace = "nowrap", document.body.appendChild(e);
+                 var itl, inputText = input.inputmask._valueGet(), previousWidth = 0;
+                 for (caretPos = 0, itl = inputText.length; caretPos <= itl; caretPos++) {
+@@ -717,9 +717,9 @@ export function factory($, window, document, undefined) {
+                 return document.body.removeChild(e), caretPos;
+             }
+             var computedStyle = (input.ownerDocument.defaultView || window).getComputedStyle(input, null), template = document.createElement("div");
+-            template.style.width = computedStyle.width, template.style.textAlign = computedStyle.textAlign, 
+-            (colorMask = document.createElement("div")).className = "im-colormask", input.parentNode.insertBefore(colorMask, input), 
+-            input.parentNode.removeChild(input), colorMask.appendChild(template), colorMask.appendChild(input), 
++            template.style.width = computedStyle.width, template.style.textAlign = computedStyle.textAlign,
++            (colorMask = document.createElement("div")).className = "im-colormask", input.parentNode.insertBefore(colorMask, input),
++            input.parentNode.removeChild(input), colorMask.appendChild(template), colorMask.appendChild(input),
+             input.style.left = template.offsetLeft + "px", $(input).on("click", function(e) {
+                 return caret(input, findCaretPos(e.clientX)), EventHandlers.clickEvent.call(input, [ e ]);
+             }), $(input).on("keydown", function(e) {
+@@ -730,7 +730,7 @@ export function factory($, window, document, undefined) {
+         }
+         function renderColorMask(input, caretPos, clear) {
+             function handleStatic() {
+-                isStatic || null !== test.fn && testPos.input !== undefined ? isStatic && (null !== test.fn && testPos.input !== undefined || "" === test.def) && (isStatic = !1, 
++                isStatic || null !== test.fn && testPos.input !== undefined ? isStatic && (null !== test.fn && testPos.input !== undefined || "" === test.def) && (isStatic = !1,
+                 maskTemplate += "</span>") : (isStatic = !0, maskTemplate += "<span class='im-static'>");
+             }
+             function handleCaret(force) {
+@@ -745,9 +745,9 @@ export function factory($, window, document, undefined) {
+                 }), !0 !== clear) {
+                     var lvp = getLastValidPosition();
+                     do {
+-                        handleCaret(), getMaskSet().validPositions[pos] ? (testPos = getMaskSet().validPositions[pos], 
+-                        test = testPos.match, ndxIntlzr = testPos.locator.slice(), handleStatic(), maskTemplate += buffer[pos]) : (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1), 
+-                        test = testPos.match, ndxIntlzr = testPos.locator.slice(), (!1 === opts.jitMasking || pos < lvp || "number" == typeof opts.jitMasking && isFinite(opts.jitMasking) && opts.jitMasking > pos) && (handleStatic(), 
++                        handleCaret(), getMaskSet().validPositions[pos] ? (testPos = getMaskSet().validPositions[pos],
++                        test = testPos.match, ndxIntlzr = testPos.locator.slice(), handleStatic(), maskTemplate += buffer[pos]) : (testPos = getTestTemplate(pos, ndxIntlzr, pos - 1),
++                        test = testPos.match, ndxIntlzr = testPos.locator.slice(), (!1 === opts.jitMasking || pos < lvp || "number" == typeof opts.jitMasking && isFinite(opts.jitMasking) && opts.jitMasking > pos) && (handleStatic(),
+                         maskTemplate += getPlaceholder(pos, test))), pos++;
+                     } while ((maxLength === undefined || pos < maxLength) && (null !== test.fn || "" !== test.def) || lvp > pos || isStatic);
+                     -1 === maskTemplate.indexOf("im-caret") && handleCaret(!0), isStatic && handleStatic();
+@@ -793,13 +793,13 @@ export function factory($, window, document, undefined) {
+                         e.preventDefault();
+                     }
+                 };
+-                input.inputmask.events[eventName] = input.inputmask.events[eventName] || [], input.inputmask.events[eventName].push(ev), 
++                input.inputmask.events[eventName] = input.inputmask.events[eventName] || [], input.inputmask.events[eventName].push(ev),
+                 -1 !== $.inArray(eventName, [ "submit", "reset" ]) ? null !== input.form && $(input.form).on(eventName, ev) : $(input).on(eventName, ev);
+             },
+             off: function(input, event) {
+                 if (input.inputmask && input.inputmask.events) {
+                     var events;
+-                    event ? (events = [])[event] = input.inputmask.events[event] : events = input.inputmask.events, 
++                    event ? (events = [])[event] = input.inputmask.events[event] : events = input.inputmask.events,
+                     $.each(events, function(eventName, evArr) {
+                         for (;evArr.length > 0; ) {
+                             var ev = evArr.pop();
+@@ -814,19 +814,19 @@ export function factory($, window, document, undefined) {
+                 var input = this, $input = $(input), k = e.keyCode, pos = caret(input);
+                 if (k === Inputmask.keyCode.BACKSPACE || k === Inputmask.keyCode.DELETE || iphone && k === Inputmask.keyCode.BACKSPACE_SAFARI || e.ctrlKey && k === Inputmask.keyCode.X && !function(eventName) {
+                     var el = document.createElement("input"), evName = "on" + eventName, isSupported = evName in el;
+-                    return isSupported || (el.setAttribute(evName, "return;"), isSupported = "function" == typeof el[evName]), 
++                    return isSupported || (el.setAttribute(evName, "return;"), isSupported = "function" == typeof el[evName]),
+                     el = null, isSupported;
+-                }("cut")) e.preventDefault(), handleRemove(input, k, pos), writeBuffer(input, getBuffer(!0), getMaskSet().p, e, input.inputmask._valueGet() !== getBuffer().join("")), 
++                }("cut")) e.preventDefault(), handleRemove(input, k, pos), writeBuffer(input, getBuffer(!0), getMaskSet().p, e, input.inputmask._valueGet() !== getBuffer().join("")),
+                 input.inputmask._valueGet() === getBufferTemplate().join("") ? $input.trigger("cleared") : !0 === isComplete(getBuffer()) && $input.trigger("complete"); else if (k === Inputmask.keyCode.END || k === Inputmask.keyCode.PAGE_DOWN) {
+                     e.preventDefault();
+                     var caretPos = seekNext(getLastValidPosition());
+-                    opts.insertMode || caretPos !== getMaskSet().maskLength || e.shiftKey || caretPos--, 
++                    opts.insertMode || caretPos !== getMaskSet().maskLength || e.shiftKey || caretPos--,
+                     caret(input, e.shiftKey ? pos.begin : caretPos, caretPos, !0);
+-                } else k === Inputmask.keyCode.HOME && !e.shiftKey || k === Inputmask.keyCode.PAGE_UP ? (e.preventDefault(), 
+-                caret(input, 0, e.shiftKey ? pos.begin : 0, !0)) : (opts.undoOnEscape && k === Inputmask.keyCode.ESCAPE || 90 === k && e.ctrlKey) && !0 !== e.altKey ? (checkVal(input, !0, !1, undoValue.split("")), 
+-                $input.trigger("click")) : k !== Inputmask.keyCode.INSERT || e.shiftKey || e.ctrlKey ? !0 === opts.tabThrough && k === Inputmask.keyCode.TAB ? (!0 === e.shiftKey ? (null === getTest(pos.begin).match.fn && (pos.begin = seekNext(pos.begin)), 
+-                pos.end = seekPrevious(pos.begin, !0), pos.begin = seekPrevious(pos.end, !0)) : (pos.begin = seekNext(pos.begin, !0), 
+-                pos.end = seekNext(pos.begin, !0), pos.end < getMaskSet().maskLength && pos.end--), 
++                } else k === Inputmask.keyCode.HOME && !e.shiftKey || k === Inputmask.keyCode.PAGE_UP ? (e.preventDefault(),
++                caret(input, 0, e.shiftKey ? pos.begin : 0, !0)) : (opts.undoOnEscape && k === Inputmask.keyCode.ESCAPE || 90 === k && e.ctrlKey) && !0 !== e.altKey ? (checkVal(input, !0, !1, undoValue.split("")),
++                $input.trigger("click")) : k !== Inputmask.keyCode.INSERT || e.shiftKey || e.ctrlKey ? !0 === opts.tabThrough && k === Inputmask.keyCode.TAB ? (!0 === e.shiftKey ? (null === getTest(pos.begin).match.fn && (pos.begin = seekNext(pos.begin)),
++                pos.end = seekPrevious(pos.begin, !0), pos.begin = seekPrevious(pos.end, !0)) : (pos.begin = seekNext(pos.begin, !0),
++                pos.end = seekNext(pos.begin, !0), pos.end < getMaskSet().maskLength && pos.end--),
+                 pos.begin < getMaskSet().maskLength && (e.preventDefault(), caret(input, pos.begin, pos.end))) : e.shiftKey || !1 === opts.insertMode && (k === Inputmask.keyCode.RIGHT ? setTimeout(function() {
+                     var caretPos = caret(input);
+                     caret(input, caretPos.begin);
+@@ -838,7 +838,7 @@ export function factory($, window, document, undefined) {
+             },
+             keypressEvent: function(e, checkval, writeOut, strict, ndx) {
+                 var input = this, $input = $(input), k = e.which || e.charCode || e.keyCode;
+-                if (!(!0 === checkval || e.ctrlKey && e.altKey) && (e.ctrlKey || e.metaKey || ignorable)) return k === Inputmask.keyCode.ENTER && undoValue !== getBuffer().join("") && (undoValue = getBuffer().join(""), 
++                if (!(!0 === checkval || e.ctrlKey && e.altKey) && (e.ctrlKey || e.metaKey || ignorable)) return k === Inputmask.keyCode.ENTER && undoValue !== getBuffer().join("") && (undoValue = getBuffer().join(""),
+                 setTimeout(function() {
+                     $input.trigger("change");
+                 }, 0)), !0;
+@@ -850,17 +850,17 @@ export function factory($, window, document, undefined) {
+                     } : caret(input), c = String.fromCharCode(k);
+                     getMaskSet().writeOutBuffer = !0;
+                     var valResult = isValid(pos, c, strict);
+-                    if (!1 !== valResult && (resetMaskSet(!0), forwardPosition = valResult.caret !== undefined ? valResult.caret : checkval ? valResult.pos + 1 : seekNext(valResult.pos), 
++                    if (!1 !== valResult && (resetMaskSet(!0), forwardPosition = valResult.caret !== undefined ? valResult.caret : checkval ? valResult.pos + 1 : seekNext(valResult.pos),
+                     getMaskSet().p = forwardPosition), !1 !== writeOut && (setTimeout(function() {
+                         opts.onKeyValidation.call(input, k, valResult, opts);
+                     }, 0), getMaskSet().writeOutBuffer && !1 !== valResult)) {
+                         var buffer = getBuffer();
+-                        writeBuffer(input, buffer, opts.numericInput && valResult.caret === undefined ? seekPrevious(forwardPosition) : forwardPosition, e, !0 !== checkval), 
++                        writeBuffer(input, buffer, opts.numericInput && valResult.caret === undefined ? seekPrevious(forwardPosition) : forwardPosition, e, !0 !== checkval),
+                         !0 !== checkval && setTimeout(function() {
+                             !0 === isComplete(buffer) && $input.trigger("complete");
+                         }, 0);
+                     }
+-                    if (e.preventDefault(), checkval) return !1 !== valResult && (valResult.forwardPosition = forwardPosition), 
++                    if (e.preventDefault(), checkval) return !1 !== valResult && (valResult.forwardPosition = forwardPosition),
+                     valResult;
+                 }
+             },
+@@ -868,9 +868,9 @@ export function factory($, window, document, undefined) {
+                 var tempValue, input = this, ev = e.originalEvent || e, $input = $(input), inputValue = input.inputmask._valueGet(!0), caretPos = caret(input);
+                 isRTL && (tempValue = caretPos.end, caretPos.end = caretPos.begin, caretPos.begin = tempValue);
+                 var valueBeforeCaret = inputValue.substr(0, caretPos.begin), valueAfterCaret = inputValue.substr(caretPos.end, inputValue.length);
+-                if (valueBeforeCaret === (isRTL ? getBufferTemplate().reverse() : getBufferTemplate()).slice(0, caretPos.begin).join("") && (valueBeforeCaret = ""), 
+-                valueAfterCaret === (isRTL ? getBufferTemplate().reverse() : getBufferTemplate()).slice(caretPos.end).join("") && (valueAfterCaret = ""), 
+-                isRTL && (tempValue = valueBeforeCaret, valueBeforeCaret = valueAfterCaret, valueAfterCaret = tempValue), 
++                if (valueBeforeCaret === (isRTL ? getBufferTemplate().reverse() : getBufferTemplate()).slice(0, caretPos.begin).join("") && (valueBeforeCaret = ""),
++                valueAfterCaret === (isRTL ? getBufferTemplate().reverse() : getBufferTemplate()).slice(caretPos.end).join("") && (valueAfterCaret = ""),
++                isRTL && (tempValue = valueBeforeCaret, valueBeforeCaret = valueAfterCaret, valueAfterCaret = tempValue),
+                 window.clipboardData && window.clipboardData.getData) inputValue = valueBeforeCaret + window.clipboardData.getData("Text") + valueAfterCaret; else {
+                     if (!ev.clipboardData || !ev.clipboardData.getData) return !0;
+                     inputValue = valueBeforeCaret + ev.clipboardData.getData("text/plain") + valueAfterCaret;
+@@ -880,8 +880,8 @@ export function factory($, window, document, undefined) {
+                     if (!1 === (pasteValue = opts.onBeforePaste.call(inputmask, inputValue, opts))) return e.preventDefault();
+                     pasteValue || (pasteValue = inputValue);
+                 }
+-                return checkVal(input, !1, !1, isRTL ? pasteValue.split("").reverse() : pasteValue.toString().split("")), 
+-                writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join("")), 
++                return checkVal(input, !1, !1, isRTL ? pasteValue.split("").reverse() : pasteValue.toString().split("")),
++                writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join("")),
+                 !0 === isComplete(getBuffer()) && $input.trigger("complete"), e.preventDefault();
+             },
+             inputFallBackEvent: function(e) {
+@@ -889,20 +889,20 @@ export function factory($, window, document, undefined) {
+                 if (getBuffer().join("") !== inputValue) {
+                     var caretPos = caret(input);
+                     if (!1 === function(input, inputValue, caretPos) {
+-                        if ("." === inputValue.charAt(caretPos.begin - 1) && "" !== opts.radixPoint && ((inputValue = inputValue.split(""))[caretPos.begin - 1] = opts.radixPoint.charAt(0), 
++                        if ("." === inputValue.charAt(caretPos.begin - 1) && "" !== opts.radixPoint && ((inputValue = inputValue.split(""))[caretPos.begin - 1] = opts.radixPoint.charAt(0),
+                         inputValue = inputValue.join("")), inputValue.charAt(caretPos.begin - 1) === opts.radixPoint && inputValue.length > getBuffer().length) {
+                             var keypress = new $.Event("keypress");
+-                            return keypress.which = opts.radixPoint.charCodeAt(0), EventHandlers.keypressEvent.call(input, keypress, !0, !0, !1, caretPos.begin - 1), 
++                            return keypress.which = opts.radixPoint.charCodeAt(0), EventHandlers.keypressEvent.call(input, keypress, !0, !0, !1, caretPos.begin - 1),
+                             !1;
+                         }
+                     }(input, inputValue, caretPos)) return !1;
+-                    if (inputValue = inputValue.replace(new RegExp("(" + Inputmask.escapeRegex(getBufferTemplate().join("")) + ")*"), ""), 
++                    if (inputValue = inputValue.replace(new RegExp("(" + Inputmask.escapeRegex(getBufferTemplate().join("")) + ")*"), ""),
+                     !1 === function(input, inputValue, caretPos) {
+                         if (iemobile) {
+                             var inputChar = inputValue.replace(getBuffer().join(""), "");
+                             if (1 === inputChar.length) {
+                                 var keypress = new $.Event("keypress");
+-                                return keypress.which = inputChar.charCodeAt(0), EventHandlers.keypressEvent.call(input, keypress, !0, !0, !1, getMaskSet().validPositions[caretPos.begin - 1] ? caretPos.begin : caretPos.begin - 1), 
++                                return keypress.which = inputChar.charCodeAt(0), EventHandlers.keypressEvent.call(input, keypress, !0, !0, !1, getMaskSet().validPositions[caretPos.begin - 1] ? caretPos.begin : caretPos.begin - 1),
+                                 !1;
+                             }
+                         }
+@@ -914,33 +914,33 @@ export function factory($, window, document, undefined) {
+                         for (var fpl = (isEntry = frontPart.length >= frontBufferPart.length) ? frontPart.length : frontBufferPart.length, i = 0; frontPart.charAt(i) === frontBufferPart.charAt(i) && i < fpl; i++) selection.begin++;
+                         isEntry && (entries += frontPart.slice(selection.begin, selection.end));
+                     }
+-                    backPart !== backBufferPart && (backPart.length > backBufferPart.length ? isEntry && (selection.end = selection.begin) : backPart.length < backBufferPart.length ? selection.end += backBufferPart.length - backPart.length : backPart.charAt(0) !== backBufferPart.charAt(0) && selection.end++), 
++                    backPart !== backBufferPart && (backPart.length > backBufferPart.length ? isEntry && (selection.end = selection.begin) : backPart.length < backBufferPart.length ? selection.end += backBufferPart.length - backPart.length : backPart.charAt(0) !== backBufferPart.charAt(0) && selection.end++),
+                     writeBuffer(input, getBuffer(), selection), entries.length > 0 ? $.each(entries.split(""), function(ndx, entry) {
+                         var keypress = new $.Event("keypress");
+                         keypress.which = entry.charCodeAt(0), ignorable = !1, EventHandlers.keypressEvent.call(input, keypress);
+-                    }) : (selection.begin === selection.end - 1 && caret(input, seekPrevious(selection.begin + 1), selection.end), 
+-                    e.keyCode = Inputmask.keyCode.DELETE, EventHandlers.keydownEvent.call(input, e)), 
++                    }) : (selection.begin === selection.end - 1 && caret(input, seekPrevious(selection.begin + 1), selection.end),
++                    e.keyCode = Inputmask.keyCode.DELETE, EventHandlers.keydownEvent.call(input, e)),
+                     e.preventDefault();
+                 }
+             },
+             setValueEvent: function(e) {
+                 this.inputmask.refreshValue = !1;
+                 var input = this, value = input.inputmask._valueGet(!0);
+-                $.isFunction(opts.onBeforeMask) && (value = opts.onBeforeMask.call(inputmask, value, opts) || value), 
+-                value = value.split(""), checkVal(input, !0, !1, isRTL ? value.reverse() : value), 
++                $.isFunction(opts.onBeforeMask) && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
++                value = value.split(""), checkVal(input, !0, !1, isRTL ? value.reverse() : value),
+                 undoValue = getBuffer().join(""), (opts.clearMaskOnLostFocus || opts.clearIncomplete) && input.inputmask._valueGet() === getBufferTemplate().join("") && input.inputmask._valueSet("");
+             },
+             focusEvent: function(e) {
+                 var input = this, nptValue = input.inputmask._valueGet();
+-                opts.showMaskOnFocus && (!opts.showMaskOnHover || opts.showMaskOnHover && "" === nptValue) && (input.inputmask._valueGet() !== getBuffer().join("") ? writeBuffer(input, getBuffer(), seekNext(getLastValidPosition())) : !1 === mouseEnter && caret(input, seekNext(getLastValidPosition()))), 
+-                !0 === opts.positionCaretOnTab && !1 === mouseEnter && "" !== nptValue && (writeBuffer(input, getBuffer(), caret(input)), 
++                opts.showMaskOnFocus && (!opts.showMaskOnHover || opts.showMaskOnHover && "" === nptValue) && (input.inputmask._valueGet() !== getBuffer().join("") ? writeBuffer(input, getBuffer(), seekNext(getLastValidPosition())) : !1 === mouseEnter && caret(input, seekNext(getLastValidPosition()))),
++                !0 === opts.positionCaretOnTab && !1 === mouseEnter && "" !== nptValue && (writeBuffer(input, getBuffer(), caret(input)),
+                 EventHandlers.clickEvent.apply(input, [ e, !0 ])), undoValue = getBuffer().join("");
+             },
+             mouseleaveEvent: function(e) {
+                 var input = this;
+                 if (mouseEnter = !1, opts.clearMaskOnLostFocus && document.activeElement !== input) {
+                     var buffer = getBuffer().slice(), nptValue = input.inputmask._valueGet();
+-                    nptValue !== input.getAttribute("placeholder") && "" !== nptValue && (-1 === getLastValidPosition() && nptValue === getBufferTemplate().join("") ? buffer = [] : clearOptionalTail(buffer), 
++                    nptValue !== input.getAttribute("placeholder") && "" !== nptValue && (-1 === getLastValidPosition() && nptValue === getBufferTemplate().join("") ? buffer = [] : clearOptionalTail(buffer),
+                     writeBuffer(input, buffer));
+                 }
+             },
+@@ -963,7 +963,7 @@ export function factory($, window, document, undefined) {
+                 setTimeout(function() {
+                     if (document.activeElement === input) {
+                         var selectedCaret = caret(input);
+-                        if (tabbed && (isRTL ? selectedCaret.end = selectedCaret.begin : selectedCaret.begin = selectedCaret.end), 
++                        if (tabbed && (isRTL ? selectedCaret.end = selectedCaret.begin : selectedCaret.begin = selectedCaret.end),
+                         selectedCaret.begin === selectedCaret.end) switch (opts.positionCaretOnClick) {
+                           case "none":
+                             break;
+@@ -997,20 +997,20 @@ export function factory($, window, document, undefined) {
+             },
+             cutEvent: function(e) {
+                 var input = this, $input = $(input), pos = caret(input), ev = e.originalEvent || e, clipboardData = window.clipboardData || ev.clipboardData, clipData = isRTL ? getBuffer().slice(pos.end, pos.begin) : getBuffer().slice(pos.begin, pos.end);
+-                clipboardData.setData("text", isRTL ? clipData.reverse().join("") : clipData.join("")), 
+-                document.execCommand && document.execCommand("copy"), handleRemove(input, Inputmask.keyCode.DELETE, pos), 
+-                writeBuffer(input, getBuffer(), getMaskSet().p, e, undoValue !== getBuffer().join("")), 
++                clipboardData.setData("text", isRTL ? clipData.reverse().join("") : clipData.join("")),
++                document.execCommand && document.execCommand("copy"), handleRemove(input, Inputmask.keyCode.DELETE, pos),
++                writeBuffer(input, getBuffer(), getMaskSet().p, e, undoValue !== getBuffer().join("")),
+                 input.inputmask._valueGet() === getBufferTemplate().join("") && $input.trigger("cleared");
+             },
+             blurEvent: function(e) {
+                 var $input = $(this), input = this;
+                 if (input.inputmask) {
+                     var nptValue = input.inputmask._valueGet(), buffer = getBuffer().slice();
+-                    "" !== nptValue && (opts.clearMaskOnLostFocus && (-1 === getLastValidPosition() && nptValue === getBufferTemplate().join("") ? buffer = [] : clearOptionalTail(buffer)), 
++                    "" !== nptValue && (opts.clearMaskOnLostFocus && (-1 === getLastValidPosition() && nptValue === getBufferTemplate().join("") ? buffer = [] : clearOptionalTail(buffer)),
+                     !1 === isComplete(buffer) && (setTimeout(function() {
+                         $input.trigger("incomplete");
+-                    }, 0), opts.clearIncomplete && (resetMaskSet(), buffer = opts.clearMaskOnLostFocus ? [] : getBufferTemplate().slice())), 
+-                    writeBuffer(input, buffer, undefined, e)), undoValue !== getBuffer().join("") && (undoValue = buffer.join(""), 
++                    }, 0), opts.clearIncomplete && (resetMaskSet(), buffer = opts.clearMaskOnLostFocus ? [] : getBufferTemplate().slice())),
++                    writeBuffer(input, buffer, undefined, e)), undoValue !== getBuffer().join("") && (undoValue = buffer.join(""),
+                     $input.trigger("change"));
+                 }
+             },
+@@ -1019,8 +1019,8 @@ export function factory($, window, document, undefined) {
+                 mouseEnter = !0, document.activeElement !== input && opts.showMaskOnHover && input.inputmask._valueGet() !== getBuffer().join("") && writeBuffer(input, getBuffer());
+             },
+             submitEvent: function(e) {
+-                undoValue !== getBuffer().join("") && $el.trigger("change"), opts.clearMaskOnLostFocus && -1 === getLastValidPosition() && el.inputmask._valueGet && el.inputmask._valueGet() === getBufferTemplate().join("") && el.inputmask._valueSet(""), 
+-                opts.removeMaskOnSubmit && (el.inputmask._valueSet(el.inputmask.unmaskedvalue(), !0), 
++                undoValue !== getBuffer().join("") && $el.trigger("change"), opts.clearMaskOnLostFocus && -1 === getLastValidPosition() && el.inputmask._valueGet && el.inputmask._valueGet() === getBufferTemplate().join("") && el.inputmask._valueSet(""),
++                opts.removeMaskOnSubmit && (el.inputmask._valueSet(el.inputmask.unmaskedvalue(), !0),
+                 setTimeout(function() {
+                     writeBuffer(el, getBuffer());
+                 }, 0));
+@@ -1040,9 +1040,9 @@ export function factory($, window, document, undefined) {
+             return el = actionObj.el, isComplete(getBuffer());
+ 
+           case "unmaskedvalue":
+-            return el !== undefined && actionObj.value === undefined || (valueBuffer = actionObj.value, 
+-            valueBuffer = ($.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer : valueBuffer).split(""), 
+-            checkVal(undefined, !1, !1, isRTL ? valueBuffer.reverse() : valueBuffer), $.isFunction(opts.onBeforeWrite) && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)), 
++            return el !== undefined && actionObj.value === undefined || (valueBuffer = actionObj.value,
++            valueBuffer = ($.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer : valueBuffer).split(""),
++            checkVal(undefined, !1, !1, isRTL ? valueBuffer.reverse() : valueBuffer), $.isFunction(opts.onBeforeWrite) && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
+             unmaskedvalue(el);
+ 
+           case "mask":
+@@ -1071,7 +1071,7 @@ export function factory($, window, document, undefined) {
+                                         return object.constructor.prototype;
+                                     });
+                                     var valueProperty = Object.getPrototypeOf ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(npt), "value") : undefined;
+-                                    valueProperty && valueProperty.get && valueProperty.set ? (valueGet = valueProperty.get, 
++                                    valueProperty && valueProperty.get && valueProperty.set ? (valueGet = valueProperty.get,
+                                     valueSet = valueProperty.set, Object.defineProperty(npt, "value", {
+                                         get: getter,
+                                         set: setter,
+@@ -1085,8 +1085,8 @@ export function factory($, window, document, undefined) {
+                                         set: setter,
+                                         configurable: !0
+                                     }));
+-                                } else document.__lookupGetter__ && npt.__lookupGetter__("value") && (valueGet = npt.__lookupGetter__("value"), 
+-                                valueSet = npt.__lookupSetter__("value"), npt.__defineGetter__("value", getter), 
++                                } else document.__lookupGetter__ && npt.__lookupGetter__("value") && (valueGet = npt.__lookupGetter__("value"),
++                                valueSet = npt.__lookupSetter__("value"), npt.__defineGetter__("value", getter),
+                                 npt.__defineSetter__("value", setter));
+                                 npt.inputmask.__valueGet = valueGet, npt.inputmask.__valueSet = valueSet;
+                             }
+@@ -1116,7 +1116,7 @@ export function factory($, window, document, undefined) {
+                                         },
+                                         set: function(elem, value) {
+                                             var result, $elem = $(elem);
+-                                            return result = valhookSet(elem, value), elem.inputmask && $elem.trigger("setvalue"), 
++                                            return result = valhookSet(elem, value), elem.inputmask && $elem.trigger("setvalue"),
+                                             result;
+                                         },
+                                         inputmaskpatch: !0
+@@ -1131,35 +1131,35 @@ export function factory($, window, document, undefined) {
+                         }
+                     }(input) : input.inputmask = undefined, isSupported;
+                 }(elem, opts);
+-                if (!1 !== isSupported && (el = elem, $el = $(el), -1 === (maxLength = el !== undefined ? el.maxLength : undefined) && (maxLength = undefined), 
+-                !0 === opts.colorMask && initializeColorMask(el), android && (el.hasOwnProperty("inputmode") && (el.inputmode = opts.inputmode, 
+-                el.setAttribute("inputmode", opts.inputmode)), "rtfm" === opts.androidHack && (!0 !== opts.colorMask && initializeColorMask(el), 
+-                el.type = "password")), !0 === isSupported && (EventRuler.on(el, "submit", EventHandlers.submitEvent), 
+-                EventRuler.on(el, "reset", EventHandlers.resetEvent), EventRuler.on(el, "mouseenter", EventHandlers.mouseenterEvent), 
+-                EventRuler.on(el, "blur", EventHandlers.blurEvent), EventRuler.on(el, "focus", EventHandlers.focusEvent), 
+-                EventRuler.on(el, "mouseleave", EventHandlers.mouseleaveEvent), !0 !== opts.colorMask && EventRuler.on(el, "click", EventHandlers.clickEvent), 
+-                EventRuler.on(el, "dblclick", EventHandlers.dblclickEvent), EventRuler.on(el, "paste", EventHandlers.pasteEvent), 
+-                EventRuler.on(el, "dragdrop", EventHandlers.pasteEvent), EventRuler.on(el, "drop", EventHandlers.pasteEvent), 
+-                EventRuler.on(el, "cut", EventHandlers.cutEvent), EventRuler.on(el, "complete", opts.oncomplete), 
+-                EventRuler.on(el, "incomplete", opts.onincomplete), EventRuler.on(el, "cleared", opts.oncleared), 
+-                android || !0 === opts.inputEventOnly ? el.removeAttribute("maxLength") : (EventRuler.on(el, "keydown", EventHandlers.keydownEvent), 
+-                EventRuler.on(el, "keypress", EventHandlers.keypressEvent)), EventRuler.on(el, "compositionstart", $.noop), 
+-                EventRuler.on(el, "compositionupdate", $.noop), EventRuler.on(el, "compositionend", $.noop), 
+-                EventRuler.on(el, "keyup", $.noop), EventRuler.on(el, "input", EventHandlers.inputFallBackEvent), 
+-                EventRuler.on(el, "beforeinput", $.noop)), EventRuler.on(el, "setvalue", EventHandlers.setValueEvent), 
++                if (!1 !== isSupported && (el = elem, $el = $(el), -1 === (maxLength = el !== undefined ? el.maxLength : undefined) && (maxLength = undefined),
++                !0 === opts.colorMask && initializeColorMask(el), android && (el.hasOwnProperty("inputmode") && (el.inputmode = opts.inputmode,
++                el.setAttribute("inputmode", opts.inputmode)), "rtfm" === opts.androidHack && (!0 !== opts.colorMask && initializeColorMask(el),
++                el.type = "password")), !0 === isSupported && (EventRuler.on(el, "submit", EventHandlers.submitEvent),
++                EventRuler.on(el, "reset", EventHandlers.resetEvent), EventRuler.on(el, "mouseenter", EventHandlers.mouseenterEvent),
++                EventRuler.on(el, "blur", EventHandlers.blurEvent), EventRuler.on(el, "focus", EventHandlers.focusEvent),
++                EventRuler.on(el, "mouseleave", EventHandlers.mouseleaveEvent), !0 !== opts.colorMask && EventRuler.on(el, "click", EventHandlers.clickEvent),
++                EventRuler.on(el, "dblclick", EventHandlers.dblclickEvent), EventRuler.on(el, "paste", EventHandlers.pasteEvent),
++                EventRuler.on(el, "dragdrop", EventHandlers.pasteEvent), EventRuler.on(el, "drop", EventHandlers.pasteEvent),
++                EventRuler.on(el, "cut", EventHandlers.cutEvent), EventRuler.on(el, "complete", opts.oncomplete),
++                EventRuler.on(el, "incomplete", opts.onincomplete), EventRuler.on(el, "cleared", opts.oncleared),
++                android || !0 === opts.inputEventOnly ? el.removeAttribute("maxLength") : (EventRuler.on(el, "keydown", EventHandlers.keydownEvent),
++                EventRuler.on(el, "keypress", EventHandlers.keypressEvent)), EventRuler.on(el, "compositionstart", $.noop),
++                EventRuler.on(el, "compositionupdate", $.noop), EventRuler.on(el, "compositionend", $.noop),
++                EventRuler.on(el, "keyup", $.noop), EventRuler.on(el, "input", EventHandlers.inputFallBackEvent),
++                EventRuler.on(el, "beforeinput", $.noop)), EventRuler.on(el, "setvalue", EventHandlers.setValueEvent),
+                 undoValue = getBufferTemplate().join(""), "" !== el.inputmask._valueGet(!0) || !1 === opts.clearMaskOnLostFocus || document.activeElement === el)) {
+                     var initialValue = $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0) : el.inputmask._valueGet(!0);
+                     "" !== initialValue && checkVal(el, !0, !1, isRTL ? initialValue.split("").reverse() : initialValue.split(""));
+                     var buffer = getBuffer().slice();
+-                    undoValue = buffer.join(""), !1 === isComplete(buffer) && opts.clearIncomplete && resetMaskSet(), 
+-                    opts.clearMaskOnLostFocus && document.activeElement !== el && (-1 === getLastValidPosition() ? buffer = [] : clearOptionalTail(buffer)), 
++                    undoValue = buffer.join(""), !1 === isComplete(buffer) && opts.clearIncomplete && resetMaskSet(),
++                    opts.clearMaskOnLostFocus && document.activeElement !== el && (-1 === getLastValidPosition() ? buffer = [] : clearOptionalTail(buffer)),
+                     writeBuffer(el, buffer), document.activeElement === el && caret(el, seekNext(getLastValidPosition()));
+                 }
+             }(el);
+             break;
+ 
+           case "format":
+-            return valueBuffer = ($.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value : actionObj.value).split(""), 
++            return valueBuffer = ($.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value : actionObj.value).split(""),
+             checkVal(undefined, !0, !1, isRTL ? valueBuffer.reverse() : valueBuffer), actionObj.metadata ? {
+                 value: isRTL ? getBuffer().slice().reverse().join("") : getBuffer().join(""),
+                 metadata: maskScope.call(this, {
+@@ -1177,13 +1177,13 @@ export function factory($, window, document, undefined) {
+ 
+           case "remove":
+             if (el && el.inputmask) {
+-                $el = $(el), el.inputmask._valueSet(opts.autoUnmask ? unmaskedvalue(el) : el.inputmask._valueGet(!0)), 
++                $el = $(el), el.inputmask._valueSet(opts.autoUnmask ? unmaskedvalue(el) : el.inputmask._valueGet(!0)),
+                 EventRuler.off(el);
+                 Object.getOwnPropertyDescriptor && Object.getPrototypeOf ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), "value") && el.inputmask.__valueGet && Object.defineProperty(el, "value", {
+                     get: el.inputmask.__valueGet,
+                     set: el.inputmask.__valueSet,
+                     configurable: !0
+-                }) : document.__lookupGetter__ && el.__lookupGetter__("value") && el.inputmask.__valueGet && (el.__defineGetter__("value", el.inputmask.__valueGet), 
++                }) : document.__lookupGetter__ && el.__lookupGetter__("value") && el.inputmask.__valueGet && (el.__defineGetter__("value", el.inputmask.__valueGet),
+                 el.__defineSetter__("value", el.inputmask.__valueSet)), el.inputmask = undefined;
+             }
+             return el;
+@@ -1289,12 +1289,12 @@ export function factory($, window, document, undefined) {
+         mask: function(elems) {
+             function importAttributeOptions(npt, opts, userOptions, dataAttribute) {
+                 function importOption(option, optionData) {
+-                    null !== (optionData = optionData !== undefined ? optionData : npt.getAttribute(dataAttribute + "-" + option)) && ("string" == typeof optionData && (0 === option.indexOf("on") ? optionData = window[optionData] : "false" === optionData ? optionData = !1 : "true" === optionData && (optionData = !0)), 
++                    null !== (optionData = optionData !== undefined ? optionData : npt.getAttribute(dataAttribute + "-" + option)) && ("string" == typeof optionData && (0 === option.indexOf("on") ? optionData = window[optionData] : "false" === optionData ? optionData = !1 : "true" === optionData && (optionData = !0)),
+                     userOptions[option] = optionData);
+                 }
+                 if (!0 === opts.importDataAttributes) {
+                     var option, dataoptions, optionData, p, attrOptions = npt.getAttribute(dataAttribute);
+-                    if (attrOptions && "" !== attrOptions && (attrOptions = attrOptions.replace(new RegExp("'", "g"), '"'), 
++                    if (attrOptions && "" !== attrOptions && (attrOptions = attrOptions.replace(new RegExp("'", "g"), '"'),
+                     dataoptions = JSON.parse("{" + attrOptions + "}")), dataoptions) {
+                         optionData = undefined;
+                         for (p in dataoptions) if ("alias" === p.toLowerCase()) {
+@@ -1314,31 +1314,31 @@ export function factory($, window, document, undefined) {
+                         importOption(option, optionData);
+                     }
+                 }
+-                return $.extend(!0, opts, userOptions), ("rtl" === npt.dir || opts.rightAlign) && (npt.style.textAlign = "right"), 
+-                ("rtl" === npt.dir || opts.numericInput) && (npt.dir = "ltr", npt.removeAttribute("dir"), 
++                return $.extend(!0, opts, userOptions), ("rtl" === npt.dir || opts.rightAlign) && (npt.style.textAlign = "right"),
++                ("rtl" === npt.dir || opts.numericInput) && (npt.dir = "ltr", npt.removeAttribute("dir"),
+                 opts.isRTL = !0), opts;
+             }
+             var that = this;
+-            return "string" == typeof elems && (elems = document.getElementById(elems) || document.querySelectorAll(elems)), 
++            return "string" == typeof elems && (elems = document.getElementById(elems) || document.querySelectorAll(elems)),
+             elems = elems.nodeName ? [ elems ] : elems, $.each(elems, function(ndx, el) {
+                 var scopedOpts = $.extend(!0, {}, that.opts);
+                 importAttributeOptions(el, scopedOpts, $.extend(!0, {}, that.userOptions), that.dataAttribute);
+                 var maskset = generateMaskSet(scopedOpts, that.noMasksCache);
+                 maskset !== undefined && (el.inputmask !== undefined && (el.inputmask.opts.autoUnmask = el.inputmask.opts.autoUnmask,
+-                el.inputmask.remove()), el.inputmask = new Inputmask(undefined, undefined, !0), 
+-                el.inputmask.opts = scopedOpts, el.inputmask.noMasksCache = that.noMasksCache, el.inputmask.userOptions = $.extend(!0, {}, that.userOptions), 
+-                el.inputmask.isRTL = scopedOpts.isRTL || scopedOpts.numericInput, el.inputmask.el = el, 
++                el.inputmask.remove()), el.inputmask = new Inputmask(undefined, undefined, !0),
++                el.inputmask.opts = scopedOpts, el.inputmask.noMasksCache = that.noMasksCache, el.inputmask.userOptions = $.extend(!0, {}, that.userOptions),
++                el.inputmask.isRTL = scopedOpts.isRTL || scopedOpts.numericInput, el.inputmask.el = el,
+                 el.inputmask.maskset = maskset, $.data(el, "_inputmask_opts", scopedOpts), maskScope.call(el.inputmask, {
+                     action: "mask"
+                 }));
+             }), elems && elems[0] ? elems[0].inputmask || this : this;
+         },
+         option: function(options, noremask) {
+-            return "string" == typeof options ? this.opts[options] : "object" == typeof options ? ($.extend(this.userOptions, options), 
++            return "string" == typeof options ? this.opts[options] : "object" == typeof options ? ($.extend(this.userOptions, options),
+             this.el && !0 !== noremask && this.mask(this.el), this) : void 0;
+         },
+         unmaskedvalue: function(value) {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "unmaskedvalue",
+                 value: value
+@@ -1350,7 +1350,7 @@ export function factory($, window, document, undefined) {
+             });
+         },
+         getemptymask: function() {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "getemptymask"
+             });
+@@ -1359,26 +1359,26 @@ export function factory($, window, document, undefined) {
+             return !this.opts.autoUnmask;
+         },
+         isComplete: function() {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "isComplete"
+             });
+         },
+         getmetadata: function() {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "getmetadata"
+             });
+         },
+         isValid: function(value) {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "isValid",
+                 value: value
+             });
+         },
+         format: function(value, metadata) {
+-            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache), 
++            return this.maskset = this.maskset || generateMaskSet(this.opts, this.noMasksCache),
+             maskScope.call(this, {
+                 action: "format",
+                 value: value,
+@@ -1387,8 +1387,8 @@ export function factory($, window, document, undefined) {
+         },
+         analyseMask: function(mask, regexMask, opts) {
+             function MaskToken(isGroup, isOptional, isQuantifier, isAlternator) {
+-                this.matches = [], this.openGroup = isGroup || !1, this.alternatorGroup = !1, this.isGroup = isGroup || !1, 
+-                this.isOptional = isOptional || !1, this.isQuantifier = isQuantifier || !1, this.isAlternator = isAlternator || !1, 
++                this.matches = [], this.openGroup = isGroup || !1, this.alternatorGroup = !1, this.isGroup = isGroup || !1,
++                this.isOptional = isOptional || !1, this.isQuantifier = isQuantifier || !1, this.isAlternator = isAlternator || !1,
+                 this.quantifier = {
+                     min: 1,
+                     max: 1
+@@ -1462,14 +1462,14 @@ export function factory($, window, document, undefined) {
+             function verifyGroupMarker(maskToken) {
+                 maskToken && maskToken.matches && $.each(maskToken.matches, function(ndx, token) {
+                     var nextToken = maskToken.matches[ndx + 1];
+-                    (nextToken === undefined || nextToken.matches === undefined || !1 === nextToken.isQuantifier) && token && token.isGroup && (token.isGroup = !1, 
+-                    regexMask || (insertTestDefinition(token, opts.groupmarker.start, 0), !0 !== token.openGroup && insertTestDefinition(token, opts.groupmarker.end))), 
++                    (nextToken === undefined || nextToken.matches === undefined || !1 === nextToken.isQuantifier) && token && token.isGroup && (token.isGroup = !1,
++                    regexMask || (insertTestDefinition(token, opts.groupmarker.start, 0), !0 !== token.openGroup && insertTestDefinition(token, opts.groupmarker.end))),
+                     verifyGroupMarker(token);
+                 });
+             }
+             function defaultCase() {
+                 if (openenings.length > 0) {
+-                    if (currentOpeningToken = openenings[openenings.length - 1], insertTestDefinition(currentOpeningToken, m), 
++                    if (currentOpeningToken = openenings[openenings.length - 1], insertTestDefinition(currentOpeningToken, m),
+                     currentOpeningToken.isAlternator) {
+                         alternator = openenings.pop();
+                         for (var mndx = 0; mndx < alternator.matches.length; mndx++) alternator.matches[mndx].isGroup = !1;
+@@ -1486,7 +1486,7 @@ export function factory($, window, document, undefined) {
+                         maskToken.matches.splice(match, 1), maskToken.matches.splice(intMatch + 1, 0, qt);
+                     }
+                     maskToken.matches[match].matches !== undefined ? maskToken.matches[match] = reverseTokens(maskToken.matches[match]) : maskToken.matches[match] = function(st) {
+-                        return st === opts.optionalmarker.start ? st = opts.optionalmarker.end : st === opts.optionalmarker.end ? st = opts.optionalmarker.start : st === opts.groupmarker.start ? st = opts.groupmarker.end : st === opts.groupmarker.end && (st = opts.groupmarker.start), 
++                        return st === opts.optionalmarker.start ? st = opts.optionalmarker.end : st === opts.optionalmarker.end ? st = opts.optionalmarker.start : st === opts.groupmarker.start ? st = opts.groupmarker.end : st === opts.groupmarker.end && (st = opts.groupmarker.start),
+                         st;
+                     }(maskToken.matches[match]);
+                 }
+@@ -1511,10 +1511,10 @@ export function factory($, window, document, undefined) {
+                   case opts.optionalmarker.end:
+                   case opts.groupmarker.end:
+                     if (openingToken = openenings.pop(), openingToken.openGroup = !1, openingToken !== undefined) if (openenings.length > 0) {
+-                        if ((currentOpeningToken = openenings[openenings.length - 1]).matches.push(openingToken), 
++                        if ((currentOpeningToken = openenings[openenings.length - 1]).matches.push(openingToken),
+                         currentOpeningToken.isAlternator) {
+                             alternator = openenings.pop();
+-                            for (var mndx = 0; mndx < alternator.matches.length; mndx++) alternator.matches[mndx].isGroup = !1, 
++                            for (var mndx = 0; mndx < alternator.matches.length; mndx++) alternator.matches[mndx].isGroup = !1,
+                             alternator.matches[mndx].alternatorGroup = !1;
+                             openenings.length > 0 ? (currentOpeningToken = openenings[openenings.length - 1]).matches.push(alternator) : currentToken.matches.push(alternator);
+                         }
+@@ -1536,10 +1536,10 @@ export function factory($, window, document, undefined) {
+                         max: mq1
+                     }, openenings.length > 0) {
+                         var matches = openenings[openenings.length - 1].matches;
+-                        (match = matches.pop()).isGroup || ((groupToken = new MaskToken(!0)).matches.push(match), 
++                        (match = matches.pop()).isGroup || ((groupToken = new MaskToken(!0)).matches.push(match),
+                         match = groupToken), matches.push(match), matches.push(quantifier);
+-                    } else (match = currentToken.matches.pop()).isGroup || (regexMask && null === match.fn && "." === match.def && (match.fn = new RegExp(match.def, opts.casing ? "i" : "")), 
+-                    (groupToken = new MaskToken(!0)).matches.push(match), match = groupToken), currentToken.matches.push(match), 
++                    } else (match = currentToken.matches.pop()).isGroup || (regexMask && null === match.fn && "." === match.def && (match.fn = new RegExp(match.def, opts.casing ? "i" : "")),
++                    (groupToken = new MaskToken(!0)).matches.push(match), match = groupToken), currentToken.matches.push(match),
+                     currentToken.matches.push(quantifier);
+                     break;
+ 
+@@ -1548,8 +1548,8 @@ export function factory($, window, document, undefined) {
+                         var subToken = (currentOpeningToken = openenings[openenings.length - 1]).matches[currentOpeningToken.matches.length - 1];
+                         lastMatch = currentOpeningToken.openGroup && (subToken.matches === undefined || !1 === subToken.isGroup && !1 === subToken.isAlternator) ? openenings.pop() : currentOpeningToken.matches.pop();
+                     } else lastMatch = currentToken.matches.pop();
+-                    if (lastMatch.isAlternator) openenings.push(lastMatch); else if (lastMatch.alternatorGroup ? (alternator = openenings.pop(), 
+-                    lastMatch.alternatorGroup = !1) : alternator = new MaskToken(!1, !1, !1, !0), alternator.matches.push(lastMatch), 
++                    if (lastMatch.isAlternator) openenings.push(lastMatch); else if (lastMatch.alternatorGroup ? (alternator = openenings.pop(),
++                    lastMatch.alternatorGroup = !1) : alternator = new MaskToken(!1, !1, !1, !0), alternator.matches.push(lastMatch),
+                     openenings.push(alternator), lastMatch.openGroup) {
+                         lastMatch.openGroup = !1;
+                         var alternatorGroup = new MaskToken(!0);
+@@ -1562,7 +1562,7 @@ export function factory($, window, document, undefined) {
+                 }
+             }
+             for (;openenings.length > 0; ) openingToken = openenings.pop(), currentToken.matches.push(openingToken);
+-            return currentToken.matches.length > 0 && (verifyGroupMarker(currentToken), maskTokens.push(currentToken)), 
++            return currentToken.matches.length > 0 && (verifyGroupMarker(currentToken), maskTokens.push(currentToken)),
+             (opts.numericInput || opts.isRTL) && reverseTokens(maskTokens[0]), maskTokens;
+         }
+     }, Inputmask.extendDefaults = function(options) {


### PR DESCRIPTION
Fixes #19088. 

Enforces the showMaskOnHover check in the `mouseenter` listener.

Creates patches to convert the raw [RobinHerbots/Inputmask](https://github.com/RobinHerbots/Inputmask/releases/tag/3.3.11) build to the modified AMP version.

/to @sparhami 
/cc @danielrozenberg 