### PR TITLE
🏗 Capture console output and verbose logging during sauce connect failures

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -31,6 +31,7 @@ TAR_FILE="$DOWNLOAD_DIR/$SC_VERSION.tar.gz"
 BINARY_FILE="$SC_VERSION/bin/sc"
 PID_FILE="sauce_connect_pid"
 LOG_FILE="sauce_connect_log"
+OUTPUT_FILE="sauce_connect_output"
 READY_FILE="sauce_connect_ready"
 READY_DELAY_SECS=120
 LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
@@ -63,7 +64,7 @@ fi
 echo "$LOG_PREFIX Unpacking $(CYAN "$TAR_FILE")"
 tar -xzf "$TAR_FILE"
 
-# Clean up old log files, if any.
+# Clean up old files, if any.
 if [[ -f "$LOG_FILE" ]]; then
   echo "$LOG_PREFIX Deleting old log file $(CYAN "$LOG_FILE")"
   rm "$LOG_FILE"
@@ -71,6 +72,10 @@ fi
 if [[ -f $PID_FILE ]]; then
   echo "$LOG_PREFIX Deleting old pid file $(CYAN "$PID_FILE")"
   rm "$PID_FILE"
+fi
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "$LOG_PREFIX Deleting old output file $(CYAN "$OUTPUT_FILE")"
+  rm "$OUTPUT_FILE"
 fi
 
 # Establish the tunnel identifier (job number on Travis / username during local dev).
@@ -82,7 +87,7 @@ fi
 
 # Launch proxy and wait for a tunnel to be created.
 echo "$LOG_PREFIX Launching $(CYAN "$BINARY_FILE")"
-"$BINARY_FILE" --verbose --tunnel-identifier "$TUNNEL_IDENTIFIER" --readyfile "$READY_FILE" --pidfile "$PID_FILE" 1>"$LOG_FILE" 2>&1 &
+"$BINARY_FILE" --verbose --tunnel-identifier "$TUNNEL_IDENTIFIER" --readyfile "$READY_FILE" --pidfile "$PID_FILE" --logfile "$LOG_FILE" 1>"$OUTPUT_FILE" 2>&1 &
 count=0
 while [ $count -lt $READY_DELAY_SECS ]
 do
@@ -90,7 +95,7 @@ do
   then
     # Print confirmation.
     PID="$(cat "$PID_FILE")"
-    TUNNEL_ID="$(grep -oP "Tunnel ID: \K.*$" "$LOG_FILE")"
+    TUNNEL_ID="$(grep -oP "Tunnel ID: \K.*$" "$OUTPUT_FILE")"
     echo "$LOG_PREFIX Sauce Connect Proxy with tunnel ID $(CYAN "$TUNNEL_ID") and identifier $(CYAN "$TUNNEL_IDENTIFIER") is now running as pid $(CYAN "$PID")"
     break
   else
@@ -101,6 +106,8 @@ do
     then
       # Print the error logs.
       echo "$LOG_PREFIX Sauce Connect Proxy has not started after $(CYAN "$READY_DELAY_SECS") seconds."
+      echo "$LOG_PREFIX Console output:"
+      cat "$OUTPUT_FILE"
       echo "$LOG_PREFIX Log file contents:"
       cat "$LOG_FILE"
       exit 1


### PR DESCRIPTION
We're debugging the sauce connect failures that are frequently occurring of late. It turns out that the verbose logs are written to a file, separate from the console output.

See https://travis-ci.org/ampproject/amphtml/jobs/490221511#L711 for example

This PR captures both the log file and the console output contents, and prints both when a connection failure occurs.