### PR TITLE
🐛♻️✅ Relax document type restrictions for auto-lightbox

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -56,7 +56,8 @@ export const ENABLED_LD_JSON_TYPES = {
 };
 
 /**
- * Types of document by Open Graph `<meta property="og:type">`
+ * Types of document by Open Graph `<meta property="og:type">` where
+ * auto-lightbox should be enabled.
  * @private @const {!Object<string, boolean>}
  */
 export const ENABLED_OG_TYPES = {

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -45,7 +45,7 @@ export const VISITED_ATTR = 'i-amphtml-auto-lightbox-visited';
 /**
  * Types of document by LD+JSON schema `@type` field where auto-lightbox should
  * be enabled.
- * @private @const {!Object<string, boolean>}
+ * @private @const {!Object<string|undefined, boolean>}
  */
 export const ENABLED_LD_JSON_TYPES = {
   'Article': true,
@@ -58,7 +58,7 @@ export const ENABLED_LD_JSON_TYPES = {
 /**
  * Types of document by Open Graph `<meta property="og:type">` where
  * auto-lightbox should be enabled.
- * @private @const {!Object<string, boolean>}
+ * @private @const {!Object<string|undefined, boolean>}
  */
 export const ENABLED_OG_TYPES = {
   'article': true,
@@ -255,7 +255,7 @@ export class DocMetaAnnotations {
    * Determines wheter the document type as defined by Open Graph meta tag
    * e.g. `<meta property="og:type">` is in a given set.
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!Object<string, boolean>} types
+   * @param {!Object<string|undefined, boolean>} types
    * @return {boolean}
    */
   static isOgTypeInSet(ampdoc, types) {
@@ -276,7 +276,7 @@ export class DocMetaAnnotations {
    * Determines wheter one of the document types (field `@type`) defined in
    * LD+JSON schema is in a given set.
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!Object<string, boolean>} types
+   * @param {!Object<string|undefined, boolean>} types
    * @return {boolean}
    */
   static isLdJsonTypeInSet(ampdoc, types) {
@@ -452,7 +452,7 @@ export function scan(ampdoc, opt_root) {
 AMP.extension(TAG, '0.1', ({ampdoc}) => {
   ampdoc.whenReady().then(() => {
     getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
-      scan(ampdoc, target);
+      scan(ampdoc, dev().assertElement(target));
     });
     scan(ampdoc);
   });

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -234,10 +234,11 @@ export class Scanner {
 
 
 /**
- * Parses document schema defined as ld+json.
+ * Parses document metadata annotations as defined by either LD+JSON schema or
+ * Open Graph <meta> tags.
  * @visibleForTesting
  */
-export class Schema {
+export class DocMetaAnnotations {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
@@ -258,7 +259,7 @@ export class Schema {
    * @return {boolean}
    */
   static isOgTypeInSet(ampdoc, types) {
-    return types[Schema.getOgType(ampdoc)];
+    return types[DocMetaAnnotations.getOgType(ampdoc)];
   }
 
   /**
@@ -279,7 +280,8 @@ export class Schema {
    * @return {boolean}
    */
   static isLdJsonTypeInSet(ampdoc, types) {
-    return Schema.getAllLdJsonTypes(ampdoc).some(type => types[type]);
+    return DocMetaAnnotations.getAllLdJsonTypes(ampdoc)
+        .some(type => types[type]);
   }
 }
 
@@ -368,8 +370,8 @@ export function resolveIsEnabledForDoc(ampdoc, candidates) {
   if (usesLightboxExplicitly(ampdoc)) {
     return resolveFalse();
   }
-  if (!Schema.isLdJsonTypeInSet(ampdoc, ENABLED_LD_JSON_TYPES) &&
-      !Schema.isOgTypeInSet(ampdoc, ENABLED_OG_TYPES)) {
+  if (!DocMetaAnnotations.isLdJsonTypeInSet(ampdoc, ENABLED_LD_JSON_TYPES) &&
+      !DocMetaAnnotations.isOgTypeInSet(ampdoc, ENABLED_OG_TYPES)) {
     return resolveFalse();
   }
   return isEmbeddedAndTrusted(ampdoc, candidates);

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -43,15 +43,24 @@ export const LIGHTBOXABLE_ATTR = 'lightbox';
 export const VISITED_ATTR = 'i-amphtml-auto-lightbox-visited';
 
 /**
- * Types of document by schema where auto-lightbox is enabled.
+ * Types of document by LD+JSON schema `@type` field where auto-lightbox should
+ * be enabled.
  * @private @const {!Object<string, boolean>}
  */
-export const ENABLED_SCHEMA_TYPES = {
+export const ENABLED_LD_JSON_TYPES = {
   'Article': true,
   'NewsArticle': true,
   'BlogPosting': true,
   'LiveBlogPosting': true,
   'DiscussionForumPosting': true,
+};
+
+/**
+ * Types of document by Open Graph `<meta property="og:type">`
+ * @private @const {!Object<string, boolean>}
+ */
+export const ENABLED_OG_TYPES = {
+  'article': true,
 };
 
 /** Factor of naturalArea vs renderArea to lightbox. */
@@ -87,7 +96,17 @@ const DISABLED_ANCESTORS =
 
 const GOOGLE_DOMAIN_RE = /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)$/;
 
+const SCRIPT_LD_JSON = 'script[type="application/ld+json"]';
+const META_OG_TYPE = 'meta[property="og:type"]';
+
 const NOOP = () => {};
+
+/**
+ * For better minification.
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {!Document|!ShadowRoot}
+ */
+const getRootNode = ampdoc => ampdoc.getRootNode();
 
 
 /** @visibleForTesting */
@@ -220,31 +239,46 @@ export class Scanner {
 export class Schema {
 
   /**
-   * Gets document type (field `@type`) where schema is defined for the
-   * canonical URL.
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @return {string|undefined}
    */
-  static getDocumentType(ampdoc) {
-    const schemaTags = ampdoc.getRootNode().querySelectorAll(
-        'script[type="application/ld+json"]');
-
-    if (schemaTags.length <= 0) {
-      return;
+  static getOgType(ampdoc) {
+    const tag = getRootNode(ampdoc).querySelector(META_OG_TYPE);
+    if (tag) {
+      return tag.getAttribute('content');
     }
+  }
 
-    const {canonicalUrl} = Services.documentInfoForDoc(ampdoc);
+  /**
+   * Determines wheter the document type as defined by Open Graph meta tag
+   * e.g. `<meta property="og:type">` is in a given set.
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Object<string, boolean>} types
+   * @return {boolean}
+   */
+  static isOgTypeInSet(ampdoc, types) {
+    return types[Schema.getOgType(ampdoc)];
+  }
 
-    for (let i = 0; i < schemaTags.length; i++) {
-      const schemaTag = schemaTags[i];
-      const parsed = tryParseJson(schemaTag./*OK*/innerText);
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @return {!Array<string>}
+   */
+  static getAllLdJsonTypes(ampdoc) {
+    return toArray(getRootNode(ampdoc).querySelectorAll(SCRIPT_LD_JSON))
+        .map(({textContent}) => ((tryParseJson(textContent) || {})['@type']))
+        .filter(typeOrUndefined => typeOrUndefined);
+  }
 
-      if (parsed &&
-          (parsed['mainEntityOfPage'] == canonicalUrl ||
-          parsed['url'] == canonicalUrl)) {
-        return parsed['@type'];
-      }
-    }
+  /**
+   * Determines wheter one of the document types (field `@type`) defined in
+   * LD+JSON schema is in a given set.
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Object<string, boolean>} types
+   * @return {boolean}
+   */
+  static isLdJsonTypeInSet(ampdoc, types) {
+    return Schema.getAllLdJsonTypes(ampdoc).some(type => types[type]);
   }
 }
 
@@ -280,11 +314,10 @@ function usesLightboxExplicitly(ampdoc) {
   const lightboxedElementsSelector =
       `[${LIGHTBOXABLE_ATTR}]:not([${VISITED_ATTR}])`;
 
-  const querySelector = selector =>
-    ampdoc.getRootNode().querySelector(selector);
+  const exists = selector => !!getRootNode(ampdoc).querySelector(selector);
 
-  return !!querySelector(requiredExtensionSelector) &&
-    !!querySelector(lightboxedElementsSelector);
+  return exists(requiredExtensionSelector) &&
+      exists(lightboxedElementsSelector);
 }
 
 
@@ -334,8 +367,8 @@ export function resolveIsEnabledForDoc(ampdoc, candidates) {
   if (usesLightboxExplicitly(ampdoc)) {
     return resolveFalse();
   }
-  const docType = Schema.getDocumentType(ampdoc);
-  if (!docType || !ENABLED_SCHEMA_TYPES[docType]) {
+  if (!Schema.isLdJsonTypeInSet(ampdoc, ENABLED_LD_JSON_TYPES) &&
+      !Schema.isOgTypeInSet(ampdoc, ENABLED_OG_TYPES)) {
     return resolveFalse();
   }
   return isEmbeddedAndTrusted(ampdoc, candidates);
@@ -415,7 +448,7 @@ export function scan(ampdoc, opt_root) {
 
 AMP.extension(TAG, '0.1', ({ampdoc}) => {
   ampdoc.whenReady().then(() => {
-    ampdoc.getRootNode().addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
+    getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
       scan(ampdoc, target);
     });
     scan(ampdoc);

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -18,7 +18,8 @@ import {AutoLightboxEvents} from '../../../../src/auto-lightbox';
 import {CommonSignals} from '../../../../src/common-signals';
 import {
   Criteria,
-  ENABLED_SCHEMA_TYPES,
+  ENABLED_LD_JSON_TYPES,
+  ENABLED_OG_TYPES,
   LIGHTBOXABLE_ATTR,
   Mutation,
   RENDER_AREA_RATIO,
@@ -36,6 +37,7 @@ import {Services} from '../../../../src/services';
 import {Signals} from '../../../../src/utils/signals';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {htmlFor} from '../../../../src/static-template';
+import {isArray} from '../../../../src/types';
 import {parseUrlDeprecated} from '../../../../src/url';
 import {tryResolve} from '../../../../src/utils/promise';
 
@@ -54,7 +56,8 @@ describes.realWin(TAG, {
 
   const {any} = sinon.match;
 
-  const schemaTypes = Object.keys(ENABLED_SCHEMA_TYPES);
+  const ldJsonSchemaTypes = Object.keys(ENABLED_LD_JSON_TYPES);
+  const ogTypes = Object.keys(ENABLED_OG_TYPES);
 
   const firstElementLeaf = el =>
     el.firstElementChild ? firstElementLeaf(el.firstElementChild) : el;
@@ -72,8 +75,12 @@ describes.realWin(TAG, {
     return candidates;
   }
 
-  const mockSchemaType = type =>
-    env.sandbox.stub(Schema, 'getDocumentType').returns(type);
+  const mockLdJsonSchemaTypes = type =>
+    env.sandbox.stub(Schema, 'getAllLdJsonTypes')
+        .returns(isArray(type) ? type : [type]);
+
+  const mockOgType = type =>
+    env.sandbox.stub(Schema, 'getOgType').returns(type);
 
   const iterProduct = (a, b, callback) => a.forEach(itemA =>
     b.forEach(itemB => callback(itemA, itemB)));
@@ -374,7 +381,8 @@ describes.realWin(TAG, {
       scan(env.ampdoc).then(scanned => scanned && Promise.all(scanned));
 
     beforeEach(() => {
-      mockSchemaType(schemaTypes[0]);
+      // mock valid type
+      mockLdJsonSchemaTypes(ldJsonSchemaTypes[0]);
     });
 
     it('does not load extension if no candidates found', function* () {
@@ -487,61 +495,191 @@ describes.realWin(TAG, {
         expect(actuallyEnabled).to.equal(shouldBeEnabled);
       });
 
-    it('rejects documents without schema', () => {
+    it('rejects documents without any type annotation', () => {
       mockIsEmbeddedAndTrustedViewer(true);
       return expectIsEnabled(false);
     });
 
-    it('rejects schema with invalid @type', () => {
-      mockIsEmbeddedAndTrustedViewer(true);
-      mockSchemaType('hamberder');
-      return expectIsEnabled(false);
-    });
+    describe('DOM selection', () => {
 
-    schemaTypes.forEach(type => {
+      const mockRootNodeContent = els => {
+        const fakeRoot = html`<div></div>`;
+        els.forEach(el => {
+          fakeRoot.appendChild(el);
+        });
+        env.sandbox.stub(env.ampdoc, 'getRootNode').returns(fakeRoot);
+      };
 
-      it(`accepts schema with @type=${type}`, () => {
-        mockSchemaType(type);
-        mockIsEmbeddedAndTrustedViewer(true);
-        return expectIsEnabled(true);
-      });
+      describe('getOgType', () => {
 
-      it(`rejects schema with @type=${type} but lightbox explicit`, () => {
-        const doc = env.win.document;
-
-        const extensionScript = createElementWithAttributes(doc, 'script', {
-          'custom-element': REQUIRED_EXTENSION,
+        it('returns empty', () => {
+          expect(Schema.getOgType(env.ampdoc)).to.be.undefined;
         });
 
-        const lightboxable = createElementWithAttributes(doc, 'amp-img', {
-          [LIGHTBOXABLE_ATTR]: '',
+        it('returns tag', () => {
+          mockRootNodeContent([
+            // Expected:
+            html`<meta property="og:type" content="foo">`,
+
+            // Filler:
+            html`<meta property="og:something" content="bar">`,
+            html`<meta property="vims and emacs are both awful" content="baz">`,
+            html`<meta name="description" content="My Website">`,
+          ]);
+
+          expect(Schema.getOgType(env.ampdoc)).to.equal('foo');
         });
 
-        doc.head.appendChild(extensionScript);
-        doc.body.appendChild(lightboxable);
-
-        mockSchemaType(type);
-        mockIsEmbeddedAndTrustedViewer(true);
-        return expectIsEnabled(false);
       });
 
-      it(`rejects schema with @type=${type} for non-embedded docs`, () => {
-        mockSchemaType(type);
-        mockIsEmbeddedAndTrustedViewer(
-            /* isEmbedded */ false,
-            /* isTrusted */ true);
-        return expectIsEnabled(false);
-      });
+      describe('getAllLdJsonTypes', () => {
 
-      it(`rejects schema with @type=${type} for untrusted viewer`, () => {
-        mockSchemaType(type);
-        mockIsEmbeddedAndTrustedViewer(
-            /* isEmbedded */ true,
-            /* isTrusted */ false);
-        return expectIsEnabled(false);
+        const createLdJsonTag = content => {
+          const tag = html`<script type="application/ld+json"></script>`;
+          tag.textContent = JSON.stringify(content);
+          return tag;
+        };
+
+        it('returns empty', () => {
+          expect(Schema.getAllLdJsonTypes(env.ampdoc).length).to.equal(0);
+        });
+
+        it('returns all found @types', () => {
+          const expectedA = 'foo';
+          const expectedB = 'bar';
+          const expectedC = 'baz';
+
+          mockRootNodeContent([
+            createLdJsonTag({'@type': expectedA}),
+            createLdJsonTag({'tacos': 'sí por favor'}),
+            createLdJsonTag({'@type': expectedB}),
+            createLdJsonTag({'@type': expectedC}),
+            createLdJsonTag(''),
+          ]);
+
+          expect(Schema.getAllLdJsonTypes(env.ampdoc)).to.deep.equal([
+            expectedA,
+            expectedB,
+            expectedC,
+          ]);
+        });
+
       });
 
     });
+
+    describe('by LD+JSON @type', () => {
+
+      it('rejects doc with invalid LD+JSON @type', () => {
+        mockIsEmbeddedAndTrustedViewer(true);
+        mockLdJsonSchemaTypes('hamberder');
+        return expectIsEnabled(false);
+      });
+
+      ldJsonSchemaTypes.forEach(type => {
+
+        it(`accepts schema with @type=${type}`, () => {
+          mockLdJsonSchemaTypes(type);
+          mockIsEmbeddedAndTrustedViewer(true);
+          return expectIsEnabled(true);
+        });
+
+        it(`rejects schema with @type=${type} but lightbox explicit`, () => {
+          const doc = env.win.document;
+
+          const extensionScript = createElementWithAttributes(doc, 'script', {
+            'custom-element': REQUIRED_EXTENSION,
+          });
+
+          const lightboxable = createElementWithAttributes(doc, 'amp-img', {
+            [LIGHTBOXABLE_ATTR]: '',
+          });
+
+          doc.head.appendChild(extensionScript);
+          doc.body.appendChild(lightboxable);
+
+          mockLdJsonSchemaTypes(type);
+          mockIsEmbeddedAndTrustedViewer(true);
+          return expectIsEnabled(false);
+        });
+
+        it(`rejects schema with @type=${type} for non-embedded docs`, () => {
+          mockLdJsonSchemaTypes(type);
+          mockIsEmbeddedAndTrustedViewer(
+              /* isEmbedded */ false,
+              /* isTrusted */ true);
+          return expectIsEnabled(false);
+        });
+
+        it(`rejects schema with @type=${type} for untrusted viewer`, () => {
+          mockLdJsonSchemaTypes(type);
+          mockIsEmbeddedAndTrustedViewer(
+              /* isEmbedded */ true,
+              /* isTrusted */ false);
+          return expectIsEnabled(false);
+        });
+
+      });
+    });
+
+    describe('by og:type', () => {
+
+      it('rejects doc with invalid <meta property="og:type">', () => {
+        mockIsEmbeddedAndTrustedViewer(true);
+        mockOgType('cinnamonroll');
+        return expectIsEnabled(false);
+      });
+
+      ogTypes.forEach(type => {
+
+        const ogTypeMeta = type =>
+          `<meta property="og:type" content="${type}">`;
+
+        it(`accepts docs with ${ogTypeMeta(type)}`, () => {
+          mockOgType(type);
+          mockIsEmbeddedAndTrustedViewer(true);
+          return expectIsEnabled(true);
+        });
+
+        it(`rejects docs with ${ogTypeMeta(type)}, lightbox explicit`, () => {
+          const doc = env.win.document;
+
+          const extensionScript = createElementWithAttributes(doc, 'script', {
+            'custom-element': REQUIRED_EXTENSION,
+          });
+
+          const lightboxable = createElementWithAttributes(doc, 'amp-img', {
+            [LIGHTBOXABLE_ATTR]: '',
+          });
+
+          doc.head.appendChild(extensionScript);
+          doc.body.appendChild(lightboxable);
+
+          mockOgType(type);
+          mockIsEmbeddedAndTrustedViewer(true);
+          return expectIsEnabled(false);
+        });
+
+        it(`rejects non-embedded docs with ${ogTypeMeta(type)}`, () => {
+          mockOgType(type);
+          mockIsEmbeddedAndTrustedViewer(
+              /* isEmbedded */ false,
+              /* isTrusted */ true);
+          return expectIsEnabled(false);
+        });
+
+        it(`rejects docs with ${ogTypeMeta(type)} for untrusted viewer`, () => {
+          mockOgType(type);
+          mockIsEmbeddedAndTrustedViewer(
+              /* isEmbedded */ true,
+              /* isTrusted */ false);
+          return expectIsEnabled(false);
+        });
+
+      });
+    });
+
+
 
   });
 

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -18,6 +18,7 @@ import {AutoLightboxEvents} from '../../../../src/auto-lightbox';
 import {CommonSignals} from '../../../../src/common-signals';
 import {
   Criteria,
+  DocMetaAnnotations,
   ENABLED_LD_JSON_TYPES,
   ENABLED_OG_TYPES,
   LIGHTBOXABLE_ATTR,
@@ -25,7 +26,6 @@ import {
   RENDER_AREA_RATIO,
   REQUIRED_EXTENSION,
   Scanner,
-  Schema,
   VIEWPORT_AREA_RATIO,
   apply,
   meetsSizingCriteria,
@@ -76,11 +76,11 @@ describes.realWin(TAG, {
   }
 
   const mockLdJsonSchemaTypes = type =>
-    env.sandbox.stub(Schema, 'getAllLdJsonTypes')
+    env.sandbox.stub(DocMetaAnnotations, 'getAllLdJsonTypes')
         .returns(isArray(type) ? type : [type]);
 
   const mockOgType = type =>
-    env.sandbox.stub(Schema, 'getOgType').returns(type);
+    env.sandbox.stub(DocMetaAnnotations, 'getOgType').returns(type);
 
   const iterProduct = (a, b, callback) => a.forEach(itemA =>
     b.forEach(itemB => callback(itemA, itemB)));
@@ -513,7 +513,7 @@ describes.realWin(TAG, {
       describe('getOgType', () => {
 
         it('returns empty', () => {
-          expect(Schema.getOgType(env.ampdoc)).to.be.undefined;
+          expect(DocMetaAnnotations.getOgType(env.ampdoc)).to.be.undefined;
         });
 
         it('returns tag', () => {
@@ -527,7 +527,7 @@ describes.realWin(TAG, {
             html`<meta name="description" content="My Website">`,
           ]);
 
-          expect(Schema.getOgType(env.ampdoc)).to.equal('foo');
+          expect(DocMetaAnnotations.getOgType(env.ampdoc)).to.equal('foo');
         });
 
       });
@@ -541,7 +541,8 @@ describes.realWin(TAG, {
         };
 
         it('returns empty', () => {
-          expect(Schema.getAllLdJsonTypes(env.ampdoc).length).to.equal(0);
+          expect(DocMetaAnnotations.getAllLdJsonTypes(env.ampdoc).length)
+              .to.equal(0);
         });
 
         it('returns all found @types', () => {
@@ -550,6 +551,7 @@ describes.realWin(TAG, {
           const expectedC = 'baz';
 
           mockRootNodeContent([
+            html`<script></script>`,
             createLdJsonTag({'@type': expectedA}),
             createLdJsonTag({'tacos': 'sí por favor'}),
             createLdJsonTag({'@type': expectedB}),
@@ -557,11 +559,12 @@ describes.realWin(TAG, {
             createLdJsonTag(''),
           ]);
 
-          expect(Schema.getAllLdJsonTypes(env.ampdoc)).to.deep.equal([
-            expectedA,
-            expectedB,
-            expectedC,
-          ]);
+          expect(DocMetaAnnotations.getAllLdJsonTypes(env.ampdoc))
+              .to.deep.equal([
+                expectedA,
+                expectedB,
+                expectedC,
+              ]);
         });
 
       });

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -682,8 +682,6 @@ describes.realWin(TAG, {
       });
     });
 
-
-
   });
 
   describe('apply', () => {


### PR DESCRIPTION
- Don't try to match LD+JSON schema URL from `mainEntityOfPage` or `url`. These fields are not present in common scenarios where Google SERP and others would parse otherwise.

- Match by Open Graph `og:type` when `article`, as it's present in almost every single document that may have malformed LD+JSON schema.

- Add a couple missing tests.

- Restructure for testing DOM-selection of type-matching nodes.