### PR TITLE
Remove bundle size check from pre-push hook

### DIFF
--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,7 +25,7 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_BUNDLE_SIZE="gulp bundle-size --on_pre_push_build"
+GULP_BUNDLE_SIZE="gulp bundle-size"
 GULP_LINT_LOCAL="gulp lint --local-changes"
 GULP_TEST_LOCAL="gulp test --local-changes --headless"
 

--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,7 +25,7 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_BUNDLE_SIZE="gulp bundle-size"
+GULP_BUNDLE_SIZE="gulp bundle-size --on_pre_push_build"
 GULP_LINT_LOCAL="gulp lint --local-changes"
 GULP_TEST_LOCAL="gulp test --local-changes --headless"
 

--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,15 +25,10 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_BUNDLE_SIZE="gulp bundle-size"
 GULP_LINT_LOCAL="gulp lint --local-changes"
 GULP_TEST_LOCAL="gulp test --local-changes --headless"
 
 echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "to skip them.)")
-echo -e "\n"
-
-echo $(GREEN "Running") $(CYAN "$GULP_BUNDLE_SIZE")
-eval $GULP_BUNDLE_SIZE || exit 1
 echo -e "\n"
 
 echo $(GREEN "Running") $(CYAN "$GULP_LINT_LOCAL")

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,8 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitBranchPointFromMaster, gitCommitHash,
-  gitDiffNameOnlyMaster} = require('../git');
+const {gitBranchPointFromMaster, gitCommitHash} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -351,14 +350,6 @@ async function performBundleSizeCheck() {
   if (argv.on_skipped_build) {
     return await skipBundleSize();
   } else {
-    if (argv.on_pre_push_build) {
-      const files = gitDiffNameOnlyMaster();
-      const runtimeFiles = files.filter(fileName => fileName.startsWith('src'));
-      if (runtimeFiles.length == 0) {
-        log('No runtime files were touched, skipping bundle size check.');
-        return;
-      }
-    }
     if (argv.on_push_build) {
       await storeBundleSize();
     } else if (argv.on_pr_build) {
@@ -383,7 +374,5 @@ gulp.task(
             + 'GitHub',
         'on_skipped_build': '  Set the status of this pull request\'s bundle '
             + 'size check in GitHub to `skipped`',
-        'on_pre_push_build': ' Skip bundle size check if no runtime files '
-            + 'were touched.',
       },
     });

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -351,13 +351,15 @@ async function performBundleSizeCheck() {
   if (argv.on_skipped_build) {
     return await skipBundleSize();
   } else {
-    if (argv.on_push_build) {
+    if (argv.on_pre_push_build) {
       const files = gitDiffNameOnlyMaster();
       const runtimeFiles = files.filter(fileName => fileName.startsWith('src'));
       if (runtimeFiles.length == 0) {
         log('No runtime files were touched, skipping bundle size check.');
         return;
       }
+    }
+    if (argv.on_push_build) {
       await storeBundleSize();
     } else if (argv.on_pr_build) {
       await reportBundleSize();
@@ -381,5 +383,7 @@ gulp.task(
             + 'GitHub',
         'on_skipped_build': '  Set the status of this pull request\'s bundle '
             + 'size check in GitHub to `skipped`',
+        'on_pre_push_build': ' Skip bundle size check if no runtime files '
+            + 'were touched.',
       },
     });

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,8 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitBranchPointFromMaster, gitCommitHash} = require('../git');
+const {gitBranchPointFromMaster, gitCommitHash,
+  gitDiffNameOnlyMaster} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -351,6 +352,12 @@ async function performBundleSizeCheck() {
     return await skipBundleSize();
   } else {
     if (argv.on_push_build) {
+      const files = gitDiffNameOnlyMaster();
+      const runtimeFiles = files.filter(fileName => fileName.startsWith('src'));
+      if (runtimeFiles.length == 0) {
+        log('No runtime files were touched, skipping bundle size check.');
+        return;
+      }
       await storeBundleSize();
     } else if (argv.on_pr_build) {
       await reportBundleSize();


### PR DESCRIPTION
UPDATE: removing bundle-size check from pre-push hook altogether. Context / discussion below.

I'm getting this error message a lot in my pre-push hook on PRs that don't touch anything in runtime, causing my pushes to fail unnecessarily. Since we have a rate-limit and this check is pretty pointless for PRs that don't touch runtime, let's remove it from the default pre-push hook. =) 

```
Running gulp bundle-size
[17:54:59] Using gulpfile ~/Code/amphtml/gulpfile.js
[17:54:59] Starting 'bundle-size'...
[17:55:00] ERROR: Failed to retrieve the max allowed bundle size from GitHub.
[17:55:00] 'bundle-size' errored after 687 ms
[17:55:00] HttpError: API rate limit exceeded for 104.132.0.90. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
    at response.text.then.message (/Users/cathyzhu/Code/amphtml/node_modules/@octokit/request/lib/request.js:55:27)
    at process._tickCallback (internal/process/next_tick.js:68:7)
error: failed to push some refs to 'git@github.com:cathyxz/amphtml.git'
```