### PR TITLE
✨Implement autoexpand for amp-form textarea element

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -155,6 +155,7 @@
     </style>
 </head>
 <body>
+
 <amp-analytics>
     <script type="application/json">
         {
@@ -180,11 +181,6 @@
         }
     </script>
 </amp-analytics>
-
-<h4>autoexpand text area</h4>
-<form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-    <textarea name="comment" autoexpand></textarea>
-</form>
 
 <h4>Search (GET non-xhr same origin)</h4>
 <form method="get" action="/form/search-html/get" target="_blank">

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -155,7 +155,6 @@
     </style>
 </head>
 <body>
-
 <amp-analytics>
     <script type="application/json">
         {
@@ -181,6 +180,11 @@
         }
     </script>
 </amp-analytics>
+
+<h4>autoexpand text area</h4>
+<form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+    <textarea name="comment" autoexpand></textarea>
+</form>
 
 <h4>Search (GET non-xhr same origin)</h4>
 <form method="get" action="/form/search-html/get" target="_blank">

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -41,9 +41,38 @@ const AMP_FORM_TEXTAREA_HAS_EXPANDED_DATA = 'iAmphtmlHasExpanded';
  */
 export class AmpFormTextarea {
   /**
-   * @param {!Document|!ShadowRoot} root
+   * Install, monitor and cleanup the document as `textarea[autoexpand]`
+   * elements are added and removed.
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
-  constructor(root) {
+  static install(ampdoc) {
+    const root = ampdoc.getRootNode();
+
+    let ampFormTextarea = null;
+    const maybeInstall = () => {
+      const autoexpandTextarea = root.querySelector('textarea[autoexpand]');
+      if (autoexpandTextarea && !ampFormTextarea) {
+        ampFormTextarea = new AmpFormTextarea(ampdoc);
+        return;
+      }
+
+      if (!autoexpandTextarea && ampFormTextarea) {
+        ampFormTextarea.dispose();
+        ampFormTextarea = null;
+        return;
+      }
+    };
+
+    listen(root, AmpEvents.DOM_UPDATE, maybeInstall);
+    maybeInstall();
+  }
+
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    const root = ampdoc.getRootNode();
+
     /** @private @const */
     this.doc_ = (root.ownerDocument || root);
 
@@ -51,7 +80,7 @@ export class AmpFormTextarea {
     this.win_ = devAssert(this.doc_.defaultView);
 
     /** @private @const */
-    this.viewport_ = Services.viewportForDoc(this.doc_);
+    this.viewport_ = Services.viewportForDoc(ampdoc);
 
     /** @private */
     this.unlisteners_ = [];

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -103,24 +103,24 @@ export function maybeRemoveResizeBehavior(element) {
 }
 
 /**
- * Expand the textarea to fit its current text, if needed.
+ * Resize the textarea to fit its current text, by expanding or shrinking if
+ * needed.
  * @param {!Element} element
  * @return {!Promise}
  */
-export function maybeExpandTextarea(element) {
+export function maybeResizeTextarea(element) {
   const resources = Services.resourcesForDoc(element);
   const win = devAssert(element.ownerDocument.defaultView);
 
   let offset = 0;
   let scrollHeightPromise = null;
 
-  if (element.hasAttribute(AMP_FORM_TEXTAREA_SHRINK_ATTR)) {
+  if (!element.hasAttribute(AMP_FORM_TEXTAREA_SHRINK_DISABLED_ATTR)) {
     scrollHeightPromise = getShrinkHeight(element);
   }
 
   return resources.measureMutateElement(element, () => {
     const computed = computedStyle(win, element);
-
     if (scrollHeightPromise == null) {
       scrollHeightPromise = Promise.resolve(element.scrollHeight);
     }

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../../src/services';
+import {computedStyle, px, setStyle} from '../../../src/style';
+
+const AMP_FORM_TEXTAREA_EXPAND_ATTR = 'autoexpand';
+
+/**
+ * This behavior can be removed when browsers implement `height: max-content`
+ * for the textarea element.
+ * https://github.com/w3c/csswg-drafts/issues/2141
+ * @param {!Element} form
+ */
+export function installAmpFormTextarea(form) {
+  form.addEventListener('input', e => {
+    const element = e.target;
+    if (element.tagName != 'TEXTAREA' ||
+        !element.hasAttribute(AMP_FORM_TEXTAREA_EXPAND_ATTR)) {
+      return;
+    }
+    maybeExpandTextarea(element);
+  });
+}
+
+/**
+ * Expand the textarea to fit its current text, if needed.
+ * @param {!Element} element
+ * @return {!Promise}
+ */
+export function maybeExpandTextarea(element) {
+  const resources = Services.resourcesForDoc(element);
+  const win = element.ownerDocument.defaultView;
+
+  let padding = 0;
+  let scrollHeight = 0;
+
+  return resources.measureMutateElement(element, () => {
+    const computed = computedStyle(win, element);
+
+    scrollHeight = element.scrollHeight;
+    padding =
+        parseInt(computed.getPropertyValue('padding-top'), 10) +
+        parseInt(computed.getPropertyValue('padding-bottom'), 10);
+  }, () => {
+    setStyle(element, 'height', px(scrollHeight - padding));
+  });
+}

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -154,14 +154,14 @@ function handleTextareaDrag(element) {
   const resources = Services.resourcesForDoc(element);
 
   Promise.all([
-    resources.measureElement(() => element.scrollHeight),
+    resources.measureElement(() => element./*OK*/scrollHeight),
     listenOncePromise(element, 'mouseup'),
   ]).then(results => {
     const heightMouseDown = results[0];
     let heightMouseUp = 0;
 
     return resources.measureMutateElement(element, () => {
-      heightMouseUp = element.scrollHeight;
+      heightMouseUp = element./*OK*/scrollHeight;
     }, () => {
       maybeRemoveResizeBehavior(element, heightMouseDown, heightMouseUp);
     });
@@ -203,7 +203,7 @@ function maybeResizeTextarea(element) {
 
   return resources.measureMutateElement(element, () => {
     const computed = computedStyle(win, element);
-    scrollHeight = element.scrollHeight;
+    scrollHeight = element./*OK*/scrollHeight;
 
     const maybeMaxHeight =
         parseInt(computed.getPropertyValue('max-height'), 10);
@@ -264,17 +264,18 @@ function getShrinkHeight(textarea) {
     const maxHeight = parseInt(computed.getPropertyValue('max-height'), 10); // TODO(cvializ): what if it's a percent?
 
     // maxHeight is NaN if the max-height property is 'none'.
-    shouldKeepTop = (isNaN(maxHeight) || textarea.scrollHeight < maxHeight);
+    shouldKeepTop =
+        (isNaN(maxHeight) || textarea./*OK*/scrollHeight < maxHeight);
   }, () => {
     // Prevent a jump from the textarea element scrolling
     if (shouldKeepTop) {
-      textarea.scrollTop = 0;
+      textarea./*OK*/scrollTop = 0;
     }
     // Append the clone to the DOM so its scrollHeight can be read
     doc.body.appendChild(clone);
   }).then(() => {
     return resources.measureMutateElement(body, () => {
-      height = clone.scrollHeight;
+      height = clone./*OK*/scrollHeight;
     }, () => {
       removeElement(clone);
     });

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -125,7 +125,7 @@ export class AmpFormTextarea {
     iterateCursor(cachedTextareaElements, element => {
       getHasOverflow(element).then(hasOverflow => {
         if (hasOverflow) {
-          user().warn('amp-form',
+          user().warn('AMP-FORM',
               '"textarea[autoexpand]" with initially scrolling content ' +
               'will not autoexpand.\n' +
               'See https://github.com/ampproject/amphtml/issues/20839');
@@ -147,11 +147,12 @@ export class AmpFormTextarea {
  * Measure if any overflow is present on the element.
  * @param {!Element} element
  * @return {!Promise<boolean>}
+ * @visibleForTesting
  */
-function getHasOverflow(element) {
+export function getHasOverflow(element) {
   const resources = Services.resourcesForDoc(element);
   return resources.measureElement(() => {
-    return element.scrollHeight > element.clientHeight;
+    return element./*OK*/scrollHeight > element./*OK*/clientHeight;
   });
 }
 
@@ -212,8 +213,9 @@ function maybeRemoveResizeBehavior(element, startHeight, endHeight) {
  * needed.
  * @param {!Element} element
  * @return {!Promise}
+ * @visibleForTesting
  */
-function maybeResizeTextarea(element) {
+export function maybeResizeTextarea(element) {
   const resources = Services.resourcesForDoc(element);
   const win = devAssert(element.ownerDocument.defaultView);
 
@@ -245,7 +247,7 @@ function maybeResizeTextarea(element) {
           parseInt(computed.getPropertyValue('border-bottom-width'), 10);
     }
   }, () => {
-    minScrollHeightPromise.then(minScrollHeight => {
+    return minScrollHeightPromise.then(minScrollHeight => {
       const height = minScrollHeight + offset;
       // Prevent the scrollbar from appearing
       // unless the text is beyond the max-height

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -20,7 +20,7 @@ form.amp-form-submit-error [submit-error] {
   display: block;
 }
 
-.i-amphtml-textarea-calculating {
+textarea:not(.i-amphtml-textarea-max) {
   overflow: hidden;
 }
 

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -20,8 +20,8 @@ form.amp-form-submit-error [submit-error] {
   display: block;
 }
 
-textarea:not(.i-amphtml-textarea-max) {
-  overflow: hidden;
+textarea[autoexpand]:not(.i-amphtml-textarea-max) {
+  overflow: hidden!important;
 }
 
 .i-amphtml-textarea-clone {

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -20,7 +20,7 @@ form.amp-form-submit-error [submit-error] {
   display: block;
 }
 
-textarea[autoexpand] {
+.i-amphtml-textarea-calculating {
   overflow: hidden;
 }
 

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -20,6 +20,17 @@ form.amp-form-submit-error [submit-error] {
   display: block;
 }
 
+textarea[autoexpand] {
+  overflow: hidden;
+}
+
+.i-amphtml-textarea-clone {
+  visibility: hidden;
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  height: 0!important;
+}
 
 .i-amphtml-validation-bubble {
   transform: translate(-50%, -100%);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1298,34 +1298,12 @@ export class AmpFormService {
    */
   installHandlers_(ampdoc) {
     return ampdoc.whenReady().then(() => {
-      this.installSubmissionHandlers_(
-          ampdoc.getRootNode().querySelectorAll('form'));
-      this.installTextareaAutoexpandHandler_(ampdoc.getRootNode());
-      this.installGlobalEventListener_(ampdoc.getRootNode());
+      const root = ampdoc.getRootNode();
+
+      this.installSubmissionHandlers_(root.querySelectorAll('form'));
+      AmpFormTextarea.install(ampdoc);
+      this.installGlobalEventListener_(root);
     });
-  }
-
-  /**
-   * @param {!Document|!ShadowRoot} root
-   */
-  installTextareaAutoexpandHandler_(root) {
-    let ampFormTextarea = null;
-    const maybeInstall = () => {
-      const autoexpandTextarea = root.querySelector('textarea[autoexpand]');
-      if (autoexpandTextarea && !ampFormTextarea) {
-        ampFormTextarea = new AmpFormTextarea(root);
-        return;
-      }
-
-      if (!autoexpandTextarea && ampFormTextarea) {
-        ampFormTextarea.dispose();
-        ampFormTextarea = null;
-        return;
-      }
-    };
-
-    root.addEventListener(AmpEvents.DOM_UPDATE, maybeInstall);
-    maybeInstall();
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -55,6 +55,7 @@ import {
   isCheckValiditySupported,
 } from './form-validators';
 import {getMode} from '../../../src/mode';
+import {installAmpFormTextarea} from './amp-form-textarea';
 import {installFormProxy} from './form-proxy';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {
@@ -207,6 +208,8 @@ export class AmpForm {
         this.form_, this.actionHandler_.bind(this), ActionTrust.HIGH);
     this.installEventHandlers_();
     this.installInputMasking_();
+    installAmpFormTextarea(this.form_);
+
 
     /** @private {?Promise} */
     this.xhrSubmitPromise_ = null;

--- a/extensions/amp-form/0.1/test/test-amp-form-textarea.js
+++ b/extensions/amp-form/0.1/test/test-amp-form-textarea.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CSS} from '../../../../build/amp-form-0.1.css';
+import {Services} from '../../../../src/services';
+import {
+  getHasOverflow,
+  maybeResizeTextarea,
+} from '../amp-form-textarea';
+import {installStylesForDoc} from '../../../../src/style-installer';
+
+describes.realWin('amp-form textarea[autoexpand]', {
+  amp: {
+    ampdoc: 'single',
+  },
+}, env => {
+  let doc;
+  let sandbox;
+  beforeEach(() => {
+    doc = env.ampdoc.getRootNode();
+    installStylesForDoc(env.ampdoc, CSS, () => {}, false, 'amp-form');
+    sandbox = env.sandbox;
+  });
+
+  describe('AmpFormTextarea', () => {
+    it('should remove autoexpand on elements with initial overflow', () => {
+
+    });
+  });
+
+  describe('getHasOverflow', () => {
+    it('should detect if an element has overflow', () => {
+      const textarea = doc.createElement('textarea');
+      textarea.setAttribute('autoexpand', '');
+      textarea.setAttribute('rows', '1');
+      textarea.setAttribute('cols', '80');
+      textarea.innerHTML = 'big text'.repeat(30);
+      doc.body.appendChild(textarea);
+
+      return expect(getHasOverflow(textarea)).to.eventually.be.true;
+    });
+
+    it('should detect if an element does not have overflow', () => {
+      const textarea = doc.createElement('textarea');
+      textarea.setAttribute('autoexpand', '');
+      textarea.setAttribute('rows', '1');
+      textarea.setAttribute('cols', '80');
+      textarea.innerHTML = 'small text';
+      doc.body.appendChild(textarea);
+
+      return expect(getHasOverflow(textarea)).to.eventually.be.false;
+    });
+  });
+
+  describe('maybeResizeTextarea', () => {
+    it('should not resize an element that has not expanded', () => {
+      const textarea = doc.createElement('textarea');
+      textarea.setAttribute('autoexpand', '');
+      textarea.setAttribute('rows', '4');
+      textarea.setAttribute('cols', '80');
+      textarea.innerHTML = 'small text';
+      doc.body.appendChild(textarea);
+
+      const fakeResources = {
+        measureMutateElement(unusedElement, measurer, mutator) {
+          measurer();
+          return mutator() || Promise.resolve();
+        },
+      };
+      sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+
+      const initialHeight = textarea.clientHeight;
+      return maybeResizeTextarea(textarea).then(() => {
+        expect(textarea.clientHeight).to.equal(initialHeight);
+      });
+    });
+
+    it('should expand an element that exceeds its boundary', () => {
+      const textarea = doc.createElement('textarea');
+      textarea.setAttribute('autoexpand', '');
+      textarea.setAttribute('rows', '4');
+      textarea.setAttribute('cols', '80');
+      textarea.innerHTML = 'big text'.repeat(100);
+      doc.body.appendChild(textarea);
+
+      const fakeResources = {
+        measureMutateElement(unusedElement, measurer, mutator) {
+          measurer();
+          return mutator() || Promise.resolve();
+        },
+      };
+      sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+
+      const initialHeight = textarea.clientHeight;
+      return maybeResizeTextarea(textarea).then(() => {
+        expect(textarea.clientHeight).to.be.greaterThan(initialHeight);
+      });
+    });
+
+    it('should shrink an element that expands and then reduces', () => {
+      const textarea = doc.createElement('textarea');
+      textarea.setAttribute('autoexpand', '');
+      textarea.setAttribute('rows', '4');
+      textarea.setAttribute('cols', '80');
+      textarea.innerHTML = 'big text'.repeat(100);
+      doc.body.appendChild(textarea);
+
+      const fakeResources = {
+        measureMutateElement(unusedElement, measurer, mutator) {
+          measurer();
+          return mutator() || Promise.resolve();
+        },
+      };
+      sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+
+      const initialHeight = textarea.clientHeight;
+      let increasedHeight;
+      return maybeResizeTextarea(textarea).then(() => {
+        increasedHeight = textarea.clientHeight;
+        expect(increasedHeight).to.be.greaterThan(initialHeight);
+      }).then(() => {
+        textarea.innerHTML = 'small text';
+        return maybeResizeTextarea(textarea);
+      }).then(() => {
+        expect(textarea.clientHeight).to.be.lessThan(increasedHeight);
+      });
+    });
+  });
+});

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -576,6 +576,19 @@ The `amp-form` extension provides [classes](#classes-and-css-hooks) to polyfill 
 
 Regular expression matching is a common validation feature supported natively on most input elements, except for `<textarea>`. We polyfill this functionality and support the `pattern` attribute on `<textarea>` elements.
 
+AMP Form provides an `autoexpand` attribute to `<textarea>` elements. This allows the textarea
+to expand to accomodate the user's rows of input up to the field's maximum size. If the user manually resizes the field, the autoexpand behavior will be removed.
+
+```html
+<textarea autoexpand></textarea>
+```
+
+AMP Form also provides an `autoshrink` attribute to use in conjunction with the `autoexpand` attribut on  `<textarea>` elements. This allows the textarea to reduce in size after the user deletes text from the element.
+
+```html
+<textarea autoexpand autoshrink></textarea>
+```
+
 ## Styling
 
 ### Classes and CSS hooks

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -583,12 +583,6 @@ to expand and shrink to accomodate the user's rows of input, up to the field's m
 <textarea autoexpand></textarea>
 ```
 
-AMP Form also provides an `autoshrink-disabled` attribute to use in conjunction with the `autoexpand` attribute on  `<textarea>` elements. This prevents the textarea from reducing its size after the user deletes text from the element.
-
-```html
-<textarea autoexpand autoshrink-disabled></textarea>
-```
-
 ## Styling
 
 ### Classes and CSS hooks

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -577,16 +577,16 @@ The `amp-form` extension provides [classes](#classes-and-css-hooks) to polyfill 
 Regular expression matching is a common validation feature supported natively on most input elements, except for `<textarea>`. We polyfill this functionality and support the `pattern` attribute on `<textarea>` elements.
 
 AMP Form provides an `autoexpand` attribute to `<textarea>` elements. This allows the textarea
-to expand to accomodate the user's rows of input up to the field's maximum size. If the user manually resizes the field, the autoexpand behavior will be removed.
+to expand and shrink to accomodate the user's rows of input, up to the field's maximum size. If the user manually resizes the field, the autoexpand behavior will be removed.
 
 ```html
 <textarea autoexpand></textarea>
 ```
 
-AMP Form also provides an `autoshrink` attribute to use in conjunction with the `autoexpand` attribut on  `<textarea>` elements. This allows the textarea to reduce in size after the user deletes text from the element.
+AMP Form also provides an `autoshrink-disabled` attribute to use in conjunction with the `autoexpand` attribute on  `<textarea>` elements. This prevents the textarea from reducing its size after the user deletes text from the element.
 
 ```html
-<textarea autoexpand autoshrink></textarea>
+<textarea autoexpand autoshrink-disabled></textarea>
 ```
 
 ## Styling

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -168,6 +168,9 @@ export const WHITELISTED_ATTRS_BY_TAGS = {
   'template': [
     'type',
   ],
+  'textarea': [
+    'autoexpand',
+  ],
 };
 
 /**

--- a/test/manual/amp-form-textarea-added.amp.html
+++ b/test/manual/amp-form-textarea-added.amp.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Forms Examples in AMP</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+    <style amp-custom>
+    </style>
+</head>
+<body>
+<h1>Test lazy-adding of autoexpand</h1>
+
+<form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <label>Username<input name="username"></label>
+    <input type="submit">
+    <div submit-success>
+        <template type="amp-mustache">
+            <p>This should work</p>
+            <textarea autoexpand></textarea>
+        </template>
+    </div>
+</form>
+</body>
+</html>

--- a/test/manual/amp-form-textarea.amp.html
+++ b/test/manual/amp-form-textarea.amp.html
@@ -77,54 +77,21 @@
     <h3><code>height: 100px</code></h3>
     <textarea class="height" name="comment" autoexpand></textarea>
 
-    <h3>inside scrolling containers</h3>
-    <div class="scroll-container">
-    <div class="scroll-container green">
-        <textarea name="comment" autoexpand></textarea>
-    </div>
-    <div class="scroll-container blue">
-        <textarea name="comment" autoexpand></textarea>
-    </div>
-    </div>
+    <h3><code>lots of existing text</code></h3>
+    <textarea class="height" name="comment" autoexpand>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</textarea>
 
-    <h3>fullscreen</h3>
-    <textarea class="fullscreen" name="comment" autoexpand autoshrink-disabled></textarea>
-
-
-    <h2>autoexpand and autoshink-disabled</h2>
-    <p><code>textarea</code> element with <code>autoexpand</code> and <code>autoshrink-disabled</code> attribute which enables autoexpand and autoshink functionality</p>
-
-    <h3>box-sizing: content-box</h3>
-    <textarea class="content-box" name="comment" autoexpand autoshrink-disabled>content box</textarea>
-
-    <h3>box-sizing: border-box</h3>
-    <textarea class="border-box" name="comment" autoexpand autoshrink-disabled>border box</textarea>
-
-    <h3>wide to test window resize</h3>
-    <textarea class="wide" name="comment" autoexpand autoshrink-disabled>wide</textarea>
-
-    <h3><code>max-height: 100px</code></h3>
-    <textarea class="max-height" name="comment" autoexpand autoshrink-disabled></textarea>
-
-    <h3><code>min-height: 100px</code></h3>
-    <textarea class="min-height" name="comment" autoexpand autoshrink-disabled></textarea>
-
-    <h3><code>height: 100px</code></h3>
-    <textarea class="height" name="comment" autoexpand autoshrink-disabled></textarea>
+    <h3><code>wide, lots of existing text</code></h3>
+    <textarea class="wide height" name="comment" autoexpand>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</textarea>
 
     <h3>inside scrolling containers</h3>
     <div class="scroll-container">
-    <div class="scroll-container green">
-        <textarea name="comment" autoexpand autoshrink-disabled></textarea>
+        <div class="scroll-container green">
+            <textarea name="comment" autoexpand></textarea>
+        </div>
+        <div class="scroll-container blue">
+            <textarea name="comment" autoexpand></textarea>
+        </div>
     </div>
-    <div class="scroll-container blue">
-        <textarea name="comment" autoexpand autoshrink-disabled></textarea>
-    </div>
-    </div>
-
-    <h3>fullscreen</h3>
-    <textarea class="fullscreen" name="comment" autoexpand autoshrink-disabled></textarea>
-
 
     <h2>amp-bind</h2>
     <amp-state id="lorem"><script type="application/json">"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</script></amp-state>

--- a/test/manual/amp-form-textarea.amp.html
+++ b/test/manual/amp-form-textarea.amp.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Forms Examples in AMP</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <style amp-custom>
+        input.user-invalid {
+            background-color: #dc4e41;
+        }
+
+        input.user-valid {
+            background-color: #4CAF50;
+        }
+
+        fieldset.user-invalid {
+            border: 3px solid #dc4e41;
+        }
+
+        fieldset.user-valid {
+            border: 3px solid #4CAF50;
+        }
+
+        form .form-message {
+            display: none;
+        }
+
+        form.user-invalid .invalid-message {
+            display: block;
+            color: #dc4e41;
+        }
+
+        form.user-valid .valid-message {
+            display: block;
+            color: #4CAF50;
+        }
+
+        form.amp-form-submitting .submitting-message {
+            display: block;
+            color: #919191;
+        }
+
+        form.amp-form-submit-success [submit-success] {
+            color: #0000ff;
+        }
+
+        form.amp-form-submit-error [submit-error] {
+            color: #dc4e41;
+        }
+
+        .verification-form label {
+          display: block;
+        }
+
+        .spinner,
+        .spinner:after {
+          border-radius: 50%;
+          width: 18px;
+          height: 18px;
+        }
+
+        .spinner {
+          visibility: hidden;
+          margin: 5px;
+          border: 9px solid rgba(0, 0, 0, 0.3);
+          border-left-color: #fff;
+          animation: spin 1.1s infinite linear;
+        }
+
+        .amp-form-verifying .spinner {
+          visibility: visible;
+        }
+
+        @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+
+        .lightbox {
+            background: rgba(0,0,0,.8);
+        }
+
+        .lightbox-content {
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            justify-content: center;
+            align-items: center;
+            color: white;
+        }
+
+
+        #poll1 li {
+            position: relative;
+            padding: 1em;
+            list-style: none;
+            margin: 0;
+            display: block;
+            height: 20px;
+        }
+
+        #poll1.amp-form-submit-success fieldset {
+            display: none;
+        }
+
+        .percentage-container {
+            z-index: 0;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+        }
+        .one-pc {
+            width: 1%;
+            height: 100%;
+            display: inline-block;
+        }
+        .Wekas .one-pc {
+            background: #dc4e41;
+        }
+        .Penguins .one-pc {
+            background: #3f51b5;
+        }
+        .Ostriches .one-pc {
+            background: #4CAF50;
+        }
+        .Kiwis .one-pc {
+            background: #00ffff;
+        }
+        .poll1-results .title {
+            z-index: 1;
+            color: black;
+            position: absolute;
+        }
+        amp-selector [option] {
+            box-sizing: border-box;
+            display: inline-block;
+            position: relative;
+        }
+        amp-selector[disabled],
+        amp-selector [disabled] {
+            opacity: .20;
+        }
+
+        .lol {
+            height: 200px;
+            overflow-y: scroll;
+        }
+        .lol textarea {
+          background: transparent;
+        }
+        .red { background-color: red; }
+        .green { background-color: green; }
+        .blue { background-color: blue; }
+
+        .content-box {
+            box-sizing: content-box;
+        }
+
+        .border-box {
+            box-sizing: border-box;
+        }
+        .wide {
+            width: 100%;
+        }
+        .max-height {
+          max-height: 100px;
+        }
+        .min-height {
+          min-height: 100px;
+        }
+        .fullscreen {
+          width: 100vw;
+          height: 100vh;
+        }
+        .height {
+          height: 100px;
+        }
+    </style>
+</head>
+<body>
+<h1>autoexpand text area</h1>
+
+<p>Copy paste text</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+<form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+
+    <h2>autoexpand</h2>
+    <p><code>textarea</code> element with <code>autoexpand</code> attribute which enables autoexpand and autoshink functionality</p>
+
+    <h3>regular autoexpand</h3>
+    <textarea name="comment1" autoexpand>regular autoexpand</textarea>
+
+    <h3>box-sizing: content-box</h3>
+    <textarea class="content-box" name="comment1" autoexpand>content box</textarea>
+
+    <h3>box-sizing: border-box</h3>
+    <textarea class="border-box" name="comment2" autoexpand>border box</textarea>
+
+    <h3>wide to test window resize</h3>
+    <textarea class="wide" name="comment1" autoexpand>wide</textarea>
+
+    <h3><code>max-height: 100px</code></h3>
+    <textarea class="max-height" name="comment1" autoexpand>content box</textarea>
+
+    <h3><code>min-height: 100px</code></h3>
+    <textarea class="min-height" name="comment1" autoexpand>content box</textarea>
+
+    <h3><code>height: 100px</code></h3>
+    <textarea class="height" name="comment4" autoexpand></textarea>
+
+    <h3>inside scrolling containers</h3>
+    <div class="lol">
+    <div class="lol green">
+        <textarea name="comment5" autoexpand></textarea>
+    </div>
+    <div class="lol blue">
+        <textarea name="comment6" autoexpand></textarea>
+    </div>
+    </div>
+
+    <h3>fullscreen</h3>
+    <textarea class="fullscreen" name="comment7" autoexpand autoshrink-disabled></textarea>
+
+
+    <h2>autoexpand and autoshink-disabled</h2>
+    <p><code>textarea</code> element with <code>autoexpand</code> and <code>autoshrink-disabled</code> attribute which enables autoexpand and autoshink functionality</p>
+
+    <h3>box-sizing: content-box</h3>
+    <textarea class="content-box" name="comment1" autoexpand autoshrink-disabled>content box</textarea>
+
+    <h3>box-sizing: border-box</h3>
+    <textarea class="border-box" name="comment2" autoexpand autoshrink-disabled>border box</textarea>
+
+    <h3>wide to test window resize</h3>
+    <textarea class="wide" name="comment3" autoexpand autoshrink-disabled>wide</textarea>
+
+    <h3><code>max-height: 100px</code></h3>
+    <textarea class="max-height" name="comment4" autoexpand autoshrink-disabled></textarea>
+
+    <h3><code>min-height: 100px</code></h3>
+    <textarea class="min-height" name="comment4" autoexpand autoshrink-disabled></textarea>
+
+    <h3><code>height: 100px</code></h3>
+    <textarea class="height" name="comment4" autoexpand autoshrink-disabled></textarea>
+
+    <h3>inside scrolling containers</h3>
+    <div class="lol">
+    <div class="lol green">
+        <textarea name="comment5" autoexpand autoshrink-disabled></textarea>
+    </div>
+    <div class="lol blue">
+        <textarea name="comment6" autoexpand autoshrink-disabled></textarea>
+    </div>
+    </div>
+
+    <h3>fullscreen</h3>
+    <textarea class="fullscreen" name="comment7" autoexpand autoshrink-disabled></textarea>
+
+
+    <h2>amp-bind</h2>
+    <amp-state id="lorem"><script type="application/json">"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</script></amp-state>
+    <amp-state id="height"><script type="application/json">5</script></amp-state>
+    <textarea name="comment8" autoexpand [text]="value"></textarea>
+
+    <p>wow text below for spacing</p>
+</form>
+    <button on="tap:AMP.setState({value: lorem})">Lorem</button>
+    <button on="tap:AMP.setState({height: 20})">Height</button>
+
+</body>
+</html>

--- a/test/manual/amp-form-textarea.amp.html
+++ b/test/manual/amp-form-textarea.amp.html
@@ -10,152 +10,13 @@
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
     <style amp-custom>
-        input.user-invalid {
-            background-color: #dc4e41;
-        }
-
-        input.user-valid {
-            background-color: #4CAF50;
-        }
-
-        fieldset.user-invalid {
-            border: 3px solid #dc4e41;
-        }
-
-        fieldset.user-valid {
-            border: 3px solid #4CAF50;
-        }
-
-        form .form-message {
-            display: none;
-        }
-
-        form.user-invalid .invalid-message {
-            display: block;
-            color: #dc4e41;
-        }
-
-        form.user-valid .valid-message {
-            display: block;
-            color: #4CAF50;
-        }
-
-        form.amp-form-submitting .submitting-message {
-            display: block;
-            color: #919191;
-        }
-
-        form.amp-form-submit-success [submit-success] {
-            color: #0000ff;
-        }
-
-        form.amp-form-submit-error [submit-error] {
-            color: #dc4e41;
-        }
-
-        .verification-form label {
-          display: block;
-        }
-
-        .spinner,
-        .spinner:after {
-          border-radius: 50%;
-          width: 18px;
-          height: 18px;
-        }
-
-        .spinner {
-          visibility: hidden;
-          margin: 5px;
-          border: 9px solid rgba(0, 0, 0, 0.3);
-          border-left-color: #fff;
-          animation: spin 1.1s infinite linear;
-        }
-
-        .amp-form-verifying .spinner {
-          visibility: visible;
-        }
-
-        @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
-
-        .lightbox {
-            background: rgba(0,0,0,.8);
-        }
-
-        .lightbox-content {
-            display: flex;
-            flex-direction: column;
-            flex-wrap: nowrap;
-            justify-content: center;
-            align-items: center;
-            color: white;
-        }
-
-
-        #poll1 li {
-            position: relative;
-            padding: 1em;
-            list-style: none;
-            margin: 0;
-            display: block;
-            height: 20px;
-        }
-
-        #poll1.amp-form-submit-success fieldset {
-            display: none;
-        }
-
-        .percentage-container {
-            z-index: 0;
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-        }
-        .one-pc {
-            width: 1%;
-            height: 100%;
-            display: inline-block;
-        }
-        .Wekas .one-pc {
-            background: #dc4e41;
-        }
-        .Penguins .one-pc {
-            background: #3f51b5;
-        }
-        .Ostriches .one-pc {
-            background: #4CAF50;
-        }
-        .Kiwis .one-pc {
-            background: #00ffff;
-        }
-        .poll1-results .title {
-            z-index: 1;
-            color: black;
-            position: absolute;
-        }
-        amp-selector [option] {
-            box-sizing: border-box;
-            display: inline-block;
-            position: relative;
-        }
-        amp-selector[disabled],
-        amp-selector [disabled] {
-            opacity: .20;
-        }
-
-        .lol {
+        .scroll-container {
             height: 200px;
             overflow-y: scroll;
         }
-        .lol textarea {
+        .scroll-container textarea {
           background: transparent;
         }
-        .red { background-color: red; }
         .green { background-color: green; }
         .blue { background-color: blue; }
 
@@ -196,84 +57,83 @@
     <p><code>textarea</code> element with <code>autoexpand</code> attribute which enables autoexpand and autoshink functionality</p>
 
     <h3>regular autoexpand</h3>
-    <textarea name="comment1" autoexpand>regular autoexpand</textarea>
+    <textarea name="comment" autoexpand>regular autoexpand</textarea>
 
     <h3>box-sizing: content-box</h3>
-    <textarea class="content-box" name="comment1" autoexpand>content box</textarea>
+    <textarea class="content-box" name="comment" autoexpand>content box</textarea>
 
     <h3>box-sizing: border-box</h3>
-    <textarea class="border-box" name="comment2" autoexpand>border box</textarea>
+    <textarea class="border-box" name="comment" autoexpand>border box</textarea>
 
     <h3>wide to test window resize</h3>
-    <textarea class="wide" name="comment1" autoexpand>wide</textarea>
+    <textarea class="wide" name="comment" autoexpand>wide</textarea>
 
     <h3><code>max-height: 100px</code></h3>
-    <textarea class="max-height" name="comment1" autoexpand>content box</textarea>
+    <textarea class="max-height" name="comment" autoexpand>content box</textarea>
 
     <h3><code>min-height: 100px</code></h3>
-    <textarea class="min-height" name="comment1" autoexpand>content box</textarea>
+    <textarea class="min-height" name="comment" autoexpand>content box</textarea>
 
     <h3><code>height: 100px</code></h3>
-    <textarea class="height" name="comment4" autoexpand></textarea>
+    <textarea class="height" name="comment" autoexpand></textarea>
 
     <h3>inside scrolling containers</h3>
-    <div class="lol">
-    <div class="lol green">
-        <textarea name="comment5" autoexpand></textarea>
+    <div class="scroll-container">
+    <div class="scroll-container green">
+        <textarea name="comment" autoexpand></textarea>
     </div>
-    <div class="lol blue">
-        <textarea name="comment6" autoexpand></textarea>
+    <div class="scroll-container blue">
+        <textarea name="comment" autoexpand></textarea>
     </div>
     </div>
 
     <h3>fullscreen</h3>
-    <textarea class="fullscreen" name="comment7" autoexpand autoshrink-disabled></textarea>
+    <textarea class="fullscreen" name="comment" autoexpand autoshrink-disabled></textarea>
 
 
     <h2>autoexpand and autoshink-disabled</h2>
     <p><code>textarea</code> element with <code>autoexpand</code> and <code>autoshrink-disabled</code> attribute which enables autoexpand and autoshink functionality</p>
 
     <h3>box-sizing: content-box</h3>
-    <textarea class="content-box" name="comment1" autoexpand autoshrink-disabled>content box</textarea>
+    <textarea class="content-box" name="comment" autoexpand autoshrink-disabled>content box</textarea>
 
     <h3>box-sizing: border-box</h3>
-    <textarea class="border-box" name="comment2" autoexpand autoshrink-disabled>border box</textarea>
+    <textarea class="border-box" name="comment" autoexpand autoshrink-disabled>border box</textarea>
 
     <h3>wide to test window resize</h3>
-    <textarea class="wide" name="comment3" autoexpand autoshrink-disabled>wide</textarea>
+    <textarea class="wide" name="comment" autoexpand autoshrink-disabled>wide</textarea>
 
     <h3><code>max-height: 100px</code></h3>
-    <textarea class="max-height" name="comment4" autoexpand autoshrink-disabled></textarea>
+    <textarea class="max-height" name="comment" autoexpand autoshrink-disabled></textarea>
 
     <h3><code>min-height: 100px</code></h3>
-    <textarea class="min-height" name="comment4" autoexpand autoshrink-disabled></textarea>
+    <textarea class="min-height" name="comment" autoexpand autoshrink-disabled></textarea>
 
     <h3><code>height: 100px</code></h3>
-    <textarea class="height" name="comment4" autoexpand autoshrink-disabled></textarea>
+    <textarea class="height" name="comment" autoexpand autoshrink-disabled></textarea>
 
     <h3>inside scrolling containers</h3>
-    <div class="lol">
-    <div class="lol green">
-        <textarea name="comment5" autoexpand autoshrink-disabled></textarea>
+    <div class="scroll-container">
+    <div class="scroll-container green">
+        <textarea name="comment" autoexpand autoshrink-disabled></textarea>
     </div>
-    <div class="lol blue">
-        <textarea name="comment6" autoexpand autoshrink-disabled></textarea>
+    <div class="scroll-container blue">
+        <textarea name="comment" autoexpand autoshrink-disabled></textarea>
     </div>
     </div>
 
     <h3>fullscreen</h3>
-    <textarea class="fullscreen" name="comment7" autoexpand autoshrink-disabled></textarea>
+    <textarea class="fullscreen" name="comment" autoexpand autoshrink-disabled></textarea>
 
 
     <h2>amp-bind</h2>
     <amp-state id="lorem"><script type="application/json">"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</script></amp-state>
     <amp-state id="height"><script type="application/json">5</script></amp-state>
-    <textarea name="comment8" autoexpand [text]="value"></textarea>
+    <textarea name="comment" autoexpand [text]="value"></textarea>
 
     <p>wow text below for spacing</p>
 </form>
     <button on="tap:AMP.setState({value: lorem})">Lorem</button>
-    <button on="tap:AMP.setState({height: 20})">Height</button>
 
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -202,5 +202,13 @@
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input mask="L0L_0L0" type="tel">
   </form>
+  <!-- Valid: textarea within form -->
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+    <textarea name="comment"></textarea>
+  </form>
+  <!-- Valid: textarea with autoexpand attribute -->
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+    <textarea name="comment" autoexpand></textarea>
+  </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -210,13 +210,13 @@
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <textarea name="comment" autoexpand></textarea>
   </form>
-  <!-- Valid: textarea with autoexpand and autoshrink attribute -->
+  <!-- Valid: textarea with autoexpand and autoshrink-disabled attribute -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-    <textarea name="comment" autoexpand autoshrink></textarea>
+    <textarea name="comment" autoexpand autoshrink-disabled></textarea>
   </form>
-  <!-- Invalid: textarea with only autoshrink attribute -->
+  <!-- Invalid: textarea with only autoshrink-disabled attribute -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-    <textarea name="comment" autoshrink></textarea>
+    <textarea name="comment" autoshrink-disabled></textarea>
   </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -210,13 +210,5 @@
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <textarea name="comment" autoexpand></textarea>
   </form>
-  <!-- Valid: textarea with autoexpand and autoshrink-disabled attribute -->
-  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-    <textarea name="comment" autoexpand autoshrink-disabled></textarea>
-  </form>
-  <!-- Invalid: textarea with only autoshrink-disabled attribute -->
-  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-    <textarea name="comment" autoshrink-disabled></textarea>
-  </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -210,5 +210,13 @@
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <textarea name="comment" autoexpand></textarea>
   </form>
+  <!-- Valid: textarea with autoexpand and autoshrink attribute -->
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+    <textarea name="comment" autoexpand autoshrink></textarea>
+  </form>
+  <!-- Invalid: textarea with only autoshrink attribute -->
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+    <textarea name="comment" autoshrink></textarea>
+  </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -235,5 +235,13 @@ feature_tests/forms.html:193:6 The tag 'template' may not appear as a descendant
 >>     ^~~~~~~~~
 feature_tests/forms.html:203:4 The tag 'input [mask] (custom mask)' requires including the 'amp-inputmask' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-inputmask) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </form>
+|    <!-- Valid: textarea within form -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <textarea name="comment"></textarea>
+|    </form>
+|    <!-- Valid: textarea with autoexpand attribute -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <textarea name="comment" autoexpand></textarea>
+|    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -243,15 +243,5 @@ feature_tests/forms.html:203:4 The tag 'input [mask] (custom mask)' requires inc
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <textarea name="comment" autoexpand></textarea>
 |    </form>
-|    <!-- Valid: textarea with autoexpand and autoshrink attribute -->
-|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-|      <textarea name="comment" autoexpand autoshrink></textarea>
-|    </form>
-|    <!-- Invalid: textarea with only autoshrink attribute -->
-|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
-|      <textarea name="comment" autoshrink></textarea>
->>     ^~~~~~~~~
-feature_tests/forms.html:219:4 The attribute 'autoexpand' in tag 'textarea' is missing or incorrect, but required by attribute 'autoshrink'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
-|    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -243,5 +243,15 @@ feature_tests/forms.html:203:4 The tag 'input [mask] (custom mask)' requires inc
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <textarea name="comment" autoexpand></textarea>
 |    </form>
+|    <!-- Valid: textarea with autoexpand and autoshrink attribute -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <textarea name="comment" autoexpand autoshrink></textarea>
+|    </form>
+|    <!-- Invalid: textarea with only autoshrink attribute -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <textarea name="comment" autoshrink></textarea>
+>>     ^~~~~~~~~
+feature_tests/forms.html:219:4 The attribute 'autoexpand' in tag 'textarea' is missing or incorrect, but required by attribute 'autoshrink'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    </form>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4629,7 +4629,7 @@ tags: {
     requires_extension: "amp-form"
   }
   attrs: {
-    name: "autoshrink"
+    name: "autoshrink-disabled"
     requires_extension: "amp-form"
     trigger: {
       also_requires_attr: "autoexpand"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4628,6 +4628,13 @@ tags: {
     name: "autoexpand"
     requires_extension: "amp-form"
   }
+  attrs: {
+    name: "autoshrink"
+    requires_extension: "amp-form"
+    trigger: {
+      also_requires_attr: "autoexpand"
+    }
+  }
   attrs: { name: "autocomplete" }
   attrs: { name: "autofocus" }
   attrs: { name: "cols" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4624,6 +4624,10 @@ tags: {
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "TEXTAREA"
+  attrs: {
+    name: "autoexpand"
+    requires_extension: "amp-form"
+  }
   attrs: { name: "autocomplete" }
   attrs: { name: "autofocus" }
   attrs: { name: "cols" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4624,18 +4624,11 @@ tags: {
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "TEXTAREA"
+  attrs: { name: "autocomplete" }
   attrs: {
     name: "autoexpand"
     requires_extension: "amp-form"
   }
-  attrs: {
-    name: "autoshrink-disabled"
-    requires_extension: "amp-form"
-    trigger: {
-      also_requires_attr: "autoexpand"
-    }
-  }
-  attrs: { name: "autocomplete" }
   attrs: { name: "autofocus" }
   attrs: { name: "cols" }
   attrs: { name: "disabled" }


### PR DESCRIPTION
WIP I will add tests before merge. I'm opening the PR now to get earlier feedback

Resolves #20224

See design doc for edge cases considered, goals and non-goals. https://docs.google.com/document/d/1jme4TcAFvyBRCUNnidSRTIdtjYjd0CbQkM4f2NABsLM

If you don't have access, feel free to request and I will share it.

It currently does not support expanding after updates via bind, but if that is part of a major use-case it can be added after this PR.

Before merge:
- [x] Add tests
- [x] ~Prevent autoexpand when initial text content is larger than the initial textarea size~ https://github.com/ampproject/amphtml/issues/20839