### PR TITLE
Updates size of publisher logo according to guidance

### DIFF
--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -305,7 +305,7 @@ The name of the story's publisher.
 
 ##### publisher-logo-src [required]
 
-A URL to the story publisher's logo in square format (1x1 aspect ratio). For example `publisher-logo-src="https://example.com/logo/1x1.png"`, where 1x1.png is a 36x36 px logo.
+A URL to the story publisher's logo in square format (1x1 aspect ratio). For example `publisher-logo-src="https://example.com/logo/1x1.png"`, where 1x1.png is a 96x96 px logo.
 
 ##### poster-portrait-src [required]
 


### PR DESCRIPTION
In https://www.ampproject.org/docs/reference/components/amp-story#publisher-logo-src-guidelines it says "The logo should be at least 96x96 pixels." but the doc mentions a logo which is 36x36.