### PR TITLE
Viewer window resize capability

### DIFF
--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -449,8 +449,6 @@
           return Promise.reject({error: 'source amp component is not valid'})
         }
         case 'resize':
-          log('window resize!', data);
-          return Promise.resolve();
         case 'documentHeight':
         case 'setFlushParams':
         case 'prerenderComplete':

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -242,7 +242,7 @@
         prerenderSize: this.prerenderSize_,
         origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
-        cap: 'a2a,focus-rect,foo,keyboard,swipe,viewerRenderTemplate',
+        cap: 'a2a,focus-rect,foo,keyboard,swipe,viewerRenderTemplate,windowResize',
       };
       log('Params:' + JSON.stringify(params));
 
@@ -448,6 +448,9 @@
         } else {
           return Promise.reject({error: 'source amp component is not valid'})
         }
+        case 'resize':
+          log('window resize!', data);
+          return Promise.resolve();
         case 'documentHeight':
         case 'setFlushParams':
         case 'prerenderComplete':

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -242,7 +242,7 @@
         prerenderSize: this.prerenderSize_,
         origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
-        cap: 'a2a,focus-rect,foo,keyboard,swipe,viewerRenderTemplate,windowResize',
+        cap: 'a2a,focus-rect,foo,keyboard,swipe,viewerRenderTemplate,win-resize-doc-height-update',
       };
       log('Params:' + JSON.stringify(params));
 

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -449,6 +449,7 @@
           return Promise.reject({error: 'source amp component is not valid'})
         }
         case 'resize':
+          log('Window resize , new document height.' data);
         case 'documentHeight':
         case 'setFlushParams':
         case 'prerenderComplete':

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -204,7 +204,7 @@ export class AmpViewerIntegration {
     if (viewer.hasCapability('focus-rect')) {
       this.initFocusHandler_(messaging);
     }
-    if (viewer.hasCapability('windowResize')) {
+    if (viewer.hasCapability('win-resize-doc-height-update')) {
       this.initWindowResizeHandler_(messaging);
     }
     if (this.highlightHandler_ != null) {

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -22,7 +22,6 @@ import {
   getHighlightParam,
 } from './highlight-handler';
 import {KeyboardHandler} from './keyboard-handler';
-import {WindowResizeHandler} from './window-resize-handler';
 import {
   Messaging,
   WindowPortEmulator,
@@ -30,6 +29,7 @@ import {
 } from './messaging/messaging';
 import {Services} from '../../../src/services';
 import {TouchHandler} from './touch-handler';
+import {WindowResizeHandler} from './window-resize-handler';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -22,6 +22,7 @@ import {
   getHighlightParam,
 } from './highlight-handler';
 import {KeyboardHandler} from './keyboard-handler';
+import {WindowResizeHandler} from './window-resize-handler';
 import {
   Messaging,
   WindowPortEmulator,
@@ -203,6 +204,9 @@ export class AmpViewerIntegration {
     if (viewer.hasCapability('focus-rect')) {
       this.initFocusHandler_(messaging);
     }
+    if (viewer.hasCapability('windowResize')) {
+      this.initWindowResizeHandler_(messaging);
+    }
     if (this.highlightHandler_ != null) {
       this.highlightHandler_.setupMessaging(messaging);
     }
@@ -216,6 +220,14 @@ export class AmpViewerIntegration {
    */
   handleUnload_(messaging) {
     return messaging.sendRequest(RequestNames.UNLOADED, dict(), true);
+  }
+
+  /**
+   * @param {!Messaging} messaging
+   * @private
+   */
+  initWindowResizeHandler_(messaging) {
+    new WindowResizeHandler(this.win, messaging);
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -180,7 +180,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
         });
 
-       it('should initiate window resize handler with capability', () => {
+        it('should initiate window resize handler with capability', () => {
           sandbox.stub(messaging, 'sendRequest').callsFake(() => {
             return Promise.resolve();
           });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -179,6 +179,21 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
             expect(initFocusHandlerStub).to.be.called;
           });
         });
+
+       it('should initiate window resize handler with capability', () => {
+          sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            return Promise.resolve();
+          });
+          sandbox.stub(viewer, 'hasCapability').withArgs('windowResize')
+              .returns(true);
+          const initWindowResizeHandlerStub =
+            sandbox.stub(ampViewerIntegration, 'initWindowResizeHandler_');
+          ampViewerIntegration.unconfirmedViewerOrigin_ = '';
+          ampViewerIntegration.openChannelAndStart_(
+              viewer, env.ampdoc, origin, messaging).then(() => {
+            expect(initWindowResizeHandlerStub).to.be.called;
+          });
+        });
       });
     });
   });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -184,8 +184,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           sandbox.stub(messaging, 'sendRequest').callsFake(() => {
             return Promise.resolve();
           });
