### PR TITLE
Pause the story when the attachment is open.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -347,6 +347,7 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     this.state_ = AttachmentState.OPEN;
 
     this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
 
     this.mutateElement(() => {
       resetStyles(this.element, ['transform', 'transition']);
@@ -367,6 +368,7 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     this.state_ = AttachmentState.CLOSED;
 
     this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, false);
 
     this.mutateElement(() => {
       resetStyles(this.element, ['transform', 'transition']);


### PR DESCRIPTION
Pause the story when the attachment is open to prevent it from auto advancing in the background, or having a video/audio from the story page playing.

#20209