### PR TITLE
🐛 amp-img: make intrinsic sizer image hidden to ATs

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -460,7 +460,7 @@ export function applyStaticLayout(element) {
     // i-amphtml-sizer element
     const sizer = htmlFor(element)`
       <i-amphtml-sizer class="i-amphtml-sizer">
-        <img class="i-amphtml-intrinsic-sizer" />
+        <img alt="" role="presentation" aria-hidden="true" class="i-amphtml-intrinsic-sizer" />
       </i-amphtml-sizer>`;
     const intrinsicSizer = sizer.firstElementChild;
     intrinsicSizer.setAttribute('src',

--- a/src/layout.js
+++ b/src/layout.js
@@ -460,7 +460,8 @@ export function applyStaticLayout(element) {
     // i-amphtml-sizer element
     const sizer = htmlFor(element)`
       <i-amphtml-sizer class="i-amphtml-sizer">
-        <img alt="" role="presentation" aria-hidden="true" class="i-amphtml-intrinsic-sizer" />
+        <img alt="" role="presentation" aria-hidden="true" 
+             class="i-amphtml-intrinsic-sizer" />
       </i-amphtml-sizer>`;
     const intrinsicSizer = sizer.firstElementChild;
     intrinsicSizer.setAttribute('src',


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/20578