### PR TITLE
✨Add support for credit card field named mask

### DIFF
--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -30,42 +30,26 @@
 <body>
   <h1>Input Masking</h1>
 
-  <!-- TODO(cvializ) -->
-  <!--
   <h2>Named Masks</h2>
   <form method="post"
       action-xhr="/form/echo-json/post"
       target="_blank">
-    <p>Plain text</p>
-    <input name="text">
-
-    <p>Single character</p>
-    <input name="char" mask="L">
-
-    <p>Email</p>
-    <input name="email" mask="email" placeholder="alice@example.com" type="search">
-
-    <p>US and Canada Phone</p>
-    <input name="phone" mask="phone-us" placeholder="+1(555) 555-5555" type="tel"></div>
-
-    <p>International Phone</p>
-    <input name="phone-intl" mask="phone" placeholder="+1(555) 555-5555" type="tel">
-
-
-    <p>mm/dd/yyyy</p>
-    <input name="date-us" mask="date-us" placeholder="mm/dd/yyyy" type="tel">
-    <p>dd/mm/yyyy</p>
-    <input name="date-intl" mask="date-intl" placeholder="dd/mm/yyyy" type="tel">
-    <p>yyyy-mm-dd</p>
-    <input name="date-iso" mask="date-iso" placeholder="yyyy-mm-dd" type="tel">
+    <p>Credit card (credit)</p>
+    <input id="credit" type="text" mask="credit" placeholder="Credit">
 
     <input type="submit">
   </form>
-  -->
+
   <h2>Custom Masks</h2>
   <form method="post"
       action-xhr="/form/echo-json/post"
       target="_blank">
+    <p>Plain text (no mask)</p>
+    <input name="text" type="text">
+
+    <p>Single character</p>
+    <input name="char" mask="L" type="text">
+
     <p>Phone</p>
     <input type="tel" mask="+1_(000)_000-0000" placeholder="+1 (555) 555-5555">
 

--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -35,7 +35,7 @@
       action-xhr="/form/echo-json/post"
       target="_blank">
     <p>Credit card (credit)</p>
-    <input id="credit" type="text" mask="credit" placeholder="Credit">
+    <input id="payment-card" type="text" mask="payment-card" placeholder="Card number">
 
     <input type="submit">
   </form>

