### PR TITLE
✨Pass doc into validator ui using url

### DIFF
--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -302,7 +302,7 @@
         const incomingDocStr = getIncomingDoc(params);
         if (incomingDocStr) {
           editor.setEditorValue(incomingDocStr);
-          const format = params['htmlFormat'] || 'AMP4ADS';
+          const format = params['htmlFormat'] || 'AMP';
           urlForm.setHtmlFormat(format)
         }
 

--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -298,9 +298,8 @@
 
         // Interprets the parameters after the '#' in the URL.
         var params = getLocationHashParams();
-
         // Extracts the code to be validated if sent as a query param.
-        const incomingDocStr = getIncomingDoc();
+        const incomingDocStr = getIncomingDoc(params);
         if (incomingDocStr) {
           editor.setEditorValue(incomingDocStr);
           const format = params['htmlFormat'] || 'AMP4ADS';

--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -298,9 +298,18 @@
 
         // Interprets the parameters after the '#' in the URL.
         var params = getLocationHashParams();
+
+        // Extracts the code to be validated if sent as a query param.
+        const incomingDocStr = getIncomingDoc();
+        if (incomingDocStr) {
+          editor.setEditorValue(incomingDocStr);
+          const format = params['htmlFormat'] || 'AMP4ADS';
+          urlForm.setHtmlFormat(format)
+        }
+
         // If #url=<url> was provided, load it, otherwise, start with the
         // minimum valid AMP document.
-        if (params.hasOwnProperty('url') && params['url']) {
+        else if (params.hasOwnProperty('url') && params['url']) {
           this.$.urlForm.setURLAndValidate(params['url']);
           // If filter=<error_category> was provided, filter error-list.
           if (params.hasOwnProperty('filter') && params['filter']) {

--- a/validator/webui/serve-standalone.go
+++ b/validator/webui/serve-standalone.go
@@ -46,7 +46,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		//
 		// Handle '/'.
 		//
-		if r.RequestURI == "/" {
+		if r.URL.Path == "/" {
 			bytes, err := ioutil.ReadFile("index.html")
 			if err != nil {
 				http.Error(w, "File not found.", http.StatusNotFound)

--- a/validator/webui/webui.js
+++ b/validator/webui/webui.js
@@ -15,7 +15,7 @@
  * limitations under the license.
  */
 
-const DOC_INPUT_PARAM = 'doc';
+const DOC_INPUT_ATTR = 'doc';
 
 // Extracts a dictionary of parameters from window.location.hash.
 function getLocationHashParams() {
@@ -54,25 +54,11 @@ function atou(str) {
   return decodeURIComponent(escape(atob(str)));
 }
 
-// Extract queryParams from url and return object.
-function getSearchParams() {
-  const {search} = window.location;
-  if (!search) {
-    return null;
-  }
-  return search.substr(1).split('&').reduce((params, entry) => {
-    const pairs = entry.split('=');
-    params[pairs[0]] = pairs[1];
-    return params;
-  }, {});
-}
-
 // Get query param that may contain an encoded document to be validated. Decode
 // and return.
-function getIncomingDoc() {
-  const params = getSearchParams();
-  if (!params || !params[DOC_INPUT_PARAM]) {
+function getIncomingDoc(params) {
+  if (!params || !params[DOC_INPUT_ATTR]) {
     return null;
   }
-  return atou(params[DOC_INPUT_PARAM]);
+  return atou(params[DOC_INPUT_ATTR]);
 }

--- a/validator/webui/webui.js
+++ b/validator/webui/webui.js
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 
+const DOC_INPUT_PARAM = 'doc';
+
 // Extracts a dictionary of parameters from window.location.hash.
 function getLocationHashParams() {
   const paramStrings = window.location.hash.substr(1).split('&');
@@ -45,4 +47,32 @@ function setLocationHashParams(params) {
     }
   }
   window.location.hash = out.join('&');
+}
+
+// Base64 encoded ascii to ucs-2 string.
+function atou(str) {
+  return decodeURIComponent(escape(atob(str)));
+}
+
+// Extract queryParams from url and return object.
+function getSearchParams() {
+  const {search} = window.location;
+  if (!search) {
+    return null;
+  }
+  return search.substr(1).split('&').reduce((params, entry) => {
+    const pairs = entry.split('=');
+    params[pairs[0]] = pairs[1];
+    return params;
+  }, {});
+}
+
+// Get query param that may contain an encoded document to be validated. Decode
+// and return.
+function getIncomingDoc() {
+  const params = getSearchParams();
+  if (!params || !params[DOC_INPUT_PARAM]) {
+    return null;
+  }
+  return atou(params[DOC_INPUT_PARAM]);
 }


### PR DESCRIPTION
We have a partner that would like the ability to construct a link to the `validator.ampproject.org` page whereby they can send the document to be validated in the url. 

This introduces that functionality by passing the document string as a base64 encoded query param, which is then inserted into the text area to be validated.

Due to the `btoa` unicode problem, I opted to use the solution given on [this mdn page](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings).  The function used for encoding:
```js
// ucs-2 string to base64 encoded ascii
function utoa(str) {
    return window.btoa(unescape(encodeURIComponent(str)));
}
```

If you would like an encoded param to use there is one in [this gist](https://gist.github.com/calebcordry/bf2e9ecd1be79277509e87c8c8aa3395)

This is pending an internal review from the Google security team.