### PR TITLE
Open page attachments links in a new tab, and don't trigger the tooltip UI.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -163,6 +163,14 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
         .querySelector('.i-amphtml-story-page-attachment-close-button')
         .addEventListener('click', () => this.close_(), true /** useCapture */);
 
+    // Always open links in a new tab.
+    this.contentEl_.addEventListener('click', event => {
+      const {target} = event;
+      if (target.tagName.toLowerCase() === 'a') {
+        target.setAttribute('target', '_blank');
+      }
+    }, true /** useCapture */);
+
     // Closes the attachment on opacity background clicks.
     this.element.addEventListener('click', event => {
       if (event.target.tagName.toLowerCase() === 'amp-story-page-attachment') {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -444,19 +444,25 @@ class ManualAdvancement extends AdvancementConfig {
 
   /**
    * For an element to trigger a tooltip it has to be descendant of
-   * amp-story-page but not of amp-story-cta-layer.
+   * amp-story-page but not of amp-story-cta-layer or amp-story-page-attachment.
    * @param {!Event} event
    * @return {boolean}
    * @private
    */
   canShowTooltip_(event) {
     let valid = true;
+    let tagName;
+
     return !!closest(dev().assertElement(event.target), el => {
-      if (el.tagName.toLowerCase() === 'amp-story-cta-layer') {
+      tagName = el.tagName.toLowerCase();
+
+      if (tagName === 'amp-story-cta-layer' ||
+          tagName === 'amp-story-page-attachment') {
         valid = false;
         return false;
       }
-      return el.tagName.toLowerCase() === 'amp-story-page' && valid;
+
+      return tagName === 'amp-story-page' && valid;
     }, /* opt_stopAt */ this.element_);
   }
 


### PR DESCRIPTION
Open page attachments links in a new tab, and don't trigger the tooltip UI.

#20209 
