### PR TITLE
🖍amp-consent: Added Additional Styling to amp-consent CMP UI

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -87,6 +87,10 @@ amp-consent.i-amphtml-consent-ui-iframe-active {
   padding: 0px !important;
   margin: 0px !important;
 
+  border-top-left-radius: 8px !important;
+  border-top-right-radius: 8px !important;
+  box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
+
   transform: translate3d(0px, 100%, 0px) !important;
 }
 

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -19,7 +19,7 @@ body {
   background-color: #fff;
   line-height: initial;
   margin: 0;
-  padding: 5px;
+  padding: 10px;
 }
 
 .bttn-primary {
@@ -42,7 +42,7 @@ h1 {
 
 #always-show {
   position: absolute;
-  top: 5px;
+  top: 10px;
   right: 10px;
 }
 
@@ -73,7 +73,7 @@ h1 {
       <div id="decision-state">
         <h1 class="animated fadeIn">Cookies, and Privacy</h1>
         <div class="decision-text animated fadeIn">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor.
         </div>
       </div>
       <div id="learn-more-state">


### PR DESCRIPTION
realtes to #19969

This implements the [box-shadow from amp-sticky-ad](https://ampbyexample.com/components/amp-sticky-ad/), as well as some border radius on the amp-consent CMP Modal.

This was done per a design review, and suggested by @spacedino 😄 

<img width="334" alt="screen shot 2018-12-26 at 5 57 54 pm" src="https://user-images.githubusercontent.com/1448289/50462142-23813680-0938-11e9-9489-a60d95c82207.png">
<img width="326" alt="screen shot 2018-12-26 at 5 58 08 pm" src="https://user-images.githubusercontent.com/1448289/50462143-23813680-0938-11e9-8eaa-796654ead9d0.png">
