### PR TITLE
[amp-list-load-more] bugfixes, code cleanup, fix demos

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -403,7 +403,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @param {<!JsonObject|!Array<JsonObject>} data
+   * @param {!JsonObject|!Array<JsonObject>} data
    * @private
    */
   maybeUpdateLoadMoreSrc_(data) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -370,14 +370,18 @@ export class AmpList extends AMP.BaseElement {
         if (itemsExpr != '.') {
           items = getValueForExpr(/**@type {!JsonObject}*/ (data), itemsExpr);
         }
-        if (this.element.hasAttribute('single-item')) {
-          items = this.forceSingleItemToArray_(items, itemsExpr);
+        user().assert(typeof items !== 'undefined',
+            'Response must contain an array or object at "%s". %s',
+            itemsExpr, this.element);
+        if (this.element.hasAttribute('single-item') && !isArray(items)) {
+          items = [items];
         }
         // TODO (cathyxz): add assertArray function
         user().assert(isArray(items),
             'Response must contain an array at "%s". %s',
             itemsExpr, this.element);
         items = /** @type {!Array} */ (items);
+
         if (this.element.hasAttribute('max-items')) {
           items = this.truncateToMaxLen_(items);
         }
@@ -397,8 +401,8 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @param {!Array} items
-   * @return {!Array}
+   * @param {!Array<?JsonObject>} items
+   * @return {!Array<?JsonObject>}
    * @private
    */
   truncateToMaxLen_(items) {
@@ -417,22 +421,6 @@ export class AmpList extends AMP.BaseElement {
     const nextExpr = this.element.getAttribute('load-more-bookmark')
       || 'load-more-src';
     this.loadMoreSrc_ = /** @type {string} */ (getValueForExpr(data, nextExpr));
-  }
-
-  /**
-   * @param {*} items
-   * @param {string} itemsExpr
-   * @return {!Array}
-   * @private
-   */
-  forceSingleItemToArray_(items, itemsExpr) {
-    user().assert(typeof items !== 'undefined',
-        'Response must contain an array or object at "%s". %s',
-        itemsExpr, this.element);
-    if (!isArray(items)) {
-      items = [items];
-    }
-    return /**@type{!Array} */(items);
   }
 
   /**

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -49,6 +49,7 @@
       flex-direction: row;
       align-items: flex-start;
       justify-content: flex-start;
+      align-content: flex-start;
     }
 
   </style>
@@ -64,8 +65,8 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=5&left=3"
-    load-more="auto"
+    src="/infinite-scroll?items=2&left=30"
+    load-more
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -65,8 +65,8 @@
 
   <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/infinite-scroll?items=2&left=30"
-    load-more
+    src="/infinite-scroll?items=5&left=3"
+    load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">

--- a/test/manual/amp-list/infinite-scroll-2.amp.html
+++ b/test/manual/amp-list/infinite-scroll-2.amp.html
@@ -59,6 +59,7 @@
       flex-direction: row;
       align-items: flex-start;
       justify-content: flex-start;
+      align-content: flex-start;
     }
 
   </style>


### PR DESCRIPTION
1. Fix jank on load-more. The jitter on the demo is due to the default `align-content` setting for flexbox. It's fixed by setting `align-content` to `flex-start`. 
2. Fix no if check for `loadEndElement` bug. Always check for `loadMoreEndElement_` because we don't provide it by default, but get rid of the unnecessary checks for the rest of them. 
3. Refactor the too long `fetch_` function for readability. 

