### PR TITLE
✨🏗 Use the `AMP_CANARY` cookie to determine canary / RC opt-in state

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -55,7 +55,7 @@ export function isCanary(win) {
 }
 
 /**
- * Returns binary type, e.g., canary, control, or production.
+ * Returns binary type, e.g., canary, production, control, or rc.
  * @param {!Window} win
  * @return {string}
  */

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -574,6 +574,10 @@ describe('getBinaryType', () => {
     expect(getBinaryType(win)).to.equal('production');
     win.AMP_CONFIG.type = 'canary';
     expect(getBinaryType(win)).to.equal('canary');
+    win.AMP_CONFIG.type = 'control';
+    expect(getBinaryType(win)).to.equal('control');
+    win.AMP_CONFIG.type = 'rc';
+    expect(getBinaryType(win)).to.equal('rc');
     delete win.AMP_CONFIG.type;
     expect(getBinaryType(win)).to.equal('unknown');
   });


### PR DESCRIPTION
This PR sets the `AMP_CANARY` cookie when the user opts in to `dev-channel` or `rc-channel` via https://cdn.ampproject.org/experiments.html

`AMP_CANARY` is `0` by default, `1` when `dev-channel` (canary release) is enabled, and `2` when `rc-channel` (rc release) is enabled.

Follow up to #20223