--- a/extensions/amp-inputmask/0.1/constants.js
+++ b/extensions/amp-inputmask/0.1/constants.js
@@ -29,12 +29,7 @@ export const MaskChars = {
 export const MASK_SEPARATOR_CHAR = ' ';
 
 export const NamedMasks = {
-  EMAIL: 'email',
-  PHONE: 'phone',
-  PHONE_US: 'phone-us',
-  DATE_INTL: 'date-intl',
-  DATE_US: 'date-us',
-  DATE_ISO: 'date-iso',
+  CREDIT: 'credit',
 };
 
 /** @enum {string} */

--- a/extensions/amp-inputmask/0.1/constants.js
+++ b/extensions/amp-inputmask/0.1/constants.js
@@ -29,7 +29,7 @@ export const MaskChars = {
 export const MASK_SEPARATOR_CHAR = ' ';
 
 export const NamedMasks = {
-  CREDIT: 'credit',
+  PAYMENT_CARD: 'payment-card',
 };
 
 /** @enum {string} */

--- a/extensions/amp-inputmask/0.1/inputmask-credit-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-credit-alias.js
@@ -22,33 +22,31 @@
 export function factory(Inputmask) {
   // TODO(cvializ): Improve card chunking support
   // https://baymard.com/checkout-usability/credit-card-patterns
-  Inputmask.extendDefinitions({
-    // TODO(cvializ): escape these definitions or make them local to the alias.
-    // matches 37 and 34, amex prefixes
-    '♤': {
-      'validator': function(chrs, buffer) {
-        const val = buffer.buffer.join('') + chrs;
-        const valExp2 = /3(4|7)/;
-        const regextest = valExp2.test(val);
-        return regextest;
-      },
-      'cardinality': 2,
-    },
-    // matches two-digit number except 34 and 37
-    '♢': {
-      'validator': function(chrs, buffer) {
-        const val = buffer.buffer.join('') + chrs;
-        const valExp2 = new RegExp('\\d\\d');
-        const regextest = valExp2.test(val);
-        return regextest && val != '34' && val != '37';
-      },
-      'cardinality': 2,
-    },
-  });
-
   Inputmask.extendAliases({
     'credit': {
-      mask: ['♢99 9999 9999 9999', '♤99 999999 99999'],
+      mask: function(opts) {
+        opts.definitions = {
+          'x': {
+            'validator': function(chrs, buffer) {
+              const val = buffer.buffer.join('') + chrs;
+              const valExp2 = new RegExp('\\d\\d');
+              const regextest = valExp2.test(val);
+              return regextest && val != '34' && val != '37';
+            },
+            'cardinality': 2,
+          },
+          'y': {
+            'validator': function(chrs, buffer) {
+              const val = buffer.buffer.join('') + chrs;
+              const valExp2 = /3(4|7)/;
+              const regextest = valExp2.test(val);
+              return regextest;
+            },
+            'cardinality': 2,
+          },
+        };
+        return ['x99 9999 9999 9999', 'y99 999999 99999'];
+      },
     },
   });
 }

--- a/extensions/amp-inputmask/0.1/inputmask-credit-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-credit-alias.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Installs an alias used to mask credit cards and enable digit chunking.
+ * https://github.com/RobinHerbots/Inputmask/issues/525
+ * @param {!Object} Inputmask
+ */
+export function factory(Inputmask) {
+  // TODO(cvializ): Improve card chunking support
+  // https://baymard.com/checkout-usability/credit-card-patterns
+  Inputmask.extendDefinitions({
+    // TODO(cvializ): escape these definitions or make them local to the alias.
+    // matches 37 and 34, amex prefixes
+    '♤': {
+      'validator': function(chrs, buffer) {
+        const val = buffer.buffer.join('') + chrs;
+        const valExp2 = /3(4|7)/;
+        const regextest = valExp2.test(val);
+        return regextest;
+      },
+      'cardinality': 2,
+    },
+    // matches two-digit number except 34 and 37
+    '♢': {
+      'validator': function(chrs, buffer) {
+        const val = buffer.buffer.join('') + chrs;
+        const valExp2 = new RegExp('\\d\\d');
+        const regextest = valExp2.test(val);
+        return regextest && val != '34' && val != '37';
+      },
+      'cardinality': 2,
+    },
+  });
+
+  Inputmask.extendAliases({
+    'credit': {
+      mask: ['♢99 9999 9999 9999', '♤99 999999 99999'],
+    },
+  });
+}

--- a/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
@@ -23,7 +23,7 @@ export function factory(Inputmask) {
   // TODO(cvializ): Improve card chunking support
   // https://baymard.com/checkout-usability/credit-card-patterns
   Inputmask.extendAliases({
-    'credit': {
+    'payment-card': {
       mask: function(opts) {
         opts.definitions = {
           'x': {

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -20,6 +20,7 @@ import {
   NamedMasks,
 } from './constants';
 import {MaskInterface} from './mask-interface';
+import {factory as inputmaskCreditAliasFactory} from './inputmask-credit-alias';
 import {factory as inputmaskCustomAliasFactory} from './inputmask-custom-alias';
 import {
   factory as inputmaskDependencyFactory,
@@ -29,12 +30,7 @@ import {
 } from '../../../third_party/inputmask/inputmask';
 
 const NamedMasksToInputmask = {
-  [NamedMasks.EMAIL]: 'email',
-  [NamedMasks.PHONE]: 'phone',
-  [NamedMasks.PHONE_US]: 'phone-us',
-  [NamedMasks.DATE_INTL]: 'dd/mm/yyyy',
-  [NamedMasks.DATE_US]: 'mm/dd/yyyy',
-  [NamedMasks.DATE_ISO]: 'yyyy-mm-dd',
+  [NamedMasks.CREDIT]: 'credit',
 };
 
 const MaskCharsToInputmask = {
@@ -70,6 +66,7 @@ export class Mask {
         inputmaskDependencyFactory(win, doc);
     Inputmask = Inputmask || inputmaskFactory(
         InputmaskDependencyLib, win, doc, undefined);
+    inputmaskCreditAliasFactory(Inputmask);
     inputmaskCustomAliasFactory(Inputmask);
 
     Inputmask.extendDefaults({
@@ -93,8 +90,13 @@ export class Mask {
       jitMasking: true,
     };
 
-    if (NamedMasksToInputmask[mask]) {
-      config.alias = NamedMasksToInputmask[mask];
+    const namedFormat = NamedMasksToInputmask[mask];
+    if (namedFormat) {
+      if (typeof namedFormat == 'object') {
+        Object.assign(config, namedFormat);
+      } else {
+        config.alias = namedFormat;
+      }
     } else {
       const inputmaskMask = convertAmpMaskToInputmask(mask);
       config.alias = 'custom';

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -20,7 +20,6 @@ import {
   NamedMasks,
 } from './constants';
 import {MaskInterface} from './mask-interface';
-import {factory as inputmaskCreditAliasFactory} from './inputmask-credit-alias';
 import {factory as inputmaskCustomAliasFactory} from './inputmask-custom-alias';
 import {
   factory as inputmaskDependencyFactory,
@@ -28,9 +27,12 @@ import {
 import {
   factory as inputmaskFactory,
 } from '../../../third_party/inputmask/inputmask';
+import {
+  factory as inputmaskPaymentCardAliasFactory,
+} from './inputmask-payment-card-alias';
 
 const NamedMasksToInputmask = {
-  [NamedMasks.CREDIT]: 'credit',
+  [NamedMasks.PAYMENT_CARD]: 'payment-card',
 };
 
 const MaskCharsToInputmask = {
@@ -66,7 +68,7 @@ export class Mask {
         inputmaskDependencyFactory(win, doc);
     Inputmask = Inputmask || inputmaskFactory(
         InputmaskDependencyLib, win, doc, undefined);
-    inputmaskCreditAliasFactory(Inputmask);
+    inputmaskPaymentCardAliasFactory(Inputmask);
     inputmaskCustomAliasFactory(Inputmask);
 
     Inputmask.extendDefaults({

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -90,7 +90,8 @@ export class Mask {
       jitMasking: true,
     };
 
-    const namedFormat = NamedMasksToInputmask[mask];
+    const trimmedMask = mask.trim();
+    const namedFormat = NamedMasksToInputmask[trimmedMask];
     if (namedFormat) {
       if (typeof namedFormat == 'object') {
         Object.assign(config, namedFormat);
@@ -98,7 +99,7 @@ export class Mask {
         config.alias = namedFormat;
       }
     } else {
-      const inputmaskMask = convertAmpMaskToInputmask(mask);
+      const inputmaskMask = convertAmpMaskToInputmask(trimmedMask);
       config.alias = 'custom';
       config.mask = () => inputmaskMask;
     }

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
@@ -40,13 +40,13 @@
     <input mask="L0L_0L0" type="tel">
     <!-- Valid: mask attr with type=search -->
     <input mask="L0L_0L0" type="search">
-    <!-- Valid: mask attr with named mask "credit" -->
-    <input mask="credit" type="tel">
-    <!-- Valid: mask attr with named mask "credit" with spaces -->
-    <input mask="credit " type="tel">
-    <input mask=" credit" type="tel">
-    <input mask=" credit " type="tel">
-    <input mask="  credit  " type="tel">
+    <!-- Valid: mask attr with named mask "payment-card" -->
+    <input mask="payment-card" type="tel">
+    <!-- Valid: mask attr with named mask "payment-card" with spaces -->
+    <input mask="payment-card " type="tel">
+    <input mask=" payment-card" type="tel">
+    <input mask=" payment-card " type="tel">
+    <input mask="  payment-card  " type="tel">
     <!-- Valid: mask attr with multiple custom masks -->
     <input mask="00000 00000-0000" type="tel">
   </form>
@@ -72,9 +72,9 @@
     <!-- Invalid: mask attr with div[contenteditable] -->
     <div contenteditable mask="L0L_0L0"></div>
     <!-- Invalid: mask attr with multiple masks that includes named mask -->
-    <input mask="LOL_0L0 credit"></div>
+    <input mask="LOL_0L0 payment-card"></div>
     <!-- Invalid: mask attr with multiple named masks -->
-    <input mask="credit credit"></div>
+    <input mask="payment-card payment-card"></div>
   </form>
   </form>
 

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
@@ -40,6 +40,15 @@
     <input mask="L0L_0L0" type="tel">
     <!-- Valid: mask attr with type=search -->
     <input mask="L0L_0L0" type="search">
+    <!-- Valid: mask attr with named mask "credit" -->
+    <input mask="credit" type="tel">
+    <!-- Valid: mask attr with named mask "credit" with spaces -->
+    <input mask="credit " type="tel">
+    <input mask=" credit" type="tel">
+    <input mask=" credit " type="tel">
+    <input mask="  credit  " type="tel">
+    <!-- Valid: mask attr with multiple custom masks -->
+    <input mask="00000 00000-0000" type="tel">
   </form>
 
 
@@ -62,6 +71,11 @@
     <input mask="L0L_0L0" type="password">
     <!-- Invalid: mask attr with div[contenteditable] -->
     <div contenteditable mask="L0L_0L0"></div>
+    <!-- Invalid: mask attr with multiple masks that includes named mask -->
+    <input mask="LOL_0L0 credit"></div>
+    <!-- Invalid: mask attr with multiple named masks -->
+    <input mask="credit credit"></div>
+  </form>
   </form>
 
 </body>

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
@@ -41,13 +41,13 @@ FAIL
 |      <input mask="L0L_0L0" type="tel">
 |      <!-- Valid: mask attr with type=search -->
 |      <input mask="L0L_0L0" type="search">
-|      <!-- Valid: mask attr with named mask "credit" -->
-|      <input mask="credit" type="tel">
-|      <!-- Valid: mask attr with named mask "credit" with spaces -->
-|      <input mask="credit " type="tel">
-|      <input mask=" credit" type="tel">
-|      <input mask=" credit " type="tel">
-|      <input mask="  credit  " type="tel">
+|      <!-- Valid: mask attr with named mask "payment-card" -->
+|      <input mask="payment-card" type="tel">
+|      <!-- Valid: mask attr with named mask "payment-card" with spaces -->
+|      <input mask="payment-card " type="tel">
+|      <input mask=" payment-card" type="tel">
+|      <input mask=" payment-card " type="tel">
+|      <input mask="  payment-card  " type="tel">
 |      <!-- Valid: mask attr with multiple custom masks -->
 |      <input mask="00000 00000-0000" type="tel">
 |    </form>
@@ -93,13 +93,13 @@ amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'contente
 >>     ^~~~~~~~~
 amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple masks that includes named mask -->
-|      <input mask="LOL_0L0 credit"></div>
+|      <input mask="LOL_0L0 payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:75:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 credit'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:75:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple named masks -->
-|      <input mask="credit credit"></div>
+|      <input mask="payment-card payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:77:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'credit credit'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:77:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |    </form>
 |    </form>
 |

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
@@ -41,6 +41,15 @@ FAIL
 |      <input mask="L0L_0L0" type="tel">
 |      <!-- Valid: mask attr with type=search -->
 |      <input mask="L0L_0L0" type="search">
+|      <!-- Valid: mask attr with named mask "credit" -->
+|      <input mask="credit" type="tel">
+|      <!-- Valid: mask attr with named mask "credit" with spaces -->
+|      <input mask="credit " type="tel">
+|      <input mask=" credit" type="tel">
+|      <input mask=" credit " type="tel">
+|      <input mask="  credit  " type="tel">
+|      <!-- Valid: mask attr with multiple custom masks -->
+|      <input mask="00000 00000-0000" type="tel">
 |    </form>
 |
 |
@@ -48,41 +57,50 @@ FAIL
 |      <!-- Invalid: mask-output attr without mask attr -->
 |      <input mask-output="raw" type="text">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:48:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:57:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=date -->
 |      <input mask="L0L_0L0" type="date">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:50:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:59:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=email -->
 |      <input mask="L0L_0L0" type="email">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:52:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:61:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=number -->
 |      <input mask="L0L_0L0" type="number">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:54:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:63:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=button -->
 |      <input mask="L0L_0L0" type="button">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:56:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:65:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=range -->
 |      <input mask="L0L_0L0" type="range">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:58:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:67:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=hidden -->
 |      <input mask="L0L_0L0" type="hidden">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:60:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:69:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=password -->
 |      <input mask="L0L_0L0" type="password">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:62:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:71:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with div[contenteditable] -->
 |      <div contenteditable mask="L0L_0L0"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:64:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:64:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
+|      <!-- Invalid: mask attr with multiple masks that includes named mask -->
+|      <input mask="LOL_0L0 credit"></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:75:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 credit'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|      <!-- Invalid: mask attr with multiple named masks -->
+|      <input mask="credit credit"></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:77:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'credit credit'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|    </form>
 |    </form>
 |
 |  </body>

--- a/extensions/amp-inputmask/README.md
+++ b/extensions/amp-inputmask/README.md
@@ -135,19 +135,19 @@ The following named masks are supported:
 <th>Description</th>
 </tr>
 <tr>
-<td><code>credit</code></td>
-<td>The user must enter a credit card number.
+<td><code>payment-card</code></td>
+<td>The user must enter a payment card number.
 The mask automatically adds spaces to chunk the numbers, and supports both
 American Express-style and Visa-style chunking.</td>
 </tr>
 </tbody>
 </table>
 
-As an example, this masked input will allow the user to enter a credit card number.
+As an example, this masked input will allow the user to enter a payment card number.
 Space characters " " will be automatically added as the user types.
 
 ```html
-<input type="tel" mask="credit" placeholder="0000 0000 0000 0000">
+<input type="tel" mask="payment-card" placeholder="0000 0000 0000 0000">
 ```
 
 #### mask-output

--- a/extensions/amp-inputmask/README.md
+++ b/extensions/amp-inputmask/README.md
@@ -56,7 +56,10 @@ them from typing incorrect characters.
 
 #### mask
 
-Specifies the mask or masks to apply to the input element. This is a space-separated list of masks.
+Specifies the mask or masks to apply to the input element.
+
+Custom masks are composed of the following characters,
+and may be listed separated by spaces:
 
 <table>
 <tr>
@@ -122,6 +125,29 @@ This mask accepts a North American phone number.
 The characters "+", "1", " ", "(", ")" and "-" will be automatically added as the user types.
 ```html
 <input type="tel" mask="+1_(000)_000-0000" placeholder="+1 (555) 555-5555">
+```
+
+The following named masks are supported:
+
+<table>
+<tr>
+<th width="30%"><code>mask</code><br></th>
+<th>Description</th>
+</tr>
+<tr>
+<td><code>credit</code></td>
+<td>The user must enter a credit card number.
+The mask automatically adds spaces to chunk the numbers, and supports both
+American Express-style and Visa-style chunking.</td>
+</tr>
+</tbody>
+</table>
+
+As an example, this masked input will allow the user to enter a credit card number.
+Space characters " " will be automatically added as the user types.
+
+```html
+<input type="tel" mask="credit" placeholder="0000 0000 0000 0000">
 ```
 
 #### mask-output

--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -38,7 +38,14 @@ tags: {
     mandatory: true
     dispatch_key: NAME_DISPATCH
     # Only allow named masks to appear alone in the mask list.
-    blacklisted_value_regex: "([^\\s]+\\scredit|credit\\s[^\\s]+)"
+    blacklisted_value_regex:
+        "([^\\s]+"      # One or more non-whitespace characters before
+        "\\s"           # a single whitespace, followed by
+        "payment-card"  # a named mask, indicating it's a list item.
+        "|"             # Or (to cover the other case):
+        "payment-card"  # A named mask followed by
+        "\\s"           # a single whitespace
+        "[^\\s]+)"      # followed by one or more non-whitespace characters.
   }
   attrs: {
     name: "mask-output"

--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -37,6 +37,8 @@ tags: {
     name: "mask"
     mandatory: true
     dispatch_key: NAME_DISPATCH
+    # Only allow named masks to appear alone in the mask list.
+    blacklisted_value_regex: "([^\\s]+\\scredit|credit\\s[^\\s]+)"
   }
   attrs: {
     name: "mask-output"

--- a/third_party/inputmask/inputmask.js
+++ b/third_party/inputmask/inputmask.js
@@ -306,6 +306,24 @@ export function factory($, window, document, undefined) {
                 } else {
                     var maskdef = (opts.definitions ? opts.definitions[element] : undefined) || Inputmask.prototype.definitions[element];
                     if (maskdef && !escaped) {
+                        // This for-loop implements "cardinality"
+                        // Removed in 4.x for unknown reasons.
+                        // Backported from https://github.com/RobinHerbots/Inputmask/blob/8d0c60f8/js/inputmask.js#L371
+                        for (var prevalidators = maskdef.prevalidator, prevalidatorsL = prevalidators ? prevalidators.length : 0, i = 1; i < maskdef.cardinality; i++) {
+                            var prevalidator = prevalidatorsL >= i ? prevalidators[i - 1] : [], validator = prevalidator.validator, cardinality = prevalidator.cardinality;
+                            mtoken.matches.splice(position++, 0, {
+                                fn: validator ? "string" == typeof validator ? new RegExp(validator, opts.casing ? "i" : "") : new function() {
+                                    this.test = validator;
+                                }() : new RegExp("."),
+                                cardinality: cardinality || 1,
+                                optionality: mtoken.isOptional,
+                                newBlockMarker: prevMatch === undefined || prevMatch.def !== (maskdef.definitionSymbol || element),
+                                casing: maskdef.casing,
+                                def: maskdef.definitionSymbol || element,
+                                placeholder: maskdef.placeholder,
+                                nativeDef: element
+                            }), prevMatch = mtoken.matches[position - 1];
+                        }
                         mtoken.matches.splice(position++, 0, {
                             fn: maskdef.validator ? typeof maskdef.validator == "string" ? new RegExp(maskdef.validator, opts.casing ? "i" : "") : new function() {
                                 this.test = maskdef.validator;

--- a/third_party/inputmask/patches/0009-support-cardinality.patch
+++ b/third_party/inputmask/patches/0009-support-cardinality.patch
@@ -1,0 +1,29 @@
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index c7181aabf..b4c16f310 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -306,6 +306,24 @@ export function factory($, window, document, undefined) {
+                 } else {
+                     var maskdef = (opts.definitions ? opts.definitions[element] : undefined) || Inputmask.prototype.definitions[element];
+                     if (maskdef && !escaped) {
++                        // This for-loop implements "cardinality"
++                        // Removed in 4.x for unknown reasons.
++                        // Backported from https://github.com/RobinHerbots/Inputmask/blob/8d0c60f8/js/inputmask.js#L371
++                        for (var prevalidators = maskdef.prevalidator, prevalidatorsL = prevalidators ? prevalidators.length : 0, i = 1; i < maskdef.cardinality; i++) {
++                            var prevalidator = prevalidatorsL >= i ? prevalidators[i - 1] : [], validator = prevalidator.validator, cardinality = prevalidator.cardinality;
++                            mtoken.matches.splice(position++, 0, {
++                                fn: validator ? "string" == typeof validator ? new RegExp(validator, opts.casing ? "i" : "") : new function() {
++                                    this.test = validator;
++                                }() : new RegExp("."),
++                                cardinality: cardinality || 1,
++                                optionality: mtoken.isOptional,
++                                newBlockMarker: prevMatch === undefined || prevMatch.def !== (maskdef.definitionSymbol || element),
++                                casing: maskdef.casing,
++                                def: maskdef.definitionSymbol || element,
++                                placeholder: maskdef.placeholder,
++                                nativeDef: element
++                            }), prevMatch = mtoken.matches[position - 1];
++                        }
+                         mtoken.matches.splice(position++, 0, {
+                             fn: maskdef.validator ? typeof maskdef.validator == "string" ? new RegExp(maskdef.validator, opts.casing ? "i" : "") : new function() {
+                                 this.test = maskdef.validator;


### PR DESCRIPTION
Fixes #20304 by implementing credit cards as a named mask. At this time, the custom mask cannot switch between two masks based on a two-character combination, which the credit card masks require (34/37) so for now we will implement credit cards as a named mask.