### PR TITLE
Fix cloudflare cacheDomain in caches.json

### DIFF
--- a/caches.json
+++ b/caches.json
@@ -12,7 +12,7 @@
       "id": "cloudflare",
       "name": "Cloudflare AMP Cache",
       "docs": "https://amp.cloudflare.com/",
-      "cacheDomain": "cdn.cloudflare.com",
+      "cacheDomain": "amp.cloudflare.com",
       "updateCacheApiDomainSuffix": "amp.cloudflare.com",
       "thirdPartyFrameDomainSuffix": "cloudflareamp.net"
     },


### PR DESCRIPTION
I don't think `cdn.cloudflare.com` is (or ever was) correct: the domain doesn't resolve, whereas `amp.cloudflare.com` does, and it also acts like a cache in the context of URLs like https://www-ampproject-org.amp.cloudflare.com/c/s/www.ampproject.org/.

@dknecht can you confirm?