### PR TITLE
🐛Fix lightbox transition when things on the page have z-index

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -26,7 +26,6 @@ amp-user-notification                                                    |   100
 amp-lightbox                                                             |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
 amp-live-list > [update]                                                 |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
 amp-image-lightbox                                                       |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-lightbox-trans                                          |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
 .i-amphtml-lbv                                                           |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
 .i-amphtml-consent-ui-mask                                               |   2147483644   |   extensions/amp-consent/1.0/amp-consent.css
 .amp-consent                                                             |   2147483645   |   extensions/amp-consent/1.0/amp-consent.css

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -274,16 +274,6 @@ amp-lightbox-gallery .amp-carousel-button {
   display: block;
 }
 
-.i-amphtml-lightbox-gallery-trans {
-  pointer-events: none !important;
-  position: fixed !important;
-  z-index: 1001 !important;
-  top: 0 !important;
-  left: 0 !important;
-  bottom: 0 !important;
-  right: 0 !important;
-}
-
 /*
  * This is necessary to fix responsive styling for video and ad
  * elements inside the lightbox. More investigation is necessary

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -97,7 +97,7 @@ amp-lightbox-gallery .amp-carousel-button {
   right: 0 !important;
   bottom: 0 !important;
   /* 
-   * The highest z-index supported by most browsers, - 5.
+   * The highest z-index supported by most browsers - 5. See: css/Z_INDEX.md
    * Note: Since the lightbox gallery may not be the last thing in the DOM,
    * this may fail to correctly stack on top of elements with the same z-index.
    * It will also fail to stack on top of things with a higher z-index.

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -96,6 +96,12 @@ amp-lightbox-gallery .amp-carousel-button {
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
+  /* 
+   * The highest z-index supported by most browsers, - 5.
+   * Note: Since the lightbox gallery may not be the last thing in the DOM,
+   * this may fail to correctly stack on top of elements with the same z-index.
+   * It will also fail to stack on top of things with a higher z-index.
+   */
   z-index: 2147483642;
 }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -960,7 +960,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const mutate = () => {
       toggle(carousel, enter);
       // Undo opacity 0 from `openLightboxGallery_`
-      setStyle(this.element, 'opacity', 1);
+      setStyle(this.element, 'opacity', '');
       // Fade in/out the background in sync with the motion.
       setStyles(container, {
         animationName: enter ? 'fadeIn' : 'fadeOut',
@@ -983,7 +983,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
     const cleanup = () => {
       toggle(this.element, enter);
-      setStyle(this.element, 'opacity', '');
       setStyle(container, 'animationName', '');
       setStyle(carousel, 'animationName', '');
       srcImg.classList.remove('i-amphtml-ghost');

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -949,6 +949,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         targetImgRect: undefined,
         styles: {
           'animationDuration': `${motionDuration}ms`,
+          // Matches z-index for `.i-amphtml-lbg`.
           'zIndex': 2147483642,
         },
         keyframesNamespace: undefined,

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -932,8 +932,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   runImgTransition_(srcImg, targetImg, enter) {
     const carousel = dev().assertElement(this.carousel_);
     const container = dev().assertElement(this.container_);
-    const transLayer = this.element.ownerDocument.createElement('div');
-    transLayer.classList.add('i-amphtml-lightbox-gallery-trans');
 
     let duration;
     let motionDuration;
@@ -944,7 +942,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       motionDuration = MOTION_DURATION_RATIO * duration;
       // Prepare the actual image animation.
       imageAnimation = prepareImageAnimation({
-        transitionContainer: transLayer,
         styleContainer: this.getAmpDoc().getHeadNode(),
         srcImg,
         targetImg,
@@ -952,6 +949,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         targetImgRect: undefined,
         styles: {
           'animationDuration': `${motionDuration}ms`,
+          'zIndex': 2147483642,
         },
         keyframesNamespace: undefined,
         curve: TRANSITION_CURVE,
@@ -960,12 +958,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
     const mutate = () => {
       toggle(carousel, enter);
-      // Make sure the background, image stack correctly.
-      setStyles(this.element, {
-        position: 'relative',
-        zIndex: 1,
-        opacity: 1,
-      });
+      // Undo opacity 0 from `openLightboxGallery_`
+      setStyle(this.element, 'opacity', 1);
       // Fade in/out the background in sync with the motion.
       setStyles(container, {
         animationName: enter ? 'fadeIn' : 'fadeOut',
@@ -984,22 +978,16 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       targetImg.classList.add('i-amphtml-ghost');
       // Apply the image animation prepared in the measure step.
       imageAnimation.applyAnimation();
-      this.getAmpDoc().getBody().appendChild(transLayer);
     };
 
     const cleanup = () => {
       toggle(this.element, enter);
-      setStyles(this.element, {
-        position: '',
-        zIndex: '',
-        opacity: '',
-      });
+      setStyle(this.element, 'opacity', '');
       setStyle(container, 'animationName', '');
       setStyle(carousel, 'animationName', '');
       srcImg.classList.remove('i-amphtml-ghost');
       targetImg.classList.remove('i-amphtml-ghost');
       imageAnimation.cleanupAnimation();
-      this.getAmpDoc().getBody().removeChild(transLayer);
     };
 
     return this.measureMutateElement(measure, mutate)

--- a/test/manual/amp-lightbox-gallery.amp.html
+++ b/test/manual/amp-lightbox-gallery.amp.html
@@ -6,7 +6,6 @@
   <link rel="canonical" href="/components/amp-lightbox-gallery/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>
   <title>amp-lightbox-gallery</title>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/test/manual/amp-lightbox-gallery.amp.html
+++ b/test/manual/amp-lightbox-gallery.amp.html
@@ -6,6 +6,7 @@
   <link rel="canonical" href="/components/amp-lightbox-gallery/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>
   <title>amp-lightbox-gallery</title>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -20,6 +21,20 @@
 
     .object-fit-none  img {
       object-fit: none;
+    }
+
+    footer {
+      position: fixed;
+      position: sticky;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 48px;
+      background-color: #fafafa;
     }
   </style>
 <body>
@@ -77,5 +92,9 @@
     lightbox
     src=https://ampbyexample-com.cdn.ampproject.org/i/s/ampbyexample.com/img/clean-2.jpg>
   </amp-img>
+
+  <footer>
+    Sticky footer
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
- Remove z-index from lightbox element during transition since it creates a new stacking context
- Move the transition layer into the lightbox element, give it the same z-index as the background
  * It will stack on top since it is after the background element
- Add a sticky footer to the manual test

//cc @aghassemi 

Fixes #20066
