### PR TITLE
🐛Fix non-mask chars remaining in field after clear all

### DIFF
--- a/third_party/inputmask/inputmask.js
+++ b/third_party/inputmask/inputmask.js
@@ -1681,9 +1681,21 @@ export function factory($, window, document, undefined) {
         var EventHandlers = {
             keydownEvent: function(e) {
                 var input = this, $input = $(input), k = e.keyCode, pos = caret(input);
-                if (k === Inputmask.keyCode.BACKSPACE || k === Inputmask.keyCode.DELETE || iphone && k === Inputmask.keyCode.BACKSPACE_SAFARI || e.ctrlKey && k === Inputmask.keyCode.X && !isInputEventSupported("cut")) {
+                if (k === Inputmask.keyCode.BACKSPACE || k === Inputmask.keyCode.DELETE || iphone && k === Inputmask.keyCode.BACKSPACE_SAFARI || (e.ctrlKey || e.metaKey) && k === Inputmask.keyCode.X && !isInputEventSupported("cut")) {
                     e.preventDefault();
+
+                    // Handle META/CTRL+DELETE clear keyboard shortcut
+                    if (e.metaKey || e.ctrlKey) {
+                        pos.begin = 0;
+                    }
+
                     handleRemove(input, k, pos);
+
+                    // Handle SelectAll then Delete
+                    if (pos.end - pos.begin == input.value.length) {
+                        resetMaskSet(false);
+                    }
+
                     writeBuffer(input, getBuffer(true), getMaskSet().p, e, input.inputmask._valueGet() !== getBuffer().join(""));
                 } else if (k === Inputmask.keyCode.END || k === Inputmask.keyCode.PAGE_DOWN) {
                     e.preventDefault();
@@ -2008,7 +2020,19 @@ export function factory($, window, document, undefined) {
                 var clipboardData = window.clipboardData || ev.clipboardData, clipData = isRTL ? getBuffer().slice(pos.end, pos.begin) : getBuffer().slice(pos.begin, pos.end);
                 clipboardData.setData("text", isRTL ? clipData.reverse().join("") : clipData.join(""));
                 if (document.execCommand) document.execCommand("copy");
+
+                // Handle META/CTRL+DELETE clear keyboard shortcut
+                if (e.metaKey || e.ctrlKey) {
+                    pos.begin = 0;
+                }
+
                 handleRemove(input, Inputmask.keyCode.DELETE, pos);
+
+                // Handle SelectAll then Delete
+                if (pos.end - pos.begin == input.value.length) {
+                    resetMaskSet(false);
+                }
+
                 writeBuffer(input, getBuffer(), getMaskSet().p, e, undoValue !== getBuffer().join(""));
             },
             blurEvent: function(e) {

--- a/third_party/inputmask/patches/0008-fix-remove-prefix.patch
+++ b/third_party/inputmask/patches/0008-fix-remove-prefix.patch
@@ -1,0 +1,47 @@
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index 412be8d43..c7181aabf 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -1681,9 +1681,21 @@ export function factory($, window, document, undefined) {
+         var EventHandlers = {
+             keydownEvent: function(e) {
+                 var input = this, $input = $(input), k = e.keyCode, pos = caret(input);
+-                if (k === Inputmask.keyCode.BACKSPACE || k === Inputmask.keyCode.DELETE || iphone && k === Inputmask.keyCode.BACKSPACE_SAFARI || e.ctrlKey && k === Inputmask.keyCode.X && !isInputEventSupported("cut")) {
++                if (k === Inputmask.keyCode.BACKSPACE || k === Inputmask.keyCode.DELETE || iphone && k === Inputmask.keyCode.BACKSPACE_SAFARI || (e.ctrlKey || e.metaKey) && k === Inputmask.keyCode.X && !isInputEventSupported("cut")) {
+                     e.preventDefault();
++
++                    // Handle META/CTRL+DELETE clear keyboard shortcut
++                    if (e.metaKey || e.ctrlKey) {
++                        pos.begin = 0;
++                    }
++
+                     handleRemove(input, k, pos);
++
++                    // Handle SelectAll then Delete
++                    if (pos.end - pos.begin == input.value.length) {
++                        resetMaskSet(false);
++                    }
++
+                     writeBuffer(input, getBuffer(true), getMaskSet().p, e, input.inputmask._valueGet() !== getBuffer().join(""));
+                 } else if (k === Inputmask.keyCode.END || k === Inputmask.keyCode.PAGE_DOWN) {
+                     e.preventDefault();
+@@ -2008,7 +2020,19 @@ export function factory($, window, document, undefined) {
+                 var clipboardData = window.clipboardData || ev.clipboardData, clipData = isRTL ? getBuffer().slice(pos.end, pos.begin) : getBuffer().slice(pos.begin, pos.end);
+                 clipboardData.setData("text", isRTL ? clipData.reverse().join("") : clipData.join(""));
+                 if (document.execCommand) document.execCommand("copy");
++
++                // Handle META/CTRL+DELETE clear keyboard shortcut
++                if (e.metaKey || e.ctrlKey) {
++                    pos.begin = 0;
++                }
++
+                 handleRemove(input, Inputmask.keyCode.DELETE, pos);
++
++                // Handle SelectAll then Delete
++                if (pos.end - pos.begin == input.value.length) {
++                    resetMaskSet(false);
++                }
++
+                 writeBuffer(input, getBuffer(), getMaskSet().p, e, undoValue !== getBuffer().join(""));
+             },
+             blurEvent: function(e) {


### PR DESCRIPTION
Before this PR doing "Select All -> Backspace" or "Select All -> Cut" would leave any prefix like "+1" remaining in the beginning of the field. This PR prevents the prefix from remaining when the field is empty after a user action.