### PR TITLE
✨Enable [src] binding and http URLs for src attribute

### DIFF
--- a/examples/date-picker-other.json
+++ b/examples/date-picker-other.json
@@ -3,14 +3,14 @@
     "id": "spooky",
     "dates": [
       "2018-02-10", "2017-11-03", "2017-11-05", "2017-11-06",
-      "FREQ=WEEKLY;DTSTART=20190101T150000Z;COUNT=30;WKST=MO;BYDAY=TU,SA"
+      "FREQ=WEEKLY;DTSTART=20190101T150000Z;COUNT=30;WKST=MO;BYDAY=FR,SU"
     ]
   }, {
     "id": "default"
   }],
-  "highlighted": ["2019-01-21"],
-  "blocked": ["2019-01-29"],
-  "date": "2019-01-20",
+  "highlighted": ["2019-01-29"],
+  "blocked": ["2019-01-21"],
+  "date": "2019-01-25",
   "startDate": "2018-05-07",
   "endDate": "2018-05-10"
 }

--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -47,7 +47,7 @@
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-date-picker" src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
-  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
@@ -298,6 +298,29 @@
 <div><span [text]="max">2018-10-10</span></div>
 <label>max: <input on="change:AMP.setState({max: event.value})" value="2018-10-10"></label>
 <amp-date-picker mode="static" layout="fixed-height" height="360" max="2018-10-10" [max]="max"></amp-date-picker>
