### PR TITLE
🏗 Enable verbose logging for sauce connect

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -32,7 +32,7 @@ BINARY_FILE="$SC_VERSION/bin/sc"
 PID_FILE="sauce_connect_pid"
 LOG_FILE="sauce_connect_log"
 READY_FILE="sauce_connect_ready"
-READY_DELAY_SECS=60
+READY_DELAY_SECS=120
 LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
 
 # Check the status of the Sauce Labs service
@@ -82,7 +82,7 @@ fi
 
 # Launch proxy and wait for a tunnel to be created.
 echo "$LOG_PREFIX Launching $(CYAN "$BINARY_FILE")"
-"$BINARY_FILE" --tunnel-identifier "$TUNNEL_IDENTIFIER" --readyfile "$READY_FILE" --pidfile "$PID_FILE" 1>"$LOG_FILE" 2>&1 &
+"$BINARY_FILE" --verbose --tunnel-identifier "$TUNNEL_IDENTIFIER" --readyfile "$READY_FILE" --pidfile "$PID_FILE" 1>"$LOG_FILE" 2>&1 &
 count=0
 while [ $count -lt $READY_DELAY_SECS ]
 do


### PR DESCRIPTION
I'm working with sauce labs support to debug our ongoing sauce connect failures.