### PR TITLE
Removes references to pre-governance change working groups

### DIFF
--- a/contributing/working-groups.md
+++ b/contributing/working-groups.md
@@ -1,9 +1,0 @@
-# Working groups
-
-AMP Project working groups bring together parties with related interests to discuss ideas for how AMP can evolve and to receive updates on new features and changes in AMP that are relevant to the group.
-
-Working groups include a group email alias as well as periodic video conferences (over Google Hangouts).
-
-The News Publisher Working Group is currently our only active working group.  See the [amp-news-publishers-wg Google group](https://groups.google.com/forum/#!forum/amp-news-publishers-wg) to express interest in joining this working group.
-
-We are actively exploring the creation of other working groups and will update this page as new working groups are created.


### PR DESCRIPTION
The notion of what an AMP Working Group is changed with the [new governance model](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#working-groups).

To avoid confusion, this removes references to the older "working groups" from our documentation.  These served a different purpose than the current working groups, focused primarily on getting feedback and posting updates to the community, and there was only one active group (for news publishers).  There will be a separate effort to think about the best way of bringing the benefits of these older working groups into AMP again, but in the meantime we'll delete this file to avoid confusion.