### PR TITLE
✨ Add new amp-digidip extension

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -432,6 +432,7 @@ exports.extensionBundles = [
   {name: 'amp-youtube', version: '0.1', type: TYPES.MEDIA},
   {name: 'amp-mowplayer', version: '0.1', type: TYPES.MEDIA},
   {name: 'amp-powr-player', version: '0.1', type: TYPES.MEDIA},
+  {name: 'amp-digidip', version: '0.1', type: TYPES.MISC},
 ];
 
 exports.aliasBundles = [

--- a/extensions/amp-digidip/0.1/amp-digidip.js
+++ b/extensions/amp-digidip/0.1/amp-digidip.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LinkShifter} from './link-shifter';
+import {Services} from '../../../src/services';
+import {getDigidipOptions} from './digidip-options';
+import {getScopeElements} from './helper';
+
+export class AmpDigidip extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampDoc_ = null;
+
+    /** @private {?../../../src/service/viewer-impl.Viewer} */
+    this.viewer_ = null;
+
+    /* @private {?./link-shifter} */
+    this.shifter_ = null;
+
+    /** @private {?Object} */
+    this.digidipOpts_ = {};
+
+  }
+
+  /** @override */
+  buildCallback() {
+    this.ampDoc_ = this.getAmpDoc();
+    this.viewer_ = Services.viewerForDoc(this.ampDoc_);
+
+    this.digidipOpts_ = getDigidipOptions(this.element);
+
+    return this.ampDoc_.whenBodyAvailable()
+        .then(() => {
+          this.letsRockIt_();
+        });
+  }
+
+  /**
+   * @private
+   */
+  letsRockIt_() {
+    const list = getScopeElements(
+        this.ampDoc_,
+        this.digidipOpts_);
+
+    this.shifter_ = new LinkShifter(
+        this.element,
+        this.viewer_,
+        this.ampDoc_);
+
+    list.forEach(nodeElement => {
+      nodeElement.addEventListener('click', event => {
+        this.shifter_.clickHandler(event);
+      }, false);
+
+      nodeElement.addEventListener('contextmenu', event => {
+        this.shifter_.clickHandler(event);
+      }, false);
+    });
+
+  }
+
+  /** @override */
+  isLayoutSupported() {
+    return true;
+  }
+}
+
+AMP.extension('amp-digidip', '0.1', AMP => {
+  AMP.registerElement('amp-digidip', AmpDigidip);
+});

--- a/extensions/amp-digidip/0.1/constants.js
+++ b/extensions/amp-digidip/0.1/constants.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const CTX_ATTR_NAME = 'digidipctx';
+export const CTX_ATTR_VALUE = () => {
+  return Date.now();
+};
+

--- a/extensions/amp-digidip/0.1/digidip-options.js
+++ b/extensions/amp-digidip/0.1/digidip-options.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {userAssert} from '../../../src/log';
+
+const errors = {
+  REQUIRED_PUB_ID: 'attribute publisher-id is required',
+};
+
+/**
+ * @param {!AmpElement} element
+ * @return {!Object}
+ */
+export function getDigidipOptions(element) {
+  return {
+    publisherId: getPublisherId(element),
+    urlWorddipWords: element.getAttribute('url-worddip-words'),
+    useWorddip: element.getAttribute('use-worddip'),
+    newTab: element.getAttribute('new-tab'),
+    encodedXhrCredentials: element.getAttribute('encoded-xhr-credentials'),
+    hostsIgnore: element.getAttribute('hosts-ignore'),
+    readingWordsExclude: element.getAttribute('reading-words-exclude'),
+    elementClickhandler: element.getAttribute('element-clickhandler'),
+    elementClickhandlerAttribute: element.getAttribute(
+        'element-clickhandler-attribute'),
+    elementIgnoreAttribute: element.getAttribute('element-ignore-attribute'),
+    elementIgnorePattern: element.getAttribute('element-ignore-pattern'),
+    elementIgnoreConsiderParents: element.getAttribute(
+        'element-ignore-consider-parents'),
+  };
+}
+
+/**
+ * @param {*} condition
+ * @param {string} message
+ */
+function enforceDigipOptions(condition, message) {
+  userAssert(
+      condition,
+      `<amp-digidip> something is wrong with option: ${message}`
+  );
+}
+
+/**
+ * @param {!Element} element
+ * @return {string}
+ */
+function getPublisherId(element) {
+  const publisherId = element.getAttribute('publisher-id');
+
+  enforceDigipOptions(publisherId, errors.REQUIRED_PUB_ID);
+
+  return publisherId;
+}
+

