### PR TITLE
🐛 amp-recaptcha-input: Specified / Check bootstrap frame origin in the recaptcha service

### DIFF
--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -295,10 +295,17 @@ export class AmpRecaptchaService {
    * @private
    */
   listenIframe_(evName, cb) {
+
+    const checkOriginWrappedCallback = (data, source, origin) => {
+      if (this.recaptchaFrameOrigin_ === origin) {
+        cb(data, source, origin);
+      }
+    };
+
     return listenFor(
         dev().assertElement(this.iframe_),
         evName,
-        cb,
+        checkOriginWrappedCallback,
         true);
   }
 

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -157,12 +157,10 @@ export class AmpRecaptchaService {
       });
 
       // Send the message
-      postMessage(
-          dev().assertElement(this.iframe_),
-          'amp-recaptcha-action',
-          message,
+      this.postMessageToIframe_(
           devAssert(this.recaptchaFrameOrigin_),
-          true);
+          message
+      );
     });
     return executePromise.promise;
   }
@@ -297,18 +295,25 @@ export class AmpRecaptchaService {
    * @private
    */
   listenIframe_(evName, cb) {
-
-    // Wrap our callback in a check for the iframe origin.
-    const checkOriginWrappedCallback = (data, source, origin) => {
-      if (origin == this.recaptchaFrameOrigin_) {
-        cb(data, source, origin);
-      }
-    };
-
     return listenFor(
         dev().assertElement(this.iframe_),
         evName,
-        checkOriginWrappedCallback,
+        cb,
+        true);
+  }
+
+  /**
+   * Function to send a message to our iframe
+   * @param {string} origin
+   * @param {!JsonObject} message
+   * @private
+   */
+  postMessageToIframe_(origin, message) {
+    postMessage(
+        dev().assertElement(this.iframe_),
+        'amp-recaptcha-action',
+        message,
+        origin,
         true);
   }
 

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -81,7 +81,7 @@ export class AmpRecaptchaService {
     /** @private {number} */
     this.registeredElementCount_ = 0;
 
-    /** @private {?String} */
+    /** @private {?string} */
     this.recaptchaFrameOrigin_ = null;
 
     /** @private {!Deferred} */
@@ -298,8 +298,8 @@ export class AmpRecaptchaService {
    */
   listenIframe_(evName, cb) {
 
-    // Wrap ouur in a check for the origin.
-    const wrappedCallback = (data, source, origin) => {
+    // Wrap our callback in a check for the iframe origin.
+    const checkOriginWrappedCallback = (data, source, origin) => {
       if (origin == this.recaptchaFrameOrigin_) {
         cb(data, source, origin);
       }
@@ -308,7 +308,7 @@ export class AmpRecaptchaService {
     return listenFor(
         dev().assertElement(this.iframe_),
         evName,
-        wrappedCallback,
+        checkOriginWrappedCallback,
         true);
   }
 

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
@@ -144,7 +144,7 @@ describes.realWin('amp-recaptcha-service', {
         });
   });
 
-  it('should postmessage to the specificed ' +
+  it('should postmessage to the specified ' +
     'recaptcha frame origin on execute', () => {
 
     expect(recaptchaService.registeredElementCount_).to.be.equal(0);
@@ -156,9 +156,8 @@ describes.realWin('amp-recaptcha-service', {
 
     return recaptchaService
         .register(fakeSitekey).then(() => {
-          expect(recaptchaService.unlisteners_.length).to.be.equal(3);
-
           recaptchaService.execute(0, '');
+
           recaptchaService.recaptchaApiReady_.resolve();
           return recaptchaService.recaptchaApiReady_.promise;
         }).then(() => {

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
@@ -45,20 +45,6 @@ describes.realWin('amp-recaptcha-service', {
         });
   });
 
-  it('should store the iframe src origin ' +
-    'to be used in message origin checking', () => {
-    expect(recaptchaService.registeredElementCount_).to.be.equal(0);
-    return recaptchaService
-        .register(fakeSitekey).then(() => {
-          expect(recaptchaService.registeredElementCount_).to.be.equal(1);
-          expect(recaptchaService.iframe_).to.be.ok;
-
-          expect(recaptchaService.recaptchaFrameOrigin_).to.be.ok;
-          expect(recaptchaService.recaptchaFrameOrigin_
-              .includes('.recaptcha.localhost')).to.be.ok;
-        });
-  });
-
   it('should only initialize once for X number of elements,' +
     ' and iframe already exists', () => {
 
@@ -157,6 +143,31 @@ describes.realWin('amp-recaptcha-service', {
           expect(executeMapKeys[0]).to.be.equal('0');
         });
   });
+
+  it('should postmessage to the specificed ' +
+    'recaptcha frame origin on execute', () => {
+
+    expect(recaptchaService.registeredElementCount_).to.be.equal(0);
+
+    const postMessageStub = sandbox.stub(
+        recaptchaService,
+        'postMessageToIframe_'
+    );
+
+    return recaptchaService
+        .register(fakeSitekey).then(() => {
+          expect(recaptchaService.unlisteners_.length).to.be.equal(3);
+
+          recaptchaService.execute(0, '');
+          recaptchaService.recaptchaApiReady_.resolve();
+          return recaptchaService.recaptchaApiReady_.promise;
+        }).then(() => {
+          expect(postMessageStub).to.be.calledWith(
+              recaptchaService.recaptchaFrameOrigin_
+          );
+        });
+  });
+
 
   it('should reject if there is no iframe on execute', () => {
     expect(recaptchaService.registeredElementCount_).to.be.equal(0);

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
@@ -45,6 +45,20 @@ describes.realWin('amp-recaptcha-service', {
         });
   });
 
+  it('should store the iframe src origin ' +
+    'to be used in message origin checking', () => {
+    expect(recaptchaService.registeredElementCount_).to.be.equal(0);
+    return recaptchaService
+        .register(fakeSitekey).then(() => {
+          expect(recaptchaService.registeredElementCount_).to.be.equal(1);
+          expect(recaptchaService.iframe_).to.be.ok;
+
+          expect(recaptchaService.recaptchaFrameOrigin_).to.be.ok;
+          expect(recaptchaService.recaptchaFrameOrigin_
+              .includes('.recaptcha.localhost')).to.be.ok;
+        });
+  });
+
   it('should only initialize once for X number of elements,' +
     ' and iframe already exists', () => {
 


### PR DESCRIPTION
closes #20352

Per a security review, it was determined recaptcha should check the frame origin in the service, as well as the iframe. And, to specify the origin to receive the messages. Instead of listening for all messages like the `IframeMessagingClient`.

See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage for context on the security concern.

![screen shot 2019-01-15 at 3 50 10 pm](https://user-images.githubusercontent.com/1448289/51217833-926e0180-18de-11e9-8595-7595ac7ab300.png)
