### PR TITLE
Doubleclick/AdSense Fast fetch: Checksum based validation

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -1033,7 +1033,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
     });
   });
 
-  describe.only('#checksumVerification', () => {
+  describe('#checksumVerification', () => {
     it('should call super if missing Algorithm header', () => {
       sandbox.stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
           .returns(Promise.resolve('foo'));

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -23,6 +23,7 @@ import {
   ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
   AdSenseAmpAutoAdsHoldoutBranches,
 } from '../../../../ads/google/adsense-amp-auto-ads';
+import {AmpA4A} from '../../../amp-a4a/0.1/amp-a4a';
 import {AmpAd} from '../../../amp-ad/0.1/amp-ad';
 import {
   AmpAdNetworkAdsenseImpl,
@@ -42,6 +43,7 @@ import {
   forceExperimentBranch,
   toggleExperiment,
 } from '../../../../src/experiments';
+import {utf8Decode, utf8Encode} from '../../../../src/utils/bytes';
 
 function createAdsenseImplElement(attributes, doc, opt_tag) {
   const tag = opt_tag || 'amp-ad';
@@ -1028,6 +1030,67 @@ describes.realWin('amp-ad-network-adsense-impl', {
     it('should return true on a non-canonical page', () => {
       impl.win.location.origin = 'https://www-somesite.cdn.ampproject.org';
       expect(impl.isXhrAllowed()).to.be.true;
+    });
+  });
+
+  describe.only('#checksumVerification', () => {
+    it('should call super if missing Algorithm header', () => {
+      sandbox.stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
+          .returns(Promise.resolve('foo'));
+      const creative = '<html><body>This is some text</body></html>';
+      const mockHeaders = {
+        get: key => {
+          switch (key) {
+            case 'AMP-Verification-Checksum-Algorithm':
+              return 'unknown';
+            case 'AMP-Verification-Checksum':
+              return btoa('2569076912');
+            default:
+              throw new Error(`unexpected header: ${key}`);
+          }
+        },
+      };
+      expect(AmpAdNetworkAdsenseImpl.prototype.maybeValidateAmpCreative(
+          utf8Encode(creative), mockHeaders)).to.eventually.equal('foo');
+    });
+
+    it('should properly validate checksum', () => {
+      const creative = '<html><body>This is some text</body></html>';
+      const mockHeaders = {
+        get: key => {
+          switch (key) {
+            case 'AMP-Verification-Checksum-Algorithm':
+              return 'djb2a-32';
+            case 'AMP-Verification-Checksum':
+              return btoa('2569076912');
+            default:
+              throw new Error(`unexpected header: ${key}`);
+          }
+        },
+      };
+      return AmpAdNetworkAdsenseImpl.prototype.maybeValidateAmpCreative(
+          utf8Encode(creative), mockHeaders).then(result => {
+        expect(result).to.be.ok;
+        expect(utf8Decode(result)).to.equal(creative);
+      });
+    });
+
+    it('should fail validation if invalid checksum', () => {
+      const creative = '<html><body>This is some text</body></html>';
+      const mockHeaders = {
+        get: key => {
+          switch (key) {
+            case 'AMP-Verification-Checksum-Algorithm':
+              return 'djb2a-32';
+            case 'AMP-Verification-Checksum':
+              return btoa('12345');
+            default:
+              throw new Error(`unexpected header: ${key}`);
+          }
+        },
+      };
+      expect(AmpAdNetworkAdsenseImpl.prototype.maybeValidateAmpCreative(
+          utf8Encode(creative), mockHeaders)).to.eventually.not.be.ok;
     });
   });
 });


### PR DESCRIPTION
For Doubleclick/AdSense Fast Fetch requests, allow for validation based on checksum header instead of crypto.  In the event that both the signing authority and ad network are the same entity (in this case Google), crypto validation does not add any security.  Checksum ensures that creative was not modified post validation and usage of SSL for transport guarantees no man in the middle attack.  

Checksum uses djb2a algorithm defined in src/string#stringHash32.  Will run as server-side controlled experiment.  Once results are verified, will launch by moving crypto validation methodology into explicit module that can be optionally imported by other fast fetch implementations (so as to not bloat AdSense/Doubleclick binaries and remove crypto key fetch).