### PR TITLE
[amp-story] Animation for expandable components

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -75,6 +75,14 @@ export const EXPANDABLE_COMPONENTS = {
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
     selector: 'amp-twitter',
   },
+  'amp-youtube': {
+    actionIcon: ActionIcon.EXPAND,
+    selector: 'amp-youtube',
+  },
+  'amp-instagram': {
+    actionIcon: ActionIcon.EXPAND,
+    selector: 'amp-instagram',
+  },
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -149,6 +149,19 @@ let embedIds = 0;
 const AMP_EMBED_DATA = '__AMP_EMBED_DATA__';
 
 /**
+ * @typedef {{
+ *  id: number,
+ *  width: number,
+ *  height: number,
+ *  scaleFactor: number,
+ *  transform: string,
+ *  verticalMargin: number,
+ *  horizontalMargin: number,
+ * }}
+ */
+let EmbedDataDef;
+
+/**
  * @const {string}
  */
 export const EMBED_ID_ATTRIBUTE_NAME = 'i-amphtml-embed-id';
@@ -168,7 +181,7 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
 /**
  * Updates embed's corresponding <style> element with embedData.
  * @param {!Element} embedStyleEl
- * @param {!Object} embedData
+ * @param {!EmbedDataDef} embedData
  */
 function updateEmbedStyleEl(embedStyleEl, embedData) {
   const embedId = embedData.id;
@@ -603,11 +616,9 @@ export class AmpStoryEmbeddedComponent {
     const embedStyleEl = dev().assertElement(embedStyleEls[embedId],
         `Failed to look up embed style element with ID ${embedId}`);
 
-    const dataForExitExpandedMode = Object.assign({},
-        embedStyleEl[AMP_EMBED_DATA],
-        {transform: `scale(${embedStyleEl[AMP_EMBED_DATA].scaleFactor})`}
-    );
-    updateEmbedStyleEl(embedStyleEl, dataForExitExpandedMode);
+    embedStyleEl[AMP_EMBED_DATA].transform =
+      `scale(${embedStyleEl[AMP_EMBED_DATA].scaleFactor})`;
+    updateEmbedStyleEl(embedStyleEl, embedStyleEl[AMP_EMBED_DATA]);
   }
 
   /**
@@ -653,11 +664,10 @@ export class AmpStoryEmbeddedComponent {
         () => {
           target.classList.toggle('i-amphtml-expanded-component', true);
 
-          const dataForExpandedMode = Object.assign({}, embedData, {
-            transform: `translate3d(${state.translateX}px,
-              ${state.translateY}px, 0) scale(1)`,
-          });
-          updateEmbedStyleEl(embedStyleEl, dataForExpandedMode);
+          embedData.transform = `translate3d(${state.translateX}px,
+            ${state.translateY}px, 0) scale(1)`;
+
+          updateEmbedStyleEl(embedStyleEl, embedData);
         });
   }
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -178,7 +178,7 @@ function updateEmbedStyleEl(embedStyleEl, embedData, expanding) {
       width: ${px(embedData.width)} !important;
       height: ${px(embedData.height)} !important;
       transform: ${expanding ? 'translate3d(' + embedData.translateX + 'px, ' +
-        embedData.translateY + ' px, 0)' : ''}
+        embedData.translateY + 'px, 0)' : ''}
         scale(${embedData.scale}) !important;
       margin: ${embedData.verticalMargin}px ${embedData.horizontalMargin}px
           !important;

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -165,7 +165,6 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
       </span>
     </div>`;
 
-
 /**
  * Updates embed's corresponding <style> element with embedData.
  * @param {!Element} embedStyleEl

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -75,14 +75,6 @@ export const EXPANDABLE_COMPONENTS = {
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
     selector: 'amp-twitter',
   },
-  'amp-youtube': {
-    actionIcon: ActionIcon.EXPAND,
-    selector: 'amp-youtube',
-  },
-  'amp-instagram': {
-    actionIcon: ActionIcon.EXPAND,
-    selector: 'amp-instagram',
-  },
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -151,11 +151,13 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
 const MIN_VERTICAL_SPACE = 48;
 
 /**
- * Limits the amount of vertical space a component can take in a page.
+ * Limits the amount of vertical space a component can take in a page, this
+ * makes sure no component is blocking the close button at the top of the
+ * expanded view.
  * @const {number}
  * @private
  */
-const VERTICAL_MAX_HEIGHT_PERCENTAGE = 0.8;
+const VERTICAL_PADDING = 96;
 
 /**
  * Padding between tooltip and vertical edges of screen.
@@ -617,16 +619,16 @@ export class AmpStoryEmbeddedComponent {
    * preparation for its animation. It resizes it to its full-screen size, and
    * scales it down to match size set by publisher, adding negative margins so
    * that content around stays put.
-   * @param {!Element} page
+   * @param {!Element} pageEl
    * @param {!Element} element
    * @param {!../../../src/service/resources-impl.Resources} resources
    */
-  static prepareForAnimation(page, element, resources) {
+  static prepareForAnimation(pageEl, element, resources) {
     const state = {};
     resources.measureMutateElement(element,
         /** measure */
         () => {
-          const pageRect = page./*OK*/getBoundingClientRect();
+          const pageRect = pageEl./*OK*/getBoundingClientRect();
           const elRect = element./*OK*/getBoundingClientRect();
 
           if (elRect.width >= elRect.height) {
@@ -634,7 +636,7 @@ export class AmpStoryEmbeddedComponent {
             state.scaleFactor = elRect.width / state.newWidth;
             state.newHeight = elRect.height / elRect.width * state.newWidth;
           } else {
-            const maxHeight = pageRect.height * VERTICAL_MAX_HEIGHT_PERCENTAGE;
+            const maxHeight = pageRect.height - VERTICAL_PADDING;
             state.newWidth = Math.min(
                 elRect.width / elRect.height * maxHeight, pageRect.width);
             state.newHeight = elRect.height / elRect.width * state.newWidth;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -31,6 +31,10 @@ import {
 } from './amp-story-store-service';
 import {AdvancementConfig} from './page-advancement';
 import {
+  AmpStoryEmbeddedComponent,
+  EXPANDABLE_COMPONENTS,
+} from './amp-story-embedded-component';
+import {
   AnimationManager,
   hasAnimations,
 } from './animation';
@@ -89,6 +93,8 @@ const Selectors = {
       'amp-story-grid-layer video',
   ALL_VIDEO: 'amp-story-grid-layer video',
 };
+
+const EMBEDDED_COMPONENTS_SELECTORS = Object.keys(EXPANDABLE_COMPONENTS);
 
 /** @private @const {string} */
 const TAG = 'amp-story-page';
@@ -351,6 +357,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (this.isActive()) {
       this.advancement_.start();
       this.maybeStartAnimations();
+      this.findAndPrepareEmbeddedComponents();
       this.checkPageHasAudio_();
       this.renderOpenAttachmentUI_();
       this.preloadAllMedia_()
@@ -416,6 +423,18 @@ export class AmpStoryPage extends AMP.BaseElement {
     });
 
     return Promise.all(mediaPromises);
+  }
+
+  /**
+   * Finds embedded compoennts in page and prepares them for their expanded view
+   * animation.
+   */
+  findAndPrepareEmbeddedComponents() {
+    EMBEDDED_COMPONENTS_SELECTORS.forEach(selector => {
+      scopedQuerySelectorAll(this.element, selector).forEach(el => {
+        AmpStoryEmbeddedComponent.prepareForAnimation(this.element, el);
+      });
+    });
   }
 
   /** @return {!Promise} */

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -426,7 +426,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Finds embedded compoennts in page and prepares them for their expanded view
+   * Finds embedded components in page and prepares them for their expanded view
    * animation.
    */
   findAndPrepareEmbeddedComponents() {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -170,7 +170,7 @@ export const NavigationDirection = {
 function debounceEmbedResize(win, page, resources) {
   return debounce(win, (el, unlisten) => {
     AmpStoryEmbeddedComponent
-        .prepareForAnimation(page, /** @type {!Element} */ (el), resources);
+        .prepareForAnimation(page, dev().assertElement(el), resources);
     if (unlisten) {
       unlisten();
     }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -33,8 +33,8 @@ import {AdvancementConfig} from './page-advancement';
 import {AmpEvents} from '../../../src/amp-events';
 import {
   AmpStoryEmbeddedComponent,
-  EXPANDABLE_COMPONENTS,
   EMBED_ID_ATTRIBUTE_NAME,
+  EXPANDABLE_COMPONENTS,
 } from './amp-story-embedded-component';
 import {
   AnimationManager,
@@ -169,7 +169,8 @@ export const NavigationDirection = {
  */
 function debounceEmbedResize(win, page, resources) {
   return debounce(win, (el, unlisten) => {
-    AmpStoryEmbeddedComponent.prepareForAnimation(page, el, resources);
+    AmpStoryEmbeddedComponent
+        .prepareForAnimation(page, /** @type {!Element} */ (el), resources);
     if (unlisten) {
       unlisten();
     }
@@ -415,7 +416,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   onResize_() {
-    this.findAndPrepareEmbeddedComponents_(true /* opt_forceResize */);
+    this.findAndPrepareEmbeddedComponents_(true /* forceResize */);
   }
 
   /** @return {!Promise} */
@@ -466,23 +467,23 @@ export class AmpStoryPage extends AMP.BaseElement {
   /**
    * Finds embedded components in page and prepares them for their expanded view
    * animation.
-   * @param {boolean} opt_forceResize
+   * @param {boolean=} forceResize
    * @private
    */
-  findAndPrepareEmbeddedComponents_(opt_forceResize = false) {
+  findAndPrepareEmbeddedComponents_(forceResize = false) {
     scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
         .forEach(el => {
           const debouncePrepareForAnimation =
             debounceEmbedResize(this.win, this.element, this.resources_);
 
-          if (opt_forceResize) {
-            debouncePrepareForAnimation(el, null);
+          if (forceResize) {
+            debouncePrepareForAnimation(el, null /* unlisten */);
           } else if (!el.hasAttribute(EMBED_ID_ATTRIBUTE_NAME)) { // Element has not been prepared for its animation yet.
             const unlisten = listen(el, AmpEvents.SIZE_CHANGED, () => {
               debouncePrepareForAnimation(el, unlisten);
             });
             // Run in case target never changes size.
-            debouncePrepareForAnimation(el, null);
+            debouncePrepareForAnimation(el, null /* unlisten */);
           }
         });
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -34,6 +34,7 @@ import {AmpEvents} from '../../../src/amp-events';
 import {
   AmpStoryEmbeddedComponent,
   EXPANDABLE_COMPONENTS,
+  EMBED_ID_ATTRIBUTE_NAME,
 } from './amp-story-embedded-component';
 import {
   AnimationManager,
@@ -414,7 +415,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   onResize_() {
-    this.findAndPrepareEmbeddedComponents_(true);
+    this.findAndPrepareEmbeddedComponents_(true /* opt_forceResize */);
   }
 
   /** @return {!Promise} */
@@ -465,23 +466,23 @@ export class AmpStoryPage extends AMP.BaseElement {
   /**
    * Finds embedded components in page and prepares them for their expanded view
    * animation.
-   * @param {boolean} forceResize
+   * @param {boolean} opt_forceResize
    * @private
    */
-  findAndPrepareEmbeddedComponents_(forceResize = false) {
+  findAndPrepareEmbeddedComponents_(opt_forceResize = false) {
     scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
         .forEach(el => {
           const debouncePrepareForAnimation =
             debounceEmbedResize(this.win, this.element, this.resources_);
 
-          if (forceResize) {
-            debouncePrepareForAnimation(el);
-          } else if (!el.id) { // Element has not been prepared for its animation yet.
+          if (opt_forceResize) {
+            debouncePrepareForAnimation(el, null);
+          } else if (!el.hasAttribute(EMBED_ID_ATTRIBUTE_NAME)) { // Element has not been prepared for its animation yet.
             const unlisten = listen(el, AmpEvents.SIZE_CHANGED, () => {
               debouncePrepareForAnimation(el, unlisten);
             });
             // Run in case target never changes size.
-            debouncePrepareForAnimation(el);
+            debouncePrepareForAnimation(el, null);
           }
         });
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -448,6 +448,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
         .forEach(el => {
           if (!el.classList.contains('i-amphtml-embedded-component')) {
+            // Since the element might be doing multiple resizes at the
+            // beginning, we have to wait some time to make sure we get the
+            // final size before we do the calculations for the animation.
             let readyForResize = true;
             listen(el, AmpEvents.SIZE_CHANGED, () => {
               readyForResize = false;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -755,10 +755,10 @@ amp-story .amp-video-eq,
   position: absolute !important;
   top: 0 !important;
   left: 0 !important;
-  margin: 8px !important;
+  margin: 12px !important;
   height: 24px !important;
   width: 24px !important;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(255, 255, 255, 0.7)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(255, 255, 255, 0.8)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
   cursor: pointer !important;
   text-align: center !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -332,7 +332,7 @@ amp-story-grid-layer a * {
 }
 
 /** Apply click shield on embedded components on initial load. */
-amp-story-grid-layer amp-twitter::after {
+amp-story-grid-layer .i-amphtml-embedded-component::after {
   content: "" !important;
   position: absolute !important;
   height: 100% !important;
@@ -341,7 +341,7 @@ amp-story-grid-layer amp-twitter::after {
   left: 0 !important;
 }
 
-.i-amphtml-expanded-mode amp-twitter::after {
+.i-amphtml-expanded-mode .i-amphtml-embedded-component::after {
   height: 0px !important;
   width: 0px !important;
 }
@@ -352,7 +352,7 @@ amp-story-grid-layer amp-twitter::after {
   z-index: auto !important;
 }
 
-.i-amphtml-expanded-mode amp-twitter {
+.i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component {
   z-index: 1 !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -354,9 +354,6 @@ amp-story-grid-layer .i-amphtml-embedded-component::after {
 
 .i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component {
   z-index: 1 !important;
-}
-
-.i-amphtml-animate-expand-in {
   transition: transform 0.225s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 


### PR DESCRIPTION
#19213 #16522

When the page is ready and the component is laid out, it resizes the component so that it matches its full-screen size, and then scales it down and adds negative margin so it matches size and positioning set by publisher.

Temporary demo link: https://stamp-demo.firebaseapp.com/examples/amp-story/artezan/clickable-anchor.html