### PR TITLE
Update mparticle.js to allow custom page names

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -242,7 +242,7 @@
     "host": "https://pixels.mparticle.com",
     "endpointPath": "/v1/!apiKey/Pixel",
     "baseParams": "et=Unknown&amp_id=_client_id_&attrs_k=!eventAttributes_Keys&attrs_v=!eventAttributes_Values&ua_k=!userAttributes_Keys&ua_v=!userAttributes_Values&ui_t=!userIdentities_Types&ui_v=!userIdentities_Values&flags_k=!customFlags_Keys&flags_v=!customFlags_Values&ct=_timestamp_&dbg=!debug&lc=!location&av=!appVersion",
-    "pageview": "https://pixels.mparticle.com/v1/!apiKey/Pixel?dt=ScreenView&n=_canonical_path_&hn=_ampdoc_url_&ttl=_title_&et=Unknown&amp_id=_client_id_&attrs_k=!eventAttributes_Keys&attrs_v=!eventAttributes_Values&ua_k=!userAttributes_Keys&ua_v=!userAttributes_Values&ui_t=!userIdentities_Types&ui_v=!userIdentities_Values&flags_k=!customFlags_Keys&flags_v=!customFlags_Values&ct=_timestamp_&dbg=!debug&lc=!location&av=!appVersion",
+    "pageview": "https://pixels.mparticle.com/v1/!apiKey/Pixel?dt=ScreenView&n=!pageName&hn=_ampdoc_url_&ttl=_title_&path=_canonical_path_&et=Unknown&amp_id=_client_id_&attrs_k=!eventAttributes_Keys&attrs_v=!eventAttributes_Values&ua_k=!userAttributes_Keys&ua_v=!userAttributes_Values&ui_t=!userIdentities_Types&ui_v=!userIdentities_Values&flags_k=!customFlags_Keys&flags_v=!customFlags_Values&ct=_timestamp_&dbg=!debug&lc=!location&av=!appVersion",
     "event": "https://pixels.mparticle.com/v1/!apiKey/Pixel?dt=AppEvent&n=!eventName&et=Unknown&amp_id=_client_id_&attrs_k=!eventAttributes_Keys&attrs_v=!eventAttributes_Values&ua_k=!userAttributes_Keys&ua_v=!userAttributes_Values&ui_t=!userIdentities_Types&ui_v=!userIdentities_Values&flags_k=!customFlags_Keys&flags_v=!customFlags_Values&ct=_timestamp_&dbg=!debug&lc=!location&av=!appVersion"
   },
   "mpulse": {

--- a/extensions/amp-analytics/0.1/vendors/mparticle.js
+++ b/extensions/amp-analytics/0.1/vendors/mparticle.js
@@ -39,9 +39,10 @@ export const MPARTICLE_CONFIG = /** @type {!JsonObject} */ ({
         'av=${appVersion}',
     'pageview': '${host}${endpointPath}?' +
         'dt=ScreenView&' +
-        'n=${canonicalPath}&' +
+        'n=${pageName}&' +
         'hn=${ampdocUrl}&' +
         'ttl=${title}&' +
+        'path=${canonicalPath}&' +
         '${baseParams}',
     'event': '${host}${endpointPath}?' +
         'dt=AppEvent&' +


### PR DESCRIPTION
This PR updates the mParticle integration to allow an alternate page name to be specified for page view events rather than always using the `canonicalPath`.

These changes are expected to be complete but I have marked the PR as `[IN PROGRESS]` because it requires a server change on our side that is not yet in place. Please hold off on merging for now and I will update the PR title (and leave a comment) once the server is ready to handle the new parameters.

Closes #19931