### PR TITLE
🐛 Avoid showing mask characters until the user reaches them

### DIFF
--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -88,6 +88,7 @@ export class Mask {
       showMaskOnHover: false,
       showMaskOnFocus: false,
       noValuePatching: true,
+      jitMasking: true,
     };
 
     if (NamedMasksToInputmask[mask]) {


### PR DESCRIPTION
Fixes #19094
Fixes #19085

And it brings `amp-inputmask` behavior in line with many e-commerce implementations.