### PR TITLE
Erase consentStr on undefined value

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -244,12 +244,15 @@ export class AmpConsent extends AMP.BaseElement {
         if (typeof data['info'] != 'string') {
           user().error(TAG, 'consent-response info only supports string, ' +
               '%s, treated as undefined', data['info']);
+          data['info'] = undefined;
         }
-        if (!data['info']) {
-          // TODO (@zhouyx #20010): Decide what's the behavior on receiving
-          // incorrect message.
-          user().error(TAG,
-              'consent-response info does not allow empty string');
+        if (data['action'] === ACTION_TYPE.DISMISS) {
+          if (data['info']) {
+            this.user().error(TAG,
+                'Consent string value %s not applicable on user dismiss, ' +
+              'stored value will be kept and used', consentString);
+          }
+          data['info'] = undefined;
         }
         consentString = data['info'];
       }
@@ -364,11 +367,8 @@ export class AmpConsent extends AMP.BaseElement {
           CONSENT_ITEM_STATE.REJECTED,
           consentString);
     } else if (action == ACTION_TYPE.DISMISS) {
-      // TODO (@zhouyx #20010): Consider it a user error if
-      // consentString is undefined, but has value before.
       this.consentStateManager_.updateConsentInstanceState(
-          CONSENT_ITEM_STATE.DISMISSED,
-          consentString);
+          CONSENT_ITEM_STATE.DISMISSED);
     }
 
     // Hide current dialog

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -189,7 +189,8 @@ export class ConsentPolicyManager {
   consentStateChangeHandler_(info) {
     const state = info['consentState'];
     const consentStr = info['consentString'];
-    this.consentString_ = consentStr || this.consentString_;
+    const prevConsentStr = this.consentString_;
+    this.consentString_ = consentStr;
     if (state === CONSENT_ITEM_STATE.UNKNOWN) {
       // consent state has not been resolved yet.
       return;
@@ -208,6 +209,8 @@ export class ConsentPolicyManager {
       if (this.consentState_ === null) {
         this.consentState_ = CONSENT_ITEM_STATE.UNKNOWN;
       }
+      // consentString doesn't change with dismiss action
+      this.consentString_ = prevConsentStr;
     } else {
       this.consentState_ = state;
     }

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -27,7 +27,7 @@ import {
 import {Deferred} from '../../../src/utils/promise';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, devAssert, user} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 
 
@@ -91,15 +91,6 @@ export class ConsentStateManager {
     if (!this.instance_) {
       dev().error(TAG, 'instance not registered');
       return;
-    }
-
-    if (state == CONSENT_ITEM_STATE.DISMISSED) {
-      if (consentStr) {
-        user().error(TAG,
-            'Consent string value %s will be ignored on user dismiss',
-            consentStr);
-        consentStr = undefined;
-      }
     }
 
     this.instance_.update(state, consentStr);
@@ -225,21 +216,25 @@ export class ConsentInstance {
    * @param {string=} consentString
    */
   update(state, consentString) {
-    const localStateValue =
+    const localState =
         this.localConsentInfo_ && this.localConsentInfo_['consentState'];
     const localConsentStr =
         this.localConsentInfo_ && this.localConsentInfo_['consentString'];
     const calculatedState =
-        recalculateConsentStateValue(state, localStateValue);
+        recalculateConsentStateValue(state, localState);
 
-    // TODO(@zhouyx) Make consentString init value to null
-    consentString = consentString || localConsentStr || undefined;
+    if (state === CONSENT_ITEM_STATE.DISMISSED) {
+      // If state is dismissed, use the old consent string.
+      this.localConsentInfo_ =
+          constructConsentInfo(calculatedState, localConsentStr);
+      return;
+    }
+
     const newConsentInfo = constructConsentInfo(calculatedState, consentString);
     const oldConsentInfo = this.localConsentInfo_;
     this.localConsentInfo_ = newConsentInfo;
 
-    if (state === CONSENT_ITEM_STATE.DISMISSED ||
-        isConsentInfoStoredValueSame(newConsentInfo, oldConsentInfo)) {
+    if (isConsentInfoStoredValueSame(newConsentInfo, oldConsentInfo)) {
       // Only update/save to localstorage if it's not dismiss
       // And the value is different from what is stored.
       return;

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -325,6 +325,20 @@ describes.realWin('amp-consent', {
       win.dispatchEvent(event);
       expect(actionSpy).to.not.be.called;
     });
+
+    it('ignore info with action dismiss', () => {
+      expectAsyncConsoleError('[amp-consent] ' +
+          'Consent string value %s not applicable on user dismiss, ' +
+          'stored value will be kept and used ');
+      event.data = {
+        'type': 'consent-response',
+        'action': 'dismiss',
+        'info': 'test',
+      };
+      event.source = iframe.contentWindow;
+      win.dispatchEvent(event);
+      expect(actionSpy).to.be.calledWith(ACTION_TYPE.DISMISS);
+    });
   });
 
   describe('UI', () => {

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -197,9 +197,7 @@ const consentObjects = [
     querySelector: '#r',
     type: 'consent-response',
     action: 'reject',
-    info: '',
     timeout: 1000,
-    info: 'reject-str',
     onclick: () => {
       showConfirmation();
     }
@@ -208,7 +206,6 @@ const consentObjects = [
     querySelector: '#d',
     type: 'consent-response',
     action: 'dismiss',
-    info: 'dismiss-str',
     timeout: 1000,
     onclick: () => {
       showConfirmation();


### PR DESCRIPTION
Closes #20010 

As we agreed, we decided to respect the incoming message. Override previously stored value. 

If the incoming consentString value is undefined, we will erase the stored value as well. 

The only exception is that, when user dismiss the prompt. We will still keep and use the stored consentString. This is because user dismiss should not lead to any state value change. 
