### PR TITLE
Report the SHA of the base (merged `master`) commit in bundle-size checks

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -328,6 +328,7 @@ async function skipBundleSize() {
  */
 async function reportBundleSize() {
   if (isPullRequest()) {
+    const baseSha = gitMergeBaseMaster();
     const bundleSize = parseFloat(getGzippedBundleSize());
     const commitHash = gitCommitHash();
     try {
@@ -336,6 +337,7 @@ async function reportBundleSize() {
             path.join('commit', commitHash, 'report')),
         json: true,
         body: {
+          baseSha,
           bundleSize,
         },
       });


### PR DESCRIPTION
Related to #20151, fixes the issue where the bundle-size is claimed to increase for PRs that are branched off from older `master` commits

See https://github.com/ampproject/amp-github-apps/pull/40 for the related change in the bundle-size GitHub App. This PR needs to be merged before the GitHub App's PR.