### PR TITLE
♻️amp-inputmask validator refactor to avoid complicated regex

### DIFF
--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
@@ -32,6 +32,8 @@
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <!-- Valid: mask attr -->
     <input mask="L0L_0L0">
+    <!-- Valid: empty mask attr -->
+    <input mask="">
     <!-- Valid: mask attr with the mask-output attr -->
     <input mask="L0L_0L0" mask-output="raw">
     <!-- Valid: mask attr with type=text -->
@@ -52,14 +54,10 @@
     <input mask="date-mm-yy" type="tel">
     <!-- Valid: mask attr with named mask "date-yyyy-mm-dd" -->
     <input mask="date-yyyy-mm-dd" type="tel">
-    <!-- Valid: mask attr with named mask with spaces -->
-    <!-- Valid: mask attr with named mask "payment-card" with spaces -->
-    <input mask="payment-card " type="tel">
-    <input mask=" payment-card" type="tel">
-    <input mask=" payment-card " type="tel">
-    <input mask="  payment-card  " type="tel">
     <!-- Valid: mask attr with multiple custom masks -->
     <input mask="00000 00000-0000" type="tel">
+    <!-- Valid: mask attr with named mask literal with escape char -->
+    <input mask="00000 p\ayment-card" type="tel">
   </form>
 
 
@@ -87,6 +85,10 @@
     <!-- Invalid: mask attr with multiple named masks -->
     <input mask="payment-card payment-card"></div>
     <input mask="payment-card date-mm-yy"></div>
+    <input mask="payment-card  date-mm-yy"></div>
+    <!-- Invalid: mask attr with spaces named masks -->
+    <input mask="payment-card "></div>
+    <input mask=" payment-card "></div>
   </form>
   </form>
 

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
@@ -33,6 +33,8 @@ FAIL
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <!-- Valid: mask attr -->
 |      <input mask="L0L_0L0">
+|      <!-- Valid: empty mask attr -->
+|      <input mask="">
 |      <!-- Valid: mask attr with the mask-output attr -->
 |      <input mask="L0L_0L0" mask-output="raw">
 |      <!-- Valid: mask attr with type=text -->
@@ -53,14 +55,10 @@ FAIL
 |      <input mask="date-mm-yy" type="tel">
 |      <!-- Valid: mask attr with named mask "date-yyyy-mm-dd" -->
 |      <input mask="date-yyyy-mm-dd" type="tel">
-|      <!-- Valid: mask attr with named mask with spaces -->
-|      <!-- Valid: mask attr with named mask "payment-card" with spaces -->
-|      <input mask="payment-card " type="tel">
-|      <input mask=" payment-card" type="tel">
-|      <input mask=" payment-card " type="tel">
-|      <input mask="  payment-card  " type="tel">
 |      <!-- Valid: mask attr with multiple custom masks -->
 |      <input mask="00000 00000-0000" type="tel">
+|      <!-- Valid: mask attr with named mask literal with escape char -->
+|      <input mask="00000 p\ayment-card" type="tel">
 |    </form>
 |
 |
@@ -68,52 +66,62 @@ FAIL
 |      <!-- Invalid: mask-output attr without mask attr -->
 |      <input mask-output="raw" type="text">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:68:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:66:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=date -->
 |      <input mask="L0L_0L0" type="date">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:70:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:68:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'date'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=email -->
 |      <input mask="L0L_0L0" type="email">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:72:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:70:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'email'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=number -->
 |      <input mask="L0L_0L0" type="number">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:74:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:72:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'number'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=button -->
 |      <input mask="L0L_0L0" type="button">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:76:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:74:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=range -->
 |      <input mask="L0L_0L0" type="range">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:78:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:76:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=hidden -->
 |      <input mask="L0L_0L0" type="hidden">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:80:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:78:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'hidden'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=password -->
 |      <input mask="L0L_0L0" type="password">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'type' in tag 'input [mask]' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:80:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with div[contenteditable] -->
 |      <div contenteditable mask="L0L_0L0"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple masks that includes named mask -->
 |      <input mask="LOL_0L0 payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:86:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'LOL_0L0 payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'LOL_0L0 payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple named masks -->
 |      <input mask="payment-card payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:88:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:86:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card payment-card'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |      <input mask="payment-card date-mm-yy"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:89:4 The attribute 'mask' in tag 'input [mask]' is set to the invalid value 'payment-card date-mm-yy'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:87:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|      <input mask="payment-card  date-mm-yy"></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:88:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|      <!-- Invalid: mask attr with spaces named masks -->
