### PR TITLE
🐛 Change a usage of ancestorElementsByTag to closestByTag.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -20,8 +20,8 @@ import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {
-  ancestorElementsByTag,
   childElementByTag,
+  closestByTag,
   removeChildren,
 } from '../../../src/dom';
 import {hasOwn} from '../../../src/utils/object';
@@ -211,7 +211,7 @@ export class AmpAdCustom extends AMP.BaseElement {
 
       // Get the parent body of this amp-ad element. It could be the body of
       // the main document, or it could be an enclosing iframe.
-      const body = ancestorElementsByTag(this.element, 'BODY')[0];
+      const body = closestByTag(this.element, 'BODY');
       const elements = body.querySelectorAll('amp-ad[type=custom]');
       for (let index = 0; index < elements.length; index++) {
         const elem = elements[index];


### PR DESCRIPTION
- Change a usage of ancestorElementsByTag to closestByTag since the latter uses a web API when available.
- Fixes #20291 

@choumx 
