### PR TITLE
🏗 Run push builds against `revert-*` branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
     - release
     - canary
     - /^amp-release-.*$/
+    - /^revert-.*$/
 addons:
   chrome: stable
   hosts:


### PR DESCRIPTION
This PR fixes the bug path described below:
- A PR is merged to `master`
- The  PR is then reverted via the GitHub Web UI
- The branch from which the revert PR originates has the prefix `revert-*`
- We currently do not generate a push build for these events
- As a result, there is no bundle-size baseline for the revert commit
- All subsequent PRs that are based on the revert commit will fail the bundle-size check

**Exhibit A:**
<img width="1262" alt="" src="https://user-images.githubusercontent.com/26553114/52510811-89194180-2bcb-11e9-85d7-f059ecf8d6c7.png">

**Exhibit B:**
https://github.com/ampproject/amphtml/blob/2b833394eb098e001325a4722c423fa4599dbb6d/.travis.yml#L28-L33


This PR makes it so that we also build revert commits.
