### PR TITLE
Fix amp-fit-text

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -97,8 +97,9 @@ class AmpFitText extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.updateFontSize_();
-    return Promise.resolve();
+    return this.mutateElement(() => {
+      this.updateFontSize_();
+    });
   }
 
   /** @private */


### PR DESCRIPTION
Wrap update font size in mutateElement.

b/118442780

Note that this fix is valid but there is still an underlying issue that needs to be fixed in runtime. tracked here #20049