### PR TITLE
Update Doubleclick pageview state token logic.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -757,6 +757,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.extensions_./*OK*/installExtensionForDoc(
           this.getAmpDoc(), 'amp-analytics');
     }
+
+    // Clear any existing pageview state token for this slot. If the response
+    // included a new token, save it to the module-level object.
+    this.removePageviewStateToken();
+    if (responseHeaders.get('amp-ff-pageview-tokens')) {
+      this.setPageviewStateToken(
+          dev.assertString(responseHeaders.get('amp-ff-pageview-tokens')));
+    }
+
     // If the server returned a size, use that, otherwise use the size that we
     // sent in the ad request.
     let size = super.extractSize(responseHeaders);
@@ -770,14 +779,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // fluid, wait until after resize happens.
     if (this.isFluidRequest_ && !this.returnedSize_) {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
-    }
-
-    // If the response included a pageview state token, check for an existing
-    // token and remove it. Then save the new one to the module level object.
-    if (responseHeaders.get('amp-ff-pageview-tokens')) {
-      this.removePageviewStateToken();
-      this.setPageviewStateToken(
-          dev().assertString(responseHeaders.get('amp-ff-pageview-tokens')));
     }
 
     return size;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -253,6 +253,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           })).to.deep.equal(size);
           expect(impl.fluidImpressionUrl_).to.not.be.ok;
         });
+
     it('should consume pageview state tokens when header is present',
         () => {
           const removePageviewStateTokenSpy =
@@ -275,6 +276,24 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(removePageviewStateTokenSpy).to.be.calledOnce;
           expect(setPageviewStateTokenSpy.withArgs('DUMMY_TOKEN')).to.be
               .calledOnce;
+        });
+    it('should remove pageview state tokens if none is provided',
+        () => {
+          const removePageviewStateTokenSpy =
+              sandbox.spy(impl, 'removePageviewStateToken');
+          const setPageviewStateTokenSpy =
+              sandbox.spy(impl, 'setPageviewStateToken');
+          expect(impl.extractSize({
+            get(name) {
+                return undefined;
+              }
+            },
+            has(name) {
+              return !!this.get(name);
+            },
+          })).to.deep.equal(size);
+          expect(removePageviewStateTokenSpy).to.be.calledOnce;
+          expect(setPageviewStateTokenSpy.not.to.be.called;
         });
 
     it('should consume sandbox header', () => {


### PR DESCRIPTION
Specifically, when processing a response for a slot, drop any existing pageview state token even if the response has none. This ensures correct behavior in cases when an ad is returned but has no token.

