### PR TITLE
Allow svg > foreignobject in AMP and AMP4ADS

### DIFF
--- a/validator/testdata/feature_tests/svg.html
+++ b/validator/testdata/feature_tests/svg.html
@@ -83,6 +83,13 @@
     </radialgradient>
   </svg>
 
+  <!-- Valid: foreignObject allowed -->
+  <svg>
+    <foreignObject x=0 y=50 width="160" height="160">
+      <div>Charteux Aegean Toyget</div>
+    </foreignObject>
+  </svg>
+
   <!-- Invalid: xml:base present -->
   <svg xml:base="javascript:alert('hello world')">
     <a href="#"><circle r="10"></a>

--- a/validator/testdata/feature_tests/svg.out
+++ b/validator/testdata/feature_tests/svg.out
@@ -92,10 +92,17 @@ feature_tests/svg.html:82:6 The tag 'stop' contains the attribute 'offset' repea
 |      </radialgradient>
 |    </svg>
 |
+|    <!-- Valid: foreignObject allowed -->
+|    <svg>
+|      <foreignObject x=0 y=50 width="160" height="160">
+|        <div>Charteux Aegean Toyget</div>
+|      </foreignObject>
+|    </svg>
+|
 |    <!-- Invalid: xml:base present -->
 |    <svg xml:base="javascript:alert('hello world')">
 >>   ^~~~~~~~~
-feature_tests/svg.html:87:2 The attribute 'xml:base' may not appear in tag 'svg'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
+feature_tests/svg.html:94:2 The attribute 'xml:base' may not appear in tag 'svg'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
 |      <a href="#"><circle r="10"></a>
 |    </svg>
 |
@@ -108,16 +115,16 @@ feature_tests/svg.html:87:2 The attribute 'xml:base' may not appear in tag 'svg'
 |    <svg>
 |      <g style="display: block; position: sticky;"/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:98:4 CSS syntax error in tag 'g' - the property 'position' is set to the disallowed value 'sticky'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+feature_tests/svg.html:105:4 CSS syntax error in tag 'g' - the property 'position' is set to the disallowed value 'sticky'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
 |      <g style="DISPLAY:BLOCK;POSITION:STICKY;"/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:99:4 CSS syntax error in tag 'g' - the property 'POSITION' is set to the disallowed value 'STICKY'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+feature_tests/svg.html:106:4 CSS syntax error in tag 'g' - the property 'POSITION' is set to the disallowed value 'STICKY'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
 |      <g style="foo:bar;"/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:100:4 The property 'foo' in attribute 'style' in tag 'g' is disallowed. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+feature_tests/svg.html:107:4 The property 'foo' in attribute 'style' in tag 'g' is disallowed. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
 |      <g style="@media only screen and (max-width: 600px)"/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:101:4 CSS syntax error in tag 'g' - saw invalid at rule '@media'. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/svg.html:108:4 CSS syntax error in tag 'g' - saw invalid at rule '@media'. [AUTHOR_STYLESHEET_PROBLEM]
 |    </svg>
 |
 |    <!-- Invalid: style tag isn't allowed. Note this is really testing the
@@ -125,7 +132,7 @@ feature_tests/svg.html:101:4 CSS syntax error in tag 'g' - saw invalid at rule '
 |    <svg>
 |      <style/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:107:4 The parent tag of tag 'style amp-custom' is 'svg', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
+feature_tests/svg.html:114:4 The parent tag of tag 'style amp-custom' is 'svg', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
 |    </svg>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3256,6 +3256,21 @@ tags: {
   html_format: AMP
   html_format: AMP4ADS
   html_format: ACTIONS
+  tag_name: "FOREIGNOBJECT"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "height" }
+  attrs: { name: "width" }
+  attrs: { name: "x" }
+  attrs: { name: "y" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://www.ampproject.org/docs/reference/spec#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: ACTIONS
   tag_name: "HKERN"
   mandatory_ancestor: "SVG"
   attrs: { name: "g1" }


### PR DESCRIPTION
Fixes #19554.

@lannka for amp4ads