### PR TITLE
Make dep-check an order of magnitude faster.

### DIFF
--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -160,6 +160,7 @@ function getSrcs() {
   }).then(files => {
     // Write all the entry modules into a single file so they can be processed
     // together.
+    fs.mkdirpSync('./.amp-build');
     const filename = './.amp-build/gulp-dep-check-collection.js';
     fs.writeFileSync(filename, files.map(file => {
       return `import '../${file}';`;

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -157,7 +157,15 @@ function getSrcs() {
         .map(getEntryModule)
         // Concat the core binary and integration binary as entry points.
         .concat('src/amp.js', '3p/integration.js'));
-  });
+  }).then(files => {
+    // Write all the entry modules into a single file so they can be processed
+    // together.
+    const filename = './.amp-build/gulp-dep-check-collection.js';
+    fs.writeFileSync(filename, files.map(file => {
+      return `import '../${file}';`
+    }).join('\n'));
+    return [filename];
+  })
 }
 
 /**
@@ -195,7 +203,9 @@ function getGraph(entryModule) {
       .pipe(source(entryModule))
       // Unfortunately we need to write the files out.
       .pipe(gulp.dest('./.amp-build'))
-      .on('end', resolve.bind(null, module));
+      .on('end', () => {
+        resolve(module);
+      });
   return promise;
 }
 

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -162,10 +162,10 @@ function getSrcs() {
     // together.
     const filename = './.amp-build/gulp-dep-check-collection.js';
     fs.writeFileSync(filename, files.map(file => {
-      return `import '../${file}';`
+      return `import '../${file}';`;
     }).join('\n'));
     return [filename];
-  })
+  });
 }
 
 /**


### PR DESCRIPTION
Runtime goes down from over 4 minutes to 20 seconds.

Change: Instead of processing every entry point by itself, create a temporary file that imports all entry points and process that.
