### PR TITLE
Fixes navigation education by setting a default embedded component state.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -431,7 +431,9 @@ export class AmpStoryStoreService {
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.HAS_SIDEBAR_STATE]: false,
       [StateProperty.INFO_DIALOG_STATE]: false,
-      [StateProperty.INTERACTIVE_COMPONENT_STATE]: {},
+      [StateProperty.INTERACTIVE_COMPONENT_STATE]: {
+        state: EmbeddedComponentState.HIDDEN,
+      },
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.PAGE_HAS_AUDIO_STATE]: false,


### PR DESCRIPTION
The navigation education overlay was broken by the lack of a default embedded component state. Because the embedded component state was not `HIDDEN` but `undefined`, the overlay would never trigger.
I'd set the other state values such as `element` but they're set to be always defined right now, so I couldn't set it to null. Making it nullable may require much work to make the linter happy.