### PR TITLE
Remove support to multiple consent instance

### DIFF
--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -191,6 +191,17 @@
             "onUpdateHref": "//updateHref"
           }
         },
+        "policy": {
+          "default": {
+            "waitFor": {
+              "myConsentId": []
+            },
+            "timeout": {
+              "seconds": 5,
+              "fallbackAction": "reject"
+            }
+          }
+        },
         "postPromptUI": "postPromptUI"
       }</script>
       <div id="ui1">

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -103,6 +103,9 @@ export class AmpConsent extends AMP.BaseElement {
 
     /** @private {!Object<string, Promise<?JsonObject>>} */
     this.remoteConfigPromises_ = map();
+
+    /** @private {?string} */
+    this.consentInstanceId_ = null;
   }
 
   /** @override */
@@ -127,6 +130,10 @@ export class AmpConsent extends AMP.BaseElement {
 
     this.consentConfig_ = config.getConsentConfig();
 
+    // ConsentConfig has verified that there's one and only one consent instance
+    this.consentInstanceId_ =
+        Object.keys(/** @type {!Object} */ (this.consentConfig_))[0];
+
     const policyConfig = config.getPolicyConfig();
 
     this.policyConfig_ = expandPolicyConfig(policyConfig, this.consentConfig_);
@@ -144,6 +151,8 @@ export class AmpConsent extends AMP.BaseElement {
             .then(manager => {
               this.consentPolicyManager_ = /** @type {!ConsentPolicyManager} */ (
                 manager);
+              this.consentPolicyManager_.setLegacyConsentInstanceId(
+                  /** @type {string} */ (this.consentInstanceId_));
               const policyKeys =
                   Object.keys(/** @type {!Object} */ (this.policyConfig_));
               for (let i = 0; i < policyKeys.length; i++) {

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -104,8 +104,7 @@ export class ConsentPolicyManager {
    * Example policy config format:
    * {
    *   "waitFor": {
-   *     "consentABC": [], // Can't support array now.
-   *                       // All items will be treated as an empty array
+   *     "consentABC": []
    *   }
    *   "timeout": {
    *     "seconds": 1,
@@ -157,7 +156,8 @@ export class ConsentPolicyManager {
   }
 
   /**
-   *
+   * Helper method to register to listen to consent instance value change
+   * and get the initial consent value
    */
   init_() {
     // Set up handler to listen to consent instance value change.
@@ -183,7 +183,7 @@ export class ConsentPolicyManager {
   }
 
   /**
-   *
+   * Handle initial consent instance value and following consent value change
    * @param {!ConsentInfoDef} info
    */
   consentStateChangeHandler_(info) {
@@ -247,7 +247,7 @@ export class ConsentPolicyManager {
     }
     return this.whenPolicyInstanceReady_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
-        return this.instances_[policyId].shouldUnblock();
+        return this.instances_[policyId].shouldEnable();
       });
     });
   }
@@ -370,6 +370,8 @@ export class ConsentPolicyInstance {
   }
 
   /**
+   * Evaluate the incoming consent state and determine if the policy instance
+   * should be resolved and what the policy state should be.
    * @param {CONSENT_ITEM_STATE} state
    * @param {boolean} isFallback
    */
@@ -422,7 +424,7 @@ export class ConsentPolicyInstance {
    * Caller need to make sure that policy status has resolved
    * @return {boolean}
    */
-  shouldUnblock() {
+  shouldEnable() {
     return (this.unblockStateLists_.indexOf(this.status_) > -1);
   }
 }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -18,10 +18,13 @@ import {CONSENT_ITEM_STATE, ConsentInfoDef} from './consent-info';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
 import {dev, user, userAssert} from '../../../src/log';
+import {Observable} from '../../../src/observable';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {hasOwn, map} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber, isObject} from '../../../src/types';
+import {map} from '../../../src/utils/object';
+import {user} from '../../../src/log';
+
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
 const TAG = 'consent-policy-manager';
@@ -43,11 +46,8 @@ export class ConsentPolicyManager {
     /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = ampdoc;
 
-    /** @private {!Object<string, ?Promise>} */
-    this.policyInstancePromises_ = map();
-
-    /** @private {!Object<string, ?function()>} */
-    this.policyInstancePromiseResolvers_ = map();
+    /** @private {!Object<string, ?Deferred>} */
+    this.policyInstancesDeferred_ = map();
 
     /** @private {!Object<string, ConsentPolicyInstance>} */
     this.instances_ = map();
@@ -56,14 +56,28 @@ export class ConsentPolicyManager {
     this.ConsentStateManagerPromise_ =
         getServicePromiseForDoc(this.ampdoc_, CONSENT_STATE_MANAGER);
 
-    const deferred = new Deferred();
+    /** @private {!Deferred} */
+    this.consentPromptInitiated_ = new Deferred();
+
+    const consentValueInitiated = new Deferred();
 
     /** @private {!Promise} */
-    this.allConsentInitated_ = deferred.promise;
+    this.consentValueInitiatedPromise_ = consentValueInitiated.promise;
 
     /** @private {?function()} */
-    this.allConsentInitatedResolver_ = deferred.resolve;
+    this.consentValueInitiatedResolver_ = consentValueInitiated.resolve;
 
+    /** @private {!Observable} */
+    this.consentStateChangeObservables_ = new Observable();
+
+    /** @private {?string} */
+    this.consentInstanceIdDepr_ = null;
+
+    /** @private {?CONSENT_ITEM_STATE} */
+    this.consentState_ = null;
+
+    /** @private {?string} */
+    this.consentString_ = null;
   }
 
   /**
@@ -77,13 +91,21 @@ export class ConsentPolicyManager {
   }
 
   /**
+   *
+   * @param {string} consentInstanceId
+   */
+  setLegacyConsentInstanceId(consentInstanceId) {
+    this.consentInstanceIdDepr_ = consentInstanceId;
+    this.init_();
+  }
+
+  /**
    * Register the policy instance
    * Example policy config format:
    * {
    *   "waitFor": {
    *     "consentABC": [], // Can't support array now.
    *                       // All items will be treated as an empty array
-   *     "consentDEF": [],
    *   }
    *   "timeout": {
    *     "seconds": 1,
@@ -105,41 +127,48 @@ export class ConsentPolicyManager {
     }
 
     const waitFor = Object.keys(config['waitFor'] || {});
+    if (waitFor.length !== 1 || waitFor[0] !== this.consentInstanceIdDepr_) {
+      user().error(TAG,
+          'invalid waitFor value, consent policy will never resolve');
+      return;
+    }
 
     const instance = new ConsentPolicyInstance(config);
 
     this.instances_[policyId] = instance;
 
-    if (this.policyInstancePromiseResolvers_[policyId]) {
-      this.policyInstancePromiseResolvers_[policyId]();
-      this.policyInstancePromiseResolvers_[policyId] = null;
-      this.policyInstancePromises_[policyId] = null;
+    if (this.policyInstancesDeferred_[policyId]) {
+      this.policyInstancesDeferred_[policyId].resolve();
+      this.policyInstancesDeferred_[policyId] = null;
     }
 
-    const initPromises = [];
-
-    this.ConsentStateManagerPromise_.then(manager => {
-      for (let i = 0; i < waitFor.length; i++) {
-        const consentId = waitFor[i];
-        const deferred = new Deferred();
-        const instanceInitValuePromise = deferred.promise;
-        let resolver = deferred.resolve;
-
-        manager.whenConsentReady(consentId).then(() => {
-          manager.onConsentStateChange(consentId, info => {
-            if (resolver) {
-              resolver();
-              resolver = null;
-            }
-            instance.consentStateChangeHandler(consentId, info);
-          });
-        });
-        initPromises.push(instanceInitValuePromise);
+    this.consentValueInitiatedPromise_.then(() => {
+      if (this.consentState_) {
+        // Has initial consent state value. Evaluate immediately
+        instance.evaluate(this.consentState_);
       }
+      this.consentStateChangeObservables_.add(state => {
+        instance.evaluate(state);
+      });
+      this.consentPromptInitiated_.promise.then(() => {
+        instance.startTimeout(this.ampdoc_.win);
+      });
+    });
+  }
 
-      this.allConsentInitated_.then(() => {
-        Promise.all(initPromises).then(() => {
-          instance.startTimeout(this.ampdoc_.win);
+  /**
+   *
+   */
+  init_() {
+    // Set up handler to listen to consent instance value change.
+    this.ConsentStateManagerPromise_.then(manager => {
+      manager.whenConsentReady(this.consentInstanceIdDepr_).then(() => {
+        manager.onConsentStateChange(this.consentInstanceIdDepr_, info => {
+          this.consentStateChangeHandler_(info);
+          if (this.consentValueInitiatedResolver_) {
+            this.consentValueInitiatedResolver_();
+            this.consentValueInitiatedResolver_ = null;
+          }
         });
       });
     });
@@ -150,10 +179,39 @@ export class ConsentPolicyManager {
    * state has been initiated with remote value. And ready to start timeout
    */
   enableTimeout() {
-    if (this.allConsentInitatedResolver_) {
-      this.allConsentInitatedResolver_();
+    this.consentPromptInitiated_.resolve();
+  }
+
+  /**
+   *
+   * @param {!ConsentInfoDef} info
+   */
+  consentStateChangeHandler_(info) {
+    const state = info['consentState'];
+    const consentStr = info['consentString'];
+    this.consentString_ = consentStr || this.consentString_;
+    if (state === CONSENT_ITEM_STATE.UNKNOWN) {
+      // consent state has not been resolved yet.
+      return;
     }
-    this.allConsentInitatedResolver_ = null;
+
+    if (state == CONSENT_ITEM_STATE.NOT_REQUIRED) {
+      const shouldOverwrite =
+          this.consentState_ != CONSENT_ITEM_STATE.ACCEPTED &&
+          this.consentState_ != CONSENT_ITEM_STATE.REJECTED;
+      // Ignore the consent item state and overwrite state value.
+      if (shouldOverwrite) {
+        this.consentState_ = CONSENT_ITEM_STATE.NOT_REQUIRED;
+      }
+    } else if (state == CONSENT_ITEM_STATE.DISMISSED) {
+      // When dismissed, use the old value
+      if (this.consentState_ === null) {
+        this.consentState_ = CONSENT_ITEM_STATE.UNKNOWN;
+      }
+    } else {
+      this.consentState_ = state;
+    }
+    this.consentStateChangeObservables_.fire(this.consentState_);
   }
 
   /**
@@ -162,13 +220,11 @@ export class ConsentPolicyManager {
    * @return {!Promise<CONSENT_POLICY_STATE>}
    */
   whenPolicyResolved(policyId) {
-    if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
-      // If customized policy is not supported
-      if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, 'can not find policy %s, ' +
-          'only predefined policies are supported', policyId);
-        return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
-      }
+    // If customized policy is not supported
+    if (!WHITELIST_POLICY[policyId]) {
+      user().error(TAG, 'can not find policy %s, ' +
+        'only predefined policies are supported', policyId);
+      return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
     }
     return this.whenPolicyInstanceReady_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
@@ -183,17 +239,15 @@ export class ConsentPolicyManager {
    * @return {!Promise<boolean>}
    */
   whenPolicyUnblock(policyId) {
-    if (!ConsentPolicyManager.isMultiSupported(this.ampdoc_.win)) {
-      // If customized policy is not supported
-      if (!WHITELIST_POLICY[policyId]) {
-        user().error(TAG, 'can not find policy %s, ' +
-          'only predefined policies are supported', policyId);
-        return Promise.resolve(false);
-      }
+    // If customized policy is not supported
+    if (!WHITELIST_POLICY[policyId]) {
+      user().error(TAG, 'can not find policy %s, ' +
+        'only predefined policies are supported', policyId);
+      return Promise.resolve(false);
     }
     return this.whenPolicyInstanceReady_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
-        return this.instances_[policyId].shouldBlock();
+        return this.instances_[policyId].shouldUnblock();
       });
     });
   }
@@ -211,15 +265,8 @@ export class ConsentPolicyManager {
     return this.whenPolicyResolved(policyId)
         .then(() => this.ConsentStateManagerPromise_)
         .then(manager => {
-          const promises = this.instances_[policyId].getConsentInstanceIds()
-              .map(consentId =>
-                manager.getConsentInstanceSharedData(consentId));
-          return Promise.all(promises);
-        }).then(sharedDatas => {
-          // preprend an empty object
-          // since Object.assign does not accept null as first argument
-          sharedDatas.unshift({});
-          return Object.assign.apply(null, sharedDatas);
+          return manager.getConsentInstanceSharedData(
+              this.consentInstanceIdDepr_);
         });
   }
 
@@ -231,12 +278,12 @@ export class ConsentPolicyManager {
    */
   getConsentStringInfo(policyId) {
     return this.whenPolicyResolved(policyId).then(() => {
-      return this.instances_[policyId].getConsentString();
+      return this.consentString_;
     });
   }
 
   /**
-   * Wait for policy instance to be ready.
+   * Wait for policy instance to be registered.
    * @param {string} policyId
    * @return {!Promise}
    */
@@ -244,12 +291,11 @@ export class ConsentPolicyManager {
     if (this.instances_[policyId]) {
       return Promise.resolve();
     }
-    if (!this.policyInstancePromises_[policyId]) {
-      const deferred = new Deferred();
-      this.policyInstancePromises_[policyId] = deferred.promise;
-      this.policyInstancePromiseResolvers_[policyId] = deferred.resolve;
+    if (!this.policyInstancesDeferred_[policyId]) {
+      this.policyInstancesDeferred_[policyId] = new Deferred();
     }
-    return /** @type {!Promise} */ (this.policyInstancePromises_[policyId]);
+    return /** @type {!Promise} */ (
+      this.policyInstancesDeferred_[policyId].promise);
   }
 }
 
@@ -259,25 +305,16 @@ export class ConsentPolicyInstance {
    * @param {!JsonObject} config
    */
   constructor(config) {
-    /** !Array<string> */
-    const pendingItems = Object.keys(config['waitFor'] || {});
-
     /** @private {!JsonObject} */
     this.config_ = config;
 
-    /** @private {!Object<string, ?CONSENT_ITEM_STATE>} */
-    this.itemToConsentState_ = map();
-
-    /** @private {?string} */
-    this.consentString_ = null;
-
-    const deferred = new Deferred();
+    const readyDeferred = new Deferred();
 
     /** @private {!Promise} */
-    this.readyPromise_ = deferred.promise;
+    this.readyPromise_ = readyDeferred.promise;
 
     /** @private {?function()} */
-    this.readyPromiseResolver_ = deferred.resolve;
+    this.readyResolver_ = readyDeferred.resolve;
 
     /** @private {CONSENT_POLICY_STATE} */
     this.status_ = CONSENT_POLICY_STATE.UNKNOWN;
@@ -286,22 +323,6 @@ export class ConsentPolicyInstance {
     this.unblockStateLists_ = config['unblockOn'] ||
         [CONSENT_POLICY_STATE.SUFFICIENT,
           CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED];
-
-    this.init_(pendingItems);
-  }
-
-  /**
-   * @param {!Array<string>} pendingItems
-   */
-  init_(pendingItems) {
-    for (let i = 0; i < pendingItems.length; i++) {
-      this.itemToConsentState_[pendingItems[i]] = null;
-    }
-  }
-
-  /** @return {Array<string>} */
-  getConsentInstanceIds() {
-    return Object.keys(this.itemToConsentState_);
   }
 
   /**
@@ -340,118 +361,42 @@ export class ConsentPolicyInstance {
 
     if (timeoutSecond != null) {
       win.setTimeout(() => {
-        this.evaluate_(true, fallbackState);
+        // Force evaluate on timeout
+        fallbackState = fallbackState || CONSENT_ITEM_STATE.UNKNOWN;
+        this.evaluate(fallbackState, true);
       }, timeoutSecond * 1000);
     }
 
   }
 
   /**
-   * consent instance state change handlerit
-   * @param {string} consentId
-   * @param {!ConsentInfoDef} info
+   * @param {CONSENT_ITEM_STATE} state
+   * @param {boolean} isFallback
    */
-  consentStateChangeHandler(consentId, info) {
-    // TODO: Keeping an array can have performance issue, change to using a map
-    // if necessary.
-    if (!hasOwn(this.itemToConsentState_, consentId)) {
-      dev().error(TAG, 'cannot find %s in policy state', consentId);
+  evaluate(state, isFallback = false) {
+    if (!state) {
+      // Not ready for evaluate yet
       return;
     }
 
-    const state = info['consentState'];
-    const consentStr = info['consentString'];
-    this.consentString_ = consentStr || this.consentString_;
-
-    if (state == CONSENT_ITEM_STATE.UNKNOWN) {
-      // consent state has not been resolved yet.
+    if (isFallback && !this.readyResolver_) {
+      // Discard fallback state if consent status has resolve before timeout.
       return;
     }
 
-    if (state == CONSENT_ITEM_STATE.NOT_REQUIRED) {
-      const shouldOverwrite =
-          this.itemToConsentState_[consentId] != CONSENT_ITEM_STATE.ACCEPTED &&
-          this.itemToConsentState_[consentId] != CONSENT_ITEM_STATE.REJECTED;
-      // Ignore the consent item state and overwrite state value.
-      if (shouldOverwrite) {
-        this.itemToConsentState_[consentId] = CONSENT_ITEM_STATE.NOT_REQUIRED;
-      }
-    } else if (state == CONSENT_ITEM_STATE.DISMISSED) {
-      // When dismissed, use the old value
-      if (this.itemToConsentState_[consentId] === null) {
-        this.itemToConsentState_[consentId] = CONSENT_ITEM_STATE.UNKNOWN;
-      }
+    if (state === CONSENT_ITEM_STATE.ACCEPTED) {
+      this.status_ = CONSENT_POLICY_STATE.SUFFICIENT;
+    } else if (state === CONSENT_ITEM_STATE.REJECTED) {
+      this.status_ = CONSENT_POLICY_STATE.INSUFFICIENT;
+    } else if (state === CONSENT_ITEM_STATE.NOT_REQUIRED) {
+      this.status_ = CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED;
     } else {
-      this.itemToConsentState_[consentId] = state;
+      this.status_ = CONSENT_POLICY_STATE.UNKNOWN;
     }
 
-    this.evaluate_();
-  }
-
-  /**
-   *
-   * @param {boolean} isForce
-   * @param {CONSENT_ITEM_STATE=} opt_fallbackState
-   */
-  evaluate_(isForce = false, opt_fallbackState) {
-    // All consent instances need to be granted
-    let isSufficient = true;
-
-    // All consent instances need to be granted or ignored
-    let isIgnored = true;
-
-    // A single consent instance is unknown
-    let isUnknown = false;
-
-    // Decide to traverse item list every time instead of keeping reject/pending
-    // counts Performance should be OK since we expect item list to be small.
-    const items = Object.keys(this.itemToConsentState_);
-    for (let i = 0; i < items.length; i++) {
-      const consentId = items[i];
-      if (this.itemToConsentState_[consentId] === null) {
-        if (isForce) {
-          // Force evaluate on timeout
-          const fallbackState = opt_fallbackState || CONSENT_ITEM_STATE.UNKNOWN;
-          this.itemToConsentState_[consentId] = fallbackState;
-        } else {
-          return;
-        }
-      }
-
-      if (this.itemToConsentState_[consentId] ==
-          CONSENT_ITEM_STATE.NOT_REQUIRED) {
-        isSufficient = false;
-      }
-
-      if (this.itemToConsentState_[consentId] == CONSENT_ITEM_STATE.REJECTED) {
-        isSufficient = false;
-        isIgnored = false;
-      }
-
-      if (this.itemToConsentState_[consentId] == CONSENT_ITEM_STATE.UNKNOWN) {
-        isSufficient = false;
-        isIgnored = false;
-        isUnknown = true;
-      }
-    }
-
-    let state = null;
-
-    if (isSufficient) {
-      state = CONSENT_POLICY_STATE.SUFFICIENT;
-    } else if (isIgnored) {
-      state = CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED;
-    } else if (isUnknown) {
-      state = CONSENT_POLICY_STATE.UNKNOWN;
-    } else {
-      state = CONSENT_POLICY_STATE.INSUFFICIENT;
-    }
-
-    this.status_ = state;
-
-    if (this.readyPromiseResolver_) {
-      this.readyPromiseResolver_();
-      this.readyPromiseResolver_ = null;
+    if (this.readyResolver_) {
+      this.readyResolver_();
+      this.readyResolver_ = null;
     }
   }
 
@@ -473,21 +418,11 @@ export class ConsentPolicyInstance {
   }
 
   /**
-   * Returns the current consent string info
-   * @return {?string}
-   */
-  getConsentString() {
-    // Return a string because we only support one consent instance now.
-    // And decide not to support multiple consent instances given CMP approach
-    return this.consentString_;
-  }
-
-  /**
-   * Returns whether the current consent policy state should block
+   * Returns whether the current consent policy state should be unblocked
    * Caller need to make sure that policy status has resolved
    * @return {boolean}
    */
-  shouldBlock() {
+  shouldUnblock() {
     return (this.unblockStateLists_.indexOf(this.status_) > -1);
   }
 }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -226,7 +226,7 @@ export class ConsentPolicyManager {
         'only predefined policies are supported', policyId);
       return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
     }
-    return this.whenPolicyInstanceReady_(policyId).then(() => {
+    return this.whenPolicyInstanceRegistered_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
         return this.instances_[policyId].getCurrentPolicyStatus();
       });
@@ -245,9 +245,9 @@ export class ConsentPolicyManager {
         'only predefined policies are supported', policyId);
       return Promise.resolve(false);
     }
-    return this.whenPolicyInstanceReady_(policyId).then(() => {
+    return this.whenPolicyInstanceRegistered_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
-        return this.instances_[policyId].shouldEnable();
+        return this.instances_[policyId].shouldUnblock();
       });
     });
   }
@@ -287,7 +287,7 @@ export class ConsentPolicyManager {
    * @param {string} policyId
    * @return {!Promise}
    */
-  whenPolicyInstanceReady_(policyId) {
+  whenPolicyInstanceRegistered_(policyId) {
     if (this.instances_[policyId]) {
       return Promise.resolve();
     }
@@ -424,7 +424,7 @@ export class ConsentPolicyInstance {
    * Caller need to make sure that policy status has resolved
    * @return {boolean}
    */
-  shouldEnable() {
+  shouldUnblock() {
     return (this.unblockStateLists_.indexOf(this.status_) > -1);
   }
 }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -17,13 +17,13 @@
 import {CONSENT_ITEM_STATE, ConsentInfoDef} from './consent-info';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
-import {dev, user, userAssert} from '../../../src/log';
 import {Observable} from '../../../src/observable';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber, isObject} from '../../../src/types';
 import {map} from '../../../src/utils/object';
-import {user} from '../../../src/log';
+import {user, userAssert} from '../../../src/log';
+
 
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -22,22 +22,33 @@ import {
   ConsentPolicyInstance,
   ConsentPolicyManager,
 } from '../consent-policy-manager';
+import {dict, map} from '../../../../src/utils/object';
+import {expandPolicyConfig} from '../consent-config';
 import {macroTask} from '../../../../testing/yield';
+
 import {
   registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
-import {toggleExperiment} from '../../../../src/experiments';
 
-describes.realWin('ConsentStateManager', {amp: 1}, env => {
+
+
+
+describes.realWin('ConsentPolicyManager', {
+  amp: {
+    extensions: ['amp-consent'],
+    ampdoc: 'single',
+  },
+}, env => {
   let win;
   let ampdoc;
   let consentManagerOnChangeSpy;
+  let consentInfoMap;
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
     consentManagerOnChangeSpy = sandbox.spy();
-    toggleExperiment(win, 'multi-consent', true);
+    consentInfoMap = map();
 
     resetServiceForTesting(win, 'consentStateManager');
     registerServiceBuilder(win, 'consentStateManager', function() {
@@ -45,49 +56,297 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         whenConsentReady: () => {return Promise.resolve();},
         onConsentStateChange: (id, handler) => {
           consentManagerOnChangeSpy(id, handler);
+          handler(consentInfoMap[id]);
         },
-        getConsentInstanceSharedData: id => {
-          const sharedData = {
-            common: id,
-          };
-          sharedData[id] = true;
-          return Promise.resolve(sharedData);
+        getConsentInstanceSharedData: () => {
+          return Promise.resolve(dict({
+            'shared': 'test',
+          }));
         },
       });
     });
+  });
+
+  afterEach(() => {
+    consentInfoMap = null;
   });
 
   describe('Consent Policy Manager', () => {
     let manager;
     beforeEach(() => {
       manager = new ConsentPolicyManager(ampdoc);
-      sandbox.stub(ConsentPolicyInstance.prototype, 'getReadyPromise')
-          .callsFake(() => {return Promise.resolve();});
+      consentInfoMap['ABC'] =
+          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test');
+      manager.setLegacyConsentInstanceId('ABC');
     });
 
-    it('register policy instance correctly', function* () {
-      manager.registerConsentPolicyInstance('test', {
-        'waitFor': {
-          'ABC': undefined,
-          'DEF': undefined,
-        },
-      });
+    it('Initiate consent value', function* () {
       yield macroTask();
-      expect(consentManagerOnChangeSpy).to.be.calledTwice;
+      expect(consentManagerOnChangeSpy).to.be.called;
       expect(consentManagerOnChangeSpy.args[0][0]).to.equal('ABC');
-      expect(consentManagerOnChangeSpy.args[1][0]).to.equal('DEF');
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+      expect(manager.consentString_).to.equal('test');
     });
 
-    describe('whenPolicyResolved', () => {
+    describe('Register policy instance', () => {
+      it('Valid consent policy', function* () {
+        manager.registerConsentPolicyInstance('default', {
+          'waitFor': {
+            'ABC': undefined,
+          },
+        });
+        yield macroTask();
+        return manager.whenPolicyResolved('default').then(status => {
+          expect(status).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+        });
+      });
+
+      it('Invalid consent policy', function* () {
+        consentInfoMap['invalid'] =
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED);
+        expectAsyncConsoleError('[consent-policy-manager] ' +
+            'invalid waitFor value, consent policy will never resolve');
+        manager.registerConsentPolicyInstance('default', {
+          'waitFor': {
+            'ABC': undefined,
+            'invalid': undefined,
+          },
+        });
+      });
+    });
+
+    it('Handle consent state change', () => {
+      // UNKNOWN Init value
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
+      expect(manager.consentState_).to.be.null;
+
+      // Dismiss override unknown
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+
+      // Not required override unknown
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.NOT_REQUIRED);
+
+      // Accept
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+
+      // UNKNOWN/NOT_REQUIRED/DISMISS cannot override ACCEPTED/REJECTED
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.ACCEPTED);
+
+      // Reject
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.REJECTED);
+
+      // UNKNOWN/NOT_REQUIRED/DISMISS cannot override ACCEPTED/REJECTED
+      manager.consentStateChangeHandler_(
+          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
+      expect(manager.consentState_).to.equal(CONSENT_ITEM_STATE.REJECTED);
+    });
+
+    describe('whenPolicyResolved/Unblock', () => {
+      it('Invalid policy value', () => {
+        expectAsyncConsoleError(/only predefined policies are supported/, 2);
+        return manager.whenPolicyResolved('invalid').then(state => {
+          expect(state).to.equal(CONSENT_POLICY_STATE.UNKNOWN);
+          return manager.whenPolicyUnblock('invalid').then(shouldUnblock => {
+            expect(shouldUnblock).to.be.false;
+          });
+        });
+      });
+
       it('return promise when policy is resolved', () => {
-        manager.registerConsentPolicyInstance('test', {});
-        return manager.whenPolicyResolved('test');
+        manager.registerConsentPolicyInstance('default', {
+          'waitFor': {
+            'ABC': undefined,
+          },
+        });
+        return manager.whenPolicyResolved('default');
       });
 
       it('handle cases when requested before policy is registered', () => {
-        const promise = manager.whenPolicyResolved('test');
-        manager.registerConsentPolicyInstance('test', {});
+        const promise = manager.whenPolicyResolved('default');
+        manager.registerConsentPolicyInstance('default', {
+          'waitFor': {
+            'ABC': undefined,
+          },
+        });
         return promise;
+      });
+    });
+
+    describe('Predefined consent policy', () => {
+      let policy;
+      beforeEach(() => {
+        manager = new ConsentPolicyManager(ampdoc);
+        consentInfoMap['ABC'] =
+            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN);
+        manager.setLegacyConsentInstanceId('ABC');
+        const defaultConfig = dict({
+          'ABC': {
+            'checkConsentHref': 'https://response1',
+          },
+        });
+
+        policy = expandPolicyConfig(dict({}), defaultConfig);
+        const keys = Object.keys(policy);
+        for (let i = 0; i < keys.length; i++) {
+          manager.registerConsentPolicyInstance(keys[i], policy[keys[i]]);
+        }
+      });
+
+      it('Not required', () => {
+        manager.consentStateChangeHandler_(
+            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
+        const promises = [];
+        promises.push(manager.whenPolicyResolved('default').then(status => {
+          expect(status).to.equal(CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
+        }));
+        promises.push(manager.whenPolicyResolved('_till_accepted').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
+            }));
+        promises.push(manager.whenPolicyResolved('_till_responded').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
+            }));
+        promises.push(manager.whenPolicyResolved('_auto_reject').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
+            }));
+
+        // Unblock
+        promises.push(manager.whenPolicyUnblock('default').then(toUnblock => {
+          expect(toUnblock).to.be.true;
+        }));
+
+        promises.push(manager.whenPolicyUnblock('_till_accepted').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_till_responded').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_auto_reject').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+        return Promise.all(promises);
+      });
+
+      it('Dismiss', () => {
+        manager.consentStateChangeHandler_(
+            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
+        const promises = [];
+        promises.push(manager.whenPolicyResolved('default').then(status => {
+          expect(status).to.equal(CONSENT_POLICY_STATE.UNKNOWN);
+        }));
+        promises.push(manager.whenPolicyResolved('_till_accepted').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN);
+            }));
+        promises.push(manager.whenPolicyResolved('_till_responded').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN);
+            }));
+        promises.push(manager.whenPolicyResolved('_auto_reject').then(
+            status => {
+              expect(status).to.equal(
+                  CONSENT_POLICY_STATE.UNKNOWN);
+            }));
+
+        // Unblock
+        promises.push(manager.whenPolicyUnblock('default').then(toUnblock => {
+          expect(toUnblock).to.be.false;
+        }));
+
+        promises.push(manager.whenPolicyUnblock('_till_accepted').then(
+            toUnblock => {
+              expect(toUnblock).to.be.false;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_till_responded').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_auto_reject').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+        return Promise.all(promises);
+      });
+
+      it('Accept', () => {
+        manager.consentStateChangeHandler_(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
+        const promises = [];
+        promises.push(manager.whenPolicyResolved('default').then(status => {
+          expect(status).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+        }));
+        promises.push(manager.whenPolicyResolved('_till_accepted').then(
+            status => {
+              expect(status).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+            }));
+        promises.push(manager.whenPolicyResolved('_till_responded').then(
+            status => {
+              expect(status).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+            }));
+        promises.push(manager.whenPolicyResolved('_auto_reject').then(
+            status => {
+              expect(status).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+            }));
+
+        return Promise.all(promises);
+      });
+
+      it('Reject', () => {
+        manager.consentStateChangeHandler_(
+            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
+        const promises = [];
+        promises.push(manager.whenPolicyResolved('default').then(status => {
+          expect(status).to.equal(CONSENT_POLICY_STATE.INSUFFICIENT);
+        }));
+
+        promises.push(manager.whenPolicyUnblock('default').then(toUnblock => {
+          expect(toUnblock).to.be.false;
+        }));
+
+        promises.push(manager.whenPolicyUnblock('_till_accepted').then(
+            toUnblock => {
+              expect(toUnblock).to.be.false;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_till_responded').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+
+        promises.push(manager.whenPolicyUnblock('_auto_reject').then(
+            toUnblock => {
+              expect(toUnblock).to.be.true;
+            }));
+
+        return Promise.all(promises);
       });
     });
   });
@@ -98,142 +357,9 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       const config = {
         'waitFor': {
           'ABC': [],
-          'DEF': [],
         },
       };
       instance = new ConsentPolicyInstance(config);
-    });
-
-    it('on consent state change', () => {
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.UNKNOWN,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.ACCEPTED,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.REJECTED,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.REJECTED,
-      });
-    });
-
-    it('on consent ignored', () => {
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.NOT_REQUIRED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': null,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.UNKNOWN,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.NOT_REQUIRED,
-      });
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-      expect(instance.itemToConsentState_).to.deep.equal({
-        'ABC': CONSENT_ITEM_STATE.ACCEPTED,
-        'DEF': CONSENT_ITEM_STATE.NOT_REQUIRED,
-      });
-
-    });
-
-    describe('getReadyPromise', () => {
-      let config;
-
-      beforeEach(() => {
-        config = {
-          'waitFor': {
-            'ABC': [],
-          },
-        };
-      });
-
-      it('promise should resolve when all consents are gathered', function* () {
-        instance = new ConsentPolicyInstance(config);
-        let ready = false;
-        instance.getReadyPromise().then(() => ready = true);
-        yield macroTask();
-        expect(ready).to.be.false;
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
-        yield macroTask();
-        expect(ready).to.be.true;
-        ready = false;
-        instance = new ConsentPolicyInstance(config);
-        instance.getReadyPromise().then(() => ready = true);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
-        yield macroTask();
-        expect(ready).to.be.true;
-      });
-
-      it('promise should resolve when consents are dimissed', function* () {
-        instance = new ConsentPolicyInstance(config);
-        let ready = false;
-        instance.getReadyPromise().then(() => ready = true);
-        yield macroTask();
-        expect(ready).to.be.false;
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
-        yield macroTask();
-        expect(ready).to.be.false;
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-        yield macroTask();
-        expect(ready).to.be.true;
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.UNKNOWN);
-      });
     });
 
     describe('timeout', () => {
@@ -246,7 +372,10 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
           'waitFor': {
             'ABC': [],
           },
-          'timeout': 1,
+          'timeout': {
+            'seconds': 1,
+            'fallbackAction': 'reject',
+          },
         };
 
         config2 = {
@@ -266,8 +395,6 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         instance = new ConsentPolicyInstance(config1);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo((CONSENT_ITEM_STATE.UNKNOWN)));
         instance.startTimeout(ampdoc.win);
         yield macroTask();
         expect(ready).to.be.false;
@@ -278,26 +405,24 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield macroTask();
         expect(ready).to.be.true;
         expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.UNKNOWN);
+            CONSENT_POLICY_STATE.INSUFFICIENT);
       });
 
-      it('promise should resolve when consents are dimissed', function* () {
+      it('consent policy resolve before timeout', function* () {
         instance = new ConsentPolicyInstance(config2);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN));
         instance.startTimeout(ampdoc.win);
         yield macroTask();
         expect(ready).to.be.false;
-        clock.tick(1999);
-        yield macroTask();
-        expect(ready).to.be.false;
-        clock.tick(1);
+        clock.tick(1000);
+        instance.evaluate(CONSENT_ITEM_STATE.DISMISSED);
         yield macroTask();
         expect(ready).to.be.true;
+        clock.tick(1001);
+        yield macroTask();
         expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.INSUFFICIENT);
+            CONSENT_POLICY_STATE.UNKNOWN);
       });
     });
 
