### PR TITLE
[WIP] Loader should not be target of click events

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -502,6 +502,7 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
 
 .i-amphtml-loading-container {
   display: block !important;
+  pointer-events: none;
   z-index: 1;
 }
 


### PR DESCRIPTION
There are instances when the loader overlays links that are actionable that the user can't invoke when the loader is visible. This is not desired.

b121193751

