### PR TITLE
✨ amp-skimlinks - new "custom-redirect-domain" option.

### DIFF
--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -16,7 +16,7 @@
 
 export const AMP_SKIMLINKS_VERSION = '1.0.2';
 export const XCUST_ATTRIBUTE_NAME = 'data-skimlinks-custom-tracking-id';
-export const AFFILIATION_API = 'https://go.skimresources.com';
+export const WAYPOINT_BASE_URL = 'https://go.skimresources.com';
 export const PLATFORM_NAME = 'amp@' + AMP_SKIMLINKS_VERSION;
 export const SKIMLINKS_REWRITER_ID = 'amp-skimlinks';
 
@@ -33,7 +33,6 @@ export const DEFAULT_CONFIG = {
   pageTrackingUrl: PAGE_IMPRESSION_TRACKING_URL,
   linksTrackingUrl: LINKS_IMPRESSIONS_TRACKING_URL,
   nonAffiliateTrackingUrl: NA_CLICK_TRACKING_URL,
-  waypointUrl: AFFILIATION_API,
   beaconUrl: DOMAIN_RESOLVER_API_URL,
 };
 

--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const AMP_SKIMLINKS_VERSION = '1.0.2';
+export const AMP_SKIMLINKS_VERSION = '1.0.3';
 export const XCUST_ATTRIBUTE_NAME = 'data-skimlinks-custom-tracking-id';
 export const WAYPOINT_BASE_URL = 'https://go.skimresources.com';
 export const PLATFORM_NAME = 'amp@' + AMP_SKIMLINKS_VERSION;

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {endsWith} from '../../../src/string';
 import {getChildJsonConfig} from '../../../src/json';
 import {getNormalizedHostnameFromUrl} from './utils';
 import {userAssert} from '../../../src/log';
