### PR TITLE
✅ Hide the share pill in visual tests, and re-enable tests that were flaky because of this

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-bookend.html
+++ b/examples/visual-tests/amp-story/amp-story-bookend.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+      .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1.hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-bookend.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-bookend.rtl.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1.hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-consent.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.html
@@ -25,6 +25,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-consent.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.rtl.html
@@ -25,6 +25,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-cta-layer.html
+++ b/examples/visual-tests/amp-story/amp-story-cta-layer.html
@@ -24,6 +24,16 @@
         left: 50%;
         transform: translate(-50%, -50%);
       }
+
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script>
       // TODO(#17108): Remove this when getMode().test is set.

--- a/examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html
+++ b/examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html
@@ -14,6 +14,16 @@
       amp-story-page {
         background: yellow;
       }
+
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script>
       // TODO(#17108): Remove this when getMode().test is set.

--- a/examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html
+++ b/examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html
@@ -15,6 +15,16 @@
         background: white;
         font-family: sans-serif;
       }
+
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script>
       // TODO(#17108): Remove this when getMode().test is set.

--- a/examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html
+++ b/examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html
@@ -15,6 +15,16 @@
         background: white;
         font-family: sans-serif;
       }
+
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script>
       // TODO(#17108): Remove this when getMode().test is set.

--- a/examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html
+++ b/examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html
@@ -15,6 +15,16 @@
         background: white;
         font-family: sans-serif;
       }
+
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script>
       // TODO(#17108): Remove this when getMode().test is set.

--- a/examples/visual-tests/amp-story/amp-story-pagination-buttons.html
+++ b/examples/visual-tests/amp-story/amp-story-pagination-buttons.html
@@ -22,6 +22,15 @@
       amp-story-page {
         background-color: white;
       }
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
     </style>
     <script type="application/ld+json">
       {

--- a/examples/visual-tests/amp-story/amp-story-sidebar.html
+++ b/examples/visual-tests/amp-story/amp-story-sidebar.html
@@ -21,6 +21,15 @@
         /* Hide the spinner for loading pages, since this causes flakes */
         display: none;
       }
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/amp-story-tooltip.html
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.html
@@ -21,6 +21,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/basic.html
+++ b/examples/visual-tests/amp-story/basic.html
@@ -24,6 +24,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/basic.rtl.html
+++ b/examples/visual-tests/amp-story/basic.rtl.html
@@ -24,6 +24,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/embed-mode-1.html
+++ b/examples/visual-tests/amp-story/embed-mode-1.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/embed-mode-2.html
+++ b/examples/visual-tests/amp-story/embed-mode-2.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/info-dialog.html
+++ b/examples/visual-tests/amp-story/info-dialog.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/info-dialog.rtl.html
+++ b/examples/visual-tests/amp-story/info-dialog.rtl.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/share-menu.html
+++ b/examples/visual-tests/amp-story/share-menu.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/share-menu.rtl.html
+++ b/examples/visual-tests/amp-story/share-menu.rtl.html
@@ -23,6 +23,16 @@
         display: none;
       }
 
+      /*
+       * The share pill text does not show in the same place consistently, and
+       * as such causes the visual tests to be flaky.  This hides the share pill
+       * with visibility: hidden, so as to keep other elements in the same place
+       * that they would otherwise be, while deflaking the tests.  See #19890.
+       */
+       .i-amphtml-story-share-pill {
+        visibility: hidden;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -338,8 +338,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -352,8 +350,6 @@
       "loading_complete_delay_ms": 500
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -364,8 +360,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -376,8 +370,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -388,8 +380,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -403,8 +393,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -417,8 +405,6 @@
       "loading_complete_delay_ms": 500
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -427,8 +413,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -438,8 +422,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -450,8 +432,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -509,8 +489,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/456056607#L640
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -520,8 +498,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -534,8 +510,6 @@
       "loading_complete_delay_ms": 500
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -547,7 +521,7 @@
     },
     {
       "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/946709
+      // See https://travis-ci.org/ampproject/amphtml/jobs/456056607#L640
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -585,8 +559,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-tooltip.js"
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/1179875
       "url": "examples/visual-tests/amp-story/amp-story-tooltip.html",
       "name": "amp-story: tooltip desktop",
       "viewport": {"width": 1440, "height": 900},
@@ -596,8 +568,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-tooltip-desktop.js"
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/1260087
       "url": "examples/visual-tests/amp-story/amp-story-pagination-buttons.html",
       "name": "amp-story: pagination-buttons desktop",
       "viewport": {"width": 1440, "height": 900},
@@ -617,8 +587,6 @@
     "interactive_tests": "examples/visual-tests/amp-story/amp-story-sidebar.js"
     },
     {
-      "flaky": true,
-      // See https://percy.io/ampproject/amphtml/builds/1260087
       "url": "examples/visual-tests/amp-story/amp-story-pagination-buttons.html",
       "name": "amp-story: pagination-buttons desktop",
       "viewport": {"width": 1440, "height": 900},


### PR DESCRIPTION
Filed #20021 to track centralizing these fixes in one place, but this PR should fix the issues to unblock PRs.

Fixes #19890 by hiding this button entirely during tests.

/cc @rsimha 