### PR TITLE
♻️ Remove duplicates from fullscreen API

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -833,15 +833,11 @@ export function whenUpgradedToCustomElement(element) {
  */
 export function fullscreenEnter(element) {
   const requestFs = element.requestFullscreen
-   || element.requestFullScreen
-   || element.webkitRequestFullscreen
-   || element.webkitRequestFullScreen
-   || element.webkitEnterFullscreen
-   || element.webkitEnterFullScreen
-   || element.msRequestFullscreen
-   || element.msRequestFullScreen
-   || element.mozRequestFullscreen
-   || element.mozRequestFullScreen;
+    || element.requestFullScreen
+    || element.webkitRequestFullscreen
+    || element.webkitEnterFullscreen
+    || element.msRequestFullscreen
+    || element.mozRequestFullScreen;
   if (requestFs) {
     requestFs.call(element);
   }
@@ -853,31 +849,30 @@ export function fullscreenEnter(element) {
  * @param {!Element} element
  */
 export function fullscreenExit(element) {
-  let exitFs = element.cancelFullScreen
-               || element.exitFullscreen
-               || element.exitFullScreen
-               || element.webkitExitFullscreen
-               || element.webkitExitFullScreen
-               || element.webkitCancelFullScreen
-               || element.mozCancelFullScreen
-               || element.msExitFullscreen;
-  if (exitFs) {
-    exitFs.call(element);
+  const elementBoundExit =
+      element.cancelFullScreen
+      || element.exitFullscreen
+      || element.webkitExitFullscreen
+      || element.webkitCancelFullScreen
+      || element.mozCancelFullScreen
+      || element.msExitFullscreen;
+  if (elementBoundExit) {
+    elementBoundExit.call(element);
     return;
   }
-  if (element.ownerDocument) {
-    exitFs = element.ownerDocument.cancelFullScreen
-             || element.ownerDocument.exitFullscreen
-             || element.ownerDocument.exitFullScreen
-             || element.ownerDocument.webkitExitFullscreen
-             || element.ownerDocument.webkitExitFullScreen
-             || element.ownerDocument.webkitCancelFullScreen
-             || element.ownerDocument.mozCancelFullScreen
-             || element.ownerDocument.msExitFullscreen;
-  }
-  if (exitFs) {
-    exitFs.call(element.ownerDocument);
+  const {ownerDocument} = element;
+  if (!ownerDocument) {
     return;
+  }
+  const docBoundExit =
+      ownerDocument.cancelFullScreen
+      || ownerDocument.exitFullscreencancelFullScreen
+      || ownerDocument.webkitExitFullscreencancelFullScreen
+      || ownerDocument.webkitCancelFullScreencancelFullScreen
+      || ownerDocument.mozCancelFullScreencancelFullScreen
+      || ownerDocument.msExitFullscreen;
+  if (docBoundExit) {
+    docBoundExit.call(ownerDocument);
   }
 }
 
@@ -889,20 +884,20 @@ export function fullscreenExit(element) {
  * @return {boolean}
  */
 export function isFullscreenElement(element) {
-  const isFullscreen = element.webkitDisplayingFullscreen;
-  if (isFullscreen) {
-    return true;
+  const {webkitDisplayingFullscreen} = element;
+  if (webkitDisplayingFullscreen !== undefined) {
+    return webkitDisplayingFullscreen;
   }
-  if (element.ownerDocument) {
-    const fullscreenElement = element.ownerDocument.fullscreenElement
-             || element.ownerDocument.webkitFullscreenElement
-             || element.ownerDocument.mozFullScreenElement
-             || element.webkitCurrentFullScreenElement;
-    if (fullscreenElement == element) {
-      return true;
-    }
+  const {ownerDocument} = element;
+  if (!ownerDocument) {
+    return false;
   }
-  return false;
+  const fullscreenElement =
+      ownerDocument.fullscreenElement
+      || ownerDocument.webkitFullscreenElement
+      || ownerDocument.mozFullScreenElement
+      || ownerDocument.webkitCurrentFullScreenElement;
+  return fullscreenElement == element;
 }
 
 /**


### PR DESCRIPTION
also:
- fix a falsy `false !== undefined` in check of `Element.webkitDisplayingFullscreen`
- make output a few extra bytes smaller. in amp-video:

```js
    h.fullscreenEnter = function () {
      var a = this.h,
        b = a.requestFullscreen || a.requestFullScreen || a.webkitRequestFullscreen || a.webkitEnterFullscreen || a.msRequestFullscreen || a.mozRequestFullScreen;
      b && b.call(a)
    };
    h.fullscreenExit = function () {
      var a = this.h,
        b = a.cancelFullScreen || a.exitFullscreen || a.webkitExitFullscreen || a.webkitCancelFullScreen || a.mozCancelFullScreen || a.msExitFullscreen;
      b ? b.call(a) : (a = a.ownerDocument) && (b = a.cancelFullScreen || a.exitFullscreencancelFullScreen || a.webkitExitFullscreencancelFullScreen || a.webkitCancelFullScreencancelFullScreen || a.mozCancelFullScreencancelFullScreen || a.msExitFullscreen) && b.call(a)
    };
    h.isFullscreen = function () {
      var a = this.h;
      var b = a.webkitDisplayingFullscreen;
      a = void 0 !== b ? b : (b = a.ownerDocument) ? (b.fullscreenElement || b.webkitFullscreenElement || b.mozFullScreenElement || b.webkitCurrentFullScreenElement) == a : !1;
      return a
    };
```

vs previous:

```js
    h.fullscreenEnter = function () {
      var a = this.h,
        b = a.requestFullscreen || a.requestFullScreen || a.webkitRequestFullscreen || a.webkitRequestFullScreen || a.webkitEnterFullscreen || a.webkitEnterFullScreen || a.msRequestFullscreen || a.msRequestFullScreen || a.mozRequestFullscreen || a.mozRequestFullScreen;
      b && b.call(a)
    };
    h.fullscreenExit = function () {
      var a = this.h,
        b = a.cancelFullScreen || a.exitFullscreen || a.exitFullScreen || a.webkitExitFullscreen || a.webkitExitFullScreen || a.webkitCancelFullScreen || a.mozCancelFullScreen || a.msExitFullscreen;
      b ? b.call(a) : (a.ownerDocument && (b = a.ownerDocument.cancelFullScreen || a.ownerDocument.exitFullscreen || a.ownerDocument.exitFullScreen || a.ownerDocument.webkitExitFullscreen || a.ownerDocument.webkitExitFullScreen || a.ownerDocument.webkitCancelFullScreen || a.ownerDocument.mozCancelFullScreen || a.ownerDocument.msExitFullscreen),
        b && b.call(a.ownerDocument))
    };
    h.isFullscreen = function () {
      var a = this.h;
      a = a.webkitDisplayingFullscreen ? !0 : a.ownerDocument && (a.ownerDocument.fullscreenElement || a.ownerDocument.webkitFullscreenElement || a.ownerDocument.mozFullScreenElement || a.webkitCurrentFullScreenElement) == a ? !0 : !1;
      return a
    };
```