### PR TITLE
🐛 Fix amp-list documentation

### DIFF
--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# <a name="amp-list"></a> `<amp-list>`
+# <a name="amp-list"></a> `amp-list`
 
 [TOC]
 


### PR DESCRIPTION
This is breaking validation since it ends up as `<a> <amp-list> </a>`

Closes https://github.com/ampproject/docs/issues/1362 