### PR TITLE
📖 Restructure docs for amp-video-docking, inform attribute in player docs

### DIFF
--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -110,8 +110,8 @@ to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/am
   </tr>
   <tr>
     <td width="40%"><strong>dock</strong></td>
-    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
-    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md">documentation on the docking extension itself.</a></td>
   </tr>
 </table>
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -110,6 +110,11 @@ Example:
     <td width="40%"><strong>common attributes</strong></td>
     <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
   </tr>
+  <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+  </tr>
 </table>
 
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -100,6 +100,11 @@ The component HTML accepts the following types of HTML nodes as children:
     <td>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3).  This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</td>
   </tr>
   <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+  </tr>
+  <tr>
     <td width="40%"><strong>common attributes</strong></td>
     <td>This element includes
     [common attributes](https://www.ampproject.org/docs/reference/common_attributes)

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -101,8 +101,8 @@ default, the first frame is displayed.</td>
   </tr>
   <tr>
     <td width="40%"><strong>dock</strong></td>
-    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
-    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md">documentation on the docking extension itself.</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>common attributes</strong></td>

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -49,4 +49,90 @@ Functionality for videos that dock to a corner.
 The `amp-video-docking` extension allows videos to be minimized to a corner or
 to a custom positioned element via the `dock` attribute.
 
-For more information, see [docking for the `VideoInterface`](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#docking).
+If this attribute is present and the video is playing manually, the video will
+be "docked" and fixed to a corner when the user scrolls out of the video
+component's visual area.
+
+- The video can be dragged and repositioned by the user on a different corner.
+- Multiple videos on the same page can be docked.
+
+This extension is used in conjunction with a [supported video player](../../spec/amp-video-interface.md).
+Currently, the supported players are:
+
+- [`amp-brightcove`](https://www.ampproject.org/docs/reference/components/amp-brightcove)
+- [`amp-ima-video`](https://www.ampproject.org/docs/reference/components/amp-ima-video)
+- [`amp-video`](https://www.ampproject.org/docs/reference/components/amp-video)
+- [`amp-video-iframe`](https://www.ampproject.org/docs/reference/components/amp-youtube)
+- [`amp-youtube`](https://www.ampproject.org/docs/reference/components/amp-youtube)
+
+### Styling
+
+The docked video can be styled by selecting elements that are created by the
+AMP runtime.
+
+#### `.amp-docked-video-shadow`
+
+References a layer that draws a `box-shadow` under the video. The shadow can be
+overridden or removed. Its opacity will change from 0 to 1 while the video is
+being docked.
+
+#### `.amp-docked-video-controls`
+
+References a layer that contains the docked video controls. Usually, this
+doesn't need to be styled. See `.amp-docked-video-controls-bg` for a background
+layer.
+
+This element also gets the classname `amp-small` applied when rendered in small areas (those under 300 pixels wide), and the classname `amp-large` when not.
+
+#### `.amp-docked-video-controls-bg`
+
+References a layer that draws an overlay background over the video and under
+the controls. It's displayed only when the controls are displayed. Its
+background can be overridden or removed.
+
+#### `.amp-docked-video-button-group`
+
+A button "group" that usually contains two buttons, with only one displayed at
+a time. It's used to draw a background when the button is active. It has a
+`border-radius` and a `background-color` set by default, both of which can be
+removed or overrridden.
+
+Direct children (`.amp-docked-video-button-group > [role=button]`) represent
+buttons, which have an SVG background. The color of the SVG can be changed by
+modifying the `fill` property. Additionally, these can be replaced by changing
+the `background` property.
+
+#### `.amp-docked-video-play`
+
+Represents the `play` button.
+
+#### `.amp-docked-video-pause`
+
+Represents the `pause` button.
+
+#### `.amp-docked-video-mute`
+
+Represents the `mute` button.
+
+#### `.amp-docked-video-unmute`
+
+Represents the `unmute` button.
+
+#### `.amp-docked-video-fullscreen`
+
+Represents the `fullscreen` button.
+
+#### `.amp-video-docked-placeholder-background`
+
+Represents a container for placeholder elements placed on the empty component area.
+
+#### `.amp-video-docked-placeholder-background-poster`
+
+Represents a layer displaying the `poster` or `placeholder` image of the video on the empty component area. Blurred by default.
+
+#### `.amp-video-docked-placeholder-icon`
+
+Represents an animated icon for a UX affordance displayed on the empty component area.
+
+This element also gets the classname `amp-small` when rendered in small viewports (those under 420 pixels wide). It also gets the classname `amp-rtl` when animating from right to left.
+

--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -91,8 +91,8 @@ to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/am
   </tr>
   <tr>
     <td width="40%"><strong>dock</strong></td>
-    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
-    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md">documentation on the docking extension itself.</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>implements-media-session</strong></td>

--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -90,6 +90,11 @@ The reasons for this policy are that:
     <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
   </tr>
   <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+  </tr>
+  <tr>
     <td width="40%"><strong>implements-media-session</strong></td>
     <td>Set this attribute if the document inside the iframe implements the [MediaSession API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API) independently.</td>
   </tr>

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -105,6 +105,11 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
     <td>Same as [controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) attribute of HTML5 video element. Only supported by certain browsers. Please see [https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) for details.</td>
   </tr>
   <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+  </tr>
+  <tr>
     <td width="40%"><strong>loop</strong></td>
     <td>If present, the video will automatically loop back to the start upon reaching the end.</td>
   </tr>

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -106,8 +106,8 @@ to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/am
   </tr>
   <tr>
     <td width="40%"><strong>dock</strong></td>
-    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
-    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md">documentation on the docking extension itself.</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>loop</strong></td>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -108,8 +108,8 @@ With the responsive layout, the width and height from the example should yield c
   </tr>
   <tr>
     <td width="40%"><strong>dock</strong></td>
-    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
-    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md">documentation on the docking extension itself.</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>credentials (optional)</strong></td>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -110,6 +110,11 @@ With the responsive layout, the width and height from the example should yield c
 </td>
   </tr>
   <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires `amp-video-docking` extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)</td>
+  </tr>
+  <tr>
     <td width="40%"><strong>credentials (optional)</strong></td>
     <td>Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
 

--- a/spec/amp-video-interface.md
+++ b/spec/amp-video-interface.md
@@ -48,7 +48,8 @@ For an example, visit [AMP By Example](https://ampbyexample.com/components/amp-v
 
 attribute: **`dock`**
 
-**Experimental feature.**
+This attributes is currently only supported for
+`amp-brightcove`, `amp-ima-video`, `amp-video`, `amp-video-iframe` and `amp-youtube`.
 
 If this attribute is present and the video is playing manually, the video will
 be "minimized" and fixed to a corner when the user scrolls out of the video
@@ -56,86 +57,15 @@ component's visual area.
 
 - The video can be dragged and repositioned by the user on a different corner.
 - Multiple videos on the same page can be docked.
-- Users can dismiss the docked video by flicking it out of view. Once dismissed
-by the user, docking will no longer occur.
 
-In order to use this attribute, the [`amp-video-docking`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md)
+In order to use this attribute, the [`amp-video-docking`](https://www.ampproject.org/docs/reference/components/amp-video-docking/)
 extension script must be present:
 
 ```
 <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
 ```
 
-### Styling
-
-The docked video can be styled by selecting class names that are defined by the
-AMP runtime.
-
-#### `.amp-docked-video-shadow`
-
-References a layer that draws a `box-shadow` under the video. The shadow can be
-overridden or removed. Its opacity will change from 0 to 1 while the video is
-being docked.
-
-#### `.amp-docked-video-controls`
-
-References a layer that contains the docked video controls. Usually, this
-doesn't need to be styled. See `.amp-docked-video-controls-bg` for a background
-layer.
-
-This element also gets the classname `amp-small` applied when rendered in small areas (those under 300 pixels wide), and the classname `amp-large` when not.
-
-#### `.amp-docked-video-controls-bg`
-
-References a layer that draws an overlay background over the video and under
-the controls. It's displayed only when the controls are displayed. Its
-background can be overridden or removed.
-
-#### `.amp-docked-video-button-group`
-
-A button "group" that usually contains two buttons, with only one displayed at
-a time. It's used to draw a background when the button is active. It has a
-`border-radius` and a `background-color` set by default, both of which can be
-removed or overrridden.
-
-Direct children (`.amp-docked-video-button-group > [role=button]`) represent
-buttons, which have an SVG background. The color of the SVG can be changed by
-modifying the `fill` property. Additionally, these can be replaced by changing
-the `background` property.
-
-#### `.amp-docked-video-play`
-
-Represents the `play` button.
-
-#### `.amp-docked-video-pause`
-
-Represents the `pause` button.
-
-#### `.amp-docked-video-mute`
-
-Represents the `mute` button.
-
-#### `.amp-docked-video-unmute`
-
-Represents the `unmute` button.
-
-#### `.amp-docked-video-fullscreen`
-
-Represents the `fullscreen` button.
-
-#### `.amp-video-docked-placeholder-background`
-
-Represents a container for placeholder elements placed on the empty component area.
-
-#### `.amp-video-docked-placeholder-background-poster`
-
-Represents a layer displaying the `poster` or `placeholder` image of the video on the empty component area. Blurred by default.
-
-#### `.amp-video-docked-placeholder-icon`
-
-Represents an animated icon for a UX affordance displayed on the empty component area.
-
-This element also gets the classname `amp-small` when rendered in small viewports (those under 420 pixels wide). It also gets the classname `amp-rtl` when animating from right to left.
+For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)
 
 <a id="rotate-to-fullscreen"></a>
 

--- a/spec/amp-video-interface.md
+++ b/spec/amp-video-interface.md
@@ -48,7 +48,7 @@ For an example, visit [AMP By Example](https://ampbyexample.com/components/amp-v
 
 attribute: **`dock`**
 
-This attributes is currently only supported for
+This attribute is currently only supported for
 `amp-brightcove`, `amp-ima-video`, `amp-video`, `amp-video-iframe` and `amp-youtube`.
 
 If this attribute is present and the video is playing manually, the video will
@@ -58,14 +58,14 @@ component's visual area.
 - The video can be dragged and repositioned by the user on a different corner.
 - Multiple videos on the same page can be docked.
 
-In order to use this attribute, the [`amp-video-docking`](https://www.ampproject.org/docs/reference/components/amp-video-docking/)
+In order to use this attribute, the [`amp-video-docking`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md)
 extension script must be present:
 
 ```
 <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
 ```
 
-For more details, see [documentation on the docking extension itself.](https://www.ampproject.org/docs/reference/components/amp-video-docking/)
+For more details, see [documentation on the docking extension itself.](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md)
 
 <a id="rotate-to-fullscreen"></a>
 


### PR DESCRIPTION
- Moves docking-specific info from `amp-video-interface.md` to extension docs themselves to remove bloat in the former.

- Removes experimental status.

- Informs of supported players where relevant.

- Add `dock` attribute info to the docs of each supported player.

## Known issues

- ~~Broken links to [undeployed `amp-video-docking` docs](https://www.ampproject.org/docs/reference/components/amp-video-docking/). I can wait for update or change the references here to the [master file in the repo.](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md)~~ Waiting for update

- ~~Markdown inside tables [renders in raw form](https://github.com/ampproject/amphtml/blob/d8aa1d746a7264345b303670ab7cbe8c3c08732d/extensions/amp-brightcove/amp-brightcove.md), which is a problem all over our docs introduced by #20684. I can either fix all the links in the docs here, or I can go through the codebase later. WDYT @aghassemi? Waiting to see what's up with #20791.~~ Fixed.