### PR TITLE
Fixing background-audio on amp-story-page.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -82,7 +82,11 @@ const Selectors = {
   ALL_AMP_MEDIA: 'amp-story-grid-layer amp-audio, ' +
       'amp-story-grid-layer amp-video, amp-story-grid-layer amp-img, ' +
       'amp-story-grid-layer amp-anim',
-  ALL_MEDIA: 'amp-story-page > audio, amp-story-grid-layer audio, ' +
+  // TODO(gmajoulet): Refactor the way these selectors are used. They will be
+  // passed to scopedQuerySelectorAll which expects only one selector and not
+  // multiple separated by commas. `> audio` has to be kept first of the list to
+  // work with this current implementation.
+  ALL_MEDIA: '> audio, amp-story-grid-layer audio, ' +
       'amp-story-grid-layer video',
   ALL_VIDEO: 'amp-story-grid-layer video',
 };


### PR DESCRIPTION
I broke the selector getting the `background-audio` media element from the page to play/unmute it in #20264.

It was repeating `amp-story-page` in the selector even though it was already querying from the `amp-story-page` itself. The new version will eventually do a `querySelector(':scope > audio')` but is a pretty fragile implementation, that we should refactor eventually.

Closes #20473