### PR TITLE
♻️ Scoped query selector fallback method

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -486,6 +486,23 @@ export function childElementsByTag(parent, tagName) {
   return scopedQuerySelectorAll/*OK*/(parent, `> ${tagName}`);
 }
 
+/**
+ * Finds all elements that matche `selector`, scoped inside `root`
+ * for user-agents that do not support native scoping.
+ *
+ * This method isn't required for modern builds, can be removed.
+ *
+ * @param {!Element} root
+ * @param {string} selector
+ * @return {!NodeList<!Element>}
+ */
+function scopedQuerySelectionFallback(root, selector) {
+  const unique = 'i-amphtml-scoped';
+  root.classList.add(unique);
+  const element = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
+  root.classList.remove(unique);
+  return element;
+}
 
 /**
  * Finds the first element that matches `selector`, scoped inside `root`.
@@ -503,16 +520,11 @@ export function scopedQuerySelector(root, selector) {
   }
 
   // Only IE.
-  const unique = 'i-amphtml-scoped';
-  root.classList.add(unique);
-  const element = root./*OK*/querySelector(`.${unique} ${selector}`);
-  root.classList.remove(unique);
-  return element;
+  return scopedQuerySelectionFallback(root, selector)[0];
 }
 
-
 /**
- * Finds the every element that matches `selector`, scoped inside `root`.
+ * Finds every element that matches `selector`, scoped inside `root`.
  * Note: in IE, this causes a quick mutation of the element's class list.
  * @param {!Element} root
  * @param {string} selector
@@ -527,11 +539,7 @@ export function scopedQuerySelectorAll(root, selector) {
   }
 
   // Only IE.
-  const unique = 'i-amphtml-scoped';
-  root.classList.add(unique);
-  const elements = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
-  root.classList.remove(unique);
-  return elements;
+  return scopedQuerySelectionFallback(root, selector);
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -520,7 +520,8 @@ export function scopedQuerySelector(root, selector) {
   }
 
   // Only IE.
-  return scopedQuerySelectionFallback(root, selector)[0];
+  const fallbackResult = scopedQuerySelectionFallback(root, selector);
+  return fallbackResult[0] === undefined ? null : fallbackResult[0];
 }
 
 /**


### PR DESCRIPTION
Scoped Query Selector Fallback for IE was duplicated. This change makes the `single_pass` build a bit smaller.
