### PR TITLE
amp-bind: Always set value for [text] in textarea

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1076,17 +1076,23 @@ export class Bind {
 
     switch (property) {
       case 'text':
-        element.textContent = String(newValue);
-        // If this is a <title> element in the <head>, update document title.
+        let updateTextContent = true;
+        const stringValue = String(newValue);
+
+        // textContent on <textarea> only works before interaction.
+        if (tag == 'TEXTAREA') {
+          element.value = stringValue;
+          // Don't also update textContent to avoid disrupting focus.
+          updateTextContent = false;
+        }
+        // If <title> element in the <head>, also update the document title.
         if (tag === 'TITLE'
             && element.parentNode === this.localWin_.document.head) {
-          this.localWin_.document.title = String(newValue);
+          this.localWin_.document.title = stringValue;
         }
-        // Setting `textContent` on TEXTAREA element only works if user
-        // has not interacted with the element, therefore `value` also needs
-        // to be set (but `value` is not an attribute on TEXTAREA)
-        if (tag == 'TEXTAREA') {
-          element.value = String(newValue);
+        // Default behavior.
+        if (updateTextContent) {
+          element.textContent = stringValue;
         }
         break;
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1080,7 +1080,7 @@ export class Bind {
         const stringValue = String(newValue);
 
         // textContent on <textarea> only works before interaction.
-        if (tag == 'TEXTAREA') {
+        if (tag === 'TEXTAREA') {
           element.value = stringValue;
           // Don't also update textContent to avoid disrupting focus.
           updateTextContent = false;

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -478,20 +478,20 @@ describe.configure().ifChrome().run('Bind', function() {
 
     it('should support binding to Node.textContent', () => {
       const element = createElement(
-          env, container, '[text]="\'a\' + \'b\' + \'c\'"');
+          env, container, '[text]="\'abc\'"');
       expect(element.textContent).to.equal('');
       return onBindReadyAndSetState(env, bind, {}).then(() => {
         expect(element.textContent).to.equal('abc');
       });
     });
 
-    it('should update value in addition to textContent for TextArea', () => {
+    it('should only set value for <textarea> elements', () => {
       const element = createElement(
-          env, container, '[text]="\'a\' + \'b\' + \'c\'"', 'textarea');
-      element.textContent = 'foo';
-      element.value = 'foo';
+          env, container, '[text]="\'abc\'"', 'textarea');
+      expect(element.textContent).to.equal('');
+      expect(element.value).to.equal('');
       return onBindReadyAndSetState(env, bind, {}).then(() => {
-        expect(element.textContent).to.equal('abc');
+        expect(element.textContent).to.equal('');
         expect(element.value).to.equal('abc');
       });
     });

--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -21,6 +21,8 @@ import {poll} from '../../../../../testing/iframe';
 const TIMEOUT = 15000;
 
 describe('amp-list (integration)', function() {
+  this.timeout(TIMEOUT);
+
   const basicBody =
     `<amp-list width=300 height=100 src="http://localhost:9876/list/fruit-data/get?cors=0">
       <template type="amp-mustache">


### PR DESCRIPTION
Fixes #20220. Tested that this does the right thing before/after interaction on Chrome/Safari.

/to @alabiaga