### PR TITLE
AMP Story page attachment component.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+amp-story-page-attachment {
+  display: block !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  z-index: 4 !important; /** Over amp-story-cta-layer. */
+  transform: translate3d(0, 100%, 0) !important;
+  /** If you change the duration of this animation, please reflect if in the JavaScript close_ method too. */
+  transition: transform 0.25s cubic-bezier(0.4, 0.0, 1, 1) !important;
+}
+
+amp-story-page-attachment.i-amphtml-story-page-attachment-open {
+  transform: translate3d(0, 0, 0) !important;
+  transition: transform 0.4s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+}
+
+.i-amphtml-story-page-attachment {
+  height: 100% !important;
+}
+
+.i-amphtml-story-page-attachment-header {
+  position: relative !important;
+  height: 40px !important;
+  background: #fff !important;
+  border-radius: 8px 8px 0 0 !important;
+  box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.12) !important;
+  z-index: 1 !important;
+}
+
+.i-amphtml-story-page-attachment-close-button {
+  display: inline-block !important;
+  margin: 8px;
+  height: 24px !important;
+  width: 24px !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(0, 0, 0, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  cursor: pointer !important;
+}
+
+.i-amphtml-story-page-attachment-container {
+  height: calc(100% - 40px) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  overflow-y: auto !important;
+  transition: background 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+}
+
+.i-amphtml-story-page-attachment-container[hidden] {
+  display: block !important;
+  background: rgba(255, 255, 255, 0.92) !important;
+}
+
+.i-amphtml-story-page-attachment-content {
+  opacity: 1 !important;
+  transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+}
+
+.i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content {
+  opacity: 0 !important;
+}
+
+.i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content > * {
+  display: none !important;
+}

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -330,7 +330,6 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     }
 
     this.mutateElement(() => {
-      this.element.classList.add('i-amphtml-story-page-attachment-dragging');
       setImportantStyles(
           this.element, {transform: translate, transition: 'none'});
     });
@@ -352,7 +351,6 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     this.mutateElement(() => {
       resetStyles(this.element, ['transform', 'transition']);
       this.element.classList.add('i-amphtml-story-page-attachment-open');
-      this.element.classList.remove('i-amphtml-story-page-attachment-dragging');
       toggle(dev().assertElement(this.containerEl_), true);
     });
   }