-          sandbox.stub(viewer, 'hasCapability').withArgs('windowResize')
-              .returns(true);
+          sandbox.stub(viewer, 'hasCapability')
+              .withArgs('win-resize-doc-height-update').returns(true);
           const initWindowResizeHandlerStub =
             sandbox.stub(ampViewerIntegration, 'initWindowResizeHandler_');
           ampViewerIntegration.unconfirmedViewerOrigin_ = '';

--- a/extensions/amp-viewer-integration/0.1/test/test-window-resize-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-window-resize-handler.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Messaging} from '../messaging/messaging';
+import {Services} from '../../../../src/services';
+import {WindowResizeHandler} from '../window-resize-handler';
+
+function fakeResizeEvent(type) {
+  return {type};
+}
+
+describes.fakeWin('WindowResizeHandler', {
+  amp: true,
+}, env => {
+  describe('WindowResizeHandler Unit Tests', function() {
+
+    class WindowPortEmulator {
+      constructor(win, origin) {
+        /** @const {!Window} */
+        this.win = win;
+        /** @private {string} */
+        this.origin_ = origin;
+      }
+
+      addEventListener() {}
+
+      postMessage(data, origin) {
+        messages.push({
+          data,
+          origin,
+        });
+      }
+      start() {}
+    }
+
+    let getContentHeightStub;
+    let win;
+    let windowResizeHandler;
+    let messaging;
+    let messages;
+
+    beforeEach(() => {
+      messages = [];
+      win = env.win;
+      const port =
+        new WindowPortEmulator(this.messageHandlers_, 'origin doesnt matter');
+      messaging = new Messaging(win, port);
+      getContentHeightStub =
+          sandbox.stub(Services.viewportForDoc(env.ampdoc), 'getContentHeight');
+      getContentHeightStub.returns('100px');
+      windowResizeHandler = new WindowResizeHandler(win, messaging);
+    });
+
+    afterEach(() => {
+      windowResizeHandler = null;
+    });
+
+    it('should forward resize event', () => {
+      windowResizeHandler.forwardEventToViewer_(fakeResizeEvent('resize'));
+      expect(messages).to.have.length(1);
+      expect(getContentHeightStub).to.be.calledOnce;
+      expect(messages[0].data.name).to.equal('resize');
+      expect(messages[0].data.data.documentHeight).to.equal('100px');
+    });
+
+    it('should no opt if event is default prevented', () => {
+      const event = fakeResizeEvent('resize');
+      event.defaultPrevented = true;
+      windowResizeHandler.forwardEventToViewer_(event);
+      expect(messages).to.have.length(0);
+    });
+
+  });
+});

--- a/extensions/amp-viewer-integration/0.1/window-resize-handler.js
+++ b/extensions/amp-viewer-integration/0.1/window-resize-handler.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../../src/services';
+import {dict} from '../../../src/utils/object';
+import {listen} from '../../../src/event-helper';
+
+/**
+ * On browser window resize, forward viewport height changes to viewer.
+ */
+export class WindowResizeHandler {
+
+  /**
+   * @param {!Window} win
+   * @param {!./messaging/messaging.Messaging} messaging
+   */
+  constructor(win, messaging) {
+    /** @const {!Window} */
+    this.win = win;
+    /** @const @private {!./messaging/messaging.Messaging} */
+    this.messaging_ = messaging;
+
+    /** @private @const {!../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = Services.viewportForDoc(this.win.document.documentElement);
+
+    this.listenForWindowResizeEvents_();
+  }
+
+  /**
+   * @private
+   */
+  listenForWindowResizeEvents_() {
+    listen(this.win, 'resize', this.forwardEventToViewer_.bind(this),
+        {capture: false});
+  }
+
+  /**
+   * @param {!Event} e
+   * @private
+   */
+  forwardEventToViewer_(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+
+    this.messaging_.sendRequest(
+        e.type,
+        dict({'documentHeight': this.viewport_.getContentHeight()}),
+        /* awaitResponse */ false
+    );
+  }
+}


### PR DESCRIPTION
Add new win-resize-doc-height-update capability to the viewer, which updates the viewer of doc height changes when the browser resizes.

b110198135