### PR TITLE
Don't force collapse on fluid slots if resize fails, as they are initiated in a collapsed state

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -677,8 +677,6 @@ export class SafeframeHostApi {
   handleFluidMessage_(payload) {
     let newHeight;
     if (!payload || !(newHeight = parseInt(payload['height'], 10))) {
-      // TODO(levitzky) Add actual error handling here.
-      this.baseInstance_.forceCollapse();
       return;
     }
     this.baseInstance_.attemptChangeHeight(newHeight)
@@ -690,8 +688,6 @@ export class SafeframeHostApi {
             dev().error(TAG, err);
             return;
           }
-          // TODO(levitzky) Add more error handling here
-          this.baseInstance_.forceCollapse();
         });
   }
 


### PR DESCRIPTION
In the current state of the code, we call forceCollapse on a fluid slot if resizing is rejected. This is superfluous as the slot begins in a collapsed state, and, worse, it actually causes a bug for above-the-fold multi-size slots, since resizing will always be rejected ATF, ultimately resulting in the ad loader element never disappearing.

Fixes #20152