### PR TITLE
Fix amp-sidebar keyboard event forwarding

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -158,8 +158,9 @@ export class AmpSidebar extends AMP.BaseElement {
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
       if (event.key == Keys.ESCAPE) {
-        event.preventDefault();
-        this.close_();
+        if (this.close_()) {
+          event.preventDefault();
+        }
       }
     });
 
@@ -339,11 +340,13 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /**
    * Hides the sidebar.
+   * @return {boolean} Whether the sidebar actually transitioned from "visible"
+   *     to "hidden".
    * @private
    */
   close_() {
     if (!this.isOpen_()) {
-      return;
+      return false;
     }
     this.viewport_.leaveOverlayMode();
     const scrollDidNotChange =
@@ -358,6 +361,7 @@ export class AmpSidebar extends AMP.BaseElement {
     if (this.openerElement_ && sidebarIsActive && scrollDidNotChange) {
       tryFocus(this.openerElement_);
     }
+    return true;
   }
   /**
    * Sidebars within <amp-story> should be 'flipped'.


### PR DESCRIPTION
It turns out that the close_() function may be a no-op if the sidebar
has already been closed, in which case we should not prevent the
default.

Currently, just by having an amp-sidebar in the AMP document, and
clicking on a blank region in the document would prevent the default and
stop forwarding the key event to the viewer. This is because the
keyboard event listener is attached onto the `document` object. We still
need to forward the keyboard event when the sidebar is already closed.

/to @choumx @aghassemi
