### PR TITLE
✨Pass consent string to 3p ad vendors

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -74,6 +74,9 @@ export class AbstractAmpContext {
     /** @type {?number} */
     this.initialConsentState = null;
 
+    /** @type {?string} */
+    this.initialConsentValue = null;
+
     /** @type {?Object} */
     this.initialLayoutRect = null;
 
@@ -308,6 +311,10 @@ export class AbstractAmpContext {
     this.tagName = context.tagName;
 
     this.embedType_ = dataObject.type || null;
+
+    if (context.initialConsentValue) {
+      this.initialConsentValue = context.initialConsentValue;
+    }
   }
 
   /**

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -299,6 +299,7 @@ export class AbstractAmpContext {
     this.domFingerprint = context.domFingerprint;
     this.hidden = context.hidden;
     this.initialConsentState = context.initialConsentState;
+    this.initialConsentValue = context.initialConsentValue;
     this.initialLayoutRect = context.initialLayoutRect;
     this.initialIntersection = context.initialIntersection;
     this.location = parseUrlDeprecated(context.location.href);
@@ -311,10 +312,6 @@ export class AbstractAmpContext {
     this.tagName = context.tagName;
 
     this.embedType_ = dataObject.type || null;
-
-    if (context.initialConsentValue) {
-      this.initialConsentValue = context.initialConsentValue;
-    }
   }
 
   /**

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -88,6 +88,10 @@ export function _ping_(global, data) {
       const TAG = 'consentSharedData';
       dev().info(TAG, global.context.consentSharedData);
     }
+    if (global.context.initialConsentValue) {
+      const TAG = 'consentStringValue';
+      dev().info(TAG, global.context.initialConsentValue);
+    }
   } else {
     global.setTimeout(() => {
       global.context.noContentAvailable();

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -149,6 +149,7 @@ window.context.sentinel;
 window.context.clientId;
 window.context.initialLayoutRect;
 window.context.initialIntersection;
+window.context.initialConsentValue;
 window.context.sourceUrl;
 window.context.experimentToggles;
 window.context.master;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -149,7 +149,6 @@ window.context.sentinel;
 window.context.clientId;
 window.context.initialLayoutRect;
 window.context.initialIntersection;
-window.context.initialConsentValue;
 window.context.sourceUrl;
 window.context.experimentToggles;
 window.context.master;

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -352,7 +352,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       getAdCid(this),
       consentPromise,
       sharedDataPromise,
-      consentStringPromise]).then(consents => {
+      consentStringPromise
+    ]).then(consents => {
       const opt_context = {
         clientId: consents[0] || null,
         container: this.container_,
@@ -360,7 +361,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         consentSharedData: consents[2],
       };
       if (isConsentV2Experiment) {
-        opt_context.initialConsentValue = consents[3];
+        opt_context['initialConsentValue'] = consents[3];
       }
 
       // In this path, the request and render start events are entangled,

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -352,7 +352,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       getAdCid(this),
       consentPromise,
       sharedDataPromise,
-      consentStringPromise
+      consentStringPromise,
     ]).then(consents => {
       const opt_context = {
         clientId: consents[0] || null,

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -350,7 +350,8 @@ export class AmpConsent extends AMP.BaseElement {
           CONSENT_ITEM_STATE.REJECTED,
           consentString);
     } else if (action == ACTION_TYPE.DISMISS) {
-      // TODO: Throw user warning at dismiss and defined consent string
+      // TODO (@zhouyx #20010): Consider it a user error if
+      // consentString is undefined, but has value before.
       this.consentStateManager_.updateConsentInstanceState(
           this.currentDisplayInstance_,
           CONSENT_ITEM_STATE.DISMISSED,

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CONSENT_ITEM_STATE} from './consent-info';
+import {CONSENT_ITEM_STATE, hasStoredValue} from './consent-info';
 import {CSS} from '../../../build/amp-consent-0.1.css';
 import {ConsentConfig, expandPolicyConfig} from './consent-config';
 import {ConsentPolicyManager} from './consent-policy-manager';
@@ -230,6 +230,10 @@ export class AmpConsent extends AMP.BaseElement {
           user().error(TAG, 'consent-response info only supports string, ' +
               '%s, treated as undefined', data['info']);
         }
+        if (!data['info']) {
+          user().error(TAG,
+              'consent-response info does not allow empty string');
+        }
         consentString = data['info'];
       }
 
@@ -346,7 +350,7 @@ export class AmpConsent extends AMP.BaseElement {
           CONSENT_ITEM_STATE.REJECTED,
           consentString);
     } else if (action == ACTION_TYPE.DISMISS) {
-      // dismiss
+      // TODO: Throw user warning at dismiss and defined consent string
       this.consentStateManager_.updateConsentInstanceState(
           this.currentDisplayInstance_,
           CONSENT_ITEM_STATE.DISMISSED,
@@ -532,25 +536,25 @@ export class AmpConsent extends AMP.BaseElement {
     // Get current consent state
     return this.consentStateManager_.getConsentInstanceInfo(instanceId)
         .then(info => {
-          const state = info['consentState'];
-          if (state == CONSENT_ITEM_STATE.ACCEPTED ||
-              state == CONSENT_ITEM_STATE.REJECTED) {
-            // Need to display post prompt ui if user previous made a decision
+          if (hasStoredValue(info)) {
+            // Has user stored value, no need to prompt
             this.isPostPromptUIRequired_ = true;
+            return;
           }
-          if (state == CONSENT_ITEM_STATE.UNKNOWN) {
-            if (!this.consentRequired_[instanceId]) {
-              this.consentStateManager_.updateConsentInstanceState(
-                  instanceId, CONSENT_ITEM_STATE.NOT_REQUIRED);
-              return;
-            }
-            this.isPostPromptUIRequired_ = true;
-            // TODO(@zhouyx):
-            // 1. Race condition on consent state change between schedule to
-            //    display and display. Add one more check before display
-            // 2. Should not schedule display with DISMISSED UNKNOWN state
-            this.scheduleDisplay_(instanceId);
+          if (!this.consentRequired_[instanceId]) {
+            // no need to prompt if remote reponse say so
+            // Also no need to display postPromptUI
+            this.consentStateManager_.updateConsentInstanceState(
+                instanceId, CONSENT_ITEM_STATE.NOT_REQUIRED);
+            return;
           }
+          // Prompt
+          this.isPostPromptUIRequired_ = true;
+          this.scheduleDisplay_(instanceId);
+
+          // TODO(@zhouyx):
+          // Race condition on consent state change between schedule to
+          // display and display. Add one more check before display
         });
   }
 

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -231,6 +231,8 @@ export class AmpConsent extends AMP.BaseElement {
               '%s, treated as undefined', data['info']);
         }
         if (!data['info']) {
+          // TODO (@zhouyx #20010): Decide what's the behavior on receiving
+          // incorrect message.
           user().error(TAG,
               'consent-response info does not allow empty string');
         }

--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -70,13 +70,11 @@ export function getStoredConsentInfo(value) {
     // legacy format
     return getLegacyStoredConsentInfo(value);
   }
-
   if (!isObject(value)) {
     throw dev().createError('Invalid stored consent value');
   }
 
   const consentState = convertValueToState(value[STORAGE_KEY.STATE]);
-
   return constructConsentInfo(consentState,
       value[STORAGE_KEY.STRING],
       (value[STORAGE_KEY.IS_DIRTY] && value[STORAGE_KEY.IS_DIRTY] === 1));
@@ -122,6 +120,9 @@ export function composeStoreValue(consentInfo, opt_forceNew) {
     obj[STORAGE_KEY.STATE] = 1;
   } else if (consentState == CONSENT_ITEM_STATE.REJECTED) {
     obj[STORAGE_KEY.STATE] = 0;
+  } else {
+    // Only store consentString and dirtyBit with reject/accept action
+    return null;
   }
 
   if (consentInfo['consentString']) {
@@ -161,7 +162,7 @@ export function calculateLegacyStateValue(consentState) {
  * @param {?ConsentInfoDef} infoB
  * @return {boolean}
  */
-export function isConsentInfoStoredValueChanged(infoA, infoB) {
+export function isConsentInfoStoredValueSame(infoA, infoB) {
   if (!infoA && !infoB) {
     return true;
   }
@@ -213,4 +214,17 @@ function convertValueToState(value) {
     return CONSENT_ITEM_STATE.REJECTED;
   }
   return CONSENT_ITEM_STATE.UNKNOWN;
+}
+
+/**
+ *
+ * @param {!ConsentInfoDef} info
+ * @return {boolean}
+ */
+export function hasStoredValue(info) {
+  if (info['consentString']) {
+    return true;
+  }
+  return info['consentState'] === CONSENT_ITEM_STATE.ACCEPTED ||
+      info['consentState'] === CONSENT_ITEM_STATE.REJECTED;
 }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -224,7 +224,8 @@ export class ConsentPolicyManager {
   }
 
   /**
-   * Get the consent string of a policy. Will only resolved if th
+   * Get the consent string value of a policy. Return a promise that resolves
+   * when the policy resolves.
    * @param {string} policyId
    * @return {!Promise<?string>}
    */
@@ -473,7 +474,7 @@ export class ConsentPolicyInstance {
 
   /**
    * Returns the current consent string info
-   * @return {?git stastring}
+   * @return {?string}
    */
   getConsentString() {
     // Return a string because we only support one consent instance now.

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -84,7 +84,6 @@ export class ConsentStateManager {
    * @param {string=} consentStr
    */
   updateConsentInstanceState(instanceId, state, consentStr) {
-    console.log('update Consent Instance State');
     if (!this.instances_[instanceId] ||
         !this.consentChangeObservables_[instanceId]) {
       dev().error(TAG, 'instance %s not registered', instanceId);

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -213,6 +213,9 @@ export class ConsentInstance {
    * @param {string=} consentString
    */
   update(state, consentString) {
+    if (state === CONSENT_ITEM_STATE.DISMISSED) {
+      consentString = undefined;
+    }
     const localStateValue =
         this.localConsentInfo_ && this.localConsentInfo_['consentState'];
     const localConsentStr =

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -21,7 +21,7 @@ import {
   composeStoreValue,
   constructConsentInfo,
   getStoredConsentInfo,
-  isConsentInfoStoredValueChanged,
+  isConsentInfoStoredValueSame,
   recalculateConsentStateValue,
 } from './consent-info';
 import {Deferred} from '../../../src/utils/promise';
@@ -89,7 +89,8 @@ export class ConsentStateManager {
       dev().error(TAG, 'instance %s not registered', instanceId);
       return;
     }
-    this.consentChangeObservables_[instanceId].fire(state);
+    this.consentChangeObservables_[instanceId].fire(
+        constructConsentInfo(state, consentStr));
     this.instances_[instanceId].update(state, consentStr);
   }
 
@@ -107,7 +108,7 @@ export class ConsentStateManager {
   /**
    * Register the handler for every consent state change.
    * @param {string} instanceId
-   * @param {function(CONSENT_ITEM_STATE)} handler
+   * @param {function(!ConsentInfoDef)} handler
    */
   onConsentStateChange(instanceId, handler) {
     devAssert(this.instances_[instanceId],
@@ -116,7 +117,7 @@ export class ConsentStateManager {
     const unlistener = this.consentChangeObservables_[instanceId].add(handler);
     // Fire first consent instance state.
     this.getConsentInstanceInfo(instanceId).then(info => {
-      handler(info['consentState']);
+      handler(info);
     });
 
     return unlistener;
@@ -218,17 +219,22 @@ export class ConsentInstance {
         this.localConsentInfo_ && this.localConsentInfo_['consentString'];
     const calculatedState =
         recalculateConsentStateValue(state, localStateValue);
-    if (consentString === undefined && localConsentStr) {
-      consentString = localConsentStr;
-    }
+
+    // TODO(@zhouyx) Make consentString init value to null
+    consentString = consentString || localConsentStr || undefined;
     const newConsentInfo = constructConsentInfo(calculatedState, consentString);
     const oldConsentInfo = this.localConsentInfo_;
     this.localConsentInfo_ = newConsentInfo;
 
-    if (!isConsentInfoStoredValueChanged(newConsentInfo, oldConsentInfo)) {
-      this.updateStoredValue_(newConsentInfo);
-      // TODO(@zhouyx): Need force update to update timestamp
+    if (state === CONSENT_ITEM_STATE.DISMISSED ||
+        isConsentInfoStoredValueSame(newConsentInfo, oldConsentInfo)) {
+      // Only update/save to localstorage if it's not dismiss
+      // And the value is different from what is stored.
+      return;
     }
+
+    // TODO(@zhouyx): Need force update to update timestamp
+    this.updateStoredValue_(newConsentInfo);
   }
 
   /**
@@ -237,7 +243,7 @@ export class ConsentInstance {
    */
   updateStoredValue_(consentInfo) {
     this.storagePromise_.then(storage => {
-      if (!isConsentInfoStoredValueChanged(
+      if (!isConsentInfoStoredValueSame(
           consentInfo, this.localConsentInfo_)) {
         // If state has changed. do not store outdated value.
         return;

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -28,7 +28,7 @@ import {Deferred} from '../../../src/utils/promise';
 import {Observable} from '../../../src/observable';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, devAssert} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 
 
@@ -84,10 +84,19 @@ export class ConsentStateManager {
    * @param {string=} consentStr
    */
   updateConsentInstanceState(instanceId, state, consentStr) {
+    console.log('update Consent Instance State');
     if (!this.instances_[instanceId] ||
         !this.consentChangeObservables_[instanceId]) {
       dev().error(TAG, 'instance %s not registered', instanceId);
       return;
+    }
+    if (state == CONSENT_ITEM_STATE.DISMISSED) {
+      if (consentStr) {
+        user().error(TAG,
+            'Consent string value %s will be ignored on user dismiss',
+            consentStr);
+        consentStr = undefined;
+      }
     }
     this.consentChangeObservables_[instanceId].fire(
         constructConsentInfo(state, consentStr));
@@ -213,9 +222,6 @@ export class ConsentInstance {
    * @param {string=} consentString
    */
   update(state, consentString) {
-    if (state === CONSENT_ITEM_STATE.DISMISSED) {
-      consentString = undefined;
-    }
     const localStateValue =
         this.localConsentInfo_ && this.localConsentInfo_['consentState'];
     const localConsentStr =

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -120,7 +120,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
       });
     });
 
-    it.only('add field only when defined', () => {
+    it('add field only when defined', () => {
       consentInfo['consentState'] = CONSENT_ITEM_STATE.REJECTED;
       expect(composeStoreValue(consentInfo)).to.deep.equal(false);
       consentInfo['idDirty'] = false;

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -19,7 +19,7 @@ import {
   composeStoreValue,
   constructConsentInfo,
   getStoredConsentInfo,
-  isConsentInfoStoredValueChanged,
+  isConsentInfoStoredValueSame,
   recalculateConsentStateValue,
 } from '../consent-info';
 import {dict} from '../../../../src/utils/object';
@@ -120,21 +120,16 @@ describes.fakeWin('ConsentInfo', {}, () => {
       });
     });
 
-    it('add field only when defined', () => {
+    it.only('add field only when defined', () => {
+      consentInfo['consentState'] = CONSENT_ITEM_STATE.REJECTED;
+      expect(composeStoreValue(consentInfo)).to.deep.equal(false);
+      consentInfo['idDirty'] = false;
       consentInfo['consentString'] = 'test';
       expect(composeStoreValue(consentInfo)).to.deep.equal({
-        'r': 'test',
-      });
-      consentInfo['idDirty'] = false;
-      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        's': 0,
         'r': 'test',
       });
       consentInfo['isDirty'] = true;
-      expect(composeStoreValue(consentInfo)).to.deep.equal({
-        'r': 'test',
-        'd': 1,
-      });
-      consentInfo['consentState'] = CONSENT_ITEM_STATE.REJECTED;
       expect(composeStoreValue(consentInfo)).to.deep.equal({
         's': 0,
         'r': 'test',
@@ -178,9 +173,9 @@ describes.fakeWin('ConsentInfo', {}, () => {
         .to.equal(CONSENT_ITEM_STATE.UNKNOWN);
   });
 
-  it('isConsentInfoStoredValueChanged', () => {
-    expect(isConsentInfoStoredValueChanged(null, null)).to.be.true;
-    expect(isConsentInfoStoredValueChanged({}, null)).to.be.false;
+  it('isConsentInfoStoredValueSame', () => {
+    expect(isConsentInfoStoredValueSame(null, null)).to.be.true;
+    expect(isConsentInfoStoredValueSame({}, null)).to.be.false;
 
     // consentInfo equals when stored value is same
     const infoA = {
@@ -189,24 +184,24 @@ describes.fakeWin('ConsentInfo', {}, () => {
     const infoB = {
       'consentState': CONSENT_ITEM_STATE.NOT_REQUIRED,
     };
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.true;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.true;
 
     infoA['consentString'] = '';
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.true;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.true;
 
     infoB['isDirty'] = false;
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.true;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.true;
 
     // consentInfo not equal
     infoA['consentState'] = CONSENT_ITEM_STATE.ACCEPTED;
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.false;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.false;
 
     infoB['consentState'] = CONSENT_ITEM_STATE.ACCEPTED;
     infoB['consentString'] = 'test';
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.false;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.false;
 
     infoA['consentString'] = 'test';
     infoB['isDirty'] = true;
-    expect(isConsentInfoStoredValueChanged(infoA, infoB)).to.be.false;
+    expect(isConsentInfoStoredValueSame(infoA, infoB)).to.be.false;
   });
 });

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -15,7 +15,8 @@
  */
 
 import * as lolex from 'lolex';
-import {CONSENT_ITEM_STATE} from '../consent-info';
+import {CONSENT_ITEM_STATE,
+  constructConsentInfo} from '../consent-info';
 import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
 import {
   ConsentPolicyInstance,
@@ -104,33 +105,38 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     it('on consent state change', () => {
-      instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
+      instance.consentStateChangeHandler('ABC',
+          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': null,
       });
       instance.consentStateChangeHandler('ABC',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': null,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.DISMISSED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.UNKNOWN,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.ACCEPTED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.ACCEPTED,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.REJECTED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.REJECTED,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.DISMISSED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.REJECTED,
@@ -139,39 +145,43 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
 
     it('on consent ignored', () => {
       instance.consentStateChangeHandler('ABC',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.NOT_REQUIRED,
         'DEF': null,
       });
-      instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
+      instance.consentStateChangeHandler('ABC',
+          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': null,
       });
       instance.consentStateChangeHandler('ABC',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': null,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.UNKNOWN);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': null,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.DISMISSED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.UNKNOWN,
       });
       instance.consentStateChangeHandler('DEF',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.NOT_REQUIRED,
       });
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.DISMISSED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
       expect(instance.itemToConsentState_).to.deep.equal({
         'ABC': CONSENT_ITEM_STATE.ACCEPTED,
         'DEF': CONSENT_ITEM_STATE.NOT_REQUIRED,
@@ -213,10 +223,12 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance.getReadyPromise().then(() => ready = true);
         yield macroTask();
         expect(ready).to.be.false;
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         yield macroTask();
         expect(ready).to.be.false;
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
         yield macroTask();
         expect(ready).to.be.true;
         expect(instance.getCurrentPolicyStatus()).to.equal(
@@ -254,7 +266,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance = new ConsentPolicyInstance(config1);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo((CONSENT_ITEM_STATE.UNKNOWN)));
         instance.startTimeout(ampdoc.win);
         yield macroTask();
         expect(ready).to.be.false;
@@ -272,7 +285,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance = new ConsentPolicyInstance(config2);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         instance.startTimeout(ampdoc.win);
         yield macroTask();
         expect(ready).to.be.false;
@@ -297,26 +311,44 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         });
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.UNKNOWN);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.UNKNOWN);
         instance.consentStateChangeHandler('ABC',
-            CONSENT_ITEM_STATE.NOT_REQUIRED);
+            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.INSUFFICIENT);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.SUFFICIENT);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.SUFFICIENT);
         instance.consentStateChangeHandler('ABC',
-            CONSENT_ITEM_STATE.NOT_REQUIRED);
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.SUFFICIENT);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.SUFFICIENT);
+      });
+
+      it('should return current consent string value', function* () {
+        instance = new ConsentPolicyInstance({
+          'waitFor': {
+            'ABC': [],
+          },
+        });
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED, 'dismiss'));
+        expect(instance.getConsentString()).to.equal('dismiss');
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'accept'));
+        expect(instance.getConsentString()).to.equal('accept');
       });
     });
 
@@ -327,11 +359,14 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
             'ABC': [],
           },
         });
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
         expect(instance.shouldBlock()).to.equal(false);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
         expect(instance.shouldBlock()).to.equal(false);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
+        instance.consentStateChangeHandler('ABC',
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
         expect(instance.shouldBlock()).to.equal(true);
       });
 
@@ -365,24 +400,27 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
       // single unknown
       instance.consentStateChangeHandler('ABC',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo((CONSENT_ITEM_STATE.NOT_REQUIRED)));
       expect(instance.getCurrentPolicyStatus()).to.equal(
           CONSENT_POLICY_STATE.UNKNOWN);
       // All ignored
       instance.consentStateChangeHandler('DEF',
-          CONSENT_ITEM_STATE.NOT_REQUIRED);
+          constructConsentInfo((CONSENT_ITEM_STATE.NOT_REQUIRED)));
       expect(instance.getCurrentPolicyStatus()).to.equal(
           CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
       // Single ignored
-      instance.consentStateChangeHandler('DEF', CONSENT_ITEM_STATE.ACCEPTED);
+      instance.consentStateChangeHandler('DEF',
+          constructConsentInfo((CONSENT_ITEM_STATE.ACCEPTED)));
       expect(instance.getCurrentPolicyStatus()).to.equal(
           CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
       // All granted
-      instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
+      instance.consentStateChangeHandler('ABC',
+          constructConsentInfo((CONSENT_ITEM_STATE.ACCEPTED)));
       expect(instance.getCurrentPolicyStatus()).to.equal(
           CONSENT_POLICY_STATE.SUFFICIENT);
       // Single rejected
-      instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+      instance.consentStateChangeHandler('ABC',
+          constructConsentInfo((CONSENT_ITEM_STATE.REJECTED)));
       expect(instance.getCurrentPolicyStatus()).to.equal(
           CONSENT_POLICY_STATE.INSUFFICIENT);
     });

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -439,10 +439,6 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield instance.get().then(v => value = v);
         expect(value).to.deep.equal(
             constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'test');
-        yield instance.get().then(v => value = v);
-        expect(value).to.deep.equal(
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
         yield instance.update(CONSENT_ITEM_STATE.REJECTED, 'test1');
         yield instance.get().then(v => value = v);
         expect(value).to.deep.equal(

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -442,7 +442,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'test');
         yield instance.get().then(v => value = v);
         expect(value).to.deep.equal(
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test'));
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
         yield instance.update(CONSENT_ITEM_STATE.REJECTED, 'test1');
         yield instance.get().then(v => value = v);
         expect(value).to.deep.equal(

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -126,32 +126,37 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       it('should call handler when consent state changes', () => {
         manager.onConsentStateChange('test', spy);
         manager.updateConsentInstanceState('test', CONSENT_ITEM_STATE.REJECTED);
-        expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.REJECTED);
+        expect(spy).to.be.calledWith(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
       });
 
       it('should call handler when consent is ignored', () => {
         manager.onConsentStateChange('test', spy);
         manager.updateConsentInstanceState('test',
             CONSENT_ITEM_STATE.NOT_REQUIRED);
-        expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.NOT_REQUIRED);
+        expect(spy).to.be.calledWith(
+            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
       });
 
       it('should call handler when register observable', function*() {
         manager.onConsentStateChange('test', spy);
         yield macroTask();
         expect(spy).to.be.calledOnce;
-        expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.UNKNOWN);
+        expect(spy).to.be.calledWith(
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
       });
 
       it('handles race condition', function* () {
         manager.onConsentStateChange('test', spy);
         manager.updateConsentInstanceState('test', CONSENT_ITEM_STATE.REJECTED);
         expect(spy).to.be.calledOnce;
-        expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.REJECTED);
+        expect(spy).to.be.calledWith(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
         yield macroTask();
         // Called with updated state value REJECT instead of UNKNOWN
         expect(spy).to.be.calledTwice;
-        expect(spy).to.be.calledWith(CONSENT_ITEM_STATE.REJECTED);
+        expect(spy).to.be.calledWith(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
       });
     });
   });
@@ -172,11 +177,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
 
           instance.update(-1, 'test');
           yield macroTask();
-          expect(storageSetSpy).to.be.calledOnce;
-          const consentInfo =
-              constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN, 'test');
-          const value = composeStoreValue(consentInfo);
-          expect(storageSetSpy).to.be.calledWith('amp-consent:test', value);
+          expect(storageSetSpy).to.not.be.called;
         });
 
         it('single consent state value', function* () {
@@ -251,26 +252,30 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
               'amp-consent:test', composeStoreValue(consentInfo));
         });
 
-        it('new consent string always override old one', function* () {
+        it('do not store consentstring with dismiss consent state',
+            function* () {
+              instance.update(CONSENT_ITEM_STATE.DISMISSED, 'old');
+              yield macroTask();
+              expect(storageSetSpy).to.not.be.called;
+            });
+
+        it('new consent string override old one', function* () {
           instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'old');
           yield macroTask();
           storageSetSpy.resetHistory();
-          instance.update(CONSENT_ITEM_STATE.DISMISSED, 'new');
+          instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'new');
           yield macroTask();
           let consentInfo =
               constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'new');
           expect(storageSetSpy).to.be.calledOnce;
           expect(storageSetSpy).to.be.calledWith(
               'amp-consent:test', composeStoreValue(consentInfo));
-
-          // empty consent string
+          // empty consent string cannot override
           storageSetSpy.resetHistory();
           yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, '');
           consentInfo =
               constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, '');
-          expect(storageSetSpy).to.be.calledOnce;
-          expect(storageSetSpy).to.be.calledWith(
-              'amp-consent:test', composeStoreValue(consentInfo));
+          expect(storageSetSpy).to.not.be.called;
         });
       });
 
