### PR TITLE
amp-mustache: Revert user error in purifier

### DIFF
--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -100,11 +100,7 @@ The output of "triple-mustache" is sanitized to only allow the following tags: `
 
 ### Sanitization
 
-Mustache output is sanitized for security reasons, which may result in certain elements and attributes being removed.
-
-A console error will be output with details of the sanitized element or attribute. For example:
-
-> [PURIFIER] Removed unsafe attribute: href="javascript:alert"
+Mustache output is sanitized for security reasons and to maintain AMP validity. This may result in certain elements and attributes being silently removed.
 
 ## Pitfalls
 

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -38,7 +38,7 @@ let DomPurifyDef;
 const DomPurify = purify(self);
 
 /** @private @const {string} */
-const TAG = 'PURIFIER';
+const TAG = 'purifier';
 
 /** @private @const {string} */
 const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
@@ -339,7 +339,6 @@ export function addPurifyHooks(purifier, diffing) {
 
   /**
    * @param {!Node} unusedNode
-   * @this {{removed: !Array}} Contains list of removed elements/attrs so far.
    */
   const afterSanitizeElements = function(unusedNode) {
     // DOMPurify doesn't have a attribute-specific tag whitelist API and
@@ -349,16 +348,6 @@ export function addPurifyHooks(purifier, diffing) {
       delete allowedTags[tag];
     });
     allowedTagsChanges.length = 0;
-
-    // Output user errors for each removed element.
-    this.removed.forEach(r => {
-      if (r.element) {
-        const {nodeName} = r.element;
-        if (nodeName !== 'REMOVE') { // <remove> is added by DOMPurify.
-          user().error(TAG, 'Removed unsafe element:', r.element.nodeName);
-        }
-      }
-    });
   };
 
   /**
@@ -413,7 +402,8 @@ export function addPurifyHooks(purifier, diffing) {
       }
     }
 
-    const classicBinding = isBindingAttribute(attrName);
+    const classicBinding = attrName[0] == '['
+        && attrName[attrName.length - 1] == ']';
     const alternativeBinding = startsWith(attrName, BIND_PREFIX);
     // Rewrite classic bindings e.g. [foo]="bar" -> data-amp-bind-foo="bar".
     // This is because DOMPurify eagerly removes attributes and re-adds them
@@ -437,6 +427,8 @@ export function addPurifyHooks(purifier, diffing) {
         attrValue = rewriteAttributeValue(tagName, attrName, attrValue);
       }
     } else {
+      user().error(TAG, `Removing "${attrName}" attribute with invalid `
+          + `value in <${tagName} ${attrName}="${attrValue}">.`);
       data.keepAttr = false;
     }
 
@@ -460,21 +452,12 @@ export function addPurifyHooks(purifier, diffing) {
     // Restore the `on` attribute which DOMPurify incorrectly flags as an
     // unknown protocol due to presence of the `:` character.
     remove(this.removed, r => {
-      // Ignore attributes belonging to other nodes.
-      if (r.from !== node) {
-        return false;
-      }
-      if (!r.attribute) {
-        return false;
-      }
-      const {name, value} = r.attribute;
-      if (name.toLowerCase() === 'on') {
-        node.setAttribute('on', value);
-        return true; // Delete from `removed` array once processed.
-      }
-      // Output user error for sanitized attributes.
-      if (!isBindingAttribute(name)) {
-        user().error(TAG, `Removed unsafe attribute: ${name}="${value}"`);
+      if (r.from === node && r.attribute) {
+        const {name, value} = r.attribute;
+        if (name.toLowerCase() === 'on') {
+          node.setAttribute('on', value);
+          return true; // Delete from `removed` array once processed.
+        }
       }
       return false;
     });
@@ -484,14 +467,6 @@ export function addPurifyHooks(purifier, diffing) {
   purifier.addHook('afterSanitizeElements', afterSanitizeElements);
   purifier.addHook('uponSanitizeAttribute', uponSanitizeAttribute);
   purifier.addHook('afterSanitizeAttributes', afterSanitizeAttributes);
-}
-
-/**
- * @param {string} attrName
- * @return {boolean}
- */
-export function isBindingAttribute(attrName) {
-  return attrName[0] == '[' && attrName[attrName.length - 1] == ']';
 }
 
 /**

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -30,7 +30,7 @@ import {startsWith} from './string';
 import {user} from './log';
 
 /** @private @const {string} */
-const TAG = 'SANITIZER';
+const TAG = 'sanitizer';
 
 /**
  * Whitelist of supported self-closing tags for Caja. These are used for
@@ -206,8 +206,8 @@ export function sanitizeHtml(html, diffing) {
         const attrName = attribs[i];
         const attrValue = attribs[i + 1];
         if (!isValidAttr(tagName, attrName, attrValue)) {
-          user().error(TAG,
-              `Removed unsafe attribute: ${attrName}="${attrValue}"`);
+          user().error(TAG, `Removing "${attrName}" attribute with invalid `
+              + `value in <${tagName} ${attrName}="${attrValue}">.`);
           continue;
         }
         emit(' ');


### PR DESCRIPTION
Fixes #20474. Reverts #20285 and #20407 (except for some documentation and unrelated test code changes).

Notes for the future:
- High-volume logging in a tight loop can cause performance issues on device. Likely due to error reporting code -- `warn()` may be preferable.
- DOMPurify's `removed` array also contains innocuous entries, e.g. custom `<remove>` node and comment nodes.
- New console errors should be slowly rolled out via experiment.