### PR TITLE
Enable consent setting and pass setting to iframe

### DIFF
--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -190,7 +190,7 @@
             "promptUI": "ui1"
           }
         },
-        "setting": {
+        "clientConfig": {
           "mytest": "test",
           "anothertest": "test2"
         },

--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -190,6 +190,10 @@
             "promptUI": "ui1"
           }
         },
+        "setting": {
+          "mytest": "test",
+          "anothertest": "test2"
+        },
         "policy": {
           "default": {
             "waitFor": {

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -31,7 +31,7 @@ import {
   getSourceUrl,
   resolveRelativeUrl,
 } from '../../../src/url';
-import {dev, user, userAssert} from '../../../src/log';
+import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -471,8 +471,8 @@ export class AmpConsent extends AMP.BaseElement {
       const request = /** @type {!JsonObject} */ ({
         'consentInstanceId': this.consentId_,
       });
-      if (this.consentConfig_['setting']) {
-        request['setting'] = this.consentConfig_['setting'];
+      if (this.consentConfig_['clientConfig']) {
+        request['clientConfig'] = this.consentConfig_['clientConfig'];
       }
       const init = {
         credentials: 'include',

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -60,8 +60,8 @@ export class ConsentConfig {
       config['postPromptUI'] = this.getConfig_()['postPromptUI'];
     }
 
-    if (this.getConfig_()['setting']) {
-      config['setting'] = this.getConfig_()['setting'];
+    if (this.getConfig_()['clientConfig']) {
+      config['clientConfig'] = this.getConfig_()['clientConfig'];
     }
 
     return config;

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -39,11 +39,32 @@ export class ConsentConfig {
   }
 
   /**
-   * Return the consents config
+   * Read the config and return the formatted consent config
    * @return {!JsonObject}
    */
   getConsentConfig() {
-    return this.getConfig_()['consents'];
+    const id = Object.keys(this.getConfig_()['consents'])[0];
+    const consentConfig = this.getConfig_()['consents'][id];
+
+    const config = dict({
+      'storageKey': id,
+    });
+
+    // TODO(zhouyx@): Assert validness.
+    const keys = Object.keys(consentConfig);
+    for (let i = 0; i < keys.length; i++) {
+      config[keys[i]] = consentConfig[keys[i]];
+    }
+
+    if (this.getConfig_()['postPromptUI']) {
+      config['postPromptUI'] = this.getConfig_()['postPromptUI'];
+    }
+
+    if (this.getConfig_()['setting']) {
+      config['setting'] = this.getConfig_()['setting'];
+    }
+
+    return config;
   }
 
   /**
@@ -52,14 +73,6 @@ export class ConsentConfig {
    */
   getPolicyConfig() {
     return this.getConfig_()['policy'] || dict({});
-  }
-
-  /**
-   * Return the postPromptUI config
-   * @return {string|undefined}
-   */
-  getPostPromptUI() {
-    return this.getConfig_()['postPromptUI'];
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -20,6 +20,7 @@ import {
   assertHttpsUrl,
 } from '../../../src/url';
 import {dev, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {
   elementByTag,
   insertAfterOrAtStart,
@@ -94,6 +95,9 @@ export class ConsentUI {
     /** @private {?Deferred} */
     this.iframeReady_ = null;
 
+    /** @private {?JsonObject} */
+    this.inlineSetting_ = null;
+
     /** @private {?Element} */
     this.placeholder_ = null;
 
@@ -135,6 +139,7 @@ export class ConsentUI {
       this.ui_ =
           this.createPromptIframeFromSrc_(promptUISrc);
       this.placeholder_ = this.createPlaceholder_();
+      this.inlineSetting_ = config['setting'] || null;
     }
   }
 
@@ -286,6 +291,13 @@ export class ConsentUI {
    * @return {!Promise}
    */
   loadIframe_() {
+    const info = dict({});
+    if (this.inlineSetting_) {
+      info['setting'] = this.inlineSetting_;
+    }
+
+    this.ui_.setAttribute('name', JSON.stringify(info));
+
     this.iframeReady_ = new Deferred();
     const {classList} = this.parent_;
     if (!elementByTag(this.parent_, 'placeholder')) {
@@ -358,6 +370,7 @@ export class ConsentUI {
     this.isFullscreen_ = false;
     classList.remove(consentUiClasses.in);
     this.isIframeVisible_ = false;
+    this.ui_.removeAttribute('name');
     removeElement(dev().assertElement(this.ui_));
 
     // TODO (torch2424): Hide mask if publisher provides the option

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -96,7 +96,7 @@ export class ConsentUI {
     this.iframeReady_ = null;
 
     /** @private {?JsonObject} */
-    this.inlineSetting_ = null;
+    this.clientConfig_ = null;
 
     /** @private {?Element} */
     this.placeholder_ = null;
@@ -139,7 +139,7 @@ export class ConsentUI {
       this.ui_ =
           this.createPromptIframeFromSrc_(promptUISrc);
       this.placeholder_ = this.createPlaceholder_();
-      this.inlineSetting_ = config['setting'] || null;
+      this.clientConfig_ = config['clientConfig'] || null;
     }
   }
 
@@ -292,8 +292,8 @@ export class ConsentUI {
    */
   loadIframe_() {
     const info = dict({});
-    if (this.inlineSetting_) {
-      info['setting'] = this.inlineSetting_;
+    if (this.clientConfig_) {
+      info['clientConfig'] = this.clientConfig_;
     }
 
     this.ui_.setAttribute('name', JSON.stringify(info));

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -104,6 +104,9 @@ describes.realWin('amp-consent', {
               'checkConsentHref': '/override',
             },
           },
+          'setting': {
+            'test': 'ABC',
+          },
           'postPromptUI': 'test',
         }));
         const postPromptUI = document.createElement('div');
@@ -116,7 +119,12 @@ describes.realWin('amp-consent', {
         expect(ampConsent.postPromptUI_).to.not.be.null;
         expect(ampConsent.consentId_).to.equal('test');
         expect(ampConsent.consentConfig_).to.deep.equal(dict({
+          'storageKey': 'test',
           'checkConsentHref': '/override',
+          'postPromptUI': 'test',
+          'setting': {
+            'test': 'ABC',
+          },
         }));
 
         expect(Object.keys(ampConsent.policyConfig_)).to.have.length(4);

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -104,7 +104,7 @@ describes.realWin('amp-consent', {
               'checkConsentHref': '/override',
             },
           },
-          'setting': {
+          'clientConfig': {
             'test': 'ABC',
           },
           'postPromptUI': 'test',
@@ -122,7 +122,7 @@ describes.realWin('amp-consent', {
           'storageKey': 'test',
           'checkConsentHref': '/override',
           'postPromptUI': 'test',
-          'setting': {
+          'clientConfig': {
             'test': 'ABC',
           },
         }));

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -51,12 +51,10 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
       appendConfigScriptElement(doc, element, defaultConfig);
       const consentConfig = new ConsentConfig(element);
       expect(consentConfig.getConsentConfig()).to.deep.equal(dict({
-        'ABC': {
-          'checkConsentHref': 'https://response1',
-        },
+        'storageKey': 'ABC',
+        'checkConsentHref': 'https://response1',
       }));
       expect(consentConfig.getPolicyConfig()).to.deep.equal(dict({}));
-      expect(consentConfig.getPostPromptUI()).to.not.be.ok;
     });
 
     it('read cmp config', () => {
@@ -64,14 +62,12 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
       element.setAttribute('type', '_ping_');
       const consentConfig = new ConsentConfig(element);
       expect(consentConfig.getConsentConfig()).to.deep.equal(dict({
-        '_ping_': {
-          'checkConsentHref': '/get-consent-v1',
-          'promptUISrc':
-              '/test/manual/diy-consent.html',
-        },
+        'storageKey': '_ping_',
+        'checkConsentHref': '/get-consent-v1',
+        'promptUISrc':
+            '/test/manual/diy-consent.html',
       }));
       expect(consentConfig.getPolicyConfig()).to.deep.equal(dict({}));
-      expect(consentConfig.getPostPromptUI()).to.not.be.ok;
     });
 
     it('merge inline config w/ cmp config', () => {
@@ -81,6 +77,9 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
             'promptIfUnknownForGeoGroup': 'eea',
             'checkConsentHref': '/override',
           },
+        },
+        'setting': {
+          'testSetting': 'ABC',
         },
         'policy': {
           'default': {
@@ -92,11 +91,14 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
       element.setAttribute('type', '_ping_');
       const consentConfig = new ConsentConfig(element);
       expect(consentConfig.getConsentConfig()).to.deep.equal(dict({
-        '_ping_': {
-          'checkConsentHref': '/override',
-          'promptUISrc':
-              '/test/manual/diy-consent.html',
-          'promptIfUnknownForGeoGroup': 'eea',
+        'storageKey': '_ping_',
+        'checkConsentHref': '/override',
+        'promptUISrc':
+            '/test/manual/diy-consent.html',
+        'promptIfUnknownForGeoGroup': 'eea',
+        'postPromptUI': 'test',
+        'setting': {
+          'testSetting': 'ABC',
         },
       }));
       expect(consentConfig.getPolicyConfig()).to.deep.equal(dict({
@@ -104,7 +106,6 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
           'waitFor': {},
         },
       }));
-      expect(consentConfig.getPostPromptUI()).to.equal('test');
     });
 
     it('assert valid config', () => {

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -78,8 +78,8 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
             'checkConsentHref': '/override',
           },
         },
-        'setting': {
-          'testSetting': 'ABC',
+        'clientConfig': {
+          'test': 'ABC',
         },
         'policy': {
           'default': {
@@ -97,8 +97,8 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
             '/test/manual/diy-consent.html',
         'promptIfUnknownForGeoGroup': 'eea',
         'postPromptUI': 'test',
-        'setting': {
-          'testSetting': 'ABC',
+        'clientConfig': {
+          'test': 'ABC',
         },
       }));
       expect(consentConfig.getPolicyConfig()).to.deep.equal(dict({

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -229,7 +229,7 @@ describes.realWin('consent-ui', {
     it('should pass the info to the iframe', function* () {
       const config = dict({
         'promptUISrc': 'https//promptUISrc',
-        'setting': {
+        'clientConfig': {
           'test': 'ABC',
         },
       });
@@ -238,7 +238,7 @@ describes.realWin('consent-ui', {
       yield macroTask();
 
       expect(consentUI.ui_.getAttribute('name')).to.deep.equal(JSON.stringify({
-        'setting': {
+        'clientConfig': {
           'test': 'ABC',
         },
       }));

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -225,6 +225,24 @@ describes.realWin('consent-ui', {
         ).to.be.true;
       });
     });
+
+    it('should pass the info to the iframe', function* () {
+      const config = dict({
+        'promptUISrc': 'https//promptUISrc',
+        'setting': {
+          'test': 'ABC',
+        },
+      });
+      consentUI = new ConsentUI(mockInstance, config);
+      consentUI.show();
+      yield macroTask();
+
+      expect(consentUI.ui_.getAttribute('name')).to.deep.equal(JSON.stringify({
+        'setting': {
+          'test': 'ABC',
+        },
+      }));
+    });
   });
 
   describe('fullscreen', () => {

--- a/test/manual/amp-consent-cmp.html
+++ b/test/manual/amp-consent-cmp.html
@@ -239,7 +239,11 @@
       <script type="application/json">
         {
         "consents": {},
-        "postPromptUI": "postPromptUI"
+        "postPromptUI": "postPromptUI",
+        "setting": {
+          "CMP_id": "asdf",
+          "other_info": "ahhhh"
+        }
       }
       </script>
       <div id="ui1">

--- a/test/manual/amp-consent-cmp.html
+++ b/test/manual/amp-consent-cmp.html
@@ -240,7 +240,7 @@
         {
         "consents": {},
         "postPromptUI": "postPromptUI",
-        "setting": {
+        "clientConfig": {
           "CMP_id": "asdf",
           "other_info": "ahhhh"
         }


### PR DESCRIPTION
Configuration looks like 
```
{
  'storageKey': ...
  'checkConsentHref': ...
  'setting': ...
  'promptUI': ...
  'postPromptUI': ...
}
```

Old config
```
{
   'storageKey': {
     'checkConsentHref': 
     'promptUI':
   }
   'setting': ...
   'postPromptUI': ...
}
   
```

The newly introduced setting object will be appended to checkConsentHref request body, and the created iframe name attribute. 

The new config format is not supported yet, this PR only converts existing format to the new format. I'll have a following PR to support new format. And please give advice on naming : )