@@ -373,7 +371,6 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     this.mutateElement(() => {
       resetStyles(this.element, ['transform', 'transition']);
       this.element.classList.remove('i-amphtml-story-page-attachment-open');
-      this.element.classList.remove('i-amphtml-story-page-attachment-dragging');
       // Note: if you change the duration here, you'll also have to change the
       // animation duration in the CSS.
       setTimeout(

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -1,0 +1,383 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Action, getStoreService} from './amp-story-store-service';
+import {Layout} from '../../../src/layout';
+import {closest} from '../../../src/dom';
+import {dev} from '../../../src/log';
+import {htmlFor} from '../../../src/static-template';
+import {resetStyles, setImportantStyles, toggle} from '../../../src/style';
+
+
+/** @const {number} */
+const TOGGLE_THRESHOLD_PX = 50;
+
+/**
+ * @enum {number}
+ */
+const AttachmentState = {
+  CLOSED: 0,
+  DRAGGING_TO_CLOSE: 1,
+  DRAGGING_TO_OPEN: 2,
+  OPEN: 3,
+};
+
+/**
+ * Drawer's template.
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const getTemplateEl = element => {
+  return htmlFor(element)`
+    <div class="i-amphtml-story-page-attachment">
+      <div class="i-amphtml-story-page-attachment-header">
+        <span
+            class="i-amphtml-story-page-attachment-close-button" role="button">
+        </span>
+      </div>
+      <div class="i-amphtml-story-page-attachment-container">
+        <div class="i-amphtml-story-page-attachment-content"></div>
+      </div>
+    </div>`;
+};
+
+/**
+ * AMP Story page attachment.
+ */
+export class AmpStoryPageAttachment extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.containerEl_ = null;
+
+    /** @private {?Element} */
+    this.contentEl_ = null;
+
+    /** @private {!AttachmentState} */
+    this.state_ = AttachmentState.CLOSED;
+
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = getStoreService(this.win);
+
+    /** @private {boolean} */
+    this.ignoreCurrentSwipeYGesture_ = false;
+
+    /** @private {!Object} */
+    this.touchEventState_ = {
+      startX: 0,
+      startY: 0,
+      lastY: 0,
+      swipingUp: null,
+      isSwipeY: null,
+    };
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout === Layout.NODISPLAY;
+  }
+
+  /** @override */
+  prerenderAllowed() {
+    return false;
+  }
+
+  /** @override */
+  buildCallback() {
+    // TODO: maybe render the header in Shadow DOM?
+    const templateEl = getTemplateEl(this.element);
+
+    this.containerEl_ = dev().assertElement(
+        templateEl.querySelector('.i-amphtml-story-page-attachment-container'));
+    this.contentEl_ = dev().assertElement(this.containerEl_
+        .querySelector('.i-amphtml-story-page-attachment-content'));
+
+    while (this.element.firstChild) {
+      this.contentEl_.appendChild(this.element.firstChild);
+    }
+
+    this.element.appendChild(templateEl);
+
+    // Ensures the content of the attachment won't be rendered/loaded until we
+    // actually need it.
+    toggle(this.containerEl_, false);
+    toggle(this.element, true);
+
+    this.initializeListeners_();
+  }
+
+  /**
+   * @private
+   */
+  initializeListeners_() {
+    this.element.querySelector('.i-amphtml-story-page-attachment-close-button')
+        .addEventListener('click', () => this.close_(), true /** useCapture */);
+
+    // Enforced by AMP validation rules.
+    const storyPageEl = this.element.parentElement;
+
+    storyPageEl.addEventListener(
+        'touchstart', this.onTouchStart_.bind(this), true /** useCapture */);
+    storyPageEl.addEventListener(
+        'touchmove', this.onTouchMove_.bind(this), true /** useCapture */);
+    storyPageEl.addEventListener(
+        'touchend', this.onTouchEnd_.bind(this), true /** useCapture */);
+  }
+
+  /**
+   * Helper to retrieve the touch coordinates from a TouchEvent.
+   * @param {!Event} event
+   * @return {?{x: number, y: number}}
+   * @private
+   */
+  getClientTouchCoordinates_(event) {
+    const {touches} = event;
+    if (!touches || touches.length < 1) {
+      return null;
+    }
+
+    const {clientX: x, clientY: y} = touches[0];
+    return {x, y};
+  }
+
+  /**
+   * Handles touchstart events to detect swipeY interactions.
+   * @param {!Event} event
+   * @private
+   */
+  onTouchStart_(event) {
+    const coordinates = this.getClientTouchCoordinates_(event);
+    if (!coordinates) {
+      return;
+    }
+
+    this.touchEventState_.startX = coordinates.x;
+    this.touchEventState_.startY = coordinates.y;
+  }
+
+  /**
+   * Handles touchmove events to detect swipeY interactions.
+   * @param {!Event} event
+   * @private
+   */
+  onTouchMove_(event) {
+    if (this.touchEventState_.isSwipeY === false) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    const coordinates = this.getClientTouchCoordinates_(event);
+    if (!coordinates) {
+      return;
+    }
+
+    const {x, y} = coordinates;
+
+    if (this.touchEventState_.isSwipeY === null) {
+      this.touchEventState_.isSwipeY =
+          Math.abs(this.touchEventState_.startY - y) >
+              Math.abs(this.touchEventState_.startX - x);
+      if (!this.touchEventState_.isSwipeY) {
+        return;
+      }
+    }
+
+    this.touchEventState_.swipingUp = y < this.touchEventState_.lastY;
+    this.touchEventState_.lastY = y;
+
+    this.onSwipeY_({
+      event,
+      data: {
+        swipingUp: this.touchEventState_.swipingUp,
+        deltaY: y - this.touchEventState_.startY,
+        last: false,
+      },
+    });
+  }
+
+  /**
+   * Handles touchend events to detect swipeY interactions.
+   * @param {!Event} event
+   * @private
+   */
+  onTouchEnd_(event) {
+    if (this.touchEventState_.isSwipeY === true) {
+      this.onSwipeY_({
+        event,
+        data: {
+          swipingUp: this.touchEventState_.swipingUp,
+          deltaY: this.touchEventState_.lastY - this.touchEventState_.startY,
+          last: true,
+        },
+      });
+    }
+
+    this.touchEventState_.startX = 0;
+    this.touchEventState_.startY = 0;
+    this.touchEventState_.lastY = 0;
+    this.touchEventState_.swipingUp = null;
+    this.touchEventState_.isSwipeY = null;
+  }
+
+  /**
+   * Handles swipeY events, detected by the touch events listeners.
+   * @param {{event: !Event, data: !Object}} gesture
+   * @private
+   */
+  onSwipeY_(gesture) {
+    const {data} = gesture;
+
+    if (this.ignoreCurrentSwipeYGesture_ === true) {
+      this.ignoreCurrentSwipeYGesture_ = !data.last;
+      return;
+    }
+
+    const {deltaY, swipingUp} = data;
+
+    // If the attachment is open, figure out if the user is trying to scroll the
+    // content, or actually close the attachment.
+    if (this.state_ === AttachmentState.OPEN) {
+      const isContentSwipe = this.isAttachmentContentDescendant_(
+          dev().assertElement(gesture.event.target));
+
+      // If user is swiping up, exit so the event bubbles up and maybe scrolls
+      // the attachment content.
+      // If user is swiping down and scrollTop is above zero, exit and let the
+      // user scroll the content.
+      // If user is swiping down and scrollTop is zero, don't exit and start
+      // dragging/closing the attachment.
+      if ((isContentSwipe && deltaY < 0) ||
+          (isContentSwipe && deltaY > 0 &&
+              this.containerEl_./*OK*/scrollTop > 0)) {
+        this.ignoreCurrentSwipeYGesture_ = true;
+        return;
+      }
+    }
+
+    gesture.event.preventDefault();
+
+    if (data.last === true) {
+      if (this.state_ === AttachmentState.DRAGGING_TO_CLOSE) {
+        (!swipingUp && deltaY > TOGGLE_THRESHOLD_PX) ?
+          this.close_() :
+          this.open();
+      }
+
+      if (this.state_ === AttachmentState.DRAGGING_TO_OPEN) {
+        (swipingUp && -deltaY > TOGGLE_THRESHOLD_PX) ?
+          this.open() :
+          this.close_();
+      }
+      return;
+    }
+
+    this.drag_(deltaY);
+  }
+
+  /**
+   * Whether the element is a descendant of attachment-content.
+   * @param {!Element} element
+   * @return {boolean}
+   * @private
+   */
+  isAttachmentContentDescendant_(element) {
+    return !!closest(element, el => {
+      return el.classList.contains('i-amphtml-story-page-attachment-content');
+    }, /* opt_stopAt */ this.element);
+  }
+
+  /**
+   * Drags the attachment on the screen upon user interaction.
+   * @param {number} deltaY
+   * @private
+   */
+  drag_(deltaY) {
+    let translate;
+
+    switch (this.state_) {
+      case AttachmentState.CLOSED:
+      case AttachmentState.DRAGGING_TO_OPEN:
+        if (deltaY > 0) {
+          return;
+        }
+        this.state_ = AttachmentState.DRAGGING_TO_OPEN;
+        translate = `translate3d(0, calc(100% + ${deltaY}px), 0)`;
+        break;
+      case AttachmentState.OPEN:
+      case AttachmentState.DRAGGING_TO_CLOSE:
+        if (deltaY < 0) {
+          return;
+        }
+        this.state_ = AttachmentState.DRAGGING_TO_CLOSE;
+        translate = `translate3d(0, ${deltaY}px, 0)`;
+        break;
+    }
+
+    this.mutateElement(() => {
+      this.element.classList.add('i-amphtml-story-page-attachment-dragging');
+      setImportantStyles(
+          this.element, {transform: translate, transition: 'none'});
+    });
+  }
+
+  /**
+   * Fully opens the attachment from its current position.
+   * @public
+   */
+  open() {
+    if (this.state_ === AttachmentState.OPEN) {
+      return;
+    }
+
+    this.state_ = AttachmentState.OPEN;
+
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
+
+    this.mutateElement(() => {
+      resetStyles(this.element, ['transform', 'transition']);
+      this.element.classList.add('i-amphtml-story-page-attachment-open');
+      this.element.classList.remove('i-amphtml-story-page-attachment-dragging');
+      toggle(dev().assertElement(this.containerEl_), true);
+    });
+  }
+
+  /**
+   * Fully closes the attachment from its current position.
+   * @private
+   */
+  close_() {
+    if (this.state_ === AttachmentState.CLOSED) {
+      return;
+    }
+
+    this.state_ = AttachmentState.CLOSED;
+
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
+
+    this.mutateElement(() => {
+      resetStyles(this.element, ['transform', 'transition']);
+      this.element.classList.remove('i-amphtml-story-page-attachment-open');
+      this.element.classList.remove('i-amphtml-story-page-attachment-dragging');
+      // Note: if you change the duration here, you'll also have to change the
+      // animation duration in the CSS.
+      setTimeout(
+          () => toggle(dev().assertElement(this.containerEl_), false), 250);
+    });
+  }
+}

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -63,7 +63,6 @@ import {listen} from '../../../src/event-helper';
 import {toArray} from '../../../src/types';
 import {toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
-
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.
  * @const {string}
@@ -101,6 +100,19 @@ const buildPlayMessageElement = element =>
         <span class="i-amphtml-story-page-play-label"></span>
         <span class='i-amphtml-story-page-play-icon'></span>
       </button>`;
+
+/**
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const buildOpenAttachmentElement = element =>
+  htmlFor(element)`
+      <div class="
+          i-amphtml-story-page-open-attachment i-amphtml-story-system-reset">
+        <span class="i-amphtml-story-page-open-attachment-icon"></span>
+        <span class="i-amphtml-story-page-open-attachment-text"
+            role="button">Swipe up</span>
+      </div>`;
 
 /**
  * amp-story-page states.
@@ -142,6 +154,9 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.playMessageEl_ = null;
+
+    /** @private {?Element} */
+    this.openAttachmentEl_ = null;
 
     /** @private @const {!Promise} */
     this.mediaLayoutPromise_ = this.waitForMediaLayout_();
@@ -331,6 +346,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.advancement_.start();
       this.maybeStartAnimations();
       this.checkPageHasAudio_();
+      this.renderAttachmentUI_();
       this.preloadAllMedia_()
           .then(() => this.startListeningToVideoEvents_())
           .then(() => this.playAllMedia_());
@@ -925,6 +941,29 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     this.mutateElement(() =>
       toggle(dev().assertElement(this.playMessageEl_), true));
+  }
+
+  /**
+   * Renders the open attachment UI affordance.
+   * @private
+   */
+  renderAttachmentUI_() {
+    const attachmentEl =
+        this.element.querySelector('amp-story-page-attachment');
+    if (!attachmentEl) {
+      return;
+    }
+
+    if (!this.openAttachmentEl_) {
+      this.openAttachmentEl_ = buildOpenAttachmentElement(this.element);
+      this.openAttachmentEl_
+          .querySelector('.i-amphtml-story-page-open-attachment-text')
+          .addEventListener('click', () => {
+            attachmentEl.getImpl().then(attachment => attachment.open());
+          });
+      this.mutateElement(
+          () => this.element.appendChild(this.openAttachmentEl_));
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -63,6 +63,7 @@ import {listen} from '../../../src/event-helper';
 import {toArray} from '../../../src/types';
 import {toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
+
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.
  * @const {string}
@@ -346,7 +347,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.advancement_.start();
       this.maybeStartAnimations();
       this.checkPageHasAudio_();
-      this.renderAttachmentUI_();
+      this.renderOpenAttachmentUI_();
       this.preloadAllMedia_()
           .then(() => this.startListeningToVideoEvents_())
           .then(() => this.playAllMedia_());
@@ -947,7 +948,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Renders the open attachment UI affordance.
    * @private
    */
-  renderAttachmentUI_() {
+  renderOpenAttachmentUI_() {
     const attachmentEl =
         this.element.querySelector('amp-story-page-attachment');
     if (!attachmentEl) {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -16,6 +16,7 @@
 
 @import './amp-story-access.css';
 @import './amp-story-desktop-panels.css';
+@import './amp-story-page-attachment.css';
 @import './amp-story-user-overridable.css';
 @import './pagination-buttons.css';
 
@@ -722,4 +723,99 @@ amp-story .amp-video-eq,
   border-radius: 24px !important;
   filter: drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.36)) !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 48 48" fill="#FFF"><path d="M0 0h48v48H0z" fill="none"/><path d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"/></svg>') !important;
+}
+
+
+/** amp-story-page open attachment message. */
+
+@keyframes open-attachment-fly-in {
+  0% {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes open-attachment-icon {
+  0% {
+    transform: translateY(5px);
+  }
+  to {
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes open-attachment-button-explode {
+  0% {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.12);
+  }
+}
+
+@keyframes open-attachment-text-color {
+  0% {
+    color: #fff;
+    text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36);
+  }
+  to {
+    color: rgba(0, 0, 0, 0.87);
+    text-shadow: none;
+  }
+}
+
+amp-story-page .i-amphtml-story-page-open-attachment {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  flex-direction: column !important;
+  position: absolute !important;
+  bottom: 12px !important;
+  left: 0 !important;
+  width: 100% !important;
+  pointer-events: none !important;
+  z-index: 3 !important;
+  animation: open-attachment-fly-in 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) both !important;
+}
+
+amp-story-page .i-amphtml-story-page-open-attachment-icon {
+  display: block !important;
+  height: 20px !important;
+  width: 24px !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#FFFFFF"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>') !important;
+  background-repeat: no-repeat !important;
+  background-position: center center !important;
+  cursor: pointer !important;
+  filter: drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.36)) !important;
+  animation: open-attachment-icon 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) 1.5s both !important;
+}
+
+amp-story-page .i-amphtml-story-page-open-attachment-text {
+  position: relative !important;
+  padding: 0 24px !important;
+  height: 32px !important;
+  cursor: pointer !important;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 15px !important;
+  line-height: 32px !important;
+  pointer-events: auto !important;
+  animation: open-attachment-text-color 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) 1.5s both !important;
+}
+
+amp-story-page .i-amphtml-story-page-open-attachment-text::after {
+  content: "";
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  background: #fff !important;
+  border-radius: 32px !important;
+  z-index: -1 !important;
+  animation: open-attachment-button-explode 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) 1.5s both !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -725,7 +725,6 @@ amp-story .amp-video-eq,
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 48 48" fill="#FFF"><path d="M0 0h48v48H0z" fill="none"/><path d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"/></svg>') !important;
 }
 
-
 /** amp-story-page open attachment message. */
 
 @keyframes open-attachment-fly-in {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -44,6 +44,7 @@ import {AmpStoryCtaLayer} from './amp-story-cta-layer';
 import {AmpStoryGridLayer} from './amp-story-grid-layer';
 import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
+import {AmpStoryPageAttachment} from './amp-story-page-attachment';
 import {AmpStoryTooltip} from './amp-story-tooltip';
 import {AmpStoryVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
@@ -2251,4 +2252,5 @@ AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story-cta-layer', AmpStoryCtaLayer);
   AMP.registerElement('amp-story-grid-layer', AmpStoryGridLayer);
   AMP.registerElement('amp-story-page', AmpStoryPage);
+  AMP.registerElement('amp-story-page-attachment', AmpStoryPageAttachment);
 });


### PR DESCRIPTION
This PR creates a new `amp-story-page-attachment` component, that has to be a direct child of `amp-story-page`, sibling of `amp-story-grid-layer`.

I had to re-write a swipe gesture recognizer to work around a scroll overflow issue. We need to call `preventDefault` on the touch events when they're meant to drag the attachment. But we don't when we need to scroll the content within the attachment. The current AMP gesture recognizer doesn't allow that, and either calls `preventDefault` on all or none of the events, which would cause issues in either cases: scroll overflow on iOS, or no scroll within the attachment.

[Demo available for a few days here on page 2.](https://stamp-gmajoulet.firebaseapp.com/examples/s20/body-painting/index.html)

This PR contains:

- The actual component
- UI interactions to drag / open / close the attachment
- Rendering the attachment content 
- Button/UI to indicate there's an attachment on the `amp-story-page`

It doesn't contain:

- Validation rules
- Pausing the story when the attachment is open
- Allowing a custom call to action text on `amp-story-page`
- Excluding videos in the attachment from the media pool
- Better fullbleed desktop UI
- Visual tests

#20209