### PR TITLE
Import amp-analytics css

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -58,7 +58,12 @@ exports.extensionBundles = [
   {name: 'amp-ad-network-gmossp-impl', version: '0.1', type: TYPES.AD},
   {name: 'amp-ad-exit', version: '0.1', type: TYPES.AD},
   {name: 'amp-addthis', version: '0.1', type: TYPES.MISC},
-  {name: 'amp-analytics', version: '0.1', type: TYPES.MISC},
+  {
+    name: 'amp-analytics',
+    version: '0.1',
+    options: {hasCss: true},
+    type: TYPES.MISC,
+  },
   {name: 'amp-anim', version: '0.1', type: TYPES.MEDIA},
   {name: 'amp-animation', version: '0.1', type: TYPES.MISC},
   {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -17,6 +17,7 @@
 import {Activity} from './activity-impl';
 import {AnalyticsConfig, mergeObjects} from './config';
 import {AnalyticsEventType} from './events';
+import {CSS} from '../../../build/amp-analytics-0.1.css';
 import {CookieWriter} from './cookie-writer';
 import {
   ExpansionOptions,
@@ -708,5 +709,5 @@ AMP.extension(TAG, '0.1', AMP => {
   installVariableService(AMP.win);
   installLinkerReaderService(AMP.win);
   // Register the element.
-  AMP.registerElement(TAG, AmpAnalytics);
+  AMP.registerElement(TAG, AmpAnalytics, CSS);
 });


### PR DESCRIPTION
Fix #19944 

We could remove the css file later on by introducing a new layout priority. 