### PR TITLE
[amp-story] Allow more parameters for pan/zoom animations ✨

### DIFF
--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -178,7 +178,7 @@
     <!-- ## Zoom-Out -->
     <amp-story-page id="zoom-out">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="zoom-out" zoom-start="4" zoom-end="1" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="zoom-out" zoom-start="3" zoom-end="1" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -190,7 +190,7 @@
     <!-- ## Pan-Left -->
     <amp-story-page id="pan-left">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-left" id="img-pan-left" horizontal-translate="600px" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="pan-left" id="img-pan-left" translate-x="600px" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -202,7 +202,7 @@
     <!-- ## Pan-Right -->
     <amp-story-page id="pan-right">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-right" animate-in-duration="4s" horizontal-translate="200px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-right" animate-in-duration="4s" translate-x="200px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -214,7 +214,7 @@
     <!-- ## Pan-Up -->
     <amp-story-page id="pan-up">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-up" animate-in-duration="4s" vertical-translate="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-up" animate-in-duration="4s" translate-y="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -226,7 +226,7 @@
     <!-- ## Pan-Down -->
     <amp-story-page id="pan-down">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-down" animate-in-duration="4s" vertical-translate="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-down" animate-in-duration="4s" translate-y="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>

--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -178,7 +178,7 @@
     <!-- ## Zoom-Out -->
     <amp-story-page id="zoom-out">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="zoom-out" zoom-start="3" zoom-end="1" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="zoom-out" scale-start="3" scale-end="1" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>

--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -166,7 +166,7 @@
     <!-- ## Zoom-In -->
     <amp-story-page id="zoom-in">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="zoom-in" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="zoom-in" zoom-start="6" zoom-end="1" animate-in-duration="1s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>

--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -166,7 +166,7 @@
     <!-- ## Zoom-In -->
     <amp-story-page id="zoom-in">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="zoom-in" zoom-start="6" zoom-end="1" animate-in-duration="1s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="zoom-in" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -178,7 +178,7 @@
     <!-- ## Zoom-Out -->
     <amp-story-page id="zoom-out">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="zoom-out" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="zoom-out" zoom-start="4" zoom-end="1" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -190,7 +190,7 @@
     <!-- ## Pan-Left -->
     <amp-story-page id="pan-left">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-left" id="img-pan-left" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026"
+        <amp-img animate-in="pan-left" id="img-pan-left" horizontal-translate="600px" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026"
           width="720" height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -202,7 +202,7 @@
     <!-- ## Pan-Right -->
     <amp-story-page id="pan-right">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-right" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-right" animate-in-duration="4s" horizontal-translate="200px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -214,7 +214,7 @@
     <!-- ## Pan-Up -->
     <amp-story-page id="pan-up">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-up" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-up" animate-in-duration="4s" vertical-translate="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>
@@ -226,7 +226,7 @@
     <!-- ## Pan-Down -->
     <amp-story-page id="pan-down">
       <amp-story-grid-layer template="fill">
-        <amp-img animate-in="pan-down" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+        <amp-img animate-in="pan-down" animate-in-duration="4s" vertical-translate="100px" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
           height="320">
         </amp-img>
       </amp-story-grid-layer>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -6,7 +6,7 @@
   <link rel="canonical" href="visual-effects.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <style amp-custom>
     amp-story-page {
       font-family: 'Roboto', sans-serif;
@@ -33,8 +33,8 @@
 
     <amp-story-page id="ken-burns-effect1">
       <amp-story-grid-layer template="fill">
-        <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="30s"
+        <div animate-in="zoom-in" animate-in-duration="5s" zoom-start="1" zoom-end="3" class="img-container">
+          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="5s" translateX="-200px"
             layout="fixed" width="1600" height="1200">
           </amp-img>
         </div>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -33,7 +33,7 @@
 
     <amp-story-page id="ken-burns-effect1">
       <amp-story-grid-layer template="fill">
-        <div animate-in="zoom-in" animate-in-duration="30s" zoom-start="1" zoom-end="3" class="img-container">
+        <div animate-in="zoom-in" animate-in-duration="30s" scale-start="1" scale-end="3" class="img-container">
           <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="30s"
             layout="fixed" width="1600" height="1200">
           </amp-img>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -33,8 +33,8 @@
 
     <amp-story-page id="ken-burns-effect1">
       <amp-story-grid-layer template="fill">
-        <div animate-in="zoom-in" animate-in-duration="5s" zoom-start="1" zoom-end="3" class="img-container">
-          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="5s" translateX="-200px"
+        <div animate-in="zoom-in" animate-in-duration="30s" zoom-start="1" zoom-end="3" class="img-container">
+          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="30s"
             layout="fixed" width="1600" height="1200">
           </amp-img>
         </div>

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -68,232 +68,273 @@ export function setStyleForPreset(el, presetName) {
   }
 }
 