@@ -311,44 +436,22 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         });
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.UNKNOWN);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.UNKNOWN);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
+
+        instance.evaluate(CONSENT_ITEM_STATE.REJECTED);
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.INSUFFICIENT);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.SUFFICIENT);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.SUFFICIENT);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.NOT_REQUIRED));
-        expect(instance.getCurrentPolicyStatus()).to.equal(
-            CONSENT_POLICY_STATE.SUFFICIENT);
-      });
 
-      it('should return current consent string value', function* () {
-        instance = new ConsentPolicyInstance({
-          'waitFor': {
-            'ABC': [],
-          },
-        });
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED, 'dismiss'));
-        expect(instance.getConsentString()).to.equal('dismiss');
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'accept'));
-        expect(instance.getConsentString()).to.equal('accept');
+        instance.evaluate(CONSENT_ITEM_STATE.ACCEPTED);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.SUFFICIENT);
+
+        instance.evaluate(CONSENT_ITEM_STATE.DISMISSED);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.UNKNOWN);
+
+        instance.evaluate(CONSENT_ITEM_STATE.NOT_REQUIRED);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
       });
     });
 
@@ -359,15 +462,14 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
             'ABC': [],
           },
         });
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.DISMISSED));
-        expect(instance.shouldBlock()).to.equal(false);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.REJECTED));
-        expect(instance.shouldBlock()).to.equal(false);
-        instance.consentStateChangeHandler('ABC',
-            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED));
-        expect(instance.shouldBlock()).to.equal(true);
+        instance.evaluate(CONSENT_ITEM_STATE.DISMISSED);
+        expect(instance.shouldUnblock()).to.equal(false);
+
+        instance.evaluate(CONSENT_ITEM_STATE.REJECTED);
+        expect(instance.shouldUnblock()).to.equal(false);
+
+        instance.evaluate(CONSENT_ITEM_STATE.ACCEPTED);
+        expect(instance.shouldUnblock()).to.equal(true);
       });
 
       it('customized should block list', () => {
@@ -382,47 +484,15 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
             CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
           ],
         });
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
-        expect(instance.shouldBlock()).to.equal(true);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
-        expect(instance.shouldBlock()).to.equal(true);
-        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.ACCEPTED);
-        expect(instance.shouldBlock()).to.equal(true);
-      });
-    });
+        instance.evaluate(CONSENT_ITEM_STATE.DISMISSED);
+        expect(instance.shouldUnblock()).to.equal(true);
 
