### PR TITLE
✨ Record new tick event fid (first input delay).

### DIFF
--- a/build-system/event-timing.extern.js
+++ b/build-system/event-timing.extern.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for the Event Timing API.
+ *
+ * Created from
+ * @see https://wicg.github.io/event-timing/
+ *
+ * @todo This should be removed when the definitions are released
+ * in closure-compiler.
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+  * @extends {PerformanceEntry}
+ */
+function PerformanceEventTiming() {}
+/** @type {number} */ PerformanceEventTiming.prototype.processingStart;
+/** @type {number} */ PerformanceEventTiming.prototype.processingEnd;
+/** @type {boolean} */ PerformanceEventTiming.prototype.cancelable;

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -118,6 +118,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
   const baseExterns = [
     'build-system/amp.extern.js',
     'build-system/dompurify.extern.js',
+    'build-system/event-timing.extern.js',
     'third_party/closure-compiler/externs/web_animations.js',
     'third_party/moment/moment.extern.js',
     'third_party/react-externs/externs.js',

--- a/extensions/amp-viewer-integration/TICKEVENTS.md
+++ b/extensions/amp-viewer-integration/TICKEVENTS.md
@@ -34,3 +34,4 @@ As an example if we executed `perf.tick('label')` we assume we have a counterpar
 | On First Visible | `ofv` | The first time the page has been turned visible. |
 | First paint time | `fp` | The time on the first non-blank paint of the page. |
 | First contentful paint time | `fcp` | First paint with content. See https://github.com/WICG/paint-timing |
+| First input delay | `fid` | Millisecond delay in handling the first user input on the page. See https://github.com/WICG/event-timing |

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -232,7 +232,7 @@ export class Performance {
       if (recordedFirstInputDelay) {
         return;
       }
-      this.tick('fid', entry.processingStart - entry.startTime);
+      this.tickDelay('fid', entry.processingStart - entry.startTime);
       recordedFirstInputDelay = true;
     };
     const observer = new this.win.PerformanceObserver(list => {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -227,13 +227,13 @@ export class Performance {
     // as to whether we have reported a value yet, since in the future it may
     // be reported twice.
     // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
-    let recordedFirstInput = false;
+    let recordedFirstInputDelay = false;
     const processEntry = entry => {
-      if (recordedFirstInput) {
+      if (recordedFirstInputDelay) {
         return;
       }
       this.tick('fid', entry.processingStart - entry.startTime);
-      recordedFirstInput = true;
+      recordedFirstInputDelay = true;
     };
     const observer = new this.win.PerformanceObserver(list => {
       list.getEntries().forEach(processEntry);

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -176,7 +176,8 @@ export class Performance {
   }
 
   /**
-   * Reports performance metrics first paint, first contentful paint, and first input delay.
+   * Reports performance metrics first paint, first contentful paint,
+   * and first input delay.
    * See https://github.com/WICG/paint-timing
    */
   registerPerformanceObserver_() {
@@ -202,7 +203,7 @@ export class Performance {
         this.tickDelta('fid', entry.processingStart - entry.startTime);
         recordedFirstInputDelay = true;
       }
-    }
+    };
 
     const entryTypesToObserve = [];
     if (this.win.PerformancePaintTiming) {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -112,8 +112,7 @@ export class Performance {
 
     // Tick window.onload event.
     whenDocumentComplete(win.document).then(() => this.onload_());
-    this.registerPaintTimingObserver_();
-    this.registerEventTimingObserver_();
+    this.registerPerformanceObserver_();
   }
 
   /**
@@ -177,13 +176,10 @@ export class Performance {
   }
 
   /**
-   * Reports first pain and first contentful paint timings.
+   * Reports performance metrics first paint, first contentful paint, and first input delay.
    * See https://github.com/WICG/paint-timing
    */
-  registerPaintTimingObserver_() {
-    if (!this.win.PerformancePaintTiming) {
-      return;
-    }
+  registerPerformanceObserver_() {
     // Chrome doesn't implement the buffered flag for PerformanceObserver.
     // That means we need to read existing entries and maintain state
     // as to whether we have reported a value yet, since in the future it may
@@ -191,6 +187,7 @@ export class Performance {
     // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
     let recordedFirstPaint = false;
     let recordedFirstContentfulPaint = false;
+    let recordedFirstInputDelay = false;
     const processEntry = entry => {
       if (entry.name == 'first-paint' && !recordedFirstPaint) {
         this.tickDelta('fp', entry.startTime + entry.duration);
@@ -201,49 +198,38 @@ export class Performance {
         this.tickDelta('fcp', entry.startTime + entry.duration);
         recordedFirstContentfulPaint = true;
       }
-    };
-    const observer = new this.win.PerformanceObserver(list => {
-      list.getEntries().forEach(processEntry);
-      this.flush();
-    });
-    // Programmatically read once as currently PerformanceObserver does not
-    // report past entries as of Chrome 61.
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
-    this.win.performance.getEntriesByType('paint').forEach(processEntry);
+      else if (entry.entryType === 'firstInput' && !recordedFirstInputDelay) {
+        this.tickDelta('fid', entry.processingStart - entry.startTime);
+        recordedFirstInputDelay = true;
+      }
+    }
 
-    observer.observe({entryTypes: ['paint']});
-  }
+    const entryTypesToObserve = [];
+    if (this.win.PerformancePaintTiming) {
+      // Programmatically read once as currently PerformanceObserver does not
+      // report past entries as of Chrome 61.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
+      this.win.performance.getEntriesByType('paint').forEach(processEntry);
+      entryTypesToObserve.push('paint');
+    }
 
-  /**
-   * Reports first input delay.
-   * See https://wicg.github.io/event-timing/
-   */
-  registerEventTimingObserver_() {
-    if (!this.win.PerformanceEventTiming) {
+    if (this.win.PerformanceEventTiming) {
+      // Programmatically read once as currently PerformanceObserver does not
+      // report past entries as of Chrome 61.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
+      this.win.performance.getEntriesByType('firstInput').forEach(processEntry);
+      entryTypesToObserve.push('firstInput');
+    }
+
+    if (entryTypesToObserve.length === 0) {
       return;
     }
-    // Chrome doesn't implement the buffered flag for PerformanceObserver.
-    // That means we need to read existing entries and maintain state
-    // as to whether we have reported a value yet, since in the future it may
-    // be reported twice.
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
-    let recordedFirstInputDelay = false;
-    const processEntry = entry => {
-      if (recordedFirstInputDelay) {
-        return;
-      }
-      this.tickDelay('fid', entry.processingStart - entry.startTime);
-      recordedFirstInputDelay = true;
-    };
+
     const observer = new this.win.PerformanceObserver(list => {
       list.getEntries().forEach(processEntry);
       this.flush();
     });
-    // Programmatically read once as currently PerformanceObserver does not
-    // report past entries as of Chrome 61.
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
-    this.win.performance.getEntriesByType('firstInput').forEach(processEntry);
-    observer.observe({entryTypes: ['firstInput']});
+    observer.observe({entryTypes: entryTypesToObserve});
   }
 
   /**

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -717,27 +717,28 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     }
   }
 
-  describe('should forward first-paint and first-contentful-paint metrics for performance entries', () => {
+  describe('should forward paint metrics for performance entries', () => {
     it('created before performance service registered', () => {
       // Pretend that the PaintTiming API exists.
       env.win.PerformancePaintTiming = true;
 
       const entries = [{
-          duration: 1,
-          entryType: "paint",
-          name: "first-paint",
-          startTime: 10,
-        },
-        {
-          duration: 5,
-          entryType: "paint",
-          name: "first-contentful-paint",
-          startTime: 10
+        duration: 1,
+        entryType: 'paint',
+        name: 'first-paint',
+        startTime: 10,
+      },
+      {
+        duration: 5,
+        entryType: 'paint',
+        name: 'first-contentful-paint',
+        startTime: 10,
       }];
       const getEntriesByType = env.sandbox.stub();
       getEntriesByType.withArgs('paint').returns(entries);
       getEntriesByType.returns([]);
-      env.sandbox.stub(env.win.performance, 'getEntriesByType').callsFake(getEntriesByType);
+      env.sandbox.stub(env.win.performance, 'getEntriesByType')
+          .callsFake(getEntriesByType);
 
       installPerformanceService(env.win);
 
@@ -769,23 +770,24 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         performanceObserver = new PerformanceObserverImpl(callback);
         return performanceObserver;
       });
-      env.sandbox.stub(env.win, 'PerformanceObserver').callsFake(PerformanceObserverStub);
+      env.sandbox.stub(env.win, 'PerformanceObserver')
+          .callsFake(PerformanceObserverStub);
 
       installPerformanceService(env.win);
 
       const perf = Services.performanceFor(env.win);
 
       const entries = [{
-          duration: 1,
-          entryType: "paint",
-          name: "first-paint",
-          startTime: 10,
-        },
-        {
-          duration: 5,
-          entryType: "paint",
-          name: "first-contentful-paint",
-          startTime: 10
+        duration: 1,
+        entryType: 'paint',
+        name: 'first-paint',
+        startTime: 10,
+      },
+      {
+        duration: 5,
+        entryType: 'paint',
+        name: 'first-contentful-paint',
+        startTime: 10,
       }];
       const list = {
         getEntries() {
@@ -796,19 +798,19 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       performanceObserver.triggerCallback(list);
       expect(perf.events_.length).to.equal(2);
       expect(perf.events_[0])
-        .to.be.jsonEqual({
-          label: 'fp',
-          delta: 11,
-        },
-        {
-          label: 'fcp',
-          delta: 15,
-        });
+          .to.be.jsonEqual({
+            label: 'fp',
+            delta: 11,
+          },
+          {
+            label: 'fcp',
+            delta: 15,
+          });
       delete env.win.PerformanceEventTiming;
     });
   });
 
-  describe('should forward first-paint and first-contentful-paint metrics for performance entries', () => {
+  describe('should forward first input metrics for performance entries', () => {
     it('created before performance service registered', () => {
       // Pretend that the EventTiming API exists.
       env.win.PerformanceEventTiming = true;
@@ -825,7 +827,8 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       const getEntriesByType = env.sandbox.stub();
       getEntriesByType.withArgs('firstInput').returns(entries);
       getEntriesByType.returns([]);
-      env.sandbox.stub(env.win.performance, 'getEntriesByType').callsFake(getEntriesByType);
+      env.sandbox.stub(env.win.performance, 'getEntriesByType')
+          .callsFake(getEntriesByType);
 
       installPerformanceService(env.win);
 
@@ -853,7 +856,8 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         performanceObserver = new PerformanceObserverImpl(callback);
         return performanceObserver;
       });
-      env.sandbox.stub(env.win, 'PerformanceObserver').callsFake(PerformanceObserverStub);
+      env.sandbox.stub(env.win, 'PerformanceObserver')
+          .callsFake(PerformanceObserverStub);
 
       installPerformanceService(env.win);
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -770,7 +770,7 @@ describes.realWin('performance with firstInput events', {amp: true}, env => {
         performanceObserver = new PerformanceObserverImpl(callback);
         return performanceObserver;
       });
-      sinon.replace(env.win, 'PerformanceObserver', PerformanceObserverStub);
+      env.sandbox.stub(env.win, 'PerformanceObserver', PerformanceObserverStub);
 
       installPerformanceService(env.win);
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -695,7 +695,7 @@ describes.realWin('performance with firstInput events', {amp: true}, env => {
       env.win.PerformanceEventTiming = true;
 
       //
-      const earlyEntries = [{
+      const entries = [{
         cancelable: true,
         duration: 8,
         entryType: 'firstInput',
@@ -705,7 +705,7 @@ describes.realWin('performance with firstInput events', {amp: true}, env => {
         startTime: 100,
       }];
       const getEntriesByType = sinon.stub();
-      getEntriesByType.withArgs('firstInput').returns(earlyEntries);
+      getEntriesByType.withArgs('firstInput').returns(entries);
       getEntriesByType.returns([]);
       sinon.replace(env.win.performance, 'getEntriesByType', getEntriesByType);
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -734,7 +734,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
           name: "first-contentful-paint",
           startTime: 10
       }];
-      const getEntriesByType = sinon.stub();
+      const getEntriesByType = env.sandbox.stub();
       getEntriesByType.withArgs('paint').returns(entries);
       getEntriesByType.returns([]);
       env.sandbox.stub(env.win.performance, 'getEntriesByType').callsFake(getEntriesByType);
@@ -762,7 +762,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       env.win.PerformancePaintTiming = true;
 
       // Stub and fake the PerformanceObserver constructor.
-      const PerformanceObserverStub = sinon.stub();
+      const PerformanceObserverStub = env.sandbox.stub();
 
       let performanceObserver;
       PerformanceObserverStub.callsFake(callback => {
@@ -822,7 +822,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         processingStart: 103,
         startTime: 100,
       }];
-      const getEntriesByType = sinon.stub();
+      const getEntriesByType = env.sandbox.stub();
       getEntriesByType.withArgs('firstInput').returns(entries);
       getEntriesByType.returns([]);
       env.sandbox.stub(env.win.performance, 'getEntriesByType').callsFake(getEntriesByType);
@@ -846,7 +846,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       env.win.PerformanceEventTiming = true;
 
       // Stub and fake the PerformanceObserver constructor.
-      const PerformanceObserverStub = sinon.stub();
+      const PerformanceObserverStub = env.sandbox.stub();
 
       let performanceObserver;
       PerformanceObserverStub.callsFake(callback => {
@@ -885,4 +885,5 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     });
   });
 });
+
 


### PR DESCRIPTION
This metric allows tracking the delay that occurs when a user first attempts to interact with a page exposed by the [Event Timing API](https://wicg.github.io/event-timing/).

I haven't introduced a test for this, and would appreciate some feedback on how I should go about this before I do. Should I use sinon to stub/fake out the `PerformanceObserver`, and send fake `firstInput` messages through the faked object?

cc @lannka