### PR TITLE
Update amp-carousel.md to be reflective of layouts supported

### DIFF
--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -29,7 +29,12 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, intrinsic, nodisplay, responsive</td>
+    <td>
+      <ul>
+        <li>carousel: fixed, fixed-height, and nodisplay.</li>
+        <li>slides: fill, fixed, fixed-height, flex-item, nodisplay, and responsive.</li>
+      </ul>
+    </td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>


### PR DESCRIPTION
Update amp-carousel.md to be reflective of layouts supported as split up by the type attribute.