-    it('policy status when there are multiple items to wait', () => {
-      instance = new ConsentPolicyInstance({
-        'waitFor': {
-          'ABC': [],
-          'DEF': [],
-        },
+        instance.evaluate(CONSENT_ITEM_STATE.REJECTED);
+        expect(instance.shouldUnblock()).to.equal(true);
+
+        instance.evaluate(CONSENT_ITEM_STATE.ACCEPTED);
+        expect(instance.shouldUnblock()).to.equal(true);
       });
-      // single unknown
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo((CONSENT_ITEM_STATE.NOT_REQUIRED)));
-      expect(instance.getCurrentPolicyStatus()).to.equal(
-          CONSENT_POLICY_STATE.UNKNOWN);
-      // All ignored
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo((CONSENT_ITEM_STATE.NOT_REQUIRED)));
-      expect(instance.getCurrentPolicyStatus()).to.equal(
-          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
-      // Single ignored
-      instance.consentStateChangeHandler('DEF',
-          constructConsentInfo((CONSENT_ITEM_STATE.ACCEPTED)));
-      expect(instance.getCurrentPolicyStatus()).to.equal(
-          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED);
-      // All granted
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo((CONSENT_ITEM_STATE.ACCEPTED)));
-      expect(instance.getCurrentPolicyStatus()).to.equal(
-          CONSENT_POLICY_STATE.SUFFICIENT);
-      // Single rejected
-      instance.consentStateChangeHandler('ABC',
-          constructConsentInfo((CONSENT_ITEM_STATE.REJECTED)));
-      expect(instance.getCurrentPolicyStatus()).to.equal(
-          CONSENT_POLICY_STATE.INSUFFICIENT);
     });
   });
 
