### PR TITLE
Have the purifier allow unknown protocols.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -20,8 +20,8 @@ import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {
-  ancestorElementsByTag,
   childElementByTag,
+  closestByTag,
   removeChildren,
 } from '../../../src/dom';
 import {hasOwn} from '../../../src/utils/object';
@@ -211,7 +211,7 @@ export class AmpAdCustom extends AMP.BaseElement {
 
       // Get the parent body of this amp-ad element. It could be the body of
       // the main document, or it could be an enclosing iframe.
-      const body = ancestorElementsByTag(this.element, 'BODY')[0];
+      const body = closestByTag(this.element, 'BODY');
       const elements = body.querySelectorAll('amp-ad[type=custom]');
       for (let index = 0; index < elements.length; index++) {
         const elem = elements[index];

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -280,6 +280,8 @@ export function purifyConfig() {
     FORCE_BODY: true,
     // Avoid need for serializing to/from string by returning Node directly.
     RETURN_DOM: true,
+    // BLACKLISTED_ATTR_VALUES are enough. Other unknown protocols are safe.
+    ALLOW_UNKNOWN_PROTOCOLS: true,
   }));
   return /** @type {!DomPurifyConfig} */ (config);
 }


### PR DESCRIPTION
- Since unsafe attribute values are already blacklisted, allowing other arbitrary protocols should be safe. This may come in handy in certain scenarios.
- Fixes #20523 

🐛 Bug fix (`:bug:`)  
@choumx 