--- a/extensions/amp-digidip/0.1/helper.js
+++ b/extensions/amp-digidip/0.1/helper.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ *
+ * @param {?../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+ * @param {!Object}  digidipOpts
+ * @return {*}
+ */
+export function getScopeElements(ampDoc, digidipOpts) {
+
+  const doc = ampDoc.getRootNode();
+
+  let scope = '';
+
+  let scopeElements = doc.querySelectorAll('*');
+
+  if (digidipOpts.elementClickhandlerAttribute !== '' &&
+      digidipOpts.elementClickhandler !== ''
+  ) {
+
+    if (digidipOpts.elementClickhandlerAttribute === 'id') {
+
+      scope = '#' + digidipOpts.elementClickhandler;
+
+      scopeElements = doc.querySelectorAll(scope);
+
+    } else if (digidipOpts.elementClickhandlerAttribute === 'class') {
+
+      scope = '.' + digidipOpts.elementClickhandler;
+
+      let classElements = doc.querySelectorAll(scope);
+
+      classElements = Object.keys(classElements).map(key => {
+
+        return classElements[key];
+      });
+
+      if (classElements.length > 0) {
+
+        classElements = classElements.filter(item => {
+
+          for (const i in classElements) {
+
+            if (classElements[i].contains(item) && classElements[i] !== item) {
+
+              return false;
+            }
+          }
+
+          return true;
+        });
+
+        scopeElements = classElements;
+
+      }
+    }
+  }
+
+  return scopeElements;
+}

--- a/extensions/amp-digidip/0.1/link-shifter.js
+++ b/extensions/amp-digidip/0.1/link-shifter.js
@@ -221,7 +221,7 @@ export class LinkShifter {
 
     if (this.digidipOpts_.hostsIgnore.length > 0) {
       const targetTest = new RegExp(
-          '(' + this.digidipOpts_.hostsIgnore.replace(/[\.]/g, '\\$&') + ')$',
+          '(' + this.digidipOpts_.hostsIgnore.replace(/[\.]/g, '\\$&').replace(/'/g, "''") + ')$',
           'i');
       if (targetTest.test(targetHost)) {
         return true;

--- a/extensions/amp-digidip/0.1/link-shifter.js
+++ b/extensions/amp-digidip/0.1/link-shifter.js
@@ -1,0 +1,308 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CTX_ATTR_NAME, CTX_ATTR_VALUE} from './constants';
+import {getDigidipOptions} from './digidip-options';
+
+export class LinkShifter {
+  /**
+   * @param {!AmpElement} ampElement
+   * @param {?../../../src/service/viewer-impl.Viewer} viewer
+   * @param {?../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+   */
+  constructor(ampElement, viewer, ampDoc) {
+    /** @private {?../../../src/service/viewer-impl.Viewer} */
+    this.viewer_ = viewer;
+
+    /** @private {?../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampDoc_ = ampDoc;
+
+    /** @private {?Event} */
+    this.event_ = null;
+
+    /** @private {?Object} */
+    this.digidipOpts_ = getDigidipOptions(ampElement);
+
+    /** @private {?RegExp} */
+    this.regexDomainUrl_ = /^https?:\/\/(www\.)?([^\/:]*)(:\d+)?(\/.*)?$/;
+  }
+
+  /**
+   * @param {!Event} event
+   */
+  clickHandler(event) {
+    this.event_ = event;
+    let htmlElement = event.srcElement;
+    const trimmedDomain = this.viewer_.win.document.domain
+        .replace(/(www\.)?(.*)/, '$2');
+
+    this.event_.stopPropagation();
+
+    // avoid firefox to trigger the event twice
+    if ((this.event_.type !== 'contextmenu') && (this.event_.button === 2)) {
+      return;
+    }
+
+    // check if the element or a parent element of it is a link in case we got
+    // a element that is child of the link element that we need
+    while (htmlElement && htmlElement.nodeName !== 'A') {
+      htmlElement = htmlElement.parentNode;
+    }
+
+    // if we could not find a valid link element, there's nothing to do
+    if (!htmlElement) {
+      return;
+    }
+
+    // check if there is a ignore_attribute and and ignore_pattern defined
+    // and check if the current element or it's parent has it
+    if (this.checkIsIgnore_(htmlElement)) {
+      return;
+    }
+
+    if (this.wasShifted_(htmlElement)) {
+      return;
+    }
+
+    if (this.isInternalLink(htmlElement, trimmedDomain)) {
+      return;
+    }
+
+    if (this.isOnBlackList_(htmlElement)) {
+      return;
+    }
+
+    this.setDigidipUrl_(htmlElement);
+  }
+
+  /**
+   * Check if the anchor element is placed in a section that
+   * has being mark to ignore the anchors inside
+   * @param {!Node} htmlElement
+   */
+  checkIsIgnore_(htmlElement) {
+    const isIgnore = Boolean(
+        this.digidipOpts_.elementIgnoreAttribute !== '' &&
+        this.digidipOpts_.elementIgnorePattern !== '');
+
+    if (!isIgnore) {
+      return false;
+    }
+
+    if (this.digidipOpts_.elementIgnoreConsiderParents === '1') {
+      const rootNode = htmlElement.getRootNode();
+      let parentSearch = htmlElement;
+
+      while (parentSearch && [rootNode].filter(subItem => {
+        return subItem === parentSearch;
+      }).length === 0 && parentSearch !== document) {
+        if (this.hasPassCondition_(parentSearch)) {
+          return true;
+        }
+        parentSearch = parentSearch.parentNode;
+      }
+    } else {
+      if (this.hasPassCondition_(htmlElement)) {
+        return true;
+      }
+    }
+
+    if (this.digidipOpts_.elementClickhandler !== '') {
+      // Note: Normally, this should not be necessary, because during the init
+      // phase, we only subscribe to the events of the defined
+      // element_clickhandler, but we had cases where the
+      // respective element was not available at this
+      // time. So following code is only for the 1% where
+      // it doesn't work. :-(
+      const selector = '#' + this.digidipOpts_.elementClickhandler;
+      const elmTmpRootNode = htmlElement.getRootNode()
+          .querySelectorAll(selector);
+
+      if (elmTmpRootNode && this.containsNode_(elmTmpRootNode, htmlElement)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @param {!Object} NodeList
+   * @param {!Node} node
+   * @return {boolean}
+   * @private
+   */
+  containsNode_(NodeList, node) {
+    let result = false;
+
+    Object.keys(NodeList).forEach(key => {
+      if (NodeList[key].contains(node)) {
+        result = true;
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Check if the element has set the condition to ignore
+   * @param {!Node} htmlElement
+   */
+  hasPassCondition_(htmlElement) {
+    let attributeValue = null;
+
+    if (htmlElement.hasAttribute(this.digidipOpts_.elementIgnoreAttribute)) {
+      attributeValue = htmlElement.getAttribute(
+          this.digidipOpts_.elementIgnoreAttribute);
+
+      const searchAttr = attributeValue.search(
+          this.digidipOpts_.elementIgnorePattern);
+
+      if (searchAttr !== -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check if the anchor element was already shifted
+   * @param {!Node} htmlElement
+   * @return {boolean}
+   * @private
+   */
+  wasShifted_(htmlElement) {
+    const ctxAttrValue = CTX_ATTR_VALUE().toString();
+
+    return (htmlElement.hasAttribute(CTX_ATTR_NAME)) &&
+        (htmlElement.getAttribute(CTX_ATTR_NAME) === ctxAttrValue);
+  }
+
+  /**
+   * Check if the anchor element leads to an internal link
+   * @param {!Node} htmlElement
+   * @param {?string} trimmedDomain
+   * @return {boolean}
+   */
+  isInternalLink(htmlElement, trimmedDomain) {
+    const href = htmlElement.getAttribute('href');
+
+    if (!(href && this.regexDomainUrl_.test(href) &&
+            RegExp.$2 !== trimmedDomain)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if the domain of the link is in a blacklist
+   * @param {!Node} htmlElement
+   * @return {boolean}
+   * @private
+   */
+  isOnBlackList_(htmlElement) {
+    const href = htmlElement.getAttribute('href');
+    this.regexDomainUrl_.test(href);
+    const targetHost = RegExp.$2;
+
+    if (this.digidipOpts_.hostsIgnore.length > 0) {
+      const targetTest = new RegExp(
+          '(' + this.digidipOpts_.hostsIgnore.replace(/[\.]/g, '\\$&') + ')$',
+          'i');
+      if (targetTest.test(targetHost)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * set the digidip tracking link
+   * @param {!Node} htmlElement
+   */
+  setDigidipUrl_(htmlElement) {
+    const oldValHref = htmlElement['href'];
+    const oldValTarget = htmlElement['target'];
+
+    this.viewer_.getReferrerUrl().then(referrerUrl => {
+      const urlParams = {
+        ppRef: referrerUrl,
+        currUrl: this.viewer_.getResolvedViewerUrl(),
+      };
+
+      htmlElement.href = this.getDigidipUrl(htmlElement, urlParams);
+
+      if (this.digidipOpts_.newTab === '1') {
+        htmlElement.target = '_blank';
+      }
+
+      // If the link has been "activated" via contextmenu,
+      // we have to keep the shifting in mind
+      if (this.event_.type === 'contextmenu') {
+        htmlElement.setAttribute(CTX_ATTR_NAME, CTX_ATTR_VALUE());
+      }
+
+      this.viewer_.win.setTimeout(() => {
+        htmlElement.href = oldValHref;
+
+        if (oldValTarget === '') {
+          htmlElement.removeAttribute('target');
+        } else {
+          htmlElement.target = oldValTarget;
+        }
+
+        if (htmlElement.hasAttribute(CTX_ATTR_NAME)) {
+          htmlElement.removeAttribute(CTX_ATTR_NAME);
+        }
+
+      }, ((this.event_.type === 'contextmenu') ? 15000 : 500));
+    });
+  }
+
+  /**
+   * @param {!Node} htmlElement
+   * @param {!Object} urlParams
+   * @return {string}
+   */
+  getDigidipUrl(htmlElement, urlParams) {
+    return this.getUrlVisit_() +
+        encodeURIComponent(htmlElement.href) +
+        (htmlElement.rev ?
+          ('&ref=' + encodeURIComponent(htmlElement.rev)) : ''
+        ) +
+        (htmlElement.getAttribute('data-ddid') ?
+          ('&wd_id=' +
+                encodeURIComponent(htmlElement.getAttribute('data-ddid'))) : ''
+        ) +
+        (urlParams.ppRef ?
+          ('&ppref=' + encodeURIComponent(urlParams.ppRef)) : ''
+        ) +
+        (urlParams.currUrl ?
+          ('&currurl=' + encodeURIComponent(urlParams.currUrl)) : ''
+        );
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getUrlVisit_() {
+    return 'http://' + this.digidipOpts_.publisherId +
+        '.digidip.net/visit?url=';
+  }
+}

--- a/extensions/amp-digidip/0.1/test/test-amp-digidip.js
+++ b/extensions/amp-digidip/0.1/test/test-amp-digidip.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as DocumentReady from '../../../../src/document-ready';
+import * as digidipOptionsModule from '../digidip-options';
+import helpersMaker from './test-helpers';
+
+describes.fakeWin('amp-digidip', {
+  amp: {
+    extensions: ['amp-digidip'],
+  },
+}, env => {
+
+  let ampDigidip, digidipOpts, helpers;
+
+  beforeEach(() => {
+    digidipOpts = {
+      'publisher-id': 'mysuperblog',
+    };
+
+    helpers = helpersMaker(env);
+    ampDigidip = helpers.createAmpDigidip(digidipOpts);
+  });
+
+  afterEach(() => {
+    env.sandbox.restore();
+  });
+
+  describe('digidipOptions', () => {
+    it('Should show an error if publisher-id is missing', () => {
+      ampDigidip = helpers.createAmpDigidip();
+
+      allowConsoleError(() =>
+        expect(() => {
+          ampDigidip.buildCallback();
+        }).to.throw()
+      );
+    });
+
+    it('Should not show any error when specifying attr publisher-id', () => {
+      ampDigidip = helpers.createAmpDigidip({
+        'publisher-id': 'mysuperblog',
+      });
+      env.sandbox
+          .stub(DocumentReady, 'whenDocumentReady')
+          .returns(Promise.reject());
+
+      expect(() => {
+        ampDigidip.buildCallback();
+      }).to.not.throw();
+    });
+  });
+
+  describe('At loading amp-digidip extension', () => {
+    it('should call method letsRockIt on buildCallback', () => {
+      env.sandbox
+          .stub(DocumentReady, 'whenDocumentReady')
+          .returns(Promise.resolve());
+
+      env.sandbox.stub(ampDigidip, 'letsRockIt_');
+
+      return ampDigidip.buildCallback().then(() => {
+        expect(ampDigidip.letsRockIt_.calledOnce).to.be.true;
+      });
+    });
+
+    it('Should read and set options', () => {
+      env.sandbox
+          .stub(DocumentReady, 'whenDocumentReady')
+          .returns(Promise.resolve());
+      env.sandbox.spy(digidipOptionsModule, 'getDigidipOptions');
+
+      const opts = {
+        'publisher-id': 'mysuperblog',
+        'new-tab': '1',
+        'hosts-ignore': 'facebook.com|youtube.com|baidu.com|wikipedia.org',
+        'reading-words-exclude': 'the|you|was|or|it|and|to|of|in|for|on|with',
+        'element-clickhandler': '',
+        'element-clickhandler-attribute': '',
+        'element-ignore-attribute': '',
+        'element-ignore-pattern': '',
+        'element-ignore-consider-parents': '0',
+      };
+
+      ampDigidip = helpers.createAmpDigidip(opts);
+      env.sandbox.stub(ampDigidip, 'letsRockIt_');
+
+      return ampDigidip.buildCallback().then(() => {
+        expect(digidipOptionsModule.getDigidipOptions.calledOnce).to.be.true;
+        expect(ampDigidip.digidipOpts_).to.deep.include({
+          publisherId: opts['publisher-id'],
+          newTab: opts['new-tab'],
+          hostsIgnore: opts['hosts-ignore'],
+          readingWordsExclude: opts['reading-words-exclude'],
+          elementClickhandler: opts['element-clickhandler'],
+          elementClickhandlerAttribute: opts['element-clickhandler-attribute'],
+          elementIgnoreAttribute: opts['element-ignore-attribute'],
+          elementIgnorePattern: opts['element-ignore-pattern'],
+          elementIgnoreConsiderParents: opts['element-ignore-consider-parents'],
+        });
+        expect(ampDigidip.digidipOpts_.hostsIgnore.split('|')).to.include
+            .members(['facebook.com']);
+      });
+    });
+  });
+});

--- a/extensions/amp-digidip/0.1/test/test-helpers.js
+++ b/extensions/amp-digidip/0.1/test/test-helpers.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpDigidip} from '../amp-digidip';
+
+const helpersMaker = env => {
+
+  return {
+    createAmpDigidip(extAttrs) {
+      const element = this.getAmpDigidipElement(extAttrs);
+      element.getAmpDoc = () => env.ampdoc;
+
+      return new AmpDigidip(element);
+    },
+
+    getAmpDigidipElement(extAttrs) {
+      const element = document.createElement('amp-digidip');
+      for (const i in extAttrs) {
+        element.setAttribute(i, extAttrs[i]);
+      }
+
+      return element;
+    },
+  };
+};
+
+export default helpersMaker;

--- a/extensions/amp-digidip/0.1/test/test-scopes-digidip.js
+++ b/extensions/amp-digidip/0.1/test/test-scopes-digidip.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-digidip';
+import {getScopeElements} from '../helper';
+
+describes.realWin('amp-digidip', {
+  amp: {
+    extensions: ['amp-digidip'],
+  },
+}, () => {
+
+  let doc;
+
+
+  beforeEach(() => {
+
+    doc = new DOMParser()
+        .parseFromString(
+            '<div id=\'scope\'></div><div class=\'scope\'></div>' +
+            '<div class=\'scope\'><div class=\'scope\'></div></div>',
+            'text/html');
+
+  });
+
+  it('Shoud find html node when there are no scope options', () => {
+
+    const scopes = getScopeElements(
+        doc,
+        {elementClickhandlerAttribute: '', elementClickhandler: ''}
+    );
+
+    expect(scopes[0].localName).to.equal('html');
+
+  });
+
+  it('Shoud find one scope node', () => {
+
+    const scopes = getScopeElements(
+        doc,
+        {elementClickhandlerAttribute: 'id', elementClickhandler: 'scope'}
+    );
+
+    expect(Object.keys(scopes).length).to.equal(1);
+
+  });
+
+  it('Shoud find two scope nodes', () => {
+
+    const scopes = getScopeElements(
+        doc,
+        {elementClickhandlerAttribute: 'class', elementClickhandler: 'scope'}
+    );
+
+    expect(Object.keys(scopes).length).to.equal(2);
+
+  });
+
+
+});

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
@@ -1,0 +1,69 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-digidip example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-digidip {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-digidip
+          layout="nodisplay"
+          publisher-id="stylebudget"
+          use-worddip="0"
+          new-tab="1"
+          encoded-xhr-credentials="bW9iaXBhbnRzOm1vYmlwYW50cw=="
+          hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+          reading-words-exclude="the|you|was|or|it|and|to|of|in|for|on|with|at|by|from|up|about|into|over|after|beneath|under|above|der|die|das|von|zu"
+          element-clickhandler=""
+          element-clickhandler-attribute=""
+          element-ignore-attribute="rel"
+          element-ignore-pattern="pass"
+          element-ignore-consider-parents="0"
+  >
+  </amp-digidip>
+  <div>
+    <p>Example of merchants links shifting</p>
+  </div>
+  <div>
+    <div>
+      <a href="https://www.amazon.de/Paulaner-Wei%C3%9Fbier-Oktoberfestbier-Ma%C3%9Fkrug-vol/dp/B005HIMJ7W/ref=sr_1_fkmr1_1?ie=UTF8&qid=1542186734&sr=8-1-fkmr1&keywords=Paulaner+1+liter+Bierdose">
+        link to amazon
+      </a>
+    </div>
+    <div>
+      <a href="https://www.gearbest.com/pest-control/pp_665269.html?wid=1112942">
+        link to gear best
+      </a>
+    </div>
+    <div id="track">
+      <a href="http://localhost:8000/examples/amp-digidip.amp.html">
+        link to local
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
@@ -10,7 +10,10 @@
   See the License for the specific language governing permissions and
   limitations under the license.
 -->
-
+<!--
+  Test Description:
+  Valid amp-test tag
+-->
 <!doctype html>
 <html ⚡>
 <head>
@@ -19,51 +22,19 @@
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    amp-digidip {
-      color: red;
-    }
-  </style>
   <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
-  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
-  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
   <amp-digidip
           layout="nodisplay"
           publisher-id="stylebudget"
-          use-worddip="0"
-          new-tab="1"
-          encoded-xhr-credentials="bW9iaXBhbnRzOm1vYmlwYW50cw=="
           hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
-          reading-words-exclude="the|you|was|or|it|and|to|of|in|for|on|with|at|by|from|up|about|into|over|after|beneath|under|above|der|die|das|von|zu"
           element-clickhandler=""
           element-clickhandler-attribute=""
           element-ignore-attribute="rel"
           element-ignore-pattern="pass"
-          element-ignore-consider-parents="0"
   >
   </amp-digidip>
-  <div>
-    <p>Example of merchants links shifting</p>
-  </div>
-  <div>
-    <div>
-      <a href="https://www.amazon.de/Paulaner-Wei%C3%9Fbier-Oktoberfestbier-Ma%C3%9Fkrug-vol/dp/B005HIMJ7W/ref=sr_1_fkmr1_1?ie=UTF8&qid=1542186734&sr=8-1-fkmr1&keywords=Paulaner+1+liter+Bierdose">
-        link to amazon
-      </a>
-    </div>
-    <div>
-      <a href="https://www.gearbest.com/pest-control/pp_665269.html?wid=1112942">
-        link to gear best
-      </a>
-    </div>
-    <div id="track">
-      <a href="http://localhost:8000/examples/amp-digidip.amp.html">
-        link to local
-      </a>
-    </div>
-  </div>
 </body>
 </html>

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.html
@@ -26,9 +26,31 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+  <!-- Valid: Activating link shifter -->
   <amp-digidip
           layout="nodisplay"
           publisher-id="stylebudget"
+          hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+          element-clickhandler=""
+          element-clickhandler-attribute=""
+          element-ignore-attribute="rel"
+          element-ignore-pattern="pass"
+  >
+  </amp-digidip>
+  <!-- Invalid: missing publisher-id attribute. -->
+  <amp-digidip
+          layout="nodisplay"
+          hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+          element-clickhandler=""
+          element-clickhandler-attribute=""
+          element-ignore-attribute="rel"
+          element-ignore-pattern="pass"
+  >
+  </amp-digidip>
+  <!-- Invalid: wrong publisher-id value. -->
+  <amp-digidip
+          layout="nodisplay"
+          publisher-id="stylebudget!"
           hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
           element-clickhandler=""
           element-clickhandler-attribute=""

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
@@ -1,4 +1,4 @@
-PASS
+FAIL
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,9 +27,35 @@ PASS
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
+|    <!-- Valid: Activating link shifter -->
 |    <amp-digidip
 |            layout="nodisplay"
 |            publisher-id="stylebudget"
+|            hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+|            element-clickhandler=""
+|            element-clickhandler-attribute=""
+|            element-ignore-attribute="rel"
+|            element-ignore-pattern="pass"
+|    >
+|    </amp-digidip>
+|    <!-- Invalid: missing publisher-id attribute. -->
+|    <amp-digidip
+>>   ^~~~~~~~~
+amp-digidip/0.1/test/validator-amp-digidip.html:41:2 The mandatory attribute 'publisher-id' is missing in tag 'amp-digidip'. (see https://www.ampproject.org/docs/reference/components/amp-digidip) [AMP_TAG_PROBLEM]
+|            layout="nodisplay"
+|            hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+|            element-clickhandler=""
+|            element-clickhandler-attribute=""
+|            element-ignore-attribute="rel"
+|            element-ignore-pattern="pass"
+|    >
+|    </amp-digidip>
+|    <!-- Invalid: wrong publisher-id value. -->
+|    <amp-digidip
+>>   ^~~~~~~~~
+amp-digidip/0.1/test/validator-amp-digidip.html:51:2 The attribute 'publisher-id' in tag 'amp-digidip' is set to the invalid value 'stylebudget!'. (see https://www.ampproject.org/docs/reference/components/amp-digidip) [DISALLOWED_HTML]
+|            layout="nodisplay"
+|            publisher-id="stylebudget!"
 |            hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
 |            element-clickhandler=""
 |            element-clickhandler-attribute=""

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
@@ -1,0 +1,21 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-digidip example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-digidip {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-digidip layout="responsive" width="150" height="80"></amp-digidip>
+|  </body>
+|  </html>

--- a/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
+++ b/extensions/amp-digidip/0.1/test/validator-amp-digidip.out
@@ -1,4 +1,20 @@
 PASS
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Valid amp-test tag
+|  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>
@@ -7,15 +23,19 @@ PASS
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      amp-digidip {
-|        color: red;
-|      }
-|    </style>
 |    <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|    <amp-digidip layout="responsive" width="150" height="80"></amp-digidip>
+|    <amp-digidip
+|            layout="nodisplay"
+|            publisher-id="stylebudget"
+|            hosts-ignore="facebook.com|youtube.com|baidu.com|wikipedia.org|twitter.com|qq.com|linkedin.com|taobao.com|live.com|hao123.com|sina.com.cn|blogspot.com|weibo.com|yandex.ru|sohu.com|vk.com|pinterest.com|wordpress.com|360.cn|instagram.com|paypal.com|msn.com|soso.com|ask.com|tumblr.com|xvideos.com|mail.ru|163.com|imdb.com|stackoverflow.com|imgur.com|reddit.com|blogger.com|cnn.com|lemonde.fr|lefigaro.fr|tukif.com|allocine.fr|parisexe.com|t.co|lequipe.fr|pagesjaunes.fr|dailymotion.com|store.steampowered.com|googleadservices.com|doubleclick.net|youtu.be|rstyle.me|mondemul.net|cdn.m6web.fr|jheberg.net|userscloud.com"
+|            element-clickhandler=""
+|            element-clickhandler-attribute=""
+|            element-ignore-attribute="rel"
+|            element-ignore-pattern="pass"
+|    >
+|    </amp-digidip>
 |  </body>
 |  </html>

--- a/extensions/amp-digidip/amp-digidip.md
+++ b/extensions/amp-digidip/amp-digidip.md
@@ -1,0 +1,204 @@
+<!--
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# `amp-digidip`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Run digidip inside your AMP page</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>nodisplay</td>
+  </tr>
+</table>
+
+## Overview
+
+
+Digidip allows you to monetise your content through affiliate marketing. It gives you instant access to over 40,000 merchant affiliate programs without the hassle of network sign ups, approvals or creating affiliate links.
+
+`amp-digidip` is the AMP version of the traditional Digidip scripts which allows you to automatically turn your normal merchant links into monetizable links and gives you access to analytics data about how your content is performing.
+
+
+## Getting started
+
+A digidip account is required in order to use [amp-digidip](https://digidip.net/)
+
+**Add the required script**
+Inside the `<head>...</head>` section of your AMP page, insert this code before the line `<script async src="https://cdn.ampproject.org/v0.js"></script>`
+
+Code:
+```html
+    <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
+```
+
+**Add the amp-digidip extension**
+Inside the `<body>...</body>` section of your AMP page, insert this code:
+
+Code:
+```html
+    <amp-digidip
+        layout="nodisplay"
+        publisher-id="<<publisher id>>"
+        hosts-ignore="<<host domains list>>"
+        element-clickhandler-attribute="<<html attribute>>"
+        element-clickhandler="<<html attribute value>>"
+        element-ignore-attribute="<<html element to be ignored when it has a specific value>>"
+        element-ignore-pattern="<<html element value to be ignored >>"
+    >
+    </amp-digidip>
+```
+
+
+The final code should like:
+
+```html
+<!doctype html>
+<html ⚡>
+<head>
+  ...
+  <script async custom-element="amp-digidip" src="https://cdn.ampproject.org/v0/amp-digidip-0.1.js"></script>
+  ...
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+    ...
+    <amp-digidip
+        layout="nodisplay"
+        publisher-id="<<publisher id>>"
+        hosts-ignore="<<host domains list>>"
+        element-clickhandler-attribute="<<html attribute>>"
+        element-clickhandler="<<html attribute value>>"
+        element-ignore-attribute="<<html element to be ignored when it has a specific value>>"
+        element-ignore-pattern="<<html element value to be ignored >>"
+    >
+    </amp-digidip>
+    ....
+</body>
+</html>
+```
+
+## Attributes
+
+##### publisher-id (required)
+
+The publisher id.
+
+Example:
+```html
+    <amp-digidip
+        ...
+        publisher-id="publisher-id-example"
+    >
+    </amp-digidip>
+```
+
+##### hosts-ignore (optional)
+
+A pipe (vertical bar) separated list of domain names.
+All the links belonging to a domain in that list will not be affiliated nor tracked by digidip.
+By default amp-digidip does not exclude any domains.
+
+Example:
+```html
+    <amp-digidip
+        ...
+        hosts-ignore="samsung.com | amazon.com"
+    >
+    </amp-digidip>
+```
+
+##### element-clickhandler-attribute (optional)
+
+The `element-clickhandler-attribute` allows you to restrict which links amp-digidip
+should affiliate and track. Only the links
+within the area defined by the provided selector and value will considered.
+By default, amp-digidip affiliate and tracks all the links on the page.
+
+The `element-clickhandler-attribute` value should be an `id` or `class` html element attribute.
+
+**WARNING:**
+Don't set this option unless you really need it. When using this option, always double check that your attribute and value is
+matching your links section.
+If you set the `element-clickhandler-attribute` you have to set the value defined by `element-clickhandle`.
+
+Examples:
+```html
+    <amp-digidip
+        ...
+        element-clickhandler-attribute="id"
+    >
+    </amp-digidip>
+```
+
+```html
+    <amp-digidip
+        ...
+        element-clickhandler-attribute="class"
+    >
+    </amp-digidip>
+```
+
+
+##### element-ignore-attribute (optional)
+
+The `element-ignore-attribute` allows you to restrict which links should be ignored. It
+The `element-ignore-attribute` value is a html element attribute included the following group: `id`, `class`, `rev`, `rel`
+
+**WARNING:**
+If you set the `element-ignore-attribute` you have to set the value defined by `element-ignore-pattern`.
+
+
+Example:
+
+```html
+    <amp-digidip
+        ...
+        element-ignore-attribute="rel"
+        element-ignore-pattern="bypass"
+    >
+    </amp-digidip>
+```
+
+##### element-ignore-pattern (optional)
+
+The `element-ignore-pattern` allows you to define the value for `element-ignore-attribute`.
+
+**WARNING:**
+If you set the `element-ignore-pattern` you have to set the value defined by `element-ignore-attribute`.
+
+
+Example:
+
+```html
+    <amp-digidip
+        ...
+        element-ignore-attribute="rel"
+        element-ignore-pattern="bypass"
+    >
+    </amp-digidip>
+```
+
+
+## Validation
+
+See [amp-digidip rules](validator-amp-digidip.protoascii) in the AMP validator specification.

--- a/extensions/amp-digidip/validator-amp-digidip.protoascii
+++ b/extensions/amp-digidip/validator-amp-digidip.protoascii
@@ -29,12 +29,6 @@ tags: {  # <amp-digidip>
   tag_name: "AMP-DIGIDIP"
   requires_extension: "amp-digidip"
   attrs: {
-    name: "publisher-id"
-  }
-  attrs: {
-    name: "hosts-ignore"
-  }
-  attrs: {
     name: "element-clickhandler-attribute"
   }
   attrs: {
@@ -45,6 +39,14 @@ tags: {  # <amp-digidip>
   }
   attrs: {
     name: "element-ignore-pattern"
+  }
+  attrs: {
+    name: "hosts-ignore"
+  }
+  attrs: {
+    name: "publisher-id"
+    mandatory: true
+    value_regex_casei: "^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$"
   }
   attr_lists: "extended-amp-global"
   amp_layout: {

--- a/extensions/amp-digidip/validator-amp-digidip.protoascii
+++ b/extensions/amp-digidip/validator-amp-digidip.protoascii
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-digidip
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-digidip"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-digidip>
+  html_format: AMP
+  tag_name: "AMP-DIGIDIP"
+  requires_extension: "amp-digidip"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-digidip"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}

--- a/extensions/amp-digidip/validator-amp-digidip.protoascii
+++ b/extensions/amp-digidip/validator-amp-digidip.protoascii
@@ -28,9 +28,26 @@ tags: {  # <amp-digidip>
   html_format: AMP
   tag_name: "AMP-DIGIDIP"
   requires_extension: "amp-digidip"
+  attrs: {
+    name: "publisher-id"
+  }
+  attrs: {
+    name: "hosts-ignore"
+  }
+  attrs: {
+    name: "element-clickhandler-attribute"
+  }
+  attrs: {
+    name: "element-clickhandler"
+  }
+  attrs: {
+    name: "element-ignore-attribute"
+  }
+  attrs: {
+    name: "element-ignore-pattern"
+  }
   attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-digidip"
   amp_layout: {
-    supported_layouts: RESPONSIVE
+    supported_layouts: NODISPLAY
   }
 }


### PR DESCRIPTION
Add new extension that enables publishers to monetize their content through digidip.net.

`amp-digidip` is the AMP version of the traditional Digidip scripts which automatically turns normal merchant links into monetizable links and gives access to analytics data about how content is performing.