### PR TITLE
Fix flaky ordering in test-performance

### DIFF
--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -596,7 +596,7 @@ describes.realWin('performance', {amp: true}, env => {
           return whenFirstVisiblePromise.then(() => {
             expect(tickSpy.withArgs('pc')).to.be.calledOnce;
             expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(0);
-            expect(getPerformanceMarks()).to.deep.equal(
+            expect(getPerformanceMarks()).to.have.members(
                 ['ol', 'pc', 'visible', 'ofv']);
           });
         });


### PR DESCRIPTION
Caused a few red builds on master after #19918.

https://travis-ci.org/ampproject/amphtml/builds/476875479
https://travis-ci.org/ampproject/amphtml/jobs/476564819