### PR TITLE
Introduce cta-landing-page-type for story ads

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad.html
@@ -1,0 +1,45 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  mkdir -p /Users/ccordry/Library/Python/2.7/lib/python/site-packages
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests that an ad designed for amp-story is passing validation.
+-->
+<!DOCTYPE html>
+<html amp4ads>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+
+    <!-- Specifies where the user is directed -->
+    <meta name="amp-cta-url" content="https://www.ampproject.org">
+
+    <!-- Specifies the call to action button text enum -->
+    <meta name="amp-cta-type" content="EXPLORE">
+
+    <!-- Specifies what type of landing page the user is direct to -->
+    <meta name="amp-cta-landing-page-type" content="NONAMP">
+
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <style amp-custom>
+     amp-img {height: 100vh}
+    </style>
+    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  </head>
+  <body>
+    <amp-img src="cats.jpg" layout="responsive" height="1280" width="720"></amp-img>
+  </body>
+</html>

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad.out
@@ -1,0 +1,46 @@
+PASS
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|    mkdir -p /Users/ccordry/Library/Python/2.7/lib/python/site-packages
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that an ad designed for amp-story is passing validation.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp4ads>
+|    <head>
+|      <meta charset="utf-8">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|
+|      <!-- Specifies where the user is directed -->
+|      <meta name="amp-cta-url" content="https://www.ampproject.org">
+|
+|      <!-- Specifies the call to action button text enum -->
+|      <meta name="amp-cta-type" content="EXPLORE">
+|
+|      <!-- Specifies what type of landing page the user is direct to -->
+|      <meta name="amp-cta-landing-page-type" content="NONAMP">
+|
+|      <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|      <style amp-custom>
+|       amp-img {height: 100vh}
+|      </style>
+|      <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    </head>
+|    <body>
+|      <amp-img src="cats.jpg" layout="responsive" height="1280" width="720"></amp-img>
+|    </body>
+|  </html>

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.html
@@ -1,0 +1,45 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Testing some common mistakes for ad creators, like forgetting to specify
+  an enum value,
+-->
+<!DOCTYPE html>
+<html amp4ads>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+
+    <!-- Should fail as an invalid meta tag. -->
+    <meta name="amp-cta" content="https://www.ampproject.org">
+
+    <!-- Should fail due to no `content=`. -->
+    <meta name="amp-cta-type">
+
+    <!-- Should fail due to invalid content choice. -->
+    <meta name="amp-cta-landing-page-type" content="GAME">
+
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <style amp-custom>
+     amp-img {height: 100vh}
+    </style>
+    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  </head>
+  <body>
+    <amp-img src="cats.jpg" layout="responsive" height="1280" width="720"></amp-img>
+  </body>
+</html>

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
@@ -37,6 +37,8 @@ amp4ads_feature_tests/amp_story_ad_errors.html:31:4 The mandatory attribute 'con
 |
 |      <!-- Should fail due to invalid content choice. -->
 |      <meta name="amp-cta-landing-page-type" content="GAME">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:34:4 The attribute 'content' in tag 'meta name=amp-cta-landing-page-type' is set to the invalid value 'GAME'. [DISALLOWED_HTML]
 |
 |      <style amp4ads-boilerplate>body{visibility:hidden}</style>
 |      <style amp-custom>

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
@@ -1,0 +1,50 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Testing some common mistakes for ad creators, like forgetting to specify
+|    an enum value,
+|  -->
+|  <!DOCTYPE html>
+|  <html amp4ads>
+|    <head>
+|      <meta charset="utf-8">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|
+|      <!-- Should fail as an invalid meta tag. -->
+|      <meta name="amp-cta" content="https://www.ampproject.org">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:28:4 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'amp-cta'. [DISALLOWED_HTML]
+|
+|      <!-- Should fail due to no `content=`. -->
+|      <meta name="amp-cta-type">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:31:4 The mandatory attribute 'content' is missing in tag 'meta name=amp-cta-type'. [DISALLOWED_HTML]
+|
+|      <!-- Should fail due to invalid content choice. -->
+|      <meta name="amp-cta-landing-page-type" content="GAME">
+|
+|      <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|      <style amp-custom>
+|       amp-img {height: 100vh}
+|      </style>
+|      <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    </head>
+|    <body>
+|      <amp-img src="cats.jpg" layout="responsive" height="1280" width="720"></amp-img>
+|    </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 790
+spec_file_revision: 791
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -864,6 +864,25 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp-cta-url"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
+# AMP metadata, name=amp-cta-landing-page-type
+# Specifies the Single Page Story Ad landing page type
+tags: {
+  html_format: AMP4ADS
+  tag_name: "META"
+  spec_name: "meta name=amp-cta-landing-page-type"
+  mandatory_parent: "HEAD"
+  unique: true
+  attrs: {
+    name: "content"
+    mandatory_oneof: ['AMP', 'NOAMP', 'STORY']
+  }
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-cta-landing-page-type"
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
@@ -6150,4 +6169,3 @@ error_formats {
   code: CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
   format: "CSS syntax error in tag '%1' - disallowed media feature '%2'."
 }
-

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -877,7 +877,10 @@ tags: {
   unique: true
   attrs: {
     name: "content"
-    mandatory_oneof: "['amp', 'nonamp', 'story']"
+    mandatory: true
+    value_casei: "amp"
+    value_casei: "nonamp"
+    value_casei: "story"
   }
   attrs: {
     name: "name"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 791
+spec_file_revision: 790
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -877,7 +877,7 @@ tags: {
   unique: true
   attrs: {
     name: "content"
-    mandatory_oneof: "['AMP', 'NONAMP', 'STORY']"
+    mandatory_oneof: "['amp', 'nonamp', 'story']"
   }
   attrs: {
     name: "name"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -877,7 +877,7 @@ tags: {
   unique: true
   attrs: {
     name: "content"
-    mandatory_oneof: ['AMP', 'NOAMP', 'STORY']
+    mandatory_oneof: "['AMP', 'NONAMP', 'STORY']"
   }
   attrs: {
     name: "name"


### PR DESCRIPTION
This optional meta tag indicates the type of landing page for an amp story ad.

3 choices: 
`<meta name="amp-cta-landing-page-type" content="NONAMP">`
`<meta name="amp-cta-landing-page-type" content="AMP">`
`<meta name="amp-cta-landing-page-type" content="STORY">`