@@ -159,12 +158,8 @@ function getInternalDomains_(docInfo) {
 function getWaypointBaseUrl(element) {
   let customSubDomain = element.getAttribute('custom-redirect-domain');
   if (customSubDomain) {
-    // Remove potential HTTP protocol.
-    customSubDomain = customSubDomain.replace(/^\/\/|^https?:\/\//, '');
-    // Remove potential trailing slash.
-    customSubDomain = endsWith(customSubDomain, '/') ?
-      customSubDomain.slice(0, -1) :
-      customSubDomain;
+    // Remove potential HTTP protocol and potential trailing slash.
+    customSubDomain = customSubDomain.replace(/^\/\/|^https?:\/\/|\/$/g, '');
 
     // Use http since publisher CNAME to go.redirectingat.com does not support
     // https.

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {endsWith} from '../../../src/string';
 import {getChildJsonConfig} from '../../../src/json';
 import {getNormalizedHostnameFromUrl} from './utils';
 import {userAssert} from '../../../src/log';
@@ -22,6 +23,7 @@ import {
   DEFAULT_CONFIG,
   GLOBAL_DOMAIN_BLACKLIST,
   OPTIONS_ERRORS,
+  WAYPOINT_BASE_URL,
 } from './constants';
 
 /**
@@ -46,6 +48,7 @@ export function getAmpSkimlinksOptions(element, docInfo) {
     tracking: getTrackingStatus_(element),
     customTrackingId: getCustomTrackingId_(element),
     linkSelector: getLinkSelector_(element),
+    waypointBaseUrl: getWaypointBaseUrl(element),
     config: getConfig_(element),
   };
 }
@@ -148,6 +151,29 @@ function getInternalDomains_(docInfo) {
 }
 
 /**
+ *
+ * @param {!Element} element
+ * @return {?string}
+ */
+function getWaypointBaseUrl(element) {
+  let customSubDomain = element.getAttribute('custom-redirect-domain');
+  if (customSubDomain) {
+    // Remove potential HTTP protocol
+    customSubDomain = customSubDomain.replace(/^\/\/|^https?:\/\//, '');
+    // Remove potential trailing slash
+    customSubDomain = endsWith(customSubDomain, '/') ?
+      customSubDomain.slice(0, -1) :
+      customSubDomain;
+
+    // Use http since publisher CNAME to go.redirectingat.com does not support
+    // https.
+    return `http://${customSubDomain}`;
+  }
+
+  return WAYPOINT_BASE_URL;
+}
+
+/**
  * @param {!Element} element
  * @return {!Object}
  */
@@ -166,8 +192,6 @@ function getConfig_(element) {
         DEFAULT_CONFIG.linksTrackingUrl,
       nonAffiliateTrackingUrl: customConfigJson['nonAffiliateTrackingUrl'] ||
         DEFAULT_CONFIG.nonAffiliateTrackingUrl,
-      waypointUrl: customConfigJson['waypointUrl'] ||
-        DEFAULT_CONFIG.waypointUrl,
       beaconUrl: customConfigJson['beaconUrl'] ||
         DEFAULT_CONFIG.beaconUrl,
     };

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -153,7 +153,7 @@ function getInternalDomains_(docInfo) {
 /**
  *
  * @param {!Element} element
- * @return {?string}
+ * @return {string}
  */
 function getWaypointBaseUrl(element) {
   let customSubDomain = element.getAttribute('custom-redirect-domain');

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -151,16 +151,17 @@ function getInternalDomains_(docInfo) {
 }
 
 /**
- *
+ * Use CNAME domain defined in "custom-redirect-domain" option if specified
+ * or "https://go.skimresources.com" by default.
  * @param {!Element} element
  * @return {string}
  */
 function getWaypointBaseUrl(element) {
   let customSubDomain = element.getAttribute('custom-redirect-domain');
   if (customSubDomain) {
-    // Remove potential HTTP protocol
+    // Remove potential HTTP protocol.
     customSubDomain = customSubDomain.replace(/^\/\/|^https?:\/\//, '');
-    // Remove potential trailing slash
+    // Remove potential trailing slash.
     customSubDomain = endsWith(customSubDomain, '/') ?
       customSubDomain.slice(0, -1) :
       customSubDomain;

--- a/extensions/amp-skimlinks/0.1/test/constants.js
+++ b/extensions/amp-skimlinks/0.1/test/constants.js
@@ -13,5 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {DEFAULT_CONFIG, WAYPOINT_BASE_URL} from '../constants';
 
 export const pubcode = 'pubXcode';
+
+export const DEFAULT_SKIM_OPTIONS = {
+  pubcode,
+  tracking: true,
+  waypointBaseUrl: WAYPOINT_BASE_URL,
+  config: DEFAULT_CONFIG,
+};

--- a/extensions/amp-skimlinks/0.1/test/helpers.js
+++ b/extensions/amp-skimlinks/0.1/test/helpers.js
@@ -16,10 +16,9 @@
 
 import {AmpSkimlinks} from '../amp-skimlinks';
 import {CustomEventReporterBuilder} from '../../../../src/extension-analytics';
-import {DEFAULT_CONFIG} from '../constants';
+import {DEFAULT_SKIM_OPTIONS} from './constants';
 import {Services} from '../../../../src/services';
 import {Tracking} from '../tracking';
-import {pubcode} from './constants';
 
 const helpersFactory = env => {
   const {win} = env;
@@ -58,12 +57,8 @@ const helpersFactory = env => {
     },
 
     createTrackingWithStubAnalytics(skimOptions) {
-      skimOptions = Object.assign(
-          {
-            tracking: true,
-            pubcode,
-            config: DEFAULT_CONFIG,
-          },
+      skimOptions = Object.assign({},
+          DEFAULT_SKIM_OPTIONS,
           skimOptions
       );
       this.stubCustomEventReporterBuilder();

--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -19,9 +19,9 @@ import {
   AffiliateLinkResolver,
 } from '../affiliate-link-resolver';
 import {DEFAULT_CONFIG} from '../constants';
+import {DEFAULT_SKIM_OPTIONS, pubcode} from './constants';
 import {Services} from '../../../../src/services';
 import {Waypoint} from '../waypoint';
-import {pubcode} from './constants';
 import helpersFactory from './helpers';
 
 const DOMAIN_RESOLVER_API_URL = DEFAULT_CONFIG.beaconUrl;
@@ -48,12 +48,9 @@ describes.fakeWin(
 
       beforeEach(() => {
         trackingService = helpers.createTrackingWithStubAnalytics();
-        const skimOptions = {
-          config: {waypointUrl: 'https://go.skimresources.com/'},
-        };
         waypoint = new Waypoint(
             env.ampdoc,
-            skimOptions,
+            DEFAULT_SKIM_OPTIONS,
             trackingService,
             'referrer'
         );
@@ -209,11 +206,11 @@ describes.fakeWin(
         describe('Does correct request to domain resolver API', () => {
           beforeEach(() => {
             mock = env.sandbox.mock(xhr);
-            const skimOptions = {
-              pubcode,
-              config: {beaconUrl: DOMAIN_RESOLVER_API_URL},
-            };
-            resolver = new AffiliateLinkResolver(xhr, skimOptions, waypoint);
+            resolver = new AffiliateLinkResolver(
+                xhr,
+                DEFAULT_SKIM_OPTIONS,
+                waypoint
+            );
           });
 
           afterEach(() => {
@@ -287,10 +284,11 @@ describes.fakeWin(
             const stubXhr = helpers.createStubXhr({
               'merchant_domains': ['merchant1.com', 'merchant2.com'],
             });
-            const skimOptions = {
-              excludedDomains: ['excluded-merchant.com'],
-              config: {beaconUrl: DOMAIN_RESOLVER_API_URL},
-            };
+            const skimOptions = Object.assign({},
+                DEFAULT_SKIM_OPTIONS,
+                {excludedDomains: ['excluded-merchant.com']}
+            );
+
             resolver = new AffiliateLinkResolver(
                 stubXhr,
                 skimOptions,
@@ -424,8 +422,11 @@ describes.fakeWin(
         });
 
         describe('getAnchorDomain_', () => {
-          const skimOptions = {config: {beaconUrl: DOMAIN_RESOLVER_API_URL}};
-          const resolver = new AffiliateLinkResolver({}, skimOptions, waypoint);
+          const resolver = new AffiliateLinkResolver(
+              {},
+              DEFAULT_SKIM_OPTIONS,
+              waypoint
+          );
 
           it('Removes  http protocol', () => {
             const anchor = helpers.createAnchor('http://test.com');

--- a/extensions/amp-skimlinks/0.1/test/test-skim-options.js
+++ b/extensions/amp-skimlinks/0.1/test/test-skim-options.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {WAYPOINT_BASE_URL} from '../constants';
 import {getAmpSkimlinksOptions} from '../skim-options';
 import helpersFactory from './helpers';
 
@@ -74,7 +75,6 @@ describes.fakeWin(
               .members(['go.redirectingat.com', 'go.skimresources.com']);
         });
 
-
         it('Should not overwrite internal & global blacklist when using option',
             () => {
               const element = helpers.createAmpSkimlinksElement({
@@ -89,6 +89,54 @@ describes.fakeWin(
               ]);
             }
         );
+      });
+
+      describe('custom-redirect-domain', () => {
+        const cname = 'go.publisher.com';
+
+        it('Should return normal waypoint base url if not defined', () => {
+          const element = helpers.createAmpSkimlinksElement({
+            'publisher-code': '123X123',
+          });
+          const options = getAmpSkimlinksOptions(element, docInfo);
+          expect(options.waypointBaseUrl).to.equal(WAYPOINT_BASE_URL);
+        });
+
+        it('Should overwrite waypoint base url if defined', () => {
+          const element = helpers.createAmpSkimlinksElement({
+            'publisher-code': '123X123',
+            'custom-redirect-domain': cname,
+          });
+          const options = getAmpSkimlinksOptions(element, docInfo);
+          expect(options.waypointBaseUrl).to.equal(`http://${cname}`);
+        });
+
+        it('Should accept redirect domain containing the protocol', () => {
+          const element = helpers.createAmpSkimlinksElement({
+            'publisher-code': '123X123',
+            'custom-redirect-domain': `http://${cname}`,
+          });
+          const options = getAmpSkimlinksOptions(element, docInfo);
+          expect(options.waypointBaseUrl).to.equal(`http://${cname}`);
+        });
+
+        it('Should force custom redirect base url to use http', () => {
+          const element = helpers.createAmpSkimlinksElement({
+            'publisher-code': '123X123',
+            'custom-redirect-domain': `https://${cname}`,
+          });
+          const options = getAmpSkimlinksOptions(element, docInfo);
+          expect(options.waypointBaseUrl).to.equal(`http://${cname}`);
+        });
+
+        it('Should remove trailing slash', () => {
+          const element = helpers.createAmpSkimlinksElement({
+            'publisher-code': '123X123',
+            'custom-redirect-domain': `https://${cname}/`,
+          });
+          const options = getAmpSkimlinksOptions(element, docInfo);
+          expect(options.waypointBaseUrl).to.equal(`http://${cname}`);
+        });
       });
     }
 );

--- a/extensions/amp-skimlinks/0.1/test/test-waypoint.js
+++ b/extensions/amp-skimlinks/0.1/test/test-waypoint.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {DEFAULT_SKIM_OPTIONS, pubcode} from './constants';
 import {Waypoint} from '../waypoint';
 import {XCUST_ATTRIBUTE_NAME} from '../constants';
 import {parseQueryString, parseUrlDeprecated} from '../../../../src/url';
-import {pubcode} from './constants';
 import helpersFactory from './helpers';
 
 describes.fakeWin(
@@ -60,12 +60,9 @@ describes.fakeWin(
           canonicalUrl: 'canonical_url',
         });
         env.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns('-120');
-        const skimOptions = {
-          config: {waypointUrl: 'https://go.skimresources.com/'},
-        };
         waypoint = new Waypoint(
             env.ampdoc,
-            skimOptions,
+            DEFAULT_SKIM_OPTIONS,
             trackingService,
             'referrer_url'
         );

--- a/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.html
+++ b/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.html
@@ -31,6 +31,7 @@
         excluded-domains="samsung.com  asos.com"
         link-selector="article:not(.no-skimlinks) a"
         custom-tracking-id="phones"
+        custom-redirect-domain="go.publisher.com"
     ></amp-skimlinks>
 </body>
 </html>

--- a/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.html
+++ b/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.html
@@ -12,7 +12,7 @@
 -->
 <!--
   Test Description:
-  Valid amp-test tag
+  Valid amp-skimlinks tag
 -->
 <!doctype html>
 <html ⚡>

--- a/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.out
+++ b/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.out
@@ -32,6 +32,7 @@ PASS
 |          excluded-domains="samsung.com  asos.com"
 |          link-selector="article:not(.no-skimlinks) a"
 |          custom-tracking-id="phones"
+|          custom-redirect-domain="go.publisher.com"
 |      ></amp-skimlinks>
 |  </body>
 |  </html>

--- a/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.out
+++ b/extensions/amp-skimlinks/0.1/test/validator-amp-skimlinks.out
@@ -13,7 +13,7 @@ PASS
 |  -->
 |  <!--
 |    Test Description:
-|    Valid amp-test tag
+|    Valid amp-skimlinks tag
 |  -->
 |  <!doctype html>
 |  <html ⚡>

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
@@ -12,7 +12,7 @@
 -->
 <!--
   Test Description:
-  Valid amp-test tag
+  Valid amp-skimlinks tag with minimal options
 -->
 <!doctype html>
 <html ⚡>

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.html
@@ -28,10 +28,6 @@
     <amp-skimlinks
         layout="nodisplay"
         publisher-code="123X123"
-        excluded-domains="samsung.com  asos.com"
-        link-selector="article:not(.no-skimlinks) a"
-        custom-tracking-id="phones"
-        custom-redirect-domain="go.publisher.com"
     ></amp-skimlinks>
 </body>
 </html>

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
@@ -1,6 +1,6 @@
 PASS
 |  <!--
-|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
@@ -13,7 +13,7 @@ PASS
 |  -->
 |  <!--
 |    Test Description:
-|    Valid amp-test tag
+|    Valid amp-skimlinks tag with minimal options
 |  -->
 |  <!doctype html>
 |  <html ⚡>

--- a/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
+++ b/extensions/amp-skimlinks/0.1/test/validator-minimal-options.out
@@ -29,10 +29,6 @@ PASS
 |      <amp-skimlinks
 |          layout="nodisplay"
 |          publisher-code="123X123"
-|          excluded-domains="samsung.com  asos.com"
-|          link-selector="article:not(.no-skimlinks) a"
-|          custom-tracking-id="phones"
-|          custom-redirect-domain="go.publisher.com"
 |      ></amp-skimlinks>
 |  </body>
 |  </html>

--- a/extensions/amp-skimlinks/0.1/waypoint.js
+++ b/extensions/amp-skimlinks/0.1/waypoint.js
@@ -85,7 +85,7 @@ export class Waypoint {
     if (xcust) {
       queryParams['xcust'] = xcust;
     }
-    const affiliationUrl = this.skimOptions_.config.waypointUrl;
+    const affiliationUrl = this.skimOptions_.waypointBaseUrl;
     return addParamsToUrl(affiliationUrl, /** @type {!JsonObject} */ (queryParams));
   }
 }

--- a/extensions/amp-skimlinks/validator-amp-skimlinks.protoascii
+++ b/extensions/amp-skimlinks/validator-amp-skimlinks.protoascii
@@ -30,6 +30,9 @@ tags: {  # <amp-skimlinks>
   tag_name: "AMP-SKIMLINKS"
   requires_extension: "amp-skimlinks"
   attrs: {
+    name: "custom-redirect-domain"
+  }
+  attrs: {
     name: "custom-tracking-id"
     value_regex_casei: "^.{0,50}$"
   }
@@ -43,9 +46,6 @@ tags: {  # <amp-skimlinks>
     name: "publisher-code"
     value_regex_casei: "^[0-9]+X[0-9]+$"
     mandatory: true
-  }
-  attrs: {
-    name: "custom-redirect-domain"
   }
   attrs: {
     name: "tracking"

--- a/extensions/amp-skimlinks/validator-amp-skimlinks.protoascii
+++ b/extensions/amp-skimlinks/validator-amp-skimlinks.protoascii
@@ -45,6 +45,9 @@ tags: {  # <amp-skimlinks>
     mandatory: true
   }
   attrs: {
+    name: "custom-redirect-domain"
+  }
+  attrs: {
     name: "tracking"
     value: "false"
     value: "true"

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -27,7 +27,7 @@ const linksTrackingUrl = RequestBank.getUrl('linksTrackingUrl') +
   '/link?data=${data}';
 const nonAffiliateTrackingUrl = RequestBank.getUrl('nonAffiliateTrackingUrl') +
   '?call=track&data=${data}';
-const waypointUrl = `${RequestBank.getUrl('waypointUrl')}`;
+const waypointUrl = `${RequestBank.getUrl('waypointUrl')}/`;
 
 // Simulated click event created by browser.click() does not trigger
 // the browser navigation when dispatched on a link.
@@ -49,13 +49,13 @@ describe('amp-skimlinks', function() {
         layout="nodisplay"
         publisher-code="123X123"
         tracking="true"
+        custom-redirect-domain="${waypointUrl}"
     >
       <script type="application/json">
         {
             "pageTrackingUrl": "${pageTrackingUrl}",
             "linksTrackingUrl": "${linksTrackingUrl}",
-            "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}",
-            "waypointUrl": "${waypointUrl}"
+            "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}"
         }
       </script>
     </amp-skimlinks>


### PR DESCRIPTION
Creating new amp-skimlinks option "custom-redirect-domain" for publishers to change the redirect URL.

Currently, if users click on a link affiliated by Skimlinks, the user will navigate first to `https://go.skimresources.com` (the default redirect domain) before being redirected to the merchant URL. With the new custom-redirect-domain attribute, the publisher can now specify its own redirect domain name. (Typically a publisher domain CNAME pointing to go.skimresources.com).
E.g:
```html
<amp-skimlinks
   ...
   custom-redirect-domain="go.androidpolice.com">
```
This configuration will send the user to `http://go.androidpolice.com` instead of `https://go.skimresources.com`.

**Note**: `waypointUrl` has been removed from the e2e tests JSON config since "custom-redirect-domain" option can now be used instead.