### PR TITLE
✅First few visual diff tests for amp-date-picker

### DIFF
--- a/examples/visual-tests/amp-date-picker/amp-date-picker.amp.html
+++ b/examples/visual-tests/amp-date-picker/amp-date-picker.amp.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-list examples</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-date-picker" src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+  <amp-date-picker
+    id="simple-date-picker"
+    type="single"
+    mode="static"
+    layout="container"
+    format="YYYY-MM-DD"
+    min="2010-01-01"
+    date="2018-12-12"
+    input-selector="[name=date1]"
+  >
+    <input name="date1" placeholder="Pick a date">
+    <button on="tap: simple-date-picker.clear">Clear</button>
+    <button on="tap: simple-date-picker.today">Today</button>
+    <button on="tap: simple-date-picker.today(offset=1)">Tomorrow</button>
+  </amp-date-picker>
+</body>
+</html>

--- a/examples/visual-tests/amp-date-picker/amp-date-picker.js
+++ b/examples/visual-tests/amp-date-picker/amp-date-picker.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const {verifyCssElements} = require('../../../build-system/tasks/visual-diff/helpers');
+
+module.exports = {
+  'select a different date': async (page, name) => {
+    await page.tap(".i-amphtml-date-picker-container .CalendarMonthGrid_month__horizontal:not(.CalendarMonthGrid_month__hideForAnimation):nth-child(2) .CalendarMonth_table > tbody > tr:nth-child(2) > td:nth-child(2)");
+    await verifyCssElements(page, name,
+      /* forbiddenCss */ null,
+      /* loadingIncompleteCss */ null,
+      /* loadingCompleteCss */ [
+        ".i-amphtml-date-picker-container .CalendarMonthGrid_month__horizontal:not(.CalendarMonthGrid_month__hideForAnimation):nth-child(2) .CalendarMonth_table > tbody > tr:nth-child(2) > td.CalendarDay__selected:nth-child(2)",
+        ".i-amphtml-date-picker-container .CalendarMonthGrid_month__horizontal:not(.CalendarMonthGrid_month__hideForAnimation):nth-child(2) .CalendarMonth_table > tbody > tr:nth-child(3) > td:nth-child(4):not(.CalendarDay__selected)"
+      ]);
+  },
+  'select previous month': async (page, name) => {
+    await page.tap(".i-amphtml-date-picker-container button.DayPickerNavigation_button:nth-child(1)");
+    await verifyCssElements(page, name,
+      /* forbiddenCss */ null,
+      /* loadingIncompleteCss */ null,
+      /* loadingCompleteCss */ [
+        ".i-amphtml-date-picker-container button[aria-label=Thursday\\,\\ November\\ 1\\,\\ 2018]"
+      ]);
+  },
+  'select next month': async (page, name) => {
+    await page.tap(".i-amphtml-date-picker-container button.DayPickerNavigation_button:nth-child(2)");
+    await verifyCssElements(page, name,
+      /* forbiddenCss */ null,
+      /* loadingIncompleteCss */ null,
+      /* loadingCompleteCss */ [
+        ".i-amphtml-date-picker-container button[aria-label=Tuesday\\,\\ January\\ 1\\,\\ 2019]"
+      ]);
+  },
+ };

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -600,5 +600,13 @@
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment-desktop.js"
     },
+    {
+      "url": "examples/visual-tests/amp-date-picker/amp-date-picker.amp.html",
+      "name": "amp-date-picker",
+      "loading_complete_css": [
+        ".i-amphtml-date-picker-container",
+      ],
+      "interactive_tests": "examples/visual-tests/amp-date-picker/amp-date-picker.js"
+    },
   ]
 }


### PR DESCRIPTION
- Added the following visual diff tests for amp-date-picker:
- static amp-date-picker
- date selection within amp-date-picker
- navigating to the previous month
- navigating to the next month

cc @cvializ or @danielrozenberg for approval
