### PR TITLE
Property check for getDefaultActionAlias on node

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -748,7 +748,8 @@ function isActionWhitelisted_(invocation, whitelist) {
   const {method, node, tagOrTarget} = invocation;
   const tagOrTargetCalled = tagOrTarget.toLowerCase();
   let methodCalled = method.toLowerCase();
-  const defaultActionAlias = node.getDefaultActionAlias();
+  const defaultActionAlias = (typeof node.getDefaultActionAlias == 'function')
+      && node.getDefaultActionAlias();
   const calledByDefaultActionAndHasDefaultAlias =
       method == DEFAULT_ACTION && (node && defaultActionAlias);
   // If called via default action 'activate', check the whitelist
@@ -914,7 +915,7 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
   let args = null;
   // Object literal. Format: {...}
   if (peek.type == TokenType.OBJECT) {
-    // Don't parse object literals. Tokenize as a single expression
+    // Don't parse object literalands. Tokenize as a single expression
     // fragment and delegate to specific action handler.
     args = map();
     const {value} = toks.next();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -747,6 +747,7 @@ export class ActionService {
 function isActionWhitelisted_(invocation, whitelist) {
   let {method} = invocation;
   const {node, tagOrTarget} = invocation;
+  // Use alias if default action is invoked.
   if (method === DEFAULT_ACTION
       && (typeof node.getDefaultActionAlias == 'function')) {
     method = node.getDefaultActionAlias();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -751,7 +751,7 @@ function isActionWhitelisted_(invocation, whitelist) {
   const defaultActionAlias = (typeof node.getDefaultActionAlias == 'function')
       && node.getDefaultActionAlias();
   const calledByDefaultActionAndHasDefaultAlias =
-      method == DEFAULT_ACTION && (node && defaultActionAlias);
+      method == DEFAULT_ACTION && (node && !!defaultActionAlias);
   // If called via default action 'activate', check the whitelist
   // against the default action alias.
   if (calledByDefaultActionAndHasDefaultAlias) {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -745,23 +745,17 @@ export class ActionService {
  * @private
  */
 function isActionWhitelisted_(invocation, whitelist) {
-  const {method, node, tagOrTarget} = invocation;
-  const tagOrTargetCalled = tagOrTarget.toLowerCase();
-  let methodCalled = method.toLowerCase();
-  const defaultActionAlias = (typeof node.getDefaultActionAlias == 'function')
-      && node.getDefaultActionAlias();
-  const calledByDefaultActionAndHasDefaultAlias =
-      method == DEFAULT_ACTION && (node && !!defaultActionAlias);
-  // If called via default action 'activate', check the whitelist
-  // against the default action alias.
-  if (calledByDefaultActionAndHasDefaultAlias) {
-    methodCalled = defaultActionAlias.toLowerCase();
+  let {method, node, tagOrTarget} = invocation;
+  if (method === DEFAULT_ACTION
+      && (typeof node.getDefaultActionAlias == 'function')) {
+    method = node.getDefaultActionAlias();
   }
-
-  return whitelist.some(({tagOrTarget, method}) => {
-    return (tagOrTarget === '*'
-        || tagOrTargetCalled == tagOrTarget.toLowerCase()) &&
-        (methodCalled == method.toLowerCase());
+  const lcMethod = method.toLowerCase();
+  const lcTagOrTarget = tagOrTarget.toLowerCase();
+  return whitelist.some(w => {
+    return (w.tagOrTarget === '*'
+        || w.tagOrTarget.toLowerCase() === lcTagOrTarget) &&
+        (w.method.toLowerCase() === lcMethod);
   });
 }
 
@@ -915,7 +909,7 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
   let args = null;
   // Object literal. Format: {...}
   if (peek.type == TokenType.OBJECT) {
-    // Don't parse object literalands. Tokenize as a single expression
+    // Don't parse object literals. Tokenize as a single expression
     // fragment and delegate to specific action handler.
     args = map();
     const {value} = toks.next();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -745,7 +745,8 @@ export class ActionService {
  * @private
  */
 function isActionWhitelisted_(invocation, whitelist) {
-  let {method, node, tagOrTarget} = invocation;
+  let {method} = invocation;
+  const {node, tagOrTarget} = invocation;
   if (method === DEFAULT_ACTION
       && (typeof node.getDefaultActionAlias == 'function')) {
     method = node.getDefaultActionAlias();
@@ -753,9 +754,13 @@ function isActionWhitelisted_(invocation, whitelist) {
   const lcMethod = method.toLowerCase();
   const lcTagOrTarget = tagOrTarget.toLowerCase();
   return whitelist.some(w => {
-    return (w.tagOrTarget === '*'
-        || w.tagOrTarget.toLowerCase() === lcTagOrTarget) &&
-        (w.method.toLowerCase() === lcMethod);
+    if (w.tagOrTarget.toLowerCase() === lcTagOrTarget
+        || (w.tagOrTarget === '*')) {
+      if (w.method.toLowerCase() === lcMethod) {
+        return true;
+      }
+    }
+    return false;
   });
 }
 


### PR DESCRIPTION
Check that function 'getDefaultActionAlias' exists on node as the node can be document whereas the method will not exist.

`b/122615607`
