### PR TITLE
Unmute tests for amp-experiment variant replacement.

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -301,9 +301,12 @@ export class GlobalVariableSource extends VariableSource {
     this.setAsync('VARIANT', /** @type {AsyncResolverDef} */(experiment => {
       return this.getVariantsValue_(variants => {
         const variant = variants[/** @type {string} */(experiment)];
-        userAssert(variant !== undefined,
-            'The value passed to VARIANT() is not a valid experiment name:' +
-                experiment);
+        if (variant === undefined) {
+          user().error(TAG,
+              'The value passed to VARIANT() is ' +
+              'not a valid experiment name:' + experiment);
+          return '';
+        }
         // When no variant assigned, use reserved keyword 'none'.
         return variant === null ? 'none' : /** @type {string} */(variant);
       }, 'VARIANT');

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -598,17 +598,17 @@ describes.sandboxed('UrlReplacements', {}, () => {
         });
   });
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should replace VARIANT', () => {
+  it('should replace VARIANT', () => {
+    expectAsyncConsoleError(/not a valid experiment name/);
     return expect(expandUrlAsync(
         '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
         /*opt_bindings*/undefined, {withVariant: true}))
         .to.eventually.equal('?x1=v1&x2=none&x3=');
   });
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should replace VARIANT with empty string if ' +
+  it('should replace VARIANT with empty string if ' +
       'amp-experiment is not configured ', () => {
+    expectAsyncConsoleError(/should be configured/);
     return expect(expandUrlAsync(
         '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)'))
         .to.eventually.equal('?x1=&x2=&x3=');
@@ -619,9 +619,9 @@ describes.sandboxed('UrlReplacements', {}, () => {
         {withVariant: true})).to.eventually.equal('?x1.v1!x2.none');
   });
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should replace VARIANTS with empty string if ' +
+  it('should replace VARIANTS with empty string if ' +
       'amp-experiment is not configured ', () => {
+    expectAsyncConsoleError(/should be configured/);
     return expect(expandUrlAsync('?VARIANTS')).to.eventually.equal('?');
   });
 


### PR DESCRIPTION
The root cause of those tests failures are actually the use of rethrowAsync: https://github.com/ampproject/amphtml/blob/master/src/service/url-expander/expander.js#L327

We might consider remove all the usage of rethrowAsync in code base. @rsimha what you think?

This PR is to unblock #20221 

also part of #16916