### PR TITLE
Launch amp-list-viewport-resize to 10%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -52,5 +52,6 @@
   "scroll-height-bounce": 0,
   "scroll-height-minheight": 0,
   "hidden-mutation-observer": 1,
-  "sandbox-ads": 1
+  "sandbox-ads": 1,
+  "amp-list-viewport-resize": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -52,5 +52,6 @@
   "scroll-height-bounce": 0,
   "scroll-height-minheight": 0,
   "hidden-mutation-observer": 1,
-  "sandbox-ads": 1
+  "sandbox-ads": 1,
+  "amp-list-viewport-resize": 0.1
 }


### PR DESCRIPTION
Part of https://github.com/ampproject/amphtml/issues/20309. 
Launches this experiment to 100% of canary and 10% of production. 