### PR TITLE
🐛Implement a safe method for appending to body

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -991,7 +991,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       targetImg.classList.add('i-amphtml-ghost');
       // Apply the image animation prepared in the measure step.
       imageAnimation.applyAnimation();
-      this.getAmpDoc().getBody().appendChild(transLayer);
+      this.getAmpDoc().appendToBody(transLayer);
     };
 
     const cleanup = () => {
@@ -1006,7 +1006,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       srcImg.classList.remove('i-amphtml-ghost');
       targetImg.classList.remove('i-amphtml-ghost');
       imageAnimation.cleanupAnimation();
-      this.getAmpDoc().getBody().removeChild(transLayer);
+      this.getAmpDoc().removeFromBody(transLayer);
     };
 
     return this.measureMutateElement(measure, mutate)

--- a/src/dom.js
+++ b/src/dom.js
@@ -572,6 +572,7 @@ export function getDataParamsFromAttributes(element, opt_computeParamNameFunc,
  */
 export function hasNextNodeInDocumentOrder(
   currentNode, root = rootNodeFor(currentNode), filter = null) {
+  // We need the 4th argument for IE.
   const walker = currentNode.ownerDocument.createTreeWalker(
       root, NodeFilter.SHOW_ALL, filter, false);
   walker.currentNode = currentNode;

--- a/src/dom.js
+++ b/src/dom.js
@@ -572,7 +572,7 @@ function toNodeFilter(filter) {
   }
 
   // For IE 9-11: This must be a function, not an object with `acceptNode`.
-  const nodeFilter = (node) => filter(node);
+  const nodeFilter = node => filter(node);
   // For non-IE, need to have an `acceptNode` property.
   nodeFilter['acceptNode'] = nodeFilter;
   return /** @type {!NodeFilter} */ (nodeFilter);

--- a/src/dom.js
+++ b/src/dom.js
@@ -216,8 +216,7 @@ export function isConnectedNode(node) {
  */
 export function rootNodeFor(node) {
   if (Node.prototype.getRootNode) {
-    // Type checker says `getRootNode` may return null.
-    return node.getRootNode() || node;
+    return node.getRootNode();
   }
   let n;
   for (n = node; !!n.parentNode; n = n.parentNode) {}
@@ -561,23 +560,22 @@ export function getDataParamsFromAttributes(element, opt_computeParamNameFunc,
 }
 
 /**
- * Whether the element have a next node in the document order.
+ * Whether the Node has a next Node in the document order.
  * This means either:
- *  a. The element itself has a nextSibling.
- *  b. Any of the element ancestors has a nextSibling.
- * @param {!Element} element
- * @param {?Node} opt_stopNode
+ *  a. The Node itself has a nextSibling.
+ *  b. Any of the Node ancestors has a nextSibling.
+ * @param {!Node} currentNode The Node to look for a following Node.
+ * @param {?Node} root A root Node to look within.
+ * @param {?NodeFilter} filter A filter to exclude certain Nodes from being
+ *    considered as a following Node.
  * @return {boolean}
  */
-export function hasNextNodeInDocumentOrder(element, opt_stopNode) {
-  let currentElement = element;
-  do {
-    if (currentElement.nextSibling) {
-      return true;
-    }
-  } while ((currentElement = currentElement.parentNode) &&
-            currentElement != opt_stopNode);
-  return false;
+export function hasNextNodeInDocumentOrder(
+  currentNode, root = rootNodeFor(currentNode), filter = null) {
+  const walker = currentNode.ownerDocument.createTreeWalker(
+      root, NodeFilter.SHOW_ALL, filter, false);
+  walker.currentNode = currentNode;
+  return !!walker.nextNode();
 }
 
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -29,6 +29,8 @@ import {waitForBodyPromise} from '../dom';
 /** @const {string} */
 const AMPDOC_PROP = '__AMPDOC';
 
+const DYNAMICALY_APPENEDED_PROP = '__AMPDOC-DYNAMIC-APPEND';
+
 
 /**
  * This service helps locate an ampdoc (`AmpDoc` instance) for any node,
@@ -397,6 +399,36 @@ export class AmpDoc {
    */
   contains(node) {
     return this.getRootNode().contains(node);
+  }
+
+  /**
+   * Appends a Node to the body of the AmpDoc and records that the Node was
+   * appended. This should be used instead of directly adding Nodes to the
+   * body of an AmpDoc.
+   * @param {!Node} node 
+   */
+  appendToBody(node) {
+    node[DYNAMICALY_APPENEDED_PROP] = true;
+    this.getBody().appendChild(node);
+  }
+
+  /**
+   * Removes a Node from the body and clears the record of it having been
+   * appended.
+   * @param {!Node} node 
+   */
+  removeFromBody(node) {
+    node[DYNAMICALY_APPENEDED_PROP] = false;
+    this.getBody().removeChild(node);
+  }
+
+  /**
+   * Checks if a Node has been appended to the AmpDoc using `appendToBody`.
+   * @param {!Node} node
+   * @return {boolean}
+   */
+  isAppendedToBody(node) {
+    return !!node[DYNAMICALY_APPENEDED_PROP];
   }
 }
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -405,7 +405,7 @@ export class AmpDoc {
    * Appends a Node to the body of the AmpDoc and records that the Node was
    * appended. This should be used instead of directly adding Nodes to the
    * body of an AmpDoc.
-   * @param {!Node} node 
+   * @param {!Node} node
    */
   appendToBody(node) {
     node[DYNAMICALY_APPENEDED_PROP] = true;
@@ -415,7 +415,7 @@ export class AmpDoc {
   /**
    * Removes a Node from the body and clears the record of it having been
    * appended.
-   * @param {!Node} node 
+   * @param {!Node} node
    */
   removeFromBody(node) {
     node[DYNAMICALY_APPENEDED_PROP] = false;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -604,15 +604,17 @@ export class Resources {
    * @private
    */
   isResourceComplete_(resource) {
-    const skipAppendedNodesFilter = /** @type {!NodeFilter} */({
-      acceptNode: (node) => {
-        return this.ampdoc.isAppendedToBody(node) ?
+    // For IE 9-11: This must be a function, not an object with `acceptNode`.
+    const skipAppendedNodesFilter = (node) => {
+      return this.ampdoc.isAppendedToBody(node) ?
             NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-      },
-    });
+    };
+    // For all other browsers.
+    skipAppendedNodesFilter['acceptNode'] = skipAppendedNodesFilter;
 
     return hasNextNodeInDocumentOrder(
-      resource.element, this.ampdoc.getRootNode(), skipAppendedNodesFilter);
+      resource.element, this.ampdoc.getRootNode(),
+      /** @type {!NodeFilter} */ (skipAppendedNodesFilter));
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -605,10 +605,10 @@ export class Resources {
    */
   isResourceComplete_(resource) {
     return hasNextNodeInDocumentOrder(
-      resource.element, this.ampdoc.getRootNode(), (node) => {
-        return this.ampdoc.isAppendedToBody(node) ?
-              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-      });
+        resource.element, this.ampdoc.getRootNode(), node => {
+          return this.ampdoc.isAppendedToBody(node) ?
+            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+        });
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -609,7 +609,12 @@ export class Resources {
       const resource = this.pendingBuildResources_[i];
       if (this.documentReady_ ||
           hasNextNodeInDocumentOrder(
-              resource.element, this.ampdoc.getRootNode())) {
+              resource.element, this.ampdoc.getRootNode(), {
+                acceptNode: (node) => {
+                  return this.ampdoc.isAppendedToBody(node) ?
+                      NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+                },
+              })) {
         // Remove resource before build to remove it from the pending list
         // in either case the build succeed or throws an error.
         this.pendingBuildResources_.splice(i--, 1);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -604,17 +604,11 @@ export class Resources {
    * @private
    */
   isResourceComplete_(resource) {
-    // For IE 9-11: This must be a function, not an object with `acceptNode`.
-    const skipAppendedNodesFilter = (node) => {
-      return this.ampdoc.isAppendedToBody(node) ?
-            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-    };
-    // For all other browsers.
-    skipAppendedNodesFilter['acceptNode'] = skipAppendedNodesFilter;
-
     return hasNextNodeInDocumentOrder(
-      resource.element, this.ampdoc.getRootNode(),
-      /** @type {!NodeFilter} */ (skipAppendedNodesFilter));
+      resource.element, this.ampdoc.getRootNode(), (node) => {
+        return this.ampdoc.isAppendedToBody(node) ?
+              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      });
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -598,6 +598,24 @@ export class Resources {
   }
 
   /**
+   * Checks if all the children are available to a Resource's Element.
+   * @param {!Resource} resource
+   * @return {boolean}
+   * @private
+   */
+  isResourceComplete_(resource) {
+    const skipAppendNodesFilter =  /** @type {!NodeFilter} */({
+      acceptNode: (node) => {
+        return this.ampdoc.isAppendedToBody(node) ?
+            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      },
+    });
+
+    return hasNextNodeInDocumentOrder(
+      resource.element, this.ampdoc.getRootNode(), skipAppendNodesFilter);
+  }
+
+  /**
    * @param {boolean=} scheduleWhenBuilt
    * @private
    */
@@ -607,14 +625,7 @@ export class Resources {
     // elements get a chance to be built.
     for (let i = 0; i < this.pendingBuildResources_.length; i++) {
       const resource = this.pendingBuildResources_[i];
-      if (this.documentReady_ ||
-          hasNextNodeInDocumentOrder(
-              resource.element, this.ampdoc.getRootNode(), {
-                acceptNode: (node) => {
-                  return this.ampdoc.isAppendedToBody(node) ?
-                      NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-                },
-              })) {
+      if (this.documentReady_ || this.isResourceComplete_(resource)) {
         // Remove resource before build to remove it from the pending list
         // in either case the build succeed or throws an error.
         this.pendingBuildResources_.splice(i--, 1);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -606,8 +606,7 @@ export class Resources {
   isResourceComplete_(resource) {
     return hasNextNodeInDocumentOrder(
         resource.element, this.ampdoc.getRootNode(), node => {
-          return this.ampdoc.isAppendedToBody(node) ?
-            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+          return this.ampdoc.isAppendedToBody(node);
         });
   }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -604,7 +604,7 @@ export class Resources {
    * @private
    */
   isResourceComplete_(resource) {
-    const skipAppendNodesFilter =  /** @type {!NodeFilter} */({
+    const skipAppendedNodesFilter = /** @type {!NodeFilter} */({
       acceptNode: (node) => {
         return this.ampdoc.isAppendedToBody(node) ?
             NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
@@ -612,7 +612,7 @@ export class Resources {
     });
 
     return hasNextNodeInDocumentOrder(
-      resource.element, this.ampdoc.getRootNode(), skipAppendNodesFilter);
+      resource.element, this.ampdoc.getRootNode(), skipAppendedNodesFilter);
   }
 
   /**

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -744,9 +744,9 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(parent);
       ancestor.appendChild(ignoredUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, (node) => {
-        return node._ignore ?
-            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, node => {
+        return node._ignore ? NodeFilter.FILTER_REJECT :
+          NodeFilter.FILTER_ACCEPT;
       })).to.be.false;
     });
 
@@ -761,9 +761,9 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(ignoredUncle);
       ancestor.appendChild(includedUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, (node) => {
-        return node._ignore ?
-            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, node => {
+        return node._ignore ? NodeFilter.FILTER_REJECT :
+          NodeFilter.FILTER_ACCEPT;
       })).to.be.true;
     });
   });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -744,11 +744,9 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(parent);
       ancestor.appendChild(ignoredUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, {
-        acceptNode: (node) => {
-          return node._ignore ?
-              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-        },
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, (node) => {
+        return node._ignore ?
+            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
       })).to.be.false;
     });
 
@@ -763,11 +761,9 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(ignoredUncle);
       ancestor.appendChild(includedUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, {
-        acceptNode: (node) => {
-          return node._ignore ?
-              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
-        },
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, (node) => {
+        return node._ignore ?
+            NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
       })).to.be.true;
     });
   });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -744,9 +744,8 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(parent);
       ancestor.appendChild(ignoredUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, node => {
-        return node._ignore ? NodeFilter.FILTER_REJECT :
-          NodeFilter.FILTER_ACCEPT;
+      expect(dom.hasNextNodeInDocumentOrder(element, null, node => {
+        return !node._ignore;
       })).to.be.false;
     });
 
@@ -761,9 +760,8 @@ describes.sandboxed('DOM', {}, env => {
       ancestor.appendChild(ignoredUncle);
       ancestor.appendChild(includedUncle);
       parent.appendChild(element);
-      expect(dom.hasNextNodeInDocumentOrder(element, undefined, node => {
-        return node._ignore ? NodeFilter.FILTER_REJECT :
-          NodeFilter.FILTER_ACCEPT;
+      expect(dom.hasNextNodeInDocumentOrder(element, null, node => {
+        return !node._ignore;
       })).to.be.true;
     });
   });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -734,6 +734,42 @@ describes.sandboxed('DOM', {}, env => {
       expect(dom.hasNextNodeInDocumentOrder(element)).to.be.true;
       expect(dom.hasNextNodeInDocumentOrder(element, parent)).to.be.false;
     });
+
+    it('should return false when the only following node is rejected', () => {
+      const element = document.createElement('div');
+      const parent = document.createElement('div');
+      const ignoredUncle = document.createElement('div');
+      const ancestor = document.createElement('div');
+      ignoredUncle._ignore = true;
+      ancestor.appendChild(parent);
+      ancestor.appendChild(ignoredUncle);
+      parent.appendChild(element);
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, {
+        acceptNode: (node) => {
+          return node._ignore ?
+              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+        },
+      })).to.be.false;
+    });
+
+    it('should return true when skipping a rejected node', () => {
+      const element = document.createElement('div');
+      const parent = document.createElement('div');
+      const ignoredUncle = document.createElement('div');
+      const includedUncle = document.createElement('div');
+      const ancestor = document.createElement('div');
+      ignoredUncle._ignore = true;
+      ancestor.appendChild(parent);
+      ancestor.appendChild(ignoredUncle);
+      ancestor.appendChild(includedUncle);
+      parent.appendChild(element);
+      expect(dom.hasNextNodeInDocumentOrder(element, undefined, {
+        acceptNode: (node) => {
+          return node._ignore ?
+              NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+        },
+      })).to.be.true;
+    });
   });
 
   describe('openWindowDialog', () => {


### PR DESCRIPTION
- Change `hasNextNodeInDocumentOrder` to use a `TreeWalker` and take an optional `NodeFilter`
- Add method to append to the body in `AmpDoc`, capturing that the node was dynamically inserted
- Change `resources-impl` to skip over Nodes appended via the `AmpDoc` method
- Change one existing usage (lightbox), will change other usages in a separate commit

For #19876
