### PR TITLE
[amp-story] Fix progress bar issue🐛

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -114,14 +114,12 @@
 }
 
 .i-amphtml-story-page-progress-value {
-  /* Do not remove `translateZ(0)` or `will-change` as they prevent an iOS
-   * repaint issue. */
+  /* Do not remove `translateZ(0)` as it prevents an iOS repaint issue. */
   background: rgba(255, 255, 255, 1) !important;
   height: 100% !important;
   width: 100% !important;
   transform: translateZ(0) scaleX(0) !important; /* 0-width by default */
   transform-origin: left !important;
-  will-change: transform, transition !important;
 }
 
 [dir=rtl] .i-amphtml-story-page-progress-value {


### PR DESCRIPTION
Fixes #20346 

With the `will-change` property on `transform, transition`, the progress bar would sometimes not be filled correctly. This might have been caused by optimizations made by it.

This PR removes the `will-change` property from the progress bar.