### PR TITLE
✨ Add Amplitude as an analytics vendor

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -49,6 +49,7 @@
       <option>adobeanalytics</option>
       <option>adobeanalytics_nativeConfig</option>
       <option>alexametrics</option>
+      <option>amplitude</option>
       <option>atinternet</option>
       <option>afsanalytics</option>
       <option>baiduanalytics</option>
@@ -214,6 +215,47 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End Alexa tracking -->
+
+<!-- Amplitude example -->
+<amp-analytics type="amplitude" id="amplitude">
+<script type="application/json">
+  {
+    "vars": {
+      "apiKey": "4dafbafda1cb85d0b3d080a95c4e59f9"
+    },
+    "triggers": {
+      "click": {
+        "on": "click",
+        "selector": "#test1",
+        "request": "event",
+        "extraUrlParams": {
+          "event": {
+            "event_type": "click button",
+            "event_properties": {
+              "button id": "test1"
+            }
+          }
+        }
+      },
+      "pageView": {
+        "on": "visible",
+        "request": "event",
+        "extraUrlParams": {
+          "event": {
+            "event_type": "page view",
+            "event_properties": {
+              "page id": "${title}"
+            },
+            "user_properties": {
+              "is amp user": true
+            }
+          }
+        }
+      }
+    }
+  }
+</script>
+</amp-analytics>
 
 <!-- AT Internet tracking -->
 <amp-analytics type="atinternet" id="atinternet">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -21,6 +21,10 @@
     "base": "https://certify-amp.alexametrics.com/atrk.gif?account=!atrk_acct&domain=!domain",
     "pageview": "https://certify-amp.alexametrics.com/atrk.gif?account=!atrk_acct&domain=!domain&jsv=amp-_amp_version_&frame_height=_viewport_height_&frame_width=_viewport_width_&title=_title_&time=_timestamp_&time_zone_offset=_timezone_&screen_params=_screen_width_x_screen_height_x_screen_color_depth_&ref_url=_document_referrer_&host_url=_source_url_&random_number=_random_&user_cookie=_client_id_&user_cookie_flag=0&user_lang=_browser_language_&amp_doc_url=_ampdoc_url_"
   },
+  "amplitude": {
+    "host": "https://api.amplitude.com?api_key=!apiKey&device_id=_client_id_&library=amp%2F_amp_version_&time=_timestamp_&language=_browser_language_&user_agent=_user_agent_",
+    "event": "https://api.amplitude.com/amp/event?api_key=!apiKey&device_id=_client_id_&library=amp%2F_amp_version_&time=_timestamp_&language=_browser_language_&user_agent=_user_agent_"
+  },
   "atinternet": {
     "base": "https://!log!domain/hit.xiti?s=!site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_",
     "suffix": "&medium=amp&&ref=_document_referrer_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -23,6 +23,7 @@ import {hasOwn} from '../../../src/utils/object';
 import {ACQUIALIFT_CONFIG} from './vendors/acquialift';
 import {AFSANALYTICS_CONFIG} from './vendors/afsanalytics';
 import {ALEXAMETRICS_CONFIG} from './vendors/alexametrics';
+import {AMPLITUDE_CONFIG} from './vendors/amplitude';
 import {ATINTERNET_CONFIG} from './vendors/atinternet';
 import {UMENGANALYTICS_CONFIG} from './vendors/umenganalytics';
 import {BAIDUANALYTICS_CONFIG} from './vendors/baiduanalytics';
@@ -174,6 +175,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'adobeanalytics_nativeConfig': ADOBEANALYTICS_NATIVECONFIG_CONFIG,
   'afsanalytics': AFSANALYTICS_CONFIG,
   'alexametrics': ALEXAMETRICS_CONFIG,
+  'amplitude': AMPLITUDE_CONFIG,
   'atinternet': ATINTERNET_CONFIG,
   'baiduanalytics': BAIDUANALYTICS_CONFIG,
   'bg': BG_CONFIG,

--- a/extensions/amp-analytics/0.1/vendors/amplitude.js
+++ b/extensions/amp-analytics/0.1/vendors/amplitude.js
@@ -47,7 +47,7 @@ export const AMPLITUDE_CONFIG = /** @type {!JsonObject} */ ({
     },
   },
   'cookies': {
-    'amplitude': {
+    'amplitude_amp_id': {
       'value': 'LINKER_PARAM(amplitude, amplitude_amp_id)',
     },
   },

--- a/extensions/amp-analytics/0.1/vendors/amplitude.js
+++ b/extensions/amp-analytics/0.1/vendors/amplitude.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const AMPLITUDE_CONFIG = /** @type {!JsonObject} */ ({
+  'transport': {
+    'beacon': true,
+    'xhrpost': true,
+    'useBody': true,
+    'image': false,
+  },
+  'vars': {
+    'deviceId': 'CLIENT_ID(amplitude_amp_id)',
+  },
+  'requests': {
+    'host': 'https://api.amplitude.com',
+    'event': {
+      'baseUrl': '${host}/amp/event',
+    },
+  },
+  'extraUrlParams': {
+    'api_key': '${apiKey}',
+    'device_id': '${deviceId}',
+    'library': 'amp/${ampVersion}',
+    'time': '${timestamp}',
+    'language': '${browserLanguage}',
+    'user_agent': '${userAgent}',
+  },
+  'linkers': {
+    'amplitude': {
+      'ids': {
+        'amplitude_amp_id': '${deviceId}',
+      },
+      'proxyOnly': false,
+    },
+  },
+  'cookies': {
+    'amplitude': {
+      'value': 'LINKER_PARAM(amplitude, amplitude_amp_id)',
+    },
+  },
+});


### PR DESCRIPTION
Resolves #19160. Adds [Amplitude](https://amplitude.com) as an amp-analytics vendor option.