@@ -335,15 +340,15 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
 
       it('send update request on consentString change', function* () {
-        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'old');
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'old');
         yield macroTask();
         expect(requestSpy).to.be.calledOnce;
-        expect(requestBody.consentState).to.be.undefined;
+        expect(requestBody.consentState).to.be.true;
         expect(requestBody.consentString).to.equal('old');
-        yield instance.update(CONSENT_ITEM_STATE.DISMISSED, 'new');
+        yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, 'new');
         yield macroTask();
         expect(requestSpy).to.be.calledTwice;
-        expect(requestBody.consentState).to.be.undefined;
+        expect(requestBody.consentState).to.be.true;
         expect(requestBody.consentString).to.equal('new');
       });
 
@@ -401,17 +406,12 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         });
 
         it('consentInfo value', function* () {
-          let testConsentInfo =
-              constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN, 'test');
-          storageValue['amp-consent:test'] = composeStoreValue(testConsentInfo);
-          yield instance.get().then(value => {
-            expect(value).to.deep.equal(testConsentInfo);
-          });
           instance.localConsentInfo_ = null;
-          testConsentInfo =
+          const testConsentInfo =
               constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test');
           storageValue['amp-consent:test'] = composeStoreValue(testConsentInfo);
           yield instance.get().then(value => {
+
             expect(value).to.deep.equal(testConsentInfo);
           });
         });
