### PR TITLE
🐛Fixes for lightbox gallery and shadow docs.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -959,6 +959,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       // Prepare the actual image animation.
       imageAnimation = prepareImageAnimation({
         styleContainer: this.getAmpDoc().getHeadNode(),
+        transitionContainer: this.getAmpDoc().getBody(),
         srcImg,
         targetImg,
         srcImgRect: undefined,
@@ -1479,5 +1480,5 @@ function lightboxManagerForDoc(element) {
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerElement(TAG, AmpLightboxGallery, CSS);
   AMP.registerServiceForDoc('amp-lightbox-manager', LightboxManager);
-  Services.extensionsFor(global).addDocFactory(installLightboxGallery);
+  Services.extensionsFor(AMP.win).addDocFactory(installLightboxGallery);
 });


### PR DESCRIPTION
- Use AMP.win instead of global.
- Use the AmpDoc's body for the transition `<img>`, since that is where the styles are and it needs to be within the same `ShadowDocument`.

Fixes #20709