### PR TITLE
Stop amp-sidebar from forwarding hotkeys to viewer

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -158,6 +158,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
       if (event.key == Keys.ESCAPE) {
+        event.preventDefault();
         this.close_();
       }
     });


### PR DESCRIPTION
The keyboard event handler in the AMP viewer extension stops forwarding
keyboard events to the viewer if the event is marked as "default
prevented". For hotkeys used by amp-sidebar (i.e., the ESC key), since
they are already consumed by the AMP component they should not be
forwarded to the viewer. This prevents double-triggering a keyboard
shortcut on the viewer side.

For more background, see #18437.

`b/117567983`

/to @choumx 