### PR TITLE
Correctly tear down previous request in requestBank

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -155,6 +155,7 @@ app.use('/request-bank/:bid/teardown/', (req, res) => {
   for (const id in b) {
     const callback = b[id];
     if (typeof callback === 'function') {
+      // Respond 404 to pending request.
       callback();
     }
     delete b[id];

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -128,11 +128,15 @@ app.use('/request-bank/:bid/withdraw/:id/', (req, res) => {
     return res.status(500).send('another client is withdrawing this ID');
   }
   const callback = function(result) {
-    res.json({
-      headers: result.headers,
-      body: result.body,
-      url: result.url,
-    });
+    if (result === undefined) {
+      res.status(404).end();
+    } else {
+      res.json({
+        headers: result.headers,
+        body: result.body,
+        url: result.url,
+      });
+    }
     delete bank[req.params.bid][key];
   };
   if (result) {
@@ -146,8 +150,15 @@ app.use('/request-bank/:bid/withdraw/:id/', (req, res) => {
  * Clean up all pending withdraw & deposit requests.
  */
 app.use('/request-bank/:bid/teardown/', (req, res) => {
-  bank[req.params.bid] = {};
   log('SERVER-LOG [TEARDOWN]');
+  const b = bank[req.params.bid];
+  for (const id in b) {
+    const callback = b[id];
+    if (typeof callback === 'function') {
+      callback();
+    }
+    delete b[id];
+  }
   res.end();
 });
 


### PR DESCRIPTION
This stops failure cascading to all following test cases.

1) respond to any waiting request with 404
2) instead of assigning a new empty object to bank, explicitly reset every field (in case the old bank object was referenced somewhere else)