### PR TITLE
🐛async-input: Fixed NonXHR GET on amp-form with Async Input Elements

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -527,7 +527,7 @@ export class AmpForm {
           this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
         }
 
-        this.handleNonXhrGet_(event);
+        this.handleNonXhrGet_();
         return Promise.resolve();
       }
 
@@ -894,7 +894,7 @@ export class AmpForm {
    */
   handleNonXhrGet_(event) {
     this.triggerFormSubmitInAnalytics_('amp-form-submit');
-    if (!event) {
+    if (event) {
       this.form_.submit();
     }
     this.setState_(FormState.INITIAL);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -527,7 +527,7 @@ export class AmpForm {
           this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
         }
 
-        this.handleNonXhrGet_();
+        this.handleNonXhrGet_(false);
         return Promise.resolve();
       }
 
@@ -548,7 +548,7 @@ export class AmpForm {
         presubmitPromises,
         SUBMIT_TIMEOUT
     ).then(
-        () => this.handlePresubmitSuccess_(trust, event),
+        () => this.handlePresubmitSuccess_(trust),
         error => this.handlePresubmitError_(/**@type {!Error}*/(error))
     );
   }
@@ -566,16 +566,15 @@ export class AmpForm {
   /**
    * Handle successful presubmit tasks
    * @param {!ActionTrust} trust
-   * @param {?Event} event
    * @return {!Promise}
    */
-  handlePresubmitSuccess_(trust, event) {
+  handlePresubmitSuccess_(trust) {
     if (this.xhrAction_) {
       return this.handleXhrSubmit_(trust);
     } else if (this.method_ == 'POST') {
       this.handleNonXhrPost_();
     } else if (this.method_ == 'GET') {
-      this.handleNonXhrGet_(event);
+      this.handleNonXhrGet_(true);
     }
 
     return Promise.resolve();
@@ -889,12 +888,14 @@ export class AmpForm {
 
   /**
    * Triggers Submit Analytics,
-   * and Form Element submit if not triggered by an event
-   * @param {?Event} event
+   * and Form Element submit if passed by param.
+   * shouldSubmitFormElement should ONLY be true
+   * If the submit event.preventDefault was called
+   * @param {boolean} shouldSubmitFormElement
    */
-  handleNonXhrGet_(event) {
+  handleNonXhrGet_(shouldSubmitFormElement) {
     this.triggerFormSubmitInAnalytics_('amp-form-submit');
-    if (event) {
+    if (shouldSubmitFormElement) {
       this.form_.submit();
     }
     this.setState_(FormState.INITIAL);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -2296,6 +2296,28 @@ describes.repeated('', {
         });
       });
 
+      it('NonXHRGet should submit async if Async Input', () => {
+        return getAmpFormWithAsyncInput().then(response => {
+          const {ampForm, getValueStub} = response;
+
+          // Make the form a NonXHRGet
+          ampForm.method_ = 'GET';
+          ampForm.xhrAction_ = null;
+
+          const formElementSubmitSpy =
+            sandbox.spy(ampForm.form_, 'submit');
+
+          const mockEvent = {
+            preventDefault: () => {},
+          };
+
+          return ampForm.submit_(ActionTrust.HIGH, mockEvent).then(() => {
+            expect(getValueStub).to.be.called;
+            expect(formElementSubmitSpy).to.be.called;
+          });
+        });
+      });
+
       it('should call getValue() on Async Input Elements', () => {
         return getAmpFormWithAsyncInput().then(response => {
           const {ampForm, getValueStub} = response;


### PR DESCRIPTION
relates to #19334 

Discovered this bug recently, I think it happened from a comment that I forgot to test afterwards, and just now came across it by accidentally breaking my manual testing muscle memory 😂 

Previously, the `this.form_.submit` wasn't getting called because the event was passed in both places (though it was not really needed). Thus I went ahead and made things more clear with a boolean, and all works now. 

Thankfully, this bug ONLY affects the Async Input case, and not the regular case 😄 

![nonxhrgetform](https://user-images.githubusercontent.com/1448289/51219082-11196d80-18e4-11e9-8d22-b02ad5f9d27c.gif)