@@ -454,7 +454,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield instance.update(CONSENT_ITEM_STATE.ACCEPTED, '');
         yield instance.get().then(v => value = v);
         expect(value).to.deep.equal(
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, ''));
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test1'));
       });
 
       it('should return unknown value with error', () => {

--- a/src/consent.js
+++ b/src/consent.js
@@ -54,3 +54,22 @@ export function getConsentPolicySharedData(ampdoc, policyId) {
             /** @type {string} */ (policyId));
       });
 }
+
+/**
+ * TODO (zhouyx@)
+ * Combine with getConsentPolicyState and return a consentInfo object.
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {string} policyId
+ * @return {!Promise<string>}
+ */
+export function getConsentPolicyInfo(ampdoc, policyId) {
+  // Return the stored consent string.
+  return Services.consentPolicyServiceForDocOrNull(ampdoc)
+      .then(consentPolicy => {
+        if (!consentPolicy) {
+          return null;
+        }
+        return consentPolicy.getConsentStringInfo(
+            /** @type {string} */ (policyId));
+      });
+}

--- a/test/manual/amp-consent-cmp.html
+++ b/test/manual/amp-consent-cmp.html
@@ -220,6 +220,14 @@
     </div>
   </header>
   <main role="main">
+    <amp-ad width=300 height=250
+        data-block-on-consent
+        type="_ping_"
+        data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
+        data-valid='true'
+        data-enable-io='true'>
+    </amp-ad>
+
     <h3>Image that is blocked by both consent</h3>
     <amp-img data-block-on-consent src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n"
       width=300 height=200></amp-img>

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -183,6 +183,7 @@ const consentObjects = [
     action: 'reject',
     info: '',
     timeout: 1000,
+    info: 'reject-str',
     onclick: () => {
       showConfirmation();
     }


### PR DESCRIPTION
We decided
1. To treat consent string undefined and empty string the same
2. Do not store consent string if consent state is not accept/reject

Also decide to completely remove the support to multiple instances (protected by experimental flag now) because consent string should handle the use case there. 