### PR TITLE
✅ Additional carousel v2 end to end tests

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -231,6 +231,20 @@ function createElementRules_() {
     },
     'AMP-CAROUSEL': {
       'slide': null,
+      // For carousel v2
+      'advance-count': null,
+      'auto-advance-count': null,
+      'auto-advance-interval': null,
+      'auto-advance': null,
+      'horizontal': null,
+      'initial-index': null,
+      'loop': null,
+      'mixed-length': null,
+      'side-slide-count': null,
+      'snap-align': null,
+      'snap-by': null,
+      'snap': null,
+      'visible-count': null,
     },
     'AMP-DATE-PICKER': {
       'max': null,

--- a/extensions/amp-carousel/0.2/amp-carousel.css
+++ b/extensions/amp-carousel/0.2/amp-carousel.css
@@ -49,7 +49,7 @@ amp-carousel {
  * TODO(sparhami) Find a solution for the clipping on all browsers.
  */
 .i-amphtml-carousel-scroll::-webkit-scrollbar {
-  height: 0;
+  display: none;
 }
 
 .i-amphtml-carousel-scroll[horizontal="true"] {

--- a/extensions/amp-carousel/0.2/auto-advance.js
+++ b/extensions/amp-carousel/0.2/auto-advance.js
@@ -17,7 +17,7 @@
 import {debounce} from '../../../src/utils/rate-limit';
 import {listenOnce} from '../../../src/event-helper';
 
-const MIN_AUTO_ADVANCE_INTERVAL = 2000;
+const MIN_AUTO_ADVANCE_INTERVAL = 1000;
 
 /**
  * @typedef {{

--- a/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
@@ -22,7 +22,7 @@ import {
 describes.endtoend('AMP carousel autoadvance', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 1000;
+  const pageHeight = 500;
   let controller;
 
   function rect(el) {

--- a/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
@@ -15,15 +15,15 @@
  */
 
 import {
-  enableExperiments,
   getSlides,
 } from './helpers';
 
 describes.endtoend('AMP carousel autoadvance', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 500;
+  const pageHeight = 600;
   let controller;
+  let ampDriver;
 
   function rect(el) {
     return controller.getElementRect(el);
@@ -31,6 +31,7 @@ describes.endtoend('AMP carousel autoadvance', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
     await controller.navigateTo(
         'http://localhost:8000/test/manual/amp-carousel-0-2/autoadvance.amp.html');

--- a/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
@@ -32,7 +32,10 @@ describes.endtoend('AMP carousel autoadvance', {
   beforeEach(async() => {
     controller = env.controller;
 
-    await enableExperiments(controller);
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/autoadvance.amp.html');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-autoadvance.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  enableExperiments,
+  getSlides,
+} from './helpers';
+
+describes.endtoend('AMP carousel autoadvance', {
+}, async env => {
+  const pageWidth = 600;
+  const pageHeight = 1000;
+  let controller;
+
+  function rect(el) {
+    return controller.getElementRect(el);
+  }
+
+  beforeEach(async() => {
+    controller = env.controller;
+
+    await enableExperiments(controller);
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/autoadvance.amp.html');
+  });
+
+  it('should move forwards', async() => {
+    const slides = await getSlides(controller);
+
+    await expect(rect(slides[1])).to.include({x: 0});
+    await expect(rect(slides[2])).to.include({x: 0});
+    await expect(rect(slides[0])).to.include({x: 0});
+  });
+
+  it.skip('should not advance while the user is touching', async() => {
+    // TODO(sparhami) Implement when touch actions are supported.
+  });
+});

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -25,8 +25,7 @@ describes.endtoend('AMP carousel', {
   /** The total number of slides in the carousel */
   const SLIDE_COUNT = 7;
   const pageWidth = 600;
-  const pageHeight = 500;
-
+  const pageHeight = 600;
   let controller;
   let ampDriver;
 
@@ -116,7 +115,7 @@ describes.endtoend('AMP carousel', {
     // Note: 513 seems to be the smallest settable width.
     controller.setWindowRect({
       width: 600,
-      height: 500,
+      height: 600,
     });
 
     const firstSlide = await getSlide(controller, 0);
@@ -131,7 +130,7 @@ describes.endtoend('AMP carousel', {
 
     controller.setWindowRect({
       width: 700,
-      height: 500,
+      height: 600,
     });
 
     // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
@@ -34,7 +34,10 @@ describes.endtoend('AMP carousel grouping', {
   beforeEach(async() => {
     controller = env.controller;
 
-    await enableExperiments(controller);
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/grouping-move-by-2.amp.html');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  enableExperiments,
+  getScrollingElement,
+  getSlides,
+} from './helpers';
+
+describes.endtoend('AMP carousel grouping', {
+}, async env => {
+  const pageWidth = 600;
+  const pageHeight = 1200;
+  const slideWidth = pageWidth / 2;
+  let controller;
+
+  function rect(el) {
+    return controller.getElementRect(el);
+  }
+
+  beforeEach(async() => {
+    controller = env.controller;
+
+    await enableExperiments(controller);
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/grouping-move-by-2.amp.html');
+  });
+
+  describe('snapping', () => {
+    it('should snap on next group when past the midpoint', async() => {
+      const el = await getScrollingElement(controller);
+      const slides = await getSlides(controller);
+
+      await controller.scrollBy(el, {left: slideWidth + 1});
+      await expect(rect(slides[2])).to.include({x: 0});
+    });
+
+    it('should snap on current group when before the midpoint', async() => {
+      const el = await getScrollingElement(controller);
+      const slides = await getSlides(controller);
+
+      await controller.scrollBy(el, {left: slideWidth - 1});
+      await expect(rect(slides[0])).to.include({x: 0});
+    });
+  });
+
+  describe('advancing', () => {
+    it('should move forwards by the advance-count', async() => {
+      const slides = await getSlides(controller);
+      const btn = await controller.findElement('[on="tap:carousel-1.next()"]');
+
+      controller.click(btn);
+      await expect(rect(slides[2])).to.include({x: 0});
+      controller.click(btn);
+      await expect(rect(slides[4])).to.include({x: 0});
+      controller.click(btn);
+      await expect(rect(slides[0])).to.include({x: 0});
+    });
+
+    it('should move backwards by the advance-count', async() => {
+      const slides = await getSlides(controller);
+      const btn = await controller.findElement('[on="tap:carousel-1.prev()"]');
+
+      controller.click(btn);
+      await expect(rect(slides[4])).to.include({x: 0});
+      controller.click(btn);
+      await expect(rect(slides[2])).to.include({x: 0});
+      controller.click(btn);
+      await expect(rect(slides[0])).to.include({x: 0});
+    });
+  });
+});

--- a/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlides,
 } from './helpers';
@@ -23,9 +22,10 @@ import {
 describes.endtoend('AMP carousel grouping', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 1200;
+  const pageHeight = 600;
   const slideWidth = pageWidth / 2;
   let controller;
+  let ampDriver;
 
   function rect(el) {
     return controller.getElementRect(el);
@@ -33,6 +33,7 @@ describes.endtoend('AMP carousel grouping', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
     await controller.navigateTo(
         'http://localhost:8000/test/manual/amp-carousel-0-2/grouping-move-by-2.amp.html');

--- a/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
@@ -66,11 +66,11 @@ describes.endtoend('AMP carousel grouping', {
       const slides = await getSlides(controller);
       const btn = await controller.findElement('[on="tap:carousel-1.next()"]');
 
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[2])).to.include({x: 0});
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[4])).to.include({x: 0});
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[0])).to.include({x: 0});
     });
 
@@ -78,11 +78,11 @@ describes.endtoend('AMP carousel grouping', {
       const slides = await getSlides(controller);
       const btn = await controller.findElement('[on="tap:carousel-1.prev()"]');
 
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[4])).to.include({x: 0});
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[2])).to.include({x: 0});
-      controller.click(btn);
+      await controller.click(btn);
       await expect(rect(slides[0])).to.include({x: 0});
     });
   });

--- a/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-max-swipe.js
@@ -22,7 +22,7 @@ import {
 describes.endtoend('AMP carousel max-swipe', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 500;
+  const pageHeight = 600;
   let controller;
   let ampDriver;
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-mixed-lengths.js
@@ -23,7 +23,7 @@ import {
 describes.endtoend('AMP carousel mixed length slides', {
 }, async env => {
   const pageWidth = 600;
-  const pageHeight = 500;
+  const pageHeight = 600;
   let controller;
   let ampDriver;
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlide,
   waitForCarouselImg,
@@ -37,7 +36,10 @@ describes.endtoend('Non-looping AMP carousel', {
   beforeEach(async() => {
     controller = env.controller;
 
-    await enableExperiments(controller);
+    await controller.navigateTo(
+      'http://localhost:8000/test/manual/amp-carousel-0-2/non-looping.amp.html');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  enableExperiments,
+  getScrollingElement,
+  getSlide,
+  waitForCarouselImg,
+} from './helpers';
+
+describes.endtoend('Non-looping AMP carousel', {
+}, async env => {
+  /** The total number of slides in the carousel */
+  const SLIDE_COUNT = 7;
+  const pageWidth = 600;
+  const pageHeight = 1200;
+
+  let controller;
+
+  function prop(el, name) {
+    return controller.getElementProperty(el, name);
+  }
+
+  beforeEach(async() => {
+    controller = env.controller;
+
+    await enableExperiments(controller);
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/non-looping.amp.html');
+  });
+
+  it('should render correctly', async() => {
+    const el = await getScrollingElement(controller);
+
+    await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * SLIDE_COUNT);
+    await waitForCarouselImg(controller, 0);
+    await controller.takeScreenshot('screenshots/render.png');
+  });
+
+  it('should layout the adjacent slide', async() => {
+    // TODO(sparhami) Verify this is on the right of the 0th slide
+    await waitForCarouselImg(controller, 1);
+  });
+
+  it('should snap when scrolling', async() => {
+    const el = await getScrollingElement(controller);
+    const firstSlide = await getSlide(controller, 0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(controller, 0);
+    await waitForCarouselImg(controller, 1);
+
+    const slideWidth = await prop(firstSlide, 'offsetWidth');
+    const scrollLeft = await prop(el, 'scrollLeft');
+    const snappedScrollLeft = scrollLeft + slideWidth;
+    const requestedScrollLeft = snappedScrollLeft + 1;
+
+    await controller.scroll(el, {left: requestedScrollLeft});
+    // We should have snapped to the edge of the slide rather than the
+    // requested scroll position.
+    await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
+    await controller.takeScreenshot('screenshots/snapped.png');
+  });
+
+  it('should have the correct scroll position when resizing', async() => {
+    // Note: 513 seems to be the smallest settable width.
+    controller.setWindowRect({
+      width: 600,
+      height: 1000,
+    });
+
+    const firstSlide = await getSlide(controller, 0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(controller, 0);
+    await waitForCarouselImg(controller, 1);
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      'x': 0,
+      'width': 600,
+    });
+
+    controller.setWindowRect({
+      width: 700,
+      height: 1000,
+    });
+
+    // Normally, resizing would cause the position to change. We're testing
+    // that the carousel moves this to the correct position again.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      'x': 0,
+      'width': 700,
+    });
+    await controller.takeScreenshot('screenshots/after-resize.png');
+  });
+});

--- a/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
@@ -25,9 +25,9 @@ describes.endtoend('Non-looping AMP carousel', {
   /** The total number of slides in the carousel */
   const SLIDE_COUNT = 7;
   const pageWidth = 600;
-  const pageHeight = 1200;
-
+  const pageHeight = 600;
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -35,9 +35,10 @@ describes.endtoend('Non-looping AMP carousel', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
     await controller.navigateTo(
-      'http://localhost:8000/test/manual/amp-carousel-0-2/non-looping.amp.html');
+        'http://localhost:8000/test/manual/amp-carousel-0-2/non-looping.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
@@ -85,7 +86,7 @@ describes.endtoend('Non-looping AMP carousel', {
     // Note: 513 seems to be the smallest settable width.
     controller.setWindowRect({
       width: 600,
-      height: 500,
+      height: 600,
     });
 
     const firstSlide = await getSlide(controller, 0);
@@ -100,7 +101,7 @@ describes.endtoend('Non-looping AMP carousel', {
 
     controller.setWindowRect({
       width: 700,
-      height: 500,
+      height: 600,
     });
 
     // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-non-looping.js
@@ -83,7 +83,7 @@ describes.endtoend('Non-looping AMP carousel', {
     // Note: 513 seems to be the smallest settable width.
     controller.setWindowRect({
       width: 600,
-      height: 1000,
+      height: 500,
     });
 
     const firstSlide = await getSlide(controller, 0);
@@ -98,7 +98,7 @@ describes.endtoend('Non-looping AMP carousel', {
 
     controller.setWindowRect({
       width: 700,
-      height: 1000,
+      height: 500,
     });
 
     // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-responsive.js
@@ -50,9 +50,11 @@ describes.endtoend('AMP Carousel responsive attributes', {
     const firstSlide = await getSlide(controller, 0);
 
     await waitForCarouselImg(controller, 0);
-    // 3 slides width width 1000 = 333 width per slide
-    await expect(prop(firstSlide, 'offsetWidth')).to.equal(333);
-    await expect(controller.getElementRect(firstSlide)).to.include({x: 0});
+    // 3 slides width width 1000 = 333 width per slide.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      width: 333,
+      x: 0,
+    });
   });
 
   it('should layout correctly after resize', async() => {
@@ -63,16 +65,17 @@ describes.endtoend('AMP Carousel responsive attributes', {
       width: 600,
       height: 600,
     });
-    // 2 slides width width 600 = 300 width per slide
-    await expect(prop(firstSlide, 'offsetWidth')).to.equal(300);
-    await expect(controller.getElementRect(firstSlide)).to.include({x: 0});
+    // 2 slides width width 600 = 300 width per slide.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      width: 300,
+      x: 0,
+    });
   });
 
   it('should retain position when changing the visible count', async() => {
     const el = await getScrollingElement(controller);
     const secondSlide = await getSlide(controller, 1);
 
-    await waitForCarouselImg(controller, 0);
     await controller.scroll(el, {left: 333});
     await expect(prop(el, 'scrollLeft')).to.equal(333);
     await controller.setWindowRect({
@@ -81,5 +84,33 @@ describes.endtoend('AMP Carousel responsive attributes', {
     });
 
     await expect(controller.getElementRect(secondSlide)).to.include({x: 0});
+  });
+
+  it('should respond to attribute changes', async() => {
+    const firstSlide = await getSlide(controller, 0);
+
+    // 3 slides width width 1000 = 333 width per slide.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      width: 333,
+      x: 0,
+    });
+    // Switch over to `visible-count="(min-width: 650px) 5, 4".
+    const btn = await controller.findElement('#responsive-5-4');
+    await controller.click(btn);
+    // 5 slides width width 1000 = 200 width per slide
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      width: 200,
+      x: 0,
+    });
+    // Now make sure new media query is active.
+    await controller.setWindowRect({
+      width: 600,
+      height: 600,
+    });
+    // 4 slides width width 600 = 150 width per slide.
+    await expect(controller.getElementRect(firstSlide)).to.include({
+      width: 150,
+      x: 0,
+    });
   });
 });

--- a/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  enableExperiments,
+  getScrollingElement,
+  getSlide,
+  waitForCarouselImg,
+} from './helpers';
+
+describes.endtoend('Vertical AMP carousel', {
+}, async env => {
+  /** The total number of slides in the carousel */
+  const SLIDE_COUNT = 7;
+  const pageWidth = 600;
+  const pageHeight = 600;
+
+  let controller;
+
+  function prop(el, name) {
+    return controller.getElementProperty(el, name);
+  }
+
+  function rect(el) {
+    return controller.getElementRect(el);
+  }
+
+  beforeEach(async() => {
+    controller = env.controller;
+
+    await enableExperiments(controller);
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/vertical.amp.html');
+  });
+
+  it('should render correctly', async() => {
+    // We should have space for SLIDE_COUNT - 1 on either side + 1 for the
+    // current slide.
+    // TODO(sparhami) Chrome has the wrong value here for scrollHeight?
+    // const el = await getScrollingElement(controller);
+    // await expect(prop(el, 'scrollHeight'))
+    //     .to.equal(carouselHeight * (2 * (SLIDE_COUNT - 1) + 1));
+    await waitForCarouselImg(controller, 0);
+    await controller.takeScreenshot('screenshots/vertical/render.png');
+  });
+
+  it('should layout the two adjacent slides', async() => {
+    // TODO(sparhami) Verify this is on the right of the 0th slide
+    await waitForCarouselImg(controller, 1);
+    // TODO(sparhami) Verify this is on the left of the 0th slide
+    await waitForCarouselImg(controller, SLIDE_COUNT - 1);
+  });
+
+  it('should snap when scrolling', async() => {
+    const el = await getScrollingElement(controller);
+    const firstSlide = await getSlide(controller, 0);
+
+    // Wait for the first two slides's imgs to load.
+    await waitForCarouselImg(controller, 0);
+    await waitForCarouselImg(controller, 1);
+
+    const {y: carouselTop} = await rect(el);
+    const slideHeight = await prop(firstSlide, 'offsetHeight');
+    const scrollTop = await prop(el, 'scrollTop');
+    const snappedScrollTop = scrollTop + slideHeight;
+    const requestedScrollTop = snappedScrollTop + 1;
+
+    await controller.scroll(el, {top: requestedScrollTop});
+    // We should have snapped to the edge of the slide rather than the
+    // requested scroll position.
+    await expect(rect(firstSlide)).to.include({y: carouselTop - slideHeight});
+    await controller.takeScreenshot('screenshots/vertical/snapped.png');
+  });
+
+  describe('looping', () => {
+    // When resting the last few slides should be translated to the top.
+    // Make sure we can move all the way forwards to the last slide and that it
+    // is in the right place.
+    it('should display slides correctly when moving forwards', async() => {
+      const el = await getScrollingElement(controller);
+      const lastSlide = await getSlide(controller, SLIDE_COUNT - 1);
+
+      // Wait for the first and last slides to load.
+      await waitForCarouselImg(controller, 0);
+      await waitForCarouselImg(controller, SLIDE_COUNT - 1);
+
+      // Go to the last slide, wait for scrolling to move.
+      const {y: carouselTop} = await rect(el);
+      const slideHeight = await prop(lastSlide, 'offsetHeight');
+      const restingScrollTop = await prop(el, 'scrollTop');
+      await controller.scrollBy(el, {
+        top: slideHeight * (SLIDE_COUNT - 1),
+      });
+
+      await expect(prop(el, 'scrollLeft')).to.not.equal(restingScrollTop);
+      await expect(prop(el, 'scrollTop')).to.equal(restingScrollTop);
+      await expect(controller.getElementRect(lastSlide)).to.include({
+        y: carouselTop,
+        height: slideHeight,
+      });
+      await controller.takeScreenshot(
+          'screenshots/vertical/loop-move-forwards-to-end.png');
+    });
+
+    // When resting the first few slides should be translated to the bottom.
+    // Make sure we can move all the way backwards to the second slide and that
+    // it is in the right place.
+    it('should display slides correctly when moving backwards', async() => {
+      const el = await getScrollingElement(controller);
+      const secondSlide = await getSlide(controller, 1);
+
+      // Wait for the first and second slides to load.
+      await waitForCarouselImg(controller, 0);
+      await waitForCarouselImg(controller, 1);
+
+      // Go to the last slide, wait for scrolling to move.
+      const {y: carouselTop} = await rect(el);
+      const slideHeight = await prop(secondSlide, 'offsetHeight');
+      const restingScrollTop = await prop(el, 'scrollTop');
+      await controller.scrollBy(el, {
+        top: -(slideHeight * (SLIDE_COUNT - 1)),
+      });
+
+      await expect(prop(el, 'scrollTop')).to.not.equal(restingScrollTop);
+      await expect(prop(el, 'scrollTop')).to.equal(restingScrollTop);
+      await expect(controller.getElementRect(secondSlide)).to.include({
+        y: carouselTop,
+        height: slideHeight,
+      });
+      await controller.takeScreenshot(
+          'screenshots/vertical/loop-move-backwards-to-second.png');
+    });
+  });
+});

--- a/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
@@ -41,7 +41,10 @@ describes.endtoend('Vertical AMP carousel', {
   beforeEach(async() => {
     controller = env.controller;
 
-    await enableExperiments(controller);
+  await controller.navigateTo(
+      'http://localhost:8000/test/manual/amp-carousel-0-2/vertical.amp.html');
+  await ampDriver.toggleExperiment('layers', true);
+  await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-vertical.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  enableExperiments,
   getScrollingElement,
   getSlide,
   waitForCarouselImg,
@@ -27,8 +26,8 @@ describes.endtoend('Vertical AMP carousel', {
   const SLIDE_COUNT = 7;
   const pageWidth = 600;
   const pageHeight = 600;
-
   let controller;
+  let ampDriver;
 
   function prop(el, name) {
     return controller.getElementProperty(el, name);
@@ -40,11 +39,12 @@ describes.endtoend('Vertical AMP carousel', {
 
   beforeEach(async() => {
     controller = env.controller;
+    ampDriver = env.ampDriver;
 
-  await controller.navigateTo(
-      'http://localhost:8000/test/manual/amp-carousel-0-2/vertical.amp.html');
-  await ampDriver.toggleExperiment('layers', true);
-  await ampDriver.toggleExperiment('amp-carousel-v2', true);
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/vertical.amp.html');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
     await controller.setWindowRect({
       width: pageWidth,
       height: pageHeight,

--- a/test/manual/amp-carousel-0-2/autoadvance.amp.html
+++ b/test/manual/amp-carousel-0-2/autoadvance.amp.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>A Basic carousel, with looping</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" auto-advance="true">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+  <button on="tap:carousel-1.prev()">Prev</button>
+  <button on="tap:carousel-1.next()">Next</button>
+  <button on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/cross-fader-max-swipe-one.amp.html
+++ b/test/manual/amp-carousel-0-2/cross-fader-max-swipe-one.amp.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-cross-fader" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>A cross-fader</h1>
+  <amp-cross-fader width="300" height="200" layout="responsive" side-slide-count="1">
+    <amp-img src="./1988_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./1992_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./1996_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2000_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2004_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2008_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2012_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2016_large.png" width=300 height=200 layout="responsive"></amp-img>
+  </amp-carousel>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/cross-fader.amp.html
+++ b/test/manual/amp-carousel-0-2/cross-fader.amp.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-cross-fader" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>A cross-fader</h1>
+  <amp-cross-fader width="300" height="200" layout="responsive" side-slide-count="1">
+    <amp-img src="./1988_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./1992_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./1996_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2000_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2004_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2008_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2012_large.png" width=300 height=200 layout="responsive"></amp-img>
+    <amp-img src="./2016_large.png" width=300 height=200 layout="responsive"></amp-img>
+  </amp-carousel>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/fixed-children.amp.html
+++ b/test/manual/amp-carousel-0-2/fixed-children.amp.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
+    amp-carousel img {
+      object-fit: cover;
+    }
+
+    .slide {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Fixed size children, centered using wrapping divs</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" snap-align="center">
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=150 height=100 layout="fixed"></amp-img>
+    </div> 
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=150 height=100 layout="fixed"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=150 height=100 layout="fixed"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img class="wide" src="../../../examples/img/hero@2x.jpg" width=150 height=100 layout="fixed"></amp-img>
+    </div>
+  </amp-carousel>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/grouping-autoadvance.amp.html
+++ b/test/manual/amp-carousel-0-2/grouping-autoadvance.amp.html
@@ -6,64 +6,65 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
     amp-carousel img {
       object-fit: cover;
+    }
+
+    .slide {
+      padding: 4px;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>Auto advance with grouping</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 2 at a time, so carousel
+    should have an aspect ratio of 6:2.
+  -->
+  <amp-carousel id="carousel-1" width="6" height="2" layout="responsive"
+      loop="false"
+      visible-count="2"
+      snap-by="2" 
+      auto-advance="true"
+      auto-advance-interval="3000"
+      auto-advance-count="2">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-  </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
+ </amp-carousel>
+  <p>
+    Note: auto advance will move back to the start, even if loop is disabled.
+  </p>
+  <p>
+    Note: if the number of slides is not evenly divisible by the group count,
+    the last advancement will show some from the previous group.
+  </p> 
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/grouping-looping.amp.html
+++ b/test/manual/amp-carousel-0-2/grouping-looping.amp.html
@@ -6,64 +6,52 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
     amp-carousel img {
       object-fit: cover;
+    }
+
+    .slide {
+      padding: 4px;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>Grouping 3 items at a time, with looping</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 3 at a time, so carousel
+    should have an aspect ratio of 9:2.
+  -->
+  <amp-carousel id="carousel-1" width="9" height="2" layout="responsive" loop="true" visible-count="3" snap-align="center">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/grouping-move-by-2.amp.html
+++ b/test/manual/amp-carousel-0-2/grouping-move-by-2.amp.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+
+    .slide {
+      padding: 4px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Move by two slides, no looping</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 2 at a time, so carousel
+    should have an aspect ratio of 6:2.
+  -->
+  <amp-carousel id="carousel-1" width="6" height="2" layout="responsive" loop="false" visible-count="2" advance-count="2" snap-by="2">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+  <button on="tap:carousel-1.prev()">Prev</button>
+  <button on="tap:carousel-1.next()">Next</button>
+  <button on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/grouping.amp.html
+++ b/test/manual/amp-carousel-0-2/grouping.amp.html
@@ -6,32 +6,27 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
     amp-carousel img {
       object-fit: cover;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>Grouping 3 items at a time</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 3 at a time, so carousel
+    should have an aspect ratio of 9:2.
+  -->
+  <amp-carousel id="carousel-1" width="9" height="2" layout="responsive" visible-count="3" snap-align="start">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
     <div>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
@@ -55,15 +50,5 @@
       <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/index.html
+++ b/test/manual/amp-carousel-0-2/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>amp-carousel 0.2</title>
+    <style>
+      li {
+        padding: 8px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h2>Experiments</h2>
+
+    <ul>
+      <li>
+        <a href="./enable-experiment.html">enable experiments</a>
+      </li>
+      <li>
+        <a href="./disable-layers.html">disable layers</a>
+      </li>
+    </ul>
+
+    <h2>Tests</h2>
+    
+    <ul>
+      <li>
+        <a href="./basic.amp.html">basic</a>
+      </li>
+      <li>
+        <a href="./max-swipe-one.amp.html">maximum swipe of one slide, looping</a>
+      </li>
+      <li>
+        <a href="./max-swipe-one-no-loop.amp.html">maximum swipe of one slide, no loop</a>
+      </li>
+      <li>
+        <a href="./fixed-children.amp.html">Fixed size children</a>
+      </li>
+      <li>
+        <a href="./grouping.amp.html">grouping</a>
+      </li>
+      <li>
+        <a href="./grouping-autoadvance.amp.html">grouping w/ autoadvance</a>
+      </li>
+      <li>
+        <a href="./grouping-looping.amp.html">grouping and looping</a> 
+      </li>
+      <li>
+        <a href="./grouping-move-by-2.amp.html">grouping, snap by 2</a>
+      </li>
+      <li>
+        <a href="./mixed-lengths.amp.html">mixed lengths</a>
+      </li>
+      <li>
+        <a href="./mixed-lengths-no-snap.amp.html">mixed lengths no snap</a>
+      </li>
+      <li>
+        <a href="./non-looping.amp.html">no looping</a>
+      </li>
+      <li>
+        <a href="./peeking-sides-centered.amp.html">peeking sides (centered)</a>
+      </li>
+      <li>
+        <a href="./peeking-sides-start-aligned.amp.html">peeking sides</a>
+      </li>
+      <li>
+        <a href="./tweets.amp.html">tweets</a>
+      </li>
+    </ul>
+  </body>
+</html>
+

--- a/test/manual/amp-carousel-0-2/non-looping.amp.html
+++ b/test/manual/amp-carousel-0-2/non-looping.amp.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Non-Looping Carousel</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="false">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+  <button on="tap:carousel-1.prev()">Prev</button>
+  <button on="tap:carousel-1.next()">Next</button>
+  <button on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/peeking-sides-centered.amp.html
+++ b/test/manual/amp-carousel-0-2/peeking-sides-centered.amp.html
@@ -2,68 +2,48 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>Basic Carousel</title>
+  <title>AMP #0</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
     amp-carousel img {
       object-fit: cover;
+    }
+
+    .slide {
+      padding: 4px;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>Peaking sides, centered, with loop</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 1.2 at a time, so carousel
+    should have an aspect ratio of 3.6:2 or 36:20.
+  -->
+  <amp-carousel id="carousel-1" width="36" height="20" layout="responsive" loop="true" visible-count="1.2" snap-align="center">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
-      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/peeking-sides-start-aligned.amp.html
+++ b/test/manual/amp-carousel-0-2/peeking-sides-start-aligned.amp.html
@@ -2,68 +2,54 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>Basic Carousel</title>
+  <title>AMP #0</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
     amp-carousel img {
       object-fit: cover;
+    }
+
+    .slide {
+      padding: 4px;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>Peaking sides, start aligned</h1>
+  <!--
+    Using aspect ratio of 3:2 for images, showing 2.5 at a time, so carousel
+    should have an aspect ratio of 7.5:2 or 75:20.
+  -->
+  <amp-carousel id="carousel-1" width="75" height="20" layout="responsive" visible-count="2.5" snap-align="start">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
+    <div class="slide">
       <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
-      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/related-items.amp.html
+++ b/test/manual/amp-carousel-0-2/related-items.amp.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Related items config</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
+    .slide {
+      position: relative;
+      display: flex;
+      height: 100%;
+    }
+
+    amp-carousel img {
+      object-fit: cover;
+    }
+
+    .carousel-container {
+      position: relative;
+    }
+
+    .carousel-sizer {
+      padding-top: calc((2 / 4.5) * 100%);
+    }
+
+    @media (min-width: 800px) {
+      .slide {
+        padding: 4px;
+      }
+
+      .carousel-sizer {
+        padding-top: calc((2 / 9) * 100%);
+      }
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script></script>
+</head>
+<body>
+  <h1>
+    width &ge; 800px: 3 slides, no snap<br/>
+    width &lt; 800px: 1 slide + .5 peeking, snap
+  </h1>
+
+  <div class="carousel-container">
+    <div class="carousel-sizer"></div>
+    <amp-carousel
+        layout="fill"
+        visible-count="(min-width: 800px) 3, 1.5"
+        snap-align="start"
+        snap="(min-width: 800px) false, true">
+      <div class="slide">
+        <amp-img layout="flex-item" src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="../../../examples/img/hero@2x.jpg"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="../../../examples/img/sea@2x.jpg"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="../../../examples/img/bigbuckbunny.jpg"></amp-img>
+      </div>
+      <div class="slide">
+        <amp-img layout="flex-item" src="../../../examples/img/sample.jpg"></amp-img>
+      </div>
+    </amp-carousel>
+  </div>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/responsive.amp.html
+++ b/test/manual/amp-carousel-0-2/responsive.amp.html
@@ -6,6 +6,7 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
     amp-carousel img {
@@ -16,8 +17,21 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+  <amp-state>
+    <script type="application/json">
+      {
+        "visibleCount": "(min-width: 800px) 3, 2"
+      }
+    </script>
+  </amp-state>
+
   <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel id="carousel-1" width="900" height="200" visible-count="(min-width: 800px) 3, 2" layout="responsive">
+  <amp-carousel
+      id="carousel-1"
+      width="900" height="200"
+      layout="responsive"
+      visible-count="(min-width: 800px) 3, 2"
+      [visible-count]="visibleCount">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
     <div>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
@@ -41,5 +55,15 @@
       <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
     </div>
   </amp-carousel>
+  <button
+      id="responsive-3-2"
+      on="tap:AMP.setState({'visibleCount': '(min-width: 800px) 3, 2'})">
+    visible-count="(min-width: 800px) 3, 2"
+  </button>
+  <button
+      id="responsive-5-4"
+      on="tap:AMP.setState({'visibleCount': '(min-width: 650px) 5, 4'})">
+    visible-count="(min-width: 650px) 5, 4"
+  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/three-slides.amp.html
+++ b/test/manual/amp-carousel-0-2/three-slides.amp.html
@@ -2,13 +2,16 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>Basic Carousel</title>
+  <title>Three slides</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
     amp-carousel img {
       object-fit: cover;
     }
@@ -17,21 +20,8 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>A Basic carousel, with looping, 3 slides</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
     <div>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
@@ -42,28 +32,6 @@
     <div>
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
-      <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/tweets.amp.html
+++ b/test/manual/amp-carousel-0-2/tweets.amp.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Tweets Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    body {
+      min-height: 100%;
+      max-width: 527px;
+      color: #eee;
+      background-color: #222;
+    }
+
+    .slide {
+      padding: 8px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Tweets</h1>
+  <amp-carousel id="carousel-1" width="600" height="600" layout="responsive" loop="false">
+    <div class="slide">
+      <amp-twitter width=1 height=1
+          layout="responsive"
+          data-theme="dark"
+          data-tweetid="775408819274969089">
+      </amp-twitter>
+    </div>
+
+    <div class="slide">
+      <amp-twitter width=1 height=1
+          layout="responsive"
+          data-theme="dark"
+          data-tweetid="775410014383026176">
+      </amp-twitter>
+    </div>
+
+    <div class="slide">
+      <amp-twitter width=1 height=1
+        layout="responsive"
+        data-theme="dark"
+        data-tweetid="775419538783567872">
+      </amp-twitter>
+    </div>
+
+    <div class="slide">
+      <amp-twitter width=1 height=1
+          layout="responsive"
+          data-theme="dark"
+          data-tweetid="775421529416929281">
+      </amp-twitter>
+    </div>
+
+    <div class="slide">
+      <amp-twitter width=1 height=1
+        layout="responsive"
+        data-cards="hidden"
+        data-theme="dark"
+        data-tweetid="1063242600734486534">
+      </amp-twitter>
+    </div>
+
+    <div class="slide">
+      <amp-twitter width=1 height=1
+        layout="responsive"
+        data-cards="hidden"
+        data-theme="dark"
+        data-tweetid="1060354223290941440">
+      </amp-twitter>
+    </div>
+  </amp-carousel>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/two-slides.amp.html
+++ b/test/manual/amp-carousel-0-2/two-slides.amp.html
@@ -2,13 +2,16 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>Basic Carousel</title>
+  <title>Three slides</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
   <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+
     amp-carousel img {
       object-fit: cover;
     }
@@ -17,21 +20,8 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-state id="carousel">
-    <script type="application/json">
-      {
-        "visibleCount": "(min-width: 800px) 3, 2"
-      }
-    </script>
-  </amp-state>
-
-  <h1>Shows 3 at a time, when width >= 800px, 2 otherwise</h1>
-  <amp-carousel
-      id="carousel-1"
-      width="900" height="200"
-      layout="responsive"
-      visible-count="(min-width: 800px) 3, 2"
-      [visible-count]="carousel.visibleCount">
+  <h1>A Basic carousel, with looping, 3 slides</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true">
     <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
     <div>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
@@ -39,31 +29,6 @@
     <div>
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
     </div>
-    <div>
-      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
-    <div>
-      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
-    </div>
   </amp-carousel>
-  <button
-      id="responsive-3-2"
-      on="tap:AMP.setState({'carousel': {'visibleCount': '(min-width: 800px) 3, 2'})">
-    visible-count="(min-width: 800px) 3, 2"
-  </button>
-  <button
-      id="responsive-5-4"
-      on="tap:AMP.setState({'carousel' : {'visibleCount': '(min-width: 650px) 5, 4'}})">
-    visible-count="(min-width: 650px) 5, 4"
-  </button>
 </body>
 </html>

--- a/test/manual/amp-carousel-0-2/vertical.amp.html
+++ b/test/manual/amp-carousel-0-2/vertical.amp.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Vertical Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+
+    .slide {
+      width: 100%;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>A vertical carousel</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" horizontal="false">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/hero@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/sea@2x.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/bigbuckbunny.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div class="slide">
+      <amp-img src="../../../examples/img/sample.jpg" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+  <button on="tap:carousel-1.prev()">Prev</button>
+  <button on="tap:carousel-1.next()">Next</button>
+  <button on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
+</body>
+</html>


### PR DESCRIPTION
Note: This needs changes from #20502 before merging.

- Reduce minimum auto advance interval to 1 second, matching carousel v1
- Support amp-bind for carousel v2
  * Still need to add validation rules
- Add tests for auto advance
- Add tests for slide grouping
- Add tests for a vertical carousel
- Add tests for non-looping carousels
- Add test for amp-bind with responsive attributes