### PR TITLE
🐛story: fix fie querySelector

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -478,7 +478,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       return mediaSet;
     }
 
-    iterateCursor(fie.win.document.querySelectorAll(selector),
+    iterateCursor(scopedQuerySelectorAll(fie.win.document, selector),
         el => mediaSet.push(el));
     return mediaSet;
   }


### PR DESCRIPTION
Friendly Iframe selector was broken with #20477

This switched to `scopedQuerySelector` which is used elsewhere in the story page.

