### PR TITLE
Replace CommonSignal "CHANGE_SIZE_END" with a change size event

### DIFF
--- a/src/amp-events.js
+++ b/src/amp-events.js
@@ -29,4 +29,5 @@ export const AmpEvents = {
   LOAD_START: 'amp:load:start',
   LOAD_END: 'amp:load:end',
   ERROR: 'amp:error',
+  SIZE_CHANGED: 'amp:size-changed',
 };

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -50,10 +50,4 @@ export const CommonSignals = {
    * The element has been unlaid out.
    */
   UNLOAD: 'unload',
-
-  /**
-   * The changeSize function has been called on the element and it is now
-   * responsible for managing its own size.
-   */
-  CHANGE_SIZE_END: 'change-size-end',
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -726,7 +726,7 @@ function createBaseCustomElementClass(win) {
       if (this.isAwaitingSize_()) {
         this.sizeProvided_();
       }
-      this.signals_.signal(CommonSignals.CHANGE_SIZE_END);
+      this.dispatchCustomEvent(AmpEvents.SIZE_CHANGED);
     }
 
     /**
@@ -1280,7 +1280,6 @@ function createBaseCustomElementClass(win) {
       this.signals_.reset(CommonSignals.LOAD_START);
       this.signals_.reset(CommonSignals.LOAD_END);
       this.signals_.reset(CommonSignals.INI_LOAD);
-      this.signals_.reset(CommonSignals.CHANGE_SIZE_END);
     }
 
     /**

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1226,11 +1226,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element).not.to.have.class('i-amphtml-layout-awaiting-size');
     });
 
-    it('should signal size-changed when size changed', () => {
+    it('should dispatch custom event size-changed when size changed', () => {
       const element = new ElementClass();
+      const spyDispatchEvent = sandbox.spy(element, 'dispatchCustomEvent');
+
       element.changeSize();
-      expect(element.signals().get(CommonSignals.CHANGE_SIZE_END)).to.be.ok;
-      return element.signals().whenSignal(CommonSignals.CHANGE_SIZE_END);
+
+      expect(spyDispatchEvent).to.be.calledWith(AmpEvents.SIZE_CHANGED);
     });
 
     describe('unlayoutCallback', () => {


### PR DESCRIPTION
For #20683, we need to get the final size of an embedded component in preparation for an animation. 

`CommonSignals.CHANGE_SIZE_END` is only executed once, so when dealing with elements that have subsequent size-changing events this is not reliable.

I searched for where `CommonSignals.CHANGE_SIZE_END` is used but is seems to only have been used in #18543  and removed sometime after.