+|      <input mask="payment-card "></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:90:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card '. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
+|      <input mask=" payment-card "></div>
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:91:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value ' payment-card '. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [DISALLOWED_HTML]
 |    </form>
 |    </form>
 |

--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -27,30 +27,118 @@ tags: {  # amp-inputmask
   }
   attr_lists: "common-extension-attrs"
 }
+
 # The input element is also defined by validator/validator-main.protoascii
 tags: {
   html_format: AMP
   tag_name: "INPUT"
-  spec_name: "input [mask]"
+  spec_name: "input [mask] (custom mask)"
   requires_extension: "amp-inputmask"
   attrs: {
     name: "mask"
     mandatory: true
     dispatch_key: NAME_DISPATCH
-    # Only allow named masks to appear alone in the mask list.
-    blacklisted_value_regex:
-        "([^\\s]+"      # One or more non-whitespace characters before
-        "\\s"           # a single whitespace, followed by
-        "payment-card"  # a named mask, indicating it's a list item.
-        "|"             # Or (to cover the other case):
-        "payment-card"  # A named mask followed by
-        "\\s"           # a single whitespace
-        "[^\\s]+)"      # followed by one or more non-whitespace characters.
-        "|([^\\s]+\\sdate-dd-mm-yyyy|date-dd-mm-yyyy\\s[^\\s]+)"
-        "|([^\\s]+\\sdate-mm-dd-yyyy|date-mm-dd-yyyy\\s[^\\s]+)"
-        "|([^\\s]+\\sdate-mm-yy|date-mm-yy\\s[^\\s]+)"
-        "|([^\\s]+\\sdate-yyyy-mm-dd|date-yyyy-mm-dd\\s[^\\s]+)"
+    blacklisted_value_regex: "(payment-card"
+        "|date-dd-mm-yyyy"
+        "|date-mm-dd-yyyy"
+        "|date-mm-yy"
+        "|date-yyyy-mm-dd"
+        ")"
   }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  attrs: { name: "[type]" }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
+  spec_name: "input [mask=payment-card]"
+  requires_extension: "amp-inputmask"
+  attrs: {
+    name: "mask"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+    value: "payment-card"
+  }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
+  spec_name: "input [mask=date-dd-mm-yyyy]"
+  requires_extension: "amp-inputmask"
+  attrs: {
+    name: "mask"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+    value: "date-dd-mm-yyyy"
+  }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
+  spec_name: "input [mask=date-mm-dd-yyyy]"
+  requires_extension: "amp-inputmask"
+  attrs: {
+    name: "mask"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+    value: "date-mm-dd-yyyy"
+  }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
+  spec_name: "input [mask=date-mm-yy]"
+  requires_extension: "amp-inputmask"
+  attrs: {
+    name: "mask"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+    value: "date-mm-yy"
+  }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
+  spec_name: "input [mask=date-yyyy-mm-dd]"
+  requires_extension: "amp-inputmask"
+  attrs: {
+    name: "mask"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+    value: "date-yyyy-mm-dd"
+  }
+  attr_lists: "amp-inputmask-common-attr"
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
+}
+
+attr_lists: {
+  name: "amp-inputmask-common-attr"
   attrs: {
     name: "mask-output"
     trigger: {
@@ -63,8 +151,6 @@ tags: {
     value: "tel"
     value: "search"
   }
-  attr_lists: "input-common-attr"
-  attr_lists: "input-name-attr"
+  # amp-bind
   attrs: { name: "[type]" }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-inputmask"
 }

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -233,7 +233,7 @@ feature_tests/forms.html:193:6 The tag 'template' may not appear as a descendant
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input mask="L0L_0L0" type="tel">
 >>     ^~~~~~~~~
-feature_tests/forms.html:203:4 The tag 'input [mask]' requires including the 'amp-inputmask' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/forms.html:203:4 The tag 'input [mask] (custom mask)' requires including the 'amp-inputmask' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </form>
 |  </body>
 |  </html>


### PR DESCRIPTION
Followup to PR #20383

Uses a simple `blacklisted_value_regex` to prevent combining named masks with custom masks and multiple named masks, and uses `dispatch_key: NAME_VALUE_DISPATCH` to allow the named masks in separate tag specs.