### PR TITLE
🐛Fix issues with animated expansion of accordion.

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -357,7 +357,7 @@ class AmpAccordion extends AMP.BaseElement {
             setStyles(sectionChild, {
               'position': '',
               'opacity': '',
-              'width': 'auto',
+              'width': '',
             });
           });
     }).then(() => {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -328,7 +328,7 @@ class AmpAccordion extends AMP.BaseElement {
     const sectionChild = section.children[1];
 
     return this.measureMutateElement(() => {
-      sectionWidth = section.offsetWidth;
+      sectionWidth = section./*OK*/offsetWidth;
     }, () => {
       // We set position and opacity to avoid a FOUC while measuring height.
       // We set the width for layouts where the height depends on the width.
@@ -394,7 +394,7 @@ class AmpAccordion extends AMP.BaseElement {
     let sectionHeight;
     let headerHeight;
     let duration;
-    const sectionHeader = section.children[0];
+    const sectionHeader = section.firstElementChild;
 
     return this.measureMutateElement(() => {
       sectionHeight = section./*OK*/offsetHeight;

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -321,14 +321,20 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   animateExpand_(section) {
-    let height, duration;
-    // Expand the div portion of the section and not the header
+    let sectionWidth;
+    let headerHeight;
+    let contentHeight;
+    let duration;
     const sectionChild = section.children[1];
 
-    return this.mutateElement(() => {
-      // We set position and opacity to avoid a FOUC while measuring height
+    return this.measureMutateElement(() => {
+      sectionWidth = section.offsetWidth;
+    }, () => {
+      // We set position and opacity to avoid a FOUC while measuring height.
+      // We set the width for layouts where the height depends on the width.
       setImportantStyles(sectionChild, {
         'position': 'fixed',
+        'width': `${sectionWidth}px`,
         'opacity': '0',
       });
       if (!section.hasAttribute('expanded')) {
@@ -338,31 +344,44 @@ class AmpAccordion extends AMP.BaseElement {
     }).then(() => {
       return this.measureMutateElement(
           () => {
-            height = sectionChild./*OK*/offsetHeight;
+            headerHeight = section./*OK*/offsetHeight;
+            contentHeight = sectionChild./*OK*/offsetHeight;
             const viewportHeight = this.getViewport().getHeight();
-            duration = this.getTransitionDuration_(Math.abs(height),
+            duration = this.getTransitionDuration_(Math.abs(contentHeight),
                 viewportHeight);
           },
           () => {
+            setStyles(section, {
+              'overflow': 'hidden',
+            });
             setStyles(sectionChild, {
               'position': '',
               'opacity': '',
-              'height': 0,
+              'width': 'auto',
             });
           });
     }).then(() => {
-      return Animation.animate(this.element, setStylesTransition(sectionChild, {
-        'height': px(numeric(0, height)),
+      const animation = new Animation(this.element);
+      animation.setCurve(EXPAND_CURVE_);
+      // We expand the whole section to make sure we do not effect the size of
+      // the content.
+      animation.add(0, setStylesTransition(section, {
+        'height': px(numeric(headerHeight, headerHeight + contentHeight)),
+      }), 1);
+      animation.add(0, setStylesTransition(sectionChild, {
         'opacity': numeric(0,1),
-      }), duration, EXPAND_CURVE_)
-          .thenAlways(() => {
-            this.mutateElement(() => {
-              setStyles(sectionChild, {
-                height: '',
-                opacity: '',
-              });
-            });
+      }), 1);
+      return animation.start(duration).thenAlways(() => {
+        this.mutateElement(() => {
+          setStyles(section, {
+            'overflow': '',
+            'height': '',
           });
+          setStyles(sectionChild, {
+            'opacity': '',
+          });
+        });
+      });
     });
   }
 
@@ -372,25 +391,33 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   animateCollapse_(section) {
-    let height, duration;
-    // Collapse the div portion of the section and not the header
-    const sectionChild = section.children[1];
-    return this.measureElement(() => {
-      height = section./*OK*/offsetHeight;
+    let sectionHeight;
+    let headerHeight;
+    let duration;
+    const sectionHeader = section.children[0];
+
+    return this.measureMutateElement(() => {
+      sectionHeight = section./*OK*/offsetHeight;
+      headerHeight = sectionHeader./*OK*/offsetHeight;
       const viewportHeight = this.getViewport().getSize().height;
-      duration = this.getTransitionDuration_(Math.abs(height),
+      duration = this.getTransitionDuration_(Math.abs(sectionHeight),
           viewportHeight);
+    }, () => {
+      setStyles(section, {
+        'overflow': 'hidden',
+      });
     }).then(() => {
-      return Animation.animate(sectionChild, setStylesTransition(sectionChild, {
-        'height': px(numeric(height, 0)),
+      return Animation.animate(section, setStylesTransition(section, {
+        'height': px(numeric(sectionHeight, headerHeight)),
       }), duration, COLLAPSE_CURVE_).thenAlways(() => {
         return this.mutateElement(() => {
           if (section.hasAttribute('expanded')) {
             this.triggerEvent_('collapse', section);
             section.removeAttribute('expanded');
           }
-          setStyles(sectionChild, {
-            height: '',
+          setStyles(section, {
+            'height': '',
+            'overflow': '',
           });
         });
       });

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -211,10 +211,10 @@ describes.realWin('amp-accordion', {
       impl.toggle_(impl.sections_[0], true);
       return poll('wait for first section to expand',
           () => impl.sections_[0].hasAttribute('expanded'));
-    })
-        .then(() => {
-          expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
-        });
+    }).then(() => {
+      return poll('wait for second section to expand',
+          () => impl.sections_[2].hasAttribute('expanded'));
+    });
   });
 
   it('should trigger a section\'s collapse event the section is expanded ' +
@@ -230,10 +230,10 @@ describes.realWin('amp-accordion', {
       impl.toggle_(impl.sections_[1], false);
       return poll('wait for first section to expand',
           () => !impl.sections_[1].hasAttribute('expanded'));
-    })
-        .then(() => {
-          expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
-        });
+    }).then(() => {
+      return poll('wait for second section to expand',
+          () => impl.sections_[2].hasAttribute('expanded'));
+    });
   });
 
   it('should stay expanded on the expand action when expanded',


### PR DESCRIPTION
- Animate the height of a section rather than the content.
  * This makes sure the content is not resized, which can cause
  squishing/stretching for images. It can also cause layout callbacks
  to occur for AMP elements.
- Set a width when measuring the section content, to allow the accordion
to get the correct height for layout="responsive" content.

Fixes #20272