### PR TITLE
✨Exit lightbox overlay mode before animation.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1151,6 +1151,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     gestures.cleanup();
 
     return this.mutateElement(() => {
+      this.getViewport().leaveLightboxMode();
       // If there's gallery, set gallery to display none
       this.container_.removeAttribute('gallery-view');
 
@@ -1161,7 +1162,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.clearDescOverflowState_();
     }).then(() => this.exit_())
         .then(() => {
-          this.getViewport().leaveLightboxMode();
           this.schedulePause(dev().assertElement(this.container_));
           this.pauseLightboxChildren_();
           this.carousel_ = null;


### PR DESCRIPTION
The exit image animation is now positioned with `position: absolute`, so you can
scroll during the animation and it will still animate correctly. This
allows the user to scroll immediately after closing the lightbox.
Previously, there was a small, but noticeable delay where you could try to scroll
and nothing would happen.