### PR TITLE
♻️Reference the Event object from the gesture.event property

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -398,52 +398,56 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @private */
   setupGestures_() {
-    // TODO (#12881): this and the subsequent use of event.preventDefault
-    // is a temporary solution to #12362. We should revisit this problem after
-    // resolving #12881 or change the use of window.event to the specific event
-    // triggering the gesture.
     this.gestures_ = Gestures.get(
         this.element,
         /* opt_shouldNotPreventDefault */true
     );
 
-    this.gestures_.onPointerDown(() => {
+    this.gestures_.onPointerDown(gesture => {
       if (this.motion_) {
         this.motion_.halt();
-        // eslint-disable-next-line no-restricted-globals
-        event.preventDefault();
+        gesture.event.preventDefault();
       }
     });
 
     // Zoomable.
-    this.gestures_.onGesture(DoubletapRecognizer, e => {
-      // eslint-disable-next-line no-restricted-globals
+    this.gestures_.onGesture(DoubletapRecognizer, gesture => {
+      const {
+        data,
+        event,
+      } = gesture;
       event.preventDefault();
       const newScale = this.scale_ == 1 ? this.maxScale_ : this.minScale_;
-      const deltaX = (this.elementBox_.width / 2) - e.data.clientX;
-      const deltaY = (this.elementBox_.height / 2) - e.data.clientY;
+      const deltaX = (this.elementBox_.width / 2) - data.clientX;
+      const deltaY = (this.elementBox_.height / 2) - data.clientY;
       this.onZoom_(newScale, deltaX, deltaY, true).then(() => {
         return this.onZoomRelease_();
       });
     });
 
-    this.gestures_.onGesture(TapzoomRecognizer, e => {
-      // eslint-disable-next-line no-restricted-globals
+    this.gestures_.onGesture(TapzoomRecognizer, gesture => {
+      const {
+        data,
+        event,
+      } = gesture;
       event.preventDefault();
-      this.onTapZoom_(e.data.centerClientX, e.data.centerClientY,
-          e.data.deltaX, e.data.deltaY);
-      if (e.data.last) {
-        this.onTapZoomRelease_(e.data.centerClientX, e.data.centerClientY,
-            e.data.deltaX, e.data.deltaY, e.data.velocityY, e.data.velocityY);
+      this.onTapZoom_(data.centerClientX, data.centerClientY,
+          data.deltaX, data.deltaY);
+      if (data.last) {
+        this.onTapZoomRelease_(data.centerClientX, data.centerClientY,
+            data.deltaX, data.deltaY, data.velocityY, data.velocityY);
       }
     });
 
-    this.gestures_.onGesture(PinchRecognizer, e => {
-      // eslint-disable-next-line no-restricted-globals
+    this.gestures_.onGesture(PinchRecognizer, gesture => {
+      const {
+        data,
+        event,
+      } = gesture;
       event.preventDefault();
-      this.onPinchZoom_(e.data.centerClientX, e.data.centerClientY,
-          e.data.deltaX, e.data.deltaY, e.data.dir);
-      if (e.data.last) {
+      this.onPinchZoom_(data.centerClientX, data.centerClientY,
+          data.deltaX, data.deltaY, data.dir);
+      if (data.last) {
         this.onZoomRelease_();
       }
     });
@@ -456,12 +460,15 @@ export class AmpImageViewer extends AMP.BaseElement {
   registerPanningGesture_() {
     // Movable.
     this.unlistenOnSwipePan_ = this.gestures_
-        .onGesture(SwipeXYRecognizer, e => {
-          // eslint-disable-next-line no-restricted-globals
+        .onGesture(SwipeXYRecognizer, gesture => {
+          const {
+            data,
+            event,
+          } = gesture;
           event.preventDefault();
-          this.onMove_(e.data.deltaX, e.data.deltaY, false);
-          if (e.data.last) {
-            this.onMoveRelease_(e.data.velocityX, e.data.velocityY);
+          this.onMove_(data.deltaX, data.deltaY, false);
+          if (data.last) {
+            this.onMoveRelease_(data.velocityX, data.velocityY);
           }
         });
   }


### PR DESCRIPTION
Follow up to #20137.

Since `window.event == gesture.event` in these callbacks, this should cause no changes to the behavior.

The issues #12362 and #12881 in the deleted TODO comment have already been closed, so it should be safe to delete the comment.
