### PR TITLE
Attempt to stabilize amp-list integration tests

### DIFF
--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -40,6 +40,14 @@ describe('amp-list (integration)', function() {
       doc = win.document;
     });
 
+    it('should build', function*() {
+      const list = doc.querySelector('amp-list');
+      expect(list).to.exist;
+      yield browser.waitForElementBuild('amp-list', TIMEOUT);
+      const container = list.querySelector('div[role="list"]');
+      expect(container).to.exist;
+    });
+
     it('should render items', function*() {
       const list = doc.querySelector('amp-list');
       expect(list).to.exist;

--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -32,7 +32,9 @@ describe('amp-list (integration)', function() {
 
   const basicTests = env => {
 
-    let browser, win, doc;
+    let browser;
+    let doc;
+    let win;
 
     beforeEach(() => {
       win = env.win;
@@ -84,7 +86,9 @@ describe('amp-list (integration)', function() {
     extensions: ['amp-list', 'amp-mustache'],
     experiments: ['amp-list-resizable-children'],
   }, env => {
-    let browser, win, doc;
+    let browser;
+    let doc;
+    let win;
 
     beforeEach(() => {
       win = env.win;
@@ -125,7 +129,9 @@ describe('amp-list (integration)', function() {
     extensions: ['amp-list', 'amp-mustache', 'amp-bind'],
     experiments: ['amp-list-resizable-children'],
   }, env => {
-    let browser, win, doc;
+    let browser;
+    let doc;
+    let win;
 
     beforeEach(() => {
       win = env.win;

--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {BrowserController} from '../../../../../testing/test-helper';
 import {isExperimentOn} from '../../../../../src/experiments';
 import {poll} from '../../../../../testing/iframe';
 
@@ -30,15 +31,22 @@ describe('amp-list (integration)', function() {
     '</amp-list>`;
 
   const basicTests = env => {
+
+    let browser, win, doc;
+
+    beforeEach(() => {
+      win = env.win;
+      browser = new BrowserController(win);
+      doc = win.document;
+    });
+
     it('should render items', function*() {
-      const list = env.win.document.querySelector('amp-list');
+      const list = doc.querySelector('amp-list');
       expect(list).to.exist;
 
-      let children;
-      yield poll('#list render', () => {
-        children = list.querySelectorAll('div[role=list] > div');
-        return children.length > 0;
-      }, /* onError */ undefined, TIMEOUT);
+      yield browser.waitForElementLayout('amp-list', TIMEOUT);
+
+      const children = list.querySelectorAll('div[role=list] > div');
 
       expect(children.length).to.equal(3);
       expect(children[0].textContent.trim()).to.equal('apple : 47 @ 0.33');
@@ -68,19 +76,21 @@ describe('amp-list (integration)', function() {
     extensions: ['amp-list', 'amp-mustache'],
     experiments: ['amp-list-resizable-children'],
   }, env => {
-    let win, doc;
+    let browser, win, doc;
 
     beforeEach(() => {
       win = env.win;
+      browser = new BrowserController(win);
       doc = win.document;
     });
 
     it('should change to layout container as action', function*() {
       expect(isExperimentOn(win, 'amp-list-resizable-children')).to.be.true;
 
-      const button = doc.querySelector('button');
       const list = doc.querySelector('amp-list');
-      button.click();
+
+      yield browser.waitForElementLayout('amp-list', TIMEOUT);
+      browser.click('button');
 
       yield poll('changes to layout container', () => {
         const layout = list.getAttribute('layout');
@@ -91,9 +101,7 @@ describe('amp-list (integration)', function() {
     });
   });
 
-  // TODO(cathyxz, #19647): Fix test on Chrome 71. Might be because
-  // amp-bind isn't ready by the time the button is clicked.
-  describes.integration.skip('[is-layout-container]', {
+  describes.integration('[is-layout-container]', {
     body: `
     <amp-state id="state">
       <script type="application/json">
@@ -109,19 +117,21 @@ describe('amp-list (integration)', function() {
     extensions: ['amp-list', 'amp-mustache', 'amp-bind'],
     experiments: ['amp-list-resizable-children'],
   }, env => {
-    let win, doc;
+    let browser, win, doc;
 
     beforeEach(() => {
       win = env.win;
+      browser = new BrowserController(win);
       doc = win.document;
     });
 
     it('should change to layout container as on bind', function*() {
       expect(isExperimentOn(win, 'amp-list-resizable-children')).to.be.true;
 
-      const button = doc.querySelector('button');
       const list = doc.querySelector('amp-list');
-      button.click();
+
+      yield browser.waitForElementLayout('amp-list', TIMEOUT);
+      browser.click('button');
 
       yield poll('changes to layout container', () => {
         const layout = list.getAttribute('layout');


### PR DESCRIPTION
1. Add a `waitForElementLayout` call before clicking buttons to change `amp-list` layout to `CONTAINER`. 
2. Use `waitForElementLayout` instead of waiting for children to equal 3. 

So most of these tests have been finishing on my laptop within 0.1 seconds for Chrome, Safari, and FF. I'm not sure I understand why the timeouts have to be so high... 