### PR TITLE
update amp-bodymovin-animation extension options

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -80,7 +80,6 @@ exports.extensionBundles = [
   {
     name: 'amp-bodymovin-animation',
     version: '0.1',
-    options: {hasCss: false},
     type: TYPES.MEDIA,
   },
   {name: 'amp-brid-player', version: '0.1', type: TYPES.MEDIA},


### PR DESCRIPTION
remove {hasCss: false} option as that is the default.