### PR TITLE
🖍 Stack `amp-lightbox-gallery` at the very top

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,34 +1,140 @@
-selector                                                                 |   z-index      |   file
----                                                                      |   ---          |   ---
-.i-amphtml-image-lightbox-container                                      |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
- i-amp-video-mask                                                        |   1            |   css/amp.css
-.i-amphtml-lbv-top-bar                                                   |   1            |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.i-amphtml-image-lightbox-viewer-image                                   |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-lightbox-viewer                                         |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.amp-video-eq                                                            |   1            |   css/amp.css
-.i-amphtml-layout-size-defined > [fallback]                              |   1            |   css/amp.css
-.i-amphtml-layout-size-defined > [placeholder]                           |   1            |   css/amp.css
-i-amphtml-video-mask                                                     |   1            |   css/amp.css
-.i-amphtml-loading-container                                             |   1            |   css/amp.css
-.i-amphtml-loader-moving-line                                            |   2            |   css/amp.css
-.i-amphtml-element > [overflow]                                          |   2            |   css/amp.css
-.i-amphtml-image-lightbox-caption                                        |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.amp-carousel-button                                                     |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
-amp-sticky-ad                                                            |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-sticky-ad-top-padding                                                |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-app-banner                                                           |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-.amp-app-banner-dismiss-button                                           |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-i-amphtml-app-banner-top-padding                                         |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-.i-amphtml-dockable-video > video.i-amphtml-dockable-video-minimizing    |   16           |   css/amp.css
-.i-amphtml-dockable-video > iframe.i-amphtml-dockable-video-minimizing   |   16           |   css/amp.css
-.i-amphtml-jank-meter                                                    |   1000         |   css/amp.css
-amp-user-notification                                                    |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
-amp-lightbox                                                             |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-amp-live-list > [update]                                                 |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
-amp-image-lightbox                                                       |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-lbv                                                           |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.i-amphtml-consent-ui-mask                                               |   2147483644   |   extensions/amp-consent/1.0/amp-consent.css
-.amp-consent                                                             |   2147483645   |   extensions/amp-consent/1.0/amp-consent.css
-.i-amphtml-sidebar-mask                                                  |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
-amp-sidebar                                                              |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
-amp-sidebar                                                              |   2147483647   |   extensions/amp-sidebar/1.0/amp-sidebar.css
+selector                                                                                                  |   z-index      |   file
+---                                                                                                       |   ---          |   ---
+.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-share-icon::before                                                                       |   -1           |   extensions/amp-story/0.1/amp-story-share.css
+amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                          |   -1           |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-story-bookend-inner::before                                                                    |   -1           |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-story-access-logo::before                                                                      |   -1           |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-carousel-spacer                                                                                |   -1           |   extensions/amp-carousel/0.2/amp-carousel.css
+.i-amphtml-story-bookend-inner::before                                                                    |   -1           |   extensions/amp-story/1.0/amp-story-bookend.css
+amp-story-page                                                                                            |   0            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.amp-video-docked-placeholder-background                                                                  |   0            |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-image-lightbox-container                                                                       |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+0%                                                                                                        |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-story-access-content                                                                           |   0            |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-lbg-desc-box.i-amphtml-lbg-overflow .i-amphtml-lbg-desc-mask                                   |   0            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after             |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/0.1/amp-story-consent.css
+amp-story-page                                                                                            |   0            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-background-overlay                                                                       |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+i-amphtml-video-mask                                                                                      |   1            |   css/video-autoplay.css
+.i-amphtml-image-slider-label-wrapper                                                                     |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-image-slider-right-mask                                                                        |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-layout-size-defined > [placeholder]                                                            |   1            |   css/amp.css
+.i-amphtml-expanded-mode amp-twitter                                                                      |   1            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-lbg-desc-box.i-amphtml-lbg-standard .i-amphtml-lbg-desc-mask                                   |   1            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+.i-amphtml-lbg-top-bar                                                                                    |   1            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/1.0/amp-story-consent.css
+div.i-amphtml-story-share-pill-container                                                                  |   1            |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-page-attachment-header                                                                   |   1            |   extensions/amp-story/1.0/amp-story-page-attachment-header.css
+.i-amphtml-loading-container                                                                              |   1            |   css/amp.css
+amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-glass-pane                                                                                     |   1            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/1.0/amp-story-hint.css
+.i-amphtml-story-bookend-fullbleed::before                                                                |   1            |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-story-background.active                                                                        |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/0.1/amp-story-consent.css
+.amp-video-eq                                                                                             |   1            |   css/video-autoplay.css
+.i-amphtml-story-background-overlay::after                                                                |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.i-amphtml-image-lightbox-viewer                                                                          |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-background-overlay                                                                       |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-background-overlay::after                                                                |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-background.active                                                                        |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-image-lightbox-viewer-image                                                                    |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/0.1/amp-story-hint.css
+.i-amphtml-layout-size-defined > [fallback]                                                               |   1            |   css/amp.css
+div.i-amphtml-story-top                                                                                   |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
+amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-story-access-header                                                                            |   2            |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/1.0/amp-story-hint.css
+.i-amphtml-story-bookend-active amp-story-page[active]::after                                             |   2            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-image-lightbox-caption                                                                         |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-bookend-active > amp-story-page[active]::after                                           |   2            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-image-slider-hint                                                                              |   2            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-element > [overflow]                                                                           |   2            |   css/amp.css
+amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-loader-moving-line                                                                             |   2            |   css/amp.css
+.i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/0.1/amp-story-hint.css
+.i-amphtml-image-slider-bar                                                                               |   3            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+amp-story-page[active] .i-amphtml-story-page-open-attachment                                              |   3            |   extensions/amp-story/1.0/amp-story.css
+amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/0.1/amp-story.css
+amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before   |   4            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+amp-story-page-attachment                                                                                 |   4            |   extensions/amp-story/1.0/amp-story-page-attachment.css
+100%                                                                                                      |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before            |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/1.0/amp-story.css
+amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                          |   10           |   extensions/amp-date-picker/0.1/amp-date-picker.css
+.amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
+amp-sticky-ad                                                                                             |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-sticky-ad-top-padding                                                                                 |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-app-banner                                                                                            |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+.amp-app-banner-dismiss-button                                                                            |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+i-amphtml-app-banner-top-padding                                                                          |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+amp-user-notification                                                                                     |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
+amp-live-list > [update]                                                                                  |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
+i-amphtml-ad-close-header                                                                                 |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+amp-lightbox                                                                                              |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+amp-image-lightbox                                                                                        |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-jank-meter                                                                                     |   1000         |   css/amp.css
+.i-amphtml-image-lightbox-trans                                                                           |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-page-play-button                                                                         |   10000        |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/0.1/amp-story-system-layer.css
+.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/1.0/amp-story-info-dialog.css
+.i-amphtml-ad-overlay-container                                                                           |   100001       |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/0.1/amp-story-info-dialog.css
+.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-share-menu                                                                               |   100001       |   extensions/amp-story/0.1/amp-story-share-menu.css
+.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/1.0/amp-story-bookend.css
+.i-amphtml-story-focused-state-layer                                                                      |   100001       |   extensions/amp-story/1.0/amp-story-tooltip.css
+.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/0.1/amp-story-system-layer.css
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                      |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-toast                                                                                    |   100002       |   extensions/amp-story/0.1/amp-story.css
+amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-desktop-panels .i-amphtml-story-share-pill-container                                     |   100002       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+[desktop] .i-amphtml-story-button-container                                                               |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                         |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+[desktop] .i-amphtml-story-top                                                                            |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-opacity-mask                                                                             |   100003       |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-share-menu                                                                               |   100003       |   extensions/amp-story/1.0/amp-story-share-menu.css
+amp-story-access                                                                                          |   100003       |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-consent                                                                                  |   100003       |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-story-toast                                                                                    |   100004       |   extensions/amp-story/1.0/amp-story.css
+amp-story-access[type=blocking]                                                                           |   100004       |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-consent                                                                                  |   100005       |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
+.i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
+amp-consent                                                                                               |   initial      |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
+amp-consent                                                                                               |   initial      |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-expanded-mode amp-story-grid-layer                                                             |   auto         |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-expanded-mode amp-story-grid-layer *                                                           |   auto         |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/0.1/amp-story-unsupported-browser-layer.css
+.i-amphtml-story-experiment-error                                                                         |   999999       |   extensions/amp-story/0.1/amp-story.css
+amp-subscriptions-dialog                                                                                  |   2147483641   |   extensions/amp-subscriptions/0.1/amp-subscriptions.css
+.amp-video-docked-shadow                                                                                  |   2147483643   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-consent-ui-mask                                                                                |   2147483644   |   extensions/amp-consent/0.1/amp-consent.css
+.i-amphtml-video-docked                                                                                   |   2147483644   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-video-docked-overlay                                                                           |   2147483645   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+amp-consent                                                                                               |   2147483645   |   extensions/amp-consent/0.1/amp-consent.css
+.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.amp-video-docked-controls                                                                                |   2147483646   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.amp-apester-fullscreen                                                                                   |   2147483646   |   extensions/amp-apester-media/0.1/amp-apester-media.css
+.amp-access-scroll-bar                                                                                    |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
+.i-amphtml-lbg                                                                                            |   2147483647   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -96,13 +96,13 @@ amp-lightbox-gallery .amp-carousel-button {
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
-  /* 
-   * The highest z-index supported by most browsers - 5. See: css/Z_INDEX.md
+  /*
+   * The highest z-index supported by most browsers. See: css/Z_INDEX.md
    * Note: Since the lightbox gallery may not be the last thing in the DOM,
    * this may fail to correctly stack on top of elements with the same z-index.
    * It will also fail to stack on top of things with a higher z-index.
    */
-  z-index: 2147483642;
+  z-index: 2147483647;
 }
 
 .i-amphtml-lbg-mask,


### PR DESCRIPTION
A lightbox should be considered a top-level modal, since it contains a top header with a close-button, so it cannot be escaped by pointer when an `<style amp-custom>`-defined header is stacked on top of it.

/to @cathyxz for approval
/cc @aghassemi per offline discussion

Google-internal context: go/auto-lightbox-irl