### PR TITLE
Pass head node, not documentElement, to refactored services

### DIFF
--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -81,8 +81,8 @@ export class A4AVariableSource extends VariableSource {
     super(ampdoc);
 
     // Use parent URL replacements service for fallback.
-    const {documentElement} = ampdoc.win.document;
-    const urlReplacements = Services.urlReplacementsForDoc(documentElement);
+    const headNode = ampdoc.getHeadNode();
+    const urlReplacements = Services.urlReplacementsForDoc(headNode);
 
     /** @private {VariableSource} global variable source for fallback. */
     this.globalVariableSource_ = urlReplacements.getVariableSource();

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -265,8 +265,7 @@ export class AmpRecaptchaService {
     // This is verified by the recaptcha frame to
     // verify the origin on its messages
     let curlsSubdomainPromise = undefined;
-    const {documentElement} = this.win_.document;
-    const isProxyOrigin = Services.urlForDoc(documentElement)
+    const isProxyOrigin = Services.urlForDoc(this.ampdoc_.getHeadNode())
         .isProxyOrigin(this.win_.location.href);
     if (isProxyOrigin) {
       curlsSubdomainPromise = tryResolve(() => {

--- a/extensions/amp-subscriptions/0.1/url-builder.js
+++ b/extensions/amp-subscriptions/0.1/url-builder.js
@@ -24,10 +24,10 @@ export class UrlBuilder {
    * @param {!Promise<string>} readerIdPromise
    */
   constructor(ampdoc, readerIdPromise) {
-    const {documentElement} = ampdoc.win.document;
+    const headNode = ampdoc.getHeadNode();
 
     /** @private @const {!../../../src/service/url-replacements-impl.UrlReplacements} */
-    this.urlReplacements_ = Services.urlReplacementsForDoc(documentElement);
+    this.urlReplacements_ = Services.urlReplacementsForDoc(headNode);
 
     /** @private @const {!Promise<string>} */
     this.readerIdPromise_ = readerIdPromise;

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -123,6 +123,14 @@ export class Navigation {
     /** @private @const {boolean} */
     this.isInABox_ = getMode(this.ampdoc.win).runtime == 'inabox';
 
+    /**
+     * Must use URL parsing scoped to `rootNode_` for correct FIE behavior.
+     * @private @const {!Element|!ShadowRoot}
+     */
+    this.serviceContext_ =
+      (this.rootNode_.nodeType == Node.DOCUMENT_NODE)
+        ? this.rootNode_.documentElement
+        : this.rootNode_;
 
     /** @private @const {!function(!Event)|undefined} */
     this.boundHandle_ = this.handle_.bind(this);
@@ -219,7 +227,7 @@ export class Navigation {
    */
   navigateTo(
     win, url, opt_requestedBy, {target = '_top', opener = false} = {}) {
-    const urlService = Services.urlForDoc(this.ampdoc.getHeadNode());
+    const urlService = Services.urlForDoc(this.serviceContext_);
     if (!urlService.isProtocolValid(url)) {
       user().error(TAG, 'Cannot navigate to invalid protocol: ' + url);
       return;
@@ -578,12 +586,7 @@ export class Navigation {
    * @private
    */
   parseUrl_(url) {
-    // Must use URL parsing scoped to this.rootNode_ for correct FIE behavior.
-    const elementOrShadowRoot = /** @type {!Element|!ShadowRoot} */ (
-      (this.rootNode_.nodeType == Node.DOCUMENT_NODE)
-        ? this.rootNode_.documentElement
-        : this.rootNode_);
-    return Services.urlForDoc(elementOrShadowRoot).parse(url);
+    return Services.urlForDoc(this.serviceContext_).parse(url);
   }
 }
 

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -127,10 +127,11 @@ export class Navigation {
      * Must use URL parsing scoped to `rootNode_` for correct FIE behavior.
      * @private @const {!Element|!ShadowRoot}
      */
-    this.serviceContext_ =
+    this.serviceContext_ = /** @type {!Element|!ShadowRoot} */ (
       (this.rootNode_.nodeType == Node.DOCUMENT_NODE)
         ? this.rootNode_.documentElement
-        : this.rootNode_;
+        : this.rootNode_
+    );
 
     /** @private @const {!function(!Event)|undefined} */
     this.boundHandle_ = this.handle_.bind(this);


### PR DESCRIPTION
Fixes #20008. For some context:

1. All services no longer accept `!Node`. This is to help prevent bugs (of this type!) caused by passing `Document` to service getters. The refactor involved replacing `win.document` with `win.document.documentElement` some cases (no functional difference).

2. A separate refactor caused four FIE-supported services (`action`, `url`, `url-replacements`, and `bind`) to require passing `Element`. However, they should be passing `ampdoc.getHeadNode()` instead of `documentElement`. This was my mistake caused by mixing up the approach for (1).

I surveyed other invocations of the services in (2) and fixed/cleaned them as well. Verified this approach fixes the error in the La Republicca site via dev console.