### PR TITLE
🖍Clean up amp-pinterest button styling

### DIFF
--- a/extensions/amp-pinterest/0.1/save-button.js
+++ b/extensions/amp-pinterest/0.1/save-button.js
@@ -53,9 +53,11 @@ export class SaveButton {
     this.color = rootElement.getAttribute('data-color');
     this.count = rootElement.getAttribute('data-count');
     this.lang = rootElement.getAttribute('data-lang');
-    const hasOneToOneDimensions = rootElement.hasAttribute('height') && rootElement.hasAttribute('width') && 
+    const hasOneToOneDimensions = rootElement.hasAttribute('height') &&
+      rootElement.hasAttribute('width') &&
       rootElement.getAttribute('height') === rootElement.getAttribute('width');
-    this.round = rootElement.getAttribute('data-round') || hasOneToOneDimensions;
+    this.round = rootElement.getAttribute('data-round') ||
+      hasOneToOneDimensions;
     this.tall = rootElement.getAttribute('data-tall');
     this.description = rootElement.getAttribute('data-description');
     /** @type {?string} */

--- a/extensions/amp-pinterest/0.1/save-button.js
+++ b/extensions/amp-pinterest/0.1/save-button.js
@@ -53,7 +53,8 @@ export class SaveButton {
     this.color = rootElement.getAttribute('data-color');
     this.count = rootElement.getAttribute('data-count');
     this.lang = rootElement.getAttribute('data-lang');
-    this.round = rootElement.getAttribute('data-round');
+    this.round = rootElement.getAttribute('data-round') ||
+        rootElement.getAttribute('height') == rootElement.getAttribute('width');
     this.tall = rootElement.getAttribute('data-tall');
     this.description = rootElement.getAttribute('data-description');
     /** @type {?string} */

--- a/extensions/amp-pinterest/0.1/save-button.js
+++ b/extensions/amp-pinterest/0.1/save-button.js
@@ -53,8 +53,9 @@ export class SaveButton {
     this.color = rootElement.getAttribute('data-color');
     this.count = rootElement.getAttribute('data-count');
     this.lang = rootElement.getAttribute('data-lang');
-    this.round = rootElement.getAttribute('data-round') ||
-        rootElement.getAttribute('height') == rootElement.getAttribute('width');
+    const hasOneToOneDimensions = rootElement.hasAttribute('height') && rootElement.hasAttribute('width') && 
+      rootElement.getAttribute('height') === rootElement.getAttribute('width');
+    this.round = rootElement.getAttribute('data-round') || hasOneToOneDimensions;
     this.tall = rootElement.getAttribute('data-tall');
     this.description = rootElement.getAttribute('data-description');
     /** @type {?string} */


### PR DESCRIPTION
- Make a style change from #20706 to be more compatible with existing uses.

Occasionally, customized CSS may overwrite rectangular button classes with a developer-inserted circular Pinterest logo. This change aids those use instances by overriding rectangular button styling with round button styling when the width and height of the inserted amp-pinterest element are 1:1. 