### PR TITLE
Tweak closing tooltip animation

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -139,7 +139,7 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
  * Minimum vertical space needed to position tooltip.
  * @const {number}
  */
-const MIN_VERTICAL_SPACE = 56;
+const MIN_VERTICAL_SPACE = 48;
 
 /**
  * Padding between tooltip and edges of screen.
@@ -642,7 +642,7 @@ export class AmpStoryEmbeddedComponent {
       state.tooltipTop = targetRect.top - MIN_VERTICAL_SPACE;
     } else if (pageRect.height - targetBottomOffset >
         MIN_VERTICAL_SPACE) { // Tooltip fits below target. Place arrow on top of the tooltip.
-      state.tooltipTop = targetRect.bottom + EDGE_PADDING * 2;
+      state.tooltipTop = targetRect.bottom + EDGE_PADDING;
       state.arrowOnTop = true;
     } else { // Element takes whole vertical space. Place tooltip on the middle.
       state.tooltipTop = pageRect.height / 2;

--- a/extensions/amp-story/1.0/amp-story-tooltip.css
+++ b/extensions/amp-story/1.0/amp-story-tooltip.css
@@ -98,13 +98,10 @@
   display: none !important;
 }
 
-.i-amphtml-hidden > .i-amphtml-story-tooltip {
-  transform: translate3d(0, 8px, 0) !important;
-  transition: transform 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
-}
-
+.i-amphtml-hidden > .i-amphtml-story-tooltip,
 .i-amphtml-hidden > .i-amphtml-story-tooltip.i-amphtml-tooltip-arrow-on-top {
-  transform: translate3d(0, -8px, 0) !important;
+  transform: translate3d(0, 0, 0) !important;
+  transition: transform 0s linear 0.15s !important;
 }
 
 .i-amphtml-story-tooltip {
@@ -120,7 +117,12 @@
   align-items: center !important;
   background: white !important;
   box-shadow: 0 1px 3px 1px rgba(0,0,0,0.24) !important;
+  transform: translate3d(0, -8px, 0) !important;
   transition: transform 0.225s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+}
+
+.i-amphtml-story-tooltip.i-amphtml-tooltip-arrow-on-top {
+  transform: translate3d(0, 8px, 0) !important;
 }
 
 .i-amphtml-tooltip-text {


### PR DESCRIPTION
Removing the `translate` animation when dismissing the tooltip, and just leaving the simple opacity fade out that is used for the "focused" state.