### PR TITLE
Removed misleading statement on amp-animation conditions 📖

### DIFF
--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -96,7 +96,7 @@ and is comprised of:
 
 ### Conditions
 
-Conditions can specify whether this animation component is included in the final animation. Currently, only `media` expression is supported.
+Conditions can specify whether this animation component is included in the final animation.
 
 #### Media query
 


### PR DESCRIPTION
`<amp-animation>` Conditions says it only supports `media` expression. This is false since it also supports `supports`. 