+
+<h3>src</h3>
+<amp-state id="flipflop">
+  <script type="application/json">true</script>
+</amp-state>
+<button on="tap:AMP.setState({flipflop: !flipflop})">Toggle src</button>
+<input id="bind-src-input" type="tel" placeholder="Pick a date">
+<amp-date-picker
+  type="single"
+  number-of-months="1"
+  mode="static"
+  src="date-picker.json"
+  [src]="flipflop ? 'date-picker.json' : 'date-picker-other.json'"
+  layout="fixed-height"
+  first-day-of-week="1"
+  height="360"
+  format="DD/MM/YYYY"
+  input-selector="#bind-src-input"
+>
+  <template type="amp-mustache" date-template id="spooky">
+    🙀
+  </template>
+</amp-date-picker>
 
 <h3>range min/max</h3>
 <h3>min</h3>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -235,7 +235,11 @@ function createElementRules_() {
     'AMP-DATE-PICKER': {
       'max': null,
       'min': null,
-      'src': null,
+      'src': {
+        'allowedProtocols': {
+          'https': true,
+        },
+      },
     },
     'AMP-GOOGLE-DOCUMENT-EMBED': {
       'src': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -235,6 +235,7 @@ function createElementRules_() {
     'AMP-DATE-PICKER': {
       'max': null,
       'min': null,
+      'src': null,
     },
     'AMP-GOOGLE-DOCUMENT-EMBED': {
       'src': null,

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -481,21 +481,17 @@ export class AmpDatePicker extends AMP.BaseElement {
 
     const min = mutations['min'];
     if (min !== undefined) {
-      this.element.setAttribute('min', min);
       newState['min'] = min;
     }
 
     const max = mutations['max'];
     if (max !== undefined) {
-      this.element.setAttribute('max', max);
       newState['max'] = max;
     }
 
     let p = null;
     const src = mutations['src'];
     if (src !== undefined) {
-      this.element.setAttribute('src', src);
-
       this.clearRenderedTemplates_();
       this.cleanupSrcTemplates_();
 

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -239,7 +239,7 @@ export class AmpDatePicker extends AMP.BaseElement {
     this.renderInfo = this.renderInfo.bind(this);
 
     /** @const */
-    this.renderDay = this.renderDay.bind(this);
+    this.renderDay = this.renderDay_.bind(this);
 
     /** @private {?Promise<string>} */
     this.infoTemplatePromise_ = null;
@@ -481,15 +481,29 @@ export class AmpDatePicker extends AMP.BaseElement {
 
     const min = mutations['min'];
     if (min !== undefined) {
+      this.element.setAttribute('min', min);
       newState['min'] = min;
     }
 
     const max = mutations['max'];
     if (max !== undefined) {
+      this.element.setAttribute('max', max);
       newState['max'] = max;
     }
 
-    this.setState_(newState);
+    let p = null;
+    const src = mutations['src'];
+    if (src !== undefined) {
+      this.element.setAttribute('src', src);
+
+      this.clearRenderedTemplates_();
+      this.cleanupSrcTemplates_();
+
+      p = this.setupSrcAttributes_();
+      this.setupTemplates_();
+    }
+
+    Promise.resolve(p).then(() => this.setState_(newState));
   }
 
   /** @override */
@@ -1477,7 +1491,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Render a day in the calendar view.
    * @param {!moment} date
    */
-  renderDay(date) {
+  renderDay_(date) {
     const key = date.format(DEFAULT_FORMAT);
     const cachedDay = this.renderedTemplates_[key];
     if (cachedDay) {

--- a/extensions/amp-date-picker/0.1/react-utils.js
+++ b/extensions/amp-date-picker/0.1/react-utils.js
@@ -37,8 +37,17 @@ function createDeferred_() {
     }
 
     /** @override */
-    shouldComponentUpdate() {
-      return this.state.value == this.props.initial;
+    componentWillReceiveProps(nextProps) {
+      const promise = nextProps['promise'];
+      if (promise) {
+        promise.then(value => this.setState({value}));
+      }
+    }
+
+    /** @override */
+    shouldComponentUpdate(props, state) {
+      return shallowDiffers(this.props, props) ||
+          shallowDiffers(this.state, state);
     }
 
     /** @override */
@@ -59,6 +68,26 @@ function createDeferred_() {
   return DeferredType;
 }
 
+/**
+ * Duplicated from Preact PureComponent implementation.
+ * https://github.com/developit/preact-compat/blob/ae018abb/src/index.js#L402
+ * Shallow compare a and b.
+ * @param {*} a
+ * @param {*} b
+ */
+function shallowDiffers(a, b) {
+  for (const i in a) {
+    if (!(i in b)) {
+      return true;
+    }
+  }
+  for (const i in b) {
+    if (a[i] !== b[i]) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /** @private {?function(new:React.Component, !Object)} */
 let DeferredType_ = null;

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -76,9 +76,13 @@
   <amp-date-picker type="range" layout="fixed-height" height="360"
       first-day-of-week="1">
   </amp-date-picker>
-  <!-- Valid: amp-date-picker with src -->
+  <!-- Valid: amp-date-picker with https src -->
   <amp-date-picker layout="fixed-height" height="360"
       src="https://data.com/dates.json?ref=CANONICAL_URL">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with http src -->
+  <amp-date-picker layout="fixed-height" height="360"
+      src="http://data.com/dates.json?ref=CANONICAL_URL">
   </amp-date-picker>
   <!-- Valid: amp-date-picker with date template -->
   <amp-date-picker layout="fixed-height" height="360">
@@ -120,6 +124,12 @@
   </amp-date-picker>
   <!-- Valid: amp-date-picker with max and min binding -->
   <amp-date-picker [min]="min" [max]="max" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with https [src] binding -->
+  <amp-date-picker [src]="'https://data.com/dates.json?ref=CANONICAL_URL'" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with http [src] binding -->
+  <amp-date-picker [src]="'http://data.com/dates.json?ref=CANONICAL_URL'" layout="fixed-height" height="360">
   </amp-date-picker>
 
   <!-- Invalid: single amp-date-picker with start-input-selector -->

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -80,10 +80,6 @@
   <amp-date-picker layout="fixed-height" height="360"
       src="https://data.com/dates.json?ref=CANONICAL_URL">
   </amp-date-picker>
-  <!-- Valid: amp-date-picker with http src -->
-  <amp-date-picker layout="fixed-height" height="360"
-      src="http://data.com/dates.json?ref=CANONICAL_URL">
-  </amp-date-picker>
   <!-- Valid: amp-date-picker with date template -->
   <amp-date-picker layout="fixed-height" height="360">
     <template type="amp-mustache" date-template default>{{D}}</template>
@@ -185,6 +181,10 @@
   </amp-date-picker>
   <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
   <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
+  </amp-date-picker>
+  <!-- Invalid: amp-date-picker with http src -->
+  <amp-date-picker layout="fixed-height" height="360"
+      src="http://data.com/dates.json?ref=CANONICAL_URL">
   </amp-date-picker>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -77,9 +77,13 @@ FAIL
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 |        first-day-of-week="1">
 |    </amp-date-picker>
-|    <!-- Valid: amp-date-picker with src -->
+|    <!-- Valid: amp-date-picker with https src -->
 |    <amp-date-picker layout="fixed-height" height="360"
 |        src="https://data.com/dates.json?ref=CANONICAL_URL">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with http src -->
+|    <amp-date-picker layout="fixed-height" height="360"
+|        src="http://data.com/dates.json?ref=CANONICAL_URL">
 |    </amp-date-picker>
 |    <!-- Valid: amp-date-picker with date template -->
 |    <amp-date-picker layout="fixed-height" height="360">
@@ -122,118 +126,124 @@ FAIL
 |    <!-- Valid: amp-date-picker with max and min binding -->
 |    <amp-date-picker [min]="min" [max]="max" layout="fixed-height" height="360">
 |    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with https [src] binding -->
+|    <amp-date-picker [src]="'https://data.com/dates.json?ref=CANONICAL_URL'" layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with http [src] binding -->
+|    <amp-date-picker [src]="'http://data.com/dates.json?ref=CANONICAL_URL'" layout="fixed-height" height="360">
+|    </amp-date-picker>
 |
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
 |    <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:129:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:129:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:142:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:134:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:137:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:137:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:141:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:151:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:141:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:151:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:148:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:148:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:152:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:152:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        first-day-of-week="7">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
 |    <template info-template type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:156:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:166:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <template date-template dates="2018-01-01" type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:157:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:167:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: amp-date-picker with bad maximum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" maximum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:159:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:169:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:159:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:169:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad minimum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" minimum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:172:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:172:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with maximum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" maximum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:165:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:175:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with minimum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" minimum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:168:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:178:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with start-date attribute -->
 |    <amp-date-picker layout="fixed-height" height="360" start-date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:171:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:181:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with date attribute -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:174:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:184:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:174:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:184:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
 |    <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:177:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:187:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |  </body>
 |  </html>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -81,10 +81,6 @@ FAIL
 |    <amp-date-picker layout="fixed-height" height="360"
 |        src="https://data.com/dates.json?ref=CANONICAL_URL">
 |    </amp-date-picker>
-|    <!-- Valid: amp-date-picker with http src -->
-|    <amp-date-picker layout="fixed-height" height="360"
-|        src="http://data.com/dates.json?ref=CANONICAL_URL">
-|    </amp-date-picker>
 |    <!-- Valid: amp-date-picker with date template -->
 |    <amp-date-picker layout="fixed-height" height="360">
 |      <template type="amp-mustache" date-template default>{{D}}</template>
@@ -136,114 +132,120 @@ FAIL
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
 |    <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:136:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:132:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:139:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:142:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:138:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:140:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:151:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:151:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:147:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:150:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:150:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:154:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:158:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        first-day-of-week="7">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
 |    <template info-template type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:166:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:162:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <template date-template dates="2018-01-01" type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:167:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:163:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: amp-date-picker with bad maximum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" maximum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:169:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:165:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:169:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:165:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad minimum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" minimum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:172:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:168:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:172:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:168:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'zero'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with maximum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" maximum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:175:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:171:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with minimum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" minimum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:178:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:174:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with start-date attribute -->
 |    <amp-date-picker layout="fixed-height" height="360" start-date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:181:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:177:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with date attribute -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:184:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:180:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:184:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:180:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
 |    <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:187:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:183:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+|    </amp-date-picker>
+|    <!-- Invalid: amp-date-picker with http src -->
+|    <amp-date-picker layout="fixed-height" height="360"
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:186:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|        src="http://data.com/dates.json?ref=CANONICAL_URL">
 |    </amp-date-picker>
 |  </body>
 |  </html>

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -432,11 +432,11 @@ The following table lists the properties that you can specify in the JSON data:
 </tr>
 <tr>
 <td><code>date</code></td>
-<td>Specifies the initially selected date. In a date picker with <code>type="range"</code> this has no effect.</td>
+<td>Specifies the initially selected date. In a date picker with <code>type="range"</code> this has no effect. In order to prevent overwriting the user's input, this value has no effect if the user has already selected a date.</td>
 </tr>
 <tr>
 <td><code>endDate</code></td>
-<td>Specifies the initially selected end date. In a date picker with <code>type="single"</code> this has no effect.</td>
+<td>Specifies the initially selected end date. In a date picker with <code>type="single"</code> this has no effect. In order to prevent overwriting the user's input, this value has no effect if the user has already selected an end date.</td>
 </tr>
 <tr>
 <td><code>highlighted</code></td>
@@ -444,7 +444,7 @@ The following table lists the properties that you can specify in the JSON data:
 </tr>
 <tr>
 <td><code>startDate</code></td>
-<td>Specifies the initially selected start date for a date picker with <code>type="range"</code>. In a date picker with <code>type="single"</code> this has no effect.</td>
+<td>Specifies the initially selected start date for a date picker with <code>type="range"</code>. In a date picker with <code>type="single"</code> this has no effect. In order to prevent overwriting the user's input, this value has no effect if the user has already selected a start date.</td>
 </tr>
 <tr>
 <td><code>templates</code></td>
@@ -452,6 +452,8 @@ The following table lists the properties that you can specify in the JSON data:
 </tr>
 </tbody>
 </table>
+
+The `src` attribute may be updated after a user gesture with [`amp-bind`](https://www.ampproject.org/docs/reference/components/amp-bind).
 
 ###### template definition objects
 

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -167,7 +167,6 @@ attr_lists: {
   attrs: {
     name: "src"
     value_url: {
-      protocol: "http"
       protocol: "https"
       allow_relative: false
     }

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -167,6 +167,7 @@ attr_lists: {
   attrs: {
     name: "src"
     value_url: {
+      protocol: "http"
       protocol: "https"
       allow_relative: false
     }
@@ -174,6 +175,7 @@ attr_lists: {
   }
   attrs: { name: "week-day-format" }
   # amp-bind
+  attrs: { name: "[src]" }
   attrs: { name: "[max]" }
   attrs: { name: "[min]" }
 }


### PR DESCRIPTION
Fixes #18548 

Changes to the `DeferredType` class were needed to allow the new Promise values passed into React to change the `state.value`. 

/to @cathyxz @nainar 
/to @CrystalFaith for documentation feedback
/cc @aghassemi