### PR TITLE
🏗 Refactor branch point logic and print a change summary before running PR checks

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -92,11 +92,14 @@ exports.gitDiffColor = function() {
 };
 
 /**
- * Returns the name of the local branch.
+ * Returns the name of the branch from which the PR originated. On Travis, this
+ * is exposed via TRAVIS_PULL_REQUEST_BRANCH.
  * @return {string}
  */
 exports.gitBranchName = function() {
-  return getStdout('git rev-parse --abbrev-ref HEAD').trim();
+  return process.env.TRAVIS ?
+    process.env.TRAVIS_PULL_REQUEST_BRANCH :
+    getStdout('git rev-parse --abbrev-ref HEAD').trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -59,8 +59,8 @@ exports.gitDiffStatMaster = function() {
 };
 
 /**
- * Returns a detailed log of commits included in a PR check, starting with the
- * branch point off of master.
+ * Returns a detailed log of commits included in a PR check, starting with (and
+ * including) the branch point off of master.
  *
  * @return {string}
  */
@@ -69,7 +69,7 @@ exports.gitDiffCommitLog = function() {
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
 "%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) %s \
-%C(green)(%cr)%C(reset)" --abbrev-commit ${branchPoint}...HEAD`).trim();
+%C(green)(%cr)%C(reset)" --abbrev-commit ${branchPoint}^...HEAD`).trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -68,7 +68,7 @@ exports.gitDiffCommitLog = function() {
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
-"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) %s \
+"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d %s%C(reset) \
 %C(green)(%cr)%C(reset)" --abbrev-commit ${branchPoint}^...HEAD`).trim();
 };
 

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -63,14 +63,15 @@ exports.gitDiffStatMaster = function() {
 };
 
 /**
- * Returns a detailed commit log starting from the branch point off of master.
+ * Returns a detailed commit log starting from (and including) the branch point
+ * off of master.
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
   const branchPoint = exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
 "%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" \
---abbrev-commit ${branchPoint}...HEAD`).trim();
+--abbrev-commit ${branchPoint}^...HEAD`).trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -63,6 +63,17 @@ exports.gitDiffStatMaster = function() {
 };
 
 /**
+ * Returns a detailed commit log starting from the branch point off of master.
+ * @return {string}
+ */
+exports.gitDiffCommitLog = function() {
+  const branchPoint = exports.gitBranchPointFromMaster();
+  return getStdout(`git -c color.ui=always log --graph --pretty=format:\
+"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" \
+--abbrev-commit ${branchPoint}...HEAD`).trim();
+};
+
+/**
  * Returns the list of files added by the local branch relative to the branch
  * point off of master, one on each line.
  * @return {!Array<string>}

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -31,15 +31,10 @@ exports.gitBranchPointFromMaster = function() {
 
 /**
  * When running on Travis, this returns the branch point of the current branch
- * off of master, as merged by Travis. When not running on Travis, returns the
- * common ancestor of the parent commit and `master`.
- * // TODO(rsimha): Revisit this logic, used by bundle-size and visual tests.
+ * off of master, as merged by Travis.
  */
 exports.gitTravisCommitRangeStart = function() {
-  if (process.env.TRAVIS_COMMIT_RANGE) {
-    return process.env.TRAVIS_COMMIT_RANGE.substr(0, 40);
-  }
-  return getStdout('git merge-base master HEAD^').trim();
+  return process.env.TRAVIS_COMMIT_RANGE.substr(0, 40);
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -38,6 +38,22 @@ exports.gitTravisCommitRangeStart = function() {
 };
 
 /**
+ */
+exports.gitTravisCommitRangeEnd = function() {
+  return process.env.TRAVIS_COMMIT_RANGE.substr(43, 40);
+};
+
+/**
+ * When running on Travis, this returns the branch point of the PR branch off of
+ * master, as present on the fork from which the PR originated.
+ */
+exports.gitTravisPrBranchPoint = function() {
+  const start = exports.gitTravisCommitRangeStart();
+  const end = exports.gitTravisCommitRangeEnd();
+  return getStdout(`git merge-base ${start} ${end}`).trim();
+};
+
+/**
  * Returns the list of files changed on the local branch relative to the branch
  * point off of master, one on each line.
  * @return {!Array<string>}
@@ -64,10 +80,9 @@ exports.gitDiffStatMaster = function() {
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
-  const commitRangeStart = exports.gitTravisCommitRangeStart();
-  return getStdout(`git -c color.ui=always log --graph --pretty=format:\
-"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" \
---abbrev-commit ${commitRangeStart}^...HEAD`).trim();
+  return getStdout('git -c color.ui=always log --graph --pretty=format:\
+"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) %s \
+%C(green)(%cr)%C(reset)" --abbrev-commit -25').trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -63,15 +63,16 @@ exports.gitDiffStatMaster = function() {
 };
 
 /**
- * Returns a detailed commit log starting from (and including) the branch point
- * off of master.
+ * Returns a detailed log of commits included in a PR check, starting with the
+ * branch point off of master.
+ *
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
-  const branchPoint = exports.gitBranchPointFromMaster();
+  const commitRangeStart = exports.gitTravisCommitRangeStart();
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
 "%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" \
---abbrev-commit ${branchPoint}^...HEAD`).trim();
+--abbrev-commit ${commitRangeStart}^...HEAD`).trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -68,8 +68,9 @@ exports.gitDiffCommitLog = function() {
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
-"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d %s%C(reset) \
-%C(green)(%cr)%C(reset)" --abbrev-commit ${branchPoint}^...HEAD`).trim();
+"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) \
+%C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
+--abbrev-commit ${branchPoint}^...HEAD`).trim();
 };
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -87,18 +87,18 @@ function timedExecOrDie(cmd) {
 }
 
 /**
- * Returns a list of files in the commit range within this pull request (PR)
- * after filtering out commits to master from other PRs.
- * @return {!Array<string>}
+ * Prints a summary of files changed by, and commits included in the PR.
  */
-function filesInPr() {
-  const files = gitDiffNameOnlyMaster();
-  const changeSummary = gitDiffStatMaster();
+function printChangeSummary() {
+  const filesChanged = gitDiffStatMaster();
   console.log(fileLogPrefix,
       'Testing the following changes at commit',
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
-  console.log(changeSummary);
-  return files;
+  console.log(filesChanged);
+
+  const commits = getStdout('git log --graph --pretty=format:"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" --abbrev-commit ' + process.env.TRAVIS_COMMIT_RANGE);
+  console.log(fileLogPrefix, 'Commits contained in this PR:');
+  console.log(commits);
 }
 
 /**
@@ -591,7 +591,8 @@ function main() {
     stopTimer('pr-check.js', startTime);
     return 0;
   }
-  const files = filesInPr();
+  printChangeSummary();
+  const files = gitDiffNameOnlyMaster();
   const buildTargets = determineBuildTargets(files);
 
   // Exit early if flag-config files are mixed with runtime files.

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -31,6 +31,7 @@ const config = require('./config');
 const minimatch = require('minimatch');
 const path = require('path');
 const {
+  gitBranchName,
   gitDiffColor,
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
@@ -101,9 +102,10 @@ function printChangeSummary() {
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
 
-  const commitLog = gitDiffCommitLog();
-  console.log(fileLogPrefix, 'Commits included in this PR check:');
-  console.log(commitLog + '\n');
+  console.log(fileLogPrefix, 'Commit log since branch',
+      colors.cyan(gitBranchName()), 'was forked from',
+      colors.cyan('master') + ':');
+  console.log(gitDiffCommitLog() + '\n');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -96,9 +96,9 @@ function printChangeSummary() {
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
 
-  const commits = getStdout('git log --graph --pretty=format:"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" --abbrev-commit ' + process.env.TRAVIS_COMMIT_RANGE);
+  const commits = getStdout('git -c color.ui=always log --graph --pretty=format:"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" --abbrev-commit -25');
   console.log(fileLogPrefix, 'Commits contained in this PR:');
-  console.log(commits);
+  console.log(commits + '\n');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -30,8 +30,16 @@ const colors = require('ansi-colors');
 const config = require('./config');
 const minimatch = require('minimatch');
 const path = require('path');
+const {
+  gitBranchPointFromMaster,
+  gitDiffColor,
+  gitDiffCommitLog,
+  gitDiffNameOnlyMaster,
+  gitDiffStatMaster,
+  gitTravisCommitRangeStart,
+  gitTravisPrBranchPoint,
+} = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
-const {gitDiffColor, gitDiffCommitLog, gitDiffNameOnlyMaster, gitDiffStatMaster} = require('./git');
 
 const fileLogPrefix = colors.bold(colors.yellow('pr-check.js:'));
 
@@ -95,6 +103,15 @@ function printChangeSummary() {
       'Testing the following changes at commit',
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
+
+  console.log(fileLogPrefix, 'TRAVIS_COMMIT_RANGE:',
+      colors.cyan(process.env.TRAVIS_COMMIT_RANGE));
+  console.log(fileLogPrefix, 'gitBranchPointFromMaster:',
+      colors.cyan(gitBranchPointFromMaster()));
+  console.log(fileLogPrefix, 'gitTravisCommitRangeStart:',
+      colors.cyan(gitTravisCommitRangeStart()));
+  console.log(fileLogPrefix, 'gitTravisPrBranchPoint:',
+      colors.cyan(gitTravisPrBranchPoint()));
 
   const commitLog = gitDiffCommitLog();
   console.log(fileLogPrefix, 'Commits included in this PR check:');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -31,13 +31,10 @@ const config = require('./config');
 const minimatch = require('minimatch');
 const path = require('path');
 const {
-  gitBranchPointFromMaster,
   gitDiffColor,
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
-  gitTravisCommitRangeStart,
-  gitTravisPrBranchPoint,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
 
@@ -103,15 +100,6 @@ function printChangeSummary() {
       'Testing the following changes at commit',
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
-
-  console.log(fileLogPrefix, 'TRAVIS_COMMIT_RANGE:',
-      colors.cyan(process.env.TRAVIS_COMMIT_RANGE));
-  console.log(fileLogPrefix, 'gitBranchPointFromMaster:',
-      colors.cyan(gitBranchPointFromMaster()));
-  console.log(fileLogPrefix, 'gitTravisCommitRangeStart:',
-      colors.cyan(gitTravisCommitRangeStart()));
-  console.log(fileLogPrefix, 'gitTravisPrBranchPoint:',
-      colors.cyan(gitTravisPrBranchPoint()));
 
   const commitLog = gitDiffCommitLog();
   console.log(fileLogPrefix, 'Commits included in this PR check:');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -31,7 +31,7 @@ const config = require('./config');
 const minimatch = require('minimatch');
 const path = require('path');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
-const {gitDiffColor, gitDiffNameOnlyMaster, gitDiffStatMaster} = require('./git');
+const {gitDiffColor, gitDiffCommitLog, gitDiffNameOnlyMaster, gitDiffStatMaster} = require('./git');
 
 const fileLogPrefix = colors.bold(colors.yellow('pr-check.js:'));
 
@@ -96,9 +96,9 @@ function printChangeSummary() {
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
 
-  const commits = getStdout('git -c color.ui=always log --graph --pretty=format:"%Cred%h%Creset %C(bold cyan)%an%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)" --abbrev-commit -25');
-  console.log(fileLogPrefix, 'Commits contained in this PR:');
-  console.log(commits + '\n');
+  const commitLog = gitDiffCommitLog();
+  console.log(fileLogPrefix, 'Commits included in this PR check:');
+  console.log(commitLog + '\n');
 }
 
 /**
@@ -574,6 +574,7 @@ function main() {
   // Run the local version of all tests.
   if (!process.env.TRAVIS) {
     process.env['LOCAL_PR_CHECK'] = true;
+    printChangeSummary();
     console.log(fileLogPrefix, 'Running all pr-check commands locally.');
     runAllCommandsLocally();
     stopTimer('pr-check.js', startTime);

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitCommitHash, gitTravisCommitRangeStart} = require('../git');
+const {gitBranchPointFromMaster, gitCommitHash} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -108,7 +108,7 @@ function isPullRequest() {
  * @return {string} the `master` ancestor's bundle size.
  */
 async function getAncestorBundleSize() {
-  const gitBranchPointSha = gitTravisCommitRangeStart();
+  const gitBranchPointSha = gitBranchPointFromMaster();
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
   return await octokit.repos.getContents(

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -83,8 +83,7 @@ function setPercyBranch() {
   if (!process.env['PERCY_BRANCH'] &&
       (!argv.master || !process.env['TRAVIS'])) {
     const userName = gitCommitterEmail();
-    const branchName = process.env['TRAVIS'] ?
-      process.env['TRAVIS_PULL_REQUEST_BRANCH'] : gitBranchName();
+    const branchName = gitBranchName();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
   }
 }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -25,8 +25,12 @@ const path = require('path');
 const request = BBPromise.promisify(require('request'));
 const sleep = require('sleep-promise');
 const tryConnect = require('try-net-connect');
+const {
+  gitBranchName,
+  gitBranchPointFromMaster,
+  gitCommitterEmail,
+} = require('../../git');
 const {execOrDie, execScriptAsync} = require('../../exec');
-const {gitBranchName, gitCommitterEmail, gitTravisCommitRangeStart} = require('../../git');
 const {log, verifyCssElements} = require('./helpers');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
 
@@ -97,7 +101,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitTravisCommitRangeStart();
+    process.env['PERCY_TARGET_COMMIT'] = gitBranchPointFromMaster();
   }
 }
 


### PR DESCRIPTION
This PR does the following:

1. Refactors the branch-point logic in `build-system/git.js`
    1. Restores the use of `gitBranchPointFromMaster` to determine the branch point of a PR (used as the comparison baseline by the visual tests and bundle size check)
    2. Gets rid of `gitTravisCommitRangeStart`, which returned an incorrect branch-point if new commits were to be merged to `master` after a PR is updated
    3. Adds `gitPrBranchPoint`, which determines the point at which the PR branch was forked from `master` on the originating fork
2. Prints a change summary before starting PR checks, starting at the branch point returned by `gitPrBranchPoint`

**Examples of this PR in action:**

1. A series of commits is uploaded to a PR from a branch that's synced with `master`:
`Branch point == 9af9ce5`
![image](https://user-images.githubusercontent.com/26553114/50235603-3e770800-0386-11e9-80da-9d1fd714e979.png)

2. A series of commits is uploaded to a PR from a branch that's not synced with `master`:
`Branch point == 18b10a2`
![image](https://user-images.githubusercontent.com/26553114/50189513-88fb7480-02f3-11e9-9199-402e043e6f18.png)

3. Starting from 2, a merge commit is uploaded to the PR to bring it up to date with `master`:
`Branch point == 4d3cfa6`
![image](https://user-images.githubusercontent.com/26553114/50189597-eee7fc00-02f3-11e9-8b61-5cae2ed77777.png)

4. Starting from 3, new commits are merged to `master` after the merge commit was uploaded, but before the Travis run begins:
`Branch point == 9af9ce5`
![image](https://user-images.githubusercontent.com/26553114/50189634-1b9c1380-02f4-11e9-887d-0fc0afca1780.png)

Follow up to #19933 
