### PR TITLE
🏗 Consolidate all Travis-related state in `build-system/travis.js`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,6 +25,7 @@
 
 'use strict';
 
+const {isTravisBuild} = require('./build-system/travis');
 const minimist = require('minimist');
 const argv = minimist(process.argv.slice(2));
 
@@ -40,7 +41,7 @@ module.exports = function(api) {
         'modules': 'commonjs',
         'loose': true,
         'targets': {
-          'browsers': process.env.TRAVIS ?
+          'browsers': isTravisBuild() ?
             ['Last 2 versions', 'safari >= 9'] : ['Last 2 versions'],
         },
       }],

--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -17,6 +17,7 @@
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 const {execScriptAsync, exec} = require('./exec');
+const {isTravisBuild} = require('./travis');
 
 const {green, cyan} = colors;
 
@@ -31,7 +32,7 @@ const killSuffix = (process.platform == 'win32') ? '>NUL' : '';
  * @param {string} command
  */
 exports.createCtrlcHandler = function(command) {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(green('Running'), cyan(command) + green('. Press'), cyan('Ctrl + C'),
         green('to cancel...'));
   }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -43,6 +43,7 @@ const {
 const {
   isTravisBuild,
   isTravisPullRequestBuild,
+  isTravisPushBuild,
   travisPullRequestSha,
 } = require('./travis');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
@@ -479,7 +480,9 @@ function runAllCommands() {
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();
-    command.runVisualDiffTests(/* opt_mode */ 'master');
+    if (isTravisPushBuild()) {
+      command.runVisualDiffTests(/* opt_mode */ 'master');
+    }
     command.runLintCheck();
     command.runJsonCheck();
     command.runDepAndTypeChecks();

--- a/build-system/single-pass.js
+++ b/build-system/single-pass.js
@@ -31,6 +31,7 @@ const relativePath = require('path').relative;
 const tempy = require('tempy');
 const through = require('through2');
 const {extensionBundles, altMainBundles, TYPES} = require('../bundles.config');
+const {isTravisBuild} = require('./travis');
 const {TopologicalSort} = require('topological-sort');
 const TYPES_VALUES = Object.keys(TYPES).map(x => TYPES[x]);
 const wrappers = require('./compile-wrappers');
@@ -419,7 +420,7 @@ function isCommonJsModule(file) {
  * @param {!Object} config
  */
 function transformPathsToTempDir(graph, config) {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log('Writing transforms to', colors.cyan(graph.tmp));
   }
   // `sorted` will always have the files that we need.

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -17,6 +17,7 @@
 
 const ava = require('gulp-ava');
 const gulp = require('gulp-help')(require('gulp'));
+const {isTravisBuild} = require('../travis');
 
 /**
  * Runs ava tests.
@@ -27,7 +28,7 @@ function runAvaTests() {
     'get-zindex/test.js',
     'prepend-global/test.js',
   ])
-      .pipe(ava({silent: !!process.env.TRAVIS}));
+      .pipe(ava({silent: !!isTravisBuild()}));
 }
 
 gulp.task('ava', 'Runs ava tests for gulp tasks', runAvaTests);

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -28,7 +28,7 @@ function runAvaTests() {
     'get-zindex/test.js',
     'prepend-global/test.js',
   ])
-      .pipe(ava({silent: !!isTravisBuild()}));
+      .pipe(ava({silent: isTravisBuild()}));
 }
 
 gulp.task('ava', 'Runs ava tests for gulp tasks', runAvaTests);

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -24,6 +24,11 @@ const octokit = require('@octokit/rest')();
 const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
+const {
+  isTravisPullRequestBuild,
+  isTravisPushBuild,
+  travisRepoSlug,
+} = require('../travis');
 const {getStdout} = require('../exec');
 const {gitCommitHash, gitTravisMasterBaseline} = require('../git');
 
@@ -58,28 +63,19 @@ function getGzippedBundleSize() {
 }
 
 /**
- * Return true if this task is running on Travis as part of a pull request.
- *
- * @return {boolean} true if running on Travis as part of a pull request.
- */
-function isPullRequest() {
-  return process.env.TRAVIS && process.env.TRAVIS_EVENT_TYPE === 'pull_request';
-}
-
-/**
  * Store the bundle size of a commit hash in the build artifacts storage
  * repository to the passed value.
  *
  * @return {!Promise}
  */
 function storeBundleSize() {
-  if (!process.env.TRAVIS || process.env.TRAVIS_EVENT_TYPE !== 'push') {
+  if (!isTravisPushBuild()) {
     log(yellow('Skipping'), cyan('--on_push_build') + ':',
         'this action can only be performed on `push` builds on Travis');
     return;
   }
 
-  if (process.env.TRAVIS_REPO_SLUG !== expectedGitHubRepoSlug) {
+  if (travisRepoSlug() !== expectedGitHubRepoSlug) {
     log(yellow('Skipping'), cyan('--on_push_build') + ':',
         'this action can only be performed on Travis builds on the',
         cyan(expectedGitHubRepoSlug), 'repository');
@@ -127,7 +123,7 @@ function storeBundleSize() {
  * Mark a pull request on Travis as skipped, via the AMP bundle-size GitHub App.
  */
 async function skipBundleSize() {
-  if (isPullRequest()) {
+  if (isTravisPullRequestBuild()) {
     const commitHash = gitCommitHash();
     try {
       const response = await requestPost(url.resolve(bundleSizeAppBaseUrl,
@@ -153,7 +149,7 @@ async function skipBundleSize() {
  * Report the size to the bundle-size GitHub App, to determine size changes.
  */
 async function reportBundleSize() {
-  if (isPullRequest()) {
+  if (isTravisPullRequestBuild()) {
     const baseSha = gitTravisMasterBaseline();
     const bundleSize = parseFloat(getGzippedBundleSize());
     const commitHash = gitCommitHash();

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -24,8 +24,9 @@ const log = require('fancy-log');
 const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
 const path = require('path');
 const {gitDiffAddedNameOnlyMaster, gitDiffNameOnlyMaster} = require('../git');
+const {isTravisBuild} = require('../travis');
 
-const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
 
 /**
  * Parses the list of files in argv, or extracts it from the commit log.
@@ -70,7 +71,7 @@ function checkLinks() {
               deadLinksFound = true;
               deadLinksFoundInFile = true;
               log('[%s] %s', colors.red('✖'), result.link);
-            } else if (!process.env.TRAVIS) {
+            } else if (!isTravisBuild()) {
               log('[%s] %s', colors.green('✔'), result.link);
             }
           });

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -20,6 +20,7 @@ const closureCompiler = require('gulp-closure-compiler');
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const gulp = require('gulp');
+const {isTravisBuild} = require('../travis');
 const {VERSION: internalRuntimeVersion} = require('../internal-version') ;
 
 const rename = require('gulp-rename');
@@ -46,7 +47,7 @@ exports.closureCompile = function(entryModuleFilename, outputDir,
       inProgress++;
       compile(entryModuleFilename, outputDir, outputFilename, options)
           .then(function() {
-            if (process.env.TRAVIS) {
+            if (isTravisBuild()) {
               // Print a progress dot after each task to avoid Travis timeouts.
               process.stdout.write('.');
             }

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -29,13 +29,14 @@ const path = require('path');
 const source = require('vinyl-source-stream');
 const through = require('through2');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
+const {isTravisBuild} = require('../travis');
 
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
 const red = msg => log(colors.red(msg));
 
-const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
 
 /**
  * @typedef {{

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -15,6 +15,9 @@
  */
 'use strict';
 
+const {gitCommitterEmail} = require('../git');
+const {isTravisBuild, travisJobNumber} = require('../travis');
+
 const COMMON_CHROME_FLAGS = [
   // Dramatically speeds up iframe creation time.
   '--disable-extensions',
@@ -66,7 +69,7 @@ module.exports = {
       ['babelify', {'sourceMapsAbsolute': true}],
     ],
     // Prevent "cannot find module" errors on Travis. See #14166.
-    bundleDelay: process.env.TRAVIS ? 5000 : 1200,
+    bundleDelay: isTravisBuild() ? 5000 : 1200,
   },
 
   reporters: ['super-dots', 'karmaSimpleReporter'],
@@ -128,7 +131,7 @@ module.exports = {
   autoWatch: true,
 
   browsers: [
-    process.env.TRAVIS ? 'Chrome_travis_ci' : 'Chrome_no_extensions',
+    isTravisBuild() ? 'Chrome_travis_ci' : 'Chrome_no_extensions',
   ],
 
   customLaunchers: {
@@ -226,7 +229,8 @@ module.exports = {
 
   sauceLabs: {
     testName: 'AMP HTML on Sauce',
-    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+    // Identifier used in build-system/sauce_connect/start_sauce_connect.sh.
+    tunnelIdentifier: isTravisBuild() ? travisJobNumber() : gitCommitterEmail(),
     startConnect: false,
     connectOptions: {
       noSslBumpDomains: 'all',
@@ -237,7 +241,7 @@ module.exports = {
     mocha: {
       reporter: 'html',
       // Longer timeout on Travis; fail quickly at local.
-      timeout: process.env.TRAVIS ? 10000 : 2000,
+      timeout: isTravisBuild() ? 10000 : 2000,
     },
     captureConsole: false,
     verboseLogging: false,
@@ -250,7 +254,7 @@ module.exports = {
   failOnEmptyTestSuite: false,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
-  browserDisconnectTolerance: process.env.TRAVIS ? 2 : 0,
+  browserDisconnectTolerance: isTravisBuild() ? 2 : 0,
 
   // Import our gulp webserver as a Karma server middleware
   // So we instantly have all the custom server endpoints available

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -34,7 +34,7 @@ const options = {
   fix: false,
   quiet: argv.quiet || false,
 };
-let collapseLintResults = !!isTravisBuild();
+let collapseLintResults = isTravisBuild();
 
 const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
 const rootDir = path.dirname(path.dirname(__dirname));

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -27,15 +27,16 @@ const log = require('fancy-log');
 const path = require('path');
 const watch = require('gulp-watch');
 const {gitDiffNameOnlyMaster} = require('../git');
+const {isTravisBuild, isTravisPullRequestBuild} = require('../travis');
 
 const isWatching = (argv.watch || argv.w) || false;
 const options = {
   fix: false,
   quiet: argv.quiet || false,
 };
-let collapseLintResults = !!process.env.TRAVIS;
+let collapseLintResults = !!isTravisBuild();
 
-const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
 const rootDir = path.dirname(path.dirname(__dirname));
 
 /**
@@ -58,7 +59,7 @@ function initializeStream(globs, streamOptions) {
  * @param {string} message
  */
 function logOnSameLine(message) {
-  if (!process.env.TRAVIS && process.stdout.isTTY) {
+  if (!isTravisBuild() && process.stdout.isTTY) {
     process.stdout.moveCursor(0, -1);
     process.stdout.cursorTo(0);
     process.stdout.clearLine();
@@ -74,7 +75,7 @@ function logOnSameLine(message) {
  * @return {boolean}
  */
 function runLinter(filePath, stream, options) {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(colors.green('Starting linter...'));
   }
   if (collapseLintResults) {
@@ -89,7 +90,7 @@ function runLinter(filePath, stream, options) {
       }))
       .pipe(eslintIfFixed(filePath))
       .pipe(eslint.result(function(result) {
-        if (!process.env.TRAVIS) {
+        if (!isTravisBuild()) {
           logOnSameLine(colors.green('Linted: ') + result.filePath);
         }
         if (options.fix && result.fixed) {
@@ -106,7 +107,7 @@ function runLinter(filePath, stream, options) {
           console./* OK*/log('travis_fold:end:lint_results');
         }
         if (results.errorCount == 0 && results.warningCount == 0) {
-          if (!process.env.TRAVIS) {
+          if (!isTravisBuild()) {
             logOnSameLine(colors.green('SUCCESS: ') +
                 'No linter warnings or errors.');
           }
@@ -155,7 +156,7 @@ function jsFilesChanged() {
  * @return {boolean}
  */
 function eslintRulesChanged() {
-  if (process.env.TRAVIS_EVENT_TYPE === 'push') {
+  if (!isTravisPullRequestBuild()) {
     return false;
   }
   return gitDiffNameOnlyMaster().filter(function(file) {
@@ -172,7 +173,7 @@ function eslintRulesChanged() {
 function setFilesToLint(files) {
   config.lintGlobs =
       config.lintGlobs.filter(e => e !== '**/*.js').concat(files);
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(colors.green('INFO: ') + 'Running lint on the following files:');
     files.forEach(file => {
       log(colors.cyan(file));
@@ -192,7 +193,7 @@ function lint() {
   if (argv.files) {
     setFilesToLint(argv.files.split(','));
   } else if (!eslintRulesChanged() &&
-      (process.env.TRAVIS_EVENT_TYPE === 'pull_request' ||
+      (isTravisPullRequestBuild() ||
        process.env.LOCAL_PR_CHECK ||
        argv['local-changes'])) {
     const jsFiles = jsFilesChanged();

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -23,6 +23,7 @@ const colors = require('ansi-colors');
 const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
+const {isTravisBuild} = require('../../travis');
 
 const {red, cyan} = colors;
 
@@ -154,7 +155,7 @@ function applyConfig(
         return writeTarget(target, fileString, argv.dryrun);
       })
       .then(() => {
-        if (!process.env.TRAVIS) {
+        if (!isTravisBuild()) {
           log('Wrote', cyan(config), 'AMP config to', cyan(target));
         }
       });
@@ -168,7 +169,7 @@ function applyConfig(
  */
 function enableLocalDev(config, target, configJson) {
   let LOCAL_DEV_AMP_CONFIG = {localDev: true};
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log('Enabled local development mode in', cyan(target));
   }
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
@@ -183,7 +184,7 @@ function enableLocalDev(config, target, configJson) {
       thirdPartyFrameHost: TESTING_HOST_NO_PROTOCOL,
       thirdPartyFrameRegex: TESTING_HOST_NO_PROTOCOL,
     });
-    if (!process.env.TRAVIS) {
+    if (!isTravisBuild()) {
       log('Set', cyan('TESTING_HOST'), 'to', cyan(TESTING_HOST),
           'in', cyan(target));
     }
@@ -200,7 +201,7 @@ function removeConfig(target) {
       .then(file => {
         let contents = file.toString();
         if (numConfigs(contents) == 0) {
-          if (!process.env.TRAVIS) {
+          if (!isTravisBuild()) {
             log('No configs found in', cyan(target));
           }
           return Promise.resolve();
@@ -210,7 +211,7 @@ function removeConfig(target) {
         /self\.AMP_CONFIG\|\|\(self\.AMP_CONFIG=.*?\/\*AMP_CONFIG\*\//;
         contents = contents.replace(config, '');
         return writeTarget(target, contents, argv.dryrun).then(() => {
-          if (!process.env.TRAVIS) {
+          if (!isTravisBuild()) {
             log('Removed existing config from', cyan(target));
           }
         });

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -921,6 +921,14 @@ const forbiddenTermsSrcInclusive = {
       'validator/engine/validator.js',
     ],
   },
+  'process\\.env\\.TRAVIS': {
+    message: 'Do not directly use process.env.TRAVIS. Instead, add a ' +
+        'function to build-system/travis.js',
+    whitelist: [
+      'build-system/check-package-manager.js',
+      'build-system/travis.js',
+    ],
+  },
   '\\.matches\\(': 'Please use matches() helper in src/dom.js',
 };
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -921,7 +921,7 @@ const forbiddenTermsSrcInclusive = {
       'validator/engine/validator.js',
     ],
   },
-  'process\\.env\\.TRAVIS': {
+  'process\\.env(\\.TRAVIS|\\[\\\'TRAVIS)': {
     message: 'Do not directly use process.env.TRAVIS. Instead, add a ' +
         'function to build-system/travis.js',
     whitelist: [

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -24,6 +24,7 @@ const minimatch = require('minimatch');
 const path = require('path');
 const {gitDiffNameOnlyMaster} = require('../../git');
 const {green, cyan, red} = colors;
+const {isTravisBuild} = require('../../travis');
 const extensionsCssMapPath = 'EXTENSIONS_CSS_MAP';
 
 /**
@@ -193,7 +194,7 @@ function unitTestsToRun(unitTestPaths) {
 
   filesChanged.forEach(file => {
     if (!fs.existsSync(file)) {
-      if (!process.env.TRAVIS) {
+      if (!isTravisBuild()) {
         log(green('INFO:'), 'Skipping', cyan(file), 'because it was deleted');
       }
     } else if (isUnitTest(file)) {

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -32,6 +32,7 @@ const {app} = require('../../test-server');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
 const {getAdTypes, unitTestsToRun} = require('./helpers');
 const {getStdout} = require('../../exec');
+const {isTravisBuild} = require('../../travis');
 
 const {green, yellow, cyan, red} = colors;
 
@@ -160,7 +161,7 @@ function printArgvMessages() {
     log(green('Launching'), cyan(chromeBase), green('with flags'),
         cyan(formattedFlagList));
   }
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(green('Run'), cyan('gulp help'),
         green('to see a list of all test flags.'));
     log(green('⤷ Use'), cyan('--nohelp'),
@@ -247,7 +248,7 @@ async function runTests() {
     c.client.verboseLogging = true;
   }
 
-  if (!process.env.TRAVIS && (argv.testnames || argv['local-changes'])) {
+  if (!isTravisBuild() && (argv.testnames || argv['local-changes'])) {
     c.reporters = ['mocha'];
   }
 
@@ -347,7 +348,7 @@ async function runTests() {
     c.reporters = c.reporters.concat(['coverage-istanbul']);
     c.coverageIstanbulReporter = {
       dir: 'test/coverage',
-      reports: process.env.TRAVIS ? ['lcov'] : ['html', 'text', 'text-summary'],
+      reports: isTravisBuild() ? ['lcov'] : ['html', 'text', 'text-summary'],
     };
   }
 
@@ -376,7 +377,7 @@ async function runTests() {
 
   // Exit tests
   // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
-  if (process.env.TRAVIS) {
+  if (isTravisBuild()) {
     setTimeout(() => {
       process.exit(processExitCode);
     }, 5000);
@@ -474,7 +475,7 @@ async function runTests() {
     const deferred = new Promise(resolverIn => {resolver = resolverIn;});
     new Karma(configBatch, function(exitCode) {
       if (argv.coverage) {
-        if (process.env.TRAVIS) {
+        if (isTravisBuild()) {
           const codecovCmd =
               './node_modules/.bin/codecov --file=test/coverage/lcov.info';
           let flags = '';

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -20,6 +20,7 @@ const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 const {exec, execOrDie, getStderr} = require('../exec');
+const {isTravisBuild} = require('../travis');
 
 const yarnExecutable = 'npx yarn';
 
@@ -32,7 +33,7 @@ function writeIfUpdated(patchedName, file) {
   if (!fs.existsSync(patchedName) ||
       fs.readFileSync(patchedName) != file) {
     fs.writeFileSync(patchedName, file);
-    if (!process.env.TRAVIS) {
+    if (!isTravisBuild()) {
       log(colors.green('Patched'), colors.cyan(patchedName));
     }
   }
@@ -146,7 +147,7 @@ function transformEs6Packages() {
       packageJson['browserify'] = {'transform': ['babelify']};
       const updatedPackageJson = JSON.stringify(packageJson, null, 2);
       fs.writeFileSync(packageJsonFile, updatedPackageJson, 'utf8');
-      if (!process.env.TRAVIS) {
+      if (!isTravisBuild()) {
         log(colors.green('Enabled ES6 transforms for runtime dependency'),
             colors.cyan(es6Package));
       }
@@ -164,7 +165,7 @@ function installCustomEslintRules() {
   exec(yarnExecutable + ' link', {'stdio': 'ignore', 'cwd': customRuleDir});
   exec(yarnExecutable + ' unlink ' + customRuleName, {'stdio': 'ignore'});
   exec(yarnExecutable + ' link ' + customRuleName, {'stdio': 'ignore'});
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(colors.green('Installed lint rules from'), colors.cyan(customRuleDir));
   }
 }
@@ -194,7 +195,7 @@ function runYarnCheck() {
  */
 function updatePackages() {
   installCustomEslintRules();
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     runYarnCheck();
   }
   patchWebAnimations();

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -53,7 +53,7 @@ function log(mode, ...messages) {
       fancyLog.error(colors.red('FATAL:'), ...messages);
       throw new Error(messages.join(' '));
     case 'travis':
-      if (process.env['TRAVIS']) {
+      if (isTravisBuild()) {
         messages.forEach(message => process.stdout.write(message));
       }
       break;

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -18,6 +18,7 @@
 const colors = require('ansi-colors');
 const fancyLog = require('fancy-log');
 const sleep = require('sleep-promise');
+const {isTravisBuild} = require('../../travis');
 
 const CSS_SELECTOR_RETRY_MS = 100;
 const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
@@ -33,7 +34,7 @@ const CSS_SELECTOR_TIMEOUT_MS =
 function log(mode, ...messages) {
   switch (mode) {
     case 'verbose':
-      if (process.env.TRAVIS) {
+      if (isTravisBuild()) {
         return;
       }
       fancyLog.info(colors.green('VERBOSE:'), ...messages);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -32,6 +32,7 @@ const {
   shortSha,
 } = require('../../git');
 const {execOrDie, execScriptAsync} = require('../../exec');
+const {isTravisBuild} = require('../../travis');
 const {log, verifyCssElements} = require('./helpers');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
 
@@ -95,7 +96,7 @@ function setPercyBranch() {
  * merge method for pull requests.)
  */
 function setPercyTargetCommit() {
-  if (process.env.TRAVIS && !argv.master) {
+  if (isTravisBuild() && !argv.master) {
     process.env['PERCY_TARGET_COMMIT'] = gitTravisMasterBaseline();
   }
 }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -78,7 +78,7 @@ function maybeOverridePercyEnvironmentVariables() {
  */
 function setPercyBranch() {
   if (!process.env['PERCY_BRANCH'] &&
-      (!argv.master || !process.env['TRAVIS'])) {
+      (!argv.master || !isTravisBuild())) {
     const userName = gitCommitterEmail();
     const branchName = gitBranchName();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
@@ -420,7 +420,7 @@ async function snapshotWebpages(percy, browser, webpages) {
           })
           .catch(testError => {
             log('travis', colors.red('○'));
-            if (!process.env['TRAVIS']) {
+            if (!isTravisBuild()) {
               log('error', testError);
             }
             testErrors.push(testError);
@@ -437,7 +437,7 @@ async function snapshotWebpages(percy, browser, webpages) {
     await sleep(WAIT_FOR_TABS_MS);
   }
   log('travis', '\n');
-  if (process.env['TRAVIS']) {
+  if (isTravisBuild()) {
     testErrors.forEach(testError => {
       log('error', testError);
     });

--- a/build-system/travis.js
+++ b/build-system/travis.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const colors = require('ansi-colors');
+const log = require('fancy-log');
+
+const {red, cyan} = colors;
+
+/**
+ * @fileoverview Provides functions that extract various kinds of Travis state.
+ */
+
+/**
+ * Returns true if this is a Travis build.
+ * @return {boolean}
+ */
+exports.isTravisBuild = function() {
+  return !!process.env.TRAVIS;
+};
+
+/**
+ * Returns true if this is a Travis PR build.
+ * @return {boolean}
+ */
+exports.isTravisPullRequestBuild = function() {
+  return exports.isTravisBuild() &&
+      process.env.TRAVIS_EVENT_TYPE === 'pull_request';
+};
+
+/**
+ * Returns true if this is a Travis Push build.
+ * @return {boolean}
+ */
+exports.isTravisPushBuild = function() {
+  return exports.isTravisBuild() &&
+      process.env.TRAVIS_EVENT_TYPE === 'push';
+};
+
+/**
+ * Returns the job number of the ongoing Travis build.
+ * @return {string}
+ */
+exports.travisJobNumber = function() {
+  if (!exports.isTravisBuild()) {
+    log(red('ERROR:'), 'This is not a Travis build. Cannot get',
+        cyan('process.env.TRAVIS_JOB_NUMBER') + '.');
+  }
+  return process.env.TRAVIS_JOB_NUMBER;
+};
+
+/**
+ * Returns the repo slug associated with the ongoing Travis build.
+ * @return {string}
+ */
+exports.travisRepoSlug = function() {
+  if (!exports.isTravisBuild()) {
+    log(red('ERROR:'), 'This is not a Travis build. Cannot get',
+        cyan('process.env.TRAVIS_REPO_SLUG') + '.');
+  }
+  return process.env.TRAVIS_REPO_SLUG;
+};
+
+/**
+ * Returns the commit SHA being tested by the ongoing Travis PR build.
+ * @return {string}
+ */
+exports.travisPullRequestSha = function() {
+  if (!exports.isTravisPullRequestBuild()) {
+    log(red('ERROR:'), 'This is not a Travis PR build. Cannot get',
+        cyan('process.env.TRAVIS_PULL_REQUEST_SHA') + '.');
+  }
+  return process.env.TRAVIS_PULL_REQUEST_SHA;
+};
+
+/**
+ * Returns the name of the branch being tested by the ongoing Travis PR build.
+ * @return {string}
+ */
+exports.travisPullRequestBranch = function() {
+  if (!exports.isTravisPullRequestBuild()) {
+    log(red('ERROR:'), 'This is not a Travis PR build. Cannot get',
+        cyan('process.env.TRAVIS_PULL_REQUEST_BRANCH') + '.');
+  }
+  return process.env.TRAVIS_PULL_REQUEST_BRANCH;
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,7 @@ const {cleanupBuildDir, closureCompile} = require('./build-system/tasks/compile'
 const {createCtrlcHandler, exitCtrlcHandler} = require('./build-system/ctrlcHandler');
 const {createModuleCompatibleES5Bundle} = require('./build-system/tasks/create-module-compatible-es5-bundle');
 const {extensionBundles, aliasBundles} = require('./bundles.config');
+const {isTravisBuild} = require('./build-system/travis');
 const {jsifyCssAsync} = require('./build-system/tasks/jsify-css');
 const {serve} = require('./build-system/tasks/serve.js');
 const {thirdPartyFrames} = require('./build-system/config');
@@ -81,7 +82,7 @@ const unminifiedAdsTarget = 'dist/amp-inabox.js';
 const unminifiedRuntimeEsmTarget = 'dist/amp-esm.js';
 const unminified3pTarget = 'dist.3p/current/integration.js';
 
-const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
 
 extensionBundles.forEach(c => declareExtension(c.name, c.version, c.options));
 aliasBundles.forEach(c => {
@@ -192,7 +193,7 @@ function endBuildStep(stepName, targetName, startTime) {
   } else {
     timeString += secs + '.' + ms + ' s)';
   }
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(stepName, cyan(targetName), green(timeString));
   }
 }
@@ -752,7 +753,7 @@ function buildExtensionJs(path, name, version, options) {
  * Prints a message that could help speed up local development.
  */
 function printNobuildHelp() {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     for (const task of NOBUILD_HELP_TASKS) { // eslint-disable-line amphtml-internal/no-for-of-statement
       if (argv._.includes(task)) {
         log(green('To skip building during future'), cyan(task),
@@ -769,7 +770,7 @@ function printNobuildHelp() {
  * @param {string} command Command being run.
  */
 function printConfigHelp(command) {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     log(green('Building the runtime for local testing with the'),
         cyan((argv.config === 'canary') ? 'canary' : 'prod'),
         green('AMP config.'));
@@ -785,7 +786,7 @@ function printConfigHelp(command) {
  * or no extensions at all.
  */
 function parseExtensionFlags() {
-  if (!process.env.TRAVIS) {
+  if (!isTravisBuild()) {
     const noExtensionsMessage = green('⤷ Use ') +
         cyan('--noextensions ') +
         green('to skip building extensions.');
@@ -900,7 +901,7 @@ function dist() {
     printConfigHelp(cmd);
   }
   if (argv.single_pass) {
-    if (!process.env.TRAVIS) {
+    if (!isTravisBuild()) {
       log(green('Not building any AMP extensions in'), cyan('single_pass'),
           green('mode.'));
     }
@@ -929,7 +930,7 @@ function dist() {
           copyCss(),
         ]);
       }).then(() => {
-        if (process.env.TRAVIS) {
+        if (isTravisBuild()) {
           // New line after all the compilation progress dots on Travis.
           console.log('\n');
         }
@@ -1057,7 +1058,7 @@ function checkTypes() {
           }),
     ]);
   }).then(() => {
-    if (process.env.TRAVIS) {
+    if (isTravisBuild()) {
       // New line after all the compilation progress dots on Travis.
       console.log('\n');
     }


### PR DESCRIPTION
The `build-system/` directory contains several references to various Travis [environment variables](https://docs.travis-ci.com/user/environment-variables/).

This PR does the following:
- Consolidates all references to `process.env.TRAVIS*` in one file, `build-system/travis.js`
- Evaluates all current usage of Travis environment state, and uses the correct helper function (if incorrect)

This is a more comprehensive fix than the initial attempt in #20719