### PR TITLE
[amp-story] Add `stop-animation-after=x` parameter to animations.

### DIFF
--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -6,7 +6,7 @@
   <link rel="canonical" href="visual-effects.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <style amp-custom>
     amp-story-page {
       font-family: 'Roboto', sans-serif;
@@ -33,9 +33,9 @@
 
     <amp-story-page id="ken-burns-effect1">
       <amp-story-grid-layer template="fill">
-        <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="30s"
-            layout="fixed" width="1600" height="1200">
+        <div animate-in="zoom-in" animate-in-duration="50s" stop-animation-after="3s" class="img-container">
+          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="50s"
+            stop-animation-after="3s" layout="fixed" width="1600" height="1200">
           </amp-img>
         </div>
       </amp-story-grid-layer>

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -46,6 +46,8 @@ const ANIMATE_IN_DELAY_ATTRIBUTE_NAME = 'animate-in-delay';
 /** const {string} */
 const ANIMATE_IN_AFTER_ATTRIBUTE_NAME = 'animate-in-after';
 /** const {string} */
+const STOP_ANIMATION_AFTER_ATTRIBUTE_NAME = 'stop-animation-after';
+/** const {string} */
 const ANIMATABLE_ELEMENTS_SELECTOR = `[${ANIMATE_IN_ATTRIBUTE_NAME}]`;
 
 
@@ -109,6 +111,9 @@ class AnimationRunner {
 
     /** @private @const */
     this.duration_ = animationDef.duration || this.presetDef_.duration || 0;
+
+    /** @private @const */
+    this.stopAfter_ = animationDef.stopAfter || null;
 
     /**
      * @private @const {!Promise<
@@ -240,6 +245,16 @@ class AnimationRunner {
    */
   startWhenReady_(runner) {
     runner.start();
+    if (this.stopAfter_) {
+      this.timer_.promise(this.stopAfter_).then(() => this.pause());
+    }
+  }
+
+  /**
+   * Pause animation.
+   */
+  pause() {
+    this.runner_.pause();
   }
 
   /** @return {boolean} */
@@ -494,6 +509,11 @@ export class AnimationManager {
     if (el.hasAttribute(ANIMATE_IN_DELAY_ATTRIBUTE_NAME)) {
       animationDef.delay =
           timeStrToMillis(el.getAttribute(ANIMATE_IN_DELAY_ATTRIBUTE_NAME));
+    }
+
+    if (el.hasAttribute(STOP_ANIMATION_AFTER_ATTRIBUTE_NAME)) {
+      animationDef.stopAfter =
+        timeStrToMillis(el.getAttribute(STOP_ANIMATION_AFTER_ATTRIBUTE_NAME));
     }
 
     if (el.hasAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME)) {


### PR DESCRIPTION
#20260

This PR only adds the code specific for this use case. It creates a `pause()` function that calls the underlying method of the wrapped `WebAnimationRunner` class.

Follow ups will be sent for:
* validation
* docs
* add animation support for hold to pause in amp-story (which will include a `resume()` callback).
