### PR TITLE
Introduce a secure way to embed sandboxed AMP

### DIFF
--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -93,6 +93,7 @@ export class AmpViewerIntegration {
     const viewer = Services.viewerForDoc(ampdoc);
     this.isWebView_ = viewer.getParam('webview') == '1';
     this.isHandShakePoll_ = viewer.hasCapability('handshakepoll');
+    const messagingToken = viewer.getParam('messagingToken');
     const origin = viewer.getParam('origin') || '';
 
     if (!this.isWebView_ && !origin) {
@@ -104,7 +105,8 @@ export class AmpViewerIntegration {
       return this.webviewPreHandshakePromise_(source, origin)
           .then(receivedPort => {
             return this.openChannelAndStart_(viewer, ampdoc, origin,
-                new Messaging(this.win, receivedPort, this.isWebView_));
+                new Messaging(
+                    this.win, receivedPort, this.isWebView_, messagingToken));
           });
     }
     /** @type {?HighlightInfoDef} */
@@ -116,7 +118,8 @@ export class AmpViewerIntegration {
     const port = new WindowPortEmulator(
         this.win, origin, this.win.parent/* target */);
     return this.openChannelAndStart_(
-        viewer, ampdoc, origin, new Messaging(this.win, port, this.isWebView_));
+        viewer, ampdoc, origin,
+        new Messaging(this.win, port, this.isWebView_, messagingToken));
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -287,13 +287,14 @@ export class Messaging {
    * @private
    */
   sendMessage_(message) {
+    const /** Object<string, *> */ finalMessage = Object.assign(message, {});
     if (this.token_) {
-      message['messagingToken'] = this.token_;
+      finalMessage['messagingToken'] = this.token_;
     }
     this.port_./*OK*/postMessage(
         this.isWebview_
-          ? JSON.stringify(message)
-          : message);
+          ? JSON.stringify(/** @type {!JsonObject} */ (finalMessage))
+          : finalMessage);
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -139,7 +139,7 @@ export class Messaging {
      * document would be "null", which defeats the purpose of an origin check.
      * An attacker could simply create a sandboxed, malicious iframe (therefore
      * having null origin), walk on the DOM frame tree to find a reference to
-     * the viewer iframe (this is not constrained bu the same origin policy),
+     * the viewer iframe (this is not constrained by the same origin policy),
      * and then send postMessage() calls to the viewer frame and pass the
      * viewer's origin checks, if any.
      *

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -120,14 +120,45 @@ export class Messaging {
    * @param {!Window} win
    * @param {!MessagePort|!WindowPortEmulator} port
    * @param {boolean=} opt_isWebview
+   * @param {string=} opt_token
    */
-  constructor(win, port, opt_isWebview) {
+  constructor(win, port, opt_isWebview, opt_token) {
     /** @const {!Window} */
     this.win = win;
     /** @const @private {!MessagePort|!WindowPortEmulator} */
     this.port_ = port;
     /** @const @private */
     this.isWebview_ = !!opt_isWebview;
+
+    /**
+     * A token that the viewer may include as an init parameter to enhance
+     * security for communication to opaque origin (a.k.a. null origin) AMP
+     * documents.
+     *
+     * For an AMP document embedded inside a sandbox iframe, the origin of the
+     * document would be "null", which defeats the purpose of an origin check.
+     * An attacker could simply create a sandboxed, malicious iframe (therefore
+     * having null origin), walk on the DOM frame tree to find a reference to
+     * the viewer iframe (this is not constrained bu the same origin policy),
+     * and then send postMessage() calls to the viewer frame and pass the
+     * viewer's origin checks, if any.
+     *
+     * The viewer could also check the source of the message to be a legitimate
+     * AMP iframe window, but the attacker could bypass that by navigating the
+     * legitimate AMP iframe window away to a malicious document. Recent
+     * browsers have banned this kind of attack, but it's tricky to rely on it.
+     *
+     * To prevent the above attack in a null origin AMP document, the viewer
+     * should include this token in an init parameter, either in the `src` or
+     * `name` attribute of the iframe, and then verify that this token is
+     * included in all the messages sent from AMP to the viewer. The attacker
+     * would not be able to steal this token under the same origin policy,
+     * because the token is inside the viewer document at a different origin
+     * and the attacker can't access it.
+     * @const @private {string|undefined}
+     */
+    this.token_ = opt_token;
+
     /** @private {number} */
     this.requestIdCounter_ = 0;
     /** @private {!Object<number, {resolve: function(*), reject: function(!Error)}>} */
@@ -256,6 +287,9 @@ export class Messaging {
    * @private
    */
   sendMessage_(message) {
+    if (this.token_) {
+      message['messagingToken'] = this.token_;
+    }
     this.port_./*OK*/postMessage(
         this.isWebview_
           ? JSON.stringify(message)

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -185,6 +185,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
 
   describe.configure().ifChrome().run('Unit Tests for messaging.js', () => {
     const viewerOrigin = 'http://localhost:9876';
+    const messagingToken = '32q4pAwei09W845V3j24o8OJIO3fE9l3q49p';
     const requestProcessor = function() {
       return Promise.resolve({});
     };
@@ -207,7 +208,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         postMessageResolve();
       });
 
-      messaging = new Messaging(window, port);
+      messaging = new Messaging(
+          window, port, /* opt_isWebview= */ false, messagingToken);
       messaging.setDefaultHandler(requestProcessor);
     });
 
@@ -231,6 +233,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         expect(postMessageSpy).to.have.been.calledWith({
           app: '__AMPHTML__',
           data: {},
+          messagingToken,
           name: 'message',
           requestid: 1,
           type: 's',
@@ -352,6 +355,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         expect(postMessageSpy).to.have.been.calledWith({
           app: '__AMPHTML__',
           data: {},
+          messagingToken,
           name: message,
           requestid: 1,
           rsvp: awaitResponse,
@@ -371,6 +375,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         expect(postMessageSpy).to.have.been.calledWith({
           app: '__AMPHTML__',
           data: {},
+          messagingToken,
           name: mName,
           requestid: 1,
           type: 's',
@@ -392,6 +397,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           app: '__AMPHTML__',
           data: null,
           error: errString,
+          messagingToken,
           name: mName,
           requestid: 1,
           type: 's',


### PR DESCRIPTION
For an AMP document embedded inside a sandbox iframe, the origin of the
document would be "null", which defeats the purpose of an origin check.
An attacker could simply create a sandboxed, malicious iframe (therefore
having null origin), walk on the DOM frame tree to find a reference to
the viewer iframe (this is not constrained by the same origin policy),
and then send postMessage() calls to the viewer frame and pass the
viewer's origin checks, if any.

The viewer could also check the source of the message to be a legitimate
AMP iframe window, but the attacker could bypass that by navigating the
legitimate AMP iframe window away to a malicious document. Recent
browsers have banned this kind of attack, but it's tricky to rely on it.

To prevent the above attack in a null origin AMP document, the viewer
should include this token in an init parameter, either in the `src` or
`name` attribute of the iframe, and then verify that this token is
included in all the messages sent from AMP to the viewer. The attacker
would not be able to steal this token under the same origin policy,
because the token is inside the viewer document at a different origin
and the attacker can't access it.

/to @choumx @chenshay @cramforce 