### PR TITLE
🏗Run all commands on Travis for non PR builds

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -603,8 +603,9 @@ function main() {
       colors.cyan(process.env.BUILD_SHARD),
       '\n');
 
-  if (process.env.TRAVIS_EVENT_TYPE === 'push') {
-    console.log(fileLogPrefix, 'Running all commands on push build.');
+  if (process.env.TRAVIS_EVENT_TYPE !== 'pull_request') {
+    console.log(fileLogPrefix,
+        'Running all commands, since this isn\'t a PR build...');
     runAllCommands();
     stopTimer('pr-check.js', startTime);
     return 0;


### PR DESCRIPTION
Before this change, triggered builds would go through the `pull_request` workflow of `pr-check.js` instead of running all commands.

See https://travis-ci.org/ampproject/amphtml/jobs/490098244#L641

Note: This doesn't change the following bundle-size logic, which continues to write the size only for `push` builds.

https://github.com/ampproject/amphtml/blob/ebe9247fb87af3dbccab2dcf2f6b3382041a95bd/build-system/tasks/bundle-size.js#L75-L80