### PR TITLE
adsense fast fetch: prevent query parameters from being renamed

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -337,14 +337,14 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         enclosingContainers.includes(ValidAdContainerTypes['AMP-STICKY-AD']);
     const parameters = {
       'client': adClientId,
-      format,
+      'format': format,
       'w': this.size_.width,
       'h': this.size_.height,
       'iu': slotname,
       'npa': consentState == CONSENT_POLICY_STATE.INSUFFICIENT ||
           consentState == CONSENT_POLICY_STATE.UNKNOWN ? 1 : null,
       'adtest': adTestOn ? 'on' : null,
-      adk,
+      'adk': adk,
       'output': 'html',
       'bc': global.SVGElement && global.document.createElementNS ? '1' : null,
       'ctypes': this.getCtypes_(),
@@ -393,9 +393,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       return googleAdUrl(
           this, ADSENSE_BASE_URL, startTime, Object.assign(
               {
-                adsid: identity.token || null,
-                jar: identity.jar || null,
-                pucrd: identity.pucrd || null,
+                'adsid': identity.token || null,
+                'jar': identity.jar || null,
+                'pucrd': identity.pucrd || null,
               },
               parameters), experimentIds);
     });


### PR DESCRIPTION
In the new single-pass flow AdSense url parameters are being renamed.  This isn't a single-pass problem, but instead a problem with how URL parameters are being set.

Regular: https://cdn.ampproject.org/v0/amp-ad-network-adsense-impl-0.1.js
Single-pass: https://cdn.ampproject.org/sp/v0/amp-ad-network-adsense-impl-0.1.js

In the former I see

    adtest:f?"on":null,adk:l,output:"html" 
    Object.assign({adsid:a.token||null,jar:a.jar||null,pucrd:a.pucrd||null}

while in the latter I see:

    adtest:f?"on":null,nT:k,output:"html"
    Object.assign({TJ:a.vj||null,ku:a.ku||null,Uu:a.Uu||null}

(Regular compiles with `--compilation_level SIMPLE_OPTIMIZATIONS` vs `--compilation_level ADVANCED` in single-pass.)

Without my change, compiling with `--single_pass` I see:

    adtest:f?"on":null,nU:k,output:"html"
    Object.assign({GK:a.yj||null,Hu:a.Hu||null,tv:a.tv||null}

With my change, I see:

    adtest:f?"on":null,adk:k,output:"html"
    Object.assign({adsid:a.yj||null,jar:a.gz||null,pucrd:a.iA||null}

You can see that advanced renaming is active (ex: `a.iA`) but the keys are still correct (ex: `pucrd`).

I'm not sure how to write a test for this, because I think we don't have any tests that run on the compiled JS, let alone the single-pass compiled JS?