### PR TITLE
Allowing clicking through the system layer to navigate.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -52,7 +52,6 @@
 
 .i-amphtml-story-system-layer-buttons {
   margin-top: 8px; /* 6px progress bar + 2px margin */
-  pointer-events: auto !important;
   display: flex !important;
   flex-direction: row !important;
   justify-content: flex-end !important;


### PR DESCRIPTION
Allowing clicking through the system layer to navigate.
The `.i-amphtml-story-system-layer-buttons` element was taking all the system-layer's width and height, and acting as a click shield.
We haven't been updating these files in several weeks, so it might have been broken this whole time...