### PR TITLE
🏗 Show progress of `browserify` transform prior to running tests

### DIFF
--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -511,7 +511,7 @@ async function runTests() {
         log(green('Running tests locally...'));
       }
     }).on('browsers_ready', function() {
-      console.log('\n');
+      console./*OK*/log('\n');
       log(green('Done. Running tests...'));
     }).on('browser_complete', function(browser) {
       const result = browser.lastResult;
@@ -532,7 +532,7 @@ async function runTests() {
         message += red(result.failed + ' FAILED');
       }
       message += '\n';
-      console./* OK*/log('\n');
+      console./*OK*/log('\n');
       log(message);
     }).start();
     return deferred;

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const babelify = require('babelify');
 const colors = require('ansi-colors');
 const config = require('../../config');
 const deglob = require('globs-to-files');
@@ -249,6 +250,19 @@ async function runTests() {
   if (!process.env.TRAVIS && (argv.testnames || argv['local-changes'])) {
     c.reporters = ['mocha'];
   }
+
+  c.browserify.configure = function(bundle) {
+    bundle.on('prebundle', function() {
+      log(green('Transforming tests with'), cyan('browserify') + green('...'));
+    });
+    bundle.on('transform', function(tr) {
+      if (tr instanceof babelify) {
+        tr.once('babelify', function() {
+          process.stdout.write('.');
+        });
+      }
+    });
+  };
 
   // Exclude chai-as-promised from runs on the full set of sauce labs browsers.
   // See test/chai-as-promised/chai-as-promised.js for why this is necessary.
@@ -496,6 +510,9 @@ async function runTests() {
       if (!argv.saucelabs && !argv.saucelabs_lite) {
         log(green('Running tests locally...'));
       }
+    }).on('browsers_ready', function() {
+      console.log('\n');
+      log(green('Done. Running tests...'));
     }).on('browser_complete', function(browser) {
       const result = browser.lastResult;
       // Prevent cases where Karma detects zero tests and still passes. #16851.


### PR DESCRIPTION
Karma applies transforms to `js` test files before running unit or integration tests. This can take a while during a full test run, and there is currently no visible indication of what's going on.

This PR adds progress dots for `browserify` transforms that happen prior to running tests.

![image](https://user-images.githubusercontent.com/26553114/51879864-f5718680-2329-11e9-85a5-2f164fa59410.png)
