### PR TITLE
history: drop url fragment in the new API for the viewer as well

### DIFF
--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -907,17 +907,16 @@ export class HistoryBindingVirtual_ {
    * @override
    */
   replace(opt_stateUpdate) {
-    if (opt_stateUpdate && opt_stateUpdate.url && !this.viewer_.hasCapability(
-        'fullReplaceHistory')) {
-      // Full URL replacement requested, but not supported by the viewer.
-      // Don't update, and return the current state.
-      const curState = /** @type {!HistoryStateDef} */ (dict(
-          {'stackIndex': this.stackIndex_}));
-      return Promise.resolve(curState);
-    }
-
     if (opt_stateUpdate && opt_stateUpdate.url) {
-      // replace fragment, only explicit fragment param will be sent
+      if (!this.viewer_.hasCapability('fullReplaceHistory')) {
+        // Full URL replacement requested, but not supported by the viewer.
+        // Don't update, and return the current state.
+        const curState = /** @type {!HistoryStateDef} */ (dict(
+            {'stackIndex': this.stackIndex_}));
+        return Promise.resolve(curState);
+      }
+
+      // replace fragment, only explicit fragment param will be sent.
       const url = opt_stateUpdate.url.replace(/#.*/, '');
       opt_stateUpdate.url = url;
     }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -918,7 +918,7 @@ export class HistoryBindingVirtual_ {
 
     if (opt_stateUpdate && opt_stateUpdate.url) {
       // replace fragment, only explicit fragment param will be sent
-      const url = (opt_stateUpdate.url || '').replace(/#.*/, '');
+      const url = opt_stateUpdate.url.replace(/#.*/, '');
       opt_stateUpdate.url = url;
     }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -915,6 +915,13 @@ export class HistoryBindingVirtual_ {
           {'stackIndex': this.stackIndex_}));
       return Promise.resolve(curState);
     }
+
+    if (opt_stateUpdate && opt_stateUpdate.url) {
+      // replace fragment, only explicit fragment param will be sent
+      const url = (opt_stateUpdate.url || '').replace(/#.*/, '');
+      opt_stateUpdate.url = url;
+    }
+
     const message = /** @type {!JsonObject} */ (
       Object.assign({'stackIndex': this.stackIndex_}, opt_stateUpdate || {})
     );

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -691,19 +691,23 @@ describes.sandboxed('HistoryBindingVirtual', {}, env => {
       capabilityStub.withArgs('fullReplaceHistory').returns(true);
       viewer.sendMessageAwaitResponse
           .withArgs('replaceHistory',
-              {stackIndex: 123, title: 'title', url: '/page'})
+              {stackIndex: 123, title: 'title', url: '/page', fragment: 'fr2'})
           .returns(Promise.resolve(
-              {stackIndex: 123, title: 'different', url: '/otherpage'}));
+              {stackIndex: 123, title: 'different',
+                url: '/otherpage', fragment: 'fr2'}));
 
       return history.replace(
-          {stackIndex: 123, title: 'title', url: '/page'}).then(state => {
-        expect(state).to.deep.equal(
-            {stackIndex: 123, title: 'different', url: '/otherpage'});
+          {stackIndex: 123, title: 'title', url: '/page#fr1', fragment: 'fr2'})
+          .then(state => {
+            expect(state).to.deep.equal(
+                {fragment: 'fr2', stackIndex: 123, title: 'different',
+                  url: '/otherpage'});
 
-        expect(onStateUpdated).to.be.calledOnce;
-        expect(onStateUpdated).to.be.calledWithMatch(
-            {stackIndex: 123, title: 'different', url: '/otherpage'});
-      });
+            expect(onStateUpdated).to.be.calledOnce;
+            expect(onStateUpdated).to.be.calledWithMatch(
+                {fragment: 'fr2', stackIndex: 123, title: 'different',
+                  url: '/otherpage'});
+          });
     });
 
     it('does not support full URL replacement', () => {


### PR DESCRIPTION
The non-viewer version of the fullHistoryReplace API already drops any fragments in the `url` param ( gets replace by the explicit `fragment` param if provided ).

The Viewer version was not doing that.

/cc @brandondiamond @peterjosling 
/to @choumx 