### PR TITLE
🐛amp-consent: Fixed URL Bar resizing for CMP Iframe modal

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Styling for the amp-consent
+ * component. This also has a lot of specific
+ * styling for the CMP Modal. Note: this does
+ * specifc percentage vs. viewport based css
+ * for the heights and tranforms of the CMP modal,
+ * to handle URL and Safari Navigation bar transitions.
+ * Please refer to the following, before changing
+ * the viewport or percentage based heights,
+ * to avoid unintentionally breaking the intended
+ * behavior.
+ *
+ * https://developers.google.com/web/updates/2016/12/url-bar-resizing
+ *
+ */
+
 amp-consent {
   /* Fixed to make position independent of page other elements. */
   position: fixed;
@@ -81,13 +97,7 @@ iframe.i-amphtml-consent-ui-fill {
   border: none;
 }
 
-/**
- * CMP Modal class appolied when asking for CMP consent.
- * See: https://developers.google.com/web/updates/2016/12/url-bar-resizing
- * For the reasoning of mixing percentages with viewport units
- */
 amp-consent.i-amphtml-consent-ui-iframe-active {
-  position: fixed !important;
   width: 100vw !important;
   height: 100vh !important;
   padding: 0px !important;

--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -81,7 +81,13 @@ iframe.i-amphtml-consent-ui-fill {
   border: none;
 }
 
+/**
+ * CMP Modal class appolied when asking for CMP consent.
+ * See: https://developers.google.com/web/updates/2016/12/url-bar-resizing
+ * For the reasoning of mixing percentages with viewport units
+ */
 amp-consent.i-amphtml-consent-ui-iframe-active {
+  position: fixed !important;
   width: 100vw !important;
   height: 100vh !important;
   padding: 0px !important;
@@ -91,7 +97,7 @@ amp-consent.i-amphtml-consent-ui-iframe-active {
   border-top-right-radius: 8px !important;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
 
-  transform: translate3d(0px, 100%, 0px) !important;
+  transform: translate3d(0px, 100vh, 0px) !important;
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
@@ -100,11 +106,12 @@ amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen {
-  transform: translate3d(0px, calc(100% - 100vh), 0px) !important;
+  top: 0px !important;
+  transform: translate3d(0px, 0px, 0px) !important;
 }
 
 amp-consent.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen > .i-amphtml-consent-ui-fill {
-  height: 100vh !important;
+  height: 100% !important;
 }
 
 @keyframes i-amphtml-consent-ui-mask {

--- a/test/manual/amp-consent-cmp.html
+++ b/test/manual/amp-consent-cmp.html
@@ -358,6 +358,12 @@
   <footer>
     <div class="brand-logo">PublisherLogo</div>
   </footer>
+
+  <script>
+    setTimeout(() => {
+      AMP.toggleExperiment('amp-consent-v2', true);
+    }, 500);
+  </script>
 </body>
 
 </html>

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -24,6 +24,7 @@ body {
 
 .bttn-primary {
   margin-right: 10px;
+  cursor: pointer;
 }
 
 .decision-text {


### PR DESCRIPTION
closes #19969

This fixes [URL Bar Resizing](https://developers.google.com/web/updates/2016/12/url-bar-resizing) for both Mobile Safari and Mobile Chrome for the amp consent modal. In the sense that, the element is not cut off by any of the url/nav bars, and transitions smoothly along with them. 

This also includes some small changes to the example, to make mobile testing easier, and [fix the `diy-consent` buttons on mobile safari](https://stackoverflow.com/questions/14795944/jquery-click-events-not-working-in-ios).

# Note

We should document for the full screen case that the safari nav bar can cover the bottom of their content, thus, we should advise them to leave some padding. Our only other option (I could find), was the make the `height: 100%`, but this will not transition smoothly, and gives a bad UX in my opinion.

# GIfs

## Before

![consentmobilebarsbefore](https://user-images.githubusercontent.com/1448289/50530014-92809b80-0aae-11e9-8de3-3d810df6c3a8.gif)

## After

![consentmobilebarsafter](https://user-images.githubusercontent.com/1448289/50530017-990f1300-0aae-11e9-98af-db41cde97b4a.gif)

