### PR TITLE
🏗 Only print TRAVIS_PULL_REQUEST_SHA in `pr-check` on Travis

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -103,12 +103,12 @@ function printChangeSummary() {
     console.log(fileLogPrefix, colors.cyan('origin/master'),
         'is currently at commit',
         colors.cyan(shortSha(gitTravisMasterBaseline())));
+    console.log(fileLogPrefix,
+        'Testing the following changes at commit',
+        colors.cyan(shortSha(process.env.TRAVIS_PULL_REQUEST_SHA)));
   }
 
   const filesChanged = gitDiffStatMaster();
-  console.log(fileLogPrefix,
-      'Testing the following changes at commit',
-      colors.cyan(shortSha(process.env.TRAVIS_PULL_REQUEST_SHA)));
   console.log(filesChanged);
 
   const branchPoint = gitMergeBaseMaster();


### PR DESCRIPTION
Fixes #20275, which is caused by changes in #20256