### PR TITLE
🔧♻️ auto-lightbox: No nesting, use array for selector

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -73,26 +73,27 @@ export const VIEWPORT_AREA_RATIO = 0.25;
 /**
  * Selector for subnodes for which the auto-lightbox treatment does not apply.
  */
-const DISABLED_ANCESTORS =
-    // Runtime-specific.
-    '[placeholder],' +
+const DISABLED_ANCESTORS = [
+  // Runtime-specific.
+  '[placeholder]',
 
-    // Explicitly opted out.
-    '[data-amp-auto-lightbox-disable],' +
+  // Explicitly opted out.
+  '[data-amp-auto-lightbox-disable]',
 
-    // Ancestors considered "actionable", i.e. that are bound to a default
-    // onclick action(e.g. `button`) or where it cannot be determined whether
-    // they're actionable or not (e.g. `amp-script`).
-    'a[href],' +
-    'amp-selector [option],' +
-    'amp-script,' +
-    'amp-story,' +
-    'button,' +
+  // Ancestors considered "actionable", i.e. that are bound to a default
+  // onclick action(e.g. `button`) or where it cannot be determined whether
+  // they're actionable or not (e.g. `amp-script`).
+  'a[href]',
+  'amp-selector [option]',
+  'amp-script',
+  'amp-story',
+  'button',
 
-    // Special treatment.
-    // TODO(alanorozco): Allow and possibly group carousels where images are the
-    // only content.
-    'amp-carousel';
+  // Special treatment.
+  // TODO(alanorozco): Allow and possibly group carousels where images are the
+  // only content.
+  'amp-carousel',
+].join(',');
 
 
 const GOOGLE_DOMAIN_RE = /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)$/;

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -89,6 +89,9 @@ const DISABLED_ANCESTORS = [
   'amp-story',
   'button',
 
+  // No nested lightboxes.
+  'amp-lightbox',
+
   // Special treatment.
   // TODO(alanorozco): Allow and possibly group carousels where images are the
   // only content.

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -237,6 +237,10 @@ describes.realWin(TAG, {
         wrapWith: () => html`<amp-story></amp-story>`,
       },
       {
+        kind: 'items inside amp-lightbox',
+        wrapWith: () => html`<amp-lightbox></amp-lightbox>`,
+      },
+      {
         kind: 'items inside a clickable link',
         wrapWith: () => html`<a href="http://hamberders.com"></a>`,
       },


### PR DESCRIPTION
- Exclude items inside `amp-lightbox`.
- Use array for `DISABLED_ANCESTORS`. This outputs the same string literal in the compiled code, so we can remove the awkward string concat syntax.