### PR TITLE
Run integration tests on SauceLabs with beta browser versions, and make these beta versions non-failing

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -156,11 +156,11 @@ module.exports = {
       platform: 'Windows 10',
       version: 'latest',
     }, SAUCE_TIMEOUT_CONFIG),
-    SL_Chrome_Dev: Object.assign({
+    SL_Chrome_Beta: Object.assign({
       base: 'SauceLabs',
       browserName: 'chrome',
       platform: 'Windows 10',
-      version: 'dev',
+      version: 'beta',
     }, SAUCE_TIMEOUT_CONFIG),
     SL_Chrome_Android_7: Object.assign({
       base: 'SauceLabs',
@@ -192,11 +192,11 @@ module.exports = {
       platform: 'Windows 10',
       version: 'latest',
     }, SAUCE_TIMEOUT_CONFIG),
-    SL_Firefox_Dev: Object.assign({
+    SL_Firefox_Beta: Object.assign({
       base: 'SauceLabs',
       browserName: 'firefox',
       platform: 'Windows 10',
-      version: 'dev',
+      version: 'beta',
     }, SAUCE_TIMEOUT_CONFIG),
     SL_Safari_12: Object.assign({
       base: 'SauceLabs',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -87,8 +87,8 @@ function getConfig() {
         //'SL_iOS_11',
         //'SL_iOS_12',
         //'SL_IE_11',
-        'SL_Chrome_Dev',
-        'SL_Firefox_Dev',
+        'SL_Chrome_Beta',
+        'SL_Firefox_Beta',
       ] : [
       // With --saucelabs_lite, a subset of the unit tests are run.
       // Only browsers that support chai-as-promised may be included below.
@@ -573,17 +573,17 @@ async function runTests() {
   /**
    * Runs tests in batches.
    *
-   * Splits stable and dev browsers to separate batches. Test failures in any of
-   * the stable browsers will return an exit code of 1, whereas test failures in
-   * any of the dev browsers will only print error messages, but will return an
-   * exit code of 0.
+   * Splits stable and beta browsers to separate batches. Test failures in any
+   * of the stable browsers will return an exit code of 1, whereas test failures
+   * in any of the beta browsers will only print error messages, but will return
+   * an exit code of 0.
    *
    * @return {number} processExitCode
    */
   async function runTestInBatches() {
-    const browsers = {stable: [], dev: []};
+    const browsers = {stable: [], beta: []};
     for (const browserId of saucelabsBrowsers) {
-      browsers[browserId.toLowerCase().endsWith('_dev') ? 'dev' : 'stable']
+      browsers[browserId.toLowerCase().endsWith('_beta') ? 'beta' : 'stable']
           .push(browserId);
     }
     if (browsers.stable.length) {
@@ -591,17 +591,21 @@ async function runTests() {
           'stable', browsers.stable);
       if (allBatchesExitCodes) {
         log(yellow('Some tests have failed on'), cyan('stable'),
-            yellow('browsers, so skipping running them on dev browsers.'));
+            yellow('browsers, so skipping running them on'), cyan('beta'),
+            yellow('browsers.'));
         return allBatchesExitCodes;
       }
     }
 
-    if (browsers.dev.length) {
+    if (browsers.beta.length) {
       const allBatchesExitCodes = await runTestInBatchesWithBrowsers(
-          'dev', browsers.dev);
+          'beta', browsers.beta);
       if (allBatchesExitCodes) {
-        log(yellow('Some tests have failed on'), cyan('dev'),
-            yellow('browsers. However, this is not a fatal error.'));
+        log(yellow('Some tests have failed on'), cyan('beta'),
+            yellow('browsers.'));
+        log(yellow('This is not currently a fatal error, but will become an'),
+            yellow('error once the beta browsers are released as next stable'),
+            yellow('version!'));
       }
     }
 

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -661,7 +661,7 @@ async function runTests() {
           } else if (argv.integration) {
             flags = ' --flags=integration_tests';
           }
-          log(green('INFO: '), 'Uploading code coverage report to',
+          log(green('INFO:'), 'Uploading code coverage report to',
               cyan('https://codecov.io/gh/ampproject/amphtml'), 'by running',
               cyan(codecovCmd + flags) + '...');
           const output = getStdout(codecovCmd + flags);

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -205,7 +205,7 @@ function printArgvMessages() {
     Object.keys(argv).forEach(arg => {
       const message = argvMessages[arg];
       if (message) {
-        log(yellow('--' + arg + ':'), green(message));
+        log(yellow(`--${arg}:`), green(message));
       }
     });
   }
@@ -240,7 +240,7 @@ function getImports(jsFile) {
   const rootDir = path.dirname(path.dirname(__dirname));
   const jsFileDir = path.dirname(jsFile);
   imports.forEach(function(file) {
-    const fullPath = path.resolve(jsFileDir, file) + '.js';
+    const fullPath = path.resolve(jsFileDir, `${file}.js`);
     if (fs.existsSync(fullPath)) {
       const relativePath = path.relative(rootDir, fullPath);
       files.push(relativePath);
@@ -285,10 +285,9 @@ function getTestsFor(srcFiles) {
  * @param {!Object<string, string>} cssJsFileMap
  */
 function addCssJsEntry(cssData, cssBinaryName, cssJsFileMap) {
-  const cssFilePath = 'extensions/' + cssData['name'] + '/' +
-      cssData['version'] + '/' + cssBinaryName + '.css';
-  const jsFilePath = 'build/' + cssBinaryName + '-' +
-      cssData['version'] + '.css.js';
+  const cssFilePath = `extensions/${cssData['name']}/${cssData['version']}/` +
+      `${cssBinaryName}.css`;
+  const jsFilePath = `build/${cssBinaryName}-${cssData['version']}.css.js`;
   cssJsFileMap[cssFilePath] = jsFilePath;
 }
 
@@ -339,7 +338,7 @@ function getJsFilesFor(cssFile, cssJsFileMap) {
       return path.extname(file) == '.js';
     });
     jsFilesInDir.forEach(jsFile => {
-      const jsFilePath = cssFileDir + '/' + jsFile;
+      const jsFilePath = `${cssFileDir}/${jsFile}`;
       if (getImports(jsFilePath).includes(cssJsFileMap[cssFile])) {
         jsFiles.push(jsFilePath);
       }
@@ -369,7 +368,7 @@ function unitTestsToRun() {
     }
   });
   if (srcFiles.length > 0) {
-    log(green('INFO: ') + 'Determining which unit tests to run...');
+    log(green('INFO:'), 'Determining which unit tests to run...');
     const moreTestsToRun = getTestsFor(srcFiles);
     moreTestsToRun.forEach(test => {
       if (!testsToRun.includes(test)) {
@@ -417,7 +416,7 @@ async function runTests() {
   }
 
   if (argv.saucelabs && !argv.integration) {
-    log(red('ERROR:'), 'Only integration tests may be run on the full set of ' +
+    log(red('ERROR:'), 'Only integration tests may be run on the full set of',
         'Sauce Labs browsers');
     log('Use', cyan('--saucelabs'), 'with', cyan('--integration'));
     process.exit();
@@ -451,11 +450,11 @@ async function runTests() {
   } else if (argv['local-changes']) {
     const testsToRun = unitTestsToRun();
     if (testsToRun.length == 0) {
-      log(green('INFO: ') +
+      log(green('INFO:'),
           'No unit tests were directly affected by local changes.');
       return Promise.resolve();
     } else {
-      log(green('INFO: ') + 'Running the following unit tests:');
+      log(green('INFO:'), 'Running the following unit tests:');
       testsToRun.forEach(test => {
         log(cyan(test));
       });
@@ -567,7 +566,7 @@ async function runTests() {
   if (processExitCode != 0) {
     log(
         red('ERROR:'),
-        yellow('Karma test failed with exit code ' + processExitCode));
+        yellow(`Karma test failed with exit code ${processExitCode}`));
     process.exitCode = processExitCode;
   }
 
@@ -658,24 +657,24 @@ async function runTests() {
           } else if (argv.integration) {
             flags = ' --flags=integration_tests';
           }
-          log(green('INFO: ') + 'Uploading code coverage report to ' +
-              cyan('https://codecov.io/gh/ampproject/amphtml') + ' by running ' +
+          log(green('INFO: '), 'Uploading code coverage report to',
+              cyan('https://codecov.io/gh/ampproject/amphtml'), 'by running',
               cyan(codecovCmd + flags) + '...');
           const output = getStdout(codecovCmd + flags);
           const viewReportPrefix = 'View report at: ';
-          const viewReport = output.match(viewReportPrefix + '.*');
+          const viewReport = output.match(`${viewReportPrefix}.*`);
           if (viewReport && viewReport.length > 0) {
-            log(green('INFO: ') + viewReportPrefix +
+            log(green('INFO:'), viewReportPrefix +
                 cyan(viewReport[0].replace(viewReportPrefix, '')));
           } else {
-            log(yellow('WARNING: ') +
-                'Code coverage report upload may have failed:\n' +
+            log(yellow('WARNING:'),
+                'Code coverage report upload may have failed:\n',
                 yellow(output));
           }
         } else {
           const coverageReportUrl =
               'file://' + path.resolve('test/coverage/index.html');
-          log(green('INFO: ') + 'Generated code coverage report at ' +
+          log(green('INFO:'), 'Generated code coverage report at',
               cyan(coverageReportUrl));
           opn(coverageReportUrl, {wait: false});
         }
@@ -695,9 +694,9 @@ async function runTests() {
         }
       }
       // Print a summary for each browser as soon as tests complete.
-      let message = browser.name + ': ';
-      message += 'Executed ' + (result.success + result.failed) +
-          ' of ' + result.total + ' (Skipped ' + result.skipped + ') ';
+      let message = `${browser.name}: Executed ` +
+          `${result.success + result.failed} of ${result.total} ` +
+          `(Skipped ${result.skipped}) `;
       if (result.failed === 0) {
         message += green('SUCCESS');
       } else {


### PR DESCRIPTION
This PR replaces and enables dev browser versions with their closest beta version on SauceLabs, and runs them in a separate batch that will not fail the entire Travis run. Eventually, coupled with #14835, we can send a daily summary of tests that are failing on beta browsers to the build cop, for triaging.

As an unrelated refactor, this PR also changes the `log` statements to use the backtick (`) operator to concatenate strings, instead of pluses. For your convenience I split this into 2 commits (f4aa87a is the actual change, 2922e81 is the backtick refactor)