### PR TITLE
✨ Mark the document visible timestamp in browser timeline

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -251,6 +251,8 @@ export class Performance {
     if (didStartInPrerender) {
       this.viewer_.whenFirstVisible().then(() => {
         docVisibleTime = this.win.Date.now();
+        // Mark this instance in the browser timeline.
+        this.mark('visible');
       });
     }
 


### PR DESCRIPTION
Adds a document visible timestamp to the browser timeline using the performance api mark method.

We need to be able to measure from this mark to the pc mark at https://github.com/ampproject/amphtml/blob/ad9c05e4d3b56a3f4f8e543237f846f9cbeb1f8e/src/service/performance-impl.js#L271 .  This will allow us to correctly measure firstViewportReady (https://github.com/ampproject/amphtml/blob/master/extensions/amp-viewer-integration/TICKEVENTS.md) from our telemetry testing framework.

See crbug.com/904879 for more details on this feature.


