### PR TITLE
Refactor dev().assert to devAssert

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -22,7 +22,7 @@
 // Note: loaded by 3p system. Cannot rely on babel polyfills.
 
 
-import {dev, rethrowAsync, user} from '../src/log';
+import {devAssert, rethrowAsync, user} from '../src/log';
 import {hasOwn, map} from '../src/utils/object';
 import {isArray} from '../src/types';
 
@@ -56,7 +56,7 @@ export function getRegistrations() {
  */
 export function register(id, draw) {
   const registrations = getRegistrations();
-  dev().assert(!registrations[id], 'Double registration %s', id);
+  devAssert(!registrations[id], 'Double registration %s', id);
   registrations[id] = draw;
 }
 

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -16,7 +16,7 @@
 import {AmpEvents} from '../src/amp-events';
 import {IframeMessagingClient} from './iframe-messaging-client';
 import {MessageType} from '../src/3p-frame-messaging';
-import {dev} from '../src/log';
+import {dev, devAssert} from '../src/log';
 import {dict} from '../src/utils/object';
 import {isExperimentOn, nextTick} from './3p';
 import {isObject} from '../src/types';
@@ -29,7 +29,7 @@ export class AbstractAmpContext {
    *  @param {!Window} win The window that the instance is built inside.
    */
   constructor(win) {
-    dev().assert(!this.isAbstractImplementation_(),
+    devAssert(!this.isAbstractImplementation_(),
         'Should not construct AbstractAmpContext instances directly');
 
     /** @protected {!Window} */
@@ -274,7 +274,7 @@ export class AbstractAmpContext {
    */
   setupMetadata_(data) {
     // TODO(alanorozco): Use metadata utils in 3p/frame-metadata
-    const dataObject = dev().assert(
+    const dataObject = devAssert(
         typeof data === 'string' ? tryParseJson(data) : data,
         'Could not setup metadata.');
 
@@ -316,7 +316,7 @@ export class AbstractAmpContext {
    */
   getHostWindow_() {
     const sentinelMatch = this.sentinel.match(/((\d+)-\d+)/);
-    dev().assert(sentinelMatch, 'Incorrect sentinel format');
+    devAssert(sentinelMatch, 'Incorrect sentinel format');
     const depth = Number(sentinelMatch[2]);
     const ancestors = [];
     for (let win = this.win_; win && win != win.parent; win = win.parent) {

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -16,7 +16,7 @@
 
 import {IframeMessagingClient} from './iframe-messaging-client';
 import {MessageType} from '../src/3p-frame-messaging';
-import {dev, user} from '../src/log';
+import {dev, devAssert, user} from '../src/log';
 import {tryParseJson} from '../src/json';
 
 /** @private @const {string} */
@@ -45,7 +45,7 @@ export class IframeTransportClient {
     // Note: amp-ad-exit will validate the vendor name before performing
     // variable substitution, so if the vendor name is not a valid one from
     // vendors.js, then its response messages will have no effect.
-    dev().assert(this.vendor_.length, 'Vendor name cannot be empty in ' +
+    devAssert(this.vendor_.length, 'Vendor name cannot be empty in ' +
         this.win_.location.href);
 
     /** @protected {!IframeMessagingClient} */
@@ -64,13 +64,13 @@ export class IframeTransportClient {
            *   {!Array<../src/3p-frame-messaging.IframeTransportEvent>}
            */
           (eventData['events']);
-          dev().assert(events,
+          devAssert(events,
               'Received malformed events list in ' + this.win_.location.href);
-          dev().assert(events.length,
+          devAssert(events.length,
               'Received empty events list in ' + this.win_.location.href);
           events.forEach(event => {
             try {
-              dev().assert(event.creativeId,
+              devAssert(event.creativeId,
                   'Received malformed event in ' + this.win_.location.href);
               this.contextFor_(event.creativeId).dispatch(event.message);
             } catch (e) {

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -21,7 +21,13 @@ import ampToolboxCacheUrl from
   '../third_party/amp-toolbox-cache-url/dist/amp-toolbox-cache-url.esm';
 
 import {IframeMessagingClient} from './iframe-messaging-client';
-import {dev, initLogConstructor, setReportError, user} from '../src/log';
+import {
+  dev,
+  devAssert,
+  initLogConstructor,
+  setReportError,
+  user,
+} from '../src/log';
 import {dict} from '../src/utils/object';
 import {isProxyOrigin, parseUrlDeprecated} from '../src/url';
 import {loadScript} from './3p';
@@ -89,7 +95,7 @@ export function initRecaptcha() {
   }
 
   // Get our sitekey from the iframe name attribute
-  dev().assert(
+  devAssert(
       dataObject.sitekey,
       'The sitekey is required for the <amp-recaptcha-input> iframe'
   );

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev, user} from '../src/log';
+import {dev, devAssert, user} from '../src/log';
 import {validateData} from '../3p/3p';
 
 /**
@@ -43,7 +43,7 @@ export function _ping_(global, data) {
   });
 
   if (data.ad_container) {
-    dev().assert(
+    devAssert(
         global.context.container == data.ad_container, 'wrong container');
   }
   if (data.valid && data.valid == 'true') {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -18,7 +18,7 @@ import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {DomFingerprint} from '../../../src/utils/dom-fingerprint';
 import {Services} from '../../../src/services';
 import {buildUrl} from './url-builder';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   getBinaryType,
@@ -353,7 +353,7 @@ function iframeNestingDepth(win) {
     w = w.parent;
     depth++;
   }
-  dev().assert(w == win.top);
+  devAssert(w == win.top);
   return depth;
 }
 
@@ -421,7 +421,7 @@ function secondWindowFromTop(win) {
     secondFromTop = secondFromTop.parent;
     depth++;
   }
-  dev().assert(secondFromTop.parent == win.top);
+  devAssert(secondFromTop.parent == win.top);
   return secondFromTop;
 }
 
@@ -619,7 +619,7 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
   try {
     const analyticsConfig =
         parseJson(responseHeaders.get(AMP_ANALYTICS_HEADER));
-    dev().assert(Array.isArray(analyticsConfig['url']));
+    devAssert(Array.isArray(analyticsConfig['url']));
     const urls = analyticsConfig['url'];
     if (!urls.length) {
       return null;
@@ -760,7 +760,7 @@ export function getEnclosingContainerTypes(adElement) {
  * @return {string|undefined} potentially modified url, undefined
  */
 export function maybeAppendErrorParameter(adUrl, parameterValue) {
-  dev().assert(!!adUrl && !!parameterValue);
+  devAssert(!!adUrl && !!parameterValue);
   // Add parameter indicating error so long as the url has not already been
   // truncated and error parameter is not already present.  Note that we assume
   // that added, error parameter length will be less than truncation parameter
@@ -771,7 +771,7 @@ export function maybeAppendErrorParameter(adUrl, parameterValue) {
     return;
   }
   const modifiedAdUrl = adUrl + `&aet=${parameterValue}`;
-  dev().assert(modifiedAdUrl.length <= MAX_URL_LENGTH);
+  devAssert(modifiedAdUrl.length <= MAX_URL_LENGTH);
   return modifiedAdUrl;
 }
 

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -21,7 +21,7 @@ import {
   serializeMessage,
 } from '../../src/3p-frame-messaging';
 import {PositionObserver} from './position-observer';
-import {dev} from '../../src/log';
+import {dev, devAssert} from '../../src/log';
 import {dict} from '../../src/utils/object';
 import {getData} from '../../src/event-helper';
 import {layoutRectFromDomRect} from '../../src/layout-rect';
@@ -162,7 +162,7 @@ export class InaboxMessagingHost {
       'targetRect': targetRect,
     }));
 
-    dev().assert(this.iframeMap_[request.sentinel]);
+    devAssert(this.iframeMap_[request.sentinel]);
     this.iframeMap_[request.sentinel].observeUnregisterFn =
         this.iframeMap_[request.sentinel].observeUnregisterFn ||
         this.positionObserver_.observe(iframe, data =>

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -69,6 +69,10 @@ const forbiddenTerms = {
   },
   'describe\\.only': '',
   'describes.*\\.only': '',
+  'dev\\(\\)\\.assert\\(': {
+    message: 'Use the devAssert function instead.',
+    whitelist: ['src/log.js'],
+  },
   'it\\.only': '',
   'Math\.random[^;()]*=': 'Use Sinon to stub!!!',
   'gulp-util': {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -32,7 +32,12 @@ import {
 } from '../../../src/url';
 import {cancellation, isCancellation} from '../../../src/error';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev, duplicateErrorIfNecessary, user} from '../../../src/log';
+import {
+  dev,
+  devAssert,
+  duplicateErrorIfNecessary,
+  user,
+} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   getAmpAdRenderOutsideViewport,
@@ -209,8 +214,8 @@ export class AmpA4A extends AMP.BaseElement {
    */
   constructor(element) {
     super(element);
-    dev().assert(AMP.AmpAdUIHandler);
-    dev().assert(AMP.AmpAdXOriginIframeHandler);
+    devAssert(AMP.AmpAdUIHandler);
+    devAssert(AMP.AmpAdXOriginIframeHandler);
 
     /** @private {?Promise<undefined>} */
     this.keysetPromise_ = null;
@@ -888,7 +893,7 @@ export class AmpA4A extends AMP.BaseElement {
    *   the refresh function complete. This is particularly handy for testing.
    */
   refresh(refreshEndCallback) {
-    dev().assert(!this.isRefreshing);
+    devAssert(!this.isRefreshing);
     this.isRefreshing = true;
     this.tearDownSlot();
     this.initiateAdRequest();
@@ -898,7 +903,7 @@ export class AmpA4A extends AMP.BaseElement {
       return Promise.resolve();
     }
     const promiseId = this.promiseId_;
-    return dev().assert(this.adPromise_).then(() => {
+    return devAssert(this.adPromise_).then(() => {
       if (!this.isRefreshing || promiseId != this.promiseId_) {
         // If this refresh cycle was canceled, such as in a no-content
         // response case, keep showing the old creative.
@@ -1201,7 +1206,7 @@ export class AmpA4A extends AMP.BaseElement {
       this.isRefreshing = false;
       return;
     }
-    dev().assert(this.uiHandler);
+    devAssert(this.uiHandler);
     // Store original size to allow for reverting on unlayoutCallback so that
     // subsequent pageview allows for ad request.
     this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
@@ -1265,7 +1270,7 @@ export class AmpA4A extends AMP.BaseElement {
           // give up and render the fallback content (or collapse the ad slot).
           const networkFailureHandlerResult =
               this.onNetworkFailure(error, /** @type {string} */ (this.adUrl_));
-          dev().assert(!!networkFailureHandlerResult);
+          devAssert(!!networkFailureHandlerResult);
           if (networkFailureHandlerResult.frameGetDisabled) {
             // Reset adUrl to null which will cause layoutCallback to not
             // fetch via frame GET.
@@ -1355,9 +1360,9 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   renderAmpCreative_(creativeMetaData) {
-    dev().assert(creativeMetaData.minifiedCreative,
+    devAssert(creativeMetaData.minifiedCreative,
         'missing minified creative');
-    dev().assert(!!this.element.ownerDocument, 'missing owner document?!');
+    devAssert(!!this.element.ownerDocument, 'missing owner document?!');
     this.maybeTriggerAnalyticsEvent_('renderFriendlyStart');
     // Create and setup friendly iframe.
     this.iframe = /** @type {!HTMLIFrameElement} */(
@@ -1506,7 +1511,7 @@ export class AmpA4A extends AMP.BaseElement {
   renderViaNameAttrOfXOriginIframe_(creativeBody) {
     /** @type {?string} */
     const method = this.experimentalNonAmpCreativeRenderMethod_;
-    dev().assert(method == XORIGIN_MODE.SAFEFRAME ||
+    devAssert(method == XORIGIN_MODE.SAFEFRAME ||
         method == XORIGIN_MODE.NAMEFRAME,
     'Unrecognized A4A cross-domain rendering mode: %s', method);
     this.maybeTriggerAnalyticsEvent_('renderSafeFrameStart');
@@ -1672,7 +1677,7 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     const analyticsEvent =
-        dev().assert(LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER[lifecycleStage]);
+        devAssert(LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER[lifecycleStage]);
     const analyticsVars = /** @type {!JsonObject} */ (Object.assign(
         dict({'time': Math.round(this.getNow_())}),
         this.getA4aAnalyticsVars(analyticsEvent)));

--- a/extensions/amp-a4a/0.1/amp-ad-network-base.js
+++ b/extensions/amp-a4a/0.1/amp-ad-network-base.js
@@ -19,7 +19,7 @@ import {
   RecoveryModeType,
 } from './amp-ad-type-defs';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {map} from '../../../src/utils/object';
 import {sendXhrRequest} from './amp-ad-utils';
@@ -77,7 +77,7 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    dev().assert(this.adResponsePromise_,
+    devAssert(this.adResponsePromise_,
         'layoutCallback invoked before XHR request!');
     return this.adResponsePromise_
         .then(response => this.invokeValidator_(response))
@@ -167,7 +167,7 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
     return response.arrayBuffer().then(unvalidatedBytes => {
       const validatorType = response.headers.get('AMP-Ad-Response-Type')
           || 'default';
-      dev().assert(this.validators_[validatorType],
+      devAssert(this.validators_[validatorType],
           'Validator never registered!');
       return this.validators_[validatorType].validate(
           this.context_, unvalidatedBytes, response.headers)
@@ -183,7 +183,7 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
    */
   invokeRenderer_(validatorOutput) {
     const renderer = this.renderers_[validatorOutput.type];
-    dev().assert(renderer, 'Renderer for AMP creatives never registered!');
+    devAssert(renderer, 'Renderer for AMP creatives never registered!');
     return renderer.render(
         this.context_, this.element, validatorOutput.creativeData)
         .catch(err =>

--- a/extensions/amp-a4a/0.1/amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/amp-ad-template-helper.js
@@ -17,7 +17,7 @@
 import {LruCache} from '../../../src/utils/lru-cache';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray} from '../../../src/types';
@@ -65,7 +65,7 @@ export class AmpAdTemplateHelper {
           .then(response => response.text());
       this.cache_.put(proxyUrl, templatePromise);
     }
-    dev().assert(templatePromise);
+    devAssert(templatePromise);
     return /** @type{!Promise<string>} */ (templatePromise);
   }
 

--- a/extensions/amp-a4a/0.1/friendly-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/friendly-frame-renderer.js
@@ -15,7 +15,7 @@
  */
 
 import {Renderer} from './amp-ad-type-defs';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {renderCreativeIntoFriendlyFrame} from './friendly-frame-util';
 
 /**
@@ -46,8 +46,8 @@ export class FriendlyFrameRenderer extends Renderer {
     const {size, adUrl} = context;
     const {creativeMetadata} = creativeData;
 
-    dev().assert(size, 'missing creative size');
-    dev().assert(adUrl, 'missing ad request url');
+    devAssert(size, 'missing creative size');
+    devAssert(adUrl, 'missing ad request url');
 
     return renderCreativeIntoFriendlyFrame(
         adUrl, size, element, creativeMetadata);

--- a/extensions/amp-a4a/0.1/refresh-intersection-observer-wrapper.js
+++ b/extensions/amp-a4a/0.1/refresh-intersection-observer-wrapper.js
@@ -17,7 +17,7 @@
 import {
   IntersectionObserverPolyfill,
 } from '../../../src/intersection-observer-polyfill';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 
 export class RefreshIntersectionObserverWrapper {
   /**
@@ -62,7 +62,7 @@ export class RefreshIntersectionObserverWrapper {
     // DATA_MANAGER_ID_NAME, but unfortunately, it can't be imported without
     // creating a cyclical dependency.
     const refreshId = element.getAttribute('data-amp-ad-refresh-id');
-    dev().assert(refreshId, 'observe invoked on element without refresh id');
+    devAssert(refreshId, 'observe invoked on element without refresh id');
 
     if (!this.viewportCallbacks_[refreshId]) {
       const viewportCallback = element.viewportCallback.bind(element);

--- a/extensions/amp-a4a/0.1/refresh-manager.js
+++ b/extensions/amp-a4a/0.1/refresh-manager.js
@@ -18,7 +18,7 @@ import {
   RefreshIntersectionObserverWrapper,
 } from './refresh-intersection-observer-wrapper';
 import {Services} from '../../../src/services';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
 /**
@@ -247,7 +247,7 @@ export class RefreshManager {
   ioCallback_(entries) {
     entries.forEach(entry => {
       const refreshManagerId = entry.target.getAttribute(DATA_MANAGER_ID_NAME);
-      dev().assert(refreshManagerId);
+      devAssert(refreshManagerId);
       const refreshManager = managers[refreshManagerId];
       if (entry.target != refreshManager.element_) {
         return;
@@ -329,7 +329,7 @@ export class RefreshManager {
    * @return {!JsonObject}
    */
   convertAndSanitizeConfiguration_(config) {
-    dev().assert(config['visiblePercentageMin'] >= 0 &&
+    devAssert(config['visiblePercentageMin'] >= 0 &&
         config['visiblePercentageMin'] <= 100,
     'visiblePercentageMin for refresh must be in the range [0, 100]');
     // Convert seconds to milliseconds.

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {base64DecodeToBytes} from '../../../src/utils/base64';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {isArray} from '../../../src/types';
 
 /** @visibleForTesting */
@@ -213,7 +213,7 @@ export class SignatureVerifier {
       return Promise.resolve(VerificationStatus.CRYPTO_UNAVAILABLE);
     }
     const signer = this.signers_[signingServiceName];
-    dev().assert(
+    devAssert(
         signer, 'Keyset for service %s not loaded before verification',
         signingServiceName);
     return signer.promise.then(success => {
@@ -306,10 +306,10 @@ export class SignatureVerifier {
               // and there's no meaningful error recovery to be done if they
               // fail, so we don't need to do them at runtime in production.
               // They're included in dev mode as a debugging aid.
-              dev().assert(
+              devAssert(
                   response.status === 200,
                   'Fast Fetch keyset spec requires status code 200');
-              dev().assert(
+              devAssert(
                   response.headers.get('Content-Type') ==
                       'application/jwk-set+json',
                   'Fast Fetch keyset spec requires Content-Type: ' +

--- a/extensions/amp-a4a/0.1/template-renderer.js
+++ b/extensions/amp-a4a/0.1/template-renderer.js
@@ -15,7 +15,7 @@
  */
 
 import {Renderer} from './amp-ad-type-defs';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {getAmpAdTemplateHelper} from './template-validator';
 import {renderCreativeIntoFriendlyFrame} from './friendly-frame-util';
 
@@ -50,8 +50,8 @@ export class TemplateRenderer extends Renderer {
     const {size, adUrl} = context;
     const {creativeMetadata} = creativeData;
 
-    dev().assert(size, 'missing creative size');
-    dev().assert(adUrl, 'missing ad request url');
+    devAssert(size, 'missing creative size');
+    devAssert(adUrl, 'missing ad request url');
 
     return renderCreativeIntoFriendlyFrame(
         adUrl, size, element, creativeMetadata)

--- a/extensions/amp-access/0.1/amp-access-client.js
+++ b/extensions/amp-access/0.1/amp-access-client.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 
@@ -137,7 +137,7 @@ export class AccessClientAdapter {
 
   /** @override */
   pingback() {
-    const promise = this.context_.buildUrl(dev().assert(this.pingbackUrl_),
+    const promise = this.context_.buildUrl(devAssert(this.pingbackUrl_),
         /* useAuthData */ true);
     return promise.then(url => {
       dev().fine(TAG, 'Pingback URL: ', url);

--- a/extensions/amp-access/0.1/amp-access-other.js
+++ b/extensions/amp-access/0.1/amp-access-other.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {isProxyOrigin} from '../../../src/url';
 
 /** @const {string} */
@@ -62,8 +62,8 @@ export class AccessOtherAdapter {
   authorize() {
     dev().fine(TAG, 'Use the authorization fallback for type=other');
     // Disallow authorization for proxy origin (`cdn.ampproject.org`).
-    dev().assert(!this.isProxyOrigin_, 'Cannot authorize for proxy origin');
-    const response = dev().assert(this.authorizationResponse_);
+    devAssert(!this.isProxyOrigin_, 'Cannot authorize for proxy origin');
+    const response = devAssert(this.authorizationResponse_);
     return Promise.resolve(response);
   }
 

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -16,7 +16,7 @@
 
 import {AccessClientAdapter} from './amp-access-client';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/dom';
 import {fetchDocument} from '../../../src/document-fetcher';
@@ -163,7 +163,7 @@ export class AccessServerAdapter {
           }));
     }).then(responseDoc => {
       dev().fine(TAG, 'Authorization response: ', responseDoc);
-      const accessDataString = dev().assert(
+      const accessDataString = devAssert(
           responseDoc.querySelector('script[id="amp-access-data"]'),
           'No authorization data available').textContent;
       const accessData = parseJson(accessDataString);

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -23,7 +23,7 @@ import {bezierCurve} from '../../../src/curve';
 import {clamp} from '../../../src/utils/math';
 import {closest, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   numeric,
@@ -205,7 +205,7 @@ class AmpAccordion extends AMP.BaseElement {
               dev().assertString(this.sessionId_));
       return sessionStr
         ? /** @type {!JsonObject} */ (
-          dev().assert(parseJson(dev().assertString(sessionStr))))
+          devAssert(parseJson(dev().assertString(sessionStr))))
         : dict();
     } catch (e) {
       dev().fine('AMP-ACCORDION',

--- a/extensions/amp-ad-custom/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/amp-ad-custom.js
@@ -23,7 +23,7 @@ import {NameFrameRenderer} from '../../amp-a4a/0.1/name-frame-renderer';
 import {TemplateRenderer} from '../../amp-a4a/0.1/template-renderer';
 import {TemplateValidator} from '../../amp-a4a/0.1/template-validator';
 import {addParamToUrl} from '../../../src/url';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {startsWith} from '../../../src/string';
 
 // These have no side-effects, and so may be reused between all instances.
@@ -45,7 +45,7 @@ export class AmpAdTemplate extends AmpAdNetworkBase {
 
     /** @const {string} */
     this.baseRequestUrl_ = this.element.getAttribute('src');
-    dev().assert(this.baseRequestUrl_,
+    devAssert(this.baseRequestUrl_,
         'Invalid network configuration: no request URL specified');
 
     this.getContext().win = this.win;

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -23,7 +23,7 @@ import {
 import {Services} from '../../../src/services';
 import {TransportMode, assertConfig, assertVendor} from './config';
 import {createFilter} from './filters/factory';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {getData} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
@@ -356,7 +356,7 @@ export class AmpAdExit extends AMP.BaseElement {
           'not in inabox case.');
       return;
     }
-    dev().assert(!this.unlisten_, 'Unlistener should not already exist.');
+    devAssert(!this.unlisten_, 'Unlistener should not already exist.');
     this.unlisten_ = listen(this.getAmpDoc().win, 'message',
         event => {
           // We shouldn't deserialize just any message...it would be too

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-shared-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-shared-state.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 
 /**
  * Maintains state in between different AdSense slots on the same page. This
@@ -46,7 +46,7 @@ export class AdsenseSharedState {
   addNewSlot(format, id, client, slotname) {
     const result = {pv: 2, prevFmts: '', prevSlotnames: ''};
     this.previousSlots_.forEach(slot => {
-      dev().assert(slot.id != id);
+      devAssert(slot.id != id);
       result.prevFmts += (result.prevFmts ? ',' : '') + slot.format;
       if (slot.slotname) {
         result.prevSlotnames +=

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -57,7 +57,7 @@ import {
   setStyle,
   setStyles,
 } from '../../../src/style';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {
   getAdSenseAmpAutoAdsExpBranch,
@@ -319,7 +319,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     // data-amp-slot-index is set by the upgradeCallback method of amp-ad.
     // TODO(bcassels): Uncomment the assertion, fixing the tests.
     // But not all tests arrange to call upgradeCallback.
-    // dev().assert(slotId != undefined);
+    // devAssert(slotId != undefined);
     const adk = this.adKey_(format);
     this.uniqueSlotId_ = slotId + adk;
     const slotname = this.element.getAttribute('data-ad-slot');
@@ -468,12 +468,12 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         !creativeMetaData.customElementExtensions.includes('amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
-      dev().assert(this.iframe);
+      devAssert(this.iframe);
       Navigation.installAnchorClickInterceptor(
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assert(!this.ampAnalyticsElement_);
+      devAssert(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -21,7 +21,7 @@ import {
 } from '../../amp-a4a/0.1/amp-a4a';
 import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {AmpTemplateCreativeDef} from '../../amp-a4a/0.1/amp-ad-type-defs';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {tryParseJson} from '../../../src/json';
 import {tryResolve} from '../../../src/utils/promise';
@@ -91,7 +91,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
   /** @override */
   getAdUrl() {
     const data = this.element.getAttribute('data-r');
-    dev().assert(data, 'Expected data-r attribte on amp-ad tag');
+    devAssert(data, 'Expected data-r attribte on amp-ad tag');
     if (getMode(this.win).localDev) {
       return `http://ads.localhost:${this.win.location.port}` +
           '/adzerk/' + data;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -70,7 +70,7 @@ import {
 } from './sra-utils';
 import {createElementWithAttributes, removeElement} from '../../../src/dom';
 import {deepMerge, dict} from '../../../src/utils/object';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {
   extractUrlExperimentId,
@@ -433,7 +433,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   shouldPreferentialRenderWithoutCrypto() {
-    dev().assert(!isCdnProxy(this.win));
+    devAssert(!isCdnProxy(this.win));
     return true;
   }
 
@@ -463,8 +463,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @return {!Object<string,string|boolean|number>}
    */
   getBlockParameters_() {
-    dev().assert(this.initialSize_);
-    dev().assert(this.jsonTargeting);
+    devAssert(this.initialSize_);
+    devAssert(this.jsonTargeting);
     const tfcd = this.jsonTargeting && this.jsonTargeting[TFCD];
     this.win['ampAdGoogleIfiCounter'] = this.win['ampAdGoogleIfiCounter'] || 1;
     this.ifi_ = (this.isRefreshing && this.ifi_) ||
@@ -901,12 +901,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         !creativeMetaData.customElementExtensions.includes('amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
-      dev().assert(this.iframe);
+      devAssert(this.iframe);
       Navigation.installAnchorClickInterceptor(
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assert(!this.ampAnalyticsElement_);
+      devAssert(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,
@@ -920,7 +920,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           !!this.postAdResponseExperimentFeatures['avr_disable_immediate']);
     }
     if (this.isRefreshing) {
-      dev().assert(this.refreshManager_);
+      devAssert(this.refreshManager_);
       this.refreshManager_.initiateRefreshCycle();
       this.isRefreshing = false;
       this.isRelayoutNeededFlag = false;
@@ -1153,10 +1153,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           checkStillCurrent();
           const sraRequestPromises = [];
           Object.keys(groupIdToBlocksAry).forEach(networkId => {
-            const blocks = dev().assert(groupIdToBlocksAry[networkId]);
+            const blocks = devAssert(groupIdToBlocksAry[networkId]);
             // TODO: filter blocks with SRA disabled?
             sraRequestPromises.push(Promise.all(blocks).then(instances => {
-              dev().assert(instances.length);
+              devAssert(instances.length);
               checkStillCurrent();
               // Exclude any instances that do not have an adPromise_ as this
               // indicates they were invalid.
@@ -1300,7 +1300,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       return;
     }
     const creativeSize = this.getCreativeSize();
-    dev().assert(creativeSize, 'this.getCreativeSize returned null');
+    devAssert(creativeSize, 'this.getCreativeSize returned null');
     this.safeframeApi_ = this.safeframeApi_ ||
         new SafeframeHostApi(
             this, this.isFluidRequest_,
@@ -1321,7 +1321,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (!this.win.opener || !/[?|&]dfpdeb/.test(this.win.location.search)) {
       return null;
     }
-    dev().assert(this.troubleshootData_.adUrl, 'ad URL does not exist yet');
+    devAssert(this.troubleshootData_.adUrl, 'ad URL does not exist yet');
     return this.troubleshootData_.adUrl.then(adUrl => {
       const slotId = this.troubleshootData_.slotId + '_' +
           this.troubleshootData_.slotIndex;
@@ -1425,7 +1425,7 @@ export function getNetworkId(element) {
  */
 function constructSRARequest_(a4a, instances) {
   // TODO(bradfrizzell): Need to add support for RTC.
-  dev().assert(instances && instances.length);
+  devAssert(instances && instances.length);
   const startTime = Date.now();
   return Promise.all(
       instances.map(instance => instance.getAdUrlDeferred.promise))

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getStyle, setStyles} from '../../../src/style';
@@ -290,7 +290,7 @@ export class SafeframeHostApi {
    * that as well.
    */
   registerSafeframeHost() {
-    dev().assert(this.sentinel_);
+    devAssert(this.sentinel_);
     safeframeHosts[this.sentinel_] = safeframeHosts[this.sentinel_] || this;
     if (!safeframeListenerCreated_) {
       safeframeListenerCreated_ = true;
@@ -307,7 +307,7 @@ export class SafeframeHostApi {
     // Set the iframe here, because when class is first created the iframe
     // element does not yet exist on this.baseInstance_. The first time
     // we receive a message we know that it now exists.
-    dev().assert(this.baseInstance_.iframe);
+    devAssert(this.baseInstance_.iframe);
     this.iframe_ = this.baseInstance_.iframe;
     this.channel = channel;
     this.setupGeom_();
@@ -326,7 +326,7 @@ export class SafeframeHostApi {
    * @private
    */
   setupGeom_() {
-    dev().assert(this.iframe_.contentWindow,
+    devAssert(this.iframe_.contentWindow,
         'Frame contentWindow unavailable.');
     const throttledUpdate = throttle(
         this.win_, this.updateGeometry_.bind(this), 1000);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -15,7 +15,7 @@
  */
 
 import {RENDERING_TYPE_HEADER, XORIGIN_MODE} from '../../amp-a4a/0.1/amp-a4a';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {getEnclosingContainerTypes} from '../../../ads/google/a4a/utils';
 import {
   isInManualExperiment,
@@ -85,7 +85,7 @@ export function combineInventoryUnits(impls) {
   let uniqueIuNamesCount = 0;
   const prevIusEncoded = [];
   impls.forEach(instance => {
-    const iu = dev().assert(instance.element.getAttribute('data-slot'));
+    const iu = devAssert(instance.element.getAttribute('data-slot'));
     const componentNames = iu.split('/');
     const encodedNames = [];
     for (let i = 0; i < componentNames.length; i++) {
@@ -127,7 +127,7 @@ export function getCookieOptOut(impls) {
  * @visibleForTesting
  */
 export function getAdks(impls) {
-  return ({'adks': impls.map(impl => dev().assert(impl.adKey)).join()});
+  return ({'adks': impls.map(impl => devAssert(impl.adKey)).join()});
 }
 
 /**
@@ -138,7 +138,7 @@ export function getAdks(impls) {
  */
 export function getSizes(impls) {
   return ({'prev_iu_szs': impls.map(impl =>
-    dev().assert(impl.parameterSize)).join()});
+    devAssert(impl.parameterSize)).join()});
 }
 
 /**
@@ -380,7 +380,7 @@ export function sraBlockCallbackHandler(
   // should match the order of blocks declared in the ad url.
   // This allows the block to start rendering while the SRA
   // response is streaming back to the client.
-  dev().assert(sraRequestAdUrlResolvers.shift())(fetchResponse);
+  devAssert(sraRequestAdUrlResolvers.shift())(fetchResponse);
   // If done, expect array to be empty (ensures ad response
   // included data for all slots).
   if (done && sraRequestAdUrlResolvers.length) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -54,7 +54,7 @@ import {
 } from '../sra-utils';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {dev} from '../../../../src/log';
+import {devAssert} from '../../../../src/log';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {utf8Decode, utf8Encode} from '../../../../src/utils/bytes';
 
@@ -387,8 +387,8 @@ describes.realWin('Doubleclick SRA', config , env => {
 
     function generateSraXhrMockCall(
       validInstances, networkId, responses, opt_xhrFail, opt_allInvalid) {
-      dev().assert(validInstances.length > 1);
-      dev().assert(!(opt_xhrFail && opt_allInvalid));
+      devAssert(validInstances.length > 1);
+      devAssert(!(opt_xhrFail && opt_allInvalid));
       // Start with nameframe method, SRA will override to use safeframe.
       const headers = {};
       headers[RENDERING_TYPE_HEADER] = XORIGIN_MODE.NAMEFRAME;
@@ -495,7 +495,7 @@ describes.realWin('Doubleclick SRA', config , env => {
         if (typeof network == 'number') {
           network = {networkId: network, instances: 1};
         }
-        dev().assert(network.instances || network.invalidInstances);
+        devAssert(network.instances || network.invalidInstances);
         const createInstances = (instanceCount, invalid) => {
           for (let i = 0; i < instanceCount; i++) {
             const impl = createA4aSraInstance(network.networkId);

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -34,7 +34,7 @@ import {
   computedStyle,
   setStyle,
 } from '../../../src/style';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {getAdCid} from '../../../src/ad-cid';
 import {getAdContainer, isAdPositionAllowed}
   from '../../../src/ad-helper';
@@ -323,7 +323,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     }
 
     const iframe = /** @type {!../../../src/layout-rect.LayoutRectDef} */(
-      dev().assert(this.iframeLayoutBox_));
+      devAssert(this.iframeLayoutBox_));
     return moveLayoutRect(iframe, box.left, box.top);
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -34,7 +34,7 @@ import {
   listenForOncePromise,
   postMessageToWindows,
 } from '../../../src/iframe-helper';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {
@@ -106,7 +106,7 @@ export class AmpAdXOriginIframeHandler {
    * @return {!Promise} awaiting render complete promise
    */
   init(iframe, opt_isA4A) {
-    dev().assert(
+    devAssert(
         !this.iframe, 'multiple invocations of init without destroy!');
     this.iframe = iframe;
     this.iframe.setAttribute('scrolling', 'no');
@@ -439,7 +439,7 @@ export class AmpAdXOriginIframeHandler {
   getIframePositionPromise_() {
     return this.viewport_.getClientRectAsync(
         dev().assertElement(this.iframe)).then(position => {
-      dev().assert(position,
+      devAssert(position,
           'element clientRect should intersects with root clientRect');
       const viewport = this.viewport_.getRect();
       return dict({

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -36,7 +36,7 @@ import {
 } from './requests';
 import {Services} from '../../../src/services';
 import {Transport} from './transport';
-import {dev, rethrowAsync, user} from '../../../src/log';
+import {dev, devAssert, rethrowAsync, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {expandTemplate} from '../../../src/string';
 import {getMode} from '../../../src/mode';
@@ -629,7 +629,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     return Promise.all([enabledOnTagLevel, enabledOnTriggerLevel])
         .then(enabled => {
-          dev().assert(enabled.length === 2);
+          devAssert(enabled.length === 2);
           return enabled[0] && enabled[1];
         });
   }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -22,7 +22,7 @@ import {
   VideoAnalyticsDetailsDef,
   VideoAnalyticsEvents,
 } from '../../../src/video-interface';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getDataParamsFromAttributes} from '../../../src/dom';
@@ -1127,8 +1127,8 @@ export class VideoEventTracker extends EventTracker {
         const normalizedPercentage = details['normalizedPercentage'];
         const normalizedPercentageInt = parseInt(normalizedPercentage, 10);
 
-        dev().assert(isFiniteNumber(normalizedPercentageInt));
-        dev().assert((normalizedPercentageInt % percentageInterval) == 0);
+        devAssert(isFiniteNumber(normalizedPercentageInt));
+        devAssert((normalizedPercentageInt % percentageInterval) == 0);
 
         if (lastPercentage == normalizedPercentageInt) {
           return;

--- a/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
@@ -16,7 +16,7 @@
 
 import {MessageType} from '../../../src/3p-frame-messaging';
 import {SubscriptionApi} from '../../../src/iframe-helper';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 
 /** @private @const {string} */
 const TAG_ = 'amp-analytics/iframe-transport-message-queue';
@@ -92,7 +92,7 @@ export class IframeTransportMessageQueue {
    * creative) is sending it.
    */
   enqueue(event) {
-    dev().assert(event && event.creativeId && event.message,
+    devAssert(event && event.creativeId && event.message,
         'Attempted to enqueue malformed message for: ' +
         event.creativeId);
     this.pendingEvents_.push(event);

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -16,7 +16,7 @@
 
 import {IframeTransportMessageQueue} from './iframe-transport-message-queue';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {hasOwn} from '../../../src/utils/object';
 import {isLongTaskApiSupported} from '../../../src/service/jank-meter';
@@ -76,7 +76,7 @@ export class IframeTransport {
     /** @private @const {string} */
     this.creativeId_ = id;
 
-    dev().assert(config && config['iframe'],
+    devAssert(config && config['iframe'],
         'Must supply iframe URL to constructor!');
     this.frameUrl_ = config['iframe'];
 
@@ -108,7 +108,7 @@ export class IframeTransport {
       this.ampWin_.document.body.appendChild(frameData.frame);
       this.createPerformanceObserver_();
     }
-    dev().assert(frameData, 'Trying to use non-existent frame');
+    devAssert(frameData, 'Trying to use non-existent frame');
   }
 
   /**
@@ -203,7 +203,7 @@ export class IframeTransport {
    */
   static markCrossDomainIframeAsDone(ampDoc, type) {
     const frameData = IframeTransport.getFrameData(type);
-    dev().assert(frameData && frameData.frame && frameData.usageCount,
+    devAssert(frameData && frameData.frame && frameData.usageCount,
         'Marked the ' + type + ' frame as done, but there is no' +
         ' record of it existing.');
     if (--(frameData.usageCount)) {
@@ -246,8 +246,8 @@ export class IframeTransport {
    */
   sendRequest(event) {
     const frameData = IframeTransport.getFrameData(this.type_);
-    dev().assert(frameData, 'Trying to send message to non-existent frame');
-    dev().assert(frameData.queue,
+    devAssert(frameData, 'Trying to send message to non-existent frame');
+    devAssert(frameData.queue,
         'Event queue is missing for messages from ' + this.type_ +
         ' to creative ID ' + this.creativeId_);
     frameData.queue.enqueue(

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -21,7 +21,7 @@ import {
 } from './variables';
 import {SANDBOX_AVAILABLE_VARS} from './sandbox-vars-whitelist';
 import {Services} from '../../../src/services';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getResourceTiming} from './resource-timing';
 import {isArray, isFiniteNumber, isObject} from '../../../src/types';
@@ -45,7 +45,7 @@ export class RequestHandler {
     this.win = this.ampdoc_.win;
 
     /** @const {string} */
-    this.baseUrl = dev().assert(request['baseUrl']);
+    this.baseUrl = devAssert(request['baseUrl']);
 
     /** @private {Array<number>|number|undefined} */
     this.batchInterval_ = request['batchInterval']; //unit is sec
@@ -280,7 +280,7 @@ export class RequestHandler {
    * Schedule sending request regarding to batchInterval
    */
   refreshBatchInterval_() {
-    dev().assert(this.batchIntervalPointer_ != null,
+    devAssert(this.batchIntervalPointer_ != null,
         'Should not start batchInterval without pointer');
     const interval = this.batchIntervalPointer_ < this.batchInterval_.length ?
       this.batchInterval_[this.batchIntervalPointer_++] :

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {base64UrlEncodeFromString} from '../../../src/utils/base64';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {isArray, isFiniteNumber} from '../../../src/types';
 import {tryResolve} from '../../../src/utils/promise';
@@ -167,7 +167,7 @@ export class VariableService {
    * @param {*} macro
    */
   register_(name, macro) {
-    dev().assert(!this.macros_[name], 'Macro "' + name
+    devAssert(!this.macros_[name], 'Macro "' + name
         + '" already registered.');
     this.macros_[name] = macro;
   }

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -16,7 +16,7 @@
 
 import {Deferred} from '../../../src/utils/promise';
 import {Observable} from '../../../src/observable';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
 /**
@@ -152,7 +152,7 @@ export class VisibilityModel {
    * @private
    */
   reset_() {
-    dev().assert(!this.eventResolver_,
+    devAssert(!this.eventResolver_,
         'Attempt to refresh visible event before previous one resolve');
     const deferred = new Deferred();
     this.eventPromise_ = deferred.promise;
@@ -357,7 +357,7 @@ export class VisibilityModel {
    * @return {boolean}
    */
   isVisibilityMatch_(visibility) {
-    dev().assert(visibility >= 0 && visibility <= 1,
+    devAssert(visibility >= 0 && visibility <= 1,
         'invalid visibility value: %s', visibility);
     // Special case: If visiblePercentageMin is 100%, then it doesn't make
     // sense to do the usual (min, max] since that would never be true.
@@ -379,7 +379,7 @@ export class VisibilityModel {
    * @private
    */
   updateCounters_(visibility) {
-    dev().assert(visibility >= 0 && visibility <= 1,
+    devAssert(visibility >= 0 && visibility <= 1,
         'invalid visibility value: %s', visibility);
     const now = Date.now();
 
@@ -407,7 +407,7 @@ export class VisibilityModel {
             Math.max(this.maxContinuousVisibleTime_, this.continuousTime_);
       } else {
         // The resource came into view: start counting.
-        dev().assert(!this.lastVisibleUpdateTime_);
+        devAssert(!this.lastVisibleUpdateTime_);
         this.firstVisibleTime_ = this.firstVisibleTime_ || now;
       }
       this.lastVisibleUpdateTime_ = now;
@@ -420,7 +420,7 @@ export class VisibilityModel {
       this.lastVisibleTime_ = now;
     } else if (prevMatchesVisibility) {
       // The resource went out of view. Do final calculations and reset state.
-      dev().assert(this.lastVisibleUpdateTime_ > 0);
+      devAssert(this.lastVisibleUpdateTime_ > 0);
 
       this.maxContinuousVisibleTime_ = Math.max(
           this.maxContinuousVisibleTime_,

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -41,7 +41,7 @@ import {
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
 import {closestBySelector, matches} from '../../../src/dom';
 import {dashToCamelCase, startsWith} from '../../../src/string';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {extractKeyframes} from './keyframes-extractor';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject, toArray} from '../../../src/types';
@@ -313,7 +313,7 @@ export class AnimationWorkletRunner extends AnimationRunner {
    * @private
    */
   applyMargins_(rect) {
-    dev().assert(rect);
+    devAssert(rect);
     rect = layoutRectLtwh(
         rect.left,
         (rect.top + this.topMargin_),
@@ -394,7 +394,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * Initializes the players but does not change the state.
    */
   init() {
-    dev().assert(!this.players_);
+    devAssert(!this.players_);
     this.players_ = this.requests_.map(request => {
       // Apply vars.
       if (request.vars) {
@@ -433,7 +433,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * @override
    */
   pause() {
-    dev().assert(this.players_);
+    devAssert(this.players_);
     this.setPlayState_(WebAnimationPlayState.PAUSED);
     this.players_.forEach(player => {
       if (player.playState == WebAnimationPlayState.RUNNING) {
@@ -446,7 +446,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * @override
    */
   resume() {
-    dev().assert(this.players_);
+    devAssert(this.players_);
     const oldRunnerPlayState = this.playState_;
     if (oldRunnerPlayState == WebAnimationPlayState.RUNNING) {
       return;
@@ -466,7 +466,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * @override
    */
   reverse() {
-    dev().assert(this.players_);
+    devAssert(this.players_);
     // TODO(nainar) there is no reverse call on WorkletAnimation
     this.players_.forEach(player => {
       player.reverse();
@@ -478,7 +478,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * @param {time} time
    */
   seekTo(time) {
-    dev().assert(this.players_);
+    devAssert(this.players_);
     this.setPlayState_(WebAnimationPlayState.PAUSED);
     this.players_.forEach(player => {
       player.pause();
@@ -493,7 +493,7 @@ export class WebAnimationRunner extends AnimationRunner {
    * @param {number} percent between 0 and 1
    */
   seekToPercent(percent) {
-    dev().assert(percent >= 0 && percent <= 1);
+    devAssert(percent >= 0 && percent <= 1);
     const totalDuration = this.getTotalDuration_();
     const time = totalDuration * percent;
     this.seekTo(time);
@@ -1608,7 +1608,7 @@ class CssContextImpl {
    * @private
    */
   getElement_(selector, selectionMethod) {
-    dev().assert(
+    devAssert(
         selectionMethod == null || selectionMethod == 'closest',
         'Unknown selection method: %s', selectionMethod);
     let element;

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -21,7 +21,7 @@ import {
   UrlReplacementPolicy,
   batchFetchJsonFor,
 } from '../../../src/batched-json';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {getSourceOrigin} from '../../../src/url';
 import {isJsonScriptTag} from '../../../src/dom';
 import {map} from '../../../src/utils/object';
@@ -80,7 +80,7 @@ export class AmpState extends AMP.BaseElement {
     const {element} = this;
     if (element.hasAttribute('overridable')) {
       Services.bindForDocOrNull(element).then(bind => {
-        dev().assert(bind, 'Bind service can not be found.');
+        devAssert(bind, 'Bind service can not be found.');
         bind.makeStateKeyOverridable(element.getAttribute('id'));
       });
     }
@@ -173,7 +173,7 @@ export class AmpState extends AMP.BaseElement {
     const state = /** @type {!JsonObject} */ (map());
     state[id] = json;
     Services.bindForDocOrNull(this.element).then(bind => {
-      dev().assert(bind, 'Bind service can not be found.');
+      devAssert(bind, 'Bind service can not be found.');
       bind.setState(state,
           /* opt_skipEval */ isInit, /* opt_isAmpStateMutation */ !isInit);
     });

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -15,7 +15,7 @@
  */
 
 import {AstNodeType} from './bind-expr-defines';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
@@ -179,7 +179,7 @@ function generateFunctionWhitelist() {
     Object.keys(functionsForType).forEach(name => {
       const func = functionsForType[name];
       if (func) {
-        dev().assert(!func.name || name === func.name, 'Listed function name ' +
+        devAssert(!func.name || name === func.name, 'Listed function name ' +
             `"${name}" doesn't match name property "${func.name}".`);
         out[type][name] = func;
       } else {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -24,7 +24,7 @@ import {Signals} from '../../../src/utils/signals';
 import {debounce} from '../../../src/utils/rate-limit';
 import {deepEquals, getValueForExpr, parseJson} from '../../../src/json';
 import {deepMerge, dict, map} from '../../../src/utils/object';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {findIndex, remove} from '../../../src/utils/array';
 import {getDetail} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
@@ -685,7 +685,7 @@ export class Bind {
   scanNode_(node, limit) {
     /** @type {!Array<!BindBindingDef>} */
     const bindings = [];
-    const doc = dev().assert(node.nodeType == Node.DOCUMENT_NODE
+    const doc = devAssert(node.nodeType == Node.DOCUMENT_NODE
       ? node : node.ownerDocument, 'ownerDocument is null.');
     // Third and fourth params of `createTreeWalker` are not optional on IE11.
     const walker = doc.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, null,

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -17,7 +17,7 @@
 import {CMP_CONFIG} from './cmps';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {deepMerge, dict} from '../../../src/utils/object';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {getChildJsonConfig} from '../../../src/json';
 import {isExperimentOn} from '../../../src/experiments';
 import {toWin} from '../../../src/types';
@@ -182,7 +182,7 @@ export class ConsentConfig {
         ['consentInstanceId', 'checkConsentHref', 'promptUISrc'];
     for (let i = 0; i < assertValues.length; i++) {
       const attribute = assertValues[i];
-      dev().assert(config[attribute], 'CMP config must specify %s', attribute);
+      devAssert(config[attribute], 'CMP config must specify %s', attribute);
     }
   }
 }

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -28,7 +28,7 @@ import {Deferred} from '../../../src/utils/promise';
 import {Observable} from '../../../src/observable';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 
 
@@ -99,7 +99,7 @@ export class ConsentStateManager {
    * @return {Promise<!ConsentInfoDef>}
    */
   getConsentInstanceInfo(instanceId) {
-    dev().assert(this.instances_[instanceId],
+    devAssert(this.instances_[instanceId],
         '%s: cannot find this instance', TAG);
     return this.instances_[instanceId].get();
   }
@@ -110,7 +110,7 @@ export class ConsentStateManager {
    * @param {function(CONSENT_ITEM_STATE)} handler
    */
   onConsentStateChange(instanceId, handler) {
-    dev().assert(this.instances_[instanceId],
+    devAssert(this.instances_[instanceId],
         '%s: cannot find this instance', TAG);
 
     const unlistener = this.consentChangeObservables_[instanceId].add(handler);
@@ -131,7 +131,7 @@ export class ConsentStateManager {
    * @param {Promise<?Object>} sharedDataPromise
    */
   setConsentInstanceSharedData(instanceId, sharedDataPromise) {
-    dev().assert(this.instances_[instanceId],
+    devAssert(this.instances_[instanceId],
         '%s: cannot find this instance', TAG);
     this.instances_[instanceId].sharedDataPromise = sharedDataPromise;
   }
@@ -144,7 +144,7 @@ export class ConsentStateManager {
    * @return {?Promise<?Object>}
    */
   getConsentInstanceSharedData(instanceId) {
-    dev().assert(this.instances_[instanceId],
+    devAssert(this.instances_[instanceId],
         '%s: cannot find this instance', TAG);
     return this.instances_[instanceId].sharedDataPromise;
   }

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -28,7 +28,7 @@ import {
   originMatches,
   redispatch,
 } from '../../../src/iframe-video';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   fullscreenEnter,
@@ -164,7 +164,7 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    dev().assert(this.videoid_);
+    devAssert(this.videoid_);
 
     this.iframe_ = createFrameFor(this, this.getIframeSrc_());
 

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -17,7 +17,7 @@
 import {Deferred} from '../../../src/utils/promise';
 import {Layout} from '../../../src/layout';
 import {allocateVariant} from './variant';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {parseJson} from '../../../src/json';
 
 const TAG = 'amp-experiment';
@@ -68,7 +68,7 @@ export class AmpExperiment extends AMP.BaseElement {
         '<script type="application/json"> child.');
 
     return /** @type {!JsonObject} */ (
-      dev().assert(parseJson(children[0].textContent)));
+      devAssert(parseJson(children[0].textContent)));
   }
 
   /**

--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {startsWith} from '../../../src/string';
 import {toWin} from '../../../src/types';
 
@@ -242,7 +242,7 @@ function setupLegacyProxy(form, proxy) {
           },
         });
       } else {
-        dev().assert(false, 'unknown property access type: %s', desc.access);
+        devAssert(false, 'unknown property access type: %s', desc.access);
       }
     } else {
       // Not a known property - proxy directly.

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -17,7 +17,7 @@
 import {AmpEvents} from '../../../src/amp-events';
 import {FxProvider} from './providers/fx-provider';
 import {Services} from '../../../src/services';
-import {dev, rethrowAsync, user} from '../../../src/log';
+import {devAssert, rethrowAsync, user} from '../../../src/log';
 import {iterateCursor} from '../../../src/dom';
 import {listen} from '../../../src/event-helper';
 import {map} from '../../../src/utils/object';
@@ -112,9 +112,9 @@ export class AmpFxCollection {
    * @param {!Element} fxElement
    */
   register_(fxElement) {
-    dev().assert(fxElement.hasAttribute('amp-fx'));
-    dev().assert(!this.seen_.includes(fxElement));
-    dev().assert(this.viewer_.isVisible());
+    devAssert(fxElement.hasAttribute('amp-fx'));
+    devAssert(!this.seen_.includes(fxElement));
+    devAssert(this.viewer_.isVisible());
 
     const fxTypes = this.getFxTypes_(fxElement);
 
@@ -133,7 +133,7 @@ export class AmpFxCollection {
    * @return {!Array<!FxType>}
    */
   getFxTypes_(fxElement) {
-    dev().assert(fxElement.hasAttribute('amp-fx'));
+    devAssert(fxElement.hasAttribute('amp-fx'));
     const fxTypes = fxElement.getAttribute('amp-fx')
         .trim()
         .toLowerCase()

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -15,7 +15,7 @@
  */
 
 import {computedStyle, setStyles} from '../../../../src/style';
-import {dev, user} from '../../../../src/log';
+import {devAssert, user} from '../../../../src/log';
 
 export const Presets = {
   'parallax': {
@@ -30,7 +30,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      devAssert(fxElement.adjustedViewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // outside viewport
       if (!top || top > fxElement.adjustedViewportHeight) {
@@ -65,7 +65,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.viewportHeight);
+      devAssert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top - (fxElement.viewportHeight *
@@ -115,7 +115,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.viewportHeight);
+      devAssert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
@@ -163,7 +163,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.viewportHeight);
+      devAssert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
@@ -211,7 +211,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.viewportHeight);
+      devAssert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top + (fxElement.viewportHeight *
@@ -261,7 +261,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.viewportHeight);
+      devAssert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
@@ -299,7 +299,7 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      devAssert(fxElement.adjustedViewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport or margins
       if (!top || (top > (1 - fxElement.getMarginStart()) *

--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
 
@@ -78,7 +78,7 @@ class AmpHulu extends AMP.BaseElement {
 
   /** @return {string} */
   getVideoIframeSrc_() {
-    dev().assert(this.eid_);
+    devAssert(this.eid_);
     return `https://player.hulu.com/site/dash/mobile_embed.html?amp=1&eid=${encodeURIComponent(this.eid_ || '')}`;
   }
 }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -22,7 +22,7 @@ import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {createCustomEvent, getData} from '../../../src/event-helper';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {endsWith} from '../../../src/string';
 import {
@@ -335,7 +335,7 @@ export class AmpIframe extends AMP.BaseElement {
     }
 
     const iframe = /** @type {!../../../src/layout-rect.LayoutRectDef} */(
-      dev().assert(this.iframeLayoutBox_));
+      devAssert(this.iframeLayoutBox_));
     return moveLayoutRect(iframe, box.left, box.top);
   }
 

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -15,7 +15,7 @@
  */
 
 import {addParamsToUrl} from '../../../src/url';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -65,7 +65,7 @@ class AmpIzlesene extends AMP.BaseElement {
       return this.videoIframeSrc_;
     }
 
-    dev().assert(this.videoid_);
+    devAssert(this.videoid_);
     let src = 'https://www.izlesene.com/embedplayer/' + encodeURIComponent(this.videoid_ || '') + '/?';
 
     const params = getDataParamsFromAttributes(this.element);

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -37,7 +37,7 @@ import {
   scopedQuerySelectorAll,
 } from '../../../src/dom';
 import {clamp} from '../../../src/utils/math';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getData, isLoaded, listen} from '../../../src/event-helper';
 import {
@@ -303,7 +303,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   findOrBuildCarousel_(lightboxGroupId) {
-    dev().assert(this.container_);
+    devAssert(this.container_);
     const existingCarousel = this.element.querySelector(
         `amp-carousel[amp-lightbox-group=${
           escapeCssSelectorIdent(lightboxGroupId)
@@ -505,7 +505,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   nextSlide_() {
-    dev().assert(this.carousel_).getImpl().then(carousel => {
+    devAssert(this.carousel_).getImpl().then(carousel => {
       carousel.interactionNext();
     });
   }
@@ -514,7 +514,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   prevSlide_() {
-    dev().assert(this.carousel_).getImpl().then(carousel => {
+    devAssert(this.carousel_).getImpl().then(carousel => {
       carousel.interactionPrev();
     });
   }
@@ -546,7 +546,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   buildTopBar_() {
-    dev().assert(this.container_);
+    devAssert(this.container_);
     this.topBar_ = this.doc_.createElement('div');
     this.topBar_.classList.add('i-amphtml-lbg-top-bar');
 
@@ -577,7 +577,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   buildButton_(label, className, action) {
-    dev().assert(this.topBar_);
+    devAssert(this.topBar_);
 
     const button = htmlFor(this.doc_)`
     <div role="button" class="i-amphtml-lbg-button">
@@ -662,7 +662,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   setupEventListeners_() {
-    dev().assert(this.container_);
+    devAssert(this.container_);
     const onToggleControls = this.onToggleControls_.bind(this);
     this.unlistenClick_ = listen(dev().assertElement(this.container_),
         'click', onToggleControls);
@@ -708,7 +708,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   getCurrentElement_() {
     const lbgId = this.currentLightboxGroupId_;
-    const currentElement = dev().assert(
+    const currentElement = devAssert(
         this.elementsMetadata_[lbgId][this.currentElemId_]
     );
     return currentElement;
@@ -807,7 +807,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   openLightboxForElement_(element) {
     this.currentElemId_ = element.lightboxItemId;
-    dev().assert(this.carousel_).getImpl()
+    devAssert(this.carousel_).getImpl()
         .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
     this.updateDescriptionBox_();
     return this.enter_();
@@ -1132,7 +1132,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       const targetSlide = dev().assertElement(
           closestBySelector(target, slideSelector));
       const targetSlideIndex = allSlides.indexOf(targetSlide);
-      dev().assert(parentCarousel).getImpl()
+      devAssert(parentCarousel).getImpl()
           .then(carousel => carousel.showSlideWhenReady(targetSlideIndex));
     }
   }
@@ -1218,7 +1218,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     if (isGalleryView) {
       return;
     }
-    dev().assert(this.carousel_).getImpl().then(carousel => {
+    devAssert(this.carousel_).getImpl().then(carousel => {
       carousel.goCallback(direction, /* animate */ true, /* autoplay */ false);
     });
   }
@@ -1384,7 +1384,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     event.stopPropagation();
     Promise.all([
       this.closeGallery_(),
-      dev().assert(this.carousel_).getImpl(),
+      devAssert(this.carousel_).getImpl(),
     ]).then(values => {
       this.currentElemId_ = id;
       values[1].showSlideWhenReady(this.currentElemId_);

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -28,7 +28,7 @@ import {
   elementByTag,
   iterateCursor,
 } from '../../../../src/dom';
-import {dev, user} from '../../../../src/log';
+import {dev, devAssert, user} from '../../../../src/log';
 import {map} from '../../../../src/utils/object';
 import {srcsetFromElement, srcsetFromSrc} from '../../../../src/srcset';
 import {toArray} from '../../../../src/types';
@@ -129,8 +129,8 @@ export class LightboxManager {
    * @return {boolean}
    */
   meetsHeuristicsForTap_(element) {
-    dev().assert(element);
-    dev().assert(element.hasAttribute('lightbox'));
+    devAssert(element);
+    devAssert(element.hasAttribute('lightbox'));
 
     if (!ELIGIBLE_TAP_TAGS[element.tagName]) {
       return false;
@@ -275,7 +275,7 @@ export class LightboxManager {
    */
   getElementsForLightboxGroup(lightboxGroupId) {
     return this.maybeInit()
-        .then(() => dev().assert(this.lightboxGroups_[lightboxGroupId]));
+        .then(() => devAssert(this.lightboxGroups_[lightboxGroupId]));
   }
 
   /**

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -33,7 +33,7 @@ import {
 } from '../../../src/style';
 import {createCustomEvent, listenOnce} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
@@ -181,7 +181,7 @@ class AmpLightbox extends AMP.BaseElement {
    * @private
    */
   takeOwnershipOfDescendants_() {
-    dev().assert(this.isScrollable_);
+    devAssert(this.isScrollable_);
     this.getComponentDescendants_(/* opt_refresh */ true).forEach(child => {
       this.setAsOwner(child);
     });
@@ -661,7 +661,7 @@ AMP.extension(TAG, '0.1', AMP => {
   // getMode check
   if (getMode().runtime == 'inabox') {
     setTransparentBody(window, /** @type {!HTMLBodyElement} */ (
-      dev().assert(document.body)));
+      devAssert(document.body)));
   }
 
   AMP.registerElement(TAG, AmpLightbox, CSS);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -33,7 +33,7 @@ import {
 } from '../../../src/batched-json';
 import {childElementByAttr, removeChildren} from '../../../src/dom';
 import {createCustomEvent, listen} from '../../../src/event-helper';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {getServiceForDoc} from '../../../src/service';
@@ -498,7 +498,7 @@ export class AmpList extends AMP.BaseElement {
    */
   doRenderPass_() {
     const current = this.renderItems_;
-    dev().assert(current && current.data, 'Nothing to render.');
+    devAssert(current && current.data, 'Nothing to render.');
     dev().info(TAG, 'pass:', current);
     const scheduleNextPass = () => {
       // If there's a new `renderItems_`, schedule it for render.

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -31,7 +31,7 @@ import {
   parseLength,
 } from '../../../src/layout';
 import {createCustomEvent} from '../../../src/event-helper';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getServiceForDoc} from '../../../src/service';
 import {
@@ -390,9 +390,9 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * @private
    */
   recalculateMargins_() {
-    dev().assert(this.viewportRect_);
-    dev().assert(this.bottomMarginExpr_);
-    dev().assert(this.topMarginExpr_);
+    devAssert(this.viewportRect_);
+    devAssert(this.bottomMarginExpr_);
+    devAssert(this.topMarginExpr_);
 
     this.resolvedTopMargin_ =
         this.validateAndResolveMargin_(this.topMarginExpr_);
@@ -407,7 +407,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * @private
    */
   applyMargins_(rect) {
-    dev().assert(rect);
+    devAssert(rect);
     rect = layoutRectLtwh(
         rect.left,
         (rect.top + this.resolvedTopMargin_),

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -18,7 +18,7 @@ import {CSS} from '../../../build/amp-social-share-0.1.css';
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {addParamsToUrl, parseQueryString} from '../../../src/url';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getDataParamsFromAttributes, openWindowDialog} from '../../../src/dom';
 import {getSocialConfig} from './amp-social-share-config';
@@ -154,7 +154,7 @@ class AmpSocialShare extends AMP.BaseElement {
     const href = dev().assertString(this.href_);
     const target = dev().assertString(this.target_);
     if (this.shareEndpoint_ === 'navigator-share:') {
-      dev().assert(navigator.share !== undefined,
+      devAssert(navigator.share !== undefined,
           'navigator.share disappeared.');
       // navigator.share() fails 'gulp check-types' validation on Travis
       navigator['share'](parseQueryString(href.substr(href.indexOf('?'))));

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -23,7 +23,7 @@ import {
 } from '../../amp-story/1.0/navigation-state';
 import {StateProperty} from '../../amp-story/1.0/amp-story-store-service';
 import {createElementWithAttributes, isJsonScriptTag} from '../../../src/dom';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getUniqueId} from './utils';
 import {isObject} from '../../../src/types';
@@ -213,7 +213,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     return Services.storyStoreServiceForOrNull(this.win).then(storeService => {
-      dev().assert(storeService, 'Could not retrieve AmpStoryStoreService');
+      devAssert(storeService, 'Could not retrieve AmpStoryStoreService');
       this.storeService_ = storeService;
 
       if (!this.isAutomaticAdInsertionAllowed_()) {

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -27,7 +27,7 @@ import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
 import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
 import {getJsonLd} from './jsonld';
@@ -585,7 +585,7 @@ export class Bookend {
 
   /** @private */
   assertBuilt_() {
-    dev().assert(this.isBuilt(), 'Bookend component needs to be built.');
+    devAssert(this.isBuilt(), 'Bookend component needs to be built.');
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -20,7 +20,7 @@ import {
   copyTextToClipboard,
   isCopyingToClipboardSupported,
 } from '../../../src/clipboard';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
@@ -136,7 +136,7 @@ function buildProviderParams(opt_params) {
  * @return {!Node}
  */
 function buildProvider(doc, shareType, opt_params) {
-  const shareProviderLocalizedStringId = dev().assert(
+  const shareProviderLocalizedStringId = devAssert(
       SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType],
       `No localized string to display name for share type ${shareType}.`);
 
@@ -215,7 +215,7 @@ export class ShareWidget {
    * @return {!Element}
    */
   build(ampdoc) {
-    dev().assert(!this.root, 'Already built.');
+    devAssert(!this.root, 'Already built.');
 
     this.ampdoc_ = ampdoc;
     this.localizationServicePromise_ =
@@ -236,7 +236,7 @@ export class ShareWidget {
    */
   getAmpDoc_() {
     return /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */ (
-      dev().assert(this.ampdoc_));
+      devAssert(this.ampdoc_));
   }
 
   /** @private */
@@ -263,7 +263,7 @@ export class ShareWidget {
 
     if (!copyTextToClipboard(this.win, url)) {
       this.localizationServicePromise_.then(localizationService => {
-        dev().assert(localizationService,
+        devAssert(localizationService,
             'Could not retrieve LocalizationService.');
         const failureString = localizationService.getLocalizedString(
             LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT);
@@ -397,7 +397,7 @@ export class ShareWidget {
    * @private
    */
   add_(node) {
-    const list = dev().assert(this.root).firstElementChild;
+    const list = devAssert(this.root).firstElementChild;
     const item = renderAsElement(this.win.document, SHARE_ITEM_TEMPLATE);
 
     item.appendChild(node);
@@ -472,7 +472,7 @@ export class ScrollableShareWidget extends ShareWidget {
           return;
         }
 
-        const icon = dev().assert(items[0].firstElementChild);
+        const icon = devAssert(items[0].firstElementChild);
 
         const leftMargin = icon./*OK*/offsetLeft - this.root./*OK*/offsetLeft;
         const iconWidth = icon./*OK*/offsetWidth;

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -87,7 +87,7 @@ import {
   toggle,
 } from '../../../src/style';
 import {debounce} from '../../../src/utils/rate-limit';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getDetail} from '../../../src/event-helper';
@@ -798,7 +798,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   next_(opt_isAutomaticAdvance) {
-    const activePage = dev().assert(this.activePage_,
+    const activePage = devAssert(this.activePage_,
         'No active page set when navigating to next page.');
 
     const lastPage = this.pages_[this.getPageCount() - 1];
@@ -820,7 +820,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   previous_() {
-    const activePage = dev().assert(this.activePage_,
+    const activePage = devAssert(this.activePage_,
         'No active page set when navigating to next page.');
     activePage.previous();
   }
@@ -1415,7 +1415,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   getPageById(id) {
     const pageIndex = this.getPageIndexById_(id);
-    return dev().assert(this.pages_[pageIndex],
+    return devAssert(this.pages_[pageIndex],
         `Page at index ${pageIndex} exists, but is missing from the array.`);
   }
 

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -28,7 +28,7 @@ import {
   WebAnimationPlayState,
 } from '../../amp-animation/0.1/web-animation-types';
 import {assertDoesNotContainDisplay, setStyles} from '../../../src/style';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {
   escapeCssSelectorIdent,
   scopedQuerySelector,
@@ -131,7 +131,7 @@ class AnimationRunner {
     /** @private {?Promise} */
     this.scheduledWait_ = null;
 
-    this.keyframes_.then(keyframes => dev().assert(
+    this.keyframes_.then(keyframes => devAssert(
         !keyframes[0].offset,
         'First keyframe offset for animation preset should be 0 or undefined'));
 
@@ -245,7 +245,7 @@ class AnimationRunner {
   /** @return {boolean} */
   hasStarted() {
     return this.isActivityScheduled_(PlaybackActivity.START) ||
-        (!!this.runner_ && dev().assert(this.runner_)
+        (!!this.runner_ && devAssert(this.runner_)
             .getPlayState() == WebAnimationPlayState.RUNNING);
   }
 
@@ -273,7 +273,7 @@ class AnimationRunner {
     this.scheduledWait_ = null;
 
     if (this.runner_) {
-      dev().assert(this.runner_).cancel();
+      devAssert(this.runner_).cancel();
     }
   }
 
@@ -304,7 +304,7 @@ class AnimationRunner {
         /**
          * @type {!../../amp-animation/0.1/web-animations.WebAnimationRunner}
          */
-        (dev().assert(
+        (devAssert(
             this.runner_,
             'Tried to execute playbackWhenReady_ before runner was resolved.'));
 
@@ -375,7 +375,7 @@ export class AnimationManager {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(root, ampdoc) {
-    dev().assert(hasAnimations(root));
+    devAssert(hasAnimations(root));
 
     /** @private @const */
     this.root_ = root;
@@ -445,7 +445,7 @@ export class AnimationManager {
 
   /** @private */
   getRunners_() {
-    return dev().assert(this.runners_, 'Executed before applyFirstFrame');
+    return devAssert(this.runners_, 'Executed before applyFirstFrame');
   }
 
   /**
@@ -458,7 +458,7 @@ export class AnimationManager {
           scopedQuerySelectorAll(this.root_, ANIMATABLE_ELEMENTS_SELECTOR),
           el => this.createRunner_(el));
     }
-    return dev().assert(this.runners_);
+    return devAssert(this.runners_);
   }
 
   /**
@@ -472,7 +472,7 @@ export class AnimationManager {
     return new AnimationRunner(
         this.root_,
         animationDef,
-        dev().assert(this.builderPromise_),
+        devAssert(this.builderPromise_),
         this.vsync_,
         this.timer_,
         this.sequence_);
@@ -566,7 +566,7 @@ class AnimationSequence {
    */
   notifyFinish(id) {
     if (id in this.subscriptionPromises_) {
-      dev().assert(this.subscriptionResolvers_[id])();
+      devAssert(this.subscriptionResolvers_[id])();
 
       delete this.subscriptionPromises_[id];
     }

--- a/extensions/amp-story/0.1/logging.js
+++ b/extensions/amp-story/0.1/logging.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {LogLevel, dev} from '../../../src/log';
+import {LogLevel, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {scopedQuerySelectorAll} from '../../../src/dom';
 import {tryResolve} from '../../../src/utils/promise';
@@ -160,10 +160,10 @@ const LogType = {
  */
 function getLogType(logTypeKey) {
   const logType = LogType[logTypeKey];
-  dev().assert(logType, `There is no log type "${logTypeKey}".`);
-  dev().assert(logType.message,
+  devAssert(logType, `There is no log type "${logTypeKey}".`);
+  devAssert(logType.message,
       `Log type "${logTypeKey}" has no associated message.`);
-  dev().assert(logType.level,
+  devAssert(logType.level,
       `Log type "${logTypeKey}" has no associated log level.`);
 
   return logType;

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -31,7 +31,7 @@ import {
 import {Services} from '../../../src/services';
 import {Sources} from './sources';
 import {ampMediaElementFor} from './utils';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {findIndex} from '../../../src/utils/array';
 import {isConnectedNode} from '../../../src/dom';
 import {toWin} from '../../../src/types';
@@ -211,7 +211,7 @@ export class MediaPool {
         return;
       }
 
-      const ctor = dev().assert(this.mediaFactory_[type],
+      const ctor = devAssert(this.mediaFactory_[type],
           `Factory for media type \`${type}\` unset.`);
 
       // Cloning nodes is faster than building them.
@@ -403,7 +403,7 @@ export class MediaPool {
 
     return removeFromDom.then(() => {
       const index = allocatedEls.indexOf(poolMediaEl);
-      dev().assert(index >= 0, 'Cannot deallocate unallocated media element.');
+      devAssert(index >= 0, 'Cannot deallocate unallocated media element.');
       allocatedEls.splice(index, 1);
       this.unallocated[mediaType].push(poolMediaEl);
     });
@@ -587,7 +587,7 @@ export class MediaPool {
     }
 
     const sources = this.sources_[domMediaEl.id];
-    dev().assert(sources instanceof Sources,
+    devAssert(sources instanceof Sources,
         'Cannot play unregistered element.');
 
     const poolMediaEl = this.reserveUnallocatedMediaElement_(mediaType) ||

--- a/extensions/amp-story/0.1/pagination-buttons.js
+++ b/extensions/amp-story/0.1/pagination-buttons.js
@@ -17,7 +17,7 @@ import {Action} from './amp-story-store-service';
 import {EventType, dispatch} from './events';
 import {Services} from '../../../src/services';
 import {StateChangeType} from './navigation-state';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
@@ -132,7 +132,7 @@ class PaginationButton {
   onClick_(e) {
     e.preventDefault();
     if (this.state_.triggers) {
-      dispatch(this.element, dev().assert(this.state_.triggers),
+      dispatch(this.element, devAssert(this.state_.triggers),
           /* opt_bubbles */ true);
       return;
     }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -15,7 +15,7 @@
  */
 import {POLL_INTERVAL_MS} from './page-advancement';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {escapeCssSelectorNth, scopedQuerySelector} from '../../../src/dom';
 import {hasOwn, map} from '../../../src/utils/object';
 import {scale, setImportantStyles} from '../../../src/style';
@@ -82,7 +82,7 @@ export class ProgressBar {
     }
 
     const segmentCount = segmentIds.length;
-    dev().assert(segmentCount > 0);
+    devAssert(segmentCount > 0);
 
     this.isBuilt_ = true;
     this.segmentCount_ = segmentCount;
@@ -139,7 +139,7 @@ export class ProgressBar {
    * @private
    */
   assertVaildSegmentId_(segmentId) {
-    dev().assert(hasOwn(this.segmentIdMap_, segmentId),
+    devAssert(hasOwn(this.segmentIdMap_, segmentId),
         'Invalid segment-id passed to progress-bar');
   }
 

--- a/extensions/amp-story/0.1/related-articles.js
+++ b/extensions/amp-story/0.1/related-articles.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {
   getSourceOrigin,
   isProtocolValid,
@@ -58,7 +58,7 @@ function buildArticleFromJson_(articleJson) {
     return null;
   }
 
-  const articleUrl = dev().assert(articleJson['url']);
+  const articleUrl = devAssert(articleJson['url']);
   user().assert(isProtocolValid(articleUrl),
       `Unsupported protocol for article URL ${articleUrl}`);
 
@@ -71,7 +71,7 @@ function buildArticleFromJson_(articleJson) {
   }
 
   const article = {
-    title: dev().assert(articleJson['title']),
+    title: devAssert(articleJson['title']),
     url: articleUrl,
     domainName: domain,
   };
@@ -79,7 +79,7 @@ function buildArticleFromJson_(articleJson) {
   if (articleJson['image']) {
     user().assert(isProtocolValid(articleJson['image']),
         `Unsupported protocol for article image URL ${articleJson['image']}`);
-    article.image = dev().assert(articleJson['image']);
+    article.image = devAssert(articleJson['image']);
   }
 
   return /** @type {!RelatedArticleDef} */ (article);

--- a/extensions/amp-story/0.1/simple-template.js
+++ b/extensions/amp-story/0.1/simple-template.js
@@ -16,7 +16,7 @@
 import {LocalizedStringId} from './localization'; // eslint-disable-line no-unused-vars
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {isArray, toWin} from '../../../src/types';
 
 
@@ -81,7 +81,7 @@ function renderSingle(doc, elementDef) {
   if (elementDef.localizedStringId) {
     const win = toWin(doc.defaultView);
     Services.localizationServiceForOrNullV01(win).then(localizationService => {
-      dev().assert(localizationService,
+      devAssert(localizationService,
           'Could not retrieve LocalizationService.');
       el.textContent = localizationService
           .getLocalizedString(/** @type {!LocalizedStringId} */ (

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -20,7 +20,7 @@ import {
   copyTextToClipboard,
   isCopyingToClipboardSupported,
 } from '../../../src/clipboard';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
 import {getRequestService} from './amp-story-request-service';
 import {isObject} from '../../../src/types';
@@ -144,7 +144,7 @@ function buildProviderParams(opt_params) {
  * @return {!Node}
  */
 function buildProvider(doc, shareType, opt_params) {
-  const shareProviderLocalizedStringId = dev().assert(
+  const shareProviderLocalizedStringId = devAssert(
       SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType],
       `No localized string to display name for share type ${shareType}.`);
 
@@ -239,7 +239,7 @@ export class ShareWidget {
    * @return {!Element}
    */
   build(ampdoc) {
-    dev().assert(!this.root, 'Already built.');
+    devAssert(!this.root, 'Already built.');
 
     this.ampdoc_ = ampdoc;
     this.localizationServicePromise_ =
@@ -260,7 +260,7 @@ export class ShareWidget {
    */
   getAmpDoc_() {
     return /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */ (
-      dev().assert(this.ampdoc_));
+      devAssert(this.ampdoc_));
   }
 
   /** @private */
@@ -287,7 +287,7 @@ export class ShareWidget {
 
     if (!copyTextToClipboard(this.win, url)) {
       this.localizationServicePromise_.then(localizationService => {
-        dev().assert(localizationService,
+        devAssert(localizationService,
             'Could not retrieve LocalizationService.');
         const failureString = localizationService.getLocalizedString(
             LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT);
@@ -387,7 +387,7 @@ export class ShareWidget {
    * @private
    */
   add_(node) {
-    const list = dev().assert(this.root).firstElementChild;
+    const list = devAssert(this.root).firstElementChild;
     const item = renderAsElement(this.win.document, SHARE_ITEM_TEMPLATE);
 
     item.appendChild(node);
@@ -469,7 +469,7 @@ export class ScrollableShareWidget extends ShareWidget {
           return;
         }
 
-        const icon = dev().assert(items[0].firstElementChild);
+        const icon = devAssert(items[0].firstElementChild);
 
         const leftMargin = icon./*OK*/offsetLeft - this.root./*OK*/offsetLeft;
         const iconWidth = icon./*OK*/offsetWidth;

--- a/extensions/amp-story/1.0/amp-story-tooltip.js
+++ b/extensions/amp-story/1.0/amp-story-tooltip.js
@@ -25,7 +25,7 @@ import {EventType, dispatch} from './events';
 import {Services} from '../../../src/services';
 import {addAttributesToElement, closest} from '../../../src/dom';
 import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
@@ -126,7 +126,7 @@ export class AmpStoryTooltip {
     this.shadowRoot_ = this.win_.document.createElement('div');
 
     this.tooltipOverlayEl_ =
-      dev().assert(this.buildTemplate_(this.win_.document));
+      devAssert(this.buildTemplate_(this.win_.document));
     createShadowRootWithStyle(this.shadowRoot_, this.tooltipOverlayEl_, CSS);
 
     this.tooltipOverlayEl_

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -84,7 +84,7 @@ import {
   toggle,
 } from '../../../src/style';
 import {debounce} from '../../../src/utils/rate-limit';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getConsentPolicyState} from '../../../src/consent';
@@ -948,7 +948,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   next_(opt_isAutomaticAdvance) {
-    const activePage = dev().assert(this.activePage_,
+    const activePage = devAssert(this.activePage_,
         'No active page set when navigating to next page.');
 
     const lastPage = this.pages_[this.getPageCount() - 1];
@@ -969,7 +969,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   previous_() {
-    const activePage = dev().assert(this.activePage_,
+    const activePage = devAssert(this.activePage_,
         'No active page set when navigating to previous page.');
     activePage.previous();
   }
@@ -1863,7 +1863,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   getPageById(id) {
     const pageIndex = this.getPageIndexById(id);
-    return dev().assert(this.pages_[pageIndex],
+    return devAssert(this.pages_[pageIndex],
         'Page at index %s exists, but is missing from the array.', pageIndex);
   }
 

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -28,7 +28,7 @@ import {
   WebAnimationPlayState,
 } from '../../amp-animation/0.1/web-animation-types';
 import {assertDoesNotContainDisplay, setStyles} from '../../../src/style';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {
   escapeCssSelectorIdent,
   scopedQuerySelector,
@@ -131,7 +131,7 @@ class AnimationRunner {
     /** @private {?Promise} */
     this.scheduledWait_ = null;
 
-    this.keyframes_.then(keyframes => dev().assert(
+    this.keyframes_.then(keyframes => devAssert(
         !keyframes[0].offset,
         'First keyframe offset for animation preset should be 0 or undefined'));
 
@@ -245,7 +245,7 @@ class AnimationRunner {
   /** @return {boolean} */
   hasStarted() {
     return this.isActivityScheduled_(PlaybackActivity.START) ||
-        (!!this.runner_ && dev().assert(this.runner_)
+        (!!this.runner_ && devAssert(this.runner_)
             .getPlayState() == WebAnimationPlayState.RUNNING);
   }
 
@@ -273,7 +273,7 @@ class AnimationRunner {
     this.scheduledWait_ = null;
 
     if (this.runner_) {
-      dev().assert(this.runner_).cancel();
+      devAssert(this.runner_).cancel();
     }
   }
 
@@ -304,7 +304,7 @@ class AnimationRunner {
         /**
          * @type {!../../amp-animation/0.1/web-animations.WebAnimationRunner}
          */
-        (dev().assert(
+        (devAssert(
             this.runner_,
             'Tried to execute playbackWhenReady_ before runner was resolved.'));
 
@@ -375,7 +375,7 @@ export class AnimationManager {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(root, ampdoc) {
-    dev().assert(hasAnimations(root));
+    devAssert(hasAnimations(root));
 
     /** @private @const */
     this.root_ = root;
@@ -445,7 +445,7 @@ export class AnimationManager {
 
   /** @private */
   getRunners_() {
-    return dev().assert(this.runners_, 'Executed before applyFirstFrame');
+    return devAssert(this.runners_, 'Executed before applyFirstFrame');
   }
 
   /**
@@ -458,7 +458,7 @@ export class AnimationManager {
           scopedQuerySelectorAll(this.root_, ANIMATABLE_ELEMENTS_SELECTOR),
           el => this.createRunner_(el));
     }
-    return dev().assert(this.runners_);
+    return devAssert(this.runners_);
   }
 
   /**
@@ -472,7 +472,7 @@ export class AnimationManager {
     return new AnimationRunner(
         this.root_,
         animationDef,
-        dev().assert(this.builderPromise_),
+        devAssert(this.builderPromise_),
         this.vsync_,
         this.timer_,
         this.sequence_);
@@ -566,7 +566,7 @@ class AnimationSequence {
    */
   notifyFinish(id) {
     if (id in this.subscriptionPromises_) {
-      dev().assert(this.subscriptionResolvers_[id])();
+      devAssert(this.subscriptionResolvers_[id])();
 
       delete this.subscriptionPromises_[id];
     }

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -34,7 +34,7 @@ import {LocalizedStringId} from '../localization';
 import {Services} from '../../../../src/services';
 import {closest} from '../../../../src/dom';
 import {createShadowRootWithStyle} from '../utils';
-import {dev, user} from '../../../../src/log';
+import {dev, devAssert, user} from '../../../../src/log';
 import {dict} from '../../../../src/utils/object';
 import {getAmpdoc} from '../../../../src/service';
 import {getJsonLd} from '../jsonld';
@@ -485,7 +485,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /** @private */
   assertBuilt_() {
-    dev().assert(this.isBuilt(), 'Bookend component needs to be built.');
+    devAssert(this.isBuilt(), 'Bookend component needs to be built.');
   }
 
   /**

--- a/extensions/amp-story/1.0/logging.js
+++ b/extensions/amp-story/1.0/logging.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {LogLevel, dev} from '../../../src/log';
+import {LogLevel, devAssert} from '../../../src/log';
 import {scopedQuerySelectorAll} from '../../../src/dom';
 import {tryResolve} from '../../../src/utils/promise';
 
@@ -159,10 +159,10 @@ const LogType = {
  */
 function getLogType(logTypeKey) {
   const logType = LogType[logTypeKey];
-  dev().assert(logType, `There is no log type "${logTypeKey}".`);
-  dev().assert(logType.message,
+  devAssert(logType, `There is no log type "${logTypeKey}".`);
+  devAssert(logType.message,
       `Log type "${logTypeKey}" has no associated message.`);
-  dev().assert(logType.level,
+  devAssert(logType.level,
       `Log type "${logTypeKey}" has no associated log level.`);
 
   return logType;

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -34,7 +34,7 @@ import {
   VideoServiceSignals,
 } from '../../../src/service/video-service-interface';
 import {ampMediaElementFor} from './utils';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {findIndex} from '../../../src/utils/array';
 import {isConnectedNode} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
@@ -249,7 +249,7 @@ export class MediaPool {
         return;
       }
 
-      const ctor = dev().assert(this.mediaFactory_[type],
+      const ctor = devAssert(this.mediaFactory_[type],
           `Factory for media type \`${type}\` unset.`);
 
       // Cloning nodes is faster than building them.
@@ -441,7 +441,7 @@ export class MediaPool {
 
     return removeFromDom.then(() => {
       const index = allocatedEls.indexOf(poolMediaEl);
-      dev().assert(index >= 0, 'Cannot deallocate unallocated media element.');
+      devAssert(index >= 0, 'Cannot deallocate unallocated media element.');
       allocatedEls.splice(index, 1);
       this.unallocated[mediaType].push(poolMediaEl);
     });
@@ -635,7 +635,7 @@ export class MediaPool {
     const placeholderEl = /** @type {!PlaceholderElementDef} */ (domMediaEl);
 
     const sources = this.sources_[placeholderEl.id];
-    dev().assert(sources instanceof Sources,
+    devAssert(sources instanceof Sources,
         'Cannot play unregistered element.');
 
     const poolMediaEl = this.reserveUnallocatedMediaElement_(mediaType) ||

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -19,7 +19,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {EventType, dispatch} from './events';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
@@ -138,7 +138,7 @@ class PaginationButton {
   onClick_(e) {
     e.preventDefault();
     if (this.state_.triggers) {
-      dispatch(this.win_, this.element, dev().assert(this.state_.triggers),
+      dispatch(this.win_, this.element, devAssert(this.state_.triggers),
           /* payload */ undefined, {bubbles: true});
       return;
     }

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -15,7 +15,7 @@
  */
 import {POLL_INTERVAL_MS} from './page-advancement';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {escapeCssSelectorNth, scopedQuerySelector} from '../../../src/dom';
 import {hasOwn, map} from '../../../src/utils/object';
 import {scale, setImportantStyles} from '../../../src/style';
@@ -85,7 +85,7 @@ export class ProgressBar {
     }
 
     const segmentCount = segmentIds.length;
-    dev().assert(segmentCount > 0);
+    devAssert(segmentCount > 0);
 
     this.isBuilt_ = true;
     this.segmentCount_ = segmentCount;
@@ -119,7 +119,7 @@ export class ProgressBar {
    * @private
    */
   assertVaildSegmentId_(segmentId) {
-    dev().assert(hasOwn(this.segmentIdMap_, segmentId),
+    devAssert(hasOwn(this.segmentIdMap_, segmentId),
         'Invalid segment-id passed to progress-bar');
   }
 

--- a/extensions/amp-story/1.0/simple-template.js
+++ b/extensions/amp-story/1.0/simple-template.js
@@ -16,7 +16,7 @@
 import {LocalizedStringId} from './localization'; // eslint-disable-line no-unused-vars
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {hasOwn} from '../../../src/utils/object';
 import {isArray, toWin} from '../../../src/types';
 
@@ -83,7 +83,7 @@ function renderSingle(doc, elementDef) {
   if (hasOwn(elementDef, 'localizedStringId')) {
     const win = toWin(doc.defaultView);
     Services.localizationServiceForOrNull(win).then(localizationService => {
-      dev().assert(localizationService,
+      devAssert(localizationService,
           'Could not retrieve LocalizationService.');
       el.textContent = localizationService
           .getLocalizedString(/** @type {!LocalizedStringId} */ (

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -31,7 +31,7 @@ import {SubscriptionAnalytics, SubscriptionAnalyticsEvents} from './analytics';
 import {SubscriptionPlatform} from './subscription-platform';
 import {ViewerSubscriptionPlatform} from './viewer-subscription-platform';
 import {ViewerTracker} from './viewer-tracker';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
@@ -336,7 +336,7 @@ export class SubscriptionService {
         );
         this.platformStore_.resolvePlatform('local', viewerPlatform);
         viewerPlatform.getEntitlements().then(entitlement => {
-          dev().assert(entitlement, 'Entitlement is null');
+          devAssert(entitlement, 'Entitlement is null');
           // Viewer authorization is redirected to use local platform instead.
           this.platformStore_.resolveEntitlement('local',
               /** @type {!./entitlement.Entitlement}*/ (entitlement));
@@ -474,7 +474,7 @@ export class SubscriptionService {
    * @return {!PageConfig}
    */
   getPageConfig() {
-    const pageConfig = dev().assert(this.pageConfig_,
+    const pageConfig = devAssert(this.pageConfig_,
         'Page config is not yet fetched');
     return /** @type {!PageConfig} */(pageConfig);
   }
@@ -522,7 +522,7 @@ export class SubscriptionService {
   delegateActionToService(action, serviceId) {
     return new Promise(resolve => {
       this.platformStore_.onPlatformResolves(serviceId, platform => {
-        dev().assert(platform, 'Platform is not registered');
+        devAssert(platform, 'Platform is not registered');
         this.subscriptionAnalytics_.event(
             SubscriptionAnalyticsEvents.ACTION_DELEGATED,
             dict({
@@ -544,7 +544,7 @@ export class SubscriptionService {
    */
   decorateServiceAction(element, serviceId, action, options) {
     this.platformStore_.onPlatformResolves(serviceId, platform => {
-      dev().assert(platform, 'Platform is not registered');
+      devAssert(platform, 'Platform is not registered');
       platform.decorateUI(element, action, options);
     });
   }

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -24,7 +24,7 @@ import {Services} from '../../../src/services';
 import {UrlBuilder} from './url-builder';
 import {assertHttpsUrl} from '../../../src/url';
 import {closestBySelector} from '../../../src/dom';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
 
@@ -200,7 +200,7 @@ export class LocalSubscriptionPlatform {
     if (!this.isPingbackEnabled) {
       return;
     }
-    const pingbackUrl = /** @type {string} */ (dev().assert(this.pingbackUrl_,
+    const pingbackUrl = /** @type {string} */ (devAssert(this.pingbackUrl_,
         'pingbackUrl is null'));
 
     const promise = this.urlBuilder_.buildUrl(pingbackUrl,

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -19,7 +19,7 @@ import {DEFAULT_SCORE_CONFIG, SubscriptionsScoreFactor}
 import {Deferred} from '../../../src/utils/promise';
 import {Entitlement} from './entitlement';
 import {Observable} from '../../../src/observable';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 
 
@@ -150,7 +150,7 @@ export class PlatformStore {
    */
   getPlatform(serviceId) {
     const platform = this.subscriptionPlatforms_[serviceId];
-    dev().assert(platform, `Platform for id ${serviceId} is not resolved`);
+    devAssert(platform, `Platform for id ${serviceId} is not resolved`);
     return platform;
   }
 
@@ -220,7 +220,7 @@ export class PlatformStore {
    * @return {!./entitlement.Entitlement} entitlement
    */
   getResolvedEntitlementFor(serviceId) {
-    dev().assert(this.entitlements_[serviceId],
+    devAssert(this.entitlements_[serviceId],
         `Platform ${serviceId} has not yet resolved with entitlements`);
     return this.entitlements_[serviceId];
   }
@@ -231,7 +231,7 @@ export class PlatformStore {
    * @return {!Promise<!./entitlement.Entitlement>} entitlement
    */
   getEntitlementPromiseFor(serviceId) {
-    dev().assert(this.entitlementDeferredMap_[serviceId],
+    devAssert(this.entitlementDeferredMap_[serviceId],
         `Platform ${serviceId} is not declared`);
     return this.entitlementDeferredMap_[serviceId].promise;
   }
@@ -415,7 +415,7 @@ export class PlatformStore {
    * @private
    */
   selectApplicablePlatform_() {
-    dev().assert(this.areAllPlatformsResolved_(),
+    devAssert(this.areAllPlatformsResolved_(),
         'All platforms are not resolved yet');
 
     // Subscriber wins immediately.

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -20,7 +20,7 @@ import {JwtHelper} from '../../amp-access/0.1/jwt';
 import {LocalSubscriptionPlatform} from './local-subscription-platform';
 import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
-import {dev, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getSourceOrigin, getWinOrigin} from '../../../src/url';
 
@@ -68,7 +68,7 @@ export class ViewerSubscriptionPlatform {
 
   /** @override */
   getEntitlements() {
-    dev().assert(this.currentProductId_, 'Current product is not set');
+    devAssert(this.currentProductId_, 'Current product is not set');
 
     const entitlementPromise = this.viewer_.sendMessageAwaitResponse(
         'auth',

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -44,7 +44,7 @@ import {
   listen,
   listenOnce,
 } from '../../../src/event-helper';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getInternalVideoElementFor} from '../../../src/utils/video';
 import {getServiceForDoc} from '../../../src/service';
@@ -551,7 +551,7 @@ export class VideoDocking {
    * @private
    */
   getDockedVideo_() {
-    return dev().assert(this.currentlyDocked_).video;
+    return devAssert(this.currentlyDocked_).video;
   }
 
   /**
@@ -768,7 +768,7 @@ export class VideoDocking {
 
     if (this.isCurrentlyDocked_(video) &&
         !isElement(this.currentlyDocked_.target)) {
-      const {posY} = dev().assert(this.currentlyDocked_).target;
+      const {posY} = devAssert(this.currentlyDocked_).target;
       return /** @type {!RelativeY} */ (dev().assertNumber(posY));
     }
 
@@ -1701,7 +1701,7 @@ export class VideoDocking {
 
     const step = 0;
 
-    const {target} = dev().assert(this.currentlyDocked_);
+    const {target} = devAssert(this.currentlyDocked_);
     const {x, y, scale} = this.getDims_(video, target, step);
 
     return this.placeAt_(video, x, y, scale, step)

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -28,7 +28,7 @@ import {
   createCustomEvent,
   listen,
 } from '../../../src/event-helper';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {once} from '../../../src/utils/function';
 import {
@@ -260,7 +260,7 @@ export class Controls {
    * @private
    */
   isPlaying_() {
-    dev().assert(this.video_);
+    devAssert(this.video_);
     return this.manager_().getPlayingState(this.video_) != PlayingStates.PAUSED;
   }
 

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -27,7 +27,7 @@ import {
   originMatches,
 } from '../../../src/iframe-video';
 import {Services} from '../../../src/services';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   disableScrollingOnIframe,
@@ -289,7 +289,7 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     this.canPlay_ = this.canPlay_ || isCanPlayEvent;
 
-    const {reject, resolve} = dev().assert(this.readyDeferred_);
+    const {reject, resolve} = devAssert(this.readyDeferred_);
 
     if (isCanPlayEvent) {
       return resolve();
@@ -300,7 +300,7 @@ class AmpVideoIframe extends AMP.BaseElement {
     }
 
     if (eventReceived == 'analytics') {
-      const spec = dev().assert(data['analytics']);
+      const spec = devAssert(data['analytics']);
 
       this.dispatchCustomAnalyticsEvent_(spec['eventType'], spec['vars']);
       return;

--- a/extensions/amp-video-service/0.1/amp-video-service.js
+++ b/extensions/amp-video-service/0.1/amp-video-service.js
@@ -30,7 +30,7 @@ import {
   VideoServiceSignals,
 } from '../../../src/service/video-service-interface';
 import {createCustomEvent, listen} from '../../../src/event-helper';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {isFiniteNumber} from '../../../src/types';
 
@@ -99,7 +99,7 @@ export class VideoService {
         video);
 
     if (this.getEntryOrNull(element)) {
-      return dev().assert(this.getEntryOrNull(element));
+      return devAssert(this.getEntryOrNull(element));
     }
 
     if (!video.supportsPlatform()) {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -29,7 +29,7 @@ import {
   removeElement,
 } from '../../../src/dom';
 import {descendsFromStory} from '../../../src/utils/story';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {
@@ -335,7 +335,7 @@ class AmpVideo extends AMP.BaseElement {
    * Propagate sources that are cached by the CDN.
    */
   propagateCachedSources_() {
-    dev().assert(this.video_);
+    devAssert(this.video_);
 
     const sources = toArray(childElementsByTag(this.element, 'source'));
 
@@ -367,7 +367,7 @@ class AmpVideo extends AMP.BaseElement {
    * @private
    */
   propagateLayoutChildren_() {
-    dev().assert(this.video_);
+    devAssert(this.video_);
 
     const sources = toArray(childElementsByTag(this.element, 'source'));
 
@@ -383,7 +383,7 @@ class AmpVideo extends AMP.BaseElement {
 
     sources.forEach(source => {
       // Cached sources should have been moved from <amp-video> to <video>.
-      dev().assert(!this.isCachedByCDN_(source));
+      devAssert(!this.isCachedByCDN_(source));
       urlService.assertHttpsUrl(source.getAttribute('src'), source);
       this.video_.appendChild(source);
     });

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -18,7 +18,7 @@ import * as dom from '../../../src/dom';
 import {CSS} from '../../../build/amp-viz-vega-0.1.css';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, user} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber, isObject} from '../../../src/types';
@@ -139,7 +139,7 @@ export class AmpVizVega extends AMP.BaseElement {
   loadData_() {
     // Validation in buildCallback should ensure one and only one of
     // src_/inlineData_ is ever set.
-    dev().assert(!this.src_ != !this.inlineData_);
+    devAssert(!this.src_ != !this.inlineData_);
 
     if (this.inlineData_) {
       this.data_ = tryParseJson(this.inlineData_, err => {

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {dict} from './utils/object';
 import {internalListenImplementation} from './event-helper-listen';
 import {parseJson} from './json';
@@ -109,7 +109,7 @@ export function deserializeMessage(message) {
     return null;
   }
   const startPos = message.indexOf('{');
-  dev().assert(startPos != -1, 'JSON missing in %s', message);
+  devAssert(startPos != -1, 'JSON missing in %s', message);
   try {
     return parseJson(message.substr(startPos));
   } catch (e) {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -15,7 +15,7 @@
  */
 
 import {assertHttpsUrl, parseUrlDeprecated} from './url';
-import {dev, user} from './log';
+import {dev, devAssert, user} from './log';
 import {dict} from './utils/object';
 import {getContextMetadata} from '../src/iframe-attributes';
 import {getMode} from './mode';
@@ -78,7 +78,7 @@ export function getIframe(
   {disallowCustom, allowFullscreen} = {}) {
   // Check that the parentElement is already in DOM. This code uses a new and
   // fast `isConnected` API and thus only used when it's available.
-  dev().assert(
+  devAssert(
       parentElement['isConnected'] === undefined ||
       parentElement['isConnected'] === true,
       'Parent element must be in DOM');

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -17,7 +17,7 @@
 import {ActionTrust, DEFAULT_ACTION} from './action-constants';
 import {Layout, LayoutPriority} from './layout';
 import {Services} from './services';
-import {dev, user} from './log';
+import {devAssert, user} from './log';
 import {getData, listen, loadPromise} from './event-helper';
 import {getMode} from './mode';
 import {isArray, toWin} from './types';
@@ -1082,10 +1082,10 @@ export class BaseElement {
    * @param {!Element=} opt_element
    */
   declareLayer(opt_element) {
-    dev().assert(isExperimentOn(this.win, 'layers'), 'Layers must be enabled' +
+    devAssert(isExperimentOn(this.win, 'layers'), 'Layers must be enabled' +
         ' to declare layer.');
     if (opt_element) {
-      dev().assert(this.element.contains(opt_element));
+      devAssert(this.element.contains(opt_element));
     }
     return this.element.getLayers().declareLayer(opt_element || this.element);
   }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -616,7 +616,7 @@ export class BaseElement {
    */
   registerDefaultAction(
     handler, alias = DEFAULT_ACTION, minTrust = ActionTrust.HIGH) {
-    dev().assert(!this.defaultActionAlias_,
+    devAssert(!this.defaultActionAlias_,
         'Default action "%s" already registered.', this.defaultActionAlias_);
     this.registerAction(alias, handler, minTrust);
     this.defaultActionAlias_ = alias;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -471,7 +471,7 @@ function createBaseCustomElementClass(win) {
      * @return {?string}
      */
     getDefaultActionAlias() {
-      dev().assert(
+      devAssert(
           this.isUpgraded(),
           'Cannot get default action alias of unupgraded element');
       return this.implementation_.getDefaultActionAlias();

--- a/src/dom.js
+++ b/src/dom.js
@@ -16,7 +16,7 @@
 
 import {Deferred} from './utils/promise';
 import {cssEscape} from '../third_party/css-escape/css-escape';
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {dict} from './utils/object';
 import {startsWith} from './string';
 import {toWin} from './types';
@@ -733,7 +733,7 @@ export function escapeCssSelectorIdent(ident) {
 export function escapeCssSelectorNth(ident) {
   const escaped = String(ident);
   // Ensure it doesn't close the nth-child psuedo class.
-  dev().assert(escaped.indexOf(')') === -1);
+  devAssert(escaped.indexOf(')') === -1);
   return escaped;
 }
 
@@ -800,7 +800,7 @@ export function isAmpElement(element) {
  * @return {!Promise<!Element>}
  */
 export function whenUpgradedToCustomElement(element) {
-  dev().assert(isAmpElement(element), 'element is not AmpElement');
+  devAssert(isAmpElement(element), 'element is not AmpElement');
   if (element.createdCallback) {
     // Element already is CustomElement;
     return Promise.resolve(element);

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -15,7 +15,7 @@
  */
 
 import {BaseElement} from './base-element';
-import {dev} from './log';
+import {devAssert} from './log';
 
 /** @type {!Array} */
 export const stubbedElements = [];
@@ -30,7 +30,7 @@ export class ElementStub extends BaseElement {
 
   /** @override */
   getLayoutPriority() {
-    return dev().assert(0, 'Cannot get priority of stubbed element');
+    return devAssert(0, 'Cannot get priority of stubbed element');
   }
 
   /** @override */

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -20,7 +20,7 @@ import {
   createElementWithAttributes,
   removeElement,
 } from './dom';
-import {dev} from './log';
+import {devAssert} from './log';
 import {dict} from './utils/object';
 import {isArray, toWin} from './types';
 import {triggerAnalyticsEvent} from './analytics';
@@ -61,7 +61,7 @@ export function insertAnalyticsElement(
     extensions./*OK*/installExtensionForDoc(ampdoc, 'amp-analytics');
   } else {
     Services.analyticsForDocOrNull(parentElement).then(analytics => {
-      dev().assert(analytics);
+      devAssert(analytics);
     });
   }
   parentElement.appendChild(analyticsElem);
@@ -80,7 +80,7 @@ class CustomEventReporter {
    * @param {!JsonObject} config
    */
   constructor(parent, config) {
-    dev().assert(config['triggers'], 'Config must have triggers defined');
+    devAssert(config['triggers'], 'Config must have triggers defined');
     /** @private {string} */
     this.id_ = parent.getResourceId();
 
@@ -92,7 +92,7 @@ class CustomEventReporter {
 
     for (const event in config['triggers']) {
       const eventType = config['triggers'][event]['on'];
-      dev().assert(eventType,
+      devAssert(eventType,
           'CustomEventReporter config must specify trigger eventType');
       const newEventType = this.getEventTypeInSandbox_(eventType);
       config['triggers'][event]['on'] = newEventType;
@@ -108,7 +108,7 @@ class CustomEventReporter {
    * @param {!JsonObject=} opt_vars A map of vars and their values.
    */
   trigger(eventType, opt_vars) {
-    dev().assert(this.config_['triggers'][eventType],
+    devAssert(this.config_['triggers'][eventType],
         'Cannot trigger non initiated eventType');
     triggerAnalyticsEvent(this.parent_,
         this.getEventTypeInSandbox_(eventType), opt_vars);
@@ -160,7 +160,7 @@ export class CustomEventReporterBuilder {
    */
   track(eventType, request) {
     request = isArray(request) ? request : [request];
-    dev().assert(!this.config_['triggers'][eventType],
+    devAssert(!this.config_['triggers'][eventType],
         'customEventReporterBuilder should not track same eventType twice');
     const requestList = [];
     for (let i = 0; i < request.length; i++) {
@@ -181,7 +181,7 @@ export class CustomEventReporterBuilder {
    * means #build() should only be called once after all eventType are added.
    */
   build() {
-    dev().assert(this.config_, 'CustomEventReporter already built');
+    devAssert(this.config_, 'CustomEventReporter already built');
     const report = new CustomEventReporter(
         this.parent_, /** @type {!JsonObject} */ (this.config_));
     this.config_ = null;

--- a/src/finite-state-machine.js
+++ b/src/finite-state-machine.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from './log';
+import {devAssert} from './log';
 
 /**
  * @template STATE
@@ -50,7 +50,7 @@ export class FiniteStateMachine {
    */
   addTransition(oldState, newState, callback) {
     const transition = this.statesToTransition_(oldState, newState);
-    dev().assert(
+    devAssert(
         !this.transitions_[transition],
         'cannot define a duplicate transition callback'
     );

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -16,7 +16,7 @@
 
 import {Observable} from './observable';
 import {Pass} from './pass';
-import {dev} from './log';
+import {devAssert} from './log';
 import {findIndex} from './utils/array';
 import {toWin} from './types';
 
@@ -405,7 +405,7 @@ export class Gestures {
    * @visibleForTesting
    */
   signalEmit_(recognizer, data, event) {
-    dev().assert(this.eventing_ == recognizer,
+    devAssert(this.eventing_ == recognizer,
         'Recognizer is not currently allowed: %s', recognizer.getType());
     const overserver = this.overservers_[recognizer.getType()];
     if (overserver) {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -16,7 +16,7 @@
 
 import {addAttributesToElement, closestBySelector} from './dom';
 import {deserializeMessage, isAmpMessage} from './3p-frame-messaging';
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {dict} from './utils/object';
 import {getData} from './event-helper';
 import {parseUrlDeprecated} from './url';
@@ -252,10 +252,10 @@ function registerGlobalListenerIfNeeded(parentWin) {
  */
 export function listenFor(
   iframe, typeOfMessage, callback, opt_is3P, opt_includingNestedWindows) {
-  dev().assert(iframe.src, 'only iframes with src supported');
-  dev().assert(!iframe.parentNode, 'cannot register events on an attached ' +
+  devAssert(iframe.src, 'only iframes with src supported');
+  devAssert(!iframe.parentNode, 'cannot register events on an attached ' +
       'iframe. It will cause hair-pulling bugs like #2942');
-  dev().assert(callback);
+  devAssert(callback);
   const parentWin = iframe.ownerDocument.defaultView;
 
   registerGlobalListenerIfNeeded(parentWin);

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -19,7 +19,7 @@ import {Observable} from '../observable';
 import {Services} from '../services';
 import {Viewport} from '../service/viewport/viewport-impl';
 import {ViewportBindingDef} from '../service/viewport/viewport-binding-def';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {iframeMessagingClientFor} from './inabox-iframe-messaging-client';
 import {isExperimentOn} from '../experiments';
 import {
@@ -289,7 +289,7 @@ export class ViewportBindingInabox {
             MessageType.SEND_POSITIONS, MessageType.POSITION,
             data => {
               this.requestPositionPromise_ = null;
-              dev().assert(data.targetRect, 'Host should send targetRect');
+              devAssert(data.targetRect, 'Host should send targetRect');
               resolve(data.targetRect);
             }
         );

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -17,7 +17,7 @@
 import {Pass} from './pass';
 import {Services} from './services';
 import {SubscriptionApi} from './iframe-helper';
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {dict} from './utils/object';
 import {isArray, isFiniteNumber} from './types';
 import {layoutRectLtwh, moveLayoutRect, rectIntersection} from './layout-rect';
@@ -211,7 +211,7 @@ export class IntersectionObserverPolyfill {
     }
 
     for (let i = 0; i < threshold.length; i++) {
-      dev().assert(isFiniteNumber(threshold[i]), 'Threshold should be a ' +
+      devAssert(isFiniteNumber(threshold[i]), 'Threshold should be a ' +
           'finite number or an array of finite numbers');
     }
 
@@ -220,7 +220,7 @@ export class IntersectionObserverPolyfill {
      * @private @const {!Array}
      */
     this.threshold_ = threshold.sort();
-    dev().assert(this.threshold_[0] >= 0 &&
+    devAssert(this.threshold_[0] >= 0 &&
         this.threshold_[this.threshold_.length - 1] <= 1,
     'Threshold should be in the range from "[0, 1]"');
 
@@ -264,7 +264,7 @@ export class IntersectionObserverPolyfill {
    */
   observe(element) {
     // Check the element is an AMP element.
-    dev().assert(element.getLayoutBox);
+    devAssert(element.getLayoutBox);
 
     // If the element already exists in current observeEntries, do nothing
     for (let i = 0; i < this.observeEntries_.length; i++) {

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -16,7 +16,7 @@
 
 import {Services} from './services';
 import {SubscriptionApi} from './iframe-helper';
-import {dev} from './log';
+import {devAssert} from './log';
 import {dict} from './utils/object';
 import {layoutRectLtwh, moveLayoutRect, rectIntersection} from './layout-rect';
 
@@ -60,7 +60,7 @@ function intersectionRatio(smaller, larger) {
  * @private
  */
 export function getIntersectionChangeEntry(element, owner, viewport) {
-  dev().assert(element.width >= 0 && element.height >= 0,
+  devAssert(element.width >= 0 && element.height >= 0,
       'Negative dimensions in element.');
   // Building an IntersectionObserverEntry.
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -19,7 +19,7 @@
  * details.
  */
 
-import {dev, user} from './log';
+import {dev, devAssert, user} from './log';
 import {htmlFor} from './static-template';
 import {isFiniteNumber} from './types';
 import {setStyle, setStyles, toggle} from './style';
@@ -266,7 +266,7 @@ export function hasNaturalDimensions(tagName) {
  */
 export function getNaturalDimensions(element) {
   const tagName = element.tagName.toUpperCase();
-  dev().assert(naturalDimensions_[tagName] !== undefined);
+  devAssert(naturalDimensions_[tagName] !== undefined);
   if (!naturalDimensions_[tagName]) {
     const doc = element.ownerDocument;
     const naturalTagName = tagName.replace(/^AMP\-/, '');
@@ -326,7 +326,7 @@ export function applyStaticLayout(element) {
   // please take care in making changes here.
   const completedLayoutAttr = element.getAttribute('i-amphtml-layout');
   if (completedLayoutAttr) {
-    const layout = /** @type {!Layout} */ (dev().assert(
+    const layout = /** @type {!Layout} */ (devAssert(
         parseLayout(completedLayoutAttr)));
     if ((layout == Layout.RESPONSIVE || layout == Layout.INTRINSIC)
       && element.firstElementChild) {

--- a/src/log.js
+++ b/src/log.js
@@ -711,8 +711,8 @@ export function devAssert(shouldBeTrueish, opt_message, opt_1, opt_2,
   if (getMode().minified) {
     return shouldBeTrueish;
   }
-  return dev().assert(shouldBeTrueish, opt_message, opt_1, opt_2, opt_3,
-      opt_4, opt_5, opt_6, opt_7, opt_8, opt_9);
+  return dev()./*Orig call*/assert(shouldBeTrueish, opt_message, opt_1, opt_2,
+      opt_3, opt_4, opt_5, opt_6, opt_7, opt_8, opt_9);
 }
 
 /**

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {Services} from './services';
-import {dev, user} from './log';
+import {devAssert, user} from './log';
 import {isArray, isObject} from './types';
 import {tryParseJson} from './json';
 
@@ -143,7 +143,7 @@ function validateMetadata(element, metadata) {
   // Ensure src of artwork has valid protocol
   if (metadata && metadata.artwork) {
     const {artwork} = metadata;
-    dev().assert(isArray(artwork));
+    devAssert(isArray(artwork));
     artwork.forEach(item => {
       if (item) {
         const src = isObject(item) ? item.src : item;

--- a/src/polyfills/fetch.js
+++ b/src/polyfills/fetch.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {hasOwn, map} from '../utils/object';
 import {isArray, isObject} from '../types';
 import {parseJson} from '../json';
@@ -157,7 +157,7 @@ class FetchResponse {
    * @return {!FetchResponse}
    */
   clone() {
-    dev().assert(!this.bodyUsed, 'Body already used');
+    devAssert(!this.bodyUsed, 'Body already used');
     return new FetchResponse(this.xhr_);
   }
 
@@ -167,7 +167,7 @@ class FetchResponse {
    * @private
    */
   drainText_() {
-    dev().assert(!this.bodyUsed, 'Body already used');
+    devAssert(!this.bodyUsed, 'Body already used');
     this.bodyUsed = true;
     return Promise.resolve(this.xhr_.responseText);
   }
@@ -212,7 +212,7 @@ function normalizeMethod(method) {
     return 'GET';
   }
   method = method.toUpperCase();
-  dev().assert(
+  devAssert(
       allowedMethods.includes(method),
       'Only one of %s is currently allowed. Got %s',
       allowedMethods.join(', '),

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from './services';
-import {dev} from './log';
+import {devAssert} from './log';
 import {getServicePromise} from './service';
 
 /**
@@ -83,7 +83,7 @@ export function hasRenderDelayingServices(win) {
 export function includedServices(win) {
   /** @const {!Document} */
   const doc = win.document;
-  dev().assert(doc.body);
+  devAssert(doc.body);
 
   return Object.keys(SERVICES).filter(service => {
     return doc.querySelector(SERVICES[service]);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -24,7 +24,7 @@ import {
 import {CommonSignals} from './common-signals';
 import {
   LogLevel, // eslint-disable-line no-unused-vars
-  dev,
+  dev, devAssert,
   initLogConstructor,
   overrideLogLevel,
   setReportError,
@@ -930,7 +930,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
   // added to script tags that go into the code path below.
   const scriptInHead = win.document.head./*OK*/querySelector(
       `[custom-element="${fnOrStruct.n}"]:not([i-amphtml-inserted])`);
-  dev().assert(scriptInHead, 'Expected to find script for extension: %s',
+  devAssert(scriptInHead, 'Expected to find script for extension: %s',
       fnOrStruct.n);
   if (!scriptInHead) {
     return false;

--- a/src/service.js
+++ b/src/service.js
@@ -24,7 +24,7 @@
 import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
 
 import {Deferred} from './utils/promise';
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {toWin} from './types';
 
 
@@ -118,9 +118,9 @@ export function getExistingServiceForDocInEmbedScope(
  */
 export function installServiceInEmbedScope(embedWin, id, service) {
   const topWin = getTopWindow(embedWin);
-  dev().assert(embedWin != topWin,
+  devAssert(embedWin != topWin,
       'Service override can only be installed in embed window: %s', id);
-  dev().assert(!isServiceRegistered(embedWin, id),
+  devAssert(!isServiceRegistered(embedWin, id),
       'Service override has already been installed: %s', id);
   registerServiceInternal(embedWin, embedWin, id, () => service);
   getServiceInternal(embedWin, id); // Force service to build.
@@ -379,15 +379,15 @@ function getAmpdocService(win) {
  * @template T
  */
 function getServiceInternal(holder, id) {
-  dev().assert(isServiceRegistered(holder, id),
+  devAssert(isServiceRegistered(holder, id),
       `Expected service ${id} to be registered`);
   const services = getServices(holder);
   const s = services[id];
   if (!s.obj) {
-    dev().assert(s.ctor, `Service ${id} registered without ctor nor impl.`);
-    dev().assert(s.context, `Service ${id} registered without context.`);
+    devAssert(s.ctor, `Service ${id} registered without ctor nor impl.`);
+    devAssert(s.context, `Service ${id} registered without context.`);
     s.obj = new s.ctor(s.context);
-    dev().assert(s.obj, `Service ${id} constructed to null.`);
+    devAssert(s.obj, `Service ${id} constructed to null.`);
     s.ctor = null;
     s.context = null;
     // The service may have been requested already, in which case we have a
@@ -518,7 +518,7 @@ export function isDisposable(service) {
  * @return {!Disposable}
  */
 export function assertDisposable(service) {
-  dev().assert(isDisposable(service), 'required to implement Disposable');
+  devAssert(isDisposable(service), 'required to implement Disposable');
   return /** @type {!Disposable} */ (service);
 }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -22,7 +22,7 @@ import {
 import {Keys} from '../utils/key-codes';
 import {Services} from '../services';
 import {debounce, throttle} from '../utils/rate-limit';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {dict, hasOwn, map} from '../utils/object';
 import {getDetail} from '../event-helper';
 import {getMode} from '../mode';
@@ -402,7 +402,7 @@ export class ActionService {
     // TODO(dvoytenko, #7063): switch back to `target.id` with form proxy.
     const targetId = target.getAttribute('id') || '';
     const debugId = target.tagName + '#' + targetId;
-    dev().assert((targetId && targetId.substring(0, 4) == 'amp-') ||
+    devAssert((targetId && targetId.substring(0, 4) == 'amp-') ||
         target.tagName.toLowerCase() in ELEMENTS_ACTIONS_MAP_,
     'AMP element or a whitelisted target element is expected: %s', debugId);
 
@@ -612,7 +612,7 @@ export class ActionService {
       }
       const actionInfos = this.matchActionInfos_(n, actionEventType);
       if (actionInfos && isEnabled(n)) {
-        return {node: n, actionInfos: dev().assert(actionInfos)};
+        return {node: n, actionInfos: devAssert(actionInfos)};
       }
       n = n.parentElement;
     }
@@ -812,7 +812,7 @@ function cloneWithoutFunctions(original, opt_dest) {
 
 /** @private */
 function notImplemented() {
-  dev().assert(null, 'Deferred events cannot access native event functions.');
+  devAssert(null, 'Deferred events cannot access native event functions.');
 }
 
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -16,7 +16,7 @@
 
 import {Deferred} from '../utils/promise';
 import {Signals} from '../utils/signals';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {
   getParentWindowFrameElement,
   registerServiceBuilder,
@@ -117,7 +117,7 @@ export class AmpDocService {
     // make sure any functionality that works for a standalone AmpDoc works if
     // the AmpDoc is loaded in a shadow doc.
     if (!this.singleDoc_) {
-      dev().assert(opt_node);
+      devAssert(opt_node);
     }
     // Otherwise discover and possibly create the ampdoc.
     let n = opt_node;
@@ -182,7 +182,7 @@ export class AmpDocService {
     // fast `isConnected` API and thus only checked on platforms that have it.
     // See https://www.chromestatus.com/feature/5676110549352448.
     if (opt_node) {
-      dev().assert(
+      devAssert(
           opt_node['isConnected'] === undefined ||
           opt_node['isConnected'] === true,
           'The node must be attached to request ampdoc.');
@@ -204,7 +204,7 @@ export class AmpDocService {
    * @restricted
    */
   installShadowDoc(url, shadowRoot) {
-    dev().assert(!shadowRoot[AMPDOC_PROP],
+    devAssert(!shadowRoot[AMPDOC_PROP],
         'The shadow root already contains ampdoc');
     const ampdoc = new AmpDocShadow(this.win, url, shadowRoot);
     shadowRoot[AMPDOC_PROP] = ampdoc;
@@ -223,7 +223,7 @@ export class AmpDocService {
    * @restricted
    */
   installShellShadowDoc() {
-    dev().assert(this.singleDoc_ === null,
+    devAssert(this.singleDoc_ === null,
         'AmpDocShell cannot be installed in single-doc mode');
     this.shellShadowDoc_ = new AmpDocShell(this.win);
     this.win.document[AMPDOC_PROP] = this.shellShadowDoc_;
@@ -266,7 +266,7 @@ export class AmpDoc {
    * @return {boolean}
    */
   isSingleDoc() {
-    return /** @type {?} */ (dev().assert(null, 'not implemented'));
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
   }
 
   /**
@@ -311,7 +311,7 @@ export class AmpDoc {
    * @return {!Document|!ShadowRoot}
    */
   getRootNode() {
-    return /** @type {?} */ (dev().assert(null, 'not implemented'));
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
   }
 
   /**
@@ -327,7 +327,7 @@ export class AmpDoc {
    * @return {boolean}
    */
   isBodyAvailable() {
-    return /** @type {?} */ (dev().assert(false, 'not implemented'));
+    return /** @type {?} */ (devAssert(false, 'not implemented'));
   }
 
   /**
@@ -347,7 +347,7 @@ export class AmpDoc {
    * @return {!Promise<!Element>}
    */
   whenBodyAvailable() {
-    return /** @type {?} */ (dev().assert(null, 'not implemented'));
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
   }
 
   /**
@@ -358,7 +358,7 @@ export class AmpDoc {
    * @return {boolean}
    */
   isReady() {
-    return /** @type {?} */ (dev().assert(null, 'not implemented'));
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
   }
 
   /**
@@ -367,7 +367,7 @@ export class AmpDoc {
    * @return {!Promise}
    */
   whenReady() {
-    return /** @type {?} */ (dev().assert(null, 'not implemented'));
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
   }
 
   /**
@@ -546,7 +546,7 @@ export class AmpDocShadow extends AmpDoc {
    * @restricted
    */
   setBody(body) {
-    dev().assert(!this.body_, 'Duplicate body');
+    devAssert(!this.body_, 'Duplicate body');
     this.body_ = body;
     this.bodyResolver_(body);
     this.bodyResolver_ = undefined;
@@ -567,7 +567,7 @@ export class AmpDocShadow extends AmpDoc {
    * @restricted
    */
   setReady() {
-    dev().assert(!this.ready_, 'Duplicate ready state');
+    devAssert(!this.ready_, 'Duplicate ready state');
     this.ready_ = true;
     this.readyResolver_();
     this.readyResolver_ = undefined;

--- a/src/service/crypto-impl.js
+++ b/src/service/crypto-impl.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {base64UrlEncodeFromBytes} from '../utils/base64';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {getService, registerServiceBuilder} from '../service';
 import {stringToBytes, utf8Encode} from '../utils/bytes';
 
@@ -170,7 +170,7 @@ export class Crypto {
    * @throws {TypeError} if `jwk` is not an RSA JSON Web Key
    */
   importPkcsKey(jwk) {
-    dev().assert(this.isPkcsAvailable());
+    devAssert(this.isPkcsAvailable());
     // Safari 10 and earlier want this as an ArrayBufferView.
     const keyData = this.isLegacyWebkit_
       ? utf8Encode(JSON.stringify(/** @type {!JsonObject} */ (jwk)))
@@ -191,7 +191,7 @@ export class Crypto {
    *     data and public key
    */
   verifyPkcs(key, signature, data) {
-    dev().assert(this.isPkcsAvailable());
+    devAssert(this.isPkcsAvailable());
     return /** @type {!Promise<boolean>} */ (
       this.subtle.verify(this.pkcsAlgo, key, signature, data)
     );

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -26,7 +26,7 @@ import {
   upgradeOrRegisterElement,
 } from './custom-element-registry';
 import {cssText} from '../../build/css';
-import {dev, rethrowAsync} from '../log';
+import {dev, devAssert, rethrowAsync} from '../log';
 import {
   getAmpdoc,
   installServiceInEmbedIfEmbeddable,
@@ -265,7 +265,7 @@ export class Extensions {
     // "Disconnect" the old script element and extension record.
     const holder = this.extensions_[extensionId];
     if (holder) {
-      dev().assert(!holder.loaded && !holder.error);
+      devAssert(!holder.loaded && !holder.error);
       delete this.extensions_[extensionId];
     }
     oldScriptElement.removeAttribute('custom-element');
@@ -283,7 +283,7 @@ export class Extensions {
    */
   loadElementClass(elementName) {
     return this.preloadExtension(elementName).then(extension => {
-      const element = dev().assert(extension.elements[elementName],
+      const element = devAssert(extension.elements[elementName],
           'Element not found: %s', elementName);
       return element.implementationClass;
     });

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -16,7 +16,7 @@
 
 import {Deferred, tryResolve} from '../utils/promise';
 import {Services} from '../services';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
 import {
@@ -173,7 +173,7 @@ export class History {
    * @return {!Promise}
    */
   replaceStateForTarget(target) {
-    dev().assert(target[0] == '#', 'target should start with a #');
+    devAssert(target[0] == '#', 'target should start with a #');
     const previousHash = this.ampdoc_.win.location.hash;
     return this.push(() => {
       this.ampdoc_.win.location.replace(previousHash || '#');
@@ -632,7 +632,7 @@ export class HistoryBindingNatural_ {
 
   /** @private */
   assertReady_() {
-    dev().assert(!this.waitingState_,
+    devAssert(!this.waitingState_,
         'The history must not be in the waiting state');
   }
 
@@ -715,7 +715,7 @@ export class HistoryBindingNatural_ {
    * @override
    */
   replaceStateForTarget(target) {
-    dev().assert(target[0] == '#', 'target should start with a #');
+    devAssert(target[0] == '#', 'target should start with a #');
     this.whenReady_(() => {
       // location.replace will fire a popstate event which is not a history
       // event, so temporarily remove the event listener and re-add it after.
@@ -835,7 +835,7 @@ export class HistoryBindingVirtual_ {
 
   /** @override */
   replaceStateForTarget(target) {
-    dev().assert(target[0] == '#', 'target should start with a #');
+    devAssert(target[0] == '#', 'target should start with a #');
     this.win.location.replace(target);
   }
 

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {computedStyle} from '../style';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {getFriendlyIframeEmbedOptional} from '../friendly-iframe-embed';
 import {getMode} from '../mode';
 import {listen} from '../event-helper';
@@ -565,7 +565,7 @@ export class LayoutElement {
    * @return {!LayoutElement}
    */
   static for(element) {
-    return /** @type {!LayoutElement} */ (dev().assert(
+    return /** @type {!LayoutElement} */ (devAssert(
         LayoutElement.forOptional(element)));
   }
 
@@ -601,7 +601,7 @@ export class LayoutElement {
       }
     }
 
-    let win = /** @type {!Window } */ (dev().assert(
+    let win = /** @type {!Window } */ (devAssert(
         node.ownerDocument.defaultView));
     let el = node;
     let op = node;
@@ -663,13 +663,13 @@ export class LayoutElement {
         op = el;
         // Update our window reference if we crossed a FIE boundary.
         if (el) {
-          win = /** @type {!Window } */ (dev().assert(
+          win = /** @type {!Window } */ (devAssert(
               el.ownerDocument.defaultView));
         }
       }
     }
 
-    dev().assert(last.nodeType === Node.DOCUMENT_NODE,
+    devAssert(last.nodeType === Node.DOCUMENT_NODE,
         'node not in the DOM tree');
     return null;
   }
@@ -727,8 +727,8 @@ export class LayoutElement {
    * @param {!LayoutElement} child
    */
   add(child) {
-    dev().assert(this.isLayer());
-    dev().assert(this.contains(child));
+    devAssert(this.isLayer());
+    devAssert(this.contains(child));
 
     // Parents track the children, but not all children are aware of their
     // parents. When a child finds its parent, it adds itself to the parent.
@@ -767,7 +767,7 @@ export class LayoutElement {
    * @param {boolean} scrollsLikeViewport
    */
   declareLayer(isRootLayer, scrollsLikeViewport) {
-    dev().assert(!scrollsLikeViewport || isRootLayer, 'Only root layers may' +
+    devAssert(!scrollsLikeViewport || isRootLayer, 'Only root layers may' +
       ' scroll like a viewport.');
 
     if (this.isLayer_) {
@@ -804,7 +804,7 @@ export class LayoutElement {
       return;
     }
 
-    const win = /** @type {!Window } */ (dev().assert(
+    const win = /** @type {!Window } */ (devAssert(
         element.ownerDocument.defaultView));
     // If it remains fixed, it will still be a layer.
     if (computedStyle(win, element).position === 'fixed') {
@@ -816,7 +816,7 @@ export class LayoutElement {
     // layer).
     const parent = this.getParentLayer() ||
         LayoutElement.getParentLayer(element, true);
-    this.transfer_(/** @type {!LayoutElement} */ (dev().assert(parent)));
+    this.transfer_(/** @type {!LayoutElement} */ (devAssert(parent)));
   }
 
   /**
@@ -1155,7 +1155,7 @@ export class LayoutElement {
     // layer.
     let isActive = activeLayer === this ||
         (!!activeLayer && activeLayer.contains(this));
-    dev().assert(ANCESTRY_CACHE.length === 0, 'ancestry cache must be empty');
+    devAssert(ANCESTRY_CACHE.length === 0, 'ancestry cache must be empty');
 
     let layer = this;
     while (layer) {
@@ -1289,7 +1289,7 @@ function sameDocument(element, other) {
  * @return {?Element}
  */
 function frameParent(node) {
-  dev().assert(node.nodeType === Node.DOCUMENT_NODE);
+  devAssert(node.nodeType === Node.DOCUMENT_NODE);
   try {
     const {defaultView} = node;
     const frameElement = defaultView && defaultView.frameElement;

--- a/src/service/position-observer/position-observer-worker.js
+++ b/src/service/position-observer/position-observer-worker.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../services';
-import {dev} from '../../log';
+import {devAssert} from '../../log';
 import {
   layoutRectEquals,
   layoutRectLtwh,
@@ -87,7 +87,7 @@ export class PositionObserverWorker {
       return;
     }
 
-    dev().assert(position.positionRect,
+    devAssert(position.positionRect,
         'PositionObserver should always trigger entry with clientRect');
     const positionRect =
     /** @type {!../../layout-rect.LayoutRectDef} */ (position.positionRect);

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -18,7 +18,7 @@ import {AmpEvents} from '../amp-events';
 import {Deferred} from '../utils/promise';
 import {Layout} from '../layout';
 import {computedStyle, toggle} from '../style';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {isBlockedByConsent} from '../error';
 import {isExperimentOn} from '../experiments';
 import {
@@ -94,7 +94,7 @@ export class Resource {
    */
   static forElement(element) {
     return /** @type {!Resource} */ (
-      dev().assert(Resource.forElementOptional(element),
+      devAssert(Resource.forElementOptional(element),
           'Missing resource prop on %s', element));
   }
 
@@ -113,7 +113,7 @@ export class Resource {
    * @param {!AmpElement} owner
    */
   static setOwner(element, owner) {
-    dev().assert(owner.contains(element), 'Owner must contain the element');
+    devAssert(owner.contains(element), 'Owner must contain the element');
     if (Resource.forElementOptional(element)) {
       Resource.forElementOptional(element).updateOwner(owner);
     }
@@ -670,7 +670,7 @@ export class Resource {
    *    viewport range given.
    */
   whenWithinViewport(viewport) {
-    dev().assert(viewport !== false);
+    devAssert(viewport !== false);
     // Resolve is already laid out or viewport is true.
     if (!this.isLayoutPending() || viewport === true) {
       return Promise.resolve();
@@ -857,9 +857,9 @@ export class Resource {
       return Promise.reject(this.lastLayoutError_);
     }
 
-    dev().assert(this.state_ != ResourceState.NOT_BUILT,
+    devAssert(this.state_ != ResourceState.NOT_BUILT,
         'Not ready to start layout: %s (%s)', this.debugid, this.state_);
-    dev().assert(this.isDisplayed(),
+    devAssert(this.isDisplayed(),
         'Not displayed for layout: %s', this.debugid);
 
     // Unwanted re-layouts are ignored.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -25,7 +25,7 @@ import {VisibilityState} from '../visibility-state';
 import {areMarginsChanged, expandLayoutRect} from '../layout-rect';
 import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {computedStyle} from '../style';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {dict, hasOwn} from '../utils/object';
 import {getSourceUrl} from '../url';
 import {checkAndFix as ieMediaCheckAndFix} from './ie-media-bug';
@@ -2044,7 +2044,7 @@ export class Resources {
    */
   scheduleLayoutOrPreload_(resource, layout, opt_parentPriority,
     opt_forceOutsideViewport) {
-    dev().assert(resource.getState() != ResourceState.NOT_BUILT &&
+    devAssert(resource.getState() != ResourceState.NOT_BUILT &&
         resource.isDisplayed(),
     'Not ready for layout: %s (%s)',
     resource.debugid, resource.getState());
@@ -2172,7 +2172,7 @@ export class Resources {
    */
   discoverResourcesForArray_(parentResource, elements, callback) {
     elements.forEach(element => {
-      dev().assert(parentResource.element.contains(element));
+      devAssert(parentResource.element.contains(element));
       this.discoverResourcesForElement_(element, callback);
     });
   }

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../services';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {dict} from '../utils/object';
 import {getSourceOrigin} from '../url';
 import {parseJson, recreateNonProtoObject} from '../json';
@@ -90,7 +90,7 @@ export class Storage {
    * @return {!Promise}
    */
   set(name, value, opt_isUpdate) {
-    dev().assert(typeof value == 'boolean', 'Only boolean values accepted');
+    devAssert(typeof value == 'boolean', 'Only boolean values accepted');
     return this.setNonBoolean(name, value, opt_isUpdate);
   }
 
@@ -224,7 +224,7 @@ export class Store {
    * @param {boolean=} opt_isUpdate
    */
   set(name, value, opt_isUpdate) {
-    dev().assert(name != '__proto__' && name != 'prototype',
+    devAssert(name != '__proto__' && name != 'prototype',
         'Name is not allowed: %s', name);
     // The structure is {key: {v: *, t: time}}
     if (this.values_[name] !== undefined) {

--- a/src/service/task-queue.js
+++ b/src/service/task-queue.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../log';
+import {devAssert} from '../log';
 
 
 /**
@@ -102,7 +102,7 @@ export class TaskQueue {
    * @param {!TaskDef} task
    */
   enqueue(task) {
-    dev().assert(
+    devAssert(
         !this.taskIdMap_[task.id], 'Task already enqueued: %s', task.id);
     this.tasks_.push(task);
     this.taskIdMap_[task.id] = task;

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {Deferred} from '../utils/promise';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {getMode} from '../mode';
 import {getService, getServiceForDoc, registerServiceBuilder} from '../service';
 import {rootNodeFor, scopedQuerySelector} from '../dom';
@@ -377,7 +377,7 @@ export class Templates {
    * @visibleForTesting
    */
   unregisterTemplate(type) {
-    dev().assert(getMode().test, 'Should only be used in test mode.');
+    devAssert(getMode().test, 'Should only be used in test mode.');
     delete this.templateClassMap_[type];
     delete this.templateClassResolvers_[type];
   }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -36,7 +36,7 @@ import {
   removeAmpJsParamsFromUrl,
   removeFragment,
 } from '../url';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {getMode} from '../mode';
 import {getTrackImpressionPromise} from '../impression.js';
 import {hasOwn} from '../utils/object';
@@ -873,7 +873,7 @@ export class UrlReplacements {
    * @return {string|!Promise<string>}
    */
   expandInputValue_(element, opt_sync) {
-    dev().assert(element.tagName == 'INPUT' &&
+    devAssert(element.tagName == 'INPUT' &&
         (element.getAttribute('type') || '').toLowerCase() == 'hidden',
     'Input value expansion only works on hidden input fields: %s', element);
 
@@ -960,7 +960,7 @@ export class UrlReplacements {
    * @return {string|undefined} Replaced string for testing
    */
   maybeExpandLink(element, defaultUrlParams) {
-    dev().assert(element.tagName == 'A');
+    devAssert(element.tagName == 'A');
     const supportedReplacements = {
       'CLIENT_ID': true,
       'QUERY_PARAM': true,

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {dev} from '../log';
+import {devAssert} from '../log';
 import {isFiniteNumber} from '../types';
 import {loadPromise} from '../event-helper';
 
@@ -158,7 +158,7 @@ export class VariableSource {
    * @return {!VariableSource}
    */
   set(varName, syncResolver) {
-    dev().assert(varName.indexOf('RETURN') == -1);
+    devAssert(varName.indexOf('RETURN') == -1);
     this.replacements_[varName] =
         this.replacements_[varName] || {sync: undefined, async: undefined};
     this.replacements_[varName].sync = syncResolver;
@@ -176,7 +176,7 @@ export class VariableSource {
    * @return {!VariableSource}
    */
   setAsync(varName, asyncResolver) {
-    dev().assert(varName.indexOf('RETURN') == -1);
+    devAssert(varName.indexOf('RETURN') == -1);
     this.replacements_[varName] =
         this.replacements_[varName] || {sync: undefined, async: undefined};
     this.replacements_[varName].async = asyncResolver;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -48,7 +48,7 @@ import {
   listenOnce,
   listenOncePromise,
 } from '../event-helper';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
 import {installAutoplayStylesForDoc} from './video/install-autoplay-styles';
@@ -181,7 +181,7 @@ export class VideoManager {
 
   /** @override */
   register(video) {
-    dev().assert(video);
+    devAssert(video);
 
     this.registerCommonActions_(video);
 
@@ -1419,7 +1419,7 @@ export class AnalyticsPercentageTracker {
     const normalizedPercentage =
       Math.floor(percentage / PERCENTAGE_INTERVAL) * PERCENTAGE_INTERVAL;
 
-    dev().assert(isFiniteNumber(normalizedPercentage));
+    devAssert(isFiniteNumber(normalizedPercentage));
 
     this.maybeTrigger_(normalizedPercentage);
 

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -28,7 +28,7 @@ import {
 import {ViewportBindingNatural_} from './viewport-binding-natural';
 import {VisibilityState} from '../../visibility-state';
 import {closestBySelector, isIframed} from '../../dom';
-import {dev} from '../../log';
+import {dev, devAssert} from '../../log';
 import {dict} from '../../utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../friendly-iframe-embed';
 import {getMode} from '../../mode';
@@ -755,7 +755,7 @@ export class Viewport {
     const fieOptional = this.getFriendlyIframeEmbed_(requestingElement);
 
     if (fieOptional) {
-      dev().assert(this.isLightboxExperimentOn(),
+      devAssert(this.isLightboxExperimentOn(),
           'Lightbox mode for A4A is only available when ' +
           "'amp-lightbox-a4a-proto' experiment is on");
 
@@ -772,7 +772,7 @@ export class Viewport {
     const fieOptional = this.getFriendlyIframeEmbed_(requestingElement);
 
     if (fieOptional) {
-      dev().assert(fieOptional).leaveFullOverlayMode();
+      devAssert(fieOptional).leaveFullOverlayMode();
     }
   }
 

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -19,7 +19,7 @@ import {JankMeter} from './jank-meter';
 import {Pass} from '../pass';
 import {Services} from '../services';
 import {cancellation} from '../error';
-import {dev, rethrowAsync} from '../log';
+import {dev, devAssert, rethrowAsync} from '../log';
 import {getService, registerServiceBuilder} from '../service';
 import {installTimerService} from './timer-impl';
 
@@ -260,7 +260,7 @@ export class Vsync {
    * @return {boolean}
    */
   canAnimate(contextNode) {
-    return this.canAnimate_(dev().assert(contextNode));
+    return this.canAnimate_(devAssert(contextNode));
   }
 
   /**
@@ -453,7 +453,7 @@ export class Vsync {
  * @param {!VsyncStateDef} state
  */
 function callTaskNoInline(callback, state) {
-  dev().assert(callback);
+  devAssert(callback);
   try {
     callback(state);
   } catch (e) {

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -29,7 +29,7 @@ import {
   iterateCursor,
   removeElement,
 } from './dom';
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {installCssTransformer} from './style-installer';
 import {setInitialDisplay, setStyle} from './style';
 import {toArray, toWin} from './types';
@@ -249,7 +249,7 @@ export function transformShadowCss(shadowRoot, css) {
  * @visibleForTesting
  */
 export function scopeShadowCss(shadowRoot, css) {
-  const id = dev().assert(shadowRoot.id);
+  const id = devAssert(shadowRoot.id);
   const doc = shadowRoot.ownerDocument;
   let rules = null;
   // Try to use a separate document.
@@ -539,7 +539,7 @@ export class ShadowDomWriterStreamer {
 
   /** @private */
   schedule_() {
-    dev().assert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
+    devAssert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
     if (!this.mergeScheduled_) {
       this.mergeScheduled_ = true;
       this.vsync_.mutate(this.boundMerge_);
@@ -557,8 +557,8 @@ export class ShadowDomWriterStreamer {
 
     // Merge body children.
     if (this.targetBody_) {
-      const inputBody = /** @type !Element */(dev().assert(this.parser_.body));
-      const targetBody = dev().assert(this.targetBody_);
+      const inputBody = /** @type !Element */(devAssert(this.parser_.body));
+      const targetBody = devAssert(this.targetBody_);
       let transferCount = 0;
       removeNoScriptElements(inputBody);
       while (inputBody.firstChild) {
@@ -633,7 +633,7 @@ export class ShadowDomWriterBulk {
 
   /** @override */
   write(chunk) {
-    dev().assert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
+    devAssert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
     if (this.eof_) {
       throw new Error('closed already');
     }
@@ -645,7 +645,7 @@ export class ShadowDomWriterBulk {
 
   /** @override */
   close() {
-    dev().assert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
+    devAssert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
     this.eof_ = true;
     this.vsync_.mutate(() => this.complete_());
     return this.success_;

--- a/src/static-template.js
+++ b/src/static-template.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from './log';
+import {devAssert} from './log';
 import {map} from './utils/object.js';
 
 let container;
@@ -49,12 +49,12 @@ export function htmlFor(nodeOrDoc) {
  * @return {!Element}
  */
 function html(strings) {
-  dev().assert(strings.length === 1, 'Improper html template tag usage.');
+  devAssert(strings.length === 1, 'Improper html template tag usage.');
   container./*OK*/innerHTML = strings[0];
 
   const el = container.firstElementChild;
-  dev().assert(el, 'No elements in template');
-  dev().assert(!el.nextElementSibling, 'Too many root elements in template');
+  devAssert(el, 'No elements in template');
+  devAssert(!el.nextElementSibling, 'Too many root elements in template');
 
   // Clear to free memory.
   container.removeChild(el);
@@ -76,9 +76,9 @@ export function htmlRefs(root) {
 
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
-    const ref = dev().assert(element.getAttribute('ref'), 'Empty ref attr');
+    const ref = devAssert(element.getAttribute('ref'), 'Empty ref attr');
     element.removeAttribute('ref');
-    dev().assert(refs[ref] === undefined, 'Duplicate ref');
+    devAssert(refs[ref] === undefined, 'Duplicate ref');
     refs[ref] = element;
   }
 

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from './services';
-import {dev, rethrowAsync} from './log';
+import {dev, devAssert, rethrowAsync} from './log';
 import {insertAfterOrAtStart, waitForBodyPromise} from './dom';
 import {map} from './utils/object';
 import {setStyles} from './style';
@@ -241,7 +241,7 @@ export function setBodyMadeVisibleForTesting(value) {
  * @param {!Document} doc The document who's body we should make visible.
  */
 export function makeBodyVisible(doc) {
-  dev().assert(doc.defaultView, 'Passed in document must have a defaultView');
+  devAssert(doc.defaultView, 'Passed in document must have a defaultView');
   const win = /** @type {!Window} */ (doc.defaultView);
   const set = () => {
     bodyMadeVisible = true;
@@ -275,7 +275,7 @@ export function makeBodyVisible(doc) {
  * @param {!Document} doc The document who's body we should make visible.
  */
 export function makeBodyVisibleRecovery(doc) {
-  dev().assert(doc.defaultView, 'Passed in document must have a defaultView');
+  devAssert(doc.defaultView, 'Passed in document must have a defaultView');
   if (bodyMadeVisible) {
     return;
   }

--- a/src/style.js
+++ b/src/style.js
@@ -15,7 +15,7 @@
  */
 
 // Note: loaded by 3p system. Cannot rely on babel polyfills.
-import {dev} from './log';
+import {dev, devAssert} from './log';
 import {map} from './utils/object.js';
 import {startsWith} from './string';
 
@@ -202,9 +202,9 @@ export function assertDoesNotContainDisplay(styles) {
  */
 export function setInitialDisplay(el, value) {
   const {style} = el;
-  dev().assert(value !== '' && value !== 'none', 'Initial display value must ' +
+  devAssert(value !== '' && value !== 'none', 'Initial display value must ' +
     'not be "none". Use toggle instead.');
-  dev().assert(!style['display'], 'setInitialDisplay MUST NOT be used for ' +
+  devAssert(!style['display'], 'setInitialDisplay MUST NOT be used for ' +
     'resetting the display style. If you are looking for display:none ' +
     'toggling, use toggle instead.');
   style['display'] = value;

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../log';
+import {devAssert} from '../log';
 
 /**
  * Interpret a byte array as a UTF-8 string.
@@ -52,7 +52,7 @@ export function stringToBytes(str) {
   const bytes = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {
     const charCode = str.charCodeAt(i);
-    dev().assert(charCode <= 255, 'Characters must be in range [0,255]');
+    devAssert(charCode <= 255, 'Characters must be in range [0,255]');
     bytes[i] = charCode;
   }
   return bytes;

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../services';
-import {dev, user} from '../log';
+import {dev, devAssert, user} from '../log';
 import {dict, map} from './object';
 import {fromIterator} from './array';
 import {getCorsUrl,
@@ -234,7 +234,7 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
  * intercepted.
  */
 export function setupInput(win, input, init) {
-  dev().assert(typeof input == 'string', 'Only URL supported: %s', input);
+  devAssert(typeof input == 'string', 'Only URL supported: %s', input);
   if (init.ampCors !== false) {
     input = getCorsUrl(win, input);
   }
@@ -254,7 +254,7 @@ export function setupInit(opt_init, opt_accept) {
   // In particular, Firefox does not tolerate `null` values for
   // `credentials`.
   const creds = init.credentials;
-  dev().assert(
+  devAssert(
       creds === undefined || creds == 'include' || creds == 'omit',
       'Only credentials=include|omit support: %s', creds);
 
@@ -265,7 +265,7 @@ export function setupInit(opt_init, opt_accept) {
   }
 
   // In edge a `TypeMismatchError` is thrown when body is set to null.
-  dev().assert(init.body !== null, 'fetch `body` can not be `null`');
+  devAssert(init.body !== null, 'fetch `body` can not be `null`');
 
   return init;
 }
@@ -311,7 +311,7 @@ export function setupJsonFetchInit(init) {
   if (fetchInit.method == 'POST' && !isFormDataWrapper(fetchInit.body)) {
     // Assume JSON strict mode where only objects or arrays are allowed
     // as body.
-    dev().assert(
+    devAssert(
         allowedJsonBodyTypes_.some(test => test(fetchInit.body)),
         'body must be of type object or array. %s',
         fetchInit.body
@@ -343,7 +343,7 @@ function normalizeMethod_(method) {
     return 'GET';
   }
   method = method.toUpperCase();
-  dev().assert(
+  devAssert(
       allowedMethods_.includes(method),
       'Only one of %s is currently allowed. Got %s',
       allowedMethods_.join(', '),

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {calculateEntryPointScriptUrl} from '../service/extension-location';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {getMode} from '../mode';
 import {getService, registerServiceBuilder} from '../service';
 
@@ -165,7 +165,7 @@ class AmpWorker {
           'from worker.');
       return;
     }
-    dev().assert(method == message.method, 'Received mismatched method ' +
+    devAssert(method == message.method, 'Received mismatched method ' +
         `(${method}, ${id}), expected ${message.method}.`);
 
     message.resolve(returnValue);

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -209,6 +209,7 @@ describe('getErrorReportData', () => {
     sandbox = sinon.sandbox;
     nextRandomNumber = 0;
     sandbox.stub(Math, 'random').callsFake(() => nextRandomNumber);
+    self.AMP_MODE = undefined;
   });
 
   afterEach(() => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -17,7 +17,7 @@
 import '../../src/polyfills';
 import '../../src/service/timer-impl';
 import {Deferred} from '../../src/utils/promise';
-import {dev, initLogConstructor, setReportError} from '../../src/log';
+import {devAssert, initLogConstructor, setReportError} from '../../src/log';
 import {getCookie, setCookie} from '../../src/cookies';
 import {getMode} from '../../src/mode';
 import {isExperimentOn, toggleExperiment} from '../../src/experiments';
@@ -418,7 +418,7 @@ const EXPERIMENTS = [
 
 if (getMode().localDev) {
   EXPERIMENTS.forEach(experiment => {
-    dev().assert(experiment.cleanupIssue, `experiment ${experiment.name} must` +
+    devAssert(experiment.cleanupIssue, `experiment ${experiment.name} must` +
         ' have a `cleanupIssue` field.');
   });
 }
@@ -580,11 +580,11 @@ function toggleExperiment_(id, name, opt_on) {
  * @param {function()} callback
  */
 function showConfirmation_(message, callback) {
-  const container = dev().assert(document.getElementById('popup-container'));
-  const messageElement = dev().assert(document.getElementById('popup-message'));
-  const confirmButton = dev().assert(
+  const container = devAssert(document.getElementById('popup-container'));
+  const messageElement = devAssert(document.getElementById('popup-message'));
+  const confirmButton = devAssert(
       document.getElementById('popup-button-ok'));
-  const cancelButton = dev().assert(
+  const cancelButton = devAssert(
       document.getElementById('popup-button-cancel'));
   const unlistenSet = [];
   const closePopup = affirmative => {


### PR DESCRIPTION
…and make the old usage illegal.

This enables type inference to work correctly. Does not yet remove unnecessary casts.

