### PR TITLE
🏗 Refactor git merge base functions

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -25,18 +25,20 @@ const {getStdout} = require('./exec');
 const commitLogMaxCount = 100;
 
 /**
- * Returns the branch point of the current branch off of master.
+ * Returns the merge base of the current branch off of master when running on
+ * a local workspace.
  * @return {string}
  */
-exports.gitBranchPointFromMaster = function() {
+exports.gitMergeBaseLocalMaster = function() {
   return getStdout('git merge-base master HEAD').trim();
 };
 
 /**
- * Returns the point at which the PR branch was forked from master. Used during
- * Travis PR builds to print the range of commits included in a PR check.
+ * Returns the merge base at which the PR branch was forked from master when
+ * running on Travis.
+ * @return {string}
  */
-exports.gitPrBranchPoint = function() {
+exports.gitMergeBaseTravisMaster = function() {
   const commitRange = process.env.TRAVIS_COMMIT_RANGE.split('...');
   return getStdout(`git merge-base ${commitRange[0]} ${commitRange[1]}`).trim();
 };
@@ -47,7 +49,7 @@ exports.gitPrBranchPoint = function() {
  * @return {!Array<string>}
  */
 exports.gitDiffNameOnlyMaster = function() {
-  const branchPoint = exports.gitBranchPointFromMaster();
+  const branchPoint = exports.gitMergeBaseLocalMaster();
   return getStdout(`git diff --name-only ${branchPoint}`).trim().split('\n');
 };
 
@@ -57,7 +59,7 @@ exports.gitDiffNameOnlyMaster = function() {
  * @return {string}
  */
 exports.gitDiffStatMaster = function() {
-  const branchPoint = exports.gitBranchPointFromMaster();
+  const branchPoint = exports.gitMergeBaseLocalMaster();
   return getStdout(`git -c color.ui=always diff --stat ${branchPoint}`);
 };
 
@@ -70,7 +72,7 @@ exports.gitDiffStatMaster = function() {
  */
 exports.gitDiffCommitLog = function() {
   const branchPoint = process.env.TRAVIS ?
-    exports.gitPrBranchPoint() : exports.gitBranchPointFromMaster();
+    exports.gitMergeBaseTravisMaster() : exports.gitMergeBaseLocalMaster();
   let commitLog = getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
 -%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
@@ -94,7 +96,7 @@ for how to fix this.`;
  * @return {!Array<string>}
  */
 exports.gitDiffAddedNameOnlyMaster = function() {
-  const branchPoint = exports.gitBranchPointFromMaster();
+  const branchPoint = exports.gitMergeBaseLocalMaster();
   return getStdout(`git diff --name-only --diff-filter=ARC ${branchPoint}`)
       .trim().split('\n');
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -44,6 +44,15 @@ exports.gitMergeBaseTravisMaster = function() {
 };
 
 /**
+ * Returns the merge vase of the current branch off of master, regardless of
+ * the running environment.
+ */
+exports.gitMergeBaseMaster = function() {
+  return process.env.TRAVIS ?
+    exports.gitMergeBaseTravisMaster() : exports.gitMergeBaseLocalMaster();
+};
+
+/**
  * Returns the list of files changed on the local branch relative to the branch
  * point off of master, one on each line.
  * @return {!Array<string>}
@@ -71,8 +80,7 @@ exports.gitDiffStatMaster = function() {
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
-  const branchPoint = process.env.TRAVIS ?
-    exports.gitMergeBaseTravisMaster() : exports.gitMergeBaseLocalMaster();
+  const branchPoint = exports.gitMergeBaseMaster();
   let commitLog = getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
 -%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -32,12 +32,12 @@ const minimatch = require('minimatch');
 const path = require('path');
 const {
   gitBranchName,
-  gitBranchPointFromMaster,
   gitDiffColor,
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
-  gitPrBranchPoint,
+  gitMergeBaseLocalMaster,
+  gitMergeBaseTravisMaster,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
 
@@ -105,7 +105,7 @@ function printChangeSummary() {
   console.log(filesChanged);
 
   const branchPoint = process.env.TRAVIS ?
-    gitPrBranchPoint() : gitBranchPointFromMaster();
+    gitMergeBaseTravisMaster() : gitMergeBaseLocalMaster();
   console.log(fileLogPrefix, 'Commit log since branch',
       colors.cyan(gitBranchName()), 'was forked from',
       colors.cyan('master'), 'at', colors.cyan(branchPoint) + ':');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,8 +36,7 @@ const {
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
-  gitMergeBaseLocalMaster,
-  gitMergeBaseTravisMaster,
+  gitMergeBaseMaster,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
 
@@ -104,8 +103,7 @@ function printChangeSummary() {
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(filesChanged);
 
-  const branchPoint = process.env.TRAVIS ?
-    gitMergeBaseTravisMaster() : gitMergeBaseLocalMaster();
+  const branchPoint = gitMergeBaseMaster();
   console.log(fileLogPrefix, 'Commit log since branch',
       colors.cyan(gitBranchName()), 'was forked from',
       colors.cyan('master'), 'at', colors.cyan(branchPoint) + ':');

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitCommitHash, gitMergeBaseLocalMaster} = require('../git');
+const {gitCommitHash, gitMergeBaseMaster} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -108,7 +108,7 @@ function isPullRequest() {
  * @return {string} the `master` ancestor's bundle size.
  */
 async function getAncestorBundleSize() {
-  const gitBranchPointSha = gitMergeBaseLocalMaster();
+  const gitBranchPointSha = gitMergeBaseMaster();
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
   return await octokit.repos.getContents(

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -26,7 +26,7 @@ const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
 const {getStdout} = require('../exec');
-const {gitBranchPointFromMaster, gitCommitHash} = require('../git');
+const {gitCommitHash, gitMergeBaseLocalMaster} = require('../git');
 
 const runtimeFile = './dist/v0.js';
 
@@ -108,7 +108,7 @@ function isPullRequest() {
  * @return {string} the `master` ancestor's bundle size.
  */
 async function getAncestorBundleSize() {
-  const gitBranchPointSha = gitBranchPointFromMaster();
+  const gitBranchPointSha = gitMergeBaseLocalMaster();
   const gitBranchPointShortSha = gitBranchPointSha.substring(0, 7);
   log('Branch point from master is', cyan(gitBranchPointShortSha));
   return await octokit.repos.getContents(

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -27,8 +27,8 @@ const sleep = require('sleep-promise');
 const tryConnect = require('try-net-connect');
 const {
   gitBranchName,
-  gitBranchPointFromMaster,
   gitCommitterEmail,
+  gitMergeBaseLocalMaster,
 } = require('../../git');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {log, verifyCssElements} = require('./helpers');
@@ -100,7 +100,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitBranchPointFromMaster();
+    process.env['PERCY_TARGET_COMMIT'] = gitMergeBaseLocalMaster();
   }
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -28,7 +28,7 @@ const tryConnect = require('try-net-connect');
 const {
   gitBranchName,
   gitCommitterEmail,
-  gitMergeBaseLocalMaster,
+  gitMergeBaseTravisMaster,
 } = require('../../git');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {log, verifyCssElements} = require('./helpers');
@@ -100,7 +100,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (process.env.TRAVIS && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitMergeBaseLocalMaster();
+    process.env['PERCY_TARGET_COMMIT'] = gitMergeBaseTravisMaster();
   }
 }
 


### PR DESCRIPTION
Clarify the names of these functions, add a function to replace multiple `process.env.TRAVIS ? ... : ...` checks, and correct a call to the local instead of Travis function in `visual-diff/index.js` (now that the names are more clear the misuse was obvious)