### PR TITLE
Revert "Enables layers in canary"

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -45,7 +45,7 @@
   "no-initial-intersection": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
-  "layers": 1,
+  "layers": 0,
   "linker-form": 1,
   "scroll-height-bounce": 0,
   "scroll-height-minheight": 0,


### PR DESCRIPTION
Reverts ampproject/amphtml#20512.

Precaution re: CSI regression in canary, and A4A team doesn't trust RC metrics yet.

> here's my hypothesis after talking to keith: viewport calculations are broken
this makes adsense more likely to send queries, because "three viewports" happens sooner
it makes doubleclick less likely to send queries, because the conditions for refresh depend on visibility and that is partly broken (I can run a query to test this but I haven't yet)
it lowers activeview rate for both (which we see)"

/to @erwinmombay /cc @jridgewell @kristoferbaxter @jeffkaufman 