### PR TITLE
[amp-list] resize amp-list on viewport resize experiment

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -230,7 +230,7 @@ export class AmpList extends AMP.BaseElement {
       this.attemptToFit_(placeholder);
     }
 
-    if (isExperimentOn(this.win, 'amp-list-resize-on-measure')) {
+    if (isExperimentOn(this.win, 'amp-list-viewport-resize')) {
       this.getViewport().onResize(() => {
         this.attemptToFit_(dev().assertElement(this.container_));
       });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -229,6 +229,13 @@ export class AmpList extends AMP.BaseElement {
     if (placeholder) {
       this.attemptToFit_(placeholder);
     }
+
+    if (isExperimentOn(this.win, 'amp-list-resize-on-measure')) {
+      this.getViewport().onResize(() => {
+        this.attemptToFit_(dev().assertElement(this.container_));
+      });
+    }
+
     return this.fetchList_();
   }
 
@@ -668,6 +675,9 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   attemptToFit_(target) {
+    if (this.element.getAttribute('layout') == Layout.CONTAINER) {
+      return;
+    }
     this.measureElement(() => {
       const scrollHeight = target./*OK*/scrollHeight;
       const height = this.element./*OK*/offsetHeight;

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -408,6 +408,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/10837',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/XXXXX',
   },
+  {
+    id: 'amp-list-viewport-resize',
+    name: 'Enables amp-list to resize on viewport resize',
+    spec: 'https://github.com/ampproject/amphtml/issues/19945',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/19945',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Related to https://github.com/ampproject/amphtml/issues/19945. 

Adds a `attemptToFit` call in `viewport.onResize`. Adjust `attemptToFit` to early return if `<amp-list>` is in layout container. 