### PR TITLE
Don't apply the click shield to videos that are in amp-story-page-attachment.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -272,7 +272,7 @@ amp-story-page[distance="2"] {
  * story.
  * See #14401
  */
-amp-story amp-video::after {
+amp-story-grid-layer amp-video::after {
   content: "" !important;
   position: absolute !important;
   height: 100% !important;


### PR DESCRIPTION
Don't apply the click shield to videos that are in amp-story-page-attachment.

(Last followup!)