### PR TITLE
Add xpath support to e2e test controllers

### DIFF
--- a/testing/e2e/functional-test-controller.js
+++ b/testing/e2e/functional-test-controller.js
@@ -175,6 +175,36 @@ export class FunctionalTestController {
   async findElements(unusedSelector) {}
 
   /**
+   * Note: Use findElement instead where possible. CSS selectors are more
+   * familiar to developers and easier to reason about. If you need to use
+   * this method, a comment explaining the xpath query can be helpful.
+   * The Find Element command is used to find the first element matching the
+   * given xpath in the current browsing context that can be used as the
+   * web element context for future element-centric commands.
+   * {@link https://www.w3.org/TR/webdriver1/#xpath}
+   * {@link https://www.w3.org/TR/webdriver1/#find-element}
+   *
+   * @param {string} xpath
+   * @return {!Promise<!ElementHandle>}
+   */
+  async findElementXPath(unusedXpath) {}
+
+  /**
+   * Note: Use findElements instead where possible. CSS selectors are more
+   * familiar to developers and easier to reason about. If you need to use
+   * this method, a comment explaining the xpath query can be helpful.
+   * The Find Elements command is used to find all elements matching the
+   * given xpath in the current browsing context that can be used as the
+   * web element context for future element-centric commands.
+   * {@link https://www.w3.org/TR/webdriver1/#xpath}
+   * {@link https://www.w3.org/TR/webdriver1/#find-elements}
+   *
+   * @param {string} xpath
+   * @return {!Promise<!Array<!ElementHandle>>}
+   */
+  async findElementsXPath(unusedXpath) {}
+
+  /**
    * The Find Element From Element command is used to find the first element
    * that is a descendent of the given element matching the given selector in
    * the current browsing context that can be used as the web element context

--- a/testing/e2e/selenium-webdriver-controller.js
+++ b/testing/e2e/selenium-webdriver-controller.js
@@ -83,7 +83,6 @@ export class SeleniumWebDriverController {
    * @override
    */
   async findElement(selector) {
-    // const {browser} = this;
     const bySelector = By.css(selector);
 
     await this.driver.wait(until.elementLocated(bySelector));
@@ -97,11 +96,38 @@ export class SeleniumWebDriverController {
    * @override
    */
   async findElements(selector) {
-    // const {browser} = this;
     const bySelector = By.css(selector);
 
     await this.driver.wait(until.elementLocated(bySelector));
     const webElements = await this.driver.findElements(bySelector);
+    return webElements.map(webElement => new ElementHandle(webElement, this));
+  }
+
+  /**
+   * @param {string} xpath
+   * @return {!Promise<!ElementHandle<!WebElement>>}
+   * @override
+   */
+  async findElementXPath(xpath) {
+    const {browser} = this;
+    const byXpath = By.xpath(xpath);
+
+    await browser.wait(until.elementLocated(byXpath));
+    const webElement = await browser.findElement(byXpath);
+    return new ElementHandle(webElement, this);
+  }
+
+  /**
+   * @param {string} xpath
+   * @return {!Promise<!Array<!ElementHandle<!WebElement>>>}
+   * @override
+   */
+  async findElementsXPath(xpath) {
+    const {browser} = this;
+    const byXpath = By.xpath(xpath);
+
+    await browser.wait(until.elementLocated(byXpath));
+    const webElements = await browser.findElements(byXpath);
     return webElements.map(webElement => new ElementHandle(webElement, this));
   }
 


### PR DESCRIPTION
This adds the xpath support that @sparhami added to cvializ/ampft-example here https://github.com/cvializ/ampft-example/commit/8daa4c9058c2aedf02623522d22da1e00276e830