-/** @const {!Object<string, !StoryAnimationPresetDef>} */
+/**
+ * @param {string} name
+ * @param {!Object} options
+ * @return {!StoryAnimationPresetDef}
+ */
 // First keyframe will always be considered offset: 0 and will be applied to the
 // element as the first frame before animation starts.
-export const PRESETS = {
-  'pulse': {
-    duration: 500,
-    easing: 'linear',
-    keyframes: [
-      {
-        offset: 0,
-        transform: 'scale(1)',
-      },
-      {
-        offset: 0.25,
-        transform: 'scale(0.95)',
-      },
-      {
-        offset: 0.75,
-        transform: 'scale(1.05)',
-      },
-      {
-        offset: 1,
-        transform: 'scale(1)',
-      },
-    ],
-  },
-  'fly-in-left': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-      return translate2d(offsetX, 0, 0, 0);
-    },
-  },
-  'fly-in-right': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = dimensions.pageWidth - dimensions.targetX;
-      return translate2d(offsetX, 0, 0, 0);
-    },
-  },
-  'fly-in-top': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetY = -(dimensions.targetY + dimensions.targetHeight);
-      return translate2d(0, offsetY, 0, 0);
-    },
-  },
-  'fly-in-bottom': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetY = dimensions.pageHeight - dimensions.targetY;
-      return translate2d(0, offsetY, 0, 0);
-    },
-  },
-  'rotate-in-left': {
-    duration: 700,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-      return rotateAndTranslate(offsetX, 0, 0, 0, -1);
-    },
-  },
-  'rotate-in-right': {
-    duration: 700,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = dimensions.pageWidth - dimensions.targetX;
-      return rotateAndTranslate(offsetX, 0, 0, 0, 1);
-    },
-  },
-  'fade-in': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes: [
-      {
-        opacity: 0,
-      },
-      {
-        opacity: 1,
-      },
-    ],
-  },
-  'drop': {
-    duration: 1600,
-    keyframes(dimensions) {
-      const maxBounceHeight =
-          Math.max(160, dimensions.targetY + dimensions.targetHeight);
-
-      return [
-        {
-          offset: 0,
-          transform: `translateY(${px(-maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
+export const getPresetDef = (name, options) => {
+  switch (name) {
+    case 'pulse':
+      return {
+        duration: 500,
+        easing: 'linear',
+        keyframes: [
+          {
+            offset: 0,
+            transform: 'scale(1)',
+          },
+          {
+            offset: 0.25,
+            transform: 'scale(0.95)',
+          },
+          {
+            offset: 0.75,
+            transform: 'scale(1.05)',
+          },
+          {
+            offset: 1,
+            transform: 'scale(1)',
+          },
+        ],
+      };
+    case 'fly-in-left':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+          return translate2d(offsetX, 0, 0, 0);
         },
-        {
-          offset: 0.3,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
+      };
+    case 'fly-in-right':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = dimensions.pageWidth - dimensions.targetX;
+          return translate2d(offsetX, 0, 0, 0);
         },
-        {
-          offset: 0.52,
-          transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
+      };
+    case 'fly-in-top':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetY = -(dimensions.targetY + dimensions.targetHeight);
+          return translate2d(0, offsetY, 0, 0);
         },
-        {
-          offset: 0.74,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
+      };
+    case 'fly-in-bottom':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetY = dimensions.pageHeight - dimensions.targetY;
+          return translate2d(0, offsetY, 0, 0);
         },
-        {
-          offset: 0.83,
-          transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
+      };
+    case 'rotate-in-left':
+      return {
+        duration: 700,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+          return rotateAndTranslate(offsetX, 0, 0, 0, -1);
         },
-        {
-          offset: 1,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
+      };
+    case 'rotate-in-right':
+      return {
+        duration: 700,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = dimensions.pageWidth - dimensions.targetX;
+          return rotateAndTranslate(offsetX, 0, 0, 0, 1);
         },
-      ];
-    },
-  },
-  'twirl-in': {
-    duration: 1000,
-    easing: 'cubic-bezier(.2,.75,.4,1)',
-    keyframes: [
-      {
-        transform: 'rotate(-540deg) scale(0.1)',
-        opacity: 0,
-      },
-      {
-        transform: 'none',
-        opacity: 1,
-      },
-    ],
-  },
-  'whoosh-in-left': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-      return whooshIn(offsetX, 0, 0, 0);
-    },
-  },
-  'whoosh-in-right': {
-    duration: 500,
-    easing: 'ease-out',
-    keyframes(dimensions) {
-      const offsetX = dimensions.pageWidth - dimensions.targetX;
-      return whooshIn(offsetX, 0, 0, 0);
-    },
-  },
-  'pan-left': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes(dimensions) {
-      const scalingFactor = calculateTargetScalingFactor(dimensions);
-      dimensions.targetWidth *= scalingFactor;
-      dimensions.targetHeight *= scalingFactor;
+      };
+    case 'fade-in':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes: [
+          {
+            opacity: 0,
+          },
+          {
+            opacity: 1,
+          },
+        ],
+      };
+    case 'drop':
+      return {
+        duration: 1600,
+        keyframes(dimensions) {
+          const maxBounceHeight =
+            Math.max(160, dimensions.targetY + dimensions.targetHeight);
 
-      const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
+          return [
+            {
+              offset: 0,
+              transform: `translateY(${px(-maxBounceHeight)})`,
+              easing: 'cubic-bezier(.75,.05,.86,.08)',
+            },
+            {
+              offset: 0.3,
+              transform: 'translateY(0)',
+              easing: 'cubic-bezier(.22,.61,.35,1)',
+            },
+            {
+              offset: 0.52,
+              transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
+              easing: 'cubic-bezier(.75,.05,.86,.08)',
+            },
+            {
+              offset: 0.74,
+              transform: 'translateY(0)',
+              easing: 'cubic-bezier(.22,.61,.35,1)',
+            },
+            {
+              offset: 0.83,
+              transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
+              easing: 'cubic-bezier(.75,.05,.86,.08)',
+            },
+            {
+              offset: 1,
+              transform: 'translateY(0)',
+              easing: 'cubic-bezier(.22,.61,.35,1)',
+            },
+          ];
+        },
+      };
+    case 'twirl-in':
+      return {
+        duration: 1000,
+        easing: 'cubic-bezier(.2,.75,.4,1)',
+        keyframes: [
+          {
+            transform: 'rotate(-540deg) scale(0.1)',
+            opacity: 0,
+          },
+          {
+            transform: 'none',
+            opacity: 1,
+          },
+        ],
+      };
+    case 'whoosh-in-left':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+          return whooshIn(offsetX, 0, 0, 0);
+        },
+      };
+    case 'whoosh-in-right':
+      return {
+        duration: 500,
+        easing: 'ease-out',
+        keyframes(dimensions) {
+          const offsetX = dimensions.pageWidth - dimensions.targetX;
+          return whooshIn(offsetX, 0, 0, 0);
+        },
+      };
+    case 'pan-left':
+      let translateX = parseFloat(options.translateX);
 
-      return scaleAndTranslate(offsetX, offsetY, 0, offsetY, scalingFactor);
-    },
-  },
-  'pan-right': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes(dimensions) {
-      const scalingFactor = calculateTargetScalingFactor(dimensions);
-      dimensions.targetWidth *= scalingFactor;
-      dimensions.targetHeight *= scalingFactor;
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes(dimensions) {
+          const scalingFactor = calculateTargetScalingFactor(dimensions);
+          dimensions.targetWidth *= scalingFactor;
+          dimensions.targetHeight *= scalingFactor;
 
-      const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
+          const offsetX = dimensions.pageWidth - dimensions.targetWidth;
+          const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-      return scaleAndTranslate(0, offsetY, offsetX, offsetY, scalingFactor);
-    },
-  },
-  'pan-down': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes(dimensions) {
-      const scalingFactor = calculateTargetScalingFactor(dimensions);
-      dimensions.targetWidth *= scalingFactor;
-      dimensions.targetHeight *= scalingFactor;
+          return scaleAndTranslate(offsetX, offsetY, translateX ?
+            offsetX + translateX : 0, offsetY, scalingFactor);
+        },
+      };
+    case 'pan-right':
+      translateX = parseFloat(options.translateX);
 
-      const offsetX = -dimensions.targetWidth / 2;
-      const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes(dimensions) {
+          const scalingFactor = calculateTargetScalingFactor(dimensions);
+          dimensions.targetWidth *= scalingFactor;
+          dimensions.targetHeight *= scalingFactor;
 
-      return scaleAndTranslate(offsetX, 0, offsetX, offsetY, scalingFactor);
-    },
-  },
-  'pan-up': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes(dimensions) {
-      const scalingFactor = calculateTargetScalingFactor(dimensions);
-      dimensions.targetWidth *= scalingFactor;
-      dimensions.targetHeight *= scalingFactor;
+          const offsetX = dimensions.pageWidth - dimensions.targetWidth;
+          const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-      const offsetX = -dimensions.targetWidth / 2;
-      const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+          return scaleAndTranslate(0, offsetY, translateX || offsetX, offsetY,
+              scalingFactor);
+        },
+      };
+    case 'pan-down':
+      let translateY = parseFloat(options.translateY);
 
-      return scaleAndTranslate(offsetX, offsetY, offsetX, 0, scalingFactor);
-    },
-  },
-  'zoom-in': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes: [
-      {transform: 'scale(1,1)'},
-      {transform: 'scale(3,3)'},
-    ],
-  },
-  'zoom-out': {
-    duration: 1000,
-    easing: 'linear',
-    keyframes: [
-      {transform: 'scale(3,3)'},
-      {transform: 'scale(1,1)'},
-    ],
-  },
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes(dimensions) {
+          const scalingFactor = calculateTargetScalingFactor(dimensions);
+          dimensions.targetWidth *= scalingFactor;
+          dimensions.targetHeight *= scalingFactor;
+
+          const offsetX = -dimensions.targetWidth / 2;
+          const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+
+          return scaleAndTranslate(offsetX, 0, offsetX, translateY || offsetY,
+              scalingFactor);
+        },
+      };
+    case 'pan-up':
+      translateY = parseFloat(options.translateY);
+
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes(dimensions) {
+          const scalingFactor = calculateTargetScalingFactor(dimensions);
+          dimensions.targetWidth *= scalingFactor;
+          dimensions.targetHeight *= scalingFactor;
+
+          const offsetX = -dimensions.targetWidth / 2;
+          const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+
+          return scaleAndTranslate(offsetX, offsetY, offsetX, translateY ?
+            offsetX + translateY : 0, scalingFactor);
+        },
+      };
+    case 'zoom-in':
+      let {zoomStart, zoomEnd} = options;
+
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes: [
+          {transform: `scale(${zoomStart || 1}, ${zoomStart || 1})`},
+          {transform: `scale(${zoomEnd || 3}, ${zoomEnd || 3})`},
+        ],
+      };
+    case 'zoom-out':
+      zoomStart = options.zoomStart;
+      zoomEnd = options.zoomEnd;
+
+      return {
+        duration: 1000,
+        easing: 'linear',
+        keyframes: [
+          {transform: `scale(${zoomStart || 3}, ${zoomStart || 3})`},
+          {transform: `scale(${zoomEnd || 1}, ${zoomEnd || 1})`},
+        ],
+      };
+  }
 };

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -315,36 +315,36 @@ export const getPresetDef = (name, options) => {
         },
       };
     case 'zoom-in':
-      let {zoomStart, zoomEnd} = options;
+      let {scaleStart, scaleEnd} = options;
 
-      if (zoomStart) {
-        userAssert(zoomEnd > zoomStart, '"zoom-end" value must be greater ' +
-        'than "zoom-start" value when using "zoom-in" animation.');
+      if (scaleStart) {
+        userAssert(scaleEnd > scaleStart, '"scale-end" value must be greater ' +
+        'than "scale-start" value when using "zoom-in" animation.');
       }
 
       return {
         duration: 1000,
         easing: 'linear',
         keyframes: [
-          {transform: `scale(${zoomStart || 1}, ${zoomStart || 1})`},
-          {transform: `scale(${zoomEnd || 3}, ${zoomEnd || 3})`},
+          {transform: `scale(${scaleStart || 1})`},
+          {transform: `scale(${scaleEnd || 3})`},
         ],
       };
     case 'zoom-out':
-      zoomStart = options.zoomStart;
-      zoomEnd = options.zoomEnd;
+      scaleStart = options.scaleStart;
+      scaleEnd = options.scaleEnd;
 
-      if (zoomStart) {
-        userAssert(zoomStart > zoomEnd, '"zoom-start" value must be higher ' +
-        'than "zoom-end" value when using "zoom-out" animation.');
+      if (scaleStart) {
+        userAssert(scaleStart > scaleEnd, '"scale-start" value must be ' +
+        'higher than "scale-end" value when using "zoom-out" animation.');
       }
 
       return {
         duration: 1000,
         easing: 'linear',
         keyframes: [
-          {transform: `scale(${zoomStart || 3}, ${zoomStart || 3})`},
-          {transform: `scale(${zoomEnd || 1}, ${zoomEnd || 1})`},
+          {transform: `scale(${scaleStart || 3})`},
+          {transform: `scale(${scaleEnd || 1})`},
         ],
       };
   }

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -273,7 +273,7 @@ export const getPresetDef = (name, options) => {
           const offsetX = dimensions.pageWidth - dimensions.targetWidth;
           const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-          return scaleAndTranslate(0, offsetY, translateX || offsetX, offsetY,
+          return scaleAndTranslate(0, offsetY, -translateX || offsetX, offsetY,
               scalingFactor);
         },
       };
@@ -291,7 +291,7 @@ export const getPresetDef = (name, options) => {
           const offsetX = -dimensions.targetWidth / 2;
           const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 
-          return scaleAndTranslate(offsetX, 0, offsetX, translateY || offsetY,
+          return scaleAndTranslate(offsetX, 0, offsetX, -translateY || offsetY,
               scalingFactor);
         },
       };
@@ -310,7 +310,7 @@ export const getPresetDef = (name, options) => {
           const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 
           return scaleAndTranslate(offsetX, offsetY, offsetX, translateY ?
-            offsetX + translateY : 0, scalingFactor);
+            offsetY + translateY : 0, scalingFactor);
         },
       };
     case 'zoom-in':

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -24,6 +24,7 @@ import {
   whooshIn,
 } from './animation-presets-utils';
 import {px} from '../../../src/style';
+import {userAssert} from '../../../src/log';
 
 const FULL_BLEED_CATEGORY = 'full-bleed';
 const FILL_TEMPLATE_LAYOUT = 'fill';
@@ -242,7 +243,7 @@ export const getPresetDef = (name, options) => {
         },
       };
     case 'pan-left':
-      let translateX = parseFloat(options.translateX);
+      let {translateX} = options;
 
       return {
         duration: 1000,
@@ -260,7 +261,7 @@ export const getPresetDef = (name, options) => {
         },
       };
     case 'pan-right':
-      translateX = parseFloat(options.translateX);
+      translateX = options.translateX;
 
       return {
         duration: 1000,
@@ -278,7 +279,7 @@ export const getPresetDef = (name, options) => {
         },
       };
     case 'pan-down':
-      let translateY = parseFloat(options.translateY);
+      let {translateY} = options;
 
       return {
         duration: 1000,
@@ -296,7 +297,7 @@ export const getPresetDef = (name, options) => {
         },
       };
     case 'pan-up':
-      translateY = parseFloat(options.translateY);
+      translateY = options.translateY;
 
       return {
         duration: 1000,
@@ -316,6 +317,11 @@ export const getPresetDef = (name, options) => {
     case 'zoom-in':
       let {zoomStart, zoomEnd} = options;
 
+      if (zoomStart) {
+        userAssert(zoomEnd > zoomStart, '"zoom-end" value must be greater ' +
+        'than "zoom-start" value when using "zoom-in" animation.');
+      }
+
       return {
         duration: 1000,
         easing: 'linear',
@@ -327,6 +333,11 @@ export const getPresetDef = (name, options) => {
     case 'zoom-out':
       zoomStart = options.zoomStart;
       zoomEnd = options.zoomEnd;
+
+      if (zoomStart) {
+        userAssert(zoomStart > zoomEnd, '"zoom-start" value must be higher ' +
+        'than "zoom-end" value when using "zoom-out" animation.');
+      }
 
       return {
         duration: 1000,

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -71,7 +71,7 @@ export function setStyleForPreset(el, presetName) {
 /**
  * @param {string} name
  * @param {!Object} options
- * @return {!StoryAnimationPresetDef}
+ * @return {?StoryAnimationPresetDef}
  */
 // First keyframe will always be considered offset: 0 and will be applied to the
 // element as the first frame before animation starts.
@@ -337,4 +337,5 @@ export const getPresetDef = (name, options) => {
         ],
       };
   }
+  return null;
 };

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -26,8 +26,14 @@ import {
 import {px} from '../../../src/style';
 import {userAssert} from '../../../src/log';
 
+/** @const {string} */
 const FULL_BLEED_CATEGORY = 'full-bleed';
+/** @const {string} */
 const FILL_TEMPLATE_LAYOUT = 'fill';
+/** @const {number} */
+const SCALE_HIGH_DEFAULT = 3;
+/** @const {number} */
+const SCALE_LOW_DEFAULT = 1;
 
 /**
  * A list of animations that are full bleed.
@@ -326,8 +332,8 @@ export const getPresetDef = (name, options) => {
         duration: 1000,
         easing: 'linear',
         keyframes: [
-          {transform: `scale(${scaleStart || 1})`},
-          {transform: `scale(${scaleEnd || 3})`},
+          {transform: `scale(${scaleStart || SCALE_LOW_DEFAULT})`},
+          {transform: `scale(${scaleEnd || SCALE_HIGH_DEFAULT})`},
         ],
       };
     case 'zoom-out':
@@ -343,8 +349,8 @@ export const getPresetDef = (name, options) => {
         duration: 1000,
         easing: 'linear',
         keyframes: [
-          {transform: `scale(${scaleStart || 3})`},
-          {transform: `scale(${scaleEnd || 1})`},
+          {transform: `scale(${scaleStart || SCALE_HIGH_DEFAULT})`},
+          {transform: `scale(${scaleEnd || SCALE_LOW_DEFAULT})`},
         ],
       };
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -22,7 +22,6 @@ import {
   StoryAnimationDimsDef,
   StoryAnimationPresetDef,
 } from './animation-types';
-import {PRESETS, setStyleForPreset} from './animation-presets';
 import {Services} from '../../../src/services';
 import {
   WebAnimationPlayState,
@@ -34,6 +33,7 @@ import {
   scopedQuerySelector,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
+import {getPresetDef, setStyleForPreset} from './animation-presets';
 import {map, omit} from '../../../src/utils/object';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 
@@ -47,7 +47,14 @@ const ANIMATE_IN_DELAY_ATTRIBUTE_NAME = 'animate-in-delay';
 const ANIMATE_IN_AFTER_ATTRIBUTE_NAME = 'animate-in-after';
 /** const {string} */
 const ANIMATABLE_ELEMENTS_SELECTOR = `[${ANIMATE_IN_ATTRIBUTE_NAME}]`;
-
+/** const {string} */
+const ZOOM_START_ATTRIBUTE_NAME = 'zoom-start';
+/** const {string} */
+const ZOOM_END_ATTRIBUTE_NAME = 'zoom-end';
+/** const {string} */
+const HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME = 'horizontal-translate';
+/** const {string} */
+const VERTICAL_TRANSLATE_ATTRIBUTE_NAME = 'vertical-translate';
 
 /**
  * @param {!Element} element
@@ -530,10 +537,27 @@ export class AnimationManager {
    */
   getPreset_(el) {
     const name = el.getAttribute(ANIMATE_IN_ATTRIBUTE_NAME);
+    const options = {};
     setStyleForPreset(el, name);
 
+    if (el.hasAttribute(ZOOM_START_ATTRIBUTE_NAME)) {
+      options.zoomStart = el.getAttribute(ZOOM_START_ATTRIBUTE_NAME);
+    }
+
+    if (el.hasAttribute(ZOOM_END_ATTRIBUTE_NAME)) {
+      options.zoomEnd = el.getAttribute(ZOOM_END_ATTRIBUTE_NAME);
+    }
+
+    if (el.hasAttribute(HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME)) {
+      options.translateX = el.getAttribute(HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME);
+    }
+
+    if (el.hasAttribute(VERTICAL_TRANSLATE_ATTRIBUTE_NAME)) {
+      options.translateY = el.getAttribute(VERTICAL_TRANSLATE_ATTRIBUTE_NAME);
+    }
+
     return userAssert(
-        PRESETS[name],
+        getPresetDef(name, options),
         'Invalid %s preset "%s" for element %s',
         ANIMATE_IN_ATTRIBUTE_NAME,
         name,

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -48,9 +48,9 @@ const ANIMATE_IN_AFTER_ATTRIBUTE_NAME = 'animate-in-after';
 /** const {string} */
 const ANIMATABLE_ELEMENTS_SELECTOR = `[${ANIMATE_IN_ATTRIBUTE_NAME}]`;
 /** const {string} */
-const ZOOM_START_ATTRIBUTE_NAME = 'zoom-start';
+const SCALE_START_ATTRIBUTE_NAME = 'scale-start';
 /** const {string} */
-const ZOOM_END_ATTRIBUTE_NAME = 'zoom-end';
+const SCALE_END_ATTRIBUTE_NAME = 'scale-end';
 /** const {string} */
 const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
 /** const {string} */
@@ -540,23 +540,23 @@ export class AnimationManager {
     const options = {};
     setStyleForPreset(el, name);
 
-    if (el.hasAttribute(ZOOM_START_ATTRIBUTE_NAME)) {
-      options.zoomStart =
-        parseFloat(el.getAttribute(ZOOM_START_ATTRIBUTE_NAME));
+    if (el.hasAttribute(SCALE_START_ATTRIBUTE_NAME)) {
+      options.scaleStart =
+        parseFloat(el.getAttribute(SCALE_START_ATTRIBUTE_NAME));
 
-      userAssert(options.zoomStart > 0, '"%s" attribute must be a ' +
+      userAssert(options.scaleStart > 0, '"%s" attribute must be a ' +
         'positive number. Found negative or zero in element %s',
-      ZOOM_START_ATTRIBUTE_NAME,
+      SCALE_START_ATTRIBUTE_NAME,
       el);
     }
 
-    if (el.hasAttribute(ZOOM_END_ATTRIBUTE_NAME)) {
-      options.zoomEnd =
-        parseFloat(el.getAttribute(ZOOM_END_ATTRIBUTE_NAME));
+    if (el.hasAttribute(SCALE_END_ATTRIBUTE_NAME)) {
+      options.scaleEnd =
+        parseFloat(el.getAttribute(SCALE_END_ATTRIBUTE_NAME));
 
-      userAssert(options.zoomEnd > 0, '"%s" attribute must be a ' +
+      userAssert(options.scaleEnd > 0, '"%s" attribute must be a ' +
         'positive number. Found negative or zero in element %s',
-      ZOOM_END_ATTRIBUTE_NAME,
+      SCALE_END_ATTRIBUTE_NAME,
       el);
     }
 

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -52,9 +52,9 @@ const ZOOM_START_ATTRIBUTE_NAME = 'zoom-start';
 /** const {string} */
 const ZOOM_END_ATTRIBUTE_NAME = 'zoom-end';
 /** const {string} */
-const HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME = 'horizontal-translate';
+const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
 /** const {string} */
-const VERTICAL_TRANSLATE_ATTRIBUTE_NAME = 'vertical-translate';
+const TRANSLATE_Y_ATTRIBUTE_NAME = 'translate-y';
 
 /**
  * @param {!Element} element
@@ -541,19 +541,43 @@ export class AnimationManager {
     setStyleForPreset(el, name);
 
     if (el.hasAttribute(ZOOM_START_ATTRIBUTE_NAME)) {
-      options.zoomStart = el.getAttribute(ZOOM_START_ATTRIBUTE_NAME);
+      options.zoomStart =
+        parseFloat(el.getAttribute(ZOOM_START_ATTRIBUTE_NAME));
+
+      userAssert(options.zoomStart > 0, '"%s" attribute must be a ' +
+        'positive number. Found negative or zero in element %s',
+      ZOOM_START_ATTRIBUTE_NAME,
+      el);
     }
 
     if (el.hasAttribute(ZOOM_END_ATTRIBUTE_NAME)) {
-      options.zoomEnd = el.getAttribute(ZOOM_END_ATTRIBUTE_NAME);
+      options.zoomEnd =
+        parseFloat(el.getAttribute(ZOOM_END_ATTRIBUTE_NAME));
+
+      userAssert(options.zoomEnd > 0, '"%s" attribute must be a ' +
+        'positive number. Found negative or zero in element %s',
+      ZOOM_END_ATTRIBUTE_NAME,
+      el);
     }
 
-    if (el.hasAttribute(HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME)) {
-      options.translateX = el.getAttribute(HORIZONTAL_TRANSLATE_ATTRIBUTE_NAME);
+    if (el.hasAttribute(TRANSLATE_X_ATTRIBUTE_NAME)) {
+      options.translateX =
+        parseFloat(el.getAttribute(TRANSLATE_X_ATTRIBUTE_NAME));
+
+      userAssert(options.translateX > 0, '"%s" attribute must be a ' +
+        'positive number. Found negative or zero in element %s',
+      TRANSLATE_X_ATTRIBUTE_NAME,
+      el);
     }
 
-    if (el.hasAttribute(VERTICAL_TRANSLATE_ATTRIBUTE_NAME)) {
-      options.translateY = el.getAttribute(VERTICAL_TRANSLATE_ATTRIBUTE_NAME);
+    if (el.hasAttribute(TRANSLATE_Y_ATTRIBUTE_NAME)) {
+      options.translateY =
+        parseFloat(el.getAttribute(TRANSLATE_Y_ATTRIBUTE_NAME));
+
+      userAssert(options.translateY > 0, '"%s" attribute must be a ' +
+        'positive number. Found negative or zero in element %s',
+      TRANSLATE_Y_ATTRIBUTE_NAME,
+      el);
     }
 
     return userAssert(

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -22,12 +22,12 @@ import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {LocalizationService} from '../localization';
-import {PRESETS} from '../animation-presets';
 import {Services} from '../../../../src/services';
 import {
   calculateTargetScalingFactor,
   targetFitsWithinPage,
 } from '../animation-presets-utils';
+import {getPresetDef} from '../animation-presets';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-full-bleed-animations', {
@@ -216,7 +216,7 @@ describes.realWin('amp-story-animations-utils', {
     const factor = factorThatWillMakeTargetFitPage * 1.25;
     expect(calculateTargetScalingFactor(dimensions)).to.equal(factor);
 
-    const calculatedKeyframes = PRESETS['pan-up'];
+    const calculatedKeyframes = getPresetDef('pan-up', {});
     calculatedKeyframes.keyframes = calculatedKeyframes.keyframes(dimensions);
 
     const offsetX = -dimensions.targetWidth / 2;


### PR DESCRIPTION
Closes #20260

New proposal is to expose the start/end arguments of the zoom and pan animations:

Scales the image from 1x to 3x over 4 seconds:
`animate-in="zoom-out"` `animate-in-duration="4s"` `zoom-start="1"` `zoom-end="3"`

Translates the image 200px horizontally to the right over 4 seconds:
`animate-in="pan-right"` `animate-in-duration="4s"` `horizontal-translate="200px"`

Potential question: why we chose to keep using `pan-right` instead of just using `pan` for all general directions and use the sign (+/-) in the value to get direction. The reasoning is that we need to be backwards compatible and not introduce any breaking changes.

A follow-up will be sent with validator changes and addition to docs. 