### PR TITLE
🐛 Correctly scope query for multiple selectors in string

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -802,6 +802,12 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-bind/0.1/bind-expr-impl.js',
     ],
   },
+  'scopeSelectorForTesting': {
+    message: 'scopeSelector is not intended to be used outside of dom.js',
+    whitelist: [
+      'src/dom.js',
+    ],
+  },
   '[^.]loadPromise': {
     message: 'Most users should use BaseElement…loadPromise.',
     whitelist: [

--- a/src/dom.js
+++ b/src/dom.js
@@ -508,6 +508,8 @@ function scopeSelector(ancestorSelector, descendantSelector) {
       .join(',');
 }
 
+export const scopeSelectorForTesting = scopeSelector;
+
 /**
  * Finds all elements that matche `selector`, scoped inside `root`
  * for user-agents that do not support native scoping.

--- a/src/dom.js
+++ b/src/dom.js
@@ -492,14 +492,9 @@ export function childElementsByTag(parent, tagName) {
  *
  * e.g.
  * ```
- *   // returns '.i-amphtml-scoped div'
- *   scopeSelector('.i-amphtml-scoped', 'div');
- *
- *   // returns ':scope div, :scope ul'
- *   scopeSelector(':scope', 'div, ul');
- *
- *   // returns 'article > div, article > ul'
- *   scopeSelector('article >', 'div, ul');
+ *   scopeSelector('.i-amphtml-scoped', 'div'); // .i-amphtml-scoped div
+ *   scopeSelector(':scope', 'div, ul');        // :scope div, :scope ul
+ *   scopeSelector('article >', 'div, ul');     // article > div, article > ul
  * ```
  *
  * @param {string} ancestorSelector

--- a/src/dom.js
+++ b/src/dom.js
@@ -487,6 +487,33 @@ export function childElementsByTag(parent, tagName) {
 }
 
 /**
+ * Prefixes a selector for ancestor selection. Splits in subselectors and
+ * applies prefix to each.
+ *
+ * e.g.
+ * ```
+ *   // returns '.i-amphtml-scoped div'
+ *   scopeSelector('.i-amphtml-scoped', 'div');
+ *
+ *   // returns ':scope div, :scope ul'
+ *   scopeSelector(':scope', 'div, ul');
+ *
+ *   // returns 'article > div, article > ul'
+ *   scopeSelector('article >', 'div, ul');
+ * ```
+ *
+ * @param {string} ancestorSelector
+ * @param {string} descendantSelector
+ * @return {string}
+ */
+function scopeSelector(ancestorSelector, descendantSelector) {
+  return descendantSelector
+      .split(',')
+      .map(subSelector => `${ancestorSelector} ${subSelector}`)
+      .join(',');
+}
+
+/**
  * Finds all elements that matche `selector`, scoped inside `root`
  * for user-agents that do not support native scoping.
  *
@@ -499,9 +526,10 @@ export function childElementsByTag(parent, tagName) {
 function scopedQuerySelectionFallback(root, selector) {
   const unique = 'i-amphtml-scoped';
   root.classList.add(unique);
-  const element = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
+  const scopedSelector = scopeSelector(`.${unique}`, selector);
+  const elements = root./*OK*/querySelectorAll(scopedSelector);
   root.classList.remove(unique);
-  return element;
+  return elements;
 }
 
 /**
@@ -516,7 +544,7 @@ export function scopedQuerySelector(root, selector) {
     scopeSelectorSupported = isScopeSelectorSupported(root);
   }
   if (scopeSelectorSupported) {
-    return root./*OK*/querySelector(`:scope ${selector}`);
+    return root./*OK*/querySelector(scopeSelector(':scope', selector));
   }
 
   // Only IE.
@@ -536,7 +564,7 @@ export function scopedQuerySelectorAll(root, selector) {
     scopeSelectorSupported = isScopeSelectorSupported(root);
   }
   if (scopeSelectorSupported) {
-    return root./*OK*/querySelectorAll(`:scope ${selector}`);
+    return root./*OK*/querySelectorAll(scopeSelector(':scope', selector));
   }
 
   // Only IE.

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -34,6 +34,27 @@ describes.sandboxed('DOM', {}, env => {
     sandbox.restore();
   });
 
+  describe('scopeSelector', () => {
+
+    const {scopeSelectorForTesting: scopeSelector} = dom;
+
+    it('concats simple', () => {
+      expect(scopeSelector('.i-amphtml-scoped', 'div'))
+          .to.equal('.i-amphtml-scoped div');
+    });
+
+    it('concats multiple selectors (2)', () => {
+      expect(scopeSelector(':scope', 'div,ul'))
+          .to.equal(':scope div,:scope ul');
+    });
+
+    it('concats multiple selectors (4)', () => {
+      expect(scopeSelector('div >', 'div,ul,ol,section'))
+          .to.equal('div > div,div > ul,div > ol,div > section');
+    });
+
+  });
+
   it('should remove all children', () => {
     const element = document.createElement('div');
     element.appendChild(document.createElement('div'));


### PR DESCRIPTION
I noticed the following in the [`amp-video-docking` binary](https://cdn.ampproject.org/v0/amp-video-docking-0.1.js):

```js
// ...
a.querySelector(":scope amp-img[placeholder],img[placeholder],[placeholder] amp-img");
// ...
```

Chunk [comes from `scopedQuerySelector`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/0.1/amp-video-docking.js#L1255):

```js
// ...
const imgEl = scopedQuerySelector(element,
    'amp-img[placeholder],img[placeholder],[placeholder] amp-img');
// ...
```

The correctly scoped selector should be:

```
:scope amp-img[placeholder],:scope img[placeholder],:scope [placeholder] amp-img
```

This PR splits the given selector and prefixes the ancestor to each part to correctly produce a scoped selector.

Output is slightly larger, but correct:

```js
// ...
a.querySelector(ka(":scope")) // ...
// ...
function ka(a) {
  var b = "amp-img[placeholder],img[placeholder],[placeholder] amp-img";
  return b.split(",").map(function (b) {
    return a + " " + b
  }).join(",")
}
// ...
```