### PR TITLE
✨ amp-skimlinks: Remove non-affiliated links from links impressions analytics.

### DIFF
--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const AMP_SKIMLINKS_VERSION = '1.0.0';
+export const AMP_SKIMLINKS_VERSION = '1.0.1';
 export const XCUST_ATTRIBUTE_NAME = 'data-skimlinks-custom-tracking-id';
 export const AFFILIATION_API = 'https://go.skimresources.com';
 export const PLATFORM_NAME = 'amp@' + AMP_SKIMLINKS_VERSION;

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -45,7 +45,7 @@ describes.fakeWin(
           const anchor = helpers.createAnchor(initialUrl);
           const replacementUrl = setNull
             ? null
-            : `https://goredirectingat.com/url=${initialUrl}`;
+            : `https://goredirectingat.com/?url=${initialUrl}`;
 
           return {anchor, replacementUrl};
         };

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -26,7 +26,6 @@ import {
   XCUST_ATTRIBUTE_NAME,
 } from '../constants';
 
-
 describes.fakeWin(
     'test-tracking',
     {
@@ -353,9 +352,7 @@ describes.fakeWin(
 
           expect(trackingData.hae).to.equal(1);
         });
-
       });
-
 
       describe('sendNaClickTracking', () => {
         it('Should send non-affiliate click tracking', () => {

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -44,7 +44,7 @@ describes.fakeWin(
           const anchor = helpers.createAnchor(initialUrl);
           const replacementUrl = setNull
             ? null
-            : `https://goredirectingat.com/?url=${initialUrl}`;
+            : `https://go.redirectingat.com/?url=${initialUrl}`;
 
           return {anchor, replacementUrl};
         };

--- a/extensions/amp-skimlinks/0.1/tracking.js
+++ b/extensions/amp-skimlinks/0.1/tracking.js
@@ -206,6 +206,11 @@ export class Tracking {
    * @private
    */
   sendLinkImpressionTracking_(commonData, numberAffiliateLinks, urls) {
+    if (numberAffiliateLinks === 0) {
+      // Nothing to send.
+      return;
+    }
+
     const data = /** @type {!JsonObject} */ (Object.assign(
         dict({
           'dl': urls,


### PR DESCRIPTION
Business logic change:

The links impression analytics request used to send all the links found on the page. We are now only sending the links that can be affiliated in order to reduce the request payload.
If no affiliate links are found on the page, we can now completely avoid sending the links impression request.