### PR TITLE
Fix amp-list-load-more doesn't shrink issue. 

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -21,9 +21,6 @@ import {CSS} from '../../../build/amp-list-0.1.css';
 import {Deferred} from '../../../src/utils/promise';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Pass} from '../../../src/pass';
-import {
-  PositionObserverFidelity,
-} from '../../../src/service/position-observer/position-observer-worker';
 import {Services} from '../../../src/services';
 import {SsrTemplateHelper} from '../../../src/ssr-template-helper';
 import {
@@ -36,13 +33,9 @@ import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
-import {getServiceForDoc} from '../../../src/service';
 import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr} from '../../../src/json';
 import {htmlFor} from '../../../src/static-template';
-import {
-  installPositionObserverServiceForDoc,
-} from '../../../src/service/position-observer/position-observer-impl';
 import {isArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyles, toggle} from '../../../src/style';
@@ -68,6 +61,12 @@ export class AmpList extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.container_ = null;
+
+    /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = null;
+
+    /** @private {?UnlistenDef} */
+    this.viewportUnlisten_ = null;
 
     /** @private {boolean} */
     this.fallbackDisplayed_ = false;
@@ -128,9 +127,6 @@ export class AmpList extends AMP.BaseElement {
     /**@private {?UnlistenDef} */
     this.unlistenLoadMore_ = null;
 
-    /** @private {?../../../src/service/position-observer/position-observer-impl.PositionObserver} */
-    this.positionObserver_ = null;
-
     this.registerAction('refresh', () => {
       if (this.layoutCompleted_) {
         this.resetIfNecessary_();
@@ -155,6 +151,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.viewport_ = this.getViewport();
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     this.ssrTemplateHelper_ = new SsrTemplateHelper(
         TAG, viewer, this.templates_);
@@ -250,12 +247,20 @@ export class AmpList extends AMP.BaseElement {
     }
 
     if (isExperimentOn(this.win, 'amp-list-viewport-resize')) {
-      this.getViewport().onResize(() => {
+      this.viewport_.onResize(() => {
         this.attemptToFit_(dev().assertElement(this.container_));
       });
     }
 
     return this.fetchList_();
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.viewportUnlisten_) {
+      this.viewportUnlisten_();
+    }
+    return true;
   }
 
   /** @override */
@@ -806,7 +811,7 @@ export class AmpList extends AMP.BaseElement {
     }
     const triggerOnScroll = this.element.getAttribute('load-more') === 'auto';
     if (triggerOnScroll) {
-      this.maybeSetupLoadMoreAuto_();
+      this.setupLoadMoreAuto_();
     }
     const loadMoreEndElement = this.getLoadMoreEndElement_();
     const loadMoreButtonClickable = this.getLoadMoreButtonClickable_();
@@ -1016,23 +1021,17 @@ export class AmpList extends AMP.BaseElement {
   /**
    * @private
    */
-  maybeSetupLoadMoreAuto_() {
-    if (!this.positionObserver_) {
-      installPositionObserverServiceForDoc(this.getAmpDoc());
-      this.positionObserver_ = getServiceForDoc(
-          this.getAmpDoc(),
-          'position-observer'
-      );
-      this.positionObserver_.observe(this.container_,
-          PositionObserverFidelity.LOW,
-          ({positionRect, viewportRect}) => {
-            const ratio = 3;
-            if (this.loadMoreSrc_ &&
-                positionRect.bottom < ratio * viewportRect.bottom) {
+  setupLoadMoreAuto_() {
+    const loadMoreButton = dev().assertElement(this.loadMoreButton_);
+    this.viewportUnlisten_ = this.viewport_.onScroll(() => {
+      this.viewport_.getClientRectAsync(loadMoreButton)
+          .then(positionRect => {
+            const vr = this.viewport_.getRect();
+            if (vr.bottom + 3 * vr.height > positionRect.bottom) {
               this.loadMoreCallback_();
             }
           });
-    }
+    });
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -65,9 +65,6 @@ export class AmpList extends AMP.BaseElement {
     /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = null;
 
-    /** @private {?UnlistenDef} */
-    this.viewportUnlisten_ = null;
-
     /** @private {boolean} */
     this.fallbackDisplayed_ = false;
 
@@ -253,14 +250,6 @@ export class AmpList extends AMP.BaseElement {
     }
 
     return this.fetchList_();
-  }
-
-  /** @override */
-  unlayoutCallback() {
-    if (this.viewportUnlisten_) {
-      this.viewportUnlisten_();
-    }
-    return true;
   }
 
   /** @override */
@@ -1023,7 +1012,7 @@ export class AmpList extends AMP.BaseElement {
    */
   setupLoadMoreAuto_() {
     const loadMoreButton = dev().assertElement(this.loadMoreButton_);
-    this.viewportUnlisten_ = this.viewport_.onScroll(() => {
+    this.viewport_.onScroll(() => {
       this.viewport_.getClientRectAsync(loadMoreButton)
           .then(positionRect => {
             const vr = this.viewport_.getRect();

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -66,7 +66,7 @@
   <amp-list width="auto" height="200"
     layout="fixed-height"
     src="/infinite-scroll?items=2&left=20"
-    load-more="manual"
+    load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">


### PR DESCRIPTION
~Dependent on https://github.com/ampproject/amphtml/pull/20157.~ Merged and rebased.

### Bug
The bug is when we change between srcs in `<amp-list load-more>`, we can get into a state where the height of the `<amp-list>` is too long for its contents because amp-list doesn't shrink (https://github.com/ampproject/amphtml/issues/19939), i.e. the bottom of the amp-list is much lower than the end of the list contents. In this case, load-more will not trigger until we scroll to 3 viewports away from the bottom of the actual `<amp-list>`, which means scrolling past a lot of nothingness. 

### Solution
Refactored the `amp-list-load-more` feature to trigger `loadMoreCallback` on `viewport.onScroll` instead of using position observer. 

Basically, this bug is because the position observer is registered on the container. The solution is to measure the position of the load-more button instead. This cannot be done with position observer because position observer does not report the dimensions of elements outside of the viewport (i.e. 3 viewports away). Thus, we use a `viewport.onScroll` trigger instead and manually measure the dimensions of the viewport and the load-more-button.