### PR TITLE
✨ amp-iframe: allow opaque origins for embed-size events

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -408,7 +408,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     listenFor(iframe, 'embed-size', data => {
       this.updateSize_(data['height'], data['width']);
-    });
+    }, undefined, undefined, /*opt_allowOpaqueOrigin*/ true);
 
     if (this.isClickToPlay_) {
       listenFor(iframe, 'embed-ready', this.activateIframe_.bind(this));

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -408,7 +408,10 @@ export class AmpIframe extends AMP.BaseElement {
 
     listenFor(iframe, 'embed-size', data => {
       this.updateSize_(data['height'], data['width']);
-    }, undefined, undefined, /*opt_allowOpaqueOrigin*/ true);
+    },
+    /*opt_is3P*/ undefined,
+    /*opt_includingNestedWindows*/ undefined,
+    /*opt_allowOpaqueOrigin*/ true);
 
     if (this.isClickToPlay_) {
       listenFor(iframe, 'embed-ready', this.activateIframe_.bind(this));

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -545,21 +545,6 @@ describes.realWin('amp-iframe', {
       expect(attemptChangeSize).to.be.calledWith(217, 114);
     });
 
-    it('should resize amp-iframe with opaque origin', function* () {
-      const ampIframe = createAmpIframe(env, {
-        src: iframeSrc,
-        sandbox: 'allow-scripts',
-        width: 100,
-        height: 100,
-        resizable: '',
-      });
-      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
-      const impl = ampIframe.implementation_;
-      const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
-      impl.updateSize_(217, '114' /* be tolerant to string number */);
-      expect(attemptChangeSize).to.be.calledWith(217, 114);
-    });
-
     it('should resize amp-iframe when only height is provided', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -468,7 +468,84 @@ describes.realWin('amp-iframe', {
       });
     });
 
+    it('should allow resize events w/o allow-same-origin', function* () {
+      const ampIframe = createAmpIframe(env, {
+        src: iframeSrc,
+        sandbox: 'allow-scripts',
+        width: 100,
+        height: 100,
+        resizable: '',
+      });
+      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+      const impl = ampIframe.implementation_;
+      return new Promise((resolve, unusedReject) => {
+        impl.updateSize_ = (height, width) => {
+          resolve({height, width});
+        };
+        const iframe = ampIframe.querySelector('iframe');
+        iframe.contentWindow.postMessage({
+          sentinel: 'amp-test',
+          type: 'requestHeight',
+          height: 217,
+          width: 113,
+        }, '*');
+      }).then(res => {
+        expect(res.height).to.equal(217);
+        expect(res.width).to.equal(113);
+      });
+    });
+
+    it('should allow resize events w/ srcdoc', function* () {
+      const srcdoc = `
+        <!doctype html>>
+        <html>
+         <body>
+          <script>
+              window.parent.postMessage({
+                sentinel: 'amp',
+                type: 'embed-size',
+                height: 200,
+                width: 300,
+              }, '*');
+          </script>
+         </body>
+        </html>
+      `;
+      const ampIframe = createAmpIframe(env, {
+        srcdoc,
+        sandbox: 'allow-scripts',
+        width: 100,
+        height: 100,
+        resizable: '',
+      });
+      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+      const impl = ampIframe.implementation_;
+      return new Promise((resolve, unusedReject) => {
+        impl.updateSize_ = (height, width) => {
+          resolve({height, width});
+        };
+      }).then(res => {
+        expect(res.height).to.equal(200);
+        expect(res.width).to.equal(300);
+      });
+    });
+
     it('should resize amp-iframe', function* () {
+      const ampIframe = createAmpIframe(env, {
+        src: iframeSrc,
+        sandbox: 'allow-scripts',
+        width: 100,
+        height: 100,
+        resizable: '',
+      });
+      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+      const impl = ampIframe.implementation_;
+      const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
+      impl.updateSize_(217, '114' /* be tolerant to string number */);
+      expect(attemptChangeSize).to.be.calledWith(217, 114);
+    });
+
+    it('should resize amp-iframe with opaque origin', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,
         sandbox: 'allow-scripts',

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -266,6 +266,7 @@ export function listenFor(
       opt_is3P
   );
 
+  const iframeOrigin = parseUrlDeprecated(iframe.src).origin;
   let events = listenForEvents[typeOfMessage] ||
     (listenForEvents[typeOfMessage] = []);
 
@@ -282,7 +283,6 @@ export function listenFor(
 
       // For `amp` sentinel origin must match unless opaque origin is allowed
       const isOpaqueAndAllowed = origin == 'null' && opt_allowOpaqueOrigin;
-      const iframeOrigin = parseUrlDeprecated(iframe.src).origin;
       if (iframeOrigin != origin && !isOpaqueAndAllowed) {
         return;
       }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -30,7 +30,6 @@ import {tryParseJson} from './json';
  */
 const UNLISTEN_SENTINEL = 'unlisten';
 
-
 /**
  * @typedef {{
  *   frame: !Element,


### PR DESCRIPTION
Closes #19989
Closes #16098

Allows `amp-iframe` to accept `embed-size` events from opaque origins. This allows `amp-iframe` without `allow-same-origin` to sent resize requests and also `amp-iframe` with `srcdoc` instead of `src` would also be allowed to send `embed-size` events ( because in both cases `origin` of the event is `null` and therefore opaque)

This required a bit of refactoring in the helper. The check for origin had to be moved one layer up.