### PR TITLE
Make Viewer URL override an expected error

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -308,7 +308,7 @@ export class Viewer {
           if (isTrusted) {
             this.resolvedViewerUrl_ = viewerUrlOverride;
           } else {
-            dev().error(TAG_, 'Untrusted viewer url override: ' +
+            dev().expectedError(TAG_, 'Untrusted viewer url override: ' +
                 viewerUrlOverride + ' at ' +
                 this.messagingOrigin_);
           }


### PR DESCRIPTION
As more companies use an AMP viewer, we're going to keep getting new
"error" reports about not trusting their origin. But it doesn't really
matter.