### PR TITLE
✨amp-ima-video: Show Controls on Hover

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -59,10 +59,6 @@ const icons = {
 
 /*eslint-enable */
 
-// Throttle for the showControls() function
-// Timeout is 1s, because showControls will hide after 3s
-const showControlsThrottled = throttle(window, showControls, 1000);
-
 const bigPlayDivDisplayStyle = 'table-cell';
 
 // Div wrapping our entire DOM.
@@ -220,6 +216,9 @@ let userTappedAndDragged;
 
 // User consent state.
 let consentState;
+
+// Throttle for the showControls() function
+let showControlsThrottled = throttle(window, showControls, 1000);
 
 /**
  * @param {!Object} global
@@ -491,6 +490,9 @@ export function imaVideo(global, data) {
   muteUnmuteDiv.addEventListener(interactEvent, onMuteUnmuteClick);
   fullscreenDiv.addEventListener(interactEvent,
       toggleFullscreen.bind(null, global));
+
+  // Timeout is 1s, because showControls will hide after 3s
+  showControlsThrottled = throttle(window, showControls, 1000);
 
   const fullScreenEvents = [
     'fullscreenchange',
@@ -1459,6 +1461,7 @@ export function getPropertiesForTesting() {
     bigPlayDiv,
     contentComplete,
     controlsDiv,
+    controlsVisible,
     hideControlsTimeout,
     imaLoadAllowed,
     interactEvent,
@@ -1472,6 +1475,15 @@ export function getPropertiesForTesting() {
     uiTicker,
     videoPlayer,
   };
+}
+
+/**
+ * Gets the throttled show controls
+ * @return {Function}
+ * @visibleForTesting
+ */
+export function getShowControlsThrottledForTesting() {
+  return showControlsThrottled;
 }
 
 /**

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -607,7 +607,7 @@ function onImaLoadSuccess(global, data) {
 function onImaLoadFail() {
   // Something blocked ima3.js from loading - ignore all IMA stuff and just play
   // content.
-  addHoverEventToElement(videoPlayer, showControls);
+  addHoverEventToElement(/** @type !Element*/(videoPlayer), showControls);
   imaLoadAllowed = false;
   postMessage({event: VideoEvents.LOAD});
 }
@@ -814,7 +814,7 @@ export function onAdsLoaderError() {
   // failing to load an ad is just as good as loading one as far as starting
   // playback is concerned because our content will be ready to play.
   postMessage({event: VideoEvents.LOAD});
-  addHoverEventToElement(videoPlayer, showControls);
+  addHoverEventToElement(/** @type !Element*/(videoPlayer), showControls);
   if (playbackStarted) {
     playVideo();
   }
@@ -831,7 +831,7 @@ export function onAdError() {
   if (adsManager) {
     adsManager.destroy();
   }
-  addHoverEventToElement(videoPlayer, showControls);
+  addHoverEventToElement(/** @type !Element*/(videoPlayer), showControls);
   playVideo();
 }
 
@@ -878,7 +878,7 @@ export function onContentPauseRequested(global) {
   }
   adsActive = true;
   postMessage({event: VideoEvents.AD_START});
-  removeHoverEventFromElement(videoPlayer, showControls);
+  removeHoverEventFromElement(/** @type !Element*/(videoPlayer), showControls);
   setStyle(adContainerDiv, 'display', 'block');
   videoPlayer.removeEventListener('ended', onContentEnded);
   showAdControls();
@@ -892,7 +892,7 @@ export function onContentPauseRequested(global) {
  */
 export function onContentResumeRequested() {
   adsActive = false;
-  addHoverEventToElement(videoPlayer, showControls);
+  addHoverEventToElement(/** @type !Element*/(videoPlayer), showControls);
   postMessage({event: VideoEvents.AD_END});
   resetControlsAfterAd();
   if (!contentComplete) {

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -150,6 +150,7 @@ exports.rules = [
       'ads/**->src/utils/base64.js',
       'ads/**->src/utils/dom-fingerprint.js',
       'ads/**->src/utils/object.js',
+      'ads/**->src/utils/rate-limit.js',
       'ads/**->src/log.js',
       'ads/**->src/mode.js',
       'ads/**->src/url.js',

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -1122,6 +1122,41 @@ describes.realWin('amp-ima-video', {
         .to.eql('none');
   });
 
+  it('shows controls on hover while playing after hidden', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+
+    imaVideoObj.imaVideo(win, {
+      width: 640,
+      height: 360,
+      src: srcUrl,
+      tag: adTagUrl,
+    });
+
+    imaVideoObj.hideControls();
+
+    expect(imaVideoObj.getPropertiesForTesting().controlsDiv.style.display)
+        .to.eql('none');
+
+    const clickEvent = new Event('click');
+    const videoPlayerElement = imaVideoObj
+        .getPropertiesForTesting().videoPlayer;
+
+    imaVideoObj.setPlayerStateForTesting(
+        imaVideoObj.getPropertiesForTesting().PlayerStates.PLAYING);
+    imaVideoObj.addHoverEventToElement(
+        videoPlayerElement,
+        imaVideoObj.showControls
+    );
+    videoPlayerElement.dispatchEvent(clickEvent);
+
+    expect(imaVideoObj.getPropertiesForTesting().controlsDiv.style.display)
+        .to.eql('flex');
+    expect(imaVideoObj.getPropertiesForTesting().hideControlsTimeout)
+        .not.to.be.undefined;
+  });
+
   it('suppresses IMA load with unknown consent', () => {
     const div = doc.createElement('div');
     div.setAttribute('id', 'c');


### PR DESCRIPTION
relates to #19393

This enables showing ima-video controls on hover, instead of onclick. This also makes sure to work on mobile devices to preserve the tap to show controls behavior, as it is in amp-video.

From a UX perspective, got an approval by @spacedino to make `amp-ima-video` to match the behavior of [`amp-video`](https://ampbyexample.com/components/amp-video/) as much as possible, and this PR falls inline with that 😄.

cc @curseagain 

# Example

## Desktop

![imavideohover](https://user-images.githubusercontent.com/1448289/50613619-eb777780-0e92-11e9-98a1-9720033d322e.gif)


## Mobile

![imavideomobile](https://user-images.githubusercontent.com/1448289/50613632-f500df80-0e92-11e9-881f-ba6a5b33e365.gif)

