### PR TITLE
✨Add responsive attribute handling for carousel v2.

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -17,6 +17,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-carousel-0.2.css';
 import {Carousel} from './carousel.js';
+import {ResponsiveAttributes} from './responsive-attributes';
 import {dev} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
@@ -44,6 +45,50 @@ class AmpCarousel extends AMP.BaseElement {
 
     /** @private {!Array<!Element>} */
     this.slides_ = [];
+
+    /** @private @const */
+    this.responsiveAttributes_ = new ResponsiveAttributes({
+      'advance-count': newValue => {
+        this.carousel_.updateAdvanceCount(Number(newValue) || 0);
+      },
+      'auto-advance': newValue => {
+        this.carousel_.updateAutoAdvance(newValue == 'true');
+      },
+      'auto-advance-count': newValue => {
+        this.carousel_.updateAutoAdvanceCount(Number(newValue) || 0);
+      },
+      'auto-advance-interval': newValue => {
+        this.carousel_.updateAutoAdvanceInterval(Number(newValue) || 0);
+      },
+      'horizontal': newValue => {
+        this.carousel_.updateHorizontal(newValue == 'true');
+      },
+      'initial-index': newValue => {
+        this.carousel_.updateInitialIndex(Number(newValue) || 0);
+      },
+      'loop': newValue => {
+        this.carousel_.updateLoop(newValue == 'true');
+      },
+      'mixed-length': newValue => {
+        this.carousel_.updateMixedLength(newValue == 'true');
+      },
+      'side-slide-count': newValue => {
+        this.carousel_.updateSideSlideCount(Number(newValue) || 0);
+      },
+      'snap': newValue => {
+        this.carousel_.updateSnap(newValue == 'true');
+      },
+      'snap-align': newValue => {
+        this.carousel_.updateAlignment(newValue);
+      },
+      'snap-by': newValue => {
+        this.carousel_.updateSnapBy(Number(newValue) || 0);
+      },
+      'visible-count': newValue => {
+        this.carousel_.updateVisibleCount(Number(newValue) || 0);
+      },
+    });
+
   }
 
   /** @override */
@@ -132,44 +177,7 @@ class AmpCarousel extends AMP.BaseElement {
    * @private
    */
   attributeMutated_(name, newValue) {
-    switch (name) {
-      case 'auto-advance':
-        this.carousel_.updateAutoAdvance(newValue == 'true');
-        break;
-      case 'auto-advance-count':
-        this.carousel_.updateAutoAdvanceCount(Number(newValue) || 0);
-        break;
-      case 'auto-advance-interval':
-        this.carousel_.updateAutoAdvanceInterval(Number(newValue) || 0);
-        break;
-      case 'horizontal':
-        this.carousel_.updateHorizontal(newValue == 'true');
-        break;
-      case 'initial-index':
-        this.carousel_.updateInitialIndex(Number(newValue) || 0);
-        break;
-      case 'loop':
-        this.carousel_.updateLoop(newValue == 'true');
-        break;
-      case 'mixed-length':
-        this.carousel_.updateMixedLength(newValue == 'true');
-        break;
-      case 'side-slide-count':
-        this.carousel_.updateSideSlideCount(Number(newValue) || 0);
-        break;
-      case 'snap':
-        this.carousel_.updateSnap(newValue == 'true');
-        break;
-      case 'snap-align':
-        this.carousel_.updateAlignment(newValue);
-        break;
-      case 'snap-by':
-        this.carousel_.updateSnapBy(Number(newValue) || 0);
-        break;
-      case 'visible-count':
-        this.carousel_.updateVisibleCount(Number(newValue) || 0);
-        break;
-    }
+    this.responsiveAttributes_.updateAttribute(name, newValue);
   }
 }
 

