### PR TITLE
Update gulp e2e

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -172,7 +172,7 @@
         "test/**/*.js",
         "extensions/**/test/**/*.js",
         "extensions/**/*e2e*/*.js",
-        "extensions/**/*e2e*.js",
+        "extensions/**/test-e2e*.js",
         "ads/**/test/**/*.js",
         "testing/**/*.js"
       ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -168,7 +168,14 @@
   },
   "overrides": [
     {
-      "files": ["test/**/*.js", "extensions/**/test/**/*.js", "ads/**/test/**/*.js", "testing/**/*.js"],
+      "files": [
+        "test/**/*.js",
+        "extensions/**/test/**/*.js",
+        "extensions/**/*e2e*/*.js",
+        "extensions/**/*e2e*.js",
+        "ads/**/test/**/*.js",
+        "testing/**/*.js"
+      ],
       "rules": {
         "require-jsdoc": 0,
         "jsdoc/check-param-names": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -171,8 +171,7 @@
       "files": [
         "test/**/*.js",
         "extensions/**/test/**/*.js",
-        "extensions/**/*e2e*/*.js",
-        "extensions/**/test-e2e*.js",
+        "extensions/**/test-e2e/*.js",        
         "ads/**/test/**/*.js",
         "testing/**/*.js"
       ],

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -94,6 +94,11 @@ const integrationTestPaths = [
   'extensions/**/test/integration/**/*.js',
 ];
 
+const e2eTestPaths = [
+  'test/e2e/*.js',
+  'extensions/**/test-e2e/*.js',
+];
+
 const devDashboardTestPaths = [
   'build-system/app-index/test/**/*.js',
 ];
@@ -138,6 +143,7 @@ module.exports = {
   unitTestPaths,
   unitTestOnSaucePaths,
   integrationTestPaths,
+  e2eTestPaths,
   lintGlobs,
   devDashboardTestPaths,
   thirdPartyFrames,

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -22,8 +22,7 @@ const mocha = require('gulp-mocha');
 function e2e() {
   return gulp.src([
     'test/e2e/*.js',
-    'extensions/**/*e2e*/*.js',
-    'extensions/**/test-e2e*.js',
+    'extensions/**/test-e2e/*.js',
   ], {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -20,12 +20,14 @@ const gulp = require('gulp-help')(require('gulp'));
 const mocha = require('gulp-mocha');
 
 function e2e() {
-  return gulp.src(['test/e2e/*.js'], {read: false})
+  return gulp.src([
+    'test/e2e/*.js',
+    'extensions/**/*e2e*/*.js',
+    'extensions/**/*e2e*.js',
+  ], {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],
       }));
 }
 
-gulp.task('e2e', 'Runs e2e tests', function() {
-  return e2e();
-});
+gulp.task('e2e', 'Runs e2e tests', e2e);

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -16,14 +16,12 @@
 
 'use strict';
 
+const config = require('../../config');
 const gulp = require('gulp-help')(require('gulp'));
 const mocha = require('gulp-mocha');
 
 function e2e() {
-  return gulp.src([
-    'test/e2e/*.js',
-    'extensions/**/test-e2e/*.js',
-  ], {read: false})
+  return gulp.src(config.e2eTestPaths, {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],
       }));

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,7 +23,7 @@ function e2e() {
   return gulp.src([
     'test/e2e/*.js',
     'extensions/**/*e2e*/*.js',
-    'extensions/**/*e2e*.js',
+    'extensions/**/test-e2e*.js',
   ], {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],


### PR DESCRIPTION
Updates `gulp e2e` to look for tests in `extensions/**/test-e2e`. The idea is that for testing a single component, it should live in its own dir.

This is in addition to tests that live in `test/e2e`, which is where tests with multiple components should live.

Example where e2e tests can live:
```
.
+-- extensions
|   +-- amp-esther
|   |   +-- 0.1 
|   |   |   +-- test
|   |   |   |   +-- test-amp-esther (not valid)
|   |   |   +-- test-e2e
|   |   |   |   +-- test-amp-esther (valid)
+-- tests
|   +-- e2e
|   |   +-- test-home-page (valid) 
```