### PR TITLE
🐛 Have purifier.js allow unknown protocols

### DIFF
--- a/src/purifier.js
+++ b/src/purifier.js
@@ -281,6 +281,7 @@ export function purifyConfig() {
     // Avoid need for serializing to/from string by returning Node directly.
     RETURN_DOM: true,
     // BLACKLISTED_ATTR_VALUES are enough. Other unknown protocols are safe.
+    // This allows native app deeplinks.
     ALLOW_UNKNOWN_PROTOCOLS: true,
   }));
   return /** @type {!DomPurifyConfig} */ (config);

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -280,6 +280,8 @@ export function purifyConfig() {
     FORCE_BODY: true,
     // Avoid need for serializing to/from string by returning Node directly.
     RETURN_DOM: true,
+    // BLACKLISTED_ATTR_VALUES are enough. Other unknown protocols are safe.
+    ALLOW_UNKNOWN_PROTOCOLS: true,
   }));
   return /** @type {!DomPurifyConfig} */ (config);
 }

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -236,7 +236,7 @@ function runSanitizerTests() {
 
     it('should allow arbitrary protocols', () => {
       expect(purify('<a href="foo://bar">link</a>')).to.be.equal(
-        '<a target="_top" href="foo://bar">link</a>');
+          '<a target="_top" href="foo://bar">link</a>');
     });
 
     it('should output "rel" attribute', () => {

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -235,8 +235,8 @@ function runSanitizerTests() {
     });
 
     it('should allow arbitrary protocols', () => {
-      expect(purify('<a href="whatsapp://send?example></a>"')).to.be.equal(
-        '<a href="whatsapp://send?example></a>"');
+      expect(purify('<a href="foo://bar">link</a>')).to.be.equal(
+        '<a target="_top" href="foo://bar">link</a>');
     });
 
     it('should output "rel" attribute', () => {

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -234,6 +234,11 @@ function runSanitizerTests() {
       expectEqualNodeLists(actual, expected);
     });
 
+    it('should allow arbitrary protocols', () => {
+      expect(purify('<a href="whatsapp://send?example></a>"')).to.be.equal(
+        '<a href="whatsapp://send?example></a>"');
+    });
+
     it('should output "rel" attribute', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(


### PR DESCRIPTION
- Dangerous attribute values are blacklisted and already sanitized. Thus, allowing other arbitrary protocols is safe.
- Fixes #20523 

@choumx 