### PR TITLE
📖 Add tip to AMPHTML layout page that leads to a quick demonstration (and remove unneeded TOC)

### DIFF
--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -16,7 +16,9 @@ limitations under the License.
 
 # AMP HTML Layout System
 
-[TOC]
+[tip]
+**TIP** - For a quick overview of what you can do with AMP's layout system, skip ahead and see all layouts in action on [Demonstrating AMP layouts](/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated.html).
+[/tip]
 
 ## Overview
 


### PR DESCRIPTION
This gets a little ugly as the tip isn' really helpful for those who consume this page through the amphtml repo.

My preferred solution would be to move a lot of these pages over to the doc repository and maintain them there going forward. Thoughts?

/cc @cramforce 