### PR TITLE
🐛 Video docking bugfix pass

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -52,8 +52,8 @@ import {htmlFor} from '../../../src/static-template';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
+import {layoutRectLtwh, moveLayoutRect} from '../../../src/layout-rect';
 import {mapRange} from '../../../src/utils/math';
-import {moveLayoutRect, layoutRectLtwh} from '../../../src/layout-rect';
 import {once} from '../../../src/utils/function';
 import {
   px,

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1311,10 +1311,10 @@ export class VideoDocking {
       return;
     }
 
-    // Don't allow dragging videos that are too early in their transition phase.
+    // Don't allow dragging videos that are transitioning.
     // This allows the user to keep scrolling while touching the inline/almost
     // inline video area.
-    if (!this.isTransitioning_) {
+    if (this.isTransitioning_) {
       return;
     }
 
@@ -1697,6 +1697,10 @@ export class VideoDocking {
     dev().info(TAG, 'undock', {video});
 
     this.getControls_().disable();
+
+    // Prevents ghosting
+    this.getControls_().hide(/* respectSticky */ false, /* immediately */ true);
+
     this.trigger_(Actions.UNDOCK);
 
     const step = 0;

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -31,7 +31,7 @@ import {
   PositionObserverFidelity,
 } from '../../../src/service/position-observer/position-observer-worker';
 import {Services} from '../../../src/services';
-import {VideoDockingEvents} from './events';
+import {VideoDockingEvents, pointerCoords} from './events';
 import {applyBreakpointClassname} from './breakpoints';
 import {
   childElementByTag,
@@ -53,7 +53,7 @@ import {installStylesForDoc} from '../../../src/style-installer';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
 import {mapRange} from '../../../src/utils/math';
-import {moveLayoutRect} from '../../../src/layout-rect';
+import {moveLayoutRect, layoutRectLtwh} from '../../../src/layout-rect';
 import {once} from '../../../src/utils/function';
 import {
   px,
@@ -114,6 +114,8 @@ let DockedDef;
 /** @typedef {{posX: !RelativeX, posY: !RelativeY}|!Element} */
 let DockTargetDef;
 
+
+// TODO(alanorozco): Reestructure this to use standard LayoutRects.
 /**
  * @typedef {{
  *   x: number,
@@ -152,20 +154,6 @@ function throttleByAnimationFrame(win, fn) {
       fn.apply(null, args);
       running = false;
     });
-  };
-}
-
-
-/**
- * @param {!MouseEvent|!TouchEvent} e
- * @return {{x: number, y: number}}
- * @private
- */
-function pointerCoords(e) {
-  const coords = (e.touches) ? e.touches[0] : e;
-  return {
-    x: dev().assertNumber(('x' in coords) ? coords.x : coords.clientX),
-    y: dev().assertNumber(('y' in coords) ? coords.y : coords.clientY),
   };
 }
 
@@ -1266,7 +1254,14 @@ export class VideoDocking {
     const previouslyDocked = this.currentlyDocked_;
     this.currentlyDocked_ = {video, target, step};
     if (!previouslyDocked || previouslyDocked.video != video) {
-      this.getControls_().setVideo(video);
+      const {
+        x,
+        y,
+        targetWidth,
+        targetHeight,
+      } = this.getTargetArea_(video, target);
+      const targetRect = layoutRectLtwh(x, y, targetWidth, targetHeight);
+      this.getControls_().setVideo(video, targetRect);
       this.trigger_(Actions.DOCK);
     }
   }

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -473,7 +473,7 @@ export class Controls {
         return;
       }
 
-      this.hide();
+      this.hide(/* respectSticky */ true);
       this.unlistenToMouseMovement_();
     });
   }

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -21,14 +21,10 @@ import {
 } from '../../../src/video-interface';
 import {Services} from '../../../src/services';
 import {Timeout} from './timeout';
-import {VideoDockingEvents} from './events';
+import {VideoDockingEvents, pointerCoords} from './events';
 import {applyBreakpointClassname} from './breakpoints';
 import {closestBySelector} from '../../../src/dom';
-import {
-  createCustomEvent,
-  listen,
-  listenOnce,
-} from '../../../src/event-helper';
+import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert} from '../../../src/log';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {once} from '../../../src/utils/function';
@@ -186,6 +182,12 @@ export class Controls {
     /** @private {?UnlistenDef} */
     this.mouseMoveUnlistener_ = null;
 
+    /** @private {?UnlistenDef} */
+    this.mouseOutUnlistener_ = null;
+
+    /** @private {?../../../src/layout-rect.LayoutRectDef} */
+    this.area_ = null;
+
     /** @private {?../../../src/video-interface.VideoOrBaseElementDef} */
     this.video_ = null;
 
@@ -207,9 +209,11 @@ export class Controls {
 
   /**
    * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!../../../src/layout-rect.LayoutRectDef} area
    */
-  setVideo(video) {
+  setVideo(video, area) {
     this.video_ = video;
+    this.area_ = area;
     this.listen_(video);
   }
 
@@ -326,22 +330,24 @@ export class Controls {
   /** @private */
   showOnTapOrHover_() {
     const {overlay} = this;
+    const boundShow = () => this.show_();
 
-    this.listenWhenEnabled_(overlay, 'click', () => {
-      this.show_();
-    });
-
-    this.listenWhenEnabled_(overlay, 'mouseover', () => {
-      // Show on hover only on mouse devices to prevent click/hover passthru.
-      if (!this.ampdoc_.getBody().classList.contains('amp-mode-mouse')) {
-        return;
-      }
-      this.show_();
-    });
+    this.listenWhenEnabled_(overlay, 'click', boundShow);
+    this.listenWhenEnabled_(overlay, 'mouseover', boundShow);
   }
 
   /** @private */
   show_() {
+    // Delay by one animation frame to stop mouseover-click sequence mistrigger.
+    // See https://jsbin.com/rohesijowi/1/edit?output on Chrome (Blink) on a
+    // touch device/device mode.
+    this.ampdoc_.win.requestAnimationFrame(() => {
+      this.showOnNextAnimationFrame_();
+    });
+  }
+
+  /** @private */
+  showOnNextAnimationFrame_() {
     const {
       container,
       overlay,
@@ -424,20 +430,20 @@ export class Controls {
   }
 
   /**
-   * @param {boolean=} respectSticky
-   * @param {boolean=} immediately Disables transition
+   * @param {boolean=} opt_respectSticky
+   * @param {boolean=} opt_immediately Disables transition
    * @public
    */
-  hide(respectSticky = false, immediately = false) {
+  hide(opt_respectSticky, opt_immediately) {
     const ampVideoDockedControlsShown = 'amp-video-docked-controls-shown';
     const {container, overlay} = this;
     if (!container.classList.contains(ampVideoDockedControlsShown)) {
       return;
     }
-    if (respectSticky && this.isSticky_) {
+    if (opt_respectSticky && this.isSticky_) {
       return;
     }
-    if (immediately) {
+    if (opt_immediately) {
       toggle(container, false);
       toggle(overlay, false);
     }
@@ -450,18 +456,37 @@ export class Controls {
     if (this.mouseMoveUnlistener_) {
       return;
     }
+
     this.mouseMoveUnlistener_ = listen(this.overlay, 'mousemove', () => {
       this.show_();
     });
 
-    listenOnce(this.overlay, 'mouseout', () => this.unlistenToMouseMove_());
+    this.mouseOutUnlistener_ = listen(this.overlay, 'mouseout', e => {
+      devAssert(this.area_);
+
+      const {x, y} = pointerCoords(e);
+      const {left, top, right, bottom} = this.area_;
+
+      // check bounding box as not to trigger this while mouse hovers over
+      // buttons
+      if (!(x < left || x > right || y < top || y > bottom)) {
+        return;
+      }
+
+      this.hide();
+      this.unlistenToMouseMovement_();
+    });
   }
 
   /** @private */
-  unlistenToMouseMove_() {
+  unlistenToMouseMovement_() {
     if (this.mouseMoveUnlistener_) {
       this.mouseMoveUnlistener_();
       this.mouseMoveUnlistener_ = null;
+    }
+    if (this.mouseOutUnlistener_) {
+      this.mouseOutUnlistener_();
+      this.mouseOutUnlistener_ = null;
     }
   }
 

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -464,7 +464,7 @@ export class Controls {
     this.mouseOutUnlistener_ = listen(this.overlay, 'mouseout', e => {
       devAssert(this.area_);
 
-      const {x, y} = pointerCoords(e);
+      const {x, y} = pointerCoords(/** @type {!MouseEvent} */ (e));
       const {left, top, right, bottom} = this.area_;
 
       // check bounding box as not to trigger this while mouse hovers over

--- a/extensions/amp-video-docking/0.1/events.js
+++ b/extensions/amp-video-docking/0.1/events.js
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
- import {dev} from '../../../src/log';
+import {dev} from '../../../src/log';
+
 
 /** @enum {string} */
 export const VideoDockingEvents = {
   DISMISS_ON_TAP: 'dock-dismiss-on-tap',
 };
+
 
 /**
  * @param {!MouseEvent|!TouchEvent} e

--- a/extensions/amp-video-docking/0.1/events.js
+++ b/extensions/amp-video-docking/0.1/events.js
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 
+ import {dev} from '../../../src/log';
+
 /** @enum {string} */
 export const VideoDockingEvents = {
   DISMISS_ON_TAP: 'dock-dismiss-on-tap',
 };
+
+/**
+ * @param {!MouseEvent|!TouchEvent} e
+ * @return {{x: number, y: number}}
+ * @private
+ */
+export function pointerCoords(e) {
+  const coords = (e.touches) ? e.touches[0] : e;
+  return {
+    x: dev().assertNumber(('x' in coords) ? coords.x : coords.clientX),
+    y: dev().assertNumber(('y' in coords) ? coords.y : coords.clientY),
+  };
+}


### PR DESCRIPTION
- Prevent invisible controls from being clicked (due to mouseover-to-tap mapping in touch devices).
- Show controls if the mouse moves within the docked video area.
- Actually keep controls sticky when paused.
- Some finer tuning of controls timeouts.
- Prevent "double-transition" when clicking on controls.
- Dragging had reversed logic for drag prevention.