### PR TITLE
✨ Support <amp-ima-video dock>

### DIFF
--- a/extensions/amp-ima-video/0.1/test/validator-amp-ima-video-dock-no-extension.html
+++ b/extensions/amp-ima-video/0.1/test/validator-amp-ima-video-dock-no-extension.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for <amp-ima-video dock> without amp-video-docking extension.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-latest.js"></script>
+</head>
+<body>
+  <!-- Invalid: dock without `amp-video-docking` extension -->
+  <amp-ima-video
+      dock
+      width=640 height=360 layout="responsive"
+      data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
+      data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+      data-poster="path/to/poster.png">
+  </amp-ima-video>
+</body>
+</html>

--- a/extensions/amp-ima-video/0.1/test/validator-amp-ima-video-dock-no-extension.out
+++ b/extensions/amp-ima-video/0.1/test/validator-amp-ima-video-dock-no-extension.out
@@ -1,0 +1,43 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for <amp-ima-video dock> without amp-video-docking extension.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-latest.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: dock without `amp-video-docking` extension -->
+|    <amp-ima-video
+>>   ^~~~~~~~~
+amp-ima-video/0.1/test/validator-amp-ima-video-dock-no-extension.html:32:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|        dock
+|        width=640 height=360 layout="responsive"
+|        data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
+|        data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+|        data-poster="path/to/poster.png">
+|    </amp-ima-video>
+|  </body>
+|  </html>

--- a/extensions/amp-ima-video/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/validator-amp-ima-video.protoascii
@@ -50,6 +50,10 @@ tags: {  # <amp-ima-video>
     }
   }
   attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
+  attrs: {
     name: "rotate-to-fullscreen"
     value: ""
   }

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1248,9 +1248,12 @@ export class VideoDocking {
    * @private
    */
   getPosterImageSrc_(element) {
-    const poster = 'poster';
-    if (element.hasAttribute(poster)) {
-      return element.getAttribute(poster);
+    const attrs = ['poster', 'data-poster'];
+    for (let i = 0; i < attrs.length; i++) {
+      const attr = attrs[i];
+      if (element.hasAttribute(attr)) {
+        return element.getAttribute(attr);
+      }
     }
     const imgEl = scopedQuerySelector(element,
         'amp-img[placeholder],img[placeholder],[placeholder] amp-img');

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -552,6 +552,11 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
     });
 
+    it('uses `data-poster` attr', () => {
+      const el = html`<amp-video data-poster=foo.png></amp-video>`;
+      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+    });
+
     it('uses `placeholder` amp-img', () => {
       const el = html`<amp-video>
           <amp-img src=foo.png placeholder></amp-img>

--- a/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-ima-video.html
+++ b/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-ima-video.html
@@ -1,0 +1,41 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for amp-video-docking tag with amp-ima-video player.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-latest.js"></script>
+  <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-latest.js"></script>
+</head>
+<body>
+  <!-- Valid: dock with `amp-ima-video` and `amp-video-docking` extensions-->
+  <amp-ima-video
+      dock
+      width=640 height=360 layout="responsive"
+      data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
+      data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+      data-poster="path/to/poster.png">
+  </amp-ima-video>
+</body>
+</html>

--- a/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-ima-video.out
+++ b/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-ima-video.out
@@ -1,0 +1,42 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for amp-video-docking tag with amp-ima-video player.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-latest.js"></script>
+|    <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-latest.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: dock with `amp-ima-video` and `amp-video-docking` extensions-->
+|    <amp-ima-video
+|        dock
+|        width=640 height=360 layout="responsive"
+|        data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
+|        data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+|        data-poster="path/to/poster.png">
+|    </amp-ima-video>
+|  </body>
+|  </html>


### PR DESCRIPTION
## Breakdown

- ✅ Validate `<amp-ima-video dock>`
- ✨ Support `data-poster` for docking placeholder per `amp-ima-video`'s API

## 🐛 Known issues

- Two sets of controls while docked video is paused. 
  /cc @torch2424 Is it possible to add an API to disable controls in `amp-ima-video` entirely?

Partial for #20759