### PR TITLE
🐛Fixed OnNetwork amp ad example

### DIFF
--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -1356,7 +1356,7 @@
   <h2>OnNetwork</h2>
   <amp-ad width="300" height="250"
       type="onnetwork"
-      data-sid="TTQsSHFzLDA="
+      data-sid="TTQsSHFzLDA=">
   </amp-ad>
 
   <h2>Open AdStream single ad</h2>
@@ -1679,9 +1679,9 @@
   </amp-ad>
 
   <h2>Speakol</h2>
-  <amp-ad width="320" height="800" 
-    type="speakol" 
-    layout="responsive" 
+  <amp-ad width="320" height="800"
+    type="speakol"
+    layout="responsive"
     data-widgetid="1825">
   </amp-ad>
 


### PR DESCRIPTION
closes #20453 

Simple fix, also fixed some formatting on another ad. Fixes ads below onNetwork not showing up, due to a missing closing tag as the issue described 😄 Confirmed the issue before this fix by the way 👍 