### PR TITLE
Fix Ampcontext variables in singlepass

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -144,6 +144,9 @@ process.env.SERVE_MODE;
 window.IS_AMP_ALT;
 
 // Exposed to ads.
+// TODO: @erwinmombay I do believe this is safe to remove because
+// All are passed to ampcontext in JsonObject. While isMaster and master is
+// calculated in ampcontext-integration within the iframe.
 window.context = {};
 window.context.sentinel;
 window.context.clientId;
@@ -153,8 +156,6 @@ window.context.sourceUrl;
 window.context.experimentToggles;
 window.context.master;
 window.context.isMaster;
-window.context.initialConsentState;
-window.context.consentSharedData;
 
 // Service Holder
 window.services;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -144,9 +144,6 @@ process.env.SERVE_MODE;
 window.IS_AMP_ALT;
 
 // Exposed to ads.
-// TODO: @erwinmombay I do believe this is safe to remove because
-// All are passed to ampcontext in JsonObject. While isMaster and master is
-// calculated in ampcontext-integration within the iframe.
 window.context = {};
 window.context.sentinel;
 window.context.clientId;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -153,6 +153,8 @@ window.context.sourceUrl;
 window.context.experimentToggles;
 window.context.master;
 window.context.isMaster;
+window.context.initialConsentState;
+window.context.consentSharedData;
 
 // Service Holder
 window.services;

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -35,6 +35,7 @@ import {
   setStyle,
 } from '../../../src/style';
 import {dev, devAssert, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {getAdCid} from '../../../src/ad-cid';
 import {getAdContainer, isAdPositionAllowed}
   from '../../../src/ad-helper';
@@ -354,12 +355,12 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       sharedDataPromise,
       consentStringPromise,
     ]).then(consents => {
-      const opt_context = {
-        clientId: consents[0] || null,
-        container: this.container_,
-        initialConsentState: consents[1],
-        consentSharedData: consents[2],
-      };
+      const opt_context = dict({
+        'clientId': consents[0] || null,
+        'container': this.container_,
+        'initialConsentState': consents[1],
+        'consentSharedData': consents[2],
+      });
       if (isConsentV2Experiment) {
         opt_context['initialConsentValue'] = consents[3];
       }

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -26,8 +26,7 @@ function createFixture() {
   return createFixtureIframe('test/fixtures/3p-ad.html', 3000, () => {});
 }
 
-// TODO: unskip this test for single pass #20002
-describe.configure().skipIfPropertiesObfuscated().run('amp-ad 3P', () => {
+describe.configure().run('amp-ad 3P', () => {
   let fixture;
 
   beforeEach(() => {


### PR DESCRIPTION
Since ad script within iframe can access the variables, I believe we should add the vars to externs. 
Let me know if this is the correct fix. 

One thing that confuses me is that does it mean we should add every var and method from ampcontext.js to the extern list. 

to @erwinmombay @lannka 

Closes #20002