### PR TITLE
📖 Cleanup issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ assignees: ''
 - If you have questions about how to use AMP or other general questions about AMP please ask them on Stack Overflow under the AMP HTML tag instead of filing an issue here: http://stackoverflow.com/questions/tagged/amp-html
 - If you have questions/issues related to Google Search please ask them in Google's AMP forum instead of filing an issue here: https://goo.gl/utQ1KZ
 
-If you have a bug for AMP please fill in the following template.  Delete everything except the headers (including this text).
+If you have a bug for AMP please fill in the following template. Delete everything except the headers (including this text).
 
 ## What's the issue?
 
@@ -20,7 +20,7 @@ Briefly describe the bug.
 
 ## How do we reproduce the issue?
 
-Please provide a public URL and ideally a reduced test case (e.g. on jsbin.com) that exhibits only your issue and nothing else.  Provide step-by-step instructions for reproducing the issue:
+Please provide a public URL and ideally a reduced test case (e.g. on jsbin.com) that exhibits only your issue and nothing else. Provide step-by-step instructions for reproducing the issue:
 
 1. Step 1 to reproduce
 2. Step 2 to reproduce
@@ -32,4 +32,4 @@ All browsers? Some specific browser? What device type?
 
 ## Which AMP version is affected?
 
-Is this a new issue? Or was it always broken? Paste the version of AMP where you saw this issue.  (You can find the version printed in your browser's console.)
+Is this a new issue? Or was it always broken? Paste the version of AMP where you saw this issue. (You can find the version printed in your browser's console.)

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,6 +1,6 @@
 ---
 name: Cherry pick template
-about: Used to request a cherry pick.  See bit.ly/amp-cherry-pick
+about: Used to request a cherry pick. See bit.ly/amp-cherry-pick
 title: "\U0001F338 Cherry pick request for <YOUR_ISSUE_NUMBER> into <RELEASE_ISSUE_NUMBER>
   (Pending)"
 labels: 'Type: Release'
@@ -8,36 +8,45 @@ assignees: cramforce
 
 ---
 
-**Replace *everything* in angle brackets in the title AND body of this issue.  If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).**
+<!--
+Replace *everything* in angle brackets in the title AND body of this issue. If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
+-->
 
 
-**GitHub issue your cherry pick is fixing:**
+## GitHub issue your cherry pick is fixing:
 
 Issue #<ISSUE_NUMBER>
 
 
-**PR that you are requesting a cherry pick for:**
+## PR that you are requesting a cherry pick for:
 
-*(Put N/A if you do not yet have a PR with a fix; edit this issue to add it when the PR is ready.)*
+<!--
+Put N/A if you do not yet have a PR with a fix; edit this issue to add it when the PR is ready.
+-->
 
 PR #<PR_NUMBER>
 
 
-**Release(s) you requesting this cherry pick into:**
+## Release(s) you requesting this cherry pick into:
 
-*Release issues can be found at https://github.com/ampproject/amphtml/labels/Type%3A%20Release*
+<!--
+Release issues can be found at https://github.com/ampproject/amphtml/labels/Type%3A%20Release
 
-*If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost.  See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).)*
+If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost. See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
+-->
 
-Production Release? <YES/NO>  If yes, Type: Release Issue #<PRODUCTION_RELEASE_ISSUE>
+Production Release? <YES/NO>
 
-Canary release? <YES/NO>  If yes, Type: Release Issue #<CANARY_RELEASE_ISSUE>, otherwise <WHY_THIS_IS_NOT_NEEDED>
+<!-- If yes: --> Release Issue #<PRODUCTION_RELEASE_ISSUE>
 
+Canary release? <YES/NO>
 
-*Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?  Be specific.*
+<!-- If yes: --> Release Issue #<CANARY_RELEASE_ISSUE>
+<!-- otherwise: --> <WHY_THIS_IS_NOT_NEEDED>
 
+## Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
+
+<!-- Be specific. -->
 <YOUR_REASONS>
-
-*Assign this issue to the current TL (cramforce) if you have permission to, otherwise leave this cc line in.*
 
 /cc @cramforce

--- a/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
@@ -1,42 +1,42 @@
 ---
 name: Intent-to-implement (I2I)
-about: Proposes a significant change/update to AMP.  See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md.
+about: Proposes a significant change/update to AMP. See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md.
 title: 'I2I: <your feature/change>'
 labels: INTENT TO IMPLEMENT
 assignees: ''
 
 ---
 
-<!---
+<!--
 Replace/remove all of the text in brackets, including this text.
 
-See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for help determining if you need to file an I2I for your change/fix, instructions on filling out this I2I template and how to get help if you have questions.  Note that If you are implementing a minor change/fix, you likely do not need to file this I2I.
+See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for help determining if you need to file an I2I for your change/fix, instructions on filling out this I2I template and how to get help if you have questions. Note that If you are implementing a minor change/fix, you likely do not need to file this I2I.
 -->
 
