### PR TITLE
✅Integration test for configRewriter

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const app = module.exports = require('express').Router();
+const app = require('express').Router();
 const minimist = require('minimist');
 const argv = minimist(
     process.argv.slice(2), {boolean: ['strictBabelTransform']});
@@ -327,3 +327,8 @@ function composeDocument(config) {
     </body>
     </html>`;
 }
+
+module.exports = {
+  app,
+  log,
+};

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -38,6 +38,7 @@ const {replaceUrls} = require('./app-utils');
 
 app.use(bodyParser.text());
 app.use('/amp4test', require('./amp4test'));
+app.use('/analytics', require('./routes/analytics'));
 
 // Append ?csp=1 to the URL to turn on the CSP header.
 // TODO: shall we turn on CSP all the time?
@@ -176,12 +177,6 @@ app.use('/api/dont-show', (req, res) => {
 app.use('/api/echo/post', (req, res) => {
   res.setHeader('Content-Type', 'application/json');
   res.end(req.body);
-});
-
-app.use('/analytics/:type', (req, res) => {
-  console.log('Analytics event received: ' + req.params.type);
-  console.log(req.query);
-  res.status(204).send();
 });
 
 /**

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -37,7 +37,7 @@ const {renderShadowViewer} = require('./shadow-viewer');
 const {replaceUrls} = require('./app-utils');
 
 app.use(bodyParser.text());
-app.use('/amp4test', require('./amp4test'));
+app.use('/amp4test', require('./amp4test').app);
 app.use('/analytics', require('./routes/analytics'));
 
 // Append ?csp=1 to the URL to turn on the CSP header.

--- a/build-system/routes/analytics.js
+++ b/build-system/routes/analytics.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const router = require('express').Router();
+
+router.use('/rewriter', (req, res) => {
+  const body = JSON.parse(req.body);
+  if (body.vars && body.vars.url) {
+    const requestsConfig = {
+      requests: {
+        endpoint: body.vars.url,
+      },
+    };
+    Object.assign(body, requestsConfig);
+  }
+
+  const extraUrlParams = {
+    extraUrlParams: {
+      testId: 12358,
+      rewritten: true,
+    },
+  };
+  Object.assign(body, extraUrlParams);
+  res.json(body);
+});
+
+router.use('/:type', (req, res) => {
+  console.log('Analytics event received: ' + req.params.type);
+  console.log(req.query);
+  res.status(204).send();
+});
+
+module.exports = router;

--- a/build-system/routes/analytics.js
+++ b/build-system/routes/analytics.js
@@ -15,8 +15,9 @@
  */
 
 const router = require('express').Router();
+const {log} = require('../amp4test');
 
-router.use('/rewriter', (req, res) => {
+router.post('/rewriter', (req, res) => {
   const body = JSON.parse(req.body);
   if (body.vars && body.vars.url) {
     const requestsConfig = {
@@ -38,8 +39,8 @@ router.use('/rewriter', (req, res) => {
 });
 
 router.use('/:type', (req, res) => {
-  console.log('Analytics event received: ' + req.params.type);
-  console.log(req.query);
+  log('Analytics event received: ' + req.params.type);
+  log(req.query);
   res.status(204).send();
 });
 

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -1,4 +1,7 @@
 {
+  "_fake_": {
+    "endpoint": "/analytics/fake"
+  },
   "acquialift": {
     "base": "https://us-east-1-decisionapi.lift.acquia.com/capture?account_id=xxxxxxxx&site_id=xxxxxxxx",
     "basicCapture": "https://us-east-1-decisionapi.lift.acquia.com/capture?account_id=xxxxxxxx&site_id=xxxxxxxx&ident=_client_id_&identsrc=amp&es=Amp&url=_canonical_url_&rurl=_document_referrer_&cttl=_title_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -15,11 +15,13 @@
  */
 
 import {IFRAME_TRANSPORTS} from './iframe-transport-vendors';
+import {getMode} from '../../../src/mode';
 import {hasOwn} from '../../../src/utils/object';
 
 // Disable auto-sorting of imports from here on.
 /* eslint-disable sort-imports-es6-autofix/sort-imports-es6 */
 
+import {_FAKE_} from './vendors/_fake_.js';
 import {ACQUIALIFT_CONFIG} from './vendors/acquialift';
 import {AFSANALYTICS_CONFIG} from './vendors/afsanalytics';
 import {ALEXAMETRICS_CONFIG} from './vendors/alexametrics';
@@ -241,6 +243,10 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'webtrekk': WEBTREKK_CONFIG,
   'webtrekk_v2': WEBTREKK_V2_CONFIG,
 });
+
+if (getMode().test || getMode().localDev) {
+  ANALYTICS_CONFIG['_fake_'] = _FAKE_;
+}
 
 ANALYTICS_CONFIG['infonline']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;

--- a/extensions/amp-analytics/0.1/vendors/_fake_.js
+++ b/extensions/amp-analytics/0.1/vendors/_fake_.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const _FAKE_ = /** @type {!JsonObject} */ ({
+  'requests': {
+    'endpoint': '/analytics/fake',
+  },
+  'transport': {
+    'useBody': true,
+  },
+  'triggers': {
+    'view': {
+      'on': 'visible',
+      'request': 'endpoint',
+    },
+  },
+  'configRewriter': {
+    'url': '/analytics/rewriter',
+  },
+  'vars': {
+    'clientId': 'CLIENT_ID(_fake_)',
+    'dataSource': 'AMP',
+  },
+});

--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -574,7 +574,7 @@ describe('amp-analytics', function() {
           <script type="application/json">
           {
             "vars": {
-              "url" : "${RequestBank.getUrl(0)}"
+              "url" : "${RequestBank.getUrl()}"
             }
           }
           </script>
@@ -586,8 +586,11 @@ describe('amp-analytics', function() {
       return browser.waitForElementLayout('amp-analytics');
     });
 
-    it('should should use config from server', () => {
-      return RequestBank.withdraw(0).then(req => {
+    it('should use config from server', () => {
+      return RequestBank.withdraw().then(req => {
+        // The config here should have been rewritten by the /analytics/rewriter
+        // endpoint. This logic is located in the file
+        // /build-system/routes/analytics.js
         const body = JSON.parse(req.body);
         expect(body.rewritten).to.be.true;
         expect(body.testId).to.equal(12358);

--- a/test/integration/test-amp-analytics.js
+++ b/test/integration/test-amp-analytics.js
@@ -568,6 +568,33 @@ describe('amp-analytics', function() {
     });
   });
 
+  describes.integration('configRewriter', {
+    body:
+      `<amp-analytics type="_fake_">
+          <script type="application/json">
+          {
+            "vars": {
+              "url" : "${RequestBank.getUrl(0)}"
+            }
+          }
+          </script>
+      </amp-analytics>`,
+    extensions: ['amp-analytics'],
+  }, env => {
+    beforeEach(() => {
+      const browser = new BrowserController(env.win);
+      return browser.waitForElementLayout('amp-analytics');
+    });
+
+    it('should should use config from server', () => {
+      return RequestBank.withdraw(0).then(req => {
+        const body = JSON.parse(req.body);
+        expect(body.rewritten).to.be.true;
+        expect(body.testId).to.equal(12358);
+      });
+    });
+  });
+
   describes.integration('type=googleanalytics', {
     body: `
       <script>


### PR DESCRIPTION
also moved the `/analytics` endpoint to its own router file.