### PR TITLE
Add NaN check to amp-pan-zoom maxScale

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -214,7 +214,11 @@ export class AmpPanZoom extends AMP.BaseElement {
   /** @override */
   onMeasureChanged() {
     if (this.resetOnResize_) {
-      this.resetContentDimensions_();
+      this.getViewport().getLayoutRectAsync(this.element).then(layoutRect => {
+        if (layoutRect.height !== 0 && layoutRect.width !== 0) {
+          this.resetContentDimensions_();
+        }
+      });
     }
   }
 
@@ -355,8 +359,7 @@ export class AmpPanZoom extends AMP.BaseElement {
 
     const sourceAspectRatio = this.sourceWidth_ / this.sourceHeight_;
 
-    this.elementBox_ = layoutRectFromDomRect(this.element
-        ./*OK*/getBoundingClientRect());
+    this.elementBox_ = this.getViewport().getLayoutRect(this.element);
 
     this.updateContentDimensions_(sourceAspectRatio);
     this.updateMaxScale_(sourceAspectRatio);

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -214,11 +214,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /** @override */
   onMeasureChanged() {
     if (this.resetOnResize_) {
-      this.getViewport().getLayoutRectAsync(this.element).then(layoutRect => {
-        if (layoutRect.height !== 0 && layoutRect.width !== 0) {
-          this.resetContentDimensions_();
-        }
-      });
+      this.resetContentDimensions_();
     }
   }
 
@@ -344,7 +340,9 @@ export class AmpPanZoom extends AMP.BaseElement {
         elementBoxRatio / sourceAspectRatio,
         sourceAspectRatio / elementBoxRatio
     );
-    this.maxScale_ = Math.max(this.maxScale_, maxScale);
+    if (!isNaN(maxScale)) {
+      this.maxScale_ = Math.max(this.maxScale_, maxScale);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/17406. 

This bug is due to onMeasureChanged being called when we toggle display none. Display none causes all dimensions to be zero, thus causing a bunch of aspect ratio related values to be set to `NaN`. Because `NaN` is infinitely large, they don't get set back to reasonable values on the next `resetContentDimensions` call. 

~The solution here is to not call `resetContentDimensions` whenever the values of `width` and `height` are 0.~

Adding a dimensions check results in an extra browser paint cycle. Since values set during display none will just get reset at the next display toggle anyway, this operation is safe so long as all values can be correctly overridden. 

Also refactored the usage of `getBoundingClientRect` since our internal `viewport-impl.js` library has more robust wrapper functions for these. 