-**Summary**
-<!---
+## Summary
+<!--
 Provide a brief description of the feature/change you are planning on implementing.
 -->
 
-**Design document**
-<!---
-Provide a link to your design document once you have one.  You do not need a design document to file this I2I.
+## Design document
+<!--
+Provide a link to your design document once you have one. You do not need a design document to file this I2I.
 -->
 
-**Motivation**
-<!---
+## Motivation
+<!--
 Explain why AMP needs this change. It may be useful to describe what AMP developers/users are forced to do without it. When possible, include links to back up your claims.
 -->
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
-<!---
+## Additional context
+<!--
 Add any other information that may help people understand your I2I.
 -->
 
-<!---
-Add anyone to this cc line that you want to notify about this I2I, including a reviewer once you have found one.  (See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for help in finding a reviewer.)
--->
 
+<!--
+Add anyone to this cc line that you want to notify about this I2I, including a reviewer once you have found one. See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for help in finding a reviewer.
+-->
 /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
@@ -1,51 +1,52 @@
 ---
 name: Intent-to-ship (I2S)
 about: Proposes launching a significant change/update to AMP that has already been
-  implemented.  https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md
+  implemented. https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md
 title: 'I2S: <your change/update>'
 labels: INTENT TO SHIP
 assignees: ''
 
 ---
 
-<!---
+<!--
 Replace/remove all of the text in brackets, including this text.
 
 Use an Intent-to-ship (I2S) issue to request the launch of a significant change/update to AMP, generally those that required an Intent-to-implement (I2I) issue.
 See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for more information.
 -->
 
-**Summary**
-<!---
+## Summary
+<!--
 Provide a brief description of the feature/change you have implemented.
 -->
 
-**Intent-to-implement (I2I) issue**
-<!---
+## Intent-to-implement (I2I) issue
+<!--
 Provide a link to the I2I issue you filed for this feature/change.
 -->
 
-**Experiment(s) to enable**
-<!---
+## Experiment(s) to enable
+<!--
 List the experiment(s) that should be enabled to launch your feature.
 -->
 
-**Required release version**
-<!---
+## Required release version
+<!--
 Link to the "Type: Release" issue for the release that contains all of the changes necessary for your launch.
 -->
 
-**Demo instructions**
-<!---
+## Demo instructions
+<!--
 Provide instructions for how to demo your feature such as a link to a demo page.
 -->
 
-**Additional context**
-<!---
+## Additional context
+<!--
 Add any other information that may be relevant in determining if your feature can ship.
 -->
 
-<!---
+
+<!--
 Add anyone to this cc line that you want to notify about this I2S, including the reviewer who you worked with on the I2I.
 -->
 /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/release_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/release_issue_template.md
@@ -4,19 +4,19 @@
 Note to onduty:
 
 Use this issue to track a release from the initial canary release build through
-production.  The community uses this issue to keep track of what is going on
+production. The community uses this issue to keep track of what is going on
 with the release so please keep this issue up to date:
 
 - As you reach each stage of the release, check the appropriate checkbox and replace <CL submit time> with the "Submitted" text from the corresponding CL, e.g. "2:49 PM, Jul 25, 2018 UTC-4".
 - If you need to perform cherry picks, add new checkboxes here (by editing this
-  issue),  making sure to use the release number for the new build.  Link the
+  issue), making sure to use the release number for the new build. Link the
   release number to the GitHub tag page the first time a given release number
   appears in the checkboxes.
 - Add any updates that may be of interest to the community (such as delays) as
   comments on this issue, including after the release is pushed to production.
 - Keep the title of the issue updated to reflect whether this issue is tracking
   the Canary or the build in Production.
-  
+
 Note: remove the backticks (``) from the link.
 -->
 
@@ -26,7 +26,6 @@ Note: remove the backticks (``) from the link.
 - [ ] Release <RELEASE_NUMBER> pushed to production (<CL submit time>)
 
 <!--
-
 If you perform cherry picks, add/update the checkboxes above as needed e.g.
 
 - [ ] Release `[<CHERRY_PICK_RELEASE_NUMBER>](...)` created with cherry picks.
@@ -35,4 +34,4 @@ If you perform cherry picks, add/update the checkboxes above as needed e.g.
 
 See the [release documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md) for more information on the release process, including how to test changes in the Dev Channel.
 
-If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new).  If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://bit.ly/amp-cherry-pick).
+If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://bit.ly/amp-cherry-pick).


### PR DESCRIPTION
- Standardizes us on using `## headings` to mark sections, instead of `**bold**`.
- Uses HTML comments to add unseen comments to the templates (particularly the cherry-pick template).
- Also removes a lot of ".  " period-double-spaces, which are bad form.