### PR TITLE
🐛 Add waitForHead and use documentReady for waitForBody

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -20,6 +20,7 @@ import {dev, devAssert} from './log';
 import {dict} from './utils/object';
 import {startsWith} from './string';
 import {toWin} from './types';
+import {isDocumentReady} from './document-ready';
 
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
@@ -87,16 +88,35 @@ export function waitForChildPromise(parent, checkFunc) {
 }
 
 /**
- * Waits for document's body to be available.
+ * Waits for document's head to be available.
+ * @param {!Document} doc
+ * @param {function()} callback
+ */
+export function waitForHead(doc, callback) {
+  waitForChild(doc.documentElement, () => !!doc.head, callback);
+}
+
+/**
+ * Waits for the document's head to be available.
+ * @param {!Document} doc
+ * @return {!Promise}
+ */
+export function waitForHeadPromise(doc) {
+  return new Promise(resolve => {
+    waitForHead(doc, resolve);
+  });
+}
+
+/**
+ * Waits for document's body to be available and ready.
  * Will be deprecated soon; use {@link AmpDoc#whenBodyAvailable} or
  * @{link DocumentState#onBodyAvailable} instead.
  * @param {!Document} doc
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  waitForChild(doc.documentElement, () => !!doc.body, callback);
+  waitForChild(doc.documentElement, () => isDocumentReady(doc), callback);
 }
-
 
 /**
  * Waits for document's body to be available.
@@ -109,7 +129,6 @@ export function waitForBodyPromise(doc) {
   });
 }
 
-
 /**
  * Removes the element.
  * @param {!Element} element
@@ -119,7 +138,6 @@ export function removeElement(element) {
     element.parentElement.removeChild(element);
   }
 }
-
 
 /**
  * Removes all child nodes of the specified element.


### PR DESCRIPTION
Implement waitForHead and change waitForBody to wait for documentReady. This change is for preventing bugs from occurring when using the `waitForBody` function and allows the body and it's children to render before the Promise resolves. Another method, `waitForHead` was implemented for cases where waiting for DOMReady would take too long for certain actions.

Issue: Resolves https://github.com/ampproject/amphtml/issues/20377