### PR TITLE
🏗 Limit commit log size in Travis logs and print branch point info

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -66,12 +66,17 @@ exports.gitDiffStatMaster = function() {
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
+  const maxCount = 100;
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
-  return getStdout(`git -c color.ui=always log --graph --pretty=format:\
-"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) \
-%C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
---abbrev-commit ${branchPoint}^...HEAD --max-count=100`).trim();
+  let commitLog = getStdout(`git -c color.ui=always log --graph \
+--pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
+-%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
+--abbrev-commit ${branchPoint}^...HEAD --max-count=${maxCount}`).trim();
+  if (commitLog.split('\n').length >= maxCount) {
+    commitLog += `\n<Output limited to ${maxCount} commits>`;
+  }
+  return commitLog;
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -70,9 +70,9 @@ exports.gitDiffStatMaster = function() {
 exports.gitDiffCommitLog = function() {
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
-  return getStdout(`git -c color.ui=always log --graph \
---pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
--%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
+  return getStdout(`git -c color.ui=always log --graph --pretty=format:\
+"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) \
+%C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
 --abbrev-commit ${branchPoint}^...HEAD \
 --max-count=${commitLogMaxCount}`).trim();
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -60,7 +60,8 @@ exports.gitDiffStatMaster = function() {
 
 /**
  * Returns a detailed log of commits included in a PR check, starting with (and
- * including) the branch point off of master.
+ * including) the branch point off of master. Limited to at most 100 commits to
+ * keep the output sane.
  *
  * @return {string}
  */
@@ -70,7 +71,7 @@ exports.gitDiffCommitLog = function() {
   return getStdout(`git -c color.ui=always log --graph --pretty=format:\
 "%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) -%C(yellow)%d%C(reset) \
 %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
---abbrev-commit ${branchPoint}^...HEAD`).trim();
+--abbrev-commit ${branchPoint}^...HEAD --max-count=100`).trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -21,6 +21,8 @@
 
 const {getStdout} = require('./exec');
 
+const commitLogMaxCount = 100;
+
 /**
  * Returns the branch point of the current branch off of master.
  * @return {string}
@@ -66,13 +68,13 @@ exports.gitDiffStatMaster = function() {
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
-  const maxCount = 100;
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
   return getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
 -%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
---abbrev-commit ${branchPoint}^...HEAD --max-count=${maxCount}`).trim();
+--abbrev-commit ${branchPoint}^...HEAD \
+--max-count=${commitLogMaxCount}`).trim();
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -69,14 +69,10 @@ exports.gitDiffCommitLog = function() {
   const maxCount = 100;
   const branchPoint = process.env.TRAVIS ?
     exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
-  let commitLog = getStdout(`git -c color.ui=always log --graph \
+  return getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
 -%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
 --abbrev-commit ${branchPoint}^...HEAD --max-count=${maxCount}`).trim();
-  if (commitLog.split('\n').length >= maxCount) {
-    commitLog += `\n<Output limited to ${maxCount} commits>`;
-  }
-  return commitLog;
 };
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -32,10 +32,12 @@ const minimatch = require('minimatch');
 const path = require('path');
 const {
   gitBranchName,
+  gitBranchPointFromMaster,
   gitDiffColor,
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
+  gitPrBranchPoint,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
 
@@ -102,9 +104,11 @@ function printChangeSummary() {
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
 
+  const branchPoint = process.env.TRAVIS ?
+    gitPrBranchPoint() : gitBranchPointFromMaster();
   console.log(fileLogPrefix, 'Commit log since branch',
       colors.cyan(gitBranchName()), 'was forked from',
-      colors.cyan('master') + ':');
+      colors.cyan('master'), 'at', colors.cyan(branchPoint) + ':');
   console.log(gitDiffCommitLog() + '\n');
 }
 


### PR DESCRIPTION
This PR avoids extremely long change summaries in Travis logs, when something is wrong with the way a branch was forked. See https://travis-ci.org/ampproject/amphtml/jobs/470147300#L616 for example.

It also prints the branch point in the Travis logs.

I suspect the occasional extra-long commit logs on Travis (computed using `TRAVIS_COMMIT_RANGE`) might be related to https://github.com/travis-ci/travis-ci/issues/4596. This could also happen when a branch on a fork was forked from some other branch, that doesn't track `origin/master`. Either way, we should print a reasonable number of commits in the change summary.

Follow up to #19954
