### PR TITLE
✨amp-recaptcha-input: Created an End-to-End Firebase Friendly Example With Glitch

### DIFF
--- a/examples/recaptcha.amp.html
+++ b/examples/recaptcha.amp.html
@@ -15,6 +15,16 @@
           min-height: 2500px;
         }
 
+        body {
+          width: 100%;
+          max-width: 900px;
+          padding: 10px;
+        }
+
+        .recaptcha-get-value {
+          width: 100%;
+        }
+
         #recaptcha-lightbox {
           background-color: rgba(0,0,0,0.5);
         }
@@ -28,8 +38,15 @@
           margin-right: auto;
         }
 
-        .push-down {
+        div.push-down {
           margin-top: 4000px;
+        }
+
+        .form-container {
+          border: 1px solid black;
+          padding: 5px;
+          margin-top: 50px;
+          margin-bottom: 50px;
         }
 
         form.amp-form-submit-success [submit-success],
@@ -88,11 +105,67 @@
       You can paste the following into a dev tools console to run the amp-recaptcha-input getValue().
       <br />
       <br />
-      document.querySelector('amp-recaptcha-input').implementation_.getValue().then(token =&gt; {console.log('Got Token!');console.log(token);})
+      <input class="recaptcha-get-value"
+        readonly
+        value="document.querySelector('amp-recaptcha-input').implementation_.getValue().then(token =&gt; {console.log('Got Token!');console.log(token);})">
+      </input>
     </p>
 
+
+    <!-- Live / Glitch Example -->
+    <div class="form-container">
+      <h2>amp-recaptcha-input Live / Glitch Example</h2>
+      <div><a href="https://glitch.com/edit/#!/torch2424-amp-glitch-express" target="_blank">Example Server Glitch Project</a></div>
+
+      <!-- Non xhr -->
+      <h4>Search (POST cross origin - current host > https://torch2424-amp-glitch-express.glitch.me/api/recaptcha)</h4>
+      <form
+        method="post"
+        action-xhr="https://torch2424-amp-glitch-express.glitch.me/api/recaptcha"
+        target="_top">
+        <fieldset>
+          <input name="clientId" type="hidden" value="CLIENT_ID(poll)" data-amp-replace="CLIENT_ID">
+          <input name="canonicalUrl" type="hidden" value="RANDOM and CANONICAL_URL" data-amp-replace="CANONICAL_URL RANDOM">
+          <label>
+            <span>Search for</span>
+            <input type="search" name="term" required>
+          </label>
+          <input name="submit-button" type="submit" value="Search">
+          <amp-recaptcha-input layout="nodisplay" name="recaptcha_token" data-sitekey="6LebBGoUAAAAAHbj1oeZMBU_rze_CutlbyzpH8VE" data-action="recaptcha_example">
+          </amp-recaptcha-input>
+        </fieldset>
+
+        <div class="loading-spinner">
+          <div class="donut">
+          </div>
+        </div>
+
+        <div submit-success>
+          <template type="amp-mustache">
+            <h1>You searched for: {{term}}</h1>
+            <h3>Response</h3>
+            <p>action: {{action}}</p>
+            <p>challenge_ts: {{challenge_ts}}</p>
+            <p>hostname: {{hostname}}</p>
+            <p>recaptcha_token: {{recaptcha_token}}</p>
+            <p>score: {{score}}</p>
+            <p>success: {{success}}</p>
+          </template>
+        </div>
+
+        <div submit-error>
+          <template type="amp-mustache">
+            <h1>Error! Please check the JS Console in your dev tools.</h1>
+            <p>{{error}}</p>
+          </template>
+        </div>
+
+      </form>
+    </div>
+
+
     <!-- Lightbox Example -->
-    <div>
+    <div class="form-container">
     <h2>amp-recaptcha-input inside amp-lightbox</h2>
       <button on="tap:recaptcha-lightbox">Open Lightbox</button>
       <amp-lightbox id="recaptcha-lightbox" layout="nodisplay">
@@ -137,14 +210,13 @@
           </form>
         </div>
       </amp-lightbox>
-    <div>
-
-
-
+    </div>
 
     <!-- Standard Example -->
-    <div>
+    <div class="form-container">
       <h2>amp-recaptcha-input Standard Example</h2>
+
+      <!-- Non xhr -->
       <h4>Search (GET non-xhr cross origin - current host > httpbin.org)</h4>
       <form method="get" action="https://httpbin.org/html" target="_blank">
         <fieldset>
@@ -164,6 +236,9 @@
           </div>
         </div>
       </form>
+
+
+      <!-- XHR -->
       <h4>Search (GET xhr cross origin current host > httpbin.org)</h4>
       <form method="get"
             action="https://httpbin.org/response-headers?AMP-Access-Control-Allow-Source-Origin=http%3A%2F%2Flocalhost%3A8000&access-control-expose-headers=AMP-Access-Control-Allow-Source-Origin"
@@ -203,12 +278,8 @@
       </form>
     </div>
 
-
-
-
-
     <!-- Scrolled in Example -->
-    <div class="push-down">
+    <div class="push-down form-container">
       <h2>Pushed down amp-recaptcha-input testing layoutCallback()</h2>
 
       <h4>Search (GET xhr cross origin current host > httpbin.org)</h4>

--- a/examples/recaptcha.amp.html
+++ b/examples/recaptcha.amp.html
@@ -147,7 +147,7 @@
             <p>action: {{action}}</p>
             <p>challenge_ts: {{challenge_ts}}</p>
             <p>hostname: {{hostname}}</p>
-            <p>recaptcha_token: {{recaptcha_token}}</p>
+            <p>submitted recaptcha_token: {{recaptcha_token}}</p>
             <p>score: {{score}}</p>
             <p>success: {{success}}</p>
           </template>

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -253,8 +253,9 @@ export class AmpRecaptchaService {
     if (getMode().localDev || getMode().test) {
       return ampToolboxCacheUrl.createCurlsSubdomain(this.win_.location.href)
           .then(curlsSubdomain => {
-            return '//' + curlsSubdomain +
-          '.recaptcha.localhost:8000/dist.3p/' +
+            return this.win_.location.protocol + '//' +
+              curlsSubdomain + '.recaptcha.' +
+              this.win_.location.host + '/dist.3p/' +
           (getMode().minified ? '$internalRuntimeVersion$/recaptcha'
             : 'current/recaptcha.max') +
           '.html';

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -253,7 +253,7 @@ export class AmpRecaptchaService {
     if (getMode().localDev || getMode().test) {
       return ampToolboxCacheUrl.createCurlsSubdomain(this.win_.location.href)
           .then(curlsSubdomain => {
-            return 'http://' + curlsSubdomain +
+            return '//' + curlsSubdomain +
           '.recaptcha.localhost:8000/dist.3p/' +
           (getMode().minified ? '$internalRuntimeVersion$/recaptcha'
             : 'current/recaptcha.max') +


### PR DESCRIPTION
relates to #2273

Context: Need to start making easy to deploy examples for partners, and other developers. And this should be done on different domains, other than localhost.

* This adds an example, that uses a [Glitch Express Server I built for AMP reCAPTCHA](https://glitch.com/edit/#!/torch2424-amp-glitch-express). This will allow us to create/send demos to other people waiting for this feature / want to give additional approvals. 

* This changes the bootstrap frame source for development mode, to use the same protocol as the parent document, and removes the hardcoded host. 

~The plan is to also implement on top of the Glitch server in an amp-by-example soon.~ I guess I dreamt that, will have to implement on the ABE Go server for this.

# Example

<img width="1440" alt="screen shot 2019-01-07 at 12 08 06 pm" src="https://user-images.githubusercontent.com/1448289/50790851-eb9dbb80-1274-11e9-83fb-4a9b57d9d958.png">
