### PR TITLE
🐛Avoid clipping bottom of carousel slides on desktop.

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -119,6 +119,16 @@ amp-carousel .amp-carousel-button.amp-disabled {
   -webkit-overflow-scrolling: touch !important;
 }
 
+/**
+ * Make sure the scrollbar does not take up space on desktop, which will cause
+ * the bottom of the slides to be cutoff. Padding + overflow is used to hide
+ * the scrollbars for all browsers.
+ * TODO(sparhami) Find a solution for the clipping on all browsers.
+ */
+.i-amphtml-slides-container::-webkit-scrollbar {
+  display: none !important;
+}
+
 /** Only hide scroll bar for touch devices as it causes jitters on desktops */
 .i-amphtml-slides-container.i-amphtml-no-scroll {
   overflow-x: hidden !important;

--- a/extensions/amp-carousel/0.2/amp-carousel.css
+++ b/extensions/amp-carousel/0.2/amp-carousel.css
@@ -42,6 +42,16 @@ amp-carousel {
   --visible-count: 1;
 }
 
+/**
+ * Make sure the scrollbar does not take up space on desktop, which will cause
+ * the bottom of the slides to be cutoff. Padding + overflow is used to hide
+ * the scrollbars for all browsers.
+ * TODO(sparhami) Find a solution for the clipping on all browsers.
+ */
+.i-amphtml-carousel-scroll::-webkit-scrollbar {
+  height: 0;
+}
+
 .i-amphtml-carousel-scroll[horizontal="true"] {
   flex-direction: row;
   scroll-snap-type-x: mandatory; /* Firefox, IE */


### PR DESCRIPTION
This partially addresses #18352, but does not work for Firefox (and presumably IE/Edge). This is a short term improvement until a better solution can be found.
