### PR TITLE
🐛 auto-lightbox: Accept all viewers per proxy origin check

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -340,6 +340,7 @@ function isProxyOriginOrLocalDev(ampdoc, candidates) {
     return false;
   }
 
+  // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
   return Services.urlForDoc(candidates[0]).isProxyOrigin(win.document.location);
 }
 

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -432,7 +432,7 @@ export function scan(ampdoc, opt_root) {
 
 
 AMP.extension(TAG, '0.1', ({ampdoc}) => {
-  ampdoc.whenBodyAvailable().then(() => {
+  ampdoc.whenReady().then(() => {
     getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
       scan(ampdoc, dev().assertElement(target));
     });

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -341,6 +341,7 @@ function isProxyOriginOrLocalDev(ampdoc) {
   }
 
   // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
+  // See #20359 for details.
   return Services.urlForDoc(firstElementChild).isProxyOrigin(win.location);
 }
 

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -326,7 +326,7 @@ function usesLightboxExplicitly(ampdoc) {
  * @param {!Array<!Element>} candidates
  * @return {boolean}
  */
-function isProxyOrigin(ampdoc, candidates) {
+function isProxyOriginOrLocalDev(ampdoc, candidates) {
   // Allow `localDev` in lieu of proxy origin for manual testing, except in
   // tests where we need to actually perform the check.
   const {win} = ampdoc;
@@ -359,7 +359,7 @@ export function isEnabledForDoc(ampdoc, candidates) {
       !DocMetaAnnotations.isOgTypeInSet(ampdoc, ENABLED_OG_TYPES)) {
     return false;
   }
-  return isProxyOrigin(ampdoc, candidates);
+  return isProxyOriginOrLocalDev(ampdoc, candidates);
 }
 
 

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -341,7 +341,7 @@ function isProxyOriginOrLocalDev(ampdoc) {
   }
 
   // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
-  // See #20359 for details.
+  // See git.io/fhQ0a (#20359) for details.
   return Services.urlForDoc(firstElementChild).isProxyOrigin(win.location);
 }
 

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -571,14 +571,15 @@ describes.realWin(TAG, {
       });
 
       ldJsonSchemaTypes.forEach(type => {
+        const typeSubObj = `{..."@type": "${type}"}`;
 
-        it(`accepts schema with @type=${type} and proxy origin`, () => {
+        it(`accepts docs with ${typeSubObj} schema and proxy origin`, () => {
           mockLdJsonSchemaTypes(type);
           mockIsProxyOrigin(true);
           expectIsEnabled(true);
         });
 
-        it(`rejects schema with @type=${type} but lightbox explicit`, () => {
+        it(`rejects docs with ${typeSubObj} schema, lightbox explicit`, () => {
           const doc = env.win.document;
 
           const extensionScript = createElementWithAttributes(doc, 'script', {
@@ -597,7 +598,7 @@ describes.realWin(TAG, {
           expectIsEnabled(false);
         });
 
-        it(`rejects schema with @type=${type} for non-proxy origin`, () => {
+        it(`rejects docs with ${typeSubObj} schema, non-proxy origin`, () => {
           mockLdJsonSchemaTypes(type);
           mockIsProxyOrigin(false);
           expectIsEnabled(false);
@@ -615,17 +616,15 @@ describes.realWin(TAG, {
       });
 
       ogTypes.forEach(type => {
+        const ogTypeMeta = `<meta property="og:type" content="${type}">`;
 
-        const ogTypeMeta = type =>
-          `<meta property="og:type" content="${type}">`;
-
-        it(`accepts docs with ${ogTypeMeta(type)} and proxy origin`, () => {
+        it(`accepts docs with ${ogTypeMeta} and proxy origin`, () => {
           mockOgType(type);
           mockIsProxyOrigin(true);
           expectIsEnabled(true);
         });
 
-        it(`rejects docs with ${ogTypeMeta(type)}, lightbox explicit`, () => {
+        it(`rejects docs with ${ogTypeMeta}, but lightbox explicit`, () => {
           const doc = env.win.document;
 
           const extensionScript = createElementWithAttributes(doc, 'script', {
@@ -644,7 +643,7 @@ describes.realWin(TAG, {
           expectIsEnabled(false);
         });
 
-        it(`rejects docs with ${ogTypeMeta(type)} for non-proxy origin`, () => {
+        it(`rejects docs with ${ogTypeMeta} for non-proxy origin`, () => {
           mockOgType(type);
           mockIsProxyOrigin(false);
           expectIsEnabled(false);

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -469,12 +469,11 @@ describes.realWin(TAG, {
 
       mockAllCriteriaMet(true);
 
-      const honoredCandidates =
-          await Promise.all(runCandidates(env.ampdoc, candidates));
+      const elected = await Promise.all(runCandidates(env.ampdoc, candidates));
 
-      expect(honoredCandidates).to.have.length(2);
-      expect(honoredCandidates[0]).to.be.undefined;
-      expect(honoredCandidates[1]).to.equal(shouldLoad);
+      expect(elected).to.have.length(2);
+      expect(elected[0]).to.be.undefined;
+      expect(elected[1]).to.equal(shouldLoad);
     });
 
   });

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -135,12 +135,12 @@ describes.realWin(TAG, {
     const meetsTreeShapeCriteriaMsg = outerHtml =>
       `Criteria.meetsTreeShapeCriteria(html\`${outerHtml}\`)`;
 
-    function itAccepts(shouldAccept, scenarios) {
-      scenarios.forEach(({kind, mutate, wrapWith}) => {
+    function itAcceptsOrRejects(scenarios) {
+      scenarios.forEach(({rejects, accepts, mutate, wrapWith}) => {
         const maybeWrap = root => wrapWith ? wrap(root, wrapWith()) : root;
         const maybeMutate = root => mutate && mutate(root);
 
-        it(`${shouldAccept ? 'accepts' : 'rejects'} ${kind}`, () => {
+        it(`${accepts ? 'accepts' : 'rejects'} ${accepts || rejects}`, () => {
           [
             html`<amp-img src="asada.png"></amp-img>`,
             html`<div><amp-img src="adobada.png"></amp-img></div>`,
@@ -159,72 +159,71 @@ describes.realWin(TAG, {
             expect(
                 Criteria.meetsTreeShapeCriteria(candidate),
                 meetsTreeShapeCriteriaMsg(scenario.outerHTML))
-                .to.equal(shouldAccept);
+                .to.equal(accepts ? true : false);
           });
         });
       });
     }
 
-    [true, false].forEach(accepts => {
-      describe('self-test', () => {
-        beforeEach(() => {
-          env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(accepts);
-        });
-        itAccepts(accepts, [{kind: 'any'}]);
+    describe('self-test', () => {
+      it('accepts', () => {
+        env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(true);
+        itAcceptsOrRejects([{accepts: 'any'}]);
+      });
+      it('rejects', () => {
+        env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(false);
+        itAcceptsOrRejects([{rejects: 'any'}]);
       });
     });
 
-    itAccepts(true, [
+    itAcceptsOrRejects([
       {
-        kind: 'elements by default',
+        accepts: 'elements by default',
       },
       {
-        kind: 'elements with a non-tap action',
+        accepts: 'elements with a non-tap action',
         mutate: el => el.setAttribute('on', 'nottap:doSomething'),
       },
       {
-        kind: 'elements inside non-clickable anchor',
+        accepts: 'elements inside non-clickable anchor',
         wrapWith: () => html`<a id=my-anchor></a>`,
       },
-    ]);
-
-    itAccepts(false, [
       {
-        kind: 'explicitly opted-out subnodes',
+        rejects: 'explicitly opted-out subnodes',
         mutate: el => el.setAttribute('data-amp-auto-lightbox-disable', ''),
       },
       {
-        kind: 'placeholder subnodes',
+        rejects: 'placeholder subnodes',
         mutate: el => el.setAttribute('placeholder', ''),
       },
       {
-        kind: 'items actionable by tap with a single action',
+        rejects: 'items actionable by tap with a single action',
         mutate: el => el.setAttribute('on', 'tap:doSomething'),
       },
       {
-        kind: 'items actionable by tap with multiple actions',
+        rejects: 'items actionable by tap with multiple actions',
         mutate: el =>
           el.setAttribute('on', 'whatever:doSomething;tap:doSomethingElse'),
       },
       {
-        kind: 'items inside an amp-selector',
+        rejects: 'items inside an amp-selector',
         mutate: el => el.setAttribute('option', ''),
         wrapWith: () => html`<amp-selector></amp-selector>`,
       },
       {
-        kind: 'items inside a button',
+        rejects: 'items inside a button',
         wrapWith: () => html`<button></button>`,
       },
       {
-        kind: 'items inside amp-script',
+        rejects: 'items inside amp-script',
         wrapWith: () => html`<amp-script></amp-script>`,
       },
       {
-        kind: 'items inside amp-story',
+        rejects: 'items inside amp-story',
         wrapWith: () => html`<amp-story></amp-story>`,
       },
       {
-        kind: 'items inside a clickable link',
+        rejects: 'items inside a clickable link',
         wrapWith: () => html`<a href="http://hamberders.com"></a>`,
       },
     ]);

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -529,8 +529,7 @@ describes.realWin(TAG, {
         };
 
         it('returns empty', () => {
-          expect(DocMetaAnnotations.getAllLdJsonTypes(env.ampdoc).length)
-              .to.equal(0);
+          expect(DocMetaAnnotations.getAllLdJsonTypes(env.ampdoc)).to.be.empty;
         });
 
         it('returns all found @types', () => {

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -480,8 +480,13 @@ describes.realWin(TAG, {
 
   describe('isEnabledForDoc', () => {
 
-    const expectIsEnabled = shouldBeEnabled =>
-      expect(isEnabledForDoc(env.ampdoc, ['foo'])).to.equal(shouldBeEnabled);
+    const expectIsEnabled = shouldBeEnabled => {
+      env.sandbox.stub(env.ampdoc, 'getBody').returns({
+        // only needs to be truthy since its ref req is mocked
+        firstElementChild: true,
+      });
+      expect(isEnabledForDoc(env.ampdoc)).to.equal(shouldBeEnabled);
+    };
 
     it('rejects documents without any type annotation', () => {
       mockIsProxyOrigin(true);

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -132,7 +132,7 @@ describes.realWin(TAG, {
 
   describe('meetsTreeShapeCriteria', () => {
 
-    const meetsTreeShapeCriteriaMsg = outerHtml =>
+    const meetsTreeShapeCriteriaMsg = ({outerHtml}) =>
       `Criteria.meetsTreeShapeCriteria(html\`${outerHtml}\`)`;
 
     function itAcceptsOrRejects(scenarios) {
@@ -156,10 +156,8 @@ describes.realWin(TAG, {
             expect(candidate).to.be.ok;
             expect(candidate.tagName).to.equal('AMP-IMG');
 
-            expect(
-                Criteria.meetsTreeShapeCriteria(candidate),
-                meetsTreeShapeCriteriaMsg(scenario.outerHTML))
-                .to.equal(accepts ? true : false);
+            expect(Criteria.meetsTreeShapeCriteria(candidate),
+                meetsTreeShapeCriteriaMsg(scenario)).to.equal(!!accepts);
           });
         });
       });

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -164,14 +164,16 @@ describes.realWin(TAG, {
     }
 
     describe('self-test', () => {
-      it('accepts', () => {
-        env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(true);
-        itAcceptsOrRejects([{accepts: 'any'}]);
-      });
-      it('rejects', () => {
-        env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(false);
-        itAcceptsOrRejects([{rejects: 'any'}]);
-      });
+      const describeCriteriaMet = (isMet, scenarios) => {
+        describe(`Criteria ${isMet ? 'met' : 'unmet'}`, () => {
+          beforeEach(() => {
+            env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(isMet);
+          });
+          itAcceptsOrRejects(scenarios);
+        });
+      };
+      describeCriteriaMet(true, [{accepts: 'any'}]);
+      describeCriteriaMet(false, [{rejects: 'any'}]);
     });
 
     itAcceptsOrRejects([

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -164,7 +164,7 @@ describes.realWin(TAG, {
     }
 
     describe('self-test', () => {
-      const describeCriteriaMet = (isMet, scenarios) => {
+      const criteriaIsMetThereforeAcceptsOrRejects = (isMet, scenarios) => {
         describe(`Criteria ${isMet ? 'met' : 'unmet'}`, () => {
           beforeEach(() => {
             env.sandbox.stub(Criteria, 'meetsTreeShapeCriteria').returns(isMet);
@@ -172,8 +172,8 @@ describes.realWin(TAG, {
           itAcceptsOrRejects(scenarios);
         });
       };
-      describeCriteriaMet(true, [{accepts: 'any'}]);
-      describeCriteriaMet(false, [{rejects: 'any'}]);
+      criteriaIsMetThereforeAcceptsOrRejects(true, [{accepts: 'any'}]);
+      criteriaIsMetThereforeAcceptsOrRejects(false, [{rejects: 'any'}]);
     });
 
     itAcceptsOrRejects([

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -432,9 +432,9 @@ describes.realWin(TAG, {
 
       await waitForAllScannedToBeResolved();
 
-      expect(a.getAttribute(LIGHTBOXABLE_ATTR)).to.be.ok;
-      expect(b.getAttribute(LIGHTBOXABLE_ATTR)).to.not.be.ok;
-      expect(c.getAttribute(LIGHTBOXABLE_ATTR)).to.be.ok;
+      expect(a).to.have.attribute(LIGHTBOXABLE_ATTR);
+      expect(b).to.not.have.attribute(LIGHTBOXABLE_ATTR);
+      expect(c).to.have.attribute(LIGHTBOXABLE_ATTR);
     });
 
     it('sets unique group for candidates that meet criteria', async() => {
@@ -472,8 +472,8 @@ describes.realWin(TAG, {
       const honoredCandidates =
           await Promise.all(runCandidates(env.ampdoc, candidates));
 
-      expect(honoredCandidates.length).to.equal(2);
-      expect(honoredCandidates[0]).to.not.be.ok;
+      expect(honoredCandidates).to.have.length(2);
+      expect(honoredCandidates[0]).to.be.undefined;
       expect(honoredCandidates[1]).to.equal(shouldLoad);
     });
 
@@ -660,7 +660,7 @@ describes.realWin(TAG, {
 
       await apply(env.ampdoc, element);
 
-      expect(element.getAttribute(LIGHTBOXABLE_ATTR)).to.be.ok;
+      expect(element).to.have.attribute(LIGHTBOXABLE_ATTR);
     });
 
     it('sets unique group for each element', async() => {


### PR DESCRIPTION
Accepts AGSA/iGSA in addition to direct Google SERP viewer.

Also makes some tests more accurate/expressive.