### PR TITLE
⏪ Revert "🐛async-input: Fixed NonXHR GET on amp-form with Async Input Elements (#20362)"

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -527,7 +527,7 @@ export class AmpForm {
           this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
         }
 
-        this.handleNonXhrGet_(/*shouldSubmitFormElement*/false);
+        this.handleNonXhrGet_(event);
         return Promise.resolve();
       }
 
@@ -548,7 +548,7 @@ export class AmpForm {
         presubmitPromises,
         SUBMIT_TIMEOUT
     ).then(
-        () => this.handlePresubmitSuccess_(trust),
+        () => this.handlePresubmitSuccess_(trust, event),
         error => this.handlePresubmitError_(/**@type {!Error}*/(error))
     );
   }
@@ -566,15 +566,16 @@ export class AmpForm {
   /**
    * Handle successful presubmit tasks
    * @param {!ActionTrust} trust
+   * @param {?Event} event
    * @return {!Promise}
    */
-  handlePresubmitSuccess_(trust) {
+  handlePresubmitSuccess_(trust, event) {
     if (this.xhrAction_) {
       return this.handleXhrSubmit_(trust);
     } else if (this.method_ == 'POST') {
       this.handleNonXhrPost_();
     } else if (this.method_ == 'GET') {
-      this.handleNonXhrGet_(/*shouldSubmitFormElement*/true);
+      this.handleNonXhrGet_(event);
     }
 
     return Promise.resolve();
@@ -888,14 +889,12 @@ export class AmpForm {
 
   /**
    * Triggers Submit Analytics,
-   * and Form Element submit if passed by param.
-   * shouldSubmitFormElement should ONLY be true
-   * If the submit event.preventDefault was called
-   * @param {boolean} shouldSubmitFormElement
+   * and Form Element submit if not triggered by an event
+   * @param {?Event} event
    */
-  handleNonXhrGet_(shouldSubmitFormElement) {
+  handleNonXhrGet_(event) {
     this.triggerFormSubmitInAnalytics_('amp-form-submit');
-    if (shouldSubmitFormElement) {
+    if (!event) {
       this.form_.submit();
     }
     this.setState_(FormState.INITIAL);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1886,7 +1886,7 @@ describes.repeated('', {
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
 
-          sandbox.stub(ampForm, 'handleNonXhrGet_')
+          sandbox.stub(ampForm, 'handleXhrSubmitSuccess_')
               .returns(Promise.resolve());
           const submitActionPromise =
             ampForm.handleSubmitAction_(/* invocation */ {});
@@ -1899,9 +1899,8 @@ describes.repeated('', {
           expect(ampForm.urlReplacement_.expandInputValueSync)
               .to.have.been.calledWith(canonicalUrlField);
 
-
-          return whenCalled(ampForm.handleNonXhrGet_).then(() => {
-            expect(form.submit).to.not.have.been.called;
+          return whenCalled(form.submit).then(() => {
+            expect(form.submit).to.have.been.calledOnce;
             expect(clientIdField.value).to.equal('');
             expect(canonicalUrlField.value).to.equal(
                 'https%3A%2F%2Fexample.com%2Famps.html');
@@ -2056,8 +2055,6 @@ describes.repeated('', {
       it('should execute form submit when not triggered through event', () => {
         return getAmpForm(getForm()).then(ampForm => {
           const form = ampForm.form_;
-
-          // Non XHR Get
           ampForm.method_ = 'GET';
           ampForm.xhrAction_ = null;
           sandbox.stub(form, 'submit');
@@ -2069,7 +2066,7 @@ describes.repeated('', {
           const submitActionPromise =
             ampForm.handleSubmitAction_(/* invocation */ {});
 
-          expect(form.submit).to.have.not.been.called;
+          expect(form.submit).to.have.been.called;
 
           return submitActionPromise;
         });
@@ -2153,7 +2150,6 @@ describes.repeated('', {
         unnamedInput.setAttribute('value', 'unnamed');
         form.appendChild(unnamedInput);
 
-        // Non XHR Get
         ampForm.method_ = 'GET';
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
@@ -2171,7 +2167,7 @@ describes.repeated('', {
           'formFields[name]': 'John Miller',
           'formFields[email]': 'j@hnmiller.com',
         };
-        expect(form.submit).to.have.not.been.called;
+        expect(form.submit).to.have.been.called;
         expect(ampForm.analyticsEvent_).to.be.calledWith(
             'amp-form-submit',
             expectedFormData
@@ -2284,8 +2280,6 @@ describes.repeated('', {
       return getAmpForm(getForm()).then(ampForm => {
         const form = ampForm.form_;
         form.id = 'registration';
-
-        // Non XHR GET
         ampForm.method_ = 'GET';
         ampForm.xhrAction_ = null;
         const clientIdField = createElement('input');
@@ -2319,7 +2313,6 @@ describes.repeated('', {
             'amp-form-submit',
             expectedFormData
         );
-
         expect(ampForm.urlReplacement_.expandInputValueAsync)
             .to.not.have.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -2329,10 +2322,12 @@ describes.repeated('', {
         expect(ampForm.urlReplacement_.expandInputValueSync)
             .to.have.been.calledWith(canonicalUrlField);
 
-        expect(form.submit).to.not.have.been.called;
-        expect(clientIdField.value).to.equal('');
-        expect(canonicalUrlField.value).to.equal(
-            'https%3A%2F%2Fexample.com%2Famps.html');
+        return whenCalled(form.submit).then(() => {
+          expect(form.submit).to.have.been.calledOnce;
+          expect(clientIdField.value).to.equal('');
+          expect(canonicalUrlField.value).to.equal(
+              'https%3A%2F%2Fexample.com%2Famps.html');
+        });
       });
     });
 
@@ -2350,28 +2345,6 @@ describes.repeated('', {
 
           return ampForm.submit_(ActionTrust.HIGH).then(() => {
             expect(assertNoSensitiveFieldsStub).to.be.called;
-          });
-        });
-      });
-
-      it('NonXHRGet should submit async if Async Input', () => {
-        return getAmpFormWithAsyncInput().then(response => {
-          const {ampForm, getValueStub} = response;
-
-          // Make the form a NonXHRGet
-          ampForm.method_ = 'GET';
-          ampForm.xhrAction_ = null;
-
-          const formElementSubmitSpy =
-            sandbox.spy(ampForm.form_, 'submit');
-
-          const mockEvent = {
-            preventDefault: () => {},
-          };
-
-          return ampForm.submit_(ActionTrust.HIGH, mockEvent).then(() => {
-            expect(getValueStub).to.be.called;
-            expect(formElementSubmitSpy).to.be.called;
           });
         });
       });


### PR DESCRIPTION
closes #20594

This reverts commit de0ea8e2bdd449181602bbb33c4d114d105c7afa.

Should fix the regression for the related issue above. See the original PR here: #20362