@@ -433,21 +503,20 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       manager = new ConsentPolicyManager(ampdoc);
       sandbox.stub(ConsentPolicyInstance.prototype, 'getReadyPromise')
           .callsFake(() => {return Promise.resolve();});
+      consentInfoMap['ABC'] = constructConsentInfo(CONSENT_ITEM_STATE.UNKNOWN);
+      manager.setLegacyConsentInstanceId('ABC');
     });
 
-    it('should return merged sharedData', function*() {
-      manager.registerConsentPolicyInstance('test', {
+    it('should return sharedData', function*() {
+      manager.registerConsentPolicyInstance('default', {
         'waitFor': {
           'ABC': undefined,
-          'DEF': undefined,
         },
       });
       yield macroTask();
-      return expect(manager.getMergedSharedData('test'))
+      return expect(manager.getMergedSharedData('default'))
           .to.eventually.deep.equal({
-            common: 'DEF',
-            ABC: true,
-            DEF: true,
+            'shared': 'test',
           });
     });
   });

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -31,9 +31,6 @@ import {
   resetServiceForTesting,
 } from '../../../../src/service';
 
-
-
-
 describes.realWin('ConsentPolicyManager', {
   amp: {
     extensions: ['amp-consent'],


### PR DESCRIPTION
As agreed, we decide to completely remove support to multiple consent instance/prompt. All such use case could be satisfied using CMP approach. 