### PR TITLE
🐛 amp-ad: fixed URL handling on uzou.js

### DIFF
--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -45,7 +45,7 @@ export function uzou(global, data) {
 
   const uzouInjector = {
     url: fixedEncodeURIComponent(
-      widgetParams['url'] ||
+        widgetParams['url'] ||
       global.context.sourceUrl ||
       global.context.canonicalUrl
     ),
@@ -63,7 +63,11 @@ export function uzou(global, data) {
   });
 }
 
-function fixedEncodeURIComponent (str) {
+/**
+ * encode URI based on RFC 3986
+ * @param {string} str url string
+ */
+function fixedEncodeURIComponent(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
     return '%' + c.charCodeAt(0).toString(16);
   });

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -44,7 +44,7 @@ export function uzou(global, data) {
   container.appendChild(d);
 
   const uzouInjector = {
-    url: encodeURIComponent(
+    url: fixedEncodeURIComponent(
       widgetParams['url'] ||
       global.context.sourceUrl ||
       global.context.canonicalUrl
@@ -60,5 +60,11 @@ export function uzou(global, data) {
 
   loadScript(global, entryPoint, () => {
     global.context.renderStart();
+  });
+}
+
+function fixedEncodeURIComponent (str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+    return '%' + c.charCodeAt(0).toString(16);
   });
 }

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -44,7 +44,7 @@ export function uzou(global, data) {
   container.appendChild(d);
 
   const uzouInjector = {
-    url: (
+    url: encodeURIComponent(
       widgetParams['url'] ||
       global.context.sourceUrl ||
       global.context.canonicalUrl

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -24,7 +24,6 @@ import {parseJson} from '../src/json';
 export function uzou(global, data) {
   validateData(data, ['widgetParams'], []);
 
-  const akamaiHost = 'speee-ad.akamaized.net';
   const prefixMap = {
     test: 'dev-',
     development: 'dev-',
@@ -33,6 +32,7 @@ export function uzou(global, data) {
   };
 
   const widgetParams = parseJson(data['widgetParams']);
+  const akamaiHost = widgetParams['akamaiHost'] || 'speee-ad.akamaized.net';
   const placementCode = widgetParams['placementCode'];
   const mode = widgetParams['mode'] || 'production';
   const entryPoint = `https://${prefixMap[mode]}${akamaiHost}/tag/${placementCode}/js/outer-frame.min.js`;
@@ -46,8 +46,8 @@ export function uzou(global, data) {
   const uzouInjector = {
     url: (
       widgetParams['url'] ||
-      global.context.canonicalUrl ||
-      global.context.sourceUrl
+      global.context.sourceUrl ||
+      global.context.canonicalUrl
     ),
     referer: widgetParams['referer'] || global.context.referrer,
   };


### PR DESCRIPTION
We have fixed URL handling on uzou.js for our ad network.

- Use `sourceUrl` instead of `canonicalUrl`
- fix `akamaiHost` to use `data-widget-params`

Could you review our commits?

Regards.