### PR TITLE
add intent-to-ship template

### DIFF
--- a/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
@@ -1,0 +1,51 @@
+---
+name: Intent-to-ship (I2S)
+about: Proposes launching a significant change/update to AMP that has already been
+  implemented.  https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md
+title: 'I2S: <your change/update>'
+labels: INTENT TO SHIP
+assignees: ''
+
+---
+
+<!---
+Replace/remove all of the text in brackets, including this text.
+
+Use an Intent-to-ship (I2S) issue to request the launch of a significant change/update to AMP, generally those that required an Intent-to-implement (I2I) issue.
+See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for more information.
+-->
+
+**Summary**
+<!---
+Provide a brief description of the feature/change you have implemented.
+-->
+
+**Intent-to-implement (I2I) issue**
+<!---
+Provide a link to the I2I issue you filed for this feature/change.
+-->
+
+**Experiment(s) to enable**
+<!---
+List the experiment(s) that should be enabled to launch your feature.
+-->
+
+**Required release version**
+<!---
+Link to the "Type: Release" issue for the release that contains all of the changes necessary for your launch.
+-->
+
+**Demo instructions**
+<!---
+Provide instructions for how to demo your feature such as a link to a demo page.
+-->
+
+**Additional context**
+<!---
+Add any other information that may be relevant in determining if your feature can ship.
+-->
+
+<!---
+Add anyone to this cc line that you want to notify about this I2S, including the reviewer who you worked with on the I2I.
+-->
+/cc @ampproject/wg-approvers


### PR DESCRIPTION
Adds an Intent-to-ship (I2S) template as part of our updated launch process [inspired by Chromium](https://www.chromium.org/blink/launching-features).

The new launch process is being documented in #19852.

/cc @ampproject/wg-infra 