### PR TITLE
[amp-story] Add support for different kinds of action icons inside the tooltip

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -27,36 +27,101 @@ import {addAttributesToElement, closest, matches} from '../../../src/dom';
 import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {findIndex} from '../../../src/utils/array';
 import {getAmpdoc} from '../../../src/service';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 import {resetStyles, setImportantStyles, toggle} from '../../../src/style';
 
 /**
- * Enum of elements that can be expanded.
+ * Action icons to be placed in tooltip.
  * @enum {string}
+ * @private
  */
-const EXPANDABLE_COMPONENTS = {
-  TWITTER: 'amp-twitter',
+const ActionIcon = {
+  LAUNCH: 'i-amphtml-tooltip-action-icon-launch',
+  EXPAND: 'i-amphtml-tooltip-action-icon-expand',
 };
 
 /**
- * Enum containing all interactive component CSS selectors.
+ * Components that can be expanded.
+ * @const {!Object}
+ * @private
+ */
+const EXPANDABLE_COMPONENTS = {
+  TWITTER: {
+    componentIcon: 'data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.' +
+    'w3.org/2000/svg" width="400" height="400"><g fill="none" fill-rule="eve' +
+    'nodd"><path d="M0 0h400v400H0z"/><path fill="%23757575" fill-rule="nonz' +
+    'ero" d="M153.62 301.59c94.34 0 145.94-78.16 145.94-145.94 0-2.22 0-4.43' +
+    '-.15-6.63A104.36 104.36 0 0 0 325 122.47a102.38 102.38 0 0 1-29.46 8.07 ' +
+    '51.47 51.47 0 0 0 22.55-28.37 102.79 102.79 0 0 1-32.57 12.45c-15.9-16.' +
+    '906-41.163-21.044-61.625-10.093-20.461 10.95-31.032 34.266-25.785 56.87' +
+    '3A145.62 145.62 0 0 1 92.4 107.81c-13.614 23.436-6.66 53.419 15.88 68.4' +
+    '7A50.91 50.91 0 0 1 85 169.86v.65c.007 24.416 17.218 45.445 41.15 50.28' +
+    'a51.21 51.21 0 0 1-23.16.88c6.72 20.894 25.976 35.208 47.92 35.62a102.9' +
+    '2 102.92 0 0 1-63.7 22 104.41 104.41 0 0 1-12.21-.74 145.21 145.21 0 0 ' +
+    '0 78.62 23"/></g></svg>',
+    actionIcon: ActionIcon.EXPAND,
+    // TODO(enriqe): change for i18n label.
+    defaultText: 'View on Twitter',
+    selector: 'amp-twitter',
+  },
+};
+
+/**
+ * Components that can be launched.
+ * @const {!Object}
+ * @private
+ */
+const LAUNCHABLE_COMPONENTS = {
+  LINK: {
+    componentIcon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
+    actionIcon: ActionIcon.LAUNCH,
+    selector: 'a[href]',
+  },
+};
+
+/**
+ * Union of expandable and launchable components.
+ * @private
+ * @const {!Object}
+ */
+const INTERACTIVE_COMPONENTS = Object.assign({}, EXPANDABLE_COMPONENTS,
+    LAUNCHABLE_COMPONENTS);
+
+/**
+ * Gets the list of components with their respective selectors.
+ * @param {!Object} components
+ * @return {!Object<string, string>}
+ */
+function getComponentSelectors(components) {
+  const obj = {};
+
+  Object.keys(components).forEach(key => {
+    obj[key] = components[key].selector;
+  });
+
+  return obj;
+}
+
+/**
+ * Contains all interactive component CSS selectors.
  * @type {!Object}
  */
-const interactiveComponents = Object.assign({}, EXPANDABLE_COMPONENTS, {
-  EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
+const interactiveComponentSelectors = Object.assign({},
+    getComponentSelectors(INTERACTIVE_COMPONENTS),
+    {EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
     '.i-amphtml-expanded-view-close-button',
-  LINK: 'a[href]',
-});
+    });
 
 /**
  * Selectors that should delegate to AmpStoryEmbeddedComponent.
- * @return {!Object<string, string>}
+ * @return {!Object}
  */
 export function embeddedComponentSelectors() {
   // Using indirect invocation to prevent no-export-side-effect issue.
-  return interactiveComponents;
+  return interactiveComponentSelectors;
 }
 
 /**
@@ -364,8 +429,10 @@ export class AmpStoryEmbeddedComponent {
    * @private
    */
   updateTooltipEl_(target) {
-    this.updateTooltipText_(target);
-    this.updateTooltipIcon_(target);
+    const embedConfig = this.getEmbedConfigFor_(target);
+    this.updateTooltipText_(target, embedConfig);
+    this.updateTooltipComponentIcon_(target, embedConfig);
+    this.updateTooltipActionIcon_(embedConfig);
     this.positionTooltip_(target);
   }
 
@@ -381,7 +448,7 @@ export class AmpStoryEmbeddedComponent {
       return;
     }
 
-    if (Object.values(EXPANDABLE_COMPONENTS)
+    if (Object.values(getComponentSelectors(EXPANDABLE_COMPONENTS))
         .includes(target.tagName.toLowerCase())) {
       this.tooltip_.addEventListener('click', this.expandComponentHandler_,
           true);
@@ -417,6 +484,21 @@ export class AmpStoryEmbeddedComponent {
 
     return parseUrlDeprecated(elUrl).href;
   }
+
+ /**
+  * Gets corresponding config for a given embed target.
+  * @param {!Element} target
+  * @return {!Object}
+  */
+ getEmbedConfigFor_(target) {
+  const componentIndex = findIndex(Object.values(INTERACTIVE_COMPONENTS),
+      config => {
+        return matches(target, config.selector);
+      });
+
+  return INTERACTIVE_COMPONENTS[
+      Object.keys(INTERACTIVE_COMPONENTS)[componentIndex]];
+ }
 
   /**
    * Animates into expanded view.
@@ -458,10 +540,12 @@ export class AmpStoryEmbeddedComponent {
   /**
    * Updates tooltip text content.
    * @param {!Element} target
+   * @param {!Object} embedConfig
    * @private
    */
-  updateTooltipText_(target) {
+  updateTooltipText_(target, embedConfig) {
     const tooltipText = target.getAttribute('data-tooltip-text') ||
+      embedConfig.defaultText ||
       getSourceOriginForElement(target, this.getElementHref_(target));
     const existingTooltipText =
       this.tooltip_.querySelector('.i-amphtml-tooltip-text');
@@ -470,19 +554,36 @@ export class AmpStoryEmbeddedComponent {
   }
 
   /**
-   * Updates tooltip icon. If no icon src is declared, it sets a default src and
-   * hides it.
+   * Updates tooltip action icon. This is found on the right of the text.
+   * @param {!Object} embedConfig
+   */
+  updateTooltipActionIcon_(embedConfig) {
+    const actionIcon =
+      this.tooltip_.querySelector('.i-amphtml-tooltip-action-icon');
+
+    this.resources_.mutateElement(devAssert(actionIcon), () => {
+      actionIcon.classList.toggle(ActionIcon.EXPAND, false);
+      actionIcon.classList.toggle(ActionIcon.LAUNCH, false);
+
+      actionIcon.classList.toggle(embedConfig.actionIcon, true);
+    });
+  }
+
+  /**
+   * Updates tooltip icon. If no icon src is declared, it sets a default for a
+   * given component type.
    * @param {!Element} target
+   * @param {!Object} embedConfig
    * @private
    */
-  updateTooltipIcon_(target) {
+  updateTooltipComponentIcon_(target, embedConfig) {
     const iconUrl = target.getAttribute('data-tooltip-icon');
     if (!isProtocolValid(iconUrl)) {
       user().error(TAG, 'The tooltip icon url is invalid');
       return;
     }
     const iconSrc = iconUrl ? parseUrlDeprecated(iconUrl).href :
-      DEFAULT_ICON_SRC;
+      embedConfig.componentIcon;
 
     const existingTooltipIcon =
       this.tooltip_.querySelector('.i-amphtml-story-tooltip-icon');
@@ -632,7 +733,7 @@ export class AmpStoryEmbeddedComponent {
           <a class="i-amphtml-story-tooltip" target="_blank" ref="tooltip">
             <div class="i-amphtml-story-tooltip-icon"><img ref="icon"></div>
             <p class="i-amphtml-tooltip-text" ref="text"></p>
-            <div class="i-amphtml-tooltip-launch-icon"></div>
+            <div class="i-amphtml-tooltip-action-icon"></div>
             <div class="i-amphtml-story-tooltip-arrow" ref="arrow"></div>
           </a>
         </section>`;

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -52,7 +52,7 @@ const EXPANDABLE_COMPONENTS = {
   TWITTER: {
     componentIcon: 'data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.' +
     'w3.org/2000/svg" width="400" height="400"><g fill="none" fill-rule="eve' +
-    'nodd"><path d="M0 0h400v400H0z"/><path fill="%23757575" fill-rule="nonz' +
+    'nodd"><path d="M0 0h400v400H0z"/><path fill="%231da1f2" fill-rule="nonz' +
     'ero" d="M153.62 301.59c94.34 0 145.94-78.16 145.94-145.94 0-2.22 0-4.43' +
     '-.15-6.63A104.36 104.36 0 0 0 325 122.47a102.38 102.38 0 0 1-29.46 8.07 ' +
     '51.47 51.47 0 0 0 22.55-28.37 102.79 102.79 0 0 1-32.57 12.45c-15.9-16.' +

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -25,7 +25,7 @@ import {EventType, dispatch} from './events';
 import {Services} from '../../../src/services';
 import {addAttributesToElement, closest, matches} from '../../../src/dom';
 import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
-import {dev, devAssert, user} from '../../../src/log';
+import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getAmpdoc} from '../../../src/service';
@@ -429,7 +429,9 @@ export class AmpStoryEmbeddedComponent {
    * @private
    */
   updateTooltipEl_(target) {
-    const embedConfig = this.getEmbedConfigFor_(target);
+    const embedConfig = userAssert(this.getEmbedConfigFor_(target), 'Invalid ' +
+      'embed config for target', target);
+
     this.updateTooltipText_(target, embedConfig);
     this.updateTooltipComponentIcon_(target, embedConfig);
     this.updateTooltipActionIcon_(embedConfig);
@@ -556,14 +558,16 @@ export class AmpStoryEmbeddedComponent {
   /**
    * Updates tooltip action icon. This is found on the right of the text.
    * @param {!Object} embedConfig
+   * @private
    */
   updateTooltipActionIcon_(embedConfig) {
     const actionIcon =
       this.tooltip_.querySelector('.i-amphtml-tooltip-action-icon');
 
     this.resources_.mutateElement(devAssert(actionIcon), () => {
-      actionIcon.classList.toggle(ActionIcon.EXPAND, false);
-      actionIcon.classList.toggle(ActionIcon.LAUNCH, false);
+      Object.values(ActionIcon).map(iconClass => {
+        actionIcon.classList.toggle(iconClass, false);
+      });
 
       actionIcon.classList.toggle(embedConfig.actionIcon, true);
     });

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -487,20 +487,20 @@ export class AmpStoryEmbeddedComponent {
     return parseUrlDeprecated(elUrl).href;
   }
 
- /**
-  * Gets corresponding config for a given embed target.
-  * @param {!Element} target
-  * @return {!Object}
-  */
- getEmbedConfigFor_(target) {
-  const componentIndex = findIndex(Object.values(INTERACTIVE_COMPONENTS),
-      config => {
-        return matches(target, config.selector);
-      });
+  /**
+   * Gets corresponding config for a given embed target.
+   * @param {!Element} target
+   * @return {!Object}
+   */
+  getEmbedConfigFor_(target) {
+    const componentIndex = findIndex(Object.values(INTERACTIVE_COMPONENTS),
+        config => {
+          return matches(target, config.selector);
+        });
 
-  return INTERACTIVE_COMPONENTS[
-      Object.keys(INTERACTIVE_COMPONENTS)[componentIndex]];
- }
+    return INTERACTIVE_COMPONENTS[
+        Object.keys(INTERACTIVE_COMPONENTS)[componentIndex]];
+  }
 
   /**
    * Animates into expanded view.

--- a/extensions/amp-story/1.0/amp-story-tooltip.css
+++ b/extensions/amp-story/1.0/amp-story-tooltip.css
@@ -151,11 +151,18 @@
   height: 100% !important;
 }
 
-.i-amphtml-tooltip-launch-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" viewBox="0 0 48 48" fill="#757575"><path d="M0 0h48v48H0z" fill="none"/><path d="M38 38H10V10h14V6H10c-2.21 0-4 1.79-4 4v28c0 2.21 1.79 4 4 4h28c2.21 0 4-1.79 4-4V24h-4v14zM28 6v4h7.17L15.51 29.66l2.83 2.83L38 12.83V20h4V6H28z"/></svg>') !important;
+.i-amphtml-tooltip-action-icon {
   width: 16px !important;
   height: 16px !important;
   padding-bottom: 2px !important;
+}
+
+.i-amphtml-tooltip-action-icon-launch {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" viewBox="0 0 48 48" fill="%23757575"><path d="M0 0h48v48H0z" fill="none"/><path d="M38 38H10V10h14V6H10c-2.21 0-4 1.79-4 4v28c0 2.21 1.79 4 4 4h28c2.21 0 4-1.79 4-4V24h-4v14zM28 6v4h7.17L15.51 29.66l2.83 2.83L38 12.83V20h4V6H28z"/></svg>') !important;
+}
+
+.i-amphtml-tooltip-action-icon-expand {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" viewBox="0 0 48 48" fill="#757575"><path d="M17.17 32.92l9.17-9.17-9.17-9.17L20 11.75l12 12-12 12z"/><path d="M0-.25h48v48H0z" fill="none"/></svg>') !important;
 }
 
 .i-amphtml-story-tooltip-arrow {

--- a/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
@@ -35,6 +35,7 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
     storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
     clickableEl = win.document.createElement('a');
+    addAttributesToElement(clickableEl, {'href': 'https://google.com'});
 
     // Making sure resource tasks run synchronously.
     sandbox.stub(Services, 'resourcesForDoc').returns({
@@ -183,13 +184,13 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
     expect(tooltipTextEl.textContent).to.equal('my cool text');
   });
 
-  it('should append local url when text attribute is not present', () => {
+  it('should append href url when text attribute is not present', () => {
     fakePage.appendChild(clickableEl);
     storeService.dispatch(Action.TOGGLE_EMBEDDED_COMPONENT, clickableEl);
 
     const tooltipTextEl = component.focusedStateOverlay_
         .querySelector('.i-amphtml-tooltip-text');
 
-    expect(tooltipTextEl.textContent).to.equal('localhost');
+    expect(tooltipTextEl.textContent).to.equal('google.com');
   });
 });


### PR DESCRIPTION
Closes: #20001

Part of: #19213 #16522

Extends support for different kind of icons on the tooltip.  
The icon on the left of the tooltip will be called: `componentIcon`, and on the right `actionIcon`.

(Follow ups will be send for i18n of the default tooltip text).

e.g.



![image](https://user-images.githubusercontent.com/5449100/51216642-1500bc00-18f3-11e9-8fd6-7e96cc68d2b9.png)


![image](https://user-images.githubusercontent.com/5449100/51155567-e8429b00-1845-11e9-9faa-1ed23e70e3ee.png)
