### PR TITLE
✅🏗Add more carousel v2 e2e tests.

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -195,20 +195,13 @@ class AmpPageFixture {
 
     // TODO(estherkim): remove hardcoded chrome driver
     const capabilities = Capabilities.chrome();
-
     // const chromeOptions = {'args': ['--headless']};
-
     // capabilities.set('chromeOptions', chromeOptions);
 
-
     const builder = new Builder().withCapabilities(capabilities);
-
     return builder.build().then(driver => {
-
       env.controller = new SeleniumWebDriverController(driver);
-
       this.driver_ = driver;
-
     });
   }
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -14,15 +14,32 @@
  * limitations under the License.
  */
 
-import 'babel-regenerator-runtime';
-import * as describes from '../../../../testing/e2e/describes-e2e';
-
 describes.endtoend('AMP carousel', {
-  engines: ['selenium'],
 }, async env => {
+  /** The total number of slides in the carousel */
+  const SLIDE_COUNT = 7;
   const slottedClass = 'i-amphtml-carousel-slotted';
+  const scrollerSelector = 'amp-carousel .i-amphtml-carousel-scroll';
 
   let controller;
+
+  function prop(el, name) {
+    return controller.getElementProperty(el, name);
+  }
+
+  async function waitForImgLoad(el) {
+    await expect(prop(el, 'naturalWidth')).to.be.greaterThan(0);
+  }
+
+  async function waitForCarouselImg(n) {
+    // We cannot use CSS's nth child due to non-slide elements in the scroll
+    // container. We query all the imgs upfront, since they might not have
+    // laid out yet.
+    const el = await controller.findElementXPath(
+        `//amp-carousel//div[contains(@class, "${slottedClass}")][${n + 1}]` +
+        '//img');
+    return await waitForImgLoad(el);
+  }
 
   async function getSlide(n) {
     return await controller.findElementXPath(
@@ -41,8 +58,186 @@ describes.endtoend('AMP carousel', {
         'http://localhost:8000/test/manual/amp-carousel-0-2/basic.amp.html');
   });
 
-  it('should distribute slides', async() => {
-    // Having the 7th slide means we have all the previous ones too.
-    await getSlide(6);
+  it('should render correctly', async() => {
+    await waitForCarouselImg(0);
+    await controller.takeScreenshot('screenshots/render.png');
+  });
+
+  it('should layout the two adjacent slides', async() => {
+    // TODO(sparhami) Verify this is on the right of the 0th slide
+    await waitForCarouselImg(1);
+    // TODO(sparhami) Verify this is on the left of the 0th slide
+    await waitForCarouselImg(SLIDE_COUNT - 1);
+  });
+
+  it('should snap when scrolling', async() => {
+    const el = await controller.findElement(scrollerSelector);
+    const firstSlide = await getSlide(0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(0);
+    await waitForCarouselImg(1);
+
+    const slideWidth = await prop(firstSlide, 'offsetWidth');
+    const scrollLeft = await prop(el, 'scrollLeft');
+    const snappedScrollLeft = scrollLeft + slideWidth;
+    const requestedScrollLeft = snappedScrollLeft + 1;
+
+    await controller.scroll(el, {left: requestedScrollLeft});
+    // We should have snapped to the edge of the slide rather than the
+    // requested scroll position.
+    await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
+    await controller.takeScreenshot('screenshots/snapped.png');
+  });
+
+  it('should reset the window after scroll', async() => {
+    const el = await controller.findElement(scrollerSelector);
+    const firstSlide = await getSlide(0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(0);
+    await waitForCarouselImg(1);
+
+    const slideWidth = await prop(firstSlide, 'offsetWidth');
+    const scrollWidth = await prop(el, 'scrollWidth');
+    const scrollLeft = await prop(el, 'scrollLeft');
+    const snappedScrollLeft = scrollLeft + slideWidth;
+    const requestedScrollLeft = snappedScrollLeft + 1;
+
+    await controller.scroll(el, {left: requestedScrollLeft});
+    // Wait for the scrolling to settle
+    await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
+    // The new scroll width/left should eventually be the same as before,
+    // since the windowing should have been reset around the new element.
+    await expect(prop(el, 'scrollWidth')).to.equal(scrollWidth);
+    await expect(prop(el, 'scrollLeft')).to.equal(scrollLeft);
+    await controller.takeScreenshot('screenshots/after-reset.png');
+  });
+
+  it('should have the correct scroll position when resizing', async() => {
+    // Note: 513 seems to be the smallest settable width.
+    controller.setWindowRect({
+      width: 300,
+      height: 1000,
+    });
+
+    const firstSlide = await getSlide(0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(0);
+    await waitForCarouselImg(1);
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      'x': 0,
+      'width': 300,
+    });
+
+    controller.setWindowRect({
+      width: 700,
+      height: 1000,
+    });
+
+    // Normally, resizing would cause the position to change. We're testing
+    // that the carousel moves this to the correct position again.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      'x': 0,
+      'width': 700,
+    });
+    await controller.takeScreenshot('screenshots/after-resize.png');
+  });
+
+  describe('looping', () => {
+    it('should show the last slide when looping', async() => {
+      const el = await controller.findElement(scrollerSelector);
+      const lastSlide = await getSlide(SLIDE_COUNT - 1);
+
+      // Wait for the first and last slides to load.
+      await waitForCarouselImg(0);
+      await waitForCarouselImg(SLIDE_COUNT - 1);
+
+      // Scroll to the previous slide by moving left by the last slide's width.
+      const slideWidth = await prop(lastSlide, 'offsetWidth');
+      const restingScrollLeft = await prop(el, 'scrollLeft');
+      const snappedScrollLeft = restingScrollLeft - slideWidth;
+      const requestedScrollLeft = snappedScrollLeft - 1;
+      await controller.scroll(el, {left: requestedScrollLeft});
+
+      await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
+      await controller.takeScreenshot('screenshots/loop-past-start.png');
+    });
+
+    it('should show the first slide when looping', async() => {
+      const el = await controller.findElement(scrollerSelector);
+      const lastSlide = await getSlide(SLIDE_COUNT - 1);
+
+      // Wait for the first and last slides to load.
+      await waitForCarouselImg(0);
+      await waitForCarouselImg(SLIDE_COUNT - 1);
+
+      // Go to the last slide, wait for scrolling to move and window to reset.
+      const slideWidth = await prop(lastSlide, 'offsetWidth');
+      const restingScrollLeft = await prop(el, 'scrollLeft');
+      const lastSlideScrollPos = restingScrollLeft - slideWidth;
+      await controller.scroll(el, {left: lastSlideScrollPos});
+      await expect(prop(el, 'scrollLeft')).to.equal(lastSlideScrollPos);
+      await expect(prop(el, 'scrollLeft')).to.equal(restingScrollLeft);
+
+      // Go to the next slide by moving the slides width to the right.
+      const snappedScrollLeft = restingScrollLeft + slideWidth;
+      const requestedScrollLeft = snappedScrollLeft + 1;
+      await controller.scroll(el, {left: requestedScrollLeft});
+
+      await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
+      await controller.takeScreenshot('screenshots/loop-past-end.png');
+    });
+
+    // When resting the last few slides should be translated to the left.
+    // Make sure we can move all the way forwards to the last slide and that it
+    // is in the right place.
+    it('should display slides correctly when moving forwards', async() => {
+      const el = await controller.findElement(scrollerSelector);
+      const lastSlide = await getSlide(SLIDE_COUNT - 1);
+
+      // Wait for the first and last slides to load.
+      await waitForCarouselImg(0);
+      await waitForCarouselImg(SLIDE_COUNT - 1);
+
+      // Go to the last slide, wait for scrolling to move.
+      const slideWidth = await prop(lastSlide, 'offsetWidth');
+      const restingScrollLeft = await prop(el, 'scrollLeft');
+      const lastSlideScrollPos = restingScrollLeft +
+          (slideWidth * (SLIDE_COUNT - 1));
+      await controller.scroll(el, {left: lastSlideScrollPos});
+
+      await expect(prop(el, 'scrollLeft')).to.not.equal(restingScrollLeft);
+      await expect(prop(el, 'scrollLeft')).to.equal(restingScrollLeft);
+      // TODO(sparhami) Make sure the slide is in the right place.
+      await controller.takeScreenshot(
+          'screenshots/loop-move-forwards-to-end.png');
+    });
+
+    // When resting the first few slides should be translated to the right.
+    // Make sure we can move all the way backwards to the second slide and that
+    // it is in the right place.
+    it('should display slides correctly when moving backwards', async() => {
+      const el = await controller.findElement(scrollerSelector);
+      const secondSlide = await getSlide(1);
+
+      // Wait for the first and second slides to load.
+      await waitForCarouselImg(0);
+      await waitForCarouselImg(1);
+
+      // Go to the last slide, wait for scrolling to move.
+      const slideWidth = await prop(secondSlide, 'offsetWidth');
+      const restingScrollLeft = await prop(el, 'scrollLeft');
+      const secondSlideScrollPos = restingScrollLeft -
+          (slideWidth * (SLIDE_COUNT - 1));
+      await controller.scroll(el, {left: secondSlideScrollPos});
+
+      await expect(prop(el, 'scrollLeft')).to.not.equal(restingScrollLeft);
+      await expect(prop(el, 'scrollLeft')).to.equal(restingScrollLeft);
+      // TODO(sparhami) Make sure the slide is in the right place.
+      await controller.takeScreenshot(
+          'screenshots/loop-move-backwards-to-second.png');
+    });
   });
 });

--- a/test/manual/amp-carousel-0-2/basic.amp.html
+++ b/test/manual/amp-carousel-0-2/basic.amp.html
@@ -8,10 +8,6 @@
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
-    body {
-      max-width: 527px;
-    }
-
     amp-carousel img {
       object-fit: cover;
     }

--- a/testing/e2e/functional-test-controller.js
+++ b/testing/e2e/functional-test-controller.js
@@ -265,6 +265,16 @@ export class FunctionalTestController {
    */
   async getElementProperty(unusedHandle, unusedProperty, opt_expect) {}
 
+
+  /**
+   * Returns the rect for a given Element.
+   * {@link https://www.w3.org/TR/webdriver1/#get-element-rect}
+   *
+   * @param {!ElementHandle} unusedHandle
+   * @return {!Promise<!{x: number, y: number, height: number. width: number}>}
+   */
+  async getElementRect(unusedHandle) {}
+
   /**
    * Return the value of the given CSS value on the given element.
    * {@link https://www.w3.org/TR/webdriver1/#get-element-css-value}

--- a/testing/e2e/selenium-webdriver-controller.js
+++ b/testing/e2e/selenium-webdriver-controller.js
@@ -16,6 +16,7 @@
 
 import {By, Condition, Key, until} from 'selenium-webdriver';
 import {ControllerPromise,ElementHandle} from './functional-test-controller';
+import {expect} from 'chai';
 import fs from 'fs';
 
 /**
@@ -201,6 +202,19 @@ export class SeleniumWebDriverController {
   }
 
   /**
+   * @param {!ElementHandle<!WebElement>} handle
+   * @return {!Promise<!{x: number, y: number, height: number. width: number}>}
+   * @override
+   */
+  getElementRect(handle) {
+    const webElement = handle.getElement();
+    return new ControllerPromise(
+        webElement.getRect(),
+        this.getWaitFn_(() => webElement.getRect()));
+  }
+
+  /**
+   * Sets width/height of the browser area.
    * @param {!WindowRectDef} rect
    * @return {!Promise}
    * @override
@@ -210,7 +224,54 @@ export class SeleniumWebDriverController {
       width,
       height,
     } = rect;
-    await this.driver.manage().window().setRect({width, height});
+
+    // Calculate the window borders, so we can set the correct size to get the
+    // desired content size.
+    const results = await Promise.all([
+      this.driver.manage().window().getRect(),
+      this.driver.findElement(By.tagName('html')),
+    ]);
+    // No Array destructuring allowed?
+    const winRect = results[0];
+    const htmlElement = results[1];
+    const htmlElementSizes = await Promise.all([
+      htmlElement.getAttribute('clientWidth'),
+      htmlElement.getAttribute('clientHeight'),
+    ]);
+    // No Array destructuring allowed?
+    const clientWidth = htmlElementSizes[0];
+    const clientHeight = htmlElementSizes[1];
+
+    const horizBorder = winRect.width - clientWidth;
+    const vertBorder = winRect.height - clientHeight;
+
+    await this.driver.manage().window().setRect({
+      width: width + horizBorder,
+      height: height + vertBorder,
+    });
+
+    // Verify the size. The browser may refuse to resize smaller than some
+    // size when not running headless. It is better to fail here rather than
+    // have the developer wonder why their test is failing on an unrelated
+    // expect. TODO: support running browsers in a headless mode, otherwise
+    // mobile resolutions cannot be tested due to the minimum width/height
+    // browsers impose. If non headless mode is supported, these asserts are
+    // still necessary, because the test may fail if the user is debugging them
+    // due to the min size and we want to make sure it fails fast.
+    const updatedWinRect = await this.driver.manage().window().getRect();
+    const resultWidth = updatedWinRect.width - horizBorder;
+    const resultHeight = updatedWinRect.height - vertBorder;
+    // TODO(sparhami) These are throwing errors, but are not causing the test
+    // to fail immediately,.Figure out why, we want the test to fail here
+    // instead of continuing.
+    expect(resultWidth).to.equal(
+        width,
+        'Failed to resize the window to the requested width. Expected: ' +
+        `${width}, actual: ${resultWidth}.`);
+    expect(resultHeight).to.equal(
+        height,
+        'Failed to resize the window to the requested height. Expected: ' +
+        `${height}, actual: ${resultHeight}.`);
   }
 
   /**


### PR DESCRIPTION
- Add a method to get an Element's rect
- Support all uses of include(s), not just indexOf based ones
- Change setWindowRect
  * Set the content area to the desired size, rather than the arbitrary browser
    window size (which includes browser UI such as borders and tab bar).
  * Add an assert to make sure the requested size was actually set,
    since browsers may refuse to set small sizes when not run as
    headless.