### PR TITLE
[amp-story] Ensure clicks on anchor tags are handled by tooltip 🐛

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -323,8 +323,7 @@ amp-story-grid-layer > * {
 
 /** Ensure clicks inside anchor tags are handled by the tooltip. */
 amp-story-grid-layer a * {
-  pointer-events: none;
-  cursor: default;
+  pointer-events: none !important;
 }
 
 /** Apply click shield on embedded components on initial load. */

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -321,6 +321,12 @@ amp-story-grid-layer > * {
   pointer-events: auto !important;
 }
 
+/** Ensure clicks inside anchor tags are handled by the tooltip. */
+amp-story-grid-layer a * {
+  pointer-events: none;
+  cursor: default;
+}
+
 /** Apply click shield on embedded components on initial load. */
 amp-story-grid-layer amp-twitter::after {
   content: "" !important;


### PR DESCRIPTION
Currently, if a publisher specifies the following markup:
`
<a href="google.com"> 
  <span> Click me! </span>
</a>
`

The click will not be handled by the tooltip code since the target will be the `<span>` element, and we currently are only handling `<a>` tags.

This PR ensures that anything inside `<a>` tags won't be clickable and that target triggering the click event will be the `<a>` tag.

Other proposals considered:
1. Add a listener on each <a> with capture: true, and use the currentTarget instead of target.
2. Check if the target is descendant of <a>.
3. Add a click shield on <a> using pseudo-element.

(1) Might interfere down the line with other event listeners.
(2) Might be costly to do on every click (especially when the DOM is deep). 
(3) Is not possible without overwriting the position of the `<a>` tag (to add a pseudo selector we need the `<a>` tag to have either `position: relative` or `position:absolute`.