### PR TITLE
🐛amp-consent: Fixed the flash of the leftover CMP Iframe Container (Flash of teal)

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -208,8 +208,8 @@ export class ConsentUI {
         classList.add('amp-hidden');
       }
 
+      this.baseInstance_.getViewport().removeFromFixedLayer(this.parent_);
       toggle(dev().assertElement(this.ui_), false);
-      this.baseInstance_.getViewport().updateFixedLayer();
       this.isVisible_ = false;
 
       this.enableScroll_();

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -57,7 +57,7 @@ describes.realWin('consent-ui', {
       getViewport: () => {
         return {
           addToFixedLayer: () => {},
-          updateFixedLayer: () => {},
+          removeFromFixedLayer: () => {},
         };
       },
       getVsync: () => {


### PR DESCRIPTION
relates to #19969

This essentially reverts #19830 . I kept this PR in a note in case I noticed something weird down the line and I am glad I did 😂I think this should be undone for the following reasons: 

1. This was meant to fix #19599 , but we eventually found the actual fix was #19603

2. `updateFixedLayer` is only used in `amp-live-list`. And I think it's more for dynamically incoming multiple fixed elements. 

3. `updateFixedLayer` throws a console error about the element already having a `top` applied before being removed.

4. `removeFromFixedLayer` appears to be the better option still, as we are hiding / removing the element, thus it should also be removed from the fixed layer, and not updated since it no longer exists.

The root cause however, is due to how the fixed layer will handle the `top` styling for elements. When we add it, the top is set to 0px for us. But when we use update to remove (which also removes all the classes), this top is re-applied which causes the flash, because the `100vh` element gets pulled to the top, before being removed. `removedFromFixedLayer`, removes this `top` styling entirely (which is what we want).

@zhouyx Let me know what you think! 😄 

# Gifs

## Bug

![flashbugampconsent](https://user-images.githubusercontent.com/1448289/50461568-29751880-0934-11e9-8444-795aa18e506f.gif)


## Fix

![flashfixampconsent](https://user-images.githubusercontent.com/1448289/50461572-3134bd00-0934-11e9-8df6-20a5b2dec640.gif)
