### PR TITLE
🐛amp-carousel: move mutate from onLayoutMeasure to layoutCallback.

### DIFF
--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -526,7 +526,7 @@ describes.realWin('SlideScroll', {
     const ampSlideScroll = await getAmpSlideScroll();
     const impl = ampSlideScroll.implementation_;
     const getLayoutWidthStub = sandbox.stub(impl, 'getLayoutWidth');
-    
+
     getLayoutWidthStub.returns(200);
     impl.onLayoutMeasure();
     expect(getLayoutWidthStub).to.have.been.calledOnce;

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -522,24 +522,30 @@ describes.realWin('SlideScroll', {
     });
   });
 
-  it('should handle layout measures (orientation changes)', () => {
-    return getAmpSlideScroll().then(ampSlideScroll => {
-      const impl = ampSlideScroll.implementation_;
-      const getLayoutWidthSpy = sandbox.stub(impl, 'getLayoutWidth').callsFake(
-          () => {
-            return impl.slideWidth_ == 400 ? 200 : 400;
-          });
-      impl.onLayoutMeasure();
-      expect(getLayoutWidthSpy).to.have.been.called;
-      expect(impl.slideWidth_).to.equal(200);
+  it('should handle layout measures (orientation changes)', async() => {
+    const ampSlideScroll = await getAmpSlideScroll();
+    const impl = ampSlideScroll.implementation_;
+    const getLayoutWidthStub = sandbox.stub(impl, 'getLayoutWidth');
+    
+    getLayoutWidthStub.returns(200);
+    impl.onLayoutMeasure();
+    expect(getLayoutWidthStub).to.have.been.calledOnce;
+    expect(impl.slideWidth_).to.equal(200);
 
-      impl.showSlide_(1);
-      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(200);
-      impl.onLayoutMeasure();
-      expect(getLayoutWidthSpy).to.have.callCount(2);
-      expect(impl.slideWidth_).to.equal(400);
-      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(400);
-    });
+    // Show the first slide, make sure the scroll position is correct.
+    impl.showSlide_(1);
+    expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(200);
+
+    // Now do a layout measure letting the component know it changed size.
+    getLayoutWidthStub.returns(400);
+    impl.onLayoutMeasure();
+    expect(getLayoutWidthStub).to.have.callCount(2);
+    expect(impl.slideWidth_).to.equal(400);
+    expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(200);
+
+    // Make sure the scroll position is correct after layoutCallback.
+    await impl.layoutCallback();
+    expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(400);
   });
 
   it('should relayout the current slide on layoutCallback', () => {


### PR DESCRIPTION
The `onLayoutMeasure` callback could fire during scrolling, causing the scroll position to incorrectly be set. Move the setting of the scroll position into layoutCallback. Since BaseCarousel implements `isRelayoutNeeded`, returning true, the `layoutCallback` will be called whenever the size of the carousel itself changes (whether on orientation or otherwise).

- Remove forced style calculation by reading the scrollLeft immediately after setting it. Instead, used the value we just requested to be set. The only situation where this would not work is if the requested `scrollLeft` was larger than the available `scrollWidth`. To cover this case, added a check to `getScrollLeftForIndex` to return 0 when there is only 1 slide. As a result, all other cases should have a `scrollWidth` of at least `slideWidth`.

Fixes #20234