### PR TITLE
✨Add AMP layer to E2E tests

### DIFF
--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides AMP-related utilities for E2E Functional Tests.
+ */
+class AmpDriver {
+  /**
+   *
+   * @param {!../functional-test-controller.FunctionalTestController} controller
+   */
+  constructor(controller) {
+    this.controller_ = controller;
+  }
+
+  /**
+   * Toggles an experiment in an AMP document. Uses the current domain.
+   * @param {string} name
+   * @param {boolean} toggle
+   */
+  async toggleExperiment(name, toggle) {
+    return this.controller_.eval_((name, toggle) => {
+      window.AMP.toggleExperiment(name, toggle);
+    }, name, toggle);
+  }
+}
+
+module.exports = {
+  AmpDriver,
+};

--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -33,7 +33,7 @@ class AmpDriver {
    * @return {!Promise}
    */
   async toggleExperiment(name, toggle) {
-    await this.controller_.eval((name, toggle) => {
+    await this.controller_.evaluate((name, toggle) => {
       window.AMP.toggleExperiment(name, toggle);
     }, name, toggle);
   }

--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -19,10 +19,10 @@
  */
 class AmpDriver {
   /**
-   *
    * @param {!../functional-test-controller.FunctionalTestController} controller
    */
   constructor(controller) {
+    /** @private @const */
     this.controller_ = controller;
   }
 
@@ -30,9 +30,10 @@ class AmpDriver {
    * Toggles an experiment in an AMP document. Uses the current domain.
    * @param {string} name
    * @param {boolean} toggle
+   * @return {!Promise}
    */
   async toggleExperiment(name, toggle) {
-    return this.controller_.eval_((name, toggle) => {
+    await this.controller_.eval((name, toggle) => {
       window.AMP.toggleExperiment(name, toggle);
     }, name, toggle);
   }

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -16,6 +16,7 @@
 
 // import to install chromedriver
 require('chromedriver'); // eslint-disable-line no-unused-vars
+const {AmpDriver} = require('./amp-driver');
 const {Builder, Capabilities} = require('selenium-webdriver');
 const {clearLastExpectError, getLastExpectError} = require('./expect');
 const {SeleniumWebDriverController} = require('./selenium-webdriver-controller');
@@ -200,7 +201,9 @@ class AmpPageFixture {
 
     const builder = new Builder().withCapabilities(capabilities);
     return builder.build().then(driver => {
-      env.controller = new SeleniumWebDriverController(driver);
+      const controller = new SeleniumWebDriverController(driver);
+      env.controller = controller;
+      env.ampDriver = new AmpDriver(controller);
       this.driver_ = driver;
     });
   }

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -400,7 +400,7 @@ class FunctionalTestController {
    * @return {!Promise}
    * @package
    */
-  async eval(unusedFn, ...unusedArgs) {}
+  async evaluate(unusedFn, ...unusedArgs) {}
 }
 
 

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -396,7 +396,7 @@ class FunctionalTestController {
   /**
    * Evaluate the given function
    * @param {function()} unusedFn
-   * @param {...} unusedArgs
+   * @param {...*} unusedArgs
    * @return {!ControllerPromise}
    * @package
    */

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -392,6 +392,15 @@ class FunctionalTestController {
    * @return {!Promise}
    */
   async scroll(unusedHandle, opt_scrollToOptions) {}
+
+  /**
+   * Evaluate the given function
+   * @param {function()} unusedFn
+   * @param {...} unusedArgs
+   * @return {!ControllerPromise}
+   * @package
+   */
+  async eval_(unusedFn, ...unusedArgs) {}
 }
 
 

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -397,10 +397,10 @@ class FunctionalTestController {
    * Evaluate the given function
    * @param {function()} unusedFn
    * @param {...*} unusedArgs
-   * @return {!ControllerPromise}
+   * @return {!Promise}
    * @package
    */
-  async eval_(unusedFn, ...unusedArgs) {}
+  async eval(unusedFn, ...unusedArgs) {}
 }
 
 

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const config = require('../../config');
 const glob = require('glob');
 const gulp = require('gulp-help')(require('gulp'));

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
 const config = require('../../config');
 const glob = require('glob');
 const gulp = require('gulp-help')(require('gulp'));

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -346,7 +346,7 @@ class SeleniumWebDriverController {
   /**
    * Evaluate the given function
    * @param {function()} fn
-   * @param {...} unusedArgs
+   * @param {...*} unusedArgs
    * @return {!ControllerPromise}
    * @override
    */

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -346,12 +346,11 @@ class SeleniumWebDriverController {
   /**
    * Evaluate the given function
    * @param {function()} fn
-   * @param {...*} unusedArgs
+   * @param {...*} args
    * @return {!ControllerPromise}
    * @override
    */
-  eval(fn, unusedArgs) {
-    const args = Array.prototype.slice.call(arguments, 1);
+  eval(fn, ...args) {
     return this.driver.executeScript(fn, ...args);
   }
 

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -350,9 +350,9 @@ class SeleniumWebDriverController {
    * @return {!ControllerPromise}
    * @override
    */
-  eval_(fn, unusedArgs) {
+  eval(fn, unusedArgs) {
     const args = Array.prototype.slice.call(arguments, 1);
-    return this.driver.executeScript.apply(this.driver, [fn].concat(args));
+    return this.driver.executeScript(fn, ...args);
   }
 
   /**

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -350,7 +350,7 @@ class SeleniumWebDriverController {
    * @return {!ControllerPromise}
    * @override
    */
-  eval(fn, ...args) {
+  evaluate(fn, ...args) {
     return this.driver.executeScript(fn, ...args);
   }
 

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -344,6 +344,18 @@ class SeleniumWebDriverController {
   }
 
   /**
+   * Evaluate the given function
+   * @param {function()} fn
+   * @param {...} unusedArgs
+   * @return {!ControllerPromise}
+   * @override
+   */
+  eval_(fn, unusedArgs) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    return this.driver.executeScript.apply(this.driver, [fn].concat(args));
+  }
+
+  /**
    * @param {!ElementHandle} handle
    * @param {string} path
    * @return {!Promise<string>} An encoded string representing the image data

--- a/extensions/amp-carousel/0.2/test-e2e/helpers.js
+++ b/extensions/amp-carousel/0.2/test-e2e/helpers.js
@@ -20,10 +20,10 @@ const SPACER_CLASS = 'i-amphtml-carousel-spacer';
 const SCROLLER_SELECTOR = `${TAG_NAME} .i-amphtml-carousel-scroll`;
 
 // TODO(sparhami) Remove once part of the test framework.
-export async function enableExperiments(controller) {
-  await controller.navigateTo(
-      'http://localhost:8000/test/manual/amp-carousel-0-2/enable-experiment.html');
-  await controller.findElement('.msg-div');
+export async function enableExperiments(controller, ampDriver) {
+  await controller.navigateTo('http://localhost:8000/');
+  await ampDriver.toggleExperiment('layers', true);
+  await ampDriver.toggleExperiment('amp-carousel-v2', true);
 }
 
 async function waitForImgLoad(controller, el) {

--- a/extensions/amp-carousel/0.2/test-e2e/helpers.js
+++ b/extensions/amp-carousel/0.2/test-e2e/helpers.js
@@ -19,13 +19,6 @@ const SLOTTED_CLASS = 'i-amphtml-carousel-slotted';
 const SPACER_CLASS = 'i-amphtml-carousel-spacer';
 const SCROLLER_SELECTOR = `${TAG_NAME} .i-amphtml-carousel-scroll`;
 
-// TODO(sparhami) Remove once part of the test framework.
-export async function enableExperiments(controller, ampDriver) {
-  await controller.navigateTo('http://localhost:8000/');
-  await ampDriver.toggleExperiment('layers', true);
-  await ampDriver.toggleExperiment('amp-carousel-v2', true);
-}
-
 async function waitForImgLoad(controller, el) {
   await expect(controller.getElementProperty(el, 'naturalWidth'))
       .to.be.greaterThan(0);

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlide,
   waitForCarouselImg,
@@ -26,7 +25,7 @@ describes.endtoend('AMP carousel', {
   /** The total number of slides in the carousel */
   const SLIDE_COUNT = 7;
   const pageWidth = 600;
-  const pageHeight = 1200;
+  const pageHeight = 500;
 
   let controller;
   let ampDriver;
@@ -39,7 +38,10 @@ describes.endtoend('AMP carousel', {
     controller = env.controller;
     ampDriver = env.ampDriver;
 
-    await enableExperiments(controller, ampDriver);
+    await controller.navigateTo('http://localhost:8000/');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
+
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,
@@ -114,7 +116,7 @@ describes.endtoend('AMP carousel', {
     // Note: 513 seems to be the smallest settable width.
     controller.setWindowRect({
       width: 600,
-      height: 1000,
+      height: 500,
     });
 
     const firstSlide = await getSlide(controller, 0);
@@ -129,7 +131,7 @@ describes.endtoend('AMP carousel', {
 
     controller.setWindowRect({
       width: 700,
-      height: 1000,
+      height: 500,
     });
 
     // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -38,7 +38,7 @@ describes.endtoend('AMP carousel', {
     controller = env.controller;
     ampDriver = env.ampDriver;
 
-    await controller.navigateTo('http://localhost:8000/');
+    await controller.navigateTo('http://localhost:8000/test/manual/amp-carousel-0-2/basic.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-carousel-v2', true);
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -29,6 +29,7 @@ describes.endtoend('AMP carousel', {
   const pageHeight = 1200;
 
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -36,8 +37,9 @@ describes.endtoend('AMP carousel', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
-    await enableExperiments(controller);
+    await enableExperiments(controller, ampDriver);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
@@ -38,7 +38,8 @@ describes.endtoend('AMP carousel max-swipe', {
     controller = env.controller;
     ampDriver = env.ampDriver;
 
-    await controller.navigateTo('http://localhost:8000/');
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/max-swipe-one.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-carousel-v2', true);
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlides,
 } from './helpers';
@@ -23,8 +22,9 @@ import {
 describes.endtoend('AMP carousel max-swipe', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 1200;
+  const pageHeight = 500;
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -36,8 +36,12 @@ describes.endtoend('AMP carousel max-swipe', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
-    await enableExperiments(controller);
+    await controller.navigateTo('http://localhost:8000/');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
+
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlides,
   getSpacersForSlide,
@@ -24,8 +23,9 @@ import {
 describes.endtoend('AMP carousel mixed length slides', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 1200;
+  const pageHeight = 500;
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -38,8 +38,12 @@ describes.endtoend('AMP carousel mixed length slides', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
-    await enableExperiments(controller);
+    await controller.navigateTo('http://localhost:8000/');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
+
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
@@ -40,7 +40,8 @@ describes.endtoend('AMP carousel mixed length slides', {
     controller = env.controller;
     ampDriver = env.ampDriver;
 
-    await controller.navigateTo('http://localhost:8000/');
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/mixed-lengths-no-snap.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-carousel-v2', true);
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlide,
   waitForCarouselImg,
@@ -24,6 +23,7 @@ import {
 describes.endtoend('AMP Carousel responsive attributes', {
 }, async env => {
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -31,8 +31,12 @@ describes.endtoend('AMP Carousel responsive attributes', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
-    await enableExperiments(controller);
+    await controller.navigateTo('http://localhost:8000/');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
+
     await controller.setWindowRect({
       width: 1000,
       height: 600,

--- a/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
@@ -33,7 +33,8 @@ describes.endtoend('AMP Carousel responsive attributes', {
     controller = env.controller;
     ampDriver = env.ampDriver;
 
-    await controller.navigateTo('http://localhost:8000/');
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/responsive.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-carousel-v2', true);
 


### PR DESCRIPTION
Related to #20457

This PR also reduces the height of the windows in some tests, since not all screens are large enough to allow windows to resize to be `1000px`.

@estherkim and I discussed configuring experiments using the top-level configuration object, like the integration tests currently do, e.g. 

```js
describes.e2e('amp-blah', {experiments: ['amp-blah-experiment']}, () => {
  /*...*/
});
```

We will work toward that. That code will consume the `AmpDriver` instance and we can factor out the `toggleExperiment` calls at that time.