### PR TITLE
♻️ Refactor dom.js to have similar functions be close to each other and have more accurate names.

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -19,7 +19,7 @@ requirement: {
 
 requirement: {
   type: BANNED_PROPERTY_CALL
-  error_message: 'Use closestBySelector, closestByTag etc in src/dom.js'
+  error_message: 'Use closestAncestorElementBySelector, closestAncestorElementByTag etc in src/dom.js'
   value: 'Element.prototype.closest'
   whitelist: 'src/dom.js'
 }

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -21,7 +21,7 @@ import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {
   childElementByTag,
-  closestByTag,
+  closestAncestorElementByTag,
   removeChildren,
 } from '../../../src/dom';
 import {hasOwn} from '../../../src/utils/object';
@@ -211,7 +211,7 @@ export class AmpAdCustom extends AMP.BaseElement {
 
       // Get the parent body of this amp-ad element. It could be the body of
       // the main document, or it could be an enclosing iframe.
-      const body = closestByTag(this.element, 'BODY');
+      const body = closestAncestorElementByTag(this.element, 'BODY');
       const elements = body.querySelectorAll('amp-ad[type=custom]');
       for (let index = 0; index < elements.length; index++) {
         const elem = elements[index];

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -21,7 +21,7 @@ import {
   VisibilityManagerForEmbed,
 } from './visibility-manager';
 import {
-  closestBySelector,
+  closestAncestorElementBySelector,
   matches,
   scopedQuerySelector,
 } from '../../../src/dom';
@@ -221,7 +221,7 @@ export class AnalyticsRoot {
         if (selectionMethod == 'scope') {
           found = scopedQuerySelector(context, selector);
         } else if (selectionMethod == 'closest') {
-          found = closestBySelector(context, selector);
+          found = closestAncestorElementBySelector(context, selector);
         } else {
           found = this.getRoot().querySelector(selector);
         }

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -39,7 +39,7 @@ import {
   setStyles,
 } from '../../../src/style';
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
-import {closestBySelector, matches} from '../../../src/dom';
+import {closestAncestorElementBySelector, matches} from '../../../src/dom';
 import {dashToCamelCase, startsWith} from '../../../src/string';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {extractKeyframes} from './keyframes-extractor';
@@ -1632,7 +1632,7 @@ class CssContextImpl {
     let element;
     try {
       if (selectionMethod == 'closest') {
-        element = closestBySelector(this.requireTarget_(), selector);
+        element = closestAncestorElementBySelector(this.requireTarget_(), selector);
       } else {
         element = this.rootNode_./*OK*/querySelector(selector);
       }

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -1632,7 +1632,8 @@ class CssContextImpl {
     let element;
     try {
       if (selectionMethod == 'closest') {
-        element = closestAncestorElementBySelector(this.requireTarget_(), selector);
+        element =
+          closestAncestorElementBySelector(this.requireTarget_(), selector);
       } else {
         element = this.rootNode_./*OK*/querySelector(selector);
       }

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -23,7 +23,7 @@ import {
 } from '../../../src/mediasession-helper';
 import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
-import {closestByTag} from '../../../src/dom';
+import {closestAncestorElementByTag} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
@@ -209,7 +209,7 @@ export class AmpAudio extends AMP.BaseElement {
    * @private
    */
   isStoryDescendant_() {
-    return closestByTag(this.element, 'AMP-STORY');
+    return closestAncestorElementByTag(this.element, 'AMP-STORY');
   }
 
   /** @private */

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -21,7 +21,7 @@ import {
 import {Services} from '../../../src/services';
 import {clamp} from '../../../src/utils/math';
 import {
-  closestByTag,
+  closestAncestorElementByTag,
   createElementWithAttributes,
   scopedQuerySelectorAll,
   whenUpgradedToCustomElement,
@@ -425,7 +425,7 @@ function isPositionValid(anchorElement, position) {
   }
   const elementToCheck = dev().assertElement(elementToCheckOrNull);
   return !BLACKLISTED_ANCESTOR_TAGS.some(tagName => {
-    if (closestByTag(elementToCheck, tagName)) {
+    if (closestAncestorElementByTag(elementToCheck, tagName)) {
       user().warn(TAG, 'Placement inside blacklisted ancestor: ' + tagName);
       return true;
     }

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -26,7 +26,7 @@ import {AmpEvents} from '../../../src/amp-events';
 import {AutoLightboxEvents} from '../../../src/auto-lightbox';
 import {CommonSignals} from '../../../src/common-signals';
 import {Services} from '../../../src/services';
-import {closestBySelector} from '../../../src/dom';
+import {closestAncestorElementBySelector} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {toArray} from '../../../src/types';
@@ -149,7 +149,7 @@ export class Criteria {
    * @return {boolean}
    */
   static meetsTreeShapeCriteria(element) {
-    if (closestBySelector(element, DISABLED_ANCESTORS)) {
+    if (closestAncestorElementBySelector(element, DISABLED_ANCESTORS)) {
       return false;
     }
     const actions = Services.actionServiceForDoc(element);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -21,7 +21,7 @@ import {ChunkPriority, chunk} from '../../../src/chunk';
 import {RAW_OBJECT_ARGS_KEY} from '../../../src/action-constants';
 import {Services} from '../../../src/services';
 import {Signals} from '../../../src/utils/signals';
-import {closestByTag, iterateCursor} from '../../../src/dom';
+import {closestAncestorElementByTag, iterateCursor} from '../../../src/dom';
 import {debounce} from '../../../src/utils/rate-limit';
 import {deepEquals, getValueForExpr, parseJson} from '../../../src/json';
 import {deepMerge, dict, map} from '../../../src/utils/object';
@@ -1178,7 +1178,7 @@ export class Bind {
     if (!Services.platformFor(this.win_).isSafari()) {
       return;
     }
-    const select = closestByTag(element, 'select');
+    const select = closestAncestorElementByTag(element, 'select');
     if (!select) {
       return;
     }

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -26,7 +26,7 @@ import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {batchFetchJsonFor} from '../../../src/batched-json';
 import {
-  closestByTag,
+  closestAncestorElementByTag,
   escapeCssSelectorIdent,
   isRTL,
   iterateCursor,
@@ -832,7 +832,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       return existingField;
     }
 
-    const form = closestByTag(this.element, 'form');
+    const form = closestAncestorElementByTag(this.element, 'form');
     if (this.mode_ == DatePickerMode.STATIC && form) {
       const hiddenInput = this.document_.createElement('input');
       hiddenInput.type = 'hidden';

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -917,7 +917,7 @@ class AmpImageLightbox extends AMP.BaseElement {
     let caption = null;
 
     // 1. Check <figure> and <figcaption>.
-    const figure = dom.closestByTag(sourceElement, 'figure');
+    const figure = dom.closestAncestorElementByTag(sourceElement, 'figure');
     if (figure) {
       caption = dom.elementByTag(figure, 'figcaption');
     }

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {closestByTag, removeElement} from '../../../src/dom';
+import {closestAncestorElementByTag, removeElement} from '../../../src/dom';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
@@ -267,7 +267,7 @@ class UrlRewriter_ {
     if (event.defaultPrevented) {
       return;
     }
-    const target = closestByTag(dev().assertElement(event.target), 'A');
+    const target = closestAncestorElementByTag(dev().assertElement(event.target), 'A');
     if (!target || !target.href) {
       return;
     }

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -267,7 +267,8 @@ class UrlRewriter_ {
     if (event.defaultPrevented) {
       return;
     }
-    const target = closestAncestorElementByTag(dev().assertElement(event.target), 'A');
+    const target =
+      closestAncestorElementByTag(dev().assertElement(event.target), 'A');
     if (!target || !target.href) {
       return;
     }

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -31,7 +31,7 @@ import {bezierCurve} from '../../../src/curve';
 import {
   childElementByTag,
   closest,
-  closestBySelector,
+  closestAncestorElementBySelector,
   elementByTag,
   escapeCssSelectorIdent,
   scopedQuerySelector,
@@ -883,7 +883,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       return true;
     }
     // Note that `<amp-carousel>` type='carousel' does not support goToSlide
-    const parentCarousel = closestBySelector(target,
+    const parentCarousel = closestAncestorElementBySelector(target,
         'amp-carousel[type="slides"]');
     if (parentCarousel && parentCarousel.isInViewport()) {
       return true;
@@ -1127,13 +1127,13 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const target = this.getCurrentElement_().sourceElement;
     // TODO(#13011): change to a tag selector after `<amp-carousel>`
     // type='carousel' starts supporting goToSlide.
-    const parentCarousel = closestBySelector(target,
+    const parentCarousel = closestAncestorElementBySelector(target,
         'amp-carousel[type="slides"]');
     if (parentCarousel) {
       const allSlides = toArray(
           scopedQuerySelectorAll(parentCarousel, SLIDE_ITEM_SELECTOR));
       const targetSlide = dev().assertElement(
-          closestBySelector(target, SLIDE_ITEM_SELECTOR));
+          closestAncestorElementBySelector(target, SLIDE_ITEM_SELECTOR));
       const targetSlideIndex = allSlides.indexOf(targetSlide);
       devAssert(parentCarousel).getImpl()
           .then(carousel => carousel.goToSlide(targetSlideIndex));

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -26,7 +26,7 @@ import {Services} from '../../../../src/services';
 import {
   childElement,
   childElementByAttr,
-  closestByTag,
+  closestAncestorElementByTag,
   elementByTag,
   iterateCursor,
 } from '../../../../src/dom';
@@ -302,7 +302,7 @@ export class LightboxManager {
   getDescription(element) {
     // If the element in question is the descendant of a figure element
     // try using the figure caption as the lightbox description.
-    const figureParent = closestByTag(element, 'figure');
+    const figureParent = closestAncestorElementByTag(element, 'figure');
     if (figureParent) {
       const figCaption = elementByTag(figureParent, 'figcaption');
       if (figCaption) {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -20,7 +20,8 @@ import {CSS} from '../../../build/amp-selector-0.1.css';
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {areEqualOrdered} from '../../../src/utils/array';
-import {closestAncestorElementBySelector, isRTL, tryFocus} from '../../../src/dom';
+import {closestAncestorElementBySelector, isRTL, tryFocus}
+  from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -20,7 +20,7 @@ import {CSS} from '../../../build/amp-selector-0.1.css';
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {areEqualOrdered} from '../../../src/utils/array';
-import {closestBySelector, isRTL, tryFocus} from '../../../src/dom';
+import {closestAncestorElementBySelector, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
@@ -365,7 +365,7 @@ export class AmpSelector extends AMP.BaseElement {
       return;
     }
     if (!el.hasAttribute('option')) {
-      el = closestBySelector(el, '[option]');
+      el = closestAncestorElementBySelector(el, '[option]');
     }
     if (el) {
       this.onOptionPicked_(el);

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -19,7 +19,7 @@ import {CSS} from '../../../build/amp-sidebar-0.1.css';
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {Toolbar} from './toolbar';
-import {closestByTag, isRTL, tryFocus} from '../../../src/dom';
+import {closestAncestorElementByTag, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {descendsFromStory} from '../../../src/utils/story';
 import {dev} from '../../../src/log';
@@ -185,7 +185,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.registerAction('close', this.close_.bind(this));
 
     element.addEventListener('click', e => {
-      const target = closestByTag(dev().assertElement(e.target), 'A');
+      const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
       if (target && target.href) {
         const tgtLoc = Services.urlForDoc(element).parse(target.href);
         const currentHref = this.getAmpDoc().win.location.href;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -185,7 +185,8 @@ export class AmpSidebar extends AMP.BaseElement {
     this.registerAction('close', this.close_.bind(this));
 
     element.addEventListener('click', e => {
-      const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
+      const target =
+        closestAncestorElementByTag(dev().assertElement(e.target), 'A');
       if (target && target.href) {
         const tgtLoc = Services.urlForDoc(element).parse(target.href);
         const currentHref = this.getAmpDoc().win.location.href;

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -23,7 +23,7 @@ import {Services} from '../../../src/services';
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {
   childElementByTag,
-  closestByTag,
+  closestAncestorElementByTag,
   isJsonScriptTag,
 } from '../../../src/dom';
 import {computedStyle, setImportantStyles} from '../../../src/style';
@@ -197,8 +197,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
   buildCallback() {
     this.assertAndParseConfig_();
 
-    const storyEl = closestByTag(this.element, 'AMP-STORY');
-    const consentEl = closestByTag(this.element, 'AMP-CONSENT');
+    const storyEl = closestAncestorElementByTag(this.element, 'AMP-STORY');
+    const consentEl = closestAncestorElementByTag(this.element, 'AMP-CONSENT');
     const consentId = consentEl.id;
     this.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -36,7 +36,7 @@ import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
 import {VideoServiceSync} from '../../../src/service/video-service-sync-impl';
 import {
-  closestBySelector,
+  closestAncestorElementBySelector,
   matches,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
@@ -186,7 +186,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @private */
   initializeMediaPool_() {
     const storyEl = dev().assertElement(
-        closestBySelector(this.element, 'amp-story'),
+        closestAncestorElementBySelector(this.element, 'amp-story'),
         'amp-story-page must be a descendant of amp-story.');
 
     storyEl.getImpl()

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {closestBySelector} from '../../../src/dom';
+import {closestAncestorElementBySelector} from '../../../src/dom';
 import {createShadowRoot} from '../../../src/shadow-embed';
 import {user, userAssert} from '../../../src/log';
 
@@ -83,7 +83,7 @@ export function unscaledClientRect(el) {
  * @return {?AmpElement}
  */
 export function ampMediaElementFor(el) {
-  return closestBySelector(el, 'amp-video, amp-audio');
+  return closestAncestorElementBySelector(el, 'amp-video, amp-audio');
 }
 
 

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -23,7 +23,7 @@ import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {
   closest,
-  closestByTag,
+  closestAncestorElementByTag,
   copyChildren,
   removeChildren,
 } from '../../../src/dom';
@@ -243,7 +243,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
    */
   getLogoSrc_() {
     const storyEl =
-            dev().assertElement(closestByTag(this.element, 'AMP-STORY'));
+            dev().assertElement(closestAncestorElementByTag(this.element, 'AMP-STORY'));
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     logoSrc ?

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -242,8 +242,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @private
    */
   getLogoSrc_() {
-    const storyEl =
-            dev().assertElement(closestAncestorElementByTag(this.element, 'AMP-STORY'));
+    const storyEl = dev().assertElement(
+        closestAncestorElementByTag(this.element, 'AMP-STORY'));
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     logoSrc ?

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -200,8 +200,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
   buildCallback() {
     this.assertAndParseConfig_();
 
-    const storyEl =
-        dev().assertElement(closestAncestorElementByTag(this.element, 'AMP-STORY'));
+    const storyEl = dev().assertElement(
+        closestAncestorElementByTag(this.element, 'AMP-STORY'));
     const consentEl = closestAncestorElementByTag(this.element, 'AMP-CONSENT');
     const consentId = consentEl.id;
 

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -27,7 +27,7 @@ import {Services} from '../../../src/services';
 import {assertAbsoluteHttpOrHttpsUrl, assertHttpsUrl} from '../../../src/url';
 import {
   childElementByTag,
-  closestByTag,
+  closestAncestorElementByTag,
   isJsonScriptTag,
 } from '../../../src/dom';
 import {computedStyle, setImportantStyles} from '../../../src/style';
@@ -201,8 +201,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
     this.assertAndParseConfig_();
 
     const storyEl =
-        dev().assertElement(closestByTag(this.element, 'AMP-STORY'));
-    const consentEl = closestByTag(this.element, 'AMP-CONSENT');
+        dev().assertElement(closestAncestorElementByTag(this.element, 'AMP-STORY'));
+    const consentEl = closestAncestorElementByTag(this.element, 'AMP-CONSENT');
     const consentId = consentEl.id;
 
     this.storeConsentId_(consentId);

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -44,7 +44,7 @@ import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
 import {VideoServiceSync} from '../../../src/service/video-service-sync-impl';
 import {
-  closestBySelector,
+  closestAncestorElementBySelector,
   iterateCursor,
   matches,
   scopedQuerySelectorAll,
@@ -268,7 +268,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @private */
   initializeMediaPool_() {
     const storyEl = dev().assertElement(
-        closestBySelector(this.element, 'amp-story'),
+        closestAncestorElementBySelector(this.element, 'amp-story'),
         'amp-story-page must be a descendant of amp-story.');
 
     storyEl.getImpl()

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {Services} from '../../../src/services';
-import {closestBySelector} from '../../../src/dom';
+import {closestAncestorElementBySelector} from '../../../src/dom';
 import {createShadowRoot} from '../../../src/shadow-embed';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin} from '../../../src/url';
@@ -86,7 +86,7 @@ export function unscaledClientRect(el) {
  * @return {?AmpElement}
  */
 export function ampMediaElementFor(el) {
-  return closestBySelector(el, 'amp-video, amp-audio');
+  return closestAncestorElementBySelector(el, 'amp-video, amp-audio');
 }
 
 

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -23,7 +23,7 @@ import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
 import {UrlBuilder} from './url-builder';
 import {assertHttpsUrl} from '../../../src/url';
-import {closestBySelector} from '../../../src/dom';
+import {closestAncestorElementBySelector} from '../../../src/dom';
 import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
@@ -119,7 +119,7 @@ export class LocalSubscriptionPlatform {
    */
   initializeListeners_() {
     this.rootNode_.addEventListener('click', e => {
-      const element = closestBySelector(dev().assertElement(e.target),
+      const element = closestAncestorElementBySelector(dev().assertElement(e.target),
           '[subscriptions-action]');
       this.handleClick_(element);
     });

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -119,8 +119,9 @@ export class LocalSubscriptionPlatform {
    */
   initializeListeners_() {
     this.rootNode_.addEventListener('click', e => {
-      const element = closestAncestorElementBySelector(dev().assertElement(e.target),
-          '[subscriptions-action]');
+      const element =
+        closestAncestorElementBySelector(dev().assertElement(e.target),
+            '[subscriptions-action]');
       this.handleClick_(element);
     });
   }

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -23,7 +23,7 @@ import {Services} from '../../../src/services';
 import {Timeout} from './timeout';
 import {VideoDockingEvents, pointerCoords} from './events';
 import {applyBreakpointClassname} from './breakpoints';
-import {closestBySelector} from '../../../src/dom';
+import {closestAncestorElementBySelector} from '../../../src/dom';
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert} from '../../../src/log';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
@@ -429,7 +429,7 @@ export class Controls {
    */
   isControlsTarget_(target) {
     return target == this.overlay ||
-      !!closestBySelector(target, '.amp-video-docked-controls');
+      !!closestAncestorElementBySelector(target, '.amp-video-docked-controls');
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -744,7 +744,7 @@ function createBaseCustomElementClass(win) {
      */
     connectedCallback() {
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
-        this.isInTemplate_ = !!dom.closestByTag(this, 'template');
+        this.isInTemplate_ = !!dom.closestAncestorElementByTag(this, 'template');
       }
       if (this.isInTemplate_) {
         return;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -744,7 +744,8 @@ function createBaseCustomElementClass(win) {
      */
     connectedCallback() {
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
-        this.isInTemplate_ = !!dom.closestAncestorElementByTag(this, 'template');
+        this.isInTemplate_ =
+          !!dom.closestAncestorElementByTag(this, 'template');
       }
       if (this.isInTemplate_) {
         return;

--- a/src/dom.js
+++ b/src/dom.js
@@ -293,6 +293,37 @@ export function closestBySelector(element, selector) {
 }
 
 /**
+ * Finds all ancestor elements that satisfy predicate.
+ * @param {!Element} child
+ * @param {function(!Element):boolean} predicate
+ * @return {!Array<!Element>}
+ */
+export function ancestorElements(child, predicate) {
+  const ancestors = [];
+  for (let ancestor = child.parentElement; ancestor;
+    ancestor = ancestor.parentElement) {
+    if (predicate(ancestor)) {
+      ancestors.push(ancestor);
+    }
+  }
+  return ancestors;
+}
+
+
+/**
+ * Finds all ancestor elements that has the specified tag name.
+ * @param {!Element} child
+ * @param {string} tagName
+ * @return {!Array<!Element>}
+ */
+export function ancestorElementsByTag(child, tagName) {
+  tagName = tagName.toUpperCase();
+  return ancestorElements(child, el => {
+    return el.tagName == tagName;
+  });
+}
+
+/**
  * Checks if the given element matches the selector
  * @param  {!Element} el The element to verify
  * @param  {string} selector The selector to check against
@@ -612,38 +643,6 @@ export function hasNextNodeInDocumentOrder(element, opt_stopNode) {
   } while ((currentElement = currentElement.parentNode) &&
             currentElement != opt_stopNode);
   return false;
-}
-
-
-/**
- * Finds all ancestor elements that satisfy predicate.
- * @param {!Element} child
- * @param {function(!Element):boolean} predicate
- * @return {!Array<!Element>}
- */
-export function ancestorElements(child, predicate) {
-  const ancestors = [];
-  for (let ancestor = child.parentElement; ancestor;
-    ancestor = ancestor.parentElement) {
-    if (predicate(ancestor)) {
-      ancestors.push(ancestor);
-    }
-  }
-  return ancestors;
-}
-
-
-/**
- * Finds all ancestor elements that has the specified tag name.
- * @param {!Element} child
- * @param {string} tagName
- * @return {!Array<!Element>}
- */
-export function ancestorElementsByTag(child, tagName) {
-  tagName = tagName.toUpperCase();
-  return ancestorElements(child, el => {
-    return el.tagName == tagName;
-  });
 }
 
 /**

--- a/src/dom.js
+++ b/src/dom.js
@@ -324,42 +324,6 @@ export function ancestorElementsByTag(child, tagName) {
 }
 
 /**
- * Checks if the given element matches the selector
- * @param  {!Element} el The element to verify
- * @param  {string} selector The selector to check against
- * @return {boolean} True if the element matched the selector. False otherwise.
- */
-export function matches(el, selector) {
-  const matcher = el.matches ||
-      el.webkitMatchesSelector ||
-      el.mozMatchesSelector ||
-      el.msMatchesSelector ||
-      el.oMatchesSelector;
-  if (matcher) {
-    return matcher.call(el, selector);
-  }
-  return false; // IE8 always returns false.
-}
-
-/**
- * Finds the first descendant element with the specified name.
- * @param {!Element|!Document|!ShadowRoot} element
- * @param {string} tagName
- * @return {?Element}
- */
-export function elementByTag(element, tagName) {
-  let elements;
-  // getElementsByTagName() is not supported on ShadowRoot.
-  if (typeof element.getElementsByTagName === 'function') {
-    elements = element.getElementsByTagName(tagName);
-  } else {
-    elements = element./*OK*/querySelectorAll(tagName);
-  }
-  return (elements && elements[0]) || null;
-}
-
-
-/**
  * Finds the first child element that satisfies the callback.
  * @param {!Element} parent
  * @param {function(!Element):boolean} callback
@@ -429,39 +393,6 @@ export function childNodes(parent, callback) {
 }
 
 /**
- * @type {boolean|undefined}
- * @visibleForTesting
- */
-let scopeSelectorSupported;
-
-/**
- * @param {boolean|undefined} val
- * @visibleForTesting
- */
-export function setScopeSelectorSupportedForTesting(val) {
-  scopeSelectorSupported = val;
-}
-
-/**
- * Test that the :scope selector is supported and behaves correctly.
- * @param {!Element} parent
- * @return {boolean}
- */
-function isScopeSelectorSupported(parent) {
-  const doc = parent.ownerDocument;
-  try {
-    const testElement = doc.createElement('div');
-    const testChild = doc.createElement('div');
-    testElement.appendChild(testChild);
-    // NOTE(cvializ, #12383): Firefox's implementation is incomplete,
-    // therefore we test actual functionality of`:scope` as well.
-    return testElement./*OK*/querySelector(':scope div') === testChild;
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
  * Finds the first child element that has the specified attribute.
  * @param {!Element} parent
  * @param {string} attr
@@ -515,6 +446,74 @@ export function childElementByTag(parent, tagName) {
  */
 export function childElementsByTag(parent, tagName) {
   return scopedQuerySelectorAll/*OK*/(parent, `> ${tagName}`);
+}
+
+/**
+ * Checks if the given element matches the selector
+ * @param  {!Element} el The element to verify
+ * @param  {string} selector The selector to check against
+ * @return {boolean} True if the element matched the selector. False otherwise.
+ */
+export function matches(el, selector) {
+  const matcher = el.matches ||
+      el.webkitMatchesSelector ||
+      el.mozMatchesSelector ||
+      el.msMatchesSelector ||
+      el.oMatchesSelector;
+  if (matcher) {
+    return matcher.call(el, selector);
+  }
+  return false; // IE8 always returns false.
+}
+
+/**
+ * Finds the first descendant element with the specified name.
+ * @param {!Element|!Document|!ShadowRoot} element
+ * @param {string} tagName
+ * @return {?Element}
+ */
+export function elementByTag(element, tagName) {
+  let elements;
+  // getElementsByTagName() is not supported on ShadowRoot.
+  if (typeof element.getElementsByTagName === 'function') {
+    elements = element.getElementsByTagName(tagName);
+  } else {
+    elements = element./*OK*/querySelectorAll(tagName);
+  }
+  return (elements && elements[0]) || null;
+}
+
+/**
+ * @type {boolean|undefined}
+ * @visibleForTesting
+ */
+let scopeSelectorSupported;
+
+/**
+ * @param {boolean|undefined} val
+ * @visibleForTesting
+ */
+export function setScopeSelectorSupportedForTesting(val) {
+  scopeSelectorSupported = val;
+}
+
+/**
+ * Test that the :scope selector is supported and behaves correctly.
+ * @param {!Element} parent
+ * @return {boolean}
+ */
+function isScopeSelectorSupported(parent) {
+  const doc = parent.ownerDocument;
+  try {
+    const testElement = doc.createElement('div');
+    const testChild = doc.createElement('div');
+    testElement.appendChild(testChild);
+    // NOTE(cvializ, #12383): Firefox's implementation is incomplete,
+    // therefore we test actual functionality of`:scope` as well.
+    return testElement./*OK*/querySelector(':scope div') === testChild;
+  } catch (e) {
+    return false;
+  }
 }
 
 /**

--- a/src/dom.js
+++ b/src/dom.js
@@ -277,7 +277,8 @@ export function closestAncestorElementByTag(element, tagName) {
 }
 
 /**
- * Finds the closest ancestor element with the specified selector from this element
+ * Finds the closest ancestor element with the specified selector from this
+ * element.
  * @param {!Element} element
  * @param {string} selector
  * @return {?Element} closest ancestor if found.

--- a/src/dom.js
+++ b/src/dom.js
@@ -260,13 +260,13 @@ export function closestNode(node, callback) {
 
 
 /**
- * Finds the closest element with the specified name from this element
+ * Finds the closest ancestor element with the specified name from this element
  * up the DOM subtree.
  * @param {!Element} element
  * @param {string} tagName
  * @return {?Element}
  */
-export function closestByTag(element, tagName) {
+export function closestAncestorElementByTag(element, tagName) {
   if (element.closest) {
     return element.closest(tagName);
   }
@@ -277,12 +277,12 @@ export function closestByTag(element, tagName) {
 }
 
 /**
- * Finds the closest element with the specified selector from this element
+ * Finds the closest ancestor element with the specified selector from this element
  * @param {!Element} element
  * @param {string} selector
  * @return {?Element} closest ancestor if found.
  */
-export function closestBySelector(element, selector) {
+export function closestAncestorElementBySelector(element, selector) {
   if (element.closest) {
     return element.closest(selector);
   }

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -18,7 +18,7 @@ import {CommonSignals} from './common-signals';
 import {Observable} from './observable';
 import {Services} from './services';
 import {Signals} from './utils/signals';
-import {closestBySelector, escapeHtml} from './dom';
+import {closestAncestorElementBySelector, escapeHtml} from './dom';
 import {dev, rethrowAsync, userAssert} from './log';
 import {disposeServicesForEmbed, getTopWindow} from './service';
 import {isDocumentReady} from './document-ready';
@@ -627,5 +627,5 @@ export function whenContentIniLoad(elementOrAmpDoc, hostWin, rect) {
  * @return {boolean}
  */
 export function isInFie(element) {
-  return !!closestBySelector(element, '.i-amphtml-fie');
+  return !!closestAncestorElementBySelector(element, '.i-amphtml-fie');
 }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {addAttributesToElement, closestBySelector} from './dom';
+import {addAttributesToElement, closestAncestorElementBySelector} from './dom';
 import {deserializeMessage, isAmpMessage} from './3p-frame-messaging';
 import {dev, devAssert} from './log';
 import {dict} from './utils/object';
@@ -495,7 +495,7 @@ export function looksLikeTrackingIframe(element) {
     return false;
   }
   // Iframe is not tracking iframe if open with user interaction
-  return !closestBySelector(element, '.i-amphtml-overlay');
+  return !closestAncestorElementBySelector(element, '.i-amphtml-overlay');
 }
 
 // Most common ad sizes

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {
-  closestByTag,
+  closestAncestorElementByTag,
   escapeCssSelectorIdent,
   isIframed,
   openWindowDialog,
@@ -310,7 +310,7 @@ export class Navigation {
     if (e.defaultPrevented) {
       return;
     }
-    const target = closestByTag(dev().assertElement(e.target), 'A');
+    const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
     if (!target || !target.href) {
       return;
     }
@@ -599,7 +599,7 @@ export class Navigation {
  * @param {!Event} e
  */
 function maybeExpandUrlParams(ampdoc, e) {
-  const target = closestByTag(dev().assertElement(e.target), 'A');
+  const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
   if (!target || !target.href) {
     // Not a click on a link.
     return;

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -310,7 +310,8 @@ export class Navigation {
     if (e.defaultPrevented) {
       return;
     }
-    const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
+    const target =
+    closestAncestorElementByTag(dev().assertElement(e.target), 'A');
     if (!target || !target.href) {
       return;
     }
@@ -599,7 +600,8 @@ export class Navigation {
  * @param {!Event} e
  */
 function maybeExpandUrlParams(ampdoc, e) {
-  const target = closestAncestorElementByTag(dev().assertElement(e.target), 'A');
+  const target =
+    closestAncestorElementByTag(dev().assertElement(e.target), 'A');
   if (!target || !target.href) {
     // Not a click on a link.
     return;

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -310,8 +310,8 @@ export class Navigation {
     if (e.defaultPrevented) {
       return;
     }
-    const target =
-    closestAncestorElementByTag(dev().assertElement(e.target), 'A');
+    const element = dev().assertElement(e.target);
+    const target = closestAncestorElementByTag(element, 'A');
     if (!target || !target.href) {
       return;
     }

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -27,7 +27,7 @@ import {
 } from './viewport-binding-ios-embed-wrapper';
 import {ViewportBindingNatural_} from './viewport-binding-natural';
 import {VisibilityState} from '../../visibility-state';
-import {closestBySelector, isIframed} from '../../dom';
+import {closestAncestorElementBySelector, isIframed} from '../../dom';
 import {dev, devAssert} from '../../log';
 import {dict} from '../../utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../friendly-iframe-embed';
@@ -611,7 +611,7 @@ export class Viewport {
    */
   getScrollingContainerFor_(element) {
     return this.vsync_.measurePromise(() =>
-      closestBySelector(element, '.i-amphtml-scrollable') ||
+      closestAncestorElementBySelector(element, '.i-amphtml-scrollable') ||
         this.binding_.getScrollingElement());
   }
 

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -14,7 +14,7 @@
   * limitations under the License.
   */
 
-import {closestByTag, waitForChild} from '../dom';
+import {closestAncestorElementByTag, waitForChild} from '../dom';
 
 
 /**
@@ -26,7 +26,7 @@ import {closestByTag, waitForChild} from '../dom';
  * @return {boolean}
  */
 export function descendsFromStory(element) {
-  return !!closestByTag(element, 'amp-story');
+  return !!closestAncestorElementByTag(element, 'amp-story');
 }
 
 /**

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -264,17 +264,26 @@ describes.sandboxed('DOM', {}, env => {
     child.className = 'child';
     element.appendChild(child);
 
-    expect(dom.closestAncestorElementBySelector(child, 'child')).to.equal(child);
-    expect(dom.closestAncestorElementBySelector(child, '.child')).to.equal(child);
-    expect(dom.closestAncestorElementBySelector(child, '#child')).to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, 'child'))
+        .to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, '.child'))
+        .to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, '#child'))
+        .to.equal(child);
 
-    expect(dom.closestAncestorElementBySelector(child, 'element')).to.equal(element);
-    expect(dom.closestAncestorElementBySelector(child, '.element')).to.equal(element);
-    expect(dom.closestAncestorElementBySelector(child, '#element')).to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, 'element'))
+        .to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, '.element'))
+        .to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, '#element'))
+        .to.equal(element);
 
-    expect(dom.closestAncestorElementBySelector(child, 'parent')).to.equal(parent);
-    expect(dom.closestAncestorElementBySelector(child, '.parent')).to.equal(parent);
-    expect(dom.closestAncestorElementBySelector(child, '#parent')).to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, 'parent'))
+        .to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, '.parent'))
+        .to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, '#parent'))
+        .to.equal(parent);
   });
 
   it('elementByTag should find first match', () => {

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -187,8 +187,8 @@ describes.sandboxed('DOM', {}, env => {
 
     expect(dom.closest(child, () => true)).to.equal(child);
     expect(dom.closestNode(child, () => true)).to.equal(child);
-    expect(dom.closestByTag(child, 'div')).to.equal(child);
-    expect(dom.closestByTag(child, 'DIV')).to.equal(child);
+    expect(dom.closestAncestorElementByTag(child, 'div')).to.equal(child);
+    expect(dom.closestAncestorElementByTag(child, 'DIV')).to.equal(child);
   });
 
   it('closest should stop search at opt_stopAt', () => {
@@ -223,16 +223,16 @@ describes.sandboxed('DOM', {}, env => {
 
     expect(dom.closest(child, e => e.tagName == 'CHILD')).to.equal(child);
     expect(dom.closestNode(child, e => e.tagName == 'CHILD')).to.equal(child);
-    expect(dom.closestByTag(child, 'child')).to.equal(child);
+    expect(dom.closestAncestorElementByTag(child, 'child')).to.equal(child);
 
     expect(dom.closest(child, e => e.tagName == 'ELEMENT')).to.equal(element);
     expect(dom.closestNode(child, e => e.tagName == 'ELEMENT'))
         .to.equal(element);
-    expect(dom.closestByTag(child, 'element')).to.equal(element);
+    expect(dom.closestAncestorElementByTag(child, 'element')).to.equal(element);
 
     expect(dom.closest(child, e => e.tagName == 'PARENT')).to.equal(parent);
     expect(dom.closestNode(child, e => e.tagName == 'PARENT')).to.equal(parent);
-    expect(dom.closestByTag(child, 'parent')).to.equal(parent);
+    expect(dom.closestAncestorElementByTag(child, 'parent')).to.equal(parent);
   });
 
   it('closestNode should find nodes as well as elements', () => {
@@ -249,7 +249,7 @@ describes.sandboxed('DOM', {}, env => {
     expect(dom.closestNode(text, n => n.nodeType == 11)).to.equal(fragment);
   });
 
-  it('closestBySelector should find first match', () => {
+  it('closestAncestorElementBySelector should find first match', () => {
     const parent = document.createElement('parent');
     parent.className = 'parent';
     parent.id = 'parent';
@@ -264,17 +264,17 @@ describes.sandboxed('DOM', {}, env => {
     child.className = 'child';
     element.appendChild(child);
 
-    expect(dom.closestBySelector(child, 'child')).to.equal(child);
-    expect(dom.closestBySelector(child, '.child')).to.equal(child);
-    expect(dom.closestBySelector(child, '#child')).to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, 'child')).to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, '.child')).to.equal(child);
+    expect(dom.closestAncestorElementBySelector(child, '#child')).to.equal(child);
 
-    expect(dom.closestBySelector(child, 'element')).to.equal(element);
-    expect(dom.closestBySelector(child, '.element')).to.equal(element);
-    expect(dom.closestBySelector(child, '#element')).to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, 'element')).to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, '.element')).to.equal(element);
+    expect(dom.closestAncestorElementBySelector(child, '#element')).to.equal(element);
 
-    expect(dom.closestBySelector(child, 'parent')).to.equal(parent);
-    expect(dom.closestBySelector(child, '.parent')).to.equal(parent);
-    expect(dom.closestBySelector(child, '#parent')).to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, 'parent')).to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, '.parent')).to.equal(parent);
+    expect(dom.closestAncestorElementBySelector(child, '#parent')).to.equal(parent);
   });
 
   it('elementByTag should find first match', () => {


### PR DESCRIPTION
- Move `ancestorElements` and `ancestorElementsByTag` close to other similar functions in `dom.js`.
- Rename `closestByTag` and `closestBySelector` to `closestAncestorElementByTag` and `closestAncestorElementBySelector`, respectively.
- Have all `child` related functions be next to all `ancestor` related functions in `dom.js`.

📖 ♻️   

@choumx @jridgewell 