### PR TITLE
🐛Quick-fix safari paste behavior with inputmask

### DIFF
--- a/third_party/inputmask/inputmask.js
+++ b/third_party/inputmask/inputmask.js
@@ -1806,7 +1806,10 @@ export function factory($, window, document, undefined) {
                     }
                 }
                 checkVal(input, false, false, pasteValue.toString().split(""));
-                writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join(""));
+                // Use settimeout to make Safari paste work
+                setTimeout(() => {
+                    writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join(""));
+                }, 0);
                 return e.preventDefault();
             },
             inputFallBackEvent: function(e) {

--- a/third_party/inputmask/patches/0007-safari-paste-fix.patch
+++ b/third_party/inputmask/patches/0007-safari-paste-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index 412be8d43..79cb5cc0a 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -1794,7 +1794,10 @@ export function factory($, window, document, undefined) {
+                     }
+                 }
+                 checkVal(input, false, false, pasteValue.toString().split(""));
+-                writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join(""));
++                // Use settimeout to make Safari paste work
++                setTimeout(() => {
++                    writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()), e, undoValue !== getBuffer().join(""));
++                }, 0);
+                 return e.preventDefault();
+             },
+             inputFallBackEvent: function(e) {


### PR DESCRIPTION
I noticed desktop Safari was having trouble with pasting into inputmasked field. This fixes it. A `setTimeout` is not ideal, but the library uses them and untangling theirs will take more time. This will bandaid it for now.