### PR TITLE
[amp-story] Add animation for expandable components

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -335,9 +335,11 @@ amp-story-grid-layer amp-twitter::after {
 
 .i-amphtml-expanded-mode amp-twitter {
   z-index: 1 !important;
-  position: absolute !important;
-  top: 15% !important;
-  left: 0 !important;
+}
+
+.i-amphtml-animate-expand-in {
+  /** If you change the duration of this animation, please reflect if in the JS animateExpanded_ method too. */
+  transition: transform 0.225s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 
 .i-amphtml-story-grid-template-with-full-bleed-animation {


### PR DESCRIPTION
#19213 #16522

Centers expandable component into center of page after prompting tooltip is clicked.

Temp demo link: https://stamp-iframe-support.firebaseapp.com/examples/amp-story/artezan/ampcomponents.html