### PR TITLE
Tiny fix to display the share menu on top of the pagination buttons.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -22,7 +22,7 @@
   left: 0 !important;
   height: 100% !important;
   width: 100% !important;
-  z-index: 100001 !important;
+  z-index: 100003 !important; /** Above pagination-buttons. */
   transform: translate3d(0, 100vh, 0) !important;
   transition-delay: 0.15s !important;
 }


### PR DESCRIPTION
Tiny z-index fix to display the share menu on top of the pagination buttons.