### PR TITLE
🖍  Edit sidebar animations/design 

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-sidebar.html
+++ b/examples/visual-tests/amp-story/amp-story-sidebar.html
@@ -43,7 +43,7 @@
         poster-portrait-src="https://picsum.photos/900/1600?image=981"
         poster-landscape-src="https://picsum.photos/1600/900?image=981"
         poster-square-src="https://picsum.photos/1600/1600?image=981">
-      <amp-sidebar id="sidebar1" layout="nodisplay" side="right">
+      <amp-sidebar id="sidebar1" layout="nodisplay" >
         <ul>
           <li>Nav item 1</li>
           <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>

--- a/extensions/amp-story/1.0/amp-story-desktop-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-user-overridable.css
@@ -19,3 +19,6 @@
   background-color: transparent;
 }
 
+amp-sidebar[side] {
+  background-color: #ffffff;
+}

--- a/extensions/amp-story/1.0/amp-story-desktop-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-user-overridable.css
@@ -19,6 +19,6 @@
   background-color: transparent;
 }
 
-amp-sidebar[side] {
+.i-amphtml-story-sidebar {
   background-color: #ffffff;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -183,7 +183,7 @@ amp-sidebar[side][open] {
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-[desktop] amp-sidebar[side][open]{
+[desktop] amp-sidebar[side][open] {
   max-width: 320px !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -179,7 +179,6 @@ amp-story-page[active] {
 }
 
 amp-sidebar[side][open] {
-  background-color: #ffffff;
   transform: translate3d(0, 0, 0) !important;
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
@@ -260,15 +259,17 @@ amp-story-page[distance="2"] {
   /* Prevent someone from making this a full-screen image */
   background-image: none !important;
   background-color: #000 !important;
+  visibility: visible;
   z-index: 100003 !important;
-  animation: i-amphtml-bookend-overlay-opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) forwards !important;
+  transition: visibility 0.3s, opacity 0.3s  cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
 .i-amphtml-story-opacity-mask[hidden] {
   opacity: 0 !important;
   pointer-events: none !important;
   display: block !important;
-  animation: i-amphtml-bookend-overlay-opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1) reverse !important;
+  visibility: hidden;
+  transition: visibility 0.2s, opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
 .i-amphtml-sidebar-mask {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -260,7 +260,7 @@ amp-story-page[distance="2"] {
   /* Prevent someone from making this a full-screen image */
   background-image: none !important;
   background-color: #000 !important;
-  z-index: 100001 !important;
+  z-index: 100003 !important;
   animation: i-amphtml-bookend-overlay-opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) forwards !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -178,8 +178,8 @@ amp-story-page[active] {
   z-index: 1 !important;
 }
 
-amp-story amp-sidebar[side][open] {
-  background-color: #ffffff !important;
+amp-sidebar[side][open] {
+  background-color: #ffffff;
   transform: translate3d(0, 0, 0) !important;
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
@@ -188,7 +188,7 @@ amp-story amp-sidebar[side][open] {
   max-width: 320px !important;
 }
 
-amp-story amp-sidebar[side] {
+amp-sidebar[side]{
   max-width: 280px !important;
   min-width: 280px !important;
   width: 280px !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -178,16 +178,16 @@ amp-story-page[active] {
   z-index: 1 !important;
 }
 
-amp-sidebar[side][open] {
+.i-amphtml-story-sidebar[open] {
   transform: translate3d(0, 0, 0) !important;
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-[desktop] amp-sidebar[side][open] {
+[desktop] .i-amphtml-story-sidebar[open] {
   max-width: 320px !important;
 }
 
-amp-sidebar[side] {
+.i-amphtml-story-sidebar {
   max-width: 280px !important;
   min-width: 280px !important;
   width: 280px !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -261,7 +261,7 @@ amp-story-page[distance="2"] {
   background-color: #000 !important;
   visibility: visible;
   z-index: 100003 !important;
-  transition: visibility 0.3s, opacity 0.3s  cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+  transition: visibility 0.3s, opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
 .i-amphtml-story-opacity-mask[hidden] {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -187,7 +187,7 @@ amp-sidebar[side][open] {
   max-width: 320px !important;
 }
 
-amp-sidebar[side]{
+amp-sidebar[side] {
   max-width: 280px !important;
   min-width: 280px !important;
   width: 280px !important;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -181,6 +181,12 @@ const STORY_LOADED_CLASS_NAME = 'i-amphtml-story-loaded';
  */
 const OPACITY_MASK_CLASS_NAME = 'i-amphtml-story-opacity-mask';
 
+/**
+ * CSS class for sidebars in stories.
+ * @const {string}
+ */
+const SIDEBAR_CLASS_NAME = 'i-amphtml-story-sidebar';
+
 /** @const {!Object<string, number>} */
 const MAX_MEDIA_ELEMENT_COUNTS = {
   [MediaType.AUDIO]: 4,
@@ -2179,6 +2185,11 @@ export class AmpStory extends AMP.BaseElement {
     if (!this.sidebar_) {
       return;
     }
+
+    this.mutateElement(() => {
+      this.sidebar_.classList.add(SIDEBAR_CLASS_NAME);
+    });
+
     this.initializeOpacityMask_();
     this.storeService_.dispatch(Action.TOGGLE_HAS_SIDEBAR,
         !!this.sidebar_);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1635,7 +1635,7 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * @private
    */
-  openOpacityMask_() {
+  initializeOpacityMask_() {
     if (!this.maskElement_) {
       const maskEl = this.win.document.createElement('div');
       maskEl.classList.add(OPACITY_MASK_CLASS_NAME);
@@ -1651,8 +1651,15 @@ export class AmpStory extends AMP.BaseElement {
       this.maskElement_ = maskEl;
       this.mutateElement(() => {
         this.element.appendChild(this.maskElement_);
+        toggle(dev().assertElement(this.maskElement_), /* display */false);
       });
     }
+  }
+
+  /**
+   * @private
+   */
+  openOpacityMask_() {
     this.mutateElement(() => {
       toggle(dev().assertElement(this.maskElement_), /* display */true);
     });
@@ -2172,6 +2179,7 @@ export class AmpStory extends AMP.BaseElement {
     if (!this.sidebar_) {
       return;
     }
+    this.initializeOpacityMask_();
     this.storeService_.dispatch(Action.TOGGLE_HAS_SIDEBAR,
         !!this.sidebar_);
 


### PR DESCRIPTION
Resolves #20625

The changes in this PR includes

- Updating CSS selectors for sidebar in stories to work in Safari/iOS
- Allowing the background of sidebar to be overridable
- Updating the z-index of the opacity mask to make the mask go on top of desktop pagination buttons
- Fixing the animation/transition for the opacity mask
- Removal of the side attribute in the sidebar visual diff tests to make the document valid amp (#19540)

The changes were manually tested.