### PR TITLE
✨ Clear Google viewer URL prefix from proxy URL

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -108,21 +108,26 @@ app.get('/serve_mode_change', (req, res) => {
 //
 // Mode can be one of:
 //   - '/', empty string, or unset for an unwrapped doc
-//   - 'a4a' for an AMP4ADS wrapper
-//   - 'a4a-3p' for a 3P AMP4ADS wrapper
-//   - 'inabox' for an AMP inabox wrapper
-//   - 'shadow' for a shadow-wrapped document
+//   - '/a4a/' for an AMP4ADS wrapper
+//   - '/a4a-3p/' for a 3P AMP4ADS wrapper
+//   - '/inabox/' for an AMP inabox wrapper
+//   - '/shadow/' for a shadow-wrapped document
 //
 // Examples:
 //   - /proxy/?url=hello.com 👉 /proxy/s/hello.com
-//   - /proxy/?url=hello.com?mode=shadow 👉 /shadow/proxy/s/hello.com
+//   - /proxy/?url=hello.com?mode=/shadow/ 👉 /shadow/proxy/s/hello.com
+//   - /proxy/?url=https://hello.com 👉 /proxy/s/hello.com
+//   - /proxy/?url=https://www.google.com/amp/s/hello.com 👉 /proxy/s/hello.com
 //
 // This passthrough is useful to generate the URL from <form> values,
 // (See ./app-index/proxy-fom.js)
 app.get('/proxy', (req, res) => {
   const {mode, url} = req.query;
   const prefix = (mode || '').replace(/\/$/, '');
-  const sufix = url.replace(/^http(s?):\/\//i, '');
+  const sufixClearPrefixReStr =
+      '^http(s?)://' +
+      '((www\.)?google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)/amp/s/)?';
+  const sufix = url.replace(new RegExp(sufixClearPrefixReStr, 'i'), '');
   res.redirect(`${prefix}/proxy/s/${sufix}`);
 });
 


### PR DESCRIPTION
Manually testing go/auto-lightbox-irl was irksome since I had to manually clear `google.com...` prefixes. Now the load URL by proxy form will do it for you!