### PR TITLE
✨ Add RC binary type

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -785,6 +785,7 @@ export function getBinaryTypeNumericalCode(type) {
     'production': '0',
     'control': '1',
     'canary': '2',
+    'rc': '3',
   }[type] || null;
 }
 


### PR DESCRIPTION
We're releasing an RC build, which will be 100% the same as the code that _will be released_ to production next week. The canary type sticks around, but it is (as it has always been) an experimental configuration of next week's code.

Proper experiment metrics should be done `canary <-> rc`, and `rc <-> control`. Comparing `canary <-> control` will not give the correct experiment metrics, because it tests experimental code _and_ experimental configurations.

/cc @ampproject/a4a