### PR TITLE
✅Fix carousel e2e tests.

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -86,7 +86,7 @@ async function e2e() {
 
   // specify tests to run
   if (argv.files) {
-    glob.sync(argv.path).forEach(file => {
+    glob.sync(argv.files).forEach(file => {
       mocha.addFile(file);
     });
   }

--- a/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-carousel.js
@@ -113,7 +113,7 @@ describes.endtoend('AMP carousel', {
 
   it('should have the correct scroll position when resizing', async() => {
     // Note: 513 seems to be the smallest settable width.
-    controller.setWindowRect({
+    await controller.setWindowRect({
       width: 600,
       height: 600,
     });
@@ -128,7 +128,7 @@ describes.endtoend('AMP carousel', {
       'width': 600,
     });
 
-    controller.setWindowRect({
+    await controller.setWindowRect({
       width: 700,
       height: 600,
     });

--- a/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-grouping.js
@@ -56,13 +56,17 @@ describes.endtoend('AMP carousel grouping', {
       await expect(rect(slides[2])).to.include({x: 0});
     });
 
-    it('should snap on current group when before the midpoint', async() => {
-      const el = await getScrollingElement(controller);
-      const slides = await getSlides(controller);
+    // TODO(sparhami) It seems like scrolling by even 1 pixel using scrollBy
+    // causes snap now. Need touch event support to actually simulate the  user
+    // scrolling.
+    it.skip('should snap on current group when before the midpoint',
+        async() => {
+          const el = await getScrollingElement(controller);
+          const slides = await getSlides(controller);
 
-      await controller.scrollBy(el, {left: slideWidth - 1});
-      await expect(rect(slides[0])).to.include({x: 0});
-    });
+          await controller.scrollBy(el, {left: slideWidth - 1});
+          await expect(rect(slides[0])).to.include({x: 0});
+        });
   });
 
   describe('advancing', () => {


### PR DESCRIPTION
- Change approach used for setting the window size to work in headless
mode.
- Skip a test that no longer works with the current approach.
