### PR TITLE
🐛Fix lightbox closing when opened from a carousel.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -60,7 +60,7 @@ import {triggerAnalyticsEvent} from '../../../src/analytics';
 const TAG = 'amp-lightbox-gallery';
 const DEFAULT_GALLERY_ID = 'amp-lightbox-gallery';
 const SLIDE_ITEM_SELECTOR =
-    '.amp-carousel-slide-item, .i-amphtml-carousel-slotted';
+    '.i-amphtml-slide-item, .i-amphtml-carousel-slotted';
 
 /**
  * Set of namespaces that indicate the lightbox controls mode.


### PR DESCRIPTION
The wrong selector is used here, causing an assert to fail. This prevents carousel syncing, but the lightbox still closes.

This was broken in #20558