### PR TITLE
🐛 amp-ad-exit border protection / click delay filters is not working on <a> element

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -95,11 +95,11 @@ export class AmpAdExit extends AMP.BaseElement {
     event = /** @type {!../../../src/service/action-impl.ActionEventDef} */(
       event);
 
+    event.preventDefault();
     if (!this.filter_(this.defaultFilters_, event) ||
         !this.filter_(target.filters, event)) {
       return;
     }
-    event.preventDefault();
     const substituteVariables =
         this.getUrlVariableRewriter_(args, event, target);
     if (target.trackingUrls) {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -212,7 +212,7 @@ describes.realWin('amp-ad-exit', {
     const event = makeClickEvent(1001);
     element.implementation_.executeAction({
       method: 'exit',
-      args: {target: 'simple'},
+      args: {target: 'twoSecondDelay'},
       event,
       satisfiesTrust: () => true,
     });


### PR DESCRIPTION
border protection / click delay is not working on <a> element because preventDefault is not called when filter return false.