### PR TITLE
Fix types for straggler callers of element service getters

### DIFF
--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -20,8 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
       'laterpay',
+      /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
       function(ampdoc) {
-        return Services.accessServiceForDoc(ampdoc).then(accessService => {
+        const element = ampdoc.getHeadNode();
+        return Services.accessServiceForDoc(element).then(accessService => {
           const source = accessService.getVendorSource('laterpay');
           const vendor = new LaterpayVendor(accessService, source);
           const adapter = /** @type {

--- a/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
@@ -20,8 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.2', function(AMP) {
   AMP.registerServiceForDoc(
       'laterpay',
+      /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
       function(ampdoc) {
-        return Services.accessServiceForDoc(ampdoc).then(accessService => {
+        const element = ampdoc.getHeadNode();
+        return Services.accessServiceForDoc(element).then(accessService => {
           const source = accessService.getVendorSource('laterpay');
           const vendor = new LaterpayVendor(accessService, source);
           const adapter = /** @type {

--- a/extensions/amp-access-poool/0.1/amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/amp-access-poool.js
@@ -20,8 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-poool', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
       'poool',
+      /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
       function(ampdoc) {
-        return Services.accessServiceForDoc(ampdoc).then(accessService => {
+        const element = ampdoc.getHeadNode();
+        return Services.accessServiceForDoc(element).then(accessService => {
           const source = accessService.getVendorSource('poool');
           const vendor = new PooolVendor(accessService, source);
           const adapter = /** @type {

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.js
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.js
@@ -20,8 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-scroll', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
       'scroll',
+      /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
       function(ampdoc) {
-        return Services.accessServiceForDoc(ampdoc).then(accessService => {
+        const element = ampdoc.getHeadNode();
+        return Services.accessServiceForDoc(element).then(accessService => {
           const source = accessService.getVendorSource('scroll');
           const vendor = new ScrollAccessVendor(ampdoc, source);
           const adapter = /** @type {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -127,7 +127,7 @@ describes.realWin('amp-analytics', {
 
     const wi = mockWindowInterface(sandbox);
     requestVerifier = new ImagePixelVerifier(wi);
-    return Services.userNotificationManagerForDoc(ampdoc).then(manager => {
+    return Services.userNotificationManagerForDoc(doc.head).then(manager => {
       uidService = manager;
     });
   });

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -336,18 +336,21 @@ class AmpFetcher {
 
 // Register the extension services.
 AMP.extension(TAG, '0.1', function(AMP) {
-  AMP.registerServiceForDoc('subscriptions-google', ampdoc => {
-    const platformService = new GoogleSubscriptionsPlatformService(ampdoc);
-    Services.subscriptionsServiceForDoc(ampdoc).then(service => {
-      service.registerPlatform(PLATFORM_ID,
-          (platformConfig, serviceAdapter) => {
-            return platformService.createPlatform(platformConfig,
-                serviceAdapter);
-          }
-      );
-    });
-    return platformService;
-  });
+  AMP.registerServiceForDoc('subscriptions-google',
+      /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+      ampdoc => {
+        const platformService = new GoogleSubscriptionsPlatformService(ampdoc);
+        const element = ampdoc.getHeadNode();
+        Services.subscriptionsServiceForDoc(element).then(service => {
+          service.registerPlatform(PLATFORM_ID,
+              (platformConfig, serviceAdapter) => {
+                return platformService.createPlatform(platformConfig,
+                    serviceAdapter);
+              }
+          );
+        });
+        return platformService;
+      });
 });
 
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -498,20 +498,18 @@ function createBaseCustomElementClass(win) {
         if (!policyId) {
           resolve(this.implementation_.buildCallback());
         } else {
-          Services.consentPolicyServiceForDocOrNull(this.getAmpDoc())
-              .then(consentPolicy => {
-                if (!consentPolicy) {
-                  return true;
-                }
-                return consentPolicy.whenPolicyUnblock(
-                    /** @type {string} */ (policyId));
-              }).then(shouldUnblock => {
-                if (shouldUnblock == true) {
-                  resolve(this.implementation_.buildCallback());
-                } else {
-                  reject(blockedByConsentError());
-                }
-              });
+          Services.consentPolicyServiceForDocOrNull(this).then(policy => {
+            if (!policy) {
+              return true;
+            }
+            return policy.whenPolicyUnblock(/** @type {string} */ (policyId));
+          }).then(shouldUnblock => {
+            if (shouldUnblock) {
+              resolve(this.implementation_.buildCallback());
+            } else {
+              reject(blockedByConsentError());
+            }
+          });
         }
       }).then(() => {
         this.preconnect(/* onLayout */false);

--- a/test/unit/test-activity.js
+++ b/test/unit/test-activity.js
@@ -79,6 +79,9 @@ describe('Activity getTotalEngagedTime', () => {
         nodeType: 1,
         style: {},
       },
+      head: {
+        nodeType: /* ELEMENT */ 1,
+      },
     };
 
     fakeWin = {
@@ -96,6 +99,7 @@ describe('Activity getTotalEngagedTime', () => {
       Promise: window.Promise,
     };
     fakeDoc.defaultView = fakeWin;
+    fakeDoc.head.defaultView = fakeWin;
 
     ampdoc = new AmpDocSingle(fakeWin);
     fakeWin.services['ampdoc'] = {obj: {
@@ -128,7 +132,7 @@ describe('Activity getTotalEngagedTime', () => {
     markElementScheduledForTesting(fakeWin, 'amp-analytics');
     installActivityServiceForTesting(ampdoc);
 
-    return Services.activityForDoc(ampdoc).then(a => {
+    return Services.activityForDoc(ampdoc.getHeadNode()).then(a => {
       activity = a;
     });
   });
@@ -283,6 +287,9 @@ describe('Activity getIncrementalEngagedTime', () => {
         nodeType: 1,
         style: {},
       },
+      head: {
+        nodeType: /* ELEMENT */ 1,
+      },
     };
 
     fakeWin = {
@@ -300,6 +307,7 @@ describe('Activity getIncrementalEngagedTime', () => {
       Promise: window.Promise,
     };
     fakeDoc.defaultView = fakeWin;
+    fakeDoc.head.defaultView = fakeWin;
 
     ampdoc = new AmpDocSingle(fakeWin);
     fakeWin.services['ampdoc'] = {obj: {
@@ -332,7 +340,7 @@ describe('Activity getIncrementalEngagedTime', () => {
     markElementScheduledForTesting(fakeWin, 'amp-analytics');
     installActivityServiceForTesting(ampdoc);
 
-    return Services.activityForDoc(ampdoc).then(a => {
+    return Services.activityForDoc(ampdoc.getHeadNode()).then(a => {
       activity = a;
     });
   });


### PR DESCRIPTION
Fixes some callers that I missed in #20031 due to missing type information. 

Passing `AmpDoc` to these service getters still works since #20031 only changed type definitions, so this PR fixes type semantics rather than functionality.