### PR TITLE
Apply length check to consent string

### DIFF
--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -27,7 +27,7 @@ import {
 import {Deferred} from '../../../src/utils/promise';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, devAssert} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 
 
@@ -255,6 +255,22 @@ export class ConsentInstance {
         // If state has changed. do not store outdated value.
         return;
       }
+
+      const consentStr = consentInfo['consentString'];
+      if (consentStr && consentStr.length > 188) {
+        // Verify the length of consentString.
+        // Limit to 500bytes
+        // 188 * 2 (utf8Encode) * 4/3 (base64) = 500
+        user().error(TAG,
+            'Cannot store consentString which length exceeds 188' +
+            'Previous stored consentInfo will be cleared');
+        // If new consentInfo value cannot be stored, need to remove previous
+        // value
+        storage.remove(this.storageKey_);
+        // TODO: Good to have a way to inform CMP service in this case
+        return;
+      }
+
       const value = composeStoreValue(
           consentInfo, this.isAmpConsentV2ExperimentOn_);
       if (value == null) {

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -37,12 +37,14 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
   let storageValue;
   let storageGetSpy;
   let storageSetSpy;
+  let storageRemoveSpy;
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
     storageValue = {};
     storageGetSpy = sandbox.spy();
     storageSetSpy = sandbox.spy();
+    storageRemoveSpy = sandbox.spy();
 
     resetServiceForTesting(win, 'storage');
     registerServiceBuilder(win, 'storage', function() {
@@ -54,6 +56,10 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         setNonBoolean: (name, value) => {
           storageSetSpy(name, value);
           storageValue[name] = value;
+          return Promise.resolve();
+        },
+        remove: name => {
+          storageRemoveSpy(name);
           return Promise.resolve();
         },
       });
@@ -114,6 +120,23 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield p;
         expect(value).to.deep.equal(
             constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, 'test-string'));
+      });
+
+      it('update consent string that exceeds max size', function* () {
+        expectAsyncConsoleError(/Cannot store consentString/);
+        manager.registerConsentInstance('test', {});
+        const MAX_LENGTH = 188;
+        let testStr = 'a';
+        for (let i = 0; i < MAX_LENGTH; i++) {
+          testStr += 'a';
+        }
+        manager.updateConsentInstanceState(
+            CONSENT_ITEM_STATE.ACCEPTED, testStr);
+        let value;
+        const p = manager.getConsentInstanceInfo().then(v => value = v);
+        yield p;
+        expect(value).to.deep.equal(
+            constructConsentInfo(CONSENT_ITEM_STATE.ACCEPTED, testStr));
       });
     });
 
@@ -222,6 +245,20 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
           expect(storageSetSpy).to.be.calledOnce;
           expect(storageSetSpy).to.be.calledWith(
               'amp-consent:test', composeStoreValue(consentInfo));
+        });
+
+        it('remove consetninfo when consentStr length exceeds', function* () {
+          expectAsyncConsoleError(/Cannot store consentString/);
+          const MAX_LENGTH = 188;
+          let testStr = 'a';
+          for (let i = 0; i < MAX_LENGTH; i++) {
+            testStr += 'a';
+          }
+          instance.update(
+              CONSENT_ITEM_STATE.ACCEPTED, testStr);
+          yield macroTask();
+          expect(storageSetSpy).to.not.be.called;
+          expect(storageRemoveSpy).to.be.calledOnce;
         });
       });
 


### PR DESCRIPTION
@lannka As we agreed offline, it's easier to apply length check instead of size check in bytes. 

