### PR TITLE
🏗🐛 Roll back sauce connect version to 4.5.1

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -22,7 +22,7 @@ YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 
-SC_VERSION="sc-4.5.3-linux"
+SC_VERSION="sc-4.5.1-linux"
 AUTHENTICATED_STATUS_URL="https://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@saucelabs.com/rest/v1/info/status"
 STATUS_URL="https://saucelabs.com/rest/v1/info/status"
 DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"


### PR DESCRIPTION
#19661 and #20384 updated the version of sauce connect used on Travis to 4.5.2 and 4.5.3 respectively. Since then, we've had multiple connection failures (not to mention outages).

Per email from Sauce support, they suspect that the new proxy is the cause of the failures. This PR rolls back to 4.5.1.

Example failure: https://travis-ci.org/ampproject/amphtml/jobs/490778249#L742
	
> From: Matt Dunn (Sauce Labs Help Center)
> Feb 11, 5:34 AM PST
> 
> Hi Raghu,
> 
> The issue here is that the connection that Sauce Connect is trying to establish its secure connection to the assigned tunnel VM that is running in the Sauce cloud, but this is connection attempt is failing:
>
> 2019-02-08 23:05:32.156 [8854] MAIN connecting to maki76101.miso.saucelabs.com - 162.222.75.6:443
> 2019-02-08 23:05:32.220 [8854] MAIN connecting to KGP server maki76101.miso.saucelabs.com took 63 ms
> 2019-02-08 23:05:32.285 [8854] KGP libevent connection error
> 2019-02-08 23:05:32.286 [8854] MAIN main loop exited, return code: 5
>
> Are you able to choose the version of Sauce Connect that you use with your Travis CI build? If so, can you try using version 4.5.1 and see if that works? There have been some changes in recent releases of Sauce Connect which may be causing this issue.
> Regards,
> 
> Matt Dunn,
> Manager of Customer Support, EMEA
> Sauce Labs

/cc @ampproject/wg-infra 