### PR TITLE
Skip flaky amp-list test

### DIFF
--- a/extensions/amp-list/0.1/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/integration/test-amp-list.js
@@ -50,14 +50,14 @@ describe('amp-list (integration)', function() {
       expect(container).to.exist;
     });
 
-    it('should render items', function*() {
+    // TODO(choumx): Frequent 10s timeout on Chrome 72.0.3626 (Linux 0.0.0).
+    it.skip('should render items', function*() {
       const list = doc.querySelector('amp-list');
       expect(list).to.exist;
 
       yield browser.waitForElementLayout('amp-list', TIMEOUT);
 
       const children = list.querySelectorAll('div[role=list] > div');
-
       expect(children.length).to.equal(3);
       expect(children[0].textContent.trim()).to.equal('apple : 47 @ 0.33');
       expect(children[1].textContent.trim()).to.equal('pear : 538 @ 0.54');


### PR DESCRIPTION
```
DESCRIBE => amp-list (integration)
  DESCRIBE => basic (mustache-0.1)
    DESCRIBE =>  
      IT => should render items
        ✗ Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
Chrome 72.0.3626 (Linux 0.0.0) amp-list (integration) basic (mustache-0.1)   should render items FAILED
```

```
DESCRIBE => amp-list (integration)
  DESCRIBE => basic (mustache-0.2)
    DESCRIBE =>  
      IT => should render items
        ✗ Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
Chrome 72.0.3626 (Linux 0.0.0) amp-list (integration) basic (mustache-0.2)   should render items FAILED
```

https://travis-ci.org/ampproject/amphtml/jobs/487624648
https://travis-ci.org/ampproject/amphtml/jobs/487627822
https://travis-ci.org/ampproject/amphtml/jobs/487623998

/to @cathyxz 