### PR TITLE
🚀 enable pre-render mode in amp-geo

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -114,6 +114,11 @@ export class AmpGeo extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     // All geo config within the amp-geo component.
     // The validator only allows one amp-geo per page


### PR DESCRIPTION
fixes #20444 

Allow `amp-geo` to pre-render.

