### PR TITLE
Exclude e2e tests when running yarn test

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -62,7 +62,7 @@ const commonIntegrationTestPaths =
     initTestsPath.concat(fixturesExamplesPaths, builtRuntimePaths);
 
 const testPaths = commonIntegrationTestPaths.concat([
-  'test/*/!(e2e)/**/*.js',
+  'test/integration/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
 ]);

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -62,7 +62,7 @@ const commonIntegrationTestPaths =
     initTestsPath.concat(fixturesExamplesPaths, builtRuntimePaths);
 
 const testPaths = commonIntegrationTestPaths.concat([
-  'test/**/*.js',
+  'test/*/!(e2e)/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
 ]);

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -62,7 +62,7 @@ const commonIntegrationTestPaths =
     initTestsPath.concat(fixturesExamplesPaths, builtRuntimePaths);
 
 const testPaths = commonIntegrationTestPaths.concat([
-  'test/integration/*.js',
+  'test/*/!(e2e)/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
 ]);


### PR DESCRIPTION
Fixes a bug where files in `test/e2e` were incorrectly being picked up by karma when running `yarn test`. 

Thanks for catching it @kristoferbaxter!