### PR TITLE
Changes to make carousel v2 work with lightbox gallery.

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -211,7 +211,7 @@ export class AmpSlideScroll extends BaseSlides {
     this.registerAction('goToSlide', invocation => {
       const {args} = invocation;
       if (args) {
-        this.showSlideWhenReady(args['index']);
+        this.goToSlide(args['index']);
       }
     }, ActionTrust.LOW);
   }
@@ -225,7 +225,7 @@ export class AmpSlideScroll extends BaseSlides {
   mutatedAttributesCallback(mutations) {
     const slide = mutations['slide'];
     if (slide !== undefined) {
-      this.showSlideWhenReady(slide);
+      this.goToSlide(slide);
     }
   }
 
@@ -553,7 +553,7 @@ export class AmpSlideScroll extends BaseSlides {
    * when element has been laid out.
    * @param {*} value
    */
-  showSlideWhenReady(value) {
+  goToSlide(value) {
     const index = parseInt(value, 10);
 
     if (!isFinite(index) || index < 0 || index >= this.noOfSlides_) {

--- a/extensions/amp-carousel/0.2/amp-carousel.css
+++ b/extensions/amp-carousel/0.2/amp-carousel.css
@@ -95,6 +95,7 @@ amp-carousel {
   width: calc(100% / var(--visible-count)) !important;
   min-width: auto !important;
   max-width: none !important;
+  height: 100%;
 }
 
 .i-amphtml-carousel-scroll[horizontal="false"][mixed-length="false"] > .i-amphtml-carousel-slotted,
@@ -103,6 +104,7 @@ amp-carousel {
   height: calc(100% / var(--visible-count)) !important;
   min-height: auto !important;
   max-height: none !important;
+  width: 100%;
 }
 
 .i-amphtml-carousel-scroll[horizontal="true"][snap="true"][mixed-length="true"] > .i-amphtml-carousel-slotted,
@@ -126,4 +128,11 @@ amp-carousel {
 
 .i-amphtml-carousel-scroll[horizontal="false"] > .i-amphtml-carousel-spacer{
   width: 100%;
+}
+
+.i-amphtml-carousel-slotted > .i-amphtml-replaced-content {
+  /*
+   * Apply contain object-fit to all replaced content to avoid distorted ratios.
+   */
+  object-fit: contain;
 }

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -19,6 +19,7 @@ import {CSS} from '../../../build/amp-carousel-0.2.css';
 import {Carousel} from './carousel.js';
 import {ResponsiveAttributes} from './responsive-attributes';
 import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -120,6 +121,9 @@ class AmpCarousel extends AMP.BaseElement {
     });
 
     this.setupActions_();
+    this.element.addEventListener('indexchange', event => {
+      this.onIndexChanged_(event);
+    });
 
     // Do some manual "slot" distribution
     this.slides_.forEach(slide => {
@@ -151,6 +155,14 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /**
+   * Moves the Carousel to a given index.
+   * @param {number} index
+   */
+  showSlideWhenReady(index) {
+    this.carousel_.goToSlide(index, {smoothScroll: false});
+  }
+
+  /**
    * @private
    */
   renderContainerDom_() {
@@ -169,6 +181,17 @@ class AmpCarousel extends AMP.BaseElement {
     this.registerAction('goToSlide', ({args}) => {
       this.carousel_.goToSlide(args['index'] || -1);
     }, ActionTrust.LOW);
+  }
+
+  /**
+   * @private
+   * @param {!CustomEvent} event
+   */
+  onIndexChanged_(event) {
+    const data = dict({'index': event.detail['index']});
+    const name = 'slideChange';
+    // TODO(sparhami) trigger an action, but not from autoadvance.
+    this.element.dispatchCustomEvent(name, data);
   }
 
   /**

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -20,6 +20,7 @@ import {Carousel} from './carousel.js';
 import {ResponsiveAttributes} from './responsive-attributes';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {getDetail} from '../../../src/event-helper';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -185,10 +186,11 @@ class AmpCarousel extends AMP.BaseElement {
 
   /**
    * @private
-   * @param {!CustomEvent} event
+   * @param {!Event} event
    */
   onIndexChanged_(event) {
-    const data = dict({'index': event.detail['index']});
+    const detail = getDetail(event);
+    const data = dict({'index': detail['index']});
     const name = 'slideChange';
     // TODO(sparhami) trigger an action, but not from autoadvance.
     this.element.dispatchCustomEvent(name, data);

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -158,7 +158,7 @@ class AmpCarousel extends AMP.BaseElement {
    * Moves the Carousel to a given index.
    * @param {number} index
    */
-  showSlideWhenReady(index) {
+  goToSlide(index) {
     this.carousel_.goToSlide(index, {smoothScroll: false});
   }
 

--- a/extensions/amp-carousel/0.2/carousel.js
+++ b/extensions/amp-carousel/0.2/carousel.js
@@ -338,7 +338,7 @@ export class Carousel {
    * carousel is not moved.
    * @param {number} index
    * @param {{
-   *   smoothScroll: boolean|undefined,
+   *   smoothScroll: (boolean|undefined),
    * }=} options
    */
   goToSlide(index, {smoothScroll = true} = {}) {

--- a/extensions/amp-carousel/0.2/carousel.js
+++ b/extensions/amp-carousel/0.2/carousel.js
@@ -31,7 +31,9 @@ import {
   forwardWrappingDistance,
   wrappingDistance,
 } from './array-util.js';
+import {createCustomEvent, listenOnce} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
+import {dict} from '../../../src/utils/object';
 import {
   getStyle,
   setImportantStyles,
@@ -39,7 +41,6 @@ import {
   setStyles,
 } from '../../../src/style';
 import {iterateCursor} from '../../../src/dom';
-import {listenOnce} from '../../../src/event-helper';
 import {mod} from '../../../src/utils/math';
 
 /**
@@ -159,6 +160,9 @@ export class Carousel {
     scrollContainer,
     runMutate,
   }) {
+    /** @private @const */
+    this.win_ = win;
+
     /** @private @const */
     this.runMutate_ = runMutate;
 
@@ -333,14 +337,22 @@ export class Carousel {
    * Moves the carousel to a given index. If the index is out of range, the
    * carousel is not moved.
    * @param {number} index
+   * @param {{
+   *   smoothScroll: boolean|undefined,
+   * }=} options
    */
-  goToSlide(index) {
+  goToSlide(index, {smoothScroll = true} = {}) {
     if (index < 0 || index > this.slides_.length - 1) {
       return;
     }
 
+    if (index == this.currentIndex_) {
+      return;
+    }
+
+    // TODO(sparhami) This does not work with side-slide-count
     this.updateCurrentIndex_(index);
-    this.scrollCurrentIntoView_();
+    this.scrollCurrentIntoView_({smoothScroll});
   }
 
   /**
@@ -501,9 +513,7 @@ export class Carousel {
       this.hideSpacersAndSlides_();
       this.resetScrollReferencePoint_(/* force */true);
       this.ignoreNextScroll_ = true;
-      runDisablingSmoothScroll(this.scrollContainer_, () => {
-        this.scrollCurrentIntoView_();
-      });
+      this.scrollCurrentIntoView_({smoothScroll: false});
     });
   }
 
@@ -523,7 +533,10 @@ export class Carousel {
    */
   updateCurrentIndex_(currentIndex) {
     this.currentIndex_ = currentIndex;
-    // TODO(sparhami) Fire an event.
+    this.element_.dispatchEvent(
+        createCustomEvent(this.win_, 'indexchange', dict({
+          'index': currentIndex,
+        })));
   }
 
   /**
@@ -839,16 +852,22 @@ export class Carousel {
   }
 
   /**
-   * Scrolls the current element into view based on its alignment,
+   * Scrolls the current element into view based on its alignment.
+   * @param {{
+   *   smoothScroll: boolean,
+   * }} options
    * @private
    */
-  scrollCurrentIntoView_() {
-    scrollContainerToElement(
-        this.slides_[this.currentIndex_],
-        this.scrollContainer_,
-        this.axis_,
-        this.alignment_
-    );
+  scrollCurrentIntoView_({smoothScroll}) {
+    const runner = smoothScroll ? (el, cb) => cb() : runDisablingSmoothScroll;
+    runner(this.scrollContainer_, () => {
+      scrollContainerToElement(
+          this.slides_[this.currentIndex_],
+          this.scrollContainer_,
+          this.axis_,
+          this.alignment_
+      );
+    });
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -824,7 +824,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   openLightboxForElement_(element) {
     this.currentElemId_ = element.lightboxItemId;
     devAssert(this.carousel_).getImpl()
-        .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
+        .then(carousel => carousel.goToSlide(this.currentElemId_));
     this.updateDescriptionBox_();
     return this.enter_();
   }
@@ -1136,7 +1136,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
           closestBySelector(target, SLIDE_ITEM_SELECTOR));
       const targetSlideIndex = allSlides.indexOf(targetSlide);
       devAssert(parentCarousel).getImpl()
-          .then(carousel => carousel.showSlideWhenReady(targetSlideIndex));
+          .then(carousel => carousel.goToSlide(targetSlideIndex));
     }
   }
 
@@ -1390,7 +1390,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       devAssert(this.carousel_).getImpl(),
     ]).then(values => {
       this.currentElemId_ = id;
-      values[1].showSlideWhenReady(this.currentElemId_);
+      values[1].goToSlide(this.currentElemId_);
       this.updateDescriptionBox_();
     });
   }

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -59,6 +59,8 @@ import {triggerAnalyticsEvent} from '../../../src/analytics';
 /** @const */
 const TAG = 'amp-lightbox-gallery';
 const DEFAULT_GALLERY_ID = 'amp-lightbox-gallery';
+const SLIDE_ITEM_SELECTOR =
+    '.amp-carousel-slide-item, .i-amphtml-carousel-slotted';
 
 /**
  * Set of namespaces that indicate the lightbox controls mode.
@@ -81,7 +83,6 @@ const MAX_TRANSITION_DURATION = 1000; // ms
 const MIN_TRANSITION_DURATION = 500; // ms
 const MAX_DISTANCE_APPROXIMATION = 250; // px
 const MOTION_DURATION_RATIO = 0.8; // fraction of animation
-
 
 /**
  * The structure that represents the metadata of a lightbox element
@@ -346,7 +347,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       return this.manager_.getElementsForLightboxGroup(lightboxGroupId);
     }).then(list => {
       this.carousel_ = htmlFor(this.doc_)`
-        <amp-carousel type="slides" layout="fill" loop></amp-carousel>`;
+        <amp-carousel type="slides" layout="fill" loop="true"></amp-carousel>`;
       this.carousel_.setAttribute('amp-lightbox-group', lightboxGroupId);
       this.buildCarouselSlides_(list);
       return this.mutateElement(() => {
@@ -1129,11 +1130,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const parentCarousel = closestBySelector(target,
         'amp-carousel[type="slides"]');
     if (parentCarousel) {
-      const slideSelector = '.i-amphtml-slide-item';
       const allSlides = toArray(
-          scopedQuerySelectorAll(parentCarousel, slideSelector));
+          scopedQuerySelectorAll(parentCarousel, SLIDE_ITEM_SELECTOR));
       const targetSlide = dev().assertElement(
-          closestBySelector(target, slideSelector));
+          closestBySelector(target, SLIDE_ITEM_SELECTOR));
       const targetSlideIndex = allSlides.indexOf(targetSlide);
       devAssert(parentCarousel).getImpl()
           .then(carousel => carousel.showSlideWhenReady(targetSlideIndex));

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -51,7 +51,7 @@ export const VIDEO_TAGS = {
 const GALLERY_TAG = 'amp-lightbox-gallery';
 const CAROUSEL_TAG = 'AMP-CAROUSEL';
 const FIGURE_TAG = 'FIGURE';
-const SLIDE_SELECTOR = '.amp-carousel-slide';
+const SLIDE_SELECTOR = '.amp-carousel-slide, .i-amphtml-carousel-slotted';
 
 /** @typedef {{
  *  srcset: ?../../../../src/srcset.Srcset,


### PR DESCRIPTION
- Change lightbox gallery selectors to also look for carousel v2 slides.
- Fire an event from the carousel internals for `<amp-carousel>` to listen to.
- Fire the `slideChanged` event from carousel v2.
- Implement `showSlideWhenReady`.
- Add height: 100% for slides so that the image viewer sizes correctly.
- Add `object-fit: contain` to match carousel v1.