### PR TITLE
Update design review documentation

### DIFF
--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -13,18 +13,17 @@ The GitHub issue for a given week's design review will have links to the designs
 
 ## Bringing your design to a design review
 
-If the design for an issue/feature you are working on has a scope larger than you can cover in a discussion in the GitHub issue or one of the other discussion channels, consider bringing it to a design review.
+Design reviews are a great way to discuss and refine your designs with knowledgeable people in the community.  Not every feature/change has to be brought to a design review.  For smaller changes a design review is completely optional; for larger changes covered by the [code and feature contribution process](https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md) work with your reviewer to determine if a design review makes sense.
 
-Note that the design review is optional and is not required for every new feature or bug fix.
+The process for bringing a design to the design review is:
 
-The process for bringing a design to the design review is as follows:
-
-* Create a software design document in a shared Google Document open to public comments.
+* Determine if you need a design document; in many cases a fully detailed Intent-to-implement (I2I) GitHub issue or other GitHub issue describing the problem and proposed solution may be sufficient.  If you have a reviewer work with them to decide what makes sense in your case, otherwise you can ask in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/) ([sign up](https://bit.ly/amp-slack-signup)).
+* If you are going to create a design document, create it as a shared Google Document open to public comments:
   * A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.
   * Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc.  [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit) and [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit) are examples of past AMP Project design docs.
   * Add this license text to the top of your design doc before sharing it with anyone else in the community (updating the year if necessary):
       ```
-      Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+      Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
@@ -34,11 +33,16 @@ The process for bringing a design to the design review is as follows:
 
       See the License for the specific language governing permissions and limitations under the License.
       ```
+* Perform a design pre-review with your reviewer if you have one; they may include other people that know the areas your design affects in this pre-review as well.  If you don't have a reviewer you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/) ([sign up](https://bit.ly/amp-slack-signup)).  It is fine to request a pre-review before your design is complete.
 
-* Perform a design pre-review with at least one [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md); you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/) ([sign up](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877)).  It is fine to request a pre-review before your design doc is complete.
+* When your design is ready to be discussed at a design review add a comment on the [Design Review GitHub issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Design%20Review) for the date/time that works best for you.  Make sure to pay attention to the time since we rotate between times that work for differents parts of the world.  Post a link to your GitHub issue/design doc and a brief summary by **Monday** on the week of your design review.  In your comment on the Design Review issue you may want to point out details of the design you'd particularly like to cover in the review.
 
-* When your design is ready to be discussed at a design review add a comment on the appropriate Design Review GitHub issue.  Post a link to the design doc and a brief summary by **Monday** on the week of your design review.
+* During the design review you'll lead the community in a conversation about your design.  The design reviews are fairly informal and don't have a fixed structure.    
+  * You don't need to have any slides or material other than your GitHub issue/design doc prepared for the design review.
+  * It can be helpful to present the GitHub issue/design doc during the meeting using the video conference "share your screen" functionality.  (If you have technical trouble doing this, someone else at the meeting can handle it.)
+  * You can assume that the people at the meeting have at least skimmed through your design to understand the area being discussed, but they may not be completely familiar with the nuances of your design.
+  * It is recommended that you start the discussion with a brief overview of your design.
+  * After the initial overview, lead the attendees through the parts of the design you would like feedback on.  If you have a reviewer, they may suggest particular areas to focus on in the discussion.
+  * We'll take notes during the design review and post them to the Design Review GitHub issue shortly after the meeting.
 
-* Update your design based on the feedback in the design review and any followup conversations in other channels.  Once your design is finalized, please provide a brief update at the start of a future design review (if you are able to attend) and submit a PDF version of your design doc in the [ampproject design-doc](https://github.com/ampproject/design-docs) repository.
-
-Although design documents are strongly encouraged, for some smaller features a well-documented design in its own GitHub issue may be sufficient for a design review.
+* Update your design based on the feedback in the design review and any followup conversations in other channels.  Once your design is finalized, please provide a brief update at the start of a future design review (if you are able to attend).  If you create a design doc submit a PDF version in the [ampproject design-doc](https://github.com/ampproject/design-docs) repository.


### PR DESCRIPTION
This updates the design review documentation to:

- make it even more clear that a design doc is optional (especially since it turns out most of our design reviews just use I2I or other GitHub issues)
- update it with the code/feature contribution process changes (e.g. mentioning reviewers instead of core committers)
- make it more clear what goes on in the design review

/cc @ampproject/wg-outreach 