--- a/extensions/amp-carousel/0.2/responsive-attributes.js
+++ b/extensions/amp-carousel/0.2/responsive-attributes.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @typedef {{
+ *   mediaQueryList: MediaQueryList,
+ *   value: string,
+ * }}
+ */
+let MediaQueriesListAndValueDef;
+
+/**
+ * Manages attributes that can respond to media queries. Uses a provided config
+ * Object invoke callback functions when the matching value changes. When an
+ * attribute changes, `updateAttribute` should be called with the name of the
+ * attribute along with the responsive MediaQuery/value pairs. This is a comma
+ * separated list of media queries followed by values.
+ *
+ * Some examples:
+ *
+ * * "(min-width: 600px) true, false"
+ * * "(min-width: 600px) 5, (min-width: 500px) 4, 3"
+ * * "(min-width: 600px) and (min-height: 800px) 5, 3"
+ * * "false"
+ * * "(min-width: 600px) true"
+ *
+ * The first value for the first media query in the list that matches is used.
+ * If there are no matching media queries, the value is an empty string.
+ */
+export class ResponsiveAttributes {
+  /**
+   * @param {!Object<string, function(string)} config A mapping of attribute
+   *    names to functions that should handle them.
+   */
+  constructor(config) {
+    /** @private @const */
+    this.config_ = config;
+
+    /** @private @const {!Object<string, string>} */
+    this.existingValuesMap_ = {};
+
+    /** @private @const {!Object<string, !MediaQueriesListAndValueDef>} */
+    this.mediaQueryListsAndValues_ = {};
+  }
+
+  /**
+   * Updates an attribute, calling the configured attribute handler with the
+   * new matching value, if it has changed. Whenever the matching media query
+   * changes, the matching value will be checked to see if it has changed. If
+   * so, the attribute handler is called.
+   * @param {string} name The name of the attribute.
+   * @param {string} newValue The new value for the attribute.
+   */
+  updateAttribute(name, newValue) {
+    const prevMqlv = this.mediaQueryListsAndValues_[name];
+    // Need to explicitly clear the onchange. Otherwise the underlying
+    // MediqaQueryLists will still be active with their callbacks.
+    if (prevMqlv) {
+      this.setOnchange_(prevMqlv, null);
+    }
+
+    const mqlv = this.getMediaQueryListsAndValues_(newValue);
+    const notifyIfChanged = () => {
+      this.notifyIfChanged_(name, this.getMatchingValue_(mqlv));
+    };
+    // Listen for future changes.
+    this.setOnchange_(mqlv, notifyIfChanged);
+    // Make sure to run once with the current value.
+    notifyIfChanged();
+    this.mediaQueryListsAndValues_[name] = mqlv;
+  }
+
+  /**
+   * @param {string} value
+   * @return {!Array<MediaQueriesListAndValueDef>}
+   * @private
+   */
+  getMediaQueryListsAndValues_(value) {
+    return value.split(',').map(part => {
+      // Find the value portion by looking at the end.
+      const {index} = /[a-z0-9.]+$/.exec(part);
+      const value = part.slice(index);
+      // The media query is everything before the value.
+      const mediaQuery = part.slice(0, index).trim();
+      const mediaQueryList = window.matchMedia(mediaQuery);
+
+      return {
+        mediaQueryList,
+        value,
+      };
+    });
+  }
+
+  /**
+   * @param {!Array<MediaQueriesListAndValueDef>} mediaQueryListsAndValues
+   * @return {string} The value for the first matching MediaQuery, or an empty
+   *    string if none match.
+   * @private
+   */
+  getMatchingValue_(mediaQueryListsAndValues) {
+    for (let i = 0; i < mediaQueryListsAndValues.length; i++) {
+      const {mediaQueryList, value} = mediaQueryListsAndValues[i];
+      if (mediaQueryList.matches) {
+        return value;
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * Notifies the configured handler function if the value of the attribute
+   * has changed since the previous call.
+   * @param {string} name The name of the attribute.
+   * @param {string} value The value of the attribute.
+   * @private
+   */
+  notifyIfChanged_(name, value) {
+    if (this.existingValuesMap_[name] === value) {
+      return;
+    }
+
+    const fn = this.config_[name];
+    if (fn) {
+      fn(value);
+    }
+
+    this.existingValuesMap_[name] = value;
+  }
+
+  /**
+   * Sets the onchange for each of the associated MediaQueryLists.
+   * @param {!Array<!MediaQueriesListAndValueDef>} mediaQueryListsAndValues
+   * @param {function()} fn
+   * @private
+   */
+  setOnchange_(mediaQueryListsAndValues, fn) {
+    mediaQueryListsAndValues.forEach(({mediaQueryList}) => {
+      mediaQueryList.onchange = fn;
+    });
+  }
+}

--- a/extensions/amp-carousel/0.2/test/test-responsive-attributes.js
+++ b/extensions/amp-carousel/0.2/test/test-responsive-attributes.js
@@ -1,0 +1,138 @@
+import {ResponsiveAttributes} from '../responsive-attributes';
+
+describe('ResponsiveAttributes', () => {
+  let matchMediaStub;
+
+  beforeEach(() => {
+    matchMediaStub = sandbox.stub(window, 'matchMedia');
+    matchMediaStub.returns({matches: false});
+    matchMediaStub.withArgs('').returns({matches: true});
+  });
+
+  it('should choose the first matching media query' , () => {
+    matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
+    matchMediaStub.withArgs('(min-width: 300px)').returns({matches: true});
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute(
+        'one', '(min-width: 600px) foo, (min-width: 300px) bar, baz');
+    expect(spy).to.have.been.calledOnce;
+    expect(spy).to.have.been.calledWith('foo');
+  });
+
+  it('should pass non-matching media queries' , () => {
+    matchMediaStub.withArgs('(min-width: 300px)').returns({matches: true});
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute(
+        'one', '(min-width: 600px) foo, (min-width: 300px) bar, baz');
+    expect(spy).to.have.been.calledOnce;
+    expect(spy).to.have.been.calledWith('bar');
+  });
+
+  it('should fall back to the default value' , () => {
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute(
+        'one', '(min-width: 600px) foo, (min-width: 300px) bar, baz');
+    expect(spy).to.have.been.calledOnce;
+    expect(spy).to.have.been.calledWith('baz');
+  });
+
+  it('should update when the matching value changes', () => {
+    matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute('one', '(min-width: 600px) foo, bar');
+    ra.updateAttribute('one', '(min-width: 600px) hello, world');
+
+    expect(spy).to.have.been.calledTwice;
+    expect(spy).to.have.been.calledWith('hello');
+  });
+
+  it('should update when the media query triggers onchange', async() => {
+    let callback;
+    let matches = false;
+
+    matchMediaStub.withArgs('(min-width: 600px)').returns({
+      get matches() {
+        return matches;
+      },
+      set onchange(cb) {
+        callback = cb;
+      },
+    });
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute('one', '(min-width: 600px) foo, bar');
+
+    expect(spy).to.have.been.calledOnce;
+    expect(spy).to.have.been.calledWith('bar');
+
+    matches = true;
+    callback();
+    await Promise.resolve();
+
+    expect(spy).to.have.been.calledTwice;
+    expect(spy).to.have.been.calledWith('foo');
+  });
+
+  it('should clear onchange when the attribute value changes', async() => {
+    const onchangeSpy = sinon.spy();
+
+    matchMediaStub.withArgs('(min-width: 600px)').returns({
+      matches: false,
+      set onchange(cb) {
+        onchangeSpy(cb);
+      },
+    });
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute('one', '(min-width: 600px) foo, bar');
+
+    expect(onchangeSpy).to.have.been.calledOnce;
+
+    ra.updateAttribute('one', '(min-width: 700px) foo, bar');
+
+    expect(onchangeSpy).to.have.been.calledTwice;
+    expect(onchangeSpy.secondCall).to.have.been.calledWith(null);
+  });
+
+  it('should handle number values' , () => {
+    matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
+
+    const spy = sinon.spy();
+    const ra = new ResponsiveAttributes({
+      'one': spy,
+    });
+
+    ra.updateAttribute(
+        'one', '(min-width: 600px) 4.2, 7');
+    expect(spy).to.have.been.calledOnce;
+    expect(spy).to.have.been.calledWith('4.2');
+  });
+
+});


### PR DESCRIPTION
This allows the component to use different attribute values based on media queries. For example, you can do `<amp-carousel snap="(min-width: 600px) true, false"></amp-carousel>` to conditionally snap based on a media query.
