### PR TITLE
✨ Support input masking four date formats

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -95,6 +95,8 @@ exports.rules = [
       'extensions/amp-date-picker/**->third_party/rrule/rrule.js',
       'extensions/amp-inputmask/**->third_party/inputmask/inputmask.js',
       'extensions/amp-inputmask/**->' +
+          'third_party/inputmask/inputmask.date.extensions.js',
+      'extensions/amp-inputmask/**->' +
           'third_party/inputmask/inputmask.dependencyLib.js',
       'extensions/amp-subscriptions/**/*.js->' +
           'third_party/subscriptions-project/apis.js',

--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -37,6 +37,18 @@
     <p>Credit card (credit)</p>
     <input id="payment-card" type="text" mask="payment-card" placeholder="Card number">
 
+    <p>mm/dd/yyyy (date-mm-dd-yyyy)</p>
+    <input name="date1" mask="date-mm-dd-yyyy" placeholder="mm/dd/yyyy" type="tel">
+
+    <p>dd/mm/yyyy (date-dd-mm-yyyy)</p>
+    <input name="date2" mask="date-dd-mm-yyyy" placeholder="dd/mm/yyyy" type="tel">
+
+    <p>yyyy-mm-dd (date-yyyy-mm-dd)</p>
+    <input name="date3" mask="date-yyyy-mm-dd" placeholder="yyyy-mm-dd" type="tel">
+
+    <p>mm/yy (date-mm-yy)</p>
+    <input name="date4" type="tel" mask="date-mm-yy" placeholder="MM/YY">
+
     <input type="submit">
   </form>
 
@@ -51,13 +63,13 @@
     <input name="char" mask="L" type="text">
 
     <p>Phone</p>
-    <input type="tel" mask="+1_(000)_000-0000" placeholder="+1 (555) 555-5555">
+    <input name="phone1" type="tel" mask="+1_(000)_000-0000" placeholder="+1 (555) 555-5555">
 
     <p>US Postal Code</p>
-    <input mask="00000 00000-0000" placeholder="10024" type="text">
+    <input name="us-postal" mask="00000 00000-0000" placeholder="10024" type="text">
 
     <p>Canadian Postal Code</p>
-    <input mask="L0L_0L0" placeholder="A1A 1A1" type="text">
+    <input name="ca-postal" mask="L0L_0L0" placeholder="A1A 1A1" type="text">
 
     <p>15 or 16 digit Credit Card (switches on length)</p>
     <input mask="0000_000000_00000 0000_0000_0000_0000 " placeholder="0000 0000 0000 0000" type="text">

--- a/extensions/amp-inputmask/0.1/constants.js
+++ b/extensions/amp-inputmask/0.1/constants.js
@@ -30,6 +30,10 @@ export const MASK_SEPARATOR_CHAR = ' ';
 
 export const NamedMasks = {
   PAYMENT_CARD: 'payment-card',
+  DATE_DD_MM_YYYY: 'date-dd-mm-yyyy',
+  DATE_MM_DD_YYYY: 'date-mm-dd-yyyy',
+  DATE_MM_YY: 'date-mm-yy',
+  DATE_YYYY_MM_DD: 'date-yyyy-mm-dd',
 };
 
 /** @enum {string} */

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -22,6 +22,9 @@ import {
 import {MaskInterface} from './mask-interface';
 import {factory as inputmaskCustomAliasFactory} from './inputmask-custom-alias';
 import {
+  factory as inputmaskDateExtensionsFactory,
+} from '../../../third_party/inputmask/inputmask.date.extensions';
+import {
   factory as inputmaskDependencyFactory,
 } from '../../../third_party/inputmask/inputmask.dependencyLib';
 import {
@@ -33,6 +36,22 @@ import {
 
 const NamedMasksToInputmask = {
   [NamedMasks.PAYMENT_CARD]: 'payment-card',
+  [NamedMasks.DATE_DD_MM_YYYY]: {
+    alias: 'datetime',
+    inputFormat: 'dd/mm/yyyy',
+  },
+  [NamedMasks.DATE_MM_DD_YYYY]: {
+    alias: 'datetime',
+    inputFormat: 'mm/dd/yyyy',
+  },
+  [NamedMasks.DATE_MM_YY]: {
+    alias: 'datetime',
+    inputFormat: 'mm/yy',
+  },
+  [NamedMasks.DATE_YYYY_MM_DD]: {
+    alias: 'datetime',
+    inputFormat: 'yyyy-mm-dd',
+  },
 };
 
 const MaskCharsToInputmask = {
@@ -68,8 +87,9 @@ export class Mask {
         inputmaskDependencyFactory(win, doc);
     Inputmask = Inputmask || inputmaskFactory(
         InputmaskDependencyLib, win, doc, undefined);
-    inputmaskPaymentCardAliasFactory(Inputmask);
     inputmaskCustomAliasFactory(Inputmask);
+    inputmaskDateExtensionsFactory(Inputmask);
+    inputmaskPaymentCardAliasFactory(Inputmask);
 
     Inputmask.extendDefaults({
       // A list of supported input type attribute values

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
@@ -40,8 +40,19 @@
     <input mask="L0L_0L0" type="tel">
     <!-- Valid: mask attr with type=search -->
     <input mask="L0L_0L0" type="search">
+    <!-- Valid: mask attr with multiple custom masks -->
+    <input mask="00000 00000-0000" type="tel">
     <!-- Valid: mask attr with named mask "payment-card" -->
     <input mask="payment-card" type="tel">
+    <!-- Valid: mask attr with named mask "date-dd-mm-yyyy" -->
+    <input mask="date-dd-mm-yyyy" type="tel">
+    <!-- Valid: mask attr with named mask "date-mm-dd-yyyy" -->
+    <input mask="date-mm-dd-yyyy" type="tel">
+    <!-- Valid: mask attr with named mask "date-mm-yy" -->
+    <input mask="date-mm-yy" type="tel">
+    <!-- Valid: mask attr with named mask "date-yyyy-mm-dd" -->
+    <input mask="date-yyyy-mm-dd" type="tel">
+    <!-- Valid: mask attr with named mask with spaces -->
     <!-- Valid: mask attr with named mask "payment-card" with spaces -->
     <input mask="payment-card " type="tel">
     <input mask=" payment-card" type="tel">
@@ -75,6 +86,7 @@
     <input mask="LOL_0L0 payment-card"></div>
     <!-- Invalid: mask attr with multiple named masks -->
     <input mask="payment-card payment-card"></div>
+    <input mask="payment-card date-mm-yy"></div>
   </form>
   </form>
 

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
@@ -41,8 +41,19 @@ FAIL
 |      <input mask="L0L_0L0" type="tel">
 |      <!-- Valid: mask attr with type=search -->
 |      <input mask="L0L_0L0" type="search">
+|      <!-- Valid: mask attr with multiple custom masks -->
+|      <input mask="00000 00000-0000" type="tel">
 |      <!-- Valid: mask attr with named mask "payment-card" -->
 |      <input mask="payment-card" type="tel">
+|      <!-- Valid: mask attr with named mask "date-dd-mm-yyyy" -->
+|      <input mask="date-dd-mm-yyyy" type="tel">
+|      <!-- Valid: mask attr with named mask "date-mm-dd-yyyy" -->
+|      <input mask="date-mm-dd-yyyy" type="tel">
+|      <!-- Valid: mask attr with named mask "date-mm-yy" -->
+|      <input mask="date-mm-yy" type="tel">
+|      <!-- Valid: mask attr with named mask "date-yyyy-mm-dd" -->
+|      <input mask="date-yyyy-mm-dd" type="tel">
+|      <!-- Valid: mask attr with named mask with spaces -->
 |      <!-- Valid: mask attr with named mask "payment-card" with spaces -->
 |      <input mask="payment-card " type="tel">
 |      <input mask=" payment-card" type="tel">
@@ -57,49 +68,52 @@ FAIL
 |      <!-- Invalid: mask-output attr without mask attr -->
 |      <input mask-output="raw" type="text">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:57:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:68:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=date -->
 |      <input mask="L0L_0L0" type="date">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:59:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:70:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=email -->
 |      <input mask="L0L_0L0" type="email">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:61:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:72:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=number -->
 |      <input mask="L0L_0L0" type="number">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:63:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:74:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=button -->
 |      <input mask="L0L_0L0" type="button">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:65:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:76:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=range -->
 |      <input mask="L0L_0L0" type="range">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:67:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:78:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=hidden -->
 |      <input mask="L0L_0L0" type="hidden">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:69:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:80:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=password -->
 |      <input mask="L0L_0L0" type="password">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:71:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with div[contenteditable] -->
 |      <div contenteditable mask="L0L_0L0"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:73:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple masks that includes named mask -->
 |      <input mask="LOL_0L0 payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:75:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:86:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple named masks -->
 |      <input mask="payment-card payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:77:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:88:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|      <input mask="payment-card date-mm-yy"></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:89:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card date-mm-yy'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |    </form>
 |    </form>
 |

--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -46,6 +46,10 @@ tags: {
         "payment-card"  # A named mask followed by
         "\\s"           # a single whitespace
         "[^\\s]+)"      # followed by one or more non-whitespace characters.
+        "|([^\\s]+\\sdate-dd-mm-yyyy|date-dd-mm-yyyy\\s[^\\s]+)"
+        "|([^\\s]+\\sdate-mm-dd-yyyy|date-mm-dd-yyyy\\s[^\\s]+)"
+        "|([^\\s]+\\sdate-mm-yy|date-mm-yy\\s[^\\s]+)"
+        "|([^\\s]+\\sdate-yyyy-mm-dd|date-yyyy-mm-dd\\s[^\\s]+)"
   }
   attrs: {
     name: "mask-output"

--- a/third_party/inputmask/inputmask.date.extensions.js
+++ b/third_party/inputmask/inputmask.date.extensions.js
@@ -1,0 +1,269 @@
+/*!
+* inputmask.date.extensions.js
+* https://github.com/RobinHerbots/Inputmask
+* Copyright (c) 2010 - 2018 Robin Herbots
+* Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
+* Version: 4.0.4
+*/
+
+export function factory(Inputmask) {
+    var $ = Inputmask.dependencyLib;
+    var formatCode = {
+        d: [ "[1-9]|[12][0-9]|3[01]", Date.prototype.setDate, "day", Date.prototype.getDate ],
+        dd: [ "0[1-9]|[12][0-9]|3[01]", Date.prototype.setDate, "day", function() {
+            return pad(Date.prototype.getDate.call(this), 2);
+        } ],
+        ddd: [ "" ],
+        dddd: [ "" ],
+        m: [ "[1-9]|1[012]", Date.prototype.setMonth, "month", function() {
+            return Date.prototype.getMonth.call(this) + 1;
+        } ],
+        mm: [ "0[1-9]|1[012]", Date.prototype.setMonth, "month", function() {
+            return pad(Date.prototype.getMonth.call(this) + 1, 2);
+        } ],
+        mmm: [ "" ],
+        mmmm: [ "" ],
+        yy: [ "[0-9]{2}", Date.prototype.setFullYear, "year", function() {
+            return pad(Date.prototype.getFullYear.call(this), 2);
+        } ],
+        yyyy: [ "[0-9]{4}", Date.prototype.setFullYear, "year", function() {
+            return pad(Date.prototype.getFullYear.call(this), 4);
+        } ],
+        h: [ "[1-9]|1[0-2]", Date.prototype.setHours, "hours", Date.prototype.getHours ],
+        hh: [ "0[1-9]|1[0-2]", Date.prototype.setHours, "hours", function() {
+            return pad(Date.prototype.getHours.call(this), 2);
+        } ],
+        hhh: [ "[0-9]+", Date.prototype.setHours, "hours", Date.prototype.getHours ],
+        H: [ "1?[0-9]|2[0-3]", Date.prototype.setHours, "hours", Date.prototype.getHours ],
+        HH: [ "[01][0-9]|2[0-3]", Date.prototype.setHours, "hours", function() {
+            return pad(Date.prototype.getHours.call(this), 2);
+        } ],
+        HHH: [ "[0-9]+", Date.prototype.setHours, "hours", Date.prototype.getHours ],
+        M: [ "[1-5]?[0-9]", Date.prototype.setMinutes, "minutes", Date.prototype.getMinutes ],
+        MM: [ "[0-5][0-9]", Date.prototype.setMinutes, "minutes", function() {
+            return pad(Date.prototype.getMinutes.call(this), 2);
+        } ],
+        s: [ "[1-5]?[0-9]", Date.prototype.setSeconds, "seconds", Date.prototype.getSeconds ],
+        ss: [ "[0-5][0-9]", Date.prototype.setSeconds, "seconds", function() {
+            return pad(Date.prototype.getSeconds.call(this), 2);
+        } ],
+        l: [ "[0-9]{3}", Date.prototype.setMilliseconds, "milliseconds", function() {
+            return pad(Date.prototype.getMilliseconds.call(this), 3);
+        } ],
+        L: [ "[0-9]{2}", Date.prototype.setMilliseconds, "milliseconds", function() {
+            return pad(Date.prototype.getMilliseconds.call(this), 2);
+        } ],
+        t: [ "[ap]" ],
+        tt: [ "[ap]m" ],
+        T: [ "[AP]" ],
+        TT: [ "[AP]M" ],
+        Z: [ "" ],
+        o: [ "" ],
+        S: [ "" ]
+    }, formatAlias = {
+        isoDate: "yyyy-mm-dd",
+        isoTime: "HH:MM:ss",
+        isoDateTime: "yyyy-mm-dd'T'HH:MM:ss",
+        isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
+    };
+    function getTokenizer(opts) {
+        if (!opts.tokenizer) {
+            var tokens = [];
+            for (var ndx in formatCode) {
+                if (tokens.indexOf(ndx[0]) === -1) tokens.push(ndx[0]);
+            }
+            opts.tokenizer = "(" + tokens.join("+|") + ")+?|.";
+            opts.tokenizer = new RegExp(opts.tokenizer, "g");
+        }
+        return opts.tokenizer;
+    }
+    function isValidDate(dateParts, currentResult) {
+        return !isFinite(dateParts.rawday) || dateParts.day == "29" && !isFinite(dateParts.rawyear) || new Date(dateParts.date.getFullYear(), isFinite(dateParts.rawmonth) ? dateParts.month : dateParts.date.getMonth() + 1, 0).getDate() >= dateParts.day ? currentResult : false;
+    }
+    function isDateInRange(dateParts, opts) {
+        var result = true;
+
+        if (!dateParts["rawyear"] || !dateParts["rawmonth"] || !dateParts["rawday"]) {
+            return false;
+        }
+
+        if (opts.min) {
+            if (dateParts["rawyear"]) {
+                var rawYear = dateParts["rawyear"].replace(/[^0-9]/g, ""), minYear = opts.min.year.substr(0, rawYear.length);
+                result = minYear <= rawYear;
+            }
+            if (dateParts["year"] === dateParts["rawyear"]) {
+                if (opts.min.date.getTime() === opts.min.date.getTime()) {
+                    result = opts.min.date.getTime() <= dateParts.date.getTime();
+                }
+            }
+        }
+        if (result && opts.max && opts.max.date.getTime() === opts.max.date.getTime()) {
+            result = opts.max.date.getTime() >= dateParts.date.getTime();
+        }
+        return result;
+    }
+    function parse(format, dateObjValue, opts, raw) {
+        var mask = "", match;
+        while (match = getTokenizer(opts).exec(format)) {
+            if (dateObjValue === undefined) {
+                if (formatCode[match[0]]) {
+                    mask += "(" + formatCode[match[0]][0] + ")";
+                } else {
+                    switch (match[0]) {
+                      case "[":
+                        mask += "(";
+                        break;
+
+                      case "]":
+                        mask += ")?";
+                        break;
+
+                      default:
+                        mask += Inputmask.escapeRegex(match[0]);
+                    }
+                }
+            } else {
+                if (formatCode[match[0]]) {
+                    if (raw !== true && formatCode[match[0]][3]) {
+                        var getFn = formatCode[match[0]][3];
+                        mask += getFn.call(dateObjValue.date);
+                    } else if (formatCode[match[0]][2]) mask += dateObjValue["raw" + formatCode[match[0]][2]]; else mask += match[0];
+                } else mask += match[0];
+            }
+        }
+        return mask;
+    }
+    function pad(val, len) {
+        val = String(val);
+        len = len || 2;
+        while (val.length < len) val = "0" + val;
+        return val;
+    }
+    function analyseMask(maskString, format, opts) {
+        var dateObj = {
+            date: new Date(1, 0, 1)
+        }, targetProp, mask = maskString, match, dateOperation, targetValidator;
+        function extendProperty(value) {
+            var correctedValue = value.replace(/[^0-9]/g, "0");
+            if (correctedValue != value) {
+                var enteredPart = value.replace(/[^0-9]/g, ""), min = (opts.min && opts.min[targetProp] || value).toString(), max = (opts.max && opts.max[targetProp] || value).toString();
+                correctedValue = enteredPart + (enteredPart < min.slice(0, enteredPart.length) ? min.slice(enteredPart.length) : enteredPart > max.slice(0, enteredPart.length) ? max.slice(enteredPart.length) : correctedValue.toString().slice(enteredPart.length));
+            }
+            return correctedValue;
+        }
+        function setValue(dateObj, value, opts) {
+            dateObj[targetProp] = extendProperty(value);
+            dateObj["raw" + targetProp] = value;
+            if (dateOperation !== undefined) dateOperation.call(dateObj.date, targetProp == "month" ? parseInt(dateObj[targetProp]) - 1 : dateObj[targetProp]);
+        }
+        if (typeof mask === "string") {
+            while (match = getTokenizer(opts).exec(format)) {
+                var value = mask.slice(0, match[0].length);
+                if (formatCode.hasOwnProperty(match[0])) {
+                    targetValidator = formatCode[match[0]][0];
+                    targetProp = formatCode[match[0]][2];
+                    dateOperation = formatCode[match[0]][1];
+                    setValue(dateObj, value, opts);
+                }
+                mask = mask.slice(value.length);
+            }
+            return dateObj;
+        } else if (mask && typeof mask === "object" && mask.hasOwnProperty("date")) {
+            return mask;
+        }
+        return undefined;
+    }
+    Inputmask.extendAliases({
+        datetime: {
+            mask: function(opts) {
+                formatCode.S = opts.i18n.ordinalSuffix.join("|");
+                opts.inputFormat = formatAlias[opts.inputFormat] || opts.inputFormat;
+                opts.displayFormat = formatAlias[opts.displayFormat] || opts.displayFormat || opts.inputFormat;
+                opts.outputFormat = formatAlias[opts.outputFormat] || opts.outputFormat || opts.inputFormat;
+                opts.placeholder = opts.placeholder !== "" ? opts.placeholder : opts.inputFormat.replace(/[\[\]]/, "");
+                opts.regex = parse(opts.inputFormat, undefined, opts);
+                return null;
+            },
+            placeholder: "",
+            inputFormat: "isoDateTime",
+            displayFormat: undefined,
+            outputFormat: undefined,
+            min: null,
+            max: null,
+            i18n: {
+                dayNames: [ "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+                monthNames: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
+                ordinalSuffix: [ "st", "nd", "rd", "th" ]
+            },
+            postValidation: function (buffer, pos, currentResult, opts, maskset) {
+                 opts.min = analyseMask(opts.min, opts.inputFormat, opts);
+                 opts.max = analyseMask(opts.max, opts.inputFormat, opts);
+
+                 var result = currentResult, dateParts = analyseMask(buffer.join(""), opts.inputFormat, opts);
+                 if (result && dateParts.date.getTime() === dateParts.date.getTime()) { //check for a valid date ~ an invalid date returns NaN which isn't equal
+                     result = isValidDate(dateParts, result);
+                    const inRange = result && isDateInRange(dateParts, opts);
+
+                    if (pos && inRange && currentResult.pos !== pos) {
+                        return {
+                            buffer: parse(opts.inputFormat, dateParts, opts),
+                            refreshFromBuffer: {start: pos, end: currentResult.pos}
+                        };
+                    }
+                }
+
+                // Automatically add a separator to fix an issue where typing
+                // valid chars into the field does not move the mask forward.
+                // https://github.com/RobinHerbots/Inputmask/issues/1514
+                const testIndex = buffer.length;
+                const test = maskset.tests[testIndex];
+                if (!test) {
+                    return result;
+                 }
+
+                const maskDateSeparators = test.map(t => t.match)
+                    .filter(m => /^[-/]$/.test(m.def));
+                const isSeparatorOnly = (maskDateSeparators.length === 1);
+                if (isSeparatorOnly) {
+                    const c = maskDateSeparators[0].def;
+                     return {
+                        buffer: buffer.concat([c]),
+                        refreshFromBuffer: {start: pos, end: buffer.length + 1},
+                     };
+                 }
+                return result;
+            },
+            onKeyDown: function(e, buffer, caretPos, opts) {
+                var input = this;
+                if (e.ctrlKey && e.keyCode === Inputmask.keyCode.RIGHT) {
+                    var today = new Date(), match, date = "";
+                    while (match = getTokenizer(opts).exec(opts.inputFormat)) {
+                        if (match[0].charAt(0) === "d") {
+                            date += pad(today.getDate(), match[0].length);
+                        } else if (match[0].charAt(0) === "m") {
+                            date += pad(today.getMonth() + 1, match[0].length);
+                        } else if (match[0] === "yyyy") {
+                            date += today.getFullYear().toString();
+                        } else if (match[0].charAt(0) === "y") {
+                            date += pad(today.getYear(), match[0].length);
+                        }
+                    }
+                    input.inputmask._valueSet(date);
+                    $(input).trigger("setvalue");
+                }
+            },
+            onUnMask: function(maskedValue, unmaskedValue, opts) {
+                return parse(opts.outputFormat, analyseMask(maskedValue, opts.inputFormat, opts), opts, true);
+            },
+            casing: function(elem, test, pos, validPositions) {
+                if (test.nativeDef.indexOf("[ap]") == 0) return elem.toLowerCase();
+                if (test.nativeDef.indexOf("[AP]") == 0) return elem.toUpperCase();
+                return elem;
+            },
+            insertMode: false,
+            shiftPositions: false
+        }
+    });
+    return Inputmask;
+}

--- a/third_party/inputmask/inputmask.js
+++ b/third_party/inputmask/inputmask.js
@@ -1387,7 +1387,7 @@ export function factory($, window, document, undefined) {
                 }
             }
             if ($.isFunction(opts.postValidation) && result !== false && !strict && fromSetValid !== true && validateOnly !== true) {
-                var postResult = opts.postValidation(getBuffer(true), pos.begin !== undefined ? isRTL ? pos.end : pos.begin : pos, result, opts);
+                var postResult = opts.postValidation(getBuffer(true), pos.begin !== undefined ? isRTL ? pos.end : pos.begin : pos, result, opts, getMaskSet());
                 if (postResult !== undefined) {
                     if (postResult.refreshFromBuffer && postResult.buffer) {
                         var refresh = postResult.refreshFromBuffer;

--- a/third_party/inputmask/patches/0010-date-extension-umd.patch
+++ b/third_party/inputmask/patches/0010-date-extension-umd.patch
@@ -1,0 +1,28 @@
+diff --git a/third_party/inputmask/inputmask.date.extensions.js b/third_party/inputmask/inputmask.date.extensions.js
+index 8f6b13f4f..ae850260c 100755
+--- a/third_party/inputmask/inputmask.date.extensions.js
++++ b/third_party/inputmask/inputmask.date.extensions.js
+@@ -6,15 +6,7 @@
+ * Version: 4.0.4
+ */
+ 
+-(function(factory) {
+-    if (typeof define === "function" && define.amd) {
+-        define([ "./inputmask" ], factory);
+-    } else if (typeof exports === "object") {
+-        module.exports = factory(require("./inputmask"));
+-    } else {
+-        factory(window.Inputmask);
+-    }
+-})(function(Inputmask) {
++export function factory(Inputmask) {
+     var $ = Inputmask.dependencyLib;
+     var formatCode = {
+         d: [ "[1-9]|[12][0-9]|3[01]", Date.prototype.setDate, "day", Date.prototype.getDate ],
+@@ -250,4 +242,4 @@
+         }
+     });
+     return Inputmask;
+-});
+\ No newline at end of file
++}

--- a/third_party/inputmask/patches/0011-add-date-separators.patch
+++ b/third_party/inputmask/patches/0011-add-date-separators.patch
@@ -1,0 +1,89 @@
+diff --git a/third_party/inputmask/inputmask.date.extensions.js b/third_party/inputmask/inputmask.date.extensions.js
+index ae850260c..b6e823315 100755
+--- a/third_party/inputmask/inputmask.date.extensions.js
++++ b/third_party/inputmask/inputmask.date.extensions.js
+@@ -82,6 +82,11 @@ export function factory(Inputmask) {
+     }
+     function isDateInRange(dateParts, opts) {
+         var result = true;
++
++        if (!dateParts["rawyear"] || !dateParts["rawmonth"] || !dateParts["rawday"]) {
++            return false;
++        }
++
+         if (opts.min) {
+             if (dateParts["rawyear"]) {
+                 var rawYear = dateParts["rawyear"].replace(/[^0-9]/g, ""), minYear = opts.min.year.substr(0, rawYear.length);
+@@ -191,23 +196,42 @@ export function factory(Inputmask) {
+                 monthNames: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
+                 ordinalSuffix: [ "st", "nd", "rd", "th" ]
+             },
+-            postValidation: function(buffer, pos, currentResult, opts) {
+-                opts.min = analyseMask(opts.min, opts.inputFormat, opts);
+-                opts.max = analyseMask(opts.max, opts.inputFormat, opts);
+-                var result = currentResult, dateParts = analyseMask(buffer.join(""), opts.inputFormat, opts);
+-                if (result && dateParts.date.getTime() === dateParts.date.getTime()) {
+-                    result = isValidDate(dateParts, result);
+-                    result = result && isDateInRange(dateParts, opts);
+-                }
+-                if (pos && result && currentResult.pos !== pos) {
+-                    return {
+-                        buffer: parse(opts.inputFormat, dateParts, opts),
+-                        refreshFromBuffer: {
+-                            start: pos,
+-                            end: currentResult.pos
+-                        }
+-                    };
++            postValidation: function (buffer, pos, currentResult, opts, maskset) {
++                 opts.min = analyseMask(opts.min, opts.inputFormat, opts);
++                 opts.max = analyseMask(opts.max, opts.inputFormat, opts);
++
++                 var result = currentResult, dateParts = analyseMask(buffer.join(""), opts.inputFormat, opts);
++                 if (result && dateParts.date.getTime() === dateParts.date.getTime()) { //check for a valid date ~ an invalid date returns NaN which isn't equal
++                     result = isValidDate(dateParts, result);
++                    const inRange = result && isDateInRange(dateParts, opts);
++
++                    if (pos && inRange && currentResult.pos !== pos) {
++                        return {
++                            buffer: parse(opts.inputFormat, dateParts, opts),
++                            refreshFromBuffer: {start: pos, end: currentResult.pos}
++                        };
++                    }
+                 }
++
++                // Automatically add a separator to fix an issue where typing
++                // valid chars into the field does not move the mask forward.
++                // https://github.com/RobinHerbots/Inputmask/issues/1514
++                const testIndex = buffer.length;
++                const test = maskset.tests[testIndex];
++                if (!test) {
++                    return result;
++                 }
++
++                const maskDateSeparators = test.map(t => t.match)
++                    .filter(m => /^[-/]$/.test(m.def));
++                const isSeparatorOnly = (maskDateSeparators.length === 1);
++                if (isSeparatorOnly) {
++                    const c = maskDateSeparators[0].def;
++                     return {
++                        buffer: buffer.concat([c]),
++                        refreshFromBuffer: {start: pos, end: buffer.length + 1},
++                     };
++                 }
+                 return result;
+             },
+             onKeyDown: function(e, buffer, caretPos, opts) {
+
+diff --git a/third_party/inputmask/inputmask.js b/third_party/inputmask/inputmask.js
+index eb4fbf75a..6ab796f7e 100644
+--- a/third_party/inputmask/inputmask.js
++++ b/third_party/inputmask/inputmask.js
+@@ -1387,7 +1387,7 @@ export function factory($, window, document, undefined) {
+                 }
+             }
+             if ($.isFunction(opts.postValidation) && result !== false && !strict && fromSetValid !== true && validateOnly !== true) {
+-                var postResult = opts.postValidation(getBuffer(true), pos.begin !== undefined ? isRTL ? pos.end : pos.begin : pos, result, opts);
++                var postResult = opts.postValidation(getBuffer(true), pos.begin !== undefined ? isRTL ? pos.end : pos.begin : pos, result, opts, getMaskSet());
+                 if (postResult !== undefined) {
+                     if (postResult.refreshFromBuffer && postResult.buffer) {
+                         var refresh = postResult.refreshFromBuffer;


### PR DESCRIPTION
This PR implements support for the following named masks to amp-inputmask:

- date-dd-mm-yyyy
  - Supports dd/mm/yyyy formatted dates
- date-mm-dd-yyyy
  - Supports mm/dd/yyyy formatted dates
- date-mm-yy
  - Supports mm/yy formatted dates
- date-yyyy-mm-dd
  - Supports ISO yyyy-mm-dd formatted dates

Known Issues
- deleting/inserting in the middle of the mask causes unexpected behavior
