### PR TITLE
More fixes for git baseline selection in pr-check

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -32,7 +32,7 @@ const commitLogMaxCount = 100;
 exports.gitMergeBaseMaster = function() {
   if (process.env.TRAVIS) {
     return getStdout(
-        `git merge-base origin/master ${process.env.TRAVIS_COMMIT}`).trim();
+        `git merge-base master ${process.env.TRAVIS_COMMIT}`).trim();
   }
   return gitMergeBaseLocalMaster();
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -32,7 +32,7 @@ const commitLogMaxCount = 100;
 exports.gitMergeBaseMaster = function() {
   if (process.env.TRAVIS) {
     return getStdout(
-        `git merge-base master ${process.env.TRAVIS_COMMIT}`).trim();
+        `git merge-base master ${process.env.TRAVIS_PULL_REQUEST_SHA}`).trim();
   }
   return gitMergeBaseLocalMaster();
 };

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -99,7 +99,6 @@ function timedExecOrDie(cmd) {
  */
 function printChangeSummary() {
   if (process.env.TRAVIS) {
-    console.log(`TRAVIS_COMMIT=${process.env.TRAVIS_COMMIT}`);
     console.log('Travis', colors.green('origin/master'), 'baseline:',
         colors.cyan(gitTravisMasterBaseline()));
   }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,8 +36,8 @@ const {
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
-  gitMasterBaseline,
   gitMergeBaseMaster,
+  gitTravisMasterBaseline,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
 
@@ -100,8 +100,10 @@ function timedExecOrDie(cmd) {
 function printChangeSummary() {
   console.log(colors.green('master'), 'merge-base:',
       colors.cyan(gitMergeBaseMaster()));
-  console.log(colors.green('master'), 'baseline:',
-      colors.cyan(gitMasterBaseline()));
+  if (process.env.TRAVIS) {
+    console.log('Travis', colors.green('origin/master'), 'baseline:',
+        colors.cyan(gitTravisMasterBaseline()));
+  }
 
   const filesChanged = gitDiffStatMaster();
   console.log(fileLogPrefix,

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,6 +36,7 @@ const {
   gitDiffCommitLog,
   gitDiffNameOnlyMaster,
   gitDiffStatMaster,
+  gitMasterBaseline,
   gitMergeBaseMaster,
 } = require('./git');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
@@ -97,6 +98,11 @@ function timedExecOrDie(cmd) {
  * Prints a summary of files changed by, and commits included in the PR.
  */
 function printChangeSummary() {
+  console.log(colors.green('master'), 'merge-base:',
+      colors.cyan(gitMergeBaseMaster()));
+  console.log(colors.green('master'), 'baseline:',
+      colors.cyan(gitMasterBaseline()));
+
   const filesChanged = gitDiffStatMaster();
   console.log(fileLogPrefix,
       'Testing the following changes at commit',

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -98,12 +98,13 @@ function timedExecOrDie(cmd) {
  * Prints a summary of files changed by, and commits included in the PR.
  */
 function printChangeSummary() {
-  console.log(colors.green('master'), 'merge-base:',
-      colors.cyan(gitMergeBaseMaster()));
   if (process.env.TRAVIS) {
+    console.log(`TRAVIS_COMMIT=${process.env.TRAVIS_COMMIT}`);
     console.log('Travis', colors.green('origin/master'), 'baseline:',
         colors.cyan(gitTravisMasterBaseline()));
   }
+  console.log(colors.green('master'), 'merge-base:',
+      colors.cyan(gitMergeBaseMaster()));
 
   const filesChanged = gitDiffStatMaster();
   console.log(fileLogPrefix,

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -99,11 +99,9 @@ function timedExecOrDie(cmd) {
  */
 function printChangeSummary() {
   if (process.env.TRAVIS) {
-    console.log('Travis', colors.green('origin/master'), 'baseline:',
-        colors.cyan(gitTravisMasterBaseline()));
+    console.log(fileLogPrefix, colors.cyan('origin/master'),
+        'is currently at commit', colors.cyan(gitTravisMasterBaseline()));
   }
-  console.log(colors.green('master'), 'merge-base:',
-      colors.cyan(gitMergeBaseMaster()));
 
   const filesChanged = gitDiffStatMaster();
   console.log(fileLogPrefix,


### PR DESCRIPTION
Turns out that `TRAVIS_COMMIT_RANGE` is frozen at the point of the PR's creation, not when the PR check is actually running.

