### PR TITLE
Points the docs for creating an AMP extension to the new contribution docs

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -7,7 +7,7 @@ extensions. If you'd like to add an extension to support your company
 video player, rich embed or just a general UI component like a star
 rating viewer, you'd do this by building an extension.
 
-- [A word on contributing](#a-word-on-contributing)
+- [Getting started](#getting-started)
 - [Naming](#naming)
 - [Directory structure](#directory-structure)
 - [Extend AMP.BaseElement](#extend-ampbaseelement)
@@ -27,17 +27,11 @@ rating viewer, you'd do this by building an extension.
 - [Type checking](#type-checking)
 - [Example PRs](#example-prs)
 
-# Checklist for creating an experiment
+## Getting started
 
--[] Create your directory structure.
--[] Create an experiment.
--[] Check previous PRs of past experiments to model your extension after, if applicable.
+This document describes how to create a new AMP extension, which is one of the most common ways of adding a new feature to AMP.
 
-## A word on contributing
-
-We suggest that you open an "Intent to Implement" GitHub issue for your
-extension as early as you can, so that we can advise you on next steps or provide early feedback on the implementation or naming. For details, see [CONTRIBUTING.md
-for more details](../CONTRIBUTING.md#phase-concept-design).
+Before diving into the details on creating a new AMP extension, please familiarize yourself with the [general process for contributing code and features to AMP](https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md).  Since you are adding a new extension you will likely need to follow the [process for making a significant change](https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md#process-for-significant-changes), including filing an ["Intent to Implement" issue](https://github.com/ampproject/amphtml/labels/INTENT%20TO%20IMPLEMENT) and finding a reviewer before you start significant development.
 
 ## Naming
 


### PR DESCRIPTION
This updates the docs for creating a new AMP extension to point to the updated contribution docs, making it more clear that there is a process a contributor will need to go through to get the new extension approved.