### PR TITLE
Gulp serve before gulp e2e

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -24,7 +24,16 @@ function e2e() {
   return gulp.src(config.e2eTestPaths, {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],
-      }));
+      })
+          // stop serving on localhost:8000
+          .once('end', () => {
+            process.exit();
+          })
+      );
 }
 
-gulp.task('e2e', 'Runs e2e tests', e2e);
+gulp.task('e2e', 'Runs e2e tests', ['serve'], e2e, {
+  options: {
+    'quiet': '  Do not log HTTP requests (default: false)',
+  },
+});

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -57,7 +57,7 @@ async function cleanUp_() {
   }
 }
 
-async function e2e2() {
+async function e2e() {
   // set up promise to return
   let resolver, rejecter;
   const deferred = new Promise((resolverIn, rejecterIn) => {
@@ -98,7 +98,7 @@ async function e2e2() {
   return deferred;
 }
 
-gulp.task('e2e', 'Runs e2e tests', e2e2, {
+gulp.task('e2e', 'Runs e2e tests', e2e, {
   options: {
     'quiet': '  Do not log HTTP requests (default: false)',
   },

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -81,17 +81,15 @@ async function e2e() {
   await launchWebServer_();
 
   // run tests
-  mocha.run(async failures => {
+  mocha.run(failures => {
     // end web server
     cleanUp_();
 
     // end task
     if (failures) {
-      process.exitCode = 0;
       return rejecter();
     }
 
-    process.exitCode = 1;
     return resolver();
   });
 

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -51,7 +51,7 @@ async function launchWebServer_() {
   return deferred;
 }
 
-async function cleanUp_() {
+function cleanUp_() {
   if (webServerProcess_ && !webServerProcess_.killed) {
     webServerProcess_.kill('SIGINT');
   }
@@ -83,7 +83,7 @@ async function e2e() {
   // run tests
   mocha.run(async failures => {
     // end web server
-    await cleanUp_();
+    cleanUp_();
 
     // end task
     if (failures) {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -16,18 +16,82 @@
 
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
+const colors = require('ansi-colors');
 const config = require('../../config');
 const gulp = require('gulp-help')(require('gulp'));
+const log = require('fancy-log');
 const mocha = require('gulp-mocha');
+const sleep = require('sleep-promise');
+const tryConnect = require('try-net-connect');
+const {execScriptAsync} = require('../../exec');
 
-function e2e() {
+const HOST = 'localhost';
+const PORT = 8000;
+const WEBSERVER_TIMEOUT_RETRIES = 10;
+
+let webServerProcess_;
+/**
+ * Launches a background AMP webserver for unminified js using gulp.
+ *
+ * Waits until the server is up and reachable, and ties its lifecycle to this
+ * process's lifecycle.
+ *
+ * @return {!Promise} a Promise that resolves when the web server is launched
+ *     and reachable.
+ */
+async function launchWebServer() {
+  webServerProcess_ = execScriptAsync(
+      `gulp serve --host ${HOST} --port ${PORT}
+      ${argv.quiet ? '--quiet' : ''}`);
+
+  webServerProcess_.on('close', code => {
+    code = code || 0;
+    if (code != 0) {
+      log('fatal', colors.cyan("'serve'"),
+          `errored with code ${code}. Cannot continue with e2e tests`);
+    }
+  });
+
+  let resolver, rejecter;
+  const deferred = new Promise((resolverIn, rejecterIn) => {
+    resolver = resolverIn;
+    rejecter = rejecterIn;
+  });
+  tryConnect({
+    host: HOST,
+    port: PORT,
+    retries: WEBSERVER_TIMEOUT_RETRIES, // retry timeout defaults to 1 sec
+  }).on('connected', () => {
+    return resolver(webServerProcess_);
+  }).on('timeout', rejecter);
+  return deferred;
+}
+
+async function cleanUp_() {
+  if (webServerProcess_ && !webServerProcess_.killed) {
+    // Explicitly exit the webserver.
+    webServerProcess_.kill('SIGKILL');
+    // The child node process has an asynchronous stdout. See #10409.
+    await sleep(100);
+  }
+}
+
+async function e2e() {
+  try {
+    await launchWebServer();
+  } catch (reason) {
+    log('fatal', `Failed to start a web server: ${reason}`);
+  }
+
   return gulp.src(config.e2eTestPaths, {read: false})
       .pipe(mocha({
         require: ['@babel/register', '../../../testing/e2e/test-module'],
       })
           // stop serving on localhost:8000
           .once('end', () => {
-            process.exit();
+            console.log('end event was hit');
+            cleanUp_();
           })
       );
 }

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import 'babel-regenerator-runtime';
-import * as describes from '../../../../testing/e2e/describes-e2e';
-
 describes.endtoend('AMP carousel', {
-  engines: ['selenium'],
 }, async env => {
   const slottedClass = 'i-amphtml-carousel-slotted';
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "gulp-git": "2.8.0",
     "gulp-help": "1.6.1",
     "gulp-load-plugins": "1.5.0",
-    "gulp-mocha": "6.0.0",
     "gulp-regexp-sourcemaps": "1.0.1",
     "gulp-rename": "1.4.0",
     "gulp-sourcemaps": "2.6.4",

--- a/test/e2e/test-github.js
+++ b/test/e2e/test-github.js
@@ -23,7 +23,7 @@ describes.endtoend('GitHub search results', {
     await controller.navigateTo('https://github.com/');
   });
 
-  it('should contain a result for the search term', async() => {
+  it.skip('should contain a result for the search term', async() => {
     const searchButtonHandle =
       await controller.findElement('.header-search-input');
     await controller.type(searchButtonHandle, 'TestCafe');
@@ -46,7 +46,7 @@ describes.endtoend('GitHub login', {
     await controller.navigateTo('https://github.com/login');
   });
 
-  it('should fail to login with no credentials', async() => {
+  it.skip('should fail to login with no credentials', async() => {
     const loginButton =
       await controller.findElement('.btn.btn-primary.btn-block');
     await controller.click(loginButton);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6685,19 +6685,6 @@ gulp-match@^1.0.3:
   dependencies:
     minimatch "^3.0.3"
 
-gulp-mocha@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-mocha/-/gulp-mocha-6.0.0.tgz#80f32bc705ce30747f355ddb8ccd96a1c73bef13"
-  integrity sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==
-  dependencies:
-    dargs "^5.1.0"
-    execa "^0.10.0"
-    mocha "^5.2.0"
-    npm-run-path "^2.0.2"
-    plugin-error "^1.0.1"
-    supports-color "^5.4.0"
-    through2 "^2.0.3"
-
 gulp-regexp-sourcemaps@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gulp-regexp-sourcemaps/-/gulp-regexp-sourcemaps-1.0.1.tgz#a8812244852c10950683a948e1c0dad0b1249979"
@@ -10162,7 +10149,7 @@ mkpath@1.0.0:
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-1.0.0.tgz#ebb3a977e7af1c683ae6fda12b545a6ba6c5853d"
   integrity sha1-67Opd+evHGg65v2hK1Raa6bFhT0=
 
-mocha@5.2.0, mocha@^5.2.0:
+mocha@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
@@ -10591,7 +10578,7 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
-npm-run-path@^2.0.0, npm-run-path@^2.0.2:
+npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=


### PR DESCRIPTION
Serve test pages before running e2e tests, so all you have to do is `gulp e2e` for testing on localhost:8000/examples

Remove unimplemented specs and already-loaded modules.

cc/ @cvializ @sparhami 