### PR TITLE
🐛 amp-ad: Fixed URL handling order on uzou.js

### DIFF
--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -45,9 +45,9 @@ export function uzou(global, data) {
 
   const uzouInjector = {
     url: fixedEncodeURIComponent(
-        widgetParams['url'] ||
-      global.context.sourceUrl ||
-      global.context.canonicalUrl
+      widgetParams['url'] ||
+      global.context.canonicalUrl ||
+      global.context.sourceUrl
     ),
     referer: widgetParams['referer'] || global.context.referrer,
   };

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -45,7 +45,7 @@ export function uzou(global, data) {
 
   const uzouInjector = {
     url: fixedEncodeURIComponent(
-      widgetParams['url'] ||
+        widgetParams['url'] ||
       global.context.canonicalUrl ||
       global.context.sourceUrl
     ),


### PR DESCRIPTION
We have fixed URL handling order for our ad network.

* Use `canonicalUrl` instead of `sourceUrl`

Could you review our commits?