### PR TITLE
Moving the page attachment header into shadow DOM.

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -277,6 +277,7 @@ exports.extensionBundles = [
         'amp-story-tooltip',
         'amp-story-consent',
         'amp-story-hint',
+        'amp-story-page-attachment-header',
         'amp-story-unsupported-browser-layer',
         'amp-story-viewport-warning-layer',
         'amp-story-info-dialog',

--- a/extensions/amp-story/1.0/amp-story-page-attachment-header.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment-header.css
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.i-amphtml-story-page-attachment-header {
+  position: relative !important;
+  height: 40px !important;
+  background: #fff !important;
+  border-radius: 8px 8px 0 0 !important;
+  box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.12) !important;
+  z-index: 1 !important;
+}
+
+.i-amphtml-story-page-attachment-close-button {
+  display: inline-block !important;
+  margin: 8px !important;
+  height: 24px !important;
+  width: 24px !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(0, 0, 0, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  cursor: pointer !important;
+}

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -36,25 +36,6 @@ amp-story-page-attachment.i-amphtml-story-page-attachment-open {
   height: 100% !important;
 }
 
-.i-amphtml-story-page-attachment-header {
-  position: relative !important;
-  height: 40px !important;
-  background: #fff !important;
-  border-radius: 8px 8px 0 0 !important;
-  box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.12) !important;
-  z-index: 1 !important;
-}
-
-.i-amphtml-story-page-attachment-close-button {
-  display: inline-block !important;
-  margin: 8px;
-  height: 24px !important;
-  width: 24px !important;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(0, 0, 0, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
-  color: rgba(0, 0, 0, 0.87) !important;
-  cursor: pointer !important;
-}
-
 .i-amphtml-story-page-attachment-container {
   height: calc(100% - 40px) !important;
   background: rgba(255, 255, 255, 1) !important;

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -15,8 +15,10 @@
  */
 
 import {Action, getStoreService} from './amp-story-store-service';
+import {CSS} from '../../../build/amp-story-page-attachment-header-1.0.css';
 import {Layout} from '../../../src/layout';
 import {closest} from '../../../src/dom';
+import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 import {resetStyles, setImportantStyles, toggle} from '../../../src/style';
@@ -43,14 +45,23 @@ const AttachmentState = {
 const getTemplateEl = element => {
   return htmlFor(element)`
     <div class="i-amphtml-story-page-attachment">
-      <div class="i-amphtml-story-page-attachment-header">
-        <span
-            class="i-amphtml-story-page-attachment-close-button" role="button">
-        </span>
-      </div>
       <div class="i-amphtml-story-page-attachment-container">
         <div class="i-amphtml-story-page-attachment-content"></div>
       </div>
+    </div>`;
+};
+
+/**
+ * Drawer's header template.
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const getHeaderEl = element => {
+  return htmlFor(element)`
+    <div class="i-amphtml-story-page-attachment-header">
+      <span
+          class="i-amphtml-story-page-attachment-close-button" role="button">
+      </span>
     </div>`;
 };
 
@@ -67,6 +78,9 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.contentEl_ = null;
+
+    /** @private {?Element} */
+    this.headerEl_ = null;
 
     /** @private {!AttachmentState} */
     this.state_ = AttachmentState.CLOSED;
@@ -99,8 +113,12 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // TODO: maybe render the header in Shadow DOM?
     const templateEl = getTemplateEl(this.element);
+
+    const headerShadowRootEl = this.win.document.createElement('div');
+    this.headerEl_ = getHeaderEl(this.element);
+    createShadowRootWithStyle(headerShadowRootEl, this.headerEl_, CSS);
+    templateEl.insertBefore(headerShadowRootEl, templateEl.firstChild);
 
     this.containerEl_ = dev().assertElement(
         templateEl.querySelector('.i-amphtml-story-page-attachment-container'));
@@ -125,7 +143,8 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
    * @private
    */
   initializeListeners_() {
-    this.element.querySelector('.i-amphtml-story-page-attachment-close-button')
+    this.headerEl_
+        .querySelector('.i-amphtml-story-page-attachment-close-button')
         .addEventListener('click', () => this.close_(), true /** useCapture */);
 
     // Enforced by AMP validation rules.


### PR DESCRIPTION
Moving the page attachment header into shadow DOM.

It ensures publishers can't override its styles, and hide/tweak the content through various CSS techniques which could become a security issue once/if we allow loading URLs and display the domain name.

#20209