### PR TITLE
Preemptive null check in fixed-layer.js

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -125,12 +125,15 @@ export class FixedLayer {
       return;
     }
 
-
-
     const fixedSelectors = [];
     const stickySelectors = [];
     for (let i = 0; i < stylesheets.length; i++) {
       const stylesheet = stylesheets[i];
+      // Rare but may happen if the document is being concurrently disposed.
+      if (!stylesheet) {
+        dev().error(TAG, 'Aborting setup due to null stylesheet.');
+        return;
+      }
       const {ownerNode} = stylesheet;
       if (stylesheet.disabled ||
               !ownerNode ||


### PR DESCRIPTION
Saw this old bug while re-triaging and thought I'd just patch it. Fixes #17024. 

/to @jridgewell 