### PR TITLE
🐛 Update contentHeight algorithms

### DIFF
--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -401,7 +401,7 @@ export class ViewportBindingIosEmbedShadowRoot_ {
     // account for margins
     const scrollingElement = this.wrapper_;
     const rect = scrollingElement./*OK*/getBoundingClientRect();
-    const style = getComputedStyle(scrollingElement);
+    const style = computedStyle(this.win, scrollingElement);
     return rect.height
         + this.paddingTop_
         + this.getBorderTop()

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -396,6 +396,9 @@ export class ViewportBindingIosEmbedShadowRoot_ {
 
   /** @override */
   getContentHeight() {
+    // Don't use scrollHeight, since it returns `MAX(viewport_height,
+    // document_height)`, even though we only want the latter. Also, it doesn't
+    // account for margins
     const scrollingElement = this.wrapper_;
     const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -396,15 +396,13 @@ export class ViewportBindingIosEmbedShadowRoot_ {
 
   /** @override */
   getContentHeight() {
-    // The reparented body inside scroller will have the correct content height.
-    // Body is overflow: hidden so that the scrollHeight include the margins of
-    // body's first and last child.
-    // Body height doesn't include paddingTop on the parent, so we add on the
-    // position of the body from the top of the viewport and subtract the
-    // scrollTop (as position relative to the viewport changes as you scroll).
-    return this.wrapper_./*OK*/scrollHeight
+    const scrollingElement = this.wrapper_;
+    const style = getComputedStyle(scrollingElement);
+    return scrollingElement./*OK*/scrollHeight
         + this.paddingTop_
-        + this.getBorderTop();
+        + this.getBorderTop()
+        + parseInt(style.marginTop, 10)
+        + parseInt(style.marginBottom, 10);
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -397,8 +397,9 @@ export class ViewportBindingIosEmbedShadowRoot_ {
   /** @override */
   getContentHeight() {
     const scrollingElement = this.wrapper_;
+    const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);
-    return scrollingElement./*OK*/scrollHeight
+    return rect.height
         + this.paddingTop_
         + this.getBorderTop()
         + parseInt(style.marginTop, 10)

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -238,6 +238,9 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   getContentHeight() {
+    // Don't use scrollHeight, since it returns `MAX(viewport_height,
+    // document_height)`, even though we only want the latter. Also, it doesn't
+    // account for margins
     const scrollingElement = this.win.document.body;
     const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -76,6 +76,9 @@ export class ViewportBindingIosEmbedWrapper_ {
     /** @private @const {boolean} */
     this.useLayers_ = isExperimentOn(this.win, 'layers');
 
+    /** @private {number} */
+    this.paddingTop_ = 0;
+
     // Setup UI.
     /** @private {boolean} */
     this.setupDone_ = false;
@@ -165,6 +168,7 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   updatePaddingTop(paddingTop) {
+    this.paddingTop_ = paddingTop;
     setImportantStyles(this.wrapper_, {
       'padding-top': px(paddingTop),
     });
@@ -234,11 +238,11 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   getContentHeight() {
-    const scrollingElement = this.wrapper_;
+    const scrollingElement = this.win.document.body;
     const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);
     return rect.height
-        + this.getBorderTop()
+        + this.paddingTop_
         + parseInt(style.marginTop, 10)
         + parseInt(style.marginBottom, 10);
   }

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -235,8 +235,9 @@ export class ViewportBindingIosEmbedWrapper_ {
   /** @override */
   getContentHeight() {
     const scrollingElement = this.wrapper_;
+    const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);
-    return scrollingElement./*OK*/scrollHeight
+    return rect.height
         + this.getBorderTop()
         + parseInt(style.marginTop, 10)
         + parseInt(style.marginBottom, 10);

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -234,14 +234,12 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   getContentHeight() {
-    // The reparented body inside wrapper will have the correct content height.
-    // Body is overflow: hidden so that the scrollHeight include the margins of
-    // body's first and last child.
-    // Body height doesn't include paddingTop on the parent, so we add on the
-    // position of the body from the top of the viewport and subtract the
-    // scrollTop (as position relative to the viewport changes as you scroll).
-    const rect = this.win.document.body./*OK*/getBoundingClientRect();
-    return rect.height + rect.top + this.getScrollTop();
+    const scrollingElement = this.wrapper_;
+    const style = getComputedStyle(scrollingElement);
+    return scrollingElement./*OK*/scrollHeight
+        + this.getBorderTop()
+        + parseInt(style.marginTop, 10)
+        + parseInt(style.marginBottom, 10);
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -17,10 +17,10 @@
 import {Observable} from '../../observable';
 import {Services} from '../../services';
 import {ViewportBindingDef} from './viewport-binding-def';
+import {computedStyle, px, setImportantStyles} from '../../style';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {px, setImportantStyles} from '../../style';
 import {waitForBody} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
 
@@ -243,7 +243,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     // account for margins
     const scrollingElement = this.win.document.body;
     const rect = scrollingElement./*OK*/getBoundingClientRect();
-    const style = getComputedStyle(scrollingElement);
+    const style = computedStyle(this.win, scrollingElement);
     return rect.height
         + this.paddingTop_
         + parseInt(style.marginTop, 10)

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -67,6 +67,9 @@ export class ViewportBindingNatural_ {
     /** @private @const {boolean} */
     this.useLayers_ = isExperimentOn(this.win, 'layers');
 
+    /** @private {number} */
+    this.paddingTop_ = 0;
+
     dev().fine(TAG_, 'initialized natural viewport');
   }
 
@@ -114,6 +117,7 @@ export class ViewportBindingNatural_ {
 
   /** @override */
   updatePaddingTop(paddingTop) {
+    this.paddingTop_ = paddingTop;
     setImportantStyles(this.win.document.documentElement, {
       'padding-top': px(paddingTop),
     });
@@ -201,7 +205,12 @@ export class ViewportBindingNatural_ {
     const scrollingElement = this.getScrollingElement();
     const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = computedStyle(this.win, scrollingElement);
+    let paddingTop = 0;
+    if (scrollingElement !== this.win.document.documentElement) {
+      paddingTop = this.paddingTop_;
+    }
     return rect.height
+        + paddingTop
         + parseInt(style.marginTop, 10)
         + parseInt(style.marginBottom, 10);
   }

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -17,10 +17,10 @@
 import {Observable} from '../../observable';
 import {Services} from '../../services';
 import {ViewportBindingDef} from './viewport-binding-def';
+import {computedStyle, px, setImportantStyles} from '../../style';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {px, setImportantStyles} from '../../style';
 
 
 const TAG_ = 'Viewport';
@@ -200,7 +200,7 @@ export class ViewportBindingNatural_ {
     // account for margins
     const scrollingElement = this.getScrollingElement();
     const rect = scrollingElement./*OK*/getBoundingClientRect();
-    const style = getComputedStyle(scrollingElement);
+    const style = computedStyle(this.win, scrollingElement);
     return rect.height
         + parseInt(style.marginTop, 10)
         + parseInt(style.marginBottom, 10);

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -195,6 +195,9 @@ export class ViewportBindingNatural_ {
 
   /** @override */
   getContentHeight() {
+    // Don't use scrollHeight, since it returns `MAX(viewport_height,
+    // document_height)`, even though we only want the latter. Also, it doesn't
+    // account for margins
     const scrollingElement = this.getScrollingElement();
     const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -196,8 +196,9 @@ export class ViewportBindingNatural_ {
   /** @override */
   getContentHeight() {
     const scrollingElement = this.getScrollingElement();
+    const rect = scrollingElement./*OK*/getBoundingClientRect();
     const style = getComputedStyle(scrollingElement);
-    return scrollingElement./*OK*/scrollHeight
+    return rect.height
         + parseInt(style.marginTop, 10)
         + parseInt(style.marginBottom, 10);
   }

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -195,14 +195,11 @@ export class ViewportBindingNatural_ {
 
   /** @override */
   getContentHeight() {
-    // The reparented body inside wrapper will have the correct content height.
-    // Body is overflow: hidden so that the scrollHeight include the margins of
-    // body's first and last child.
-    // Body height doesn't include paddingTop on the parent, so we add on the
-    // position of the body from the top of the viewport and subtract the
-    // scrollTop (as position relative to the viewport changes as you scroll).
-    const rect = this.win.document.body./*OK*/getBoundingClientRect();
-    return rect.height + rect.top + this.getScrollTop();
+    const scrollingElement = this.getScrollingElement();
+    const style = getComputedStyle(scrollingElement);
+    return scrollingElement./*OK*/scrollHeight
+        + parseInt(style.marginTop, 10)
+        + parseInt(style.marginBottom, 10);
   }
 
   /** @override */


### PR DESCRIPTION
We'll now take into account the scrolling element's margins. We're also changing iOS to use the wrapper element, since the body may not have size defined.

Fixes #13343
Fixes #19941 