### PR TITLE
📖Create examples for country phone number formats

### DIFF
--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -189,6 +189,70 @@
   </form>
 
 
+  <h2>All <code>&lt;amp-story&gt;</code> locale phone numbers</h2>
+  <p>Some have multiple formats possible</p>
+  <form method="post"
+      action-xhr="/form/echo-json/post"
+      target="_blank"
+      id="form-e">
+    <table>
+      <thead><th>Country</th><th>format</th><th>field</th></thead>
+      <tbody>
+        <tr><td>Algeria</td><td><code>+213-00-000-0000</code></td><td><input type="tel" id="e-phone-dz" name="phone-dz" mask="+213-00-000-0000" data-cc="DZ" data-cd="Algeria"></td></tr>
+        <tr><td>Argentina</td><td><code>+54(000)000-0000</code></td><td><input type="tel" id="e-phone-ar" name="phone-ar" mask="+54(000)000-0000" data-cc="AR" data-cd="Argentina"></td></tr>
+        <tr><td>Bahrain</td><td><code>+973-0000-0000</code></td><td><input type="tel" id="e-phone-bh" name="phone-bh" mask="+\973-0000-0000" data-cc="BH" data-cd="Bahrain"></td></tr>
+        <tr><td>Belize</td><td><code>+501-000-0000</code></td><td><input type="tel" id="e-phone-bz" name="phone-bz" mask="+501-000-0000" data-cc="BZ" data-cd="Belize"></td></tr>
+        <tr><td>Bolivia</td><td><code>+591-0-000-0000</code></td><td><input type="tel" id="e-phone-bo" name="phone-bo" mask="+5\91-0-000-0000" data-cc="BO" data-cd="Bolivia"></td></tr>
+        <tr><td>Brazil</td><td><code>+55-00-0000-0000</code></td><td><input type="tel" id="e-phone-br" name="phone-br" mask="+55-00-0000-0000 +55-00-00000-0000" data-cc="BR" data-cd="Brazil"></td></tr>
+        <tr><td>Chile</td><td><code>+56-0-0000-0000</code></td><td><input type="tel" id="e-phone-cl" name="phone-cl" mask="+56-0-0000-0000" data-cc="CL" data-cd="Chile"></td></tr>
+        <tr><td>China (PRC)</td><td><code>+86(000)0000-0000</code></td><td><input type="tel" id="e-phone-cn" name="phone-cn" mask="+86(000)0000-0000 +86(000)0000-000 +86-00-00000-00000" data-cc="CN" data-cd="China (PRC)"></td></tr>
+        <tr><td>Colombia</td><td><code>+57(000)000-0000</code></td><td><input type="tel" id="e-phone-co" name="phone-co" mask="+57(000)000-0000" data-cc="CO" data-cd="Colombia"></td></tr>
+        <tr><td>Costa Rica</td><td><code>+506-0000-0000</code></td><td><input type="tel" id="e-phone-cr" name="phone-cr" mask="+506-0000-0000" data-cc="CR" data-cd="Costa Rica"></td></tr>
+        <tr><td>Cuba</td><td><code>+53-0-000-0000</code></td><td><input type="tel" id="e-phone-cu" name="phone-cu" mask="+53-0-000-0000" data-cc="CU" data-cd="Cuba"></td></tr>
+        <tr><td>Ecuador</td><td><code>+593-0-000-0000</code></td><td><input type="tel" id="e-phone-ec" name="phone-ec" mask="+5\93-0-000-0000 +5\93-00-000-0000" data-cc="EC" data-cd="Ecuador"></td></tr>
+        <tr><td>Egypt</td><td><code>+20(000)000-0000</code></td><td><input type="tel" id="e-phone-eg" name="phone-eg" mask="+20(000)000-0000" data-cc="EG" data-cd="Egypt"></td></tr>
+        <tr><td>El Salvador</td><td><code>+503-00-00-0000</code></td><td><input type="tel" id="e-phone-sv" name="phone-sv" mask="+503-00-00-0000" data-cc="SV" data-cd="El Salvador"></td></tr>
+        <tr><td>France</td><td><code>+33-0-00-00-00-00</code></td><td><input type="tel" id="e-phone-fr" name="phone-fr" mask="+33-0-00-00-00-00" data-cc="FR" data-cd="France"></td></tr>
+        <tr><td>Germany</td><td><code>+49-000-000</code></td><td><input type="tel" id="e-phone-de" name="phone-de" mask="+4\9-000-000 +4\9(000)00-00 +4\9(000)00-000 +4\9(000)00-0000 +4\9(000)000-0000 +4\9(0000)000-0000" data-cc="DE" data-cd="Germany"></td></tr>
+        <tr><td>Guatemala</td><td><code>+502-0-000-0000</code></td><td><input type="tel" id="e-phone-gt" name="phone-gt" mask="+502-0-000-0000" data-cc="GT" data-cd="Guatemala"></td></tr>
+        <tr><td>Honduras</td><td><code>+504-0000-0000</code></td><td><input type="tel" id="e-phone-hn" name="phone-hn" mask="+504-0000-0000" data-cc="HN" data-cd="Honduras"></td></tr>
+        <tr><td>India</td><td><code>+91(0000)000-000</code></td><td><input type="tel" id="e-phone-in" name="phone-in" mask="+\91(0000)000-000" data-cc="IN" data-cd="India"></td></tr>
+        <tr><td>Indonesia</td><td><code>+62(800)000-0000</code></td><td><input type="tel" id="e-phone-id" name="phone-id" mask="+62(800)000-0000 +62-00-000-00 +62-00-000-000 +62-00-000-0000 +62(800)000-000 +62(800)000-00-000" data-cc="ID" data-cd="Indonesia"></td></tr>
+        <tr><td>Iraq</td><td><code>+964(000)000-0000</code></td><td><input type="tel" id="e-phone-iq" name="phone-iq" mask="+\964(000)000-0000" data-cc="IQ" data-cd="Iraq"></td></tr>
+        <tr><td>Italy</td><td><code>+39(000)0000-00-00</code></td><td><input type="tel" id="e-phone-it" name="phone-it" mask=" +3\9(000)0000-00-00 +3\9(000)0000-000 +3\9(000)000-000 +3\9(000)00-000 +3\9(000)00-00 +3\9(00)00-00 +3\9(300)000-00-00 +3\9(300)00-00-00" data-cc="IT" data-cd="Italy"></td></tr>
+        <tr><td>Japan</td><td><code>+81(000)000-000</code></td><td><input type="tel" id="e-phone-jp" name="phone-jp" mask="+81(000)000-000 +81-00-0000-0000" data-cc="JP" data-cd="Japan"></td></tr>
+        <tr><td>Jordan</td><td><code>+962-0-0000-0000</code></td><td><input type="tel" id="e-phone-jo" name="phone-jo" mask="+\962-0-0000-0000" data-cc="JO" data-cd="Jordan"></td></tr>
+        <tr><td>Korea (South)</td><td><code>+82-00-000-0000</code></td><td><input type="tel" id="e-phone-kr" name="phone-kr" mask="+82-00-000-0000" data-cc="KR" data-cd="Korea (South)"></td></tr>
+        <tr><td>Kuwait</td><td><code>+965-0000-0000</code></td><td><input type="tel" id="e-phone-kw" name="phone-kw" mask="+\965-0000-0000" data-cc="KW" data-cd="Kuwait"></td></tr>
+        <tr><td>Lebanon</td><td><code>+961-00-000-000</code></td><td><input type="tel" id="e-phone-lb" name="phone-lb" mask="+\961-00-000-000 +\961-0-000-000" data-cc="LB" data-cd="Lebanon"></td></tr>
+        <tr><td>Libya</td><td><code>+218-00-000-000</code></td><td><input type="tel" id="e-phone-ly" name="phone-ly" mask="+218-00-000-000 +218-21-000-0000" data-cc="LY" data-cd="Libya"></td></tr>
+        <tr><td>Mexico</td><td><code>+52-00-00-0000</code></td><td><input type="tel" id="e-phone-mx" name="phone-mx" mask="+52-00-00-0000 +52(000)000-0000" data-cc="MX" data-cd="Mexico"></td></tr>
+        <tr><td>Morocco</td><td><code>+212-00-0000-000</code></td><td><input type="tel" id="e-phone-ma" name="phone-ma" mask="+212-00-0000-000" data-cc="MA" data-cd="Morocco"></td></tr>
+        <tr><td>Netherlands</td><td><code>+31-00-000-0000</code></td><td><input type="tel" id="e-phone-nl" name="phone-nl" mask="+31-00-000-0000" data-cc="NL" data-cd="Netherlands"></td></tr>
+        <tr><td>Nicaragua</td><td><code>+505-0000-0000</code></td><td><input type="tel" id="e-phone-ni" name="phone-ni" mask="+505-0000-0000" data-cc="NI" data-cd="Nicaragua"></td></tr>
+        <tr><td>Norway</td><td><code>+47(000)00-000</code></td><td><input type="tel" id="e-phone-no" name="phone-no" mask="+47(000)00-000" data-cc="NO" data-cd="Norway"></td></tr>
+        <tr><td>Oman</td><td><code>+968-00-000-000</code></td><td><input type="tel" id="e-phone-om" name="phone-om" mask="+\968-00-000-000" data-cc="OM" data-cd="Oman"></td></tr>
+        <tr><td>Panama</td><td><code>+507-000-0000</code></td><td><input type="tel" id="e-phone-pa" name="phone-pa" mask="+507-000-0000" data-cc="PA" data-cd="Panama"></td></tr>
+        <tr><td>Paraguay</td><td><code>+595(000)000-000</code></td><td><input type="tel" id="e-phone-py" name="phone-py" mask="+5\95(000)000-000" data-cc="PY" data-cd="Paraguay"></td></tr>
+        <tr><td>Peru</td><td><code>+51(000)000-000</code></td><td><input type="tel" id="e-phone-pe" name="phone-pe" mask="+51(000)000-000" data-cc="PE" data-cd="Peru"></td></tr>
+        <tr><td>Portugal</td><td><code>+351-00-000-0000</code></td><td><input type="tel" id="e-phone-pt" name="phone-pt" mask="+351-00-000-0000" data-cc="PT" data-cd="Portugal"></td></tr>
+        <tr><td>Qatar</td><td><code>+974-0000-0000</code></td><td><input type="tel" id="e-phone-qa" name="phone-qa" mask="+\974-0000-0000" data-cc="QA" data-cd="Qatar"></td></tr>
+        <tr><td>Russia</td><td><code>+7(000)000-00-00</code></td><td><input type="tel" id="e-phone-ru" name="phone-ru" mask="+7(000)000-00-00" data-cc="RU" data-cd="Russia"></td></tr>
+        <tr><td>Saudi Arabia</td><td><code>+966-5-0000-0000</code></td><td><input type="tel" id="e-phone-sa" name="phone-sa" mask="+\966-5-0000-0000 +\966-0-000-000" data-cc="SA" data-cd="Saudi Arabia"></td></tr>
+        <tr><td>Spain</td><td><code>+34(000)000-000</code></td><td><input type="tel" id="e-phone-es" name="phone-es" mask="+34(000)000-000" data-cc="ES" data-cd="Spain"></td></tr>
+        <tr><td>Syrian Arab Republic</td><td><code>+963-00-0000-000</code></td><td><input type="tel" id="e-phone-sy" name="phone-sy" mask="+\963-00-0000-000" data-cc="SY" data-cd="Syrian Arab Republic"></td></tr>
+        <tr><td>Taiwan</td><td><code>+886-0000-0000</code></td><td><input type="tel" id="e-phone-tw" name="phone-tw" mask="+886-0000-0000 +886-0-0000-0000" data-cc="TW" data-cd="Taiwan"></td></tr>
+        <tr><td>Tunisia</td><td><code>+216-00-000-000</code></td><td><input type="tel" id="e-phone-tn" name="phone-tn" mask="+216-00-000-000" data-cc="TN" data-cd="Tunisia"></td></tr>
+        <tr><td>Turkey</td><td><code>+90(000)000-0000</code></td><td><input type="tel" id="e-phone-tr" name="phone-tr" mask="+\90(000)000-0000" data-cc="TR" data-cd="Turkey"></td></tr>
+        <tr><td>United Arab Emirates</td><td><code>+971-50-000-0000</code></td><td><input type="tel" id="e-phone-ae" name="phone-ae" mask="+\971-50-000-0000 +\971-0-000-0000" data-cc="AE" data-cd="United Arab Emirates"></td></tr>
+        <tr><td>United Kingdom<!-- https://www.area-codes.org.uk/more/about-uk-area-codes.php --></td><td><code>+44-00-0000-0000</code></td><td><input type="tel" id="e-phone-uk" name="phone-uk" mask="+44-00-0000-0000" data-cc="UK" data-cd="United Kingdom"></td></tr>
+        <tr><td>Uruguay</td><td><code>+598-0-000-00-00</code></td><td><input type="tel" id="e-phone-uy" name="phone-uy" mask="+5\98-0-000-00-00" data-cc="UY" data-cd="Uruguay"></td></tr>
+        <tr><td>USA and Canada</td><td><code>+1(000)000-0000</code></td><td><input type="tel" id="e-phone-us" name="phone-us" mask="+1(000)000-0000" data-cd="USA and Canada"></td></tr>
+        <tr><td>Venezuela</td><td><code>+58(000)000-0000</code></td><td><input type="tel" id="e-phone-ve" name="phone-ve" mask="+58(000)000-0000" data-cc="VE" data-cd="Venezuela"></td></tr>
+        <tr><td>Vietnam</td><td><code>+84(000)0000-000</code></td><td><input type="tel" id="e-phone-vn" name="phone-vn" mask="+84(000)0000-000 +84-00-0000-000" data-cc="VN" data-cd="Vietnam"></td></tr>
+        <tr><td>Yemen</td><td><code>+967-000-000-000</code></td><td><input type="tel" id="e-phone-ye" name="phone-ye" mask="+\967-000-000-000 +\967-0-000-000 +\967-00-000-000" data-cc="YE" data-cd="Yemen"></td></tr>
+      </tbody>
+    </table>
     <input type="submit">
   </form>
 


### PR DESCRIPTION
Instead of having dedicated masks for phone number formats, we will allow publishers to use custom masks to specify their desired phone format instead of prescribing one for the country.

These example masks use the countries from the [amp-story extension's set of locales](https://github.com/ampproject/amphtml/blob/bc6cd097cc84c641151b550bc3994133f10e95c6/extensions/amp-story/1.0/_locales). For non-country specific locales like `ar` and `es-419`, the countries supported by glibc for that language were used. https://github.com/zerovm/glibc/blob/master/localedata/SUPPORTED

Their order might need tweaking to ensure correct behavior.