### PR TITLE
✨ amp-next-page: Send document title/URL changes to the viewer

### DIFF
--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -41,7 +41,7 @@ let HistoryIdDef;
 let HistoryStateDef;
 
 /**
- * @typedef {{title: (string|undefined), fragment: (string|undefined), data: (!JsonObject|undefined)}}
+ * @typedef {{title: (string|undefined), fragment: (string|undefined), url: (string|undefined), canonicalUrl: (string|undefined), data: (!JsonObject|undefined)}}
  */
 let HistoryStateUpdateDef;
 
@@ -542,8 +542,10 @@ export class HistoryBindingNatural_ {
     return this.whenReady_(() => {
       const newState = this.mergeStateUpdate_(
           this.getState_(), opt_stateUpdate || {});
-      this.historyReplaceState_(newState, /* title */ undefined,
-          newState.fragment ? ('#' + newState.fragment) : undefined);
+      const url = (newState.url || '').replace(/#.*/, '');
+      const fragment = newState.fragment ? '#' + newState.fragment : '';
+      this.historyReplaceState_(newState, newState.title,
+          (url || fragment) ? url + fragment : undefined);
       return tryResolve(() =>
         this.mergeStateUpdate_(newState, {stackIndex: this.stackIndex_})
       );
@@ -905,6 +907,12 @@ export class HistoryBindingVirtual_ {
    * @override
    */
   replace(opt_stateUpdate) {
+    if (opt_stateUpdate && opt_stateUpdate.url && !this.viewer_.hasCapability(
+        'fullReplaceHistory')) {
+      // Full URL replacement requested, but not supported by the viewer.
+      // Don't update, and return the current state.
+      return Promise.resolve({'stackIndex': this.stackIndex_});
+    }
     const message = /** @type {!JsonObject} */ (
       Object.assign({'stackIndex': this.stackIndex_}, opt_stateUpdate || {})
     );

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -911,8 +911,8 @@ export class HistoryBindingVirtual_ {
         'fullReplaceHistory')) {
       // Full URL replacement requested, but not supported by the viewer.
       // Don't update, and return the current state.
-      const curState = /** @type {!HistoryStateDef} */ dict(
-          {'stackIndex': this.stackIndex_});
+      const curState = /** @type {!HistoryStateDef} */ (dict(
+          {'stackIndex': this.stackIndex_}));
       return Promise.resolve(curState);
     }
     const message = /** @type {!JsonObject} */ (

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -911,7 +911,9 @@ export class HistoryBindingVirtual_ {
         'fullReplaceHistory')) {
       // Full URL replacement requested, but not supported by the viewer.
       // Don't update, and return the current state.
-      return Promise.resolve({'stackIndex': this.stackIndex_});
+      const curState = /** @type {!HistoryStateDef} */ dict(
+          {'stackIndex': this.stackIndex_});
+      return Promise.resolve(curState);
     }
     const message = /** @type {!JsonObject} */ (
       Object.assign({'stackIndex': this.stackIndex_}, opt_stateUpdate || {})

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -553,22 +553,24 @@ describes.sandboxed('HistoryBindingNatural', {}, () => {
 });
 
 
-describe('HistoryBindingVirtual', () => {
+describes.sandboxed('HistoryBindingVirtual', {}, env => {
   let sandbox;
 
   let history;
   let viewer;
+  let capabilityStub;
 
   let onStateUpdated;
   let onHistoryPopped;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
+    sandbox = env.sandbox;
     onStateUpdated = sandbox.spy();
+    capabilityStub = sandbox.stub();
     viewer = {
       onMessage: sandbox.stub().returns(() => {}),
       sendMessageAwaitResponse: sandbox.stub().returns(Promise.resolve()),
-      hasCapability: sandbox.stub().returns(false),
+      hasCapability: capabilityStub,
     };
     history = new HistoryBindingVirtual_(window, viewer);
     history.setOnStateUpdated(onStateUpdated);
@@ -680,7 +682,7 @@ describe('HistoryBindingVirtual', () => {
     });
 
     it('supports full URL replacement', () => {
-      viewer.hasCapability.withArgs('fullReplaceHistory').returns(true);
+      capabilityStub.withArgs('fullReplaceHistory').returns(true);
       viewer.sendMessageAwaitResponse
           .withArgs('replaceHistory',
               {stackIndex: 123, title: 'title', url: '/page'})
@@ -699,7 +701,7 @@ describe('HistoryBindingVirtual', () => {
     });
 
     it('does not support full URL replacement', () => {
-      viewer.hasCapability.withArgs('fullReplaceHistory').returns(false);
+      capabilityStub.withArgs('fullReplaceHistory').returns(false);
 
       return history.replace(
           {stackIndex: 123, title: 'title', url: '/page'}).then(state => {

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -532,22 +532,28 @@ describes.sandboxed('HistoryBindingNatural', {}, () => {
   it('should update path from URL parameter', () => {
     const path = '/path';
     const query = '?query=1';
+    const prevHref = document.location.href;
     return history.replace({url: path + query}).then(() => {
       expect(document.location.pathname).to.equal(path);
       expect(document.location.search).to.equal(query);
+      return history.replace({url: prevHref});
     });
   });
 
   it('should strip fragment from URL parameter', () => {
+    const prevHref = document.location.href;
     return history.replace({url: '/path?query=1#fragment'}).then(() => {
       expect(document.location.hash).to.equal('');
+      return history.replace({url: prevHref});
     });
   });
 
   it('should append the fragment parameter to the URL parameter', () => {
     const fragment = 'test';
+    const {href, hash} = document.location;
     return history.replace({url: '/path?query=1', fragment}).then(() => {
       expect(document.location.hash).to.equal(`#${fragment}`);
+      return history.replace({url: href, fragment: hash});
     });
   });
 });


### PR DESCRIPTION
Implements the draft spec for the updated viewer history API.

Sends document title, path and canonical URLs to the viewer on document change.

