### PR TITLE
amp-list load-more validation

### DIFF
--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -107,7 +107,7 @@
     src="https://data.com/articles.json?ref=CANONICAL_URL"
     load-more="manual"
     load-more-bookmark="next">
-    <div load-more-button></div>
+    <button load-more-button></button>
     <div load-more-loading></div>
     <div load-more-failed></div>
     <div load-more-end></div>

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -102,6 +102,17 @@
     load-more="manual"
     load-more-bookmark="next"></amp-list>
   </amp-list>
+  <!-- Valid amp-list with custom children -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next">
+    <div load-more-button></div>
+    <div load-more-loading></div>
+    <div load-more-failed></div>
+    <div load-more-end></div>
+  </amp-list>
+  </amp-list>
   <!-- Invalid: unsupported "binding" attribute value -->
   <amp-list width=10 height=10
             src="https://data.com/articles.json?ref=CANONICAL_URL"
@@ -133,5 +144,10 @@
     load-more="gibberish"
     load-more-bookmark="next"></amp-list>
   </amp-list>
+  <!-- Invalid load-more attributes -->
+  <div load-more-button></div>
+  <div load-more-loading></div>
+  <div load-more-failed></div>
+  <div load-more-end></div>
 </body>
 </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -107,10 +107,10 @@
     src="https://data.com/articles.json?ref=CANONICAL_URL"
     load-more="manual"
     load-more-bookmark="next">
-    <button load-more-button></button>
-    <div load-more-loading></div>
-    <div load-more-failed></div>
-    <div load-more-end></div>
+    <amp-list-load-more load-more-button></amp-list-load-more>
+    <amp-list-load-more load-more-loading></amp-list-load-more>
+    <amp-list-load-more load-more-failed></amp-list-load-more>
+    <amp-list-load-more load-more-end></amp-list-load-more>
   </amp-list>
   </amp-list>
   <!-- Invalid: unsupported "binding" attribute value -->
@@ -149,5 +149,6 @@
   <div load-more-loading></div>
   <div load-more-failed></div>
   <div load-more-end></div>
+  <amp-list-load-more></amp-list-load-more>
 </body>
 </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -86,6 +86,21 @@
     src="https://data.com/articles.json?ref=CANONICAL_URL"
     auto-resize>
   <div></div>
+  <!-- Valid amp-list with load-more="auto" attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="auto"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with load-more="manual" attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with load-more and optional load-more-bookmark attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next"></amp-list>
   </amp-list>
   <!-- Invalid: unsupported "binding" attribute value -->
   <amp-list width=10 height=10
@@ -106,6 +121,17 @@
        which isn't supported. -->
   <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
     <div></div>
+  </amp-list>
+  <!-- Invalid amp-list with load-more attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more></amp-list>
+  </amp-list>
+  <!-- Invalid amp-list with bad load-more attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="gibberish"
+    load-more-bookmark="next"></amp-list>
   </amp-list>
 </body>
 </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -112,10 +112,10 @@ amp-list/0.1/test/validator-amp-list.html:85:2 The attribute 'auto-resize' in ta
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more="manual"
 |      load-more-bookmark="next">
-|      <button load-more-button></button>
-|      <div load-more-loading></div>
-|      <div load-more-failed></div>
-|      <div load-more-end></div>
+|      <amp-list-load-more load-more-button></amp-list-load-more>
+|      <amp-list-load-more load-more-loading></amp-list-load-more>
+|      <amp-list-load-more load-more-failed></amp-list-load-more>
+|      <amp-list-load-more load-more-end></amp-list-load-more>
 |    </amp-list>
 |    </amp-list>
 |    <!-- Invalid: unsupported "binding" attribute value -->
@@ -174,5 +174,8 @@ amp-list/0.1/test/validator-amp-list.html:150:2 The attribute 'load-more-failed'
 |    <div load-more-end></div>
 >>   ^~~~~~~~~
 amp-list/0.1/test/validator-amp-list.html:151:2 The attribute 'load-more-end' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <amp-list-load-more></amp-list-load-more>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:152:2 The parent tag of tag 'amp-list-load-more' is 'body', but it can only be 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -107,10 +107,21 @@ amp-list/0.1/test/validator-amp-list.html:85:2 The attribute 'auto-resize' in ta
 |      load-more="manual"
 |      load-more-bookmark="next"></amp-list>
 |    </amp-list>
+|    <!-- Valid amp-list with custom children -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next">
+|      <div load-more-button></div>
+|      <div load-more-loading></div>
+|      <div load-more-failed></div>
+|      <div load-more-end></div>
+|    </amp-list>
+|    </amp-list>
 |    <!-- Invalid: unsupported "binding" attribute value -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:106:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:117:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              binding="this-is-an-error">
 |      <div></div>
@@ -118,37 +129,50 @@ amp-list/0.1/test/validator-amp-list.html:106:2 The attribute 'binding' in tag '
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:112:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:123:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: missing at least src or [src]. -->
 |    <amp-list width=10 height=10>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:117:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:128:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:122:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:133:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid amp-list with load-more attribute -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:126:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:137:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more></amp-list>
 |    </amp-list>
-|    <!-- Valid amp-list with bad load-more attribute -->
+|    <!-- Invalid amp-list with bad load-more attribute -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:131:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:142:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more="gibberish"
 |      load-more-bookmark="next"></amp-list>
 |    </amp-list>
+|    <!-- Invalid load-more attributes -->
+|    <div load-more-button></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:148:2 The attribute 'load-more-button' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div load-more-loading></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:149:2 The attribute 'load-more-loading' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div load-more-failed></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:150:2 The attribute 'load-more-failed' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div load-more-end></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:151:2 The attribute 'load-more-end' may not appear in tag 'div'. [DISALLOWED_HTML]
 |  </body>
 |  </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -112,7 +112,7 @@ amp-list/0.1/test/validator-amp-list.html:85:2 The attribute 'auto-resize' in ta
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more="manual"
 |      load-more-bookmark="next">
-|      <div load-more-button></div>
+|      <button load-more-button></button>
 |      <div load-more-loading></div>
 |      <div load-more-failed></div>
 |      <div load-more-end></div>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -91,11 +91,26 @@ amp-list/0.1/test/validator-amp-list.html:85:2 The attribute 'auto-resize' in ta
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      auto-resize>
 |    <div></div>
+|    <!-- Valid amp-list with load-more="auto" attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="auto"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with load-more="manual" attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with load-more and optional load-more-bookmark attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next"></amp-list>
 |    </amp-list>
 |    <!-- Invalid: unsupported "binding" attribute value -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:91:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:106:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              binding="this-is-an-error">
 |      <div></div>
@@ -103,22 +118,37 @@ amp-list/0.1/test/validator-amp-list.html:91:2 The attribute 'binding' in tag 'a
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:97:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:112:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: missing at least src or [src]. -->
 |    <amp-list width=10 height=10>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:102:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:117:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:107:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:122:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
 |      <div></div>
+|    </amp-list>
+|    <!-- Invalid amp-list with load-more attribute -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:126:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with bad load-more attribute -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:131:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="gibberish"
+|      load-more-bookmark="next"></amp-list>
 |    </amp-list>
 |  </body>
 |  </html>

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -105,6 +105,33 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     supported_layouts: RESPONSIVE
   }
 }
+tags: { # amp-list load-more children
+  html_format: AMP
+  spec_name: "AMP-LIST LOAD-MORE CHILDREN"
+  tag_name: "DIV"
+  mandatory_parent: "AMP-LIST"
+  attrs: {
+    name: "load-more-button"
+    value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
+  }
+  attrs: {
+    name: "load-more-failed"
+    value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
+  }
+  attrs: {
+    name: "load-more-loading"
+    value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
+
+  }
+  attrs: {
+    name: "load-more-end"
+    value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
+  }
+}
 # AMP4EMAIL disallows mustache in src attribute.
 tags: {  # <amp-list>
   html_format: AMP4EMAIL

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -96,9 +96,6 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     deprecation: "[src]"
   }
   attr_lists: "extended-amp-global"
-  reference_points: {
-    tag_spec_name: "AMP-LIST [load-more] items"
-  }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -108,10 +105,12 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     supported_layouts: RESPONSIVE
   }
 }
-tags: { # amp-list load-more children
+
+tags: { # amp-list-load-more
   html_format: AMP
-  tag_name: "$REFERENCE_POINT"
-  spec_name: "AMP-LIST [load-more] items"
+  html_format: EXPERIMENTAL
+  tag_name: "AMP-LIST-LOAD-MORE"
+  requires_extension: "amp-list"
   mandatory_parent: "AMP-LIST"
   attrs: {
     name: "load-more-button"
@@ -130,6 +129,7 @@ tags: { # amp-list load-more children
     value: ""
   }
 }
+
 # AMP4EMAIL disallows mustache in src attribute.
 tags: {  # <amp-list>
   html_format: AMP4EMAIL

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -55,6 +55,17 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
   }
   attrs: { name: "credentials" }
   attrs: { name: "items" }
+  attrs: {
+    name: "load-more"
+    value: "auto"
+    value: "manual"
+   }
+  attrs: {
+    name: "load-more-bookmark"
+    trigger: {
+    also_requires_attr: "load-more"
+    }
+  }
   attrs: { name: "max-items" }
   attrs: {
     name: "reset-on-refresh"

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -115,18 +115,22 @@ tags: { # amp-list-load-more
   attrs: {
     name: "load-more-button"
     value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
   attrs: {
     name: "load-more-failed"
     value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
   attrs: {
     name: "load-more-loading"
     value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
   attrs: {
     name: "load-more-end"
     value: ""
+    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
 }
 

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -96,6 +96,9 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     deprecation: "[src]"
   }
   attr_lists: "extended-amp-global"
+  reference_points: {
+    tag_spec_name: "AMP-LIST [load-more] items"
+  }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -107,29 +110,24 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
 }
 tags: { # amp-list load-more children
   html_format: AMP
-  spec_name: "AMP-LIST LOAD-MORE CHILDREN"
-  tag_name: "DIV"
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-LIST [load-more] items"
   mandatory_parent: "AMP-LIST"
   attrs: {
     name: "load-more-button"
     value: ""
-    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
   attrs: {
     name: "load-more-failed"
     value: ""
-    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
   attrs: {
     name: "load-more-loading"
     value: ""
-    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
-
   }
   attrs: {
     name: "load-more-end"
     value: ""
-    mandatory_oneof: "['load-more-button', 'load-more-failed', 'load-more-end', 'load-more-loading']"
   }
 }
 # AMP4EMAIL disallows mustache in src attribute.


### PR DESCRIPTION
DO NOT MERGE THIS UNTIL INFINITE SCROLL IS READY TO LAUNCH. 

The documentation for `amp-list load-more` is https://github.com/ampproject/amphtml/pull/19967. 
1. Introducing `load-more` and `load-more-bookmark` as attributes on `amp-list`. 
2. Allowing child elements in `amp-list` to contain elements containing `load-more-loading`, `load-more-failed`, `load-more-button`, `load-more-end`. 

To Reviewers: please take a look at the comment regarding the children with attributes and let me know if there's a better way or more precise validation rule that we should use. 