### PR TITLE
📖🐛 Actually render markdown in docs tables

### DIFF
--- a/extensions/amp-3d-gltf/amp-3d-gltf.md
+++ b/extensions/amp-3d-gltf/amp-3d-gltf.md
@@ -79,7 +79,7 @@ Unsupported features:
   <tr>
     <td width="40%"><p><strong>alpha [optional]</strong></p></td>
     <td><p>A Boolean attribute that specifies whether free space on canvas is transparent. By default, free space is filled with black.
-Default value is <code>false</code>.</p></td>
+  Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>antialiasing [optional]</strong></p></td>

--- a/extensions/amp-3d-gltf/amp-3d-gltf.md
+++ b/extensions/amp-3d-gltf/amp-3d-gltf.md
@@ -73,33 +73,33 @@ Unsupported features:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>src [required]</strong></p></td>
-    <td><p>A required attribute that specifies the URL to the gltf file.</p></td>
+    <td width="40%"><strong>src [required]</strong></td>
+    <td>A required attribute that specifies the URL to the gltf file.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>alpha [optional]</strong></p></td>
-    <td><p>A Boolean attribute that specifies whether free space on canvas is transparent. By default, free space is filled with black.
-  Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>alpha [optional]</strong></td>
+    <td>A Boolean attribute that specifies whether free space on canvas is transparent. By default, free space is filled with black.
+Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>antialiasing [optional]</strong></p></td>
-    <td><p>A Boolean attribute that specifies whether to turn on antialiasing. Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>antialiasing [optional]</strong></td>
+    <td>A Boolean attribute that specifies whether to turn on antialiasing. Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>clearColor [optional]</strong></p></td>
-    <td><p>A string that must contain valid CSS color, that will be used to fill free space on canvas.</p></td>
+    <td width="40%"><strong>clearColor [optional]</strong></td>
+    <td>A string that must contain valid CSS color, that will be used to fill free space on canvas.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>maxPixelRatio [optional]</strong></p></td>
-    <td><p>A numeric value that specifies the upper limit for the pixelRatio render option. The default is <code>window.devicePixelRatio</code>.</p></td>
+    <td width="40%"><strong>maxPixelRatio [optional]</strong></td>
+    <td>A numeric value that specifies the upper limit for the pixelRatio render option. The default is <code>window.devicePixelRatio</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoRotate [optional]</strong></p></td>
-    <td><p>A Boolean attribute that specifies whether to automatically rotate the camera around the model's center. Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>autoRotate [optional]</strong></td>
+    <td>A Boolean attribute that specifies whether to automatically rotate the camera around the model's center. Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>enableZoom [optional]</strong></p></td>
-    <td><p>A Boolean attribute that specifies whether to turn on zoom. Default value is <code>true</code>.</p></td>
+    <td width="40%"><strong>enableZoom [optional]</strong></td>
+    <td>A Boolean attribute that specifies whether to turn on zoom. Default value is <code>true</code>.</td>
   </tr>
 </table>
 

--- a/extensions/amp-3d-gltf/amp-3d-gltf.md
+++ b/extensions/amp-3d-gltf/amp-3d-gltf.md
@@ -73,33 +73,33 @@ Unsupported features:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>src [required]</strong></td>
-    <td>A required attribute that specifies the URL to the gltf file.</td>
+    <td width="40%"><p><strong>src [required]</strong></p></td>
+    <td><p>A required attribute that specifies the URL to the gltf file.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>alpha [optional]</strong></td>
-    <td>A Boolean attribute that specifies whether free space on canvas is transparent. By default, free space is filled with black.
-    Default value is `false`.</td>
+    <td width="40%"><p><strong>alpha [optional]</strong></p></td>
+    <td><p>A Boolean attribute that specifies whether free space on canvas is transparent. By default, free space is filled with black.
+Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>antialiasing [optional]</strong></td>
-    <td>A Boolean attribute that specifies whether to turn on antialiasing. Default value is `false`.</td>
+    <td width="40%"><p><strong>antialiasing [optional]</strong></p></td>
+    <td><p>A Boolean attribute that specifies whether to turn on antialiasing. Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>clearColor [optional]</strong></td>
-    <td>A string that must contain valid CSS color, that will be used to fill free space on canvas.</td>
+    <td width="40%"><p><strong>clearColor [optional]</strong></p></td>
+    <td><p>A string that must contain valid CSS color, that will be used to fill free space on canvas.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>maxPixelRatio [optional]</strong></td>
-    <td>A numeric value that specifies the upper limit for the pixelRatio render option. The default is `window.devicePixelRatio`.</td>
+    <td width="40%"><p><strong>maxPixelRatio [optional]</strong></p></td>
+    <td><p>A numeric value that specifies the upper limit for the pixelRatio render option. The default is <code>window.devicePixelRatio</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoRotate [optional]</strong></td>
-    <td>A Boolean attribute that specifies whether to automatically rotate the camera around the model's center. Default value is `false`.</td>
+    <td width="40%"><p><strong>autoRotate [optional]</strong></p></td>
+    <td><p>A Boolean attribute that specifies whether to automatically rotate the camera around the model's center. Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>enableZoom [optional]</strong></td>
-    <td>A Boolean attribute that specifies whether to turn on zoom. Default value is `true`.</td>
+    <td width="40%"><p><strong>enableZoom [optional]</strong></p></td>
+    <td><p>A Boolean attribute that specifies whether to turn on zoom. Default value is <code>true</code>.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -58,11 +58,11 @@ With the `responsive` layout, the width and height in this should yield correct 
     <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
     <td ><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-<li>the video is automatically muted before autoplay starts</li>
-<li>when the video is scrolled out of view, the video is paused</li>
-<li>when the video is scrolled into view, the video resumes playback</li>
-<li>when the user taps the video, the video is unmuted</li>
-<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+  <li>the video is automatically muted before autoplay starts</li>
+  <li>when the video is scrolled out of view, the video is paused</li>
+  <li>when the video is scrolled into view, the video resumes playback</li>
+  <li>when the user taps the video, the video is unmuted</li>
+  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
 </ul>
 <p>for example <code>setModelRotation(x=0.5, xMin=0, xMax=3.14)</code> will change <code>x</code> component of rotation to <code>1.57</code>.</p></td>
   </tr>

--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -51,24 +51,24 @@ With the `responsive` layout, the width and height in this should yield correct 
 
 <table>
   <tr>
-    <td width="40%"><strong><strong>Examples</strong></td>
-    <td>The sdnPlayoutId from 3Q SDN.</td>
+    <td width="40%"><p><strong><strong>Examples</strong></p></td>
+    <td><p>The sdnPlayoutId from 3Q SDN.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay (optional)</strong></td>
-    <td >If this attribute is present, and the browser supports autoplay:
-      <ul>
-        <li>the video is automatically muted before autoplay starts</li>
-        <li>when the video is scrolled out of view, the video is paused</li>
-        <li>when the video is scrolled into view, the video resumes playback</li>
-        <li>when the user taps the video, the video is unmuted</li>
-        <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
-      </ul>
-    for example `setModelRotation(x=0.5, xMin=0, xMax=3.14)` will change `x` component of rotation to `1.57`.</td>
+    <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
+    <td ><p>If this attribute is present, and the browser supports autoplay:</p>
+<ul>
+<li>the video is automatically muted before autoplay starts</li>
+<li>when the video is scrolled out of view, the video is paused</li>
+<li>when the video is scrolled into view, the video resumes playback</li>
+<li>when the user taps the video, the video is unmuted</li>
+<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+</ul>
+<p>for example <code>setModelRotation(x=0.5, xMin=0, xMax=3.14)</code> will change <code>x</code> component of rotation to <code>1.57</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -51,11 +51,11 @@ With the `responsive` layout, the width and height in this should yield correct 
 
 <table>
   <tr>
-    <td width="40%"><p><strong><strong>Examples</strong></p></td>
-    <td><p>The sdnPlayoutId from 3Q SDN.</p></td>
+    <td width="40%"><strong><strong>Examples</strong></td>
+    <td>The sdnPlayoutId from 3Q SDN.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
+    <td width="40%"><strong>autoplay (optional)</strong></td>
     <td ><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
@@ -67,8 +67,8 @@ With the `responsive` layout, the width and height in this should yield correct 
 <p>for example <code>setModelRotation(x=0.5, xMin=0, xMax=3.14)</code> will change <code>x</code> component of rotation to <code>1.57</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -111,20 +111,20 @@ The events below will be triggered on `section`s of `accordion`.
 #### Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong><code>animate</code></strong></p></td>
-    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to animate the expansion / collapse of all accordion sections.</p></td>
+    <td width="40%"><strong><code>animate</code></strong></td>
+    <td>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to animate the expansion / collapse of all accordion sections.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong><code>disable-session-states</code></strong></p></td>
-    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to opt out of preserving the collapsed/expanded state of the accordion.</p></td>
+    <td width="40%"><strong><code>disable-session-states</code></strong></td>
+    <td>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to opt out of preserving the collapsed/expanded state of the accordion.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong><code>expanded</code></strong></p></td>
-    <td><p>Set this attribute on a <code>&lt;section&gt;</code> to display the section as expanded on page load.</p></td>
+    <td width="40%"><strong><code>expanded</code></strong></td>
+    <td>Set this attribute on a <code>&lt;section&gt;</code> to display the section as expanded on page load.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong><code>expand-single-section</code></strong></p></td>
-    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to only allow one <code>&lt;section&gt;</code> to be expanded at a time. If the user focuses on one <code>&lt;section&gt;</code> any other previously expanded <code>&lt;section&gt;</code> will be collapsed.</p></td>
+    <td width="40%"><strong><code>expand-single-section</code></strong></td>
+    <td>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to only allow one <code>&lt;section&gt;</code> to be expanded at a time. If the user focuses on one <code>&lt;section&gt;</code> any other previously expanded <code>&lt;section&gt;</code> will be collapsed.</td>
   </tr>
 </table>
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -111,20 +111,20 @@ The events below will be triggered on `section`s of `accordion`.
 #### Attributes
 <table>
   <tr>
-    <td width="40%"><strong>`animate`</strong></td>
-    <td>Set this attribute on the `<amp-accordion>` to animate the expansion / collapse of all accordion sections.</td>
+    <td width="40%"><p><strong><code>animate</code></strong></p></td>
+    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to animate the expansion / collapse of all accordion sections.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>`disable-session-states`</strong></td>
-    <td>Set this attribute on the `<amp-accordion>` to opt out of preserving the collapsed/expanded state of the accordion.</td>
+    <td width="40%"><p><strong><code>disable-session-states</code></strong></p></td>
+    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to opt out of preserving the collapsed/expanded state of the accordion.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>`expanded`</strong></td>
-    <td>Set this attribute on a `<section>` to display the section as expanded on page load.</td>
+    <td width="40%"><p><strong><code>expanded</code></strong></p></td>
+    <td><p>Set this attribute on a <code>&lt;section&gt;</code> to display the section as expanded on page load.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>`expand-single-section`</strong></td>
-    <td>Set this attribute on the `<amp-accordion>` to only allow one `<section>` to be expanded at a time. If the user focuses on one `<section>` any other previously expanded `<section>` will be collapsed.</td>
+    <td width="40%"><p><strong><code>expand-single-section</code></strong></p></td>
+    <td><p>Set this attribute on the <code>&lt;amp-accordion&gt;</code> to only allow one <code>&lt;section&gt;</code> to be expanded at a time. If the user focuses on one <code>&lt;section&gt;</code> any other previously expanded <code>&lt;section&gt;</code> will be collapsed.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -401,8 +401,8 @@ See the `AmpAdExitConfig` typedef in [config.js](https://github.com/ampproject/a
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>id</strong></td>
-    <td>An `id` is required so that `amp-exit` can be referenced by tappable elements.</td>
+    <td width="40%"><p><strong>id</strong></p></td>
+    <td><p>An <code>id</code> is required so that <code>amp-exit</code> can be referenced by tappable elements.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -401,8 +401,8 @@ See the `AmpAdExitConfig` typedef in [config.js](https://github.com/ampproject/a
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>id</strong></p></td>
-    <td><p>An <code>id</code> is required so that <code>amp-exit</code> can be referenced by tappable elements.</p></td>
+    <td width="40%"><strong>id</strong></td>
+    <td>An <code>id</code> is required so that <code>amp-exit</code> can be referenced by tappable elements.</td>
   </tr>
 </table>
 

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -76,41 +76,41 @@ The `<amp-ad>` requires width and height values to be specified according to the
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>type (required)</strong></p></td>
-    <td><p>Specifies an identifier for the <a href="#supported-ad-networks">ad network</a>. The <code>type</code>attribute selects the template to use for the ad tag.</p></td>
+    <td width="40%"><strong>type (required)</strong></td>
+    <td>Specifies an identifier for the <a href="#supported-ad-networks">ad network</a>. The <code>type</code>attribute selects the template to use for the ad tag.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>src (optional)</strong></p></td>
-    <td><p>Use this attribute to load a script tag for the specified ad network. This can be used for ad networks that require exactly a single script tag to be inserted in the page. The <code>src</code> value must have a prefix that is white-listed for the specified ad network, and the value must use <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>src (optional)</strong></td>
+    <td>Use this attribute to load a script tag for the specified ad network. This can be used for ad networks that require exactly a single script tag to be inserted in the page. The <code>src</code> value must have a prefix that is white-listed for the specified ad network, and the value must use <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-foo-bar</strong></p></td>
-    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
+    <td width="40%"><strong>data-foo-bar</strong></td>
+    <td>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-vars-foo-bar</strong></p></td>
-    <td><p>Attributes starting with <code>data-vars-</code> are reserved for <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute"><code>amp-analytics</code> vars</a>.</p></td>
+    <td width="40%"><strong>data-vars-foo-bar</strong></td>
+    <td>Attributes starting with <code>data-vars-</code> are reserved for <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute"><code>amp-analytics</code> vars</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>json (optional)</strong></p></td>
-    <td><p>Use this attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.</p></td>
+    <td width="40%"><strong>json (optional)</strong></td>
+    <td>Use this attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-consent-notification-id (optional)</strong></p></td>
-    <td><p>If provided, requires confirming the <a href="https://www.ampproject.org/docs/reference/components/amp-user-notification.html">amp-user-notification</a> with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. This means that ad rendering is delayed until the user confirms the notification.</p></td>
+    <td width="40%"><strong>data-consent-notification-id (optional)</strong></td>
+    <td>If provided, requires confirming the <a href="https://www.ampproject.org/docs/reference/components/amp-user-notification.html">amp-user-notification</a> with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. This means that ad rendering is delayed until the user confirms the notification.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-loading-strategy (optional)</strong></p></td>
-    <td><p>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the <code>data-loading-strategy</code> attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions. Note, specifying <code>prefer-viewability-over-views</code> as the value also automatically optimizes viewability.</p></td>
+    <td width="40%"><strong>data-loading-strategy (optional)</strong></td>
+    <td>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the <code>data-loading-strategy</code> attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions. Note, specifying <code>prefer-viewability-over-views</code> as the value also automatically optimizes viewability.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-ad-container-id (optional)</strong></p></td>
-    <td><p>Informs the ad of the container component id in the case of attempting to collapse. The container component must be an <code>&lt;amp-layout&gt;</code> component that's parent of the ad. When the <code>data-ad-container-id</code> is specified, and such a <code>&lt;amp-layout&gt;</code> container component is found, AMP runtime will try to collapse the container component instead of the ad component during no fill. This feature can be useful when an ad indicator is in presence.</p>
+    <td width="40%"><strong>data-ad-container-id (optional)</strong></td>
+    <td>Informs the ad of the container component id in the case of attempting to collapse. The container component must be an <code>&lt;amp-layout&gt;</code> component that's parent of the ad. When the <code>data-ad-container-id</code> is specified, and such a <code>&lt;amp-layout&gt;</code> container component is found, AMP runtime will try to collapse the container component instead of the ad component during no fill. This feature can be useful when an ad indicator is in presence.
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -76,41 +76,41 @@ The `<amp-ad>` requires width and height values to be specified according to the
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>type (required)</strong></td>
-    <td>Specifies an identifier for the [ad network](#supported-ad-networks). The `type`attribute selects the template to use for the ad tag.</td>
+    <td width="40%"><p><strong>type (required)</strong></p></td>
+    <td><p>Specifies an identifier for the <a href="#supported-ad-networks">ad network</a>. The <code>type</code>attribute selects the template to use for the ad tag.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>src (optional)</strong></td>
-    <td>Use this attribute to load a script tag for the specified ad network. This can be used for ad networks that require exactly a single script tag to be inserted in the page. The `src` value must have a prefix that is white-listed for the specified ad network, and the value must use `https` protocol.</td>
+    <td width="40%"><p><strong>src (optional)</strong></p></td>
+    <td><p>Use this attribute to load a script tag for the specified ad network. This can be used for ad networks that require exactly a single script tag to be inserted in the page. The <code>src</code> value must have a prefix that is white-listed for the specified ad network, and the value must use <code>https</code> protocol.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-foo-bar</strong></td>
-    <td>Most ad networks require further configuration, which can be passed to the network by using HTML `data-` attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the [ad network](#supported-ad-networks) on which attributes can be used.</td>
+    <td width="40%"><p><strong>data-foo-bar</strong></p></td>
+    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-vars-foo-bar</strong></td>
-    <td>Attributes starting with `data-vars-` are reserved for [`amp-analytics` vars](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute).</td>
+    <td width="40%"><p><strong>data-vars-foo-bar</strong></p></td>
+    <td><p>Attributes starting with <code>data-vars-</code> are reserved for <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute"><code>amp-analytics</code> vars</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>json (optional)</strong></td>
-    <td>Use this attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.</td>
+    <td width="40%"><p><strong>json (optional)</strong></p></td>
+    <td><p>Use this attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-consent-notification-id (optional)</strong></td>
-    <td>If provided, requires confirming the [amp-user-notification](https://www.ampproject.org/docs/reference/components/amp-user-notification.html) with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. This means that ad rendering is delayed until the user confirms the notification.</td>
+    <td width="40%"><p><strong>data-consent-notification-id (optional)</strong></p></td>
+    <td><p>If provided, requires confirming the <a href="https://www.ampproject.org/docs/reference/components/amp-user-notification.html">amp-user-notification</a> with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. This means that ad rendering is delayed until the user confirms the notification.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-loading-strategy (optional)</strong></td>
-    <td>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the `data-loading-strategy` attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions.  Note, specifying `prefer-viewability-over-views` as the value also automatically optimizes viewability.</td>
+    <td width="40%"><p><strong>data-loading-strategy (optional)</strong></p></td>
+    <td><p>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the <code>data-loading-strategy</code> attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions.  Note, specifying <code>prefer-viewability-over-views</code> as the value also automatically optimizes viewability.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-ad-container-id (optional)</strong></td>
-    <td>Informs the ad of the container component id in the case of attempting to collapse. The container component must be an `<amp-layout>` component that's parent of the ad. When the `data-ad-container-id` is specified, and such a `<amp-layout>` container component is found, AMP runtime will try to collapse the container component instead of the ad component during no fill. This feature can be useful when an ad indicator is in presence.
+    <td width="40%"><p><strong>data-ad-container-id (optional)</strong></p></td>
+    <td><p>Informs the ad of the container component id in the case of attempting to collapse. The container component must be an <code>&lt;amp-layout&gt;</code> component that's parent of the ad. When the <code>data-ad-container-id</code> is specified, and such a <code>&lt;amp-layout&gt;</code> container component is found, AMP runtime will try to collapse the container component instead of the ad component during no fill. This feature can be useful when an ad indicator is in presence.</p>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -85,7 +85,7 @@ The `<amp-ad>` requires width and height values to be specified according to the
   </tr>
   <tr>
     <td width="40%"><p><strong>data-foo-bar</strong></p></td>
-    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
+    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-vars-foo-bar</strong></p></td>
@@ -101,7 +101,7 @@ The `<amp-ad>` requires width and height values to be specified according to the
   </tr>
   <tr>
     <td width="40%"><p><strong>data-loading-strategy (optional)</strong></p></td>
-    <td><p>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the <code>data-loading-strategy</code> attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions.  Note, specifying <code>prefer-viewability-over-views</code> as the value also automatically optimizes viewability.</p></td>
+    <td><p>Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. Without the <code>data-loading-strategy</code> attribute, the number is 3 by default. You can specify a float value in the range of [0, 3] (If the value is not specified the value is set to 1.25). Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions. Note, specifying <code>prefer-viewability-over-views</code> as the value also automatically optimizes viewability.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-ad-container-id (optional)</strong></p></td>

--- a/extensions/amp-addthis/amp-addthis.md
+++ b/extensions/amp-addthis/amp-addthis.md
@@ -88,38 +88,36 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-pub-id</strong></td>
-    <td>The AddThis publisher ID found in the URL in the [AddThis dashboard](https://addthis.com/dashboard) after logging in. For example, in the URL `https://www.addthis.com/dashboard#gallery/pub/ra-5c191331410932ff`, `ra-5c191331410932ff` is the publisher ID.</td>
+    <td width="40%"><p><strong>data-pub-id</strong></p></td>
+    <td><p>The AddThis publisher ID found in the URL in the <a href="https://addthis.com/dashboard">AddThis dashboard</a> after logging in. For example, in the URL <code>https://www.addthis.com/dashboard#gallery/pub/ra-5c191331410932ff</code>, <code>ra-5c191331410932ff</code> is the publisher ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-widget-id</strong></td>
-    <td>The AddThis widget ID for the tool to be displayed, also found on the [AddThis dashboard](https://addthis.com/dashboard). The widget Id for a specific tool can be found by opening that tool in the AddThis dashboard and copying the last part of the URL. For example, in the URL `https://www.addthis.com/dashboard#tool-config/pub/ra-5c191331410932ff/widgetId/957l`, `957l` is the widget Id.</td>
+    <td width="40%"><p><strong>data-widget-id</strong></p></td>
+    <td><p>The AddThis widget ID for the tool to be displayed, also found on the <a href="https://addthis.com/dashboard">AddThis dashboard</a>. The widget Id for a specific tool can be found by opening that tool in the AddThis dashboard and copying the last part of the URL. For example, in the URL <code>https://www.addthis.com/dashboard#tool-config/pub/ra-5c191331410932ff/widgetId/957l</code>, <code>957l</code> is the widget Id.</p></td>
   </tr>
   <tr>
-     <td width="40%"><strong>data-widget-type</strong></td>
-     <td>
-      Attribute that describes the type of widget.
-      <ul>
-         <li>Floating: `data-widget-type="floating"`</li>
-         <li>Inline: `data-widget-type="inline"`</li>
-       </ul>
-     </td>
+     <td width="40%"><p><strong>data-widget-type</strong></p></td>
+     <td><p>Attribute that describes the type of widget.</p>
+<ul>
+<li>Floating: `data-widget-type="floating"`</li>
+<li>Inline: `data-widget-type="inline"`</li>
+</ul></td>
    </tr>
   <tr>
-    <td width="40%"><strong>data-title</strong></td>
-    <td>Optional. If set, this is the title that the AddThis tool will attempt to share when sharing occurs. If not set, the title of the document containing the `amp-addthis` tag will be used.</td>
+    <td width="40%"><p><strong>data-title</strong></p></td>
+    <td><p>Optional. If set, this is the title that the AddThis tool will attempt to share when sharing occurs. If not set, the title of the document containing the <code>amp-addthis</code> tag will be used.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-url</strong></td>
-    <td>Optional. If set, this is the URL that the AddThis tool will attempt to share when sharing occurs. If not set, the `location.href` property of the document containing the `amp-addthis` tag will be used.</td>
+    <td width="40%"><p><strong>data-url</strong></p></td>
+    <td><p>Optional. If set, this is the URL that the AddThis tool will attempt to share when sharing occurs. If not set, the <code>location.href</code> property of the document containing the <code>amp-addthis</code> tag will be used.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-media</strong></td>
-    <td>Optional. If set, this is an URL for a piece of media (e.g., image or video) that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</td>
+    <td width="40%"><p><strong>data-media</strong></p></td>
+    <td><p>Optional. If set, this is an URL for a piece of media (e.g., image or video) that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-description</strong></td>
-    <td>Optional. If set, this is the description of the page that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</td>
+    <td width="40%"><p><strong>data-description</strong></p></td>
+    <td><p>Optional. If set, this is the description of the page that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-addthis/amp-addthis.md
+++ b/extensions/amp-addthis/amp-addthis.md
@@ -99,8 +99,8 @@ Example:
      <td width="40%"><p><strong>data-widget-type</strong></p></td>
      <td><p>Attribute that describes the type of widget.</p>
 <ul>
-<li>Floating: `data-widget-type="floating"`</li>
-<li>Inline: `data-widget-type="inline"`</li>
+  <li>Floating: `data-widget-type="floating"`</li>
+  <li>Inline: `data-widget-type="inline"`</li>
 </ul></td>
    </tr>
   <tr>

--- a/extensions/amp-addthis/amp-addthis.md
+++ b/extensions/amp-addthis/amp-addthis.md
@@ -88,36 +88,36 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-pub-id</strong></p></td>
-    <td><p>The AddThis publisher ID found in the URL in the <a href="https://addthis.com/dashboard">AddThis dashboard</a> after logging in. For example, in the URL <code>https://www.addthis.com/dashboard#gallery/pub/ra-5c191331410932ff</code>, <code>ra-5c191331410932ff</code> is the publisher ID.</p></td>
+    <td width="40%"><strong>data-pub-id</strong></td>
+    <td>The AddThis publisher ID found in the URL in the <a href="https://addthis.com/dashboard">AddThis dashboard</a> after logging in. For example, in the URL <code>https://www.addthis.com/dashboard#gallery/pub/ra-5c191331410932ff</code>, <code>ra-5c191331410932ff</code> is the publisher ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-widget-id</strong></p></td>
-    <td><p>The AddThis widget ID for the tool to be displayed, also found on the <a href="https://addthis.com/dashboard">AddThis dashboard</a>. The widget Id for a specific tool can be found by opening that tool in the AddThis dashboard and copying the last part of the URL. For example, in the URL <code>https://www.addthis.com/dashboard#tool-config/pub/ra-5c191331410932ff/widgetId/957l</code>, <code>957l</code> is the widget Id.</p></td>
+    <td width="40%"><strong>data-widget-id</strong></td>
+    <td>The AddThis widget ID for the tool to be displayed, also found on the <a href="https://addthis.com/dashboard">AddThis dashboard</a>. The widget Id for a specific tool can be found by opening that tool in the AddThis dashboard and copying the last part of the URL. For example, in the URL <code>https://www.addthis.com/dashboard#tool-config/pub/ra-5c191331410932ff/widgetId/957l</code>, <code>957l</code> is the widget Id.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>data-widget-type</strong></p></td>
-     <td><p>Attribute that describes the type of widget.</p>
+     <td width="40%"><strong>data-widget-type</strong></td>
+     <td>Attribute that describes the type of widget.</p>
 <ul>
   <li>Floating: `data-widget-type="floating"`</li>
   <li>Inline: `data-widget-type="inline"`</li>
 </ul></td>
    </tr>
   <tr>
-    <td width="40%"><p><strong>data-title</strong></p></td>
-    <td><p>Optional. If set, this is the title that the AddThis tool will attempt to share when sharing occurs. If not set, the title of the document containing the <code>amp-addthis</code> tag will be used.</p></td>
+    <td width="40%"><strong>data-title</strong></td>
+    <td>Optional. If set, this is the title that the AddThis tool will attempt to share when sharing occurs. If not set, the title of the document containing the <code>amp-addthis</code> tag will be used.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-url</strong></p></td>
-    <td><p>Optional. If set, this is the URL that the AddThis tool will attempt to share when sharing occurs. If not set, the <code>location.href</code> property of the document containing the <code>amp-addthis</code> tag will be used.</p></td>
+    <td width="40%"><strong>data-url</strong></td>
+    <td>Optional. If set, this is the URL that the AddThis tool will attempt to share when sharing occurs. If not set, the <code>location.href</code> property of the document containing the <code>amp-addthis</code> tag will be used.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-media</strong></p></td>
-    <td><p>Optional. If set, this is an URL for a piece of media (e.g., image or video) that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</p></td>
+    <td width="40%"><strong>data-media</strong></td>
+    <td>Optional. If set, this is an URL for a piece of media (e.g., image or video) that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-description</strong></p></td>
-    <td><p>Optional. If set, this is the description of the page that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</p></td>
+    <td width="40%"><strong>data-description</strong></td>
+    <td>Optional. If set, this is the description of the page that the AddThis tool will attempt to share when sharing occurs. If not set, this is left undefined.</td>
   </tr>
 </table>
 

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -60,30 +60,30 @@ In the future, additional functionality, such as animation playback control, cou
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>Similar to the <code>src</code> attribute on the <code>img</code> tag. The value must be a URL that
-  points to a publicly-cacheable image file. Cache providers may rewrite these
-  URLs when ingesting AMP files to point to a cached version of the image.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>Similar to the <code>src</code> attribute on the <code>img</code> tag. The value must be a URL that
+points to a publicly-cacheable image file. Cache providers may rewrite these
+URLs when ingesting AMP files to point to a cached version of the image.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>srcset</strong></p></td>
-     <td><p>Same as <code>srcset</code> attribute on the <code>img</code> tag.</p></td>
+     <td width="40%"><strong>srcset</strong></td>
+     <td>Same as <code>srcset</code> attribute on the <code>img</code> tag.</td>
    </tr>
    <tr>
-      <td width="40%"><p><strong>alt</strong></p></td>
-      <td><p>A string of alternate text, similar to the <code>alt</code> attribute on <code>img</code>.</p></td>
+      <td width="40%"><strong>alt</strong></td>
+      <td>A string of alternate text, similar to the <code>alt</code> attribute on <code>img</code>.</td>
     </tr>
     <tr>
-       <td width="40%"><p><strong>attribution</strong></p></td>
-       <td><p>A string that indicates the attribution of the image. For example, <code>attribution="CC courtesy of Cats on Flicker"</code>.</p></td>
+       <td width="40%"><strong>attribution</strong></td>
+       <td>A string that indicates the attribution of the image. For example, <code>attribution="CC courtesy of Cats on Flicker"</code>.</td>
      </tr>
      <tr>
-        <td width="40%"><p><strong>height and width</strong></p></td>
-        <td><p>An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image.</p></td>
+        <td width="40%"><strong>height and width</strong></td>
+        <td>An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image.</td>
       </tr>
       <tr>
-         <td width="40%"><p><strong>common attributes</strong></p></td>
-         <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+         <td width="40%"><strong>common attributes</strong></td>
+         <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
        </tr>
 </table>
 

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -60,30 +60,30 @@ In the future, additional functionality, such as animation playback control, cou
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>Similar to the `src` attribute on the `img` tag. The value must be a URL that
-    points to a publicly-cacheable image file. Cache providers may rewrite these
-    URLs when ingesting AMP files to point to a cached version of the image.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>Similar to the <code>src</code> attribute on the <code>img</code> tag. The value must be a URL that
+points to a publicly-cacheable image file. Cache providers may rewrite these
+URLs when ingesting AMP files to point to a cached version of the image.</p></td>
   </tr>
   <tr>
-     <td width="40%"><strong>srcset</strong></td>
-     <td>Same as `srcset` attribute on the `img` tag.</td>
+     <td width="40%"><p><strong>srcset</strong></p></td>
+     <td><p>Same as <code>srcset</code> attribute on the <code>img</code> tag.</p></td>
    </tr>
    <tr>
-      <td width="40%"><strong>alt</strong></td>
-      <td>A string of alternate text, similar to the `alt` attribute on `img`.</td>
+      <td width="40%"><p><strong>alt</strong></p></td>
+      <td><p>A string of alternate text, similar to the <code>alt</code> attribute on <code>img</code>.</p></td>
     </tr>
     <tr>
-       <td width="40%"><strong>attribution</strong></td>
-       <td>A string that indicates the attribution of the image. For example, `attribution="CC courtesy of Cats on Flicker"`.</td>
+       <td width="40%"><p><strong>attribution</strong></p></td>
+       <td><p>A string that indicates the attribution of the image. For example, <code>attribution="CC courtesy of Cats on Flicker"</code>.</p></td>
      </tr>
      <tr>
-        <td width="40%"><strong>height and width</strong></td>
-        <td>An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image.</td>
+        <td width="40%"><p><strong>height and width</strong></p></td>
+        <td><p>An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image.</p></td>
       </tr>
       <tr>
-         <td width="40%"><strong>common attributes</strong></td>
-         <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+         <td width="40%"><p><strong>common attributes</strong></p></td>
+         <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
        </tr>
 </table>
 

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -62,8 +62,8 @@ In the future, additional functionality, such as animation playback control, cou
   <tr>
     <td width="40%"><p><strong>src</strong></p></td>
     <td><p>Similar to the <code>src</code> attribute on the <code>img</code> tag. The value must be a URL that
-points to a publicly-cacheable image file. Cache providers may rewrite these
-URLs when ingesting AMP files to point to a cached version of the image.</p></td>
+  points to a publicly-cacheable image file. Cache providers may rewrite these
+  URLs when ingesting AMP files to point to a cached version of the image.</p></td>
   </tr>
   <tr>
      <td width="40%"><p><strong>srcset</strong></p></td>

--- a/extensions/amp-apester-media/amp-apester-media.md
+++ b/extensions/amp-apester-media/amp-apester-media.md
@@ -61,12 +61,12 @@ Playlist Mode:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-apester-media-id</strong></p></td>
-    <td><p>This attribute is required for single mode, and it represents the ID of the media (string value).</p></td>
+    <td width="40%"><strong>data-apester-media-id</strong></td>
+    <td>This attribute is required for single mode, and it represents the ID of the media (string value).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-apester-channel-token</strong></p></td>
-    <td><p>This attribute is required for playlist mode, and it represents the token of the channel (string value).</p></td>
+    <td width="40%"><strong>data-apester-channel-token</strong></td>
+    <td>This attribute is required for playlist mode, and it represents the token of the channel (string value).</td>
   </tr>
 </table>
 

--- a/extensions/amp-apester-media/amp-apester-media.md
+++ b/extensions/amp-apester-media/amp-apester-media.md
@@ -61,12 +61,12 @@ Playlist Mode:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-apester-media-id</strong></td>
-    <td>This attribute is required for single mode, and it represents the ID of the media (string value).</td>
+    <td width="40%"><p><strong>data-apester-media-id</strong></p></td>
+    <td><p>This attribute is required for single mode, and it represents the ID of the media (string value).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-apester-channel-token</strong></td>
-    <td>This attribute is required for playlist mode, and it represents the token of the channel (string value).</td>
+    <td width="40%"><p><strong>data-apester-channel-token</strong></p></td>
+    <td><p>This attribute is required for playlist mode, and it represents the token of the channel (string value).</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -69,29 +69,29 @@ For example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>preload</strong></p></td>
-    <td><p>If present, sets the preload attribute in the html <code>&lt;audio&gt;</code> tag which specifies if the author thinks that the audio file should be loaded when the page loads.</p></td>
+    <td width="40%"><strong>preload</strong></td>
+    <td>If present, sets the preload attribute in the html <code>&lt;audio&gt;</code> tag which specifies if the author thinks that the audio file should be loaded when the page loads.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If present, the attribute implies that the audio will start playing as soon as
-  it is ready.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If present, the attribute implies that the audio will start playing as soon as
+it is ready.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>loop</strong></p></td>
-    <td><p>If present, the audio will automatically loop back to the start upon reaching the end.</p></td>
+    <td width="40%"><strong>loop</strong></td>
+    <td>If present, the audio will automatically loop back to the start upon reaching the end.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>muted</strong></p></td>
-    <td><p>If present, will mute the audio by default.</p></td>
+    <td width="40%"><strong>muted</strong></td>
+    <td>If present, will mute the audio by default.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>controlsList</strong></p></td>
-    <td><p>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 audio element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</p></td>
+    <td width="40%"><strong>controlsList</strong></td>
+    <td>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 audio element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</td>
   </tr>
 </table>
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -79,7 +79,7 @@ For example:
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If present, the attribute implies that the audio will start playing as soon as
-it is ready.</p></td>
+  it is ready.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>loop</strong></p></td>

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -69,29 +69,29 @@ For example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>Required if no `<source>` children are present. Must be HTTPS.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>preload</strong></td>
-    <td>If present, sets the preload attribute in the html `<audio>` tag which specifies if the author thinks that the audio file should be loaded when the page loads.</td>
+    <td width="40%"><p><strong>preload</strong></p></td>
+    <td><p>If present, sets the preload attribute in the html <code>&lt;audio&gt;</code> tag which specifies if the author thinks that the audio file should be loaded when the page loads.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If present, the attribute implies that the audio will start playing as soon as
-    it is ready.</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If present, the attribute implies that the audio will start playing as soon as
+it is ready.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>loop</strong></td>
-    <td>If present, the audio will automatically loop back to the start upon reaching the end.</td>
+    <td width="40%"><p><strong>loop</strong></p></td>
+    <td><p>If present, the audio will automatically loop back to the start upon reaching the end.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>muted</strong></td>
-    <td>If present, will mute the audio by default.</td>
+    <td width="40%"><p><strong>muted</strong></p></td>
+    <td><p>If present, will mute the audio by default.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>controlsList</strong></td>
-    <td>Same as [controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) attribute of HTML5 audio element. Only supported by certain browsers. Please see [https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) for details.</td>
+    <td width="40%"><p><strong>controlsList</strong></p></td>
+    <td><p>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 audio element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -82,16 +82,16 @@ should be specified on the tag.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>type (required)</strong></td>
-    <td>An identifier for the ad network.</td>
+    <td width="40%"><p><strong>type (required)</strong></p></td>
+    <td><p>An identifier for the ad network.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-foo-bar</strong></td>
-    <td>Most ad networks require further configuration, which can be passed to the network by using HTML `data-` attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the [ad network](#supported-ad-networks) on which attributes can be used.</td>
+    <td width="40%"><p><strong>data-foo-bar</strong></p></td>
+    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -87,7 +87,7 @@ should be specified on the tag.
   </tr>
   <tr>
     <td width="40%"><p><strong>data-foo-bar</strong></p></td>
-    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
+    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -82,16 +82,16 @@ should be specified on the tag.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>type (required)</strong></p></td>
-    <td><p>An identifier for the ad network.</p></td>
+    <td width="40%"><strong>type (required)</strong></td>
+    <td>An identifier for the ad network.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-foo-bar</strong></p></td>
-    <td><p>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</p></td>
+    <td width="40%"><strong>data-foo-bar</strong></td>
+    <td>Most ad networks require further configuration, which can be passed to the network by using HTML <code>data-</code> attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar". See the documentation for the <a href="#supported-ad-networks">ad network</a> on which attributes can be used.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-beopinion/amp-beopinion.md
+++ b/extensions/amp-beopinion/amp-beopinion.md
@@ -79,25 +79,25 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-account (required)</strong></td>
-    <td>The ID of the BeOpinion account (page owner).</td>
+    <td width="40%"><p><strong>data-account (required)</strong></p></td>
+    <td><p>The ID of the BeOpinion account (page owner).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-content (optional)</strong></td>
-    <td>The ID of the BeOpinion content to be displayed on the page.</td>
+    <td width="40%"><p><strong>data-content (optional)</strong></p></td>
+    <td><p>The ID of the BeOpinion content to be displayed on the page.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-name (optional)</strong></td>
-    <td>The name of the BeOpinion slot on the page.</td>
+    <td width="40%"><p><strong>data-name (optional)</strong></p></td>
+    <td><p>The name of the BeOpinion slot on the page.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-my-content (optional - `amp-ad` only !)</strong></td>
-    <td>For `amp-ad` elements of type `beopinion`, the value can be set to `"0"` (default value).
-    Warning: the `amp-beopinion` element overrides this value to `"1"`, to prevent the serving of ads outside of an `amp-ad` element.</td>
+    <td width="40%"><p><strong>data-my-content (optional - <code>amp-ad</code> only !)</strong></p></td>
+    <td><p>For <code>amp-ad</code> elements of type <code>beopinion</code>, the value can be set to <code>"0"</code> (default value).
+Warning: the <code>amp-beopinion</code> element overrides this value to <code>"1"</code>, to prevent the serving of ads outside of an <code>amp-ad</code> element.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-beopinion/amp-beopinion.md
+++ b/extensions/amp-beopinion/amp-beopinion.md
@@ -79,25 +79,25 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-account (required)</strong></p></td>
-    <td><p>The ID of the BeOpinion account (page owner).</p></td>
+    <td width="40%"><strong>data-account (required)</strong></td>
+    <td>The ID of the BeOpinion account (page owner).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-content (optional)</strong></p></td>
-    <td><p>The ID of the BeOpinion content to be displayed on the page.</p></td>
+    <td width="40%"><strong>data-content (optional)</strong></td>
+    <td>The ID of the BeOpinion content to be displayed on the page.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-name (optional)</strong></p></td>
-    <td><p>The name of the BeOpinion slot on the page.</p></td>
+    <td width="40%"><strong>data-name (optional)</strong></td>
+    <td>The name of the BeOpinion slot on the page.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-my-content (optional - <code>amp-ad</code> only !)</strong></p></td>
-    <td><p>For <code>amp-ad</code> elements of type <code>beopinion</code>, the value can be set to <code>"0"</code> (default value).
-  Warning: the <code>amp-beopinion</code> element overrides this value to <code>"1"</code>, to prevent the serving of ads outside of an <code>amp-ad</code> element.</p></td>
+    <td width="40%"><strong>data-my-content (optional - <code>amp-ad</code> only !)</strong></td>
+    <td>For <code>amp-ad</code> elements of type <code>beopinion</code>, the value can be set to <code>"0"</code> (default value).
+Warning: the <code>amp-beopinion</code> element overrides this value to <code>"1"</code>, to prevent the serving of ads outside of an <code>amp-ad</code> element.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-beopinion/amp-beopinion.md
+++ b/extensions/amp-beopinion/amp-beopinion.md
@@ -93,7 +93,7 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
   <tr>
     <td width="40%"><p><strong>data-my-content (optional - <code>amp-ad</code> only !)</strong></p></td>
     <td><p>For <code>amp-ad</code> elements of type <code>beopinion</code>, the value can be set to <code>"0"</code> (default value).
-Warning: the <code>amp-beopinion</code> element overrides this value to <code>"1"</code>, to prevent the serving of ads outside of an <code>amp-ad</code> element.</p></td>
+  Warning: the <code>amp-beopinion</code> element overrides this value to <code>"1"</code>, to prevent the serving of ads outside of an <code>amp-ad</code> element.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -653,7 +653,7 @@ AMP batches XMLHttpRequests (XHRs) to JSON endpoints, that is, you can use a sin
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
+    <td width="40%"><strong>src</strong></td>
     <td><p>The URL of the remote endpoint that will return the JSON that will update this <code>amp-state</code>. This must be a CORS HTTP service.</p>
 <p>The <code>src</code> attribute allows all standard URL variable substitutions. See the <a href="../../spec/amp-var-substitutions.md">Substitutions Guide</a> for more info.</p>
 <p>{% call callout('Important', type='caution') %}
@@ -661,7 +661,7 @@ AMP batches XMLHttpRequests (XHRs) to JSON endpoints, that is, you can use a sin
   {% endcall %}</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>credentials (optional)</strong></p></td>
+    <td width="40%"><strong>credentials (optional)</strong></td>
     <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
 <ul>
   <li>Supported values: `omit`, `include`</li>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -657,15 +657,15 @@ AMP batches XMLHttpRequests (XHRs) to JSON endpoints, that is, you can use a sin
     <td><p>The URL of the remote endpoint that will return the JSON that will update this <code>amp-state</code>. This must be a CORS HTTP service.</p>
 <p>The <code>src</code> attribute allows all standard URL variable substitutions. See the <a href="../../spec/amp-var-substitutions.md">Substitutions Guide</a> for more info.</p>
 <p>{% call callout('Important', type='caution') %}
-The endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
-{% endcall %}</p></td>
+  The endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
+  {% endcall %}</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>credentials (optional)</strong></p></td>
     <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
 <ul>
-<li>Supported values: `omit`, `include`</li>
-<li>Default: `omit`</li>
+  <li>Supported values: `omit`, `include`</li>
+  <li>Default: `omit`</li>
 </ul>
 <p>To send credentials, pass the value of <code>include</code>. If this value is set, the response must follow the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp">AMP CORS security guidelines</a>.</p></td>
   </tr>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -653,25 +653,21 @@ AMP batches XMLHttpRequests (XHRs) to JSON endpoints, that is, you can use a sin
 
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>The URL of the remote endpoint that will return the JSON that will update this `amp-state`. This must be a CORS HTTP service.
-
-    The `src` attribute allows all standard URL variable substitutions. See the [Substitutions Guide](../../spec/amp-var-substitutions.md) for more info.
-
-    {% call callout('Important', type='caution') %}
-    The endpoint must implement the requirements specified in the [CORS Requests in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests) spec.
-    {% endcall %}</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>The URL of the remote endpoint that will return the JSON that will update this <code>amp-state</code>. This must be a CORS HTTP service.</p>
+<p>The <code>src</code> attribute allows all standard URL variable substitutions. See the <a href="../../spec/amp-var-substitutions.md">Substitutions Guide</a> for more info.</p>
+<p>{% call callout('Important', type='caution') %}
+The endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
+{% endcall %}</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>credentials (optional)</strong></td>
-    <td>
-      Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
-      <ul>
-          <li>Supported values: `omit`, `include`</li>
-          <li>Default: `omit`</li>
-      </ul>
-      To send credentials, pass the value of `include`. If this value is set, the response must follow the [AMP CORS security guidelines](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp).
-    </td>
+    <td width="40%"><p><strong>credentials (optional)</strong></p></td>
+    <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
+<ul>
+<li>Supported values: `omit`, `include`</li>
+<li>Default: `omit`</li>
+</ul>
+<p>To send credentials, pass the value of <code>include</code>. If this value is set, the response must follow the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp">AMP CORS security guidelines</a>.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
+++ b/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
@@ -67,7 +67,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><p><strong>loop (optional)</strong></p></td>
-    <td><p>Indicates whether the animation should be looping or not.  By default, this attribute is set to <code>true</code>. Values for this attribute can be: <code>true</code>, <code>false</code>, or a number value. If a number is specified, the animation loops that number of times.</p></td>
+    <td><p>Indicates whether the animation should be looping or not. By default, this attribute is set to <code>true</code>. Values for this attribute can be: <code>true</code>, <code>false</code>, or a number value. If a number is specified, the animation loops that number of times.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>noautoplay (optional)</strong></p></td>

--- a/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
+++ b/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
@@ -62,24 +62,24 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>The path to the exported Bodymovin animation object. Must be `https` protocol.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>The path to the exported Bodymovin animation object. Must be <code>https</code> protocol.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>loop (optional)</strong></td>
-    <td>Indicates whether the animation should be looping or not.  By default, this attribute is set to `true`. Values for this attribute can be: `true`, `false`, or a number value. If a number is specified, the animation loops that number of times.</td>
+    <td width="40%"><p><strong>loop (optional)</strong></p></td>
+    <td><p>Indicates whether the animation should be looping or not.  By default, this attribute is set to <code>true</code>. Values for this attribute can be: <code>true</code>, <code>false</code>, or a number value. If a number is specified, the animation loops that number of times.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>noautoplay (optional)</strong></td>
-    <td>By default, an animation autoplays. If this attribute is added the video waits for an action to start playing.</td>
+    <td width="40%"><p><strong>noautoplay (optional)</strong></p></td>
+    <td><p>By default, an animation autoplays. If this attribute is added the video waits for an action to start playing.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>renderer (optional)</strong></td>
-    <td>By default, this component uses the SVG renderer, this uses a light version of the Bodymovin animation player. However, if developers feel that they need the full player and want to use an HTML renderer they may do so by specifying the `renderer` attribute to be `html`.<br>This attribute only accepts the values `html` and `svg`.</td>
+    <td width="40%"><p><strong>renderer (optional)</strong></p></td>
+    <td><p>By default, this component uses the SVG renderer, this uses a light version of the Bodymovin animation player. However, if developers feel that they need the full player and want to use an HTML renderer they may do so by specifying the <code>renderer</code> attribute to be <code>html</code>.<br>This attribute only accepts the values <code>html</code> and <code>svg</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
+++ b/extensions/amp-bodymovin-animation/amp-bodymovin-animation.md
@@ -62,24 +62,24 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>The path to the exported Bodymovin animation object. Must be <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>The path to the exported Bodymovin animation object. Must be <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>loop (optional)</strong></p></td>
-    <td><p>Indicates whether the animation should be looping or not. By default, this attribute is set to <code>true</code>. Values for this attribute can be: <code>true</code>, <code>false</code>, or a number value. If a number is specified, the animation loops that number of times.</p></td>
+    <td width="40%"><strong>loop (optional)</strong></td>
+    <td>Indicates whether the animation should be looping or not. By default, this attribute is set to <code>true</code>. Values for this attribute can be: <code>true</code>, <code>false</code>, or a number value. If a number is specified, the animation loops that number of times.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>noautoplay (optional)</strong></p></td>
-    <td><p>By default, an animation autoplays. If this attribute is added the video waits for an action to start playing.</p></td>
+    <td width="40%"><strong>noautoplay (optional)</strong></td>
+    <td>By default, an animation autoplays. If this attribute is added the video waits for an action to start playing.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>renderer (optional)</strong></p></td>
-    <td><p>By default, this component uses the SVG renderer, this uses a light version of the Bodymovin animation player. However, if developers feel that they need the full player and want to use an HTML renderer they may do so by specifying the <code>renderer</code> attribute to be <code>html</code>.<br>This attribute only accepts the values <code>html</code> and <code>svg</code>.</p></td>
+    <td width="40%"><strong>renderer (optional)</strong></td>
+    <td>By default, this component uses the SVG renderer, this uses a light version of the Bodymovin animation player. However, if developers feel that they need the full player and want to use an HTML renderer they may do so by specifying the <code>renderer</code> attribute to be <code>html</code>.<br>This attribute only accepts the values <code>html</code> and <code>svg</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -63,11 +63,11 @@ Examples:
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-<li>the video is automatically muted before autoplay starts</li>
-<li>when the video is scrolled out of view, the video is paused</li>
-<li>when the video is scrolled into view, the video resumes playback</li>
-<li>when the user taps the video, the video is unmuted</li>
-<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+  <li>the video is automatically muted before autoplay starts</li>
+  <li>when the video is scrolled out of view, the video is paused</li>
+  <li>when the video is scrolled into view, the video resumes playback</li>
+  <li>when the user taps the video, the video is unmuted</li>
+  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
 </ul></td>
   </tr>
   <tr>

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -60,41 +60,39 @@ Examples:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>
-      If this attribute is present, and the browser supports autoplay:
-      <ul>
-          <li>the video is automatically muted before autoplay starts</li>
-          <li>when the video is scrolled out of view, the video is paused</li>
-          <li>when the video is scrolled into view, the video resumes playback</li>
-          <li>when the user taps the video, the video is unmuted</li>
-          <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+<ul>
+<li>the video is automatically muted before autoplay starts</li>
+<li>when the video is scrolled out of view, the video is paused</li>
+<li>when the video is scrolled into view, the video resumes playback</li>
+<li>when the user taps the video, the video is unmuted</li>
+<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-partner</strong></td>
-    <td>The Brid.tv partner id.</td>
+    <td width="40%"><p><strong>data-partner</strong></p></td>
+    <td><p>The Brid.tv partner id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-player</strong></td>
-    <td>The Brid.tv player id. Specific to every partner.</td>
+    <td width="40%"><p><strong>data-player</strong></p></td>
+    <td><p>The Brid.tv player id. Specific to every partner.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-video</strong></td>
-    <td>The Brid.tv video ID.</td>
+    <td width="40%"><p><strong>data-video</strong></p></td>
+    <td><p>The Brid.tv video ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playlist</strong></td>
-    <td>The Brid.tv playlist ID. Embed must either have video or playlist or outstream attribute.</td>
+    <td width="40%"><p><strong>data-playlist</strong></p></td>
+    <td><p>The Brid.tv playlist ID. Embed must either have video or playlist or outstream attribute.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-outstream</strong></td>
-    <td>The Brid.tv outstream unit ID.</td>
+    <td width="40%"><p><strong>data-outstream</strong></p></td>
+    <td><p>The Brid.tv outstream unit ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -60,8 +60,8 @@ Examples:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
   <li>when the video is scrolled out of view, the video is paused</li>
@@ -71,28 +71,28 @@ Examples:
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-partner</strong></p></td>
-    <td><p>The Brid.tv partner id.</p></td>
+    <td width="40%"><strong>data-partner</strong></td>
+    <td>The Brid.tv partner id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-player</strong></p></td>
-    <td><p>The Brid.tv player id. Specific to every partner.</p></td>
+    <td width="40%"><strong>data-player</strong></td>
+    <td>The Brid.tv player id. Specific to every partner.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-video</strong></p></td>
-    <td><p>The Brid.tv video ID.</p></td>
+    <td width="40%"><strong>data-video</strong></td>
+    <td>The Brid.tv video ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playlist</strong></p></td>
-    <td><p>The Brid.tv playlist ID. Embed must either have video or playlist or outstream attribute.</p></td>
+    <td width="40%"><strong>data-playlist</strong></td>
+    <td>The Brid.tv playlist ID. Embed must either have video or playlist or outstream attribute.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-outstream</strong></p></td>
-    <td><p>The Brid.tv outstream unit ID.</p></td>
+    <td width="40%"><strong>data-outstream</strong></td>
+    <td>The Brid.tv outstream unit ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -64,51 +64,49 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-account</strong></td>
-    <td>The Brightcove Video Cloud or Perform account id.</td>
+    <td width="40%"><p><strong>data-account</strong></p></td>
+    <td><p>The Brightcove Video Cloud or Perform account id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-player or data-player-id</strong></td>
-    <td>The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".<br>`data-player` is preferred. `data-player-id` is also supported for backwards-compatibility.</td>
+    <td width="40%"><p><strong>data-player or data-player-id</strong></p></td>
+    <td><p>The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".<br><code>data-player</code> is preferred. <code>data-player-id</code> is also supported for backwards-compatibility.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-embed</strong></td>
-    <td>The Brightcove player id. This is a GUID or "default". The default value and most common value is "default".</td>
+    <td width="40%"><p><strong>data-embed</strong></p></td>
+    <td><p>The Brightcove player id. This is a GUID or "default". The default value and most common value is "default".</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-video-id</strong></td>
-    <td>The Video Cloud video id. Most Video Cloud players will need this.<br>This is not used for Perform players by default; use it if you have added a plugin that expects a `videoId` param in the query string.</td>
+    <td width="40%"><p><strong>data-video-id</strong></p></td>
+    <td><p>The Video Cloud video id. Most Video Cloud players will need this.<br>This is not used for Perform players by default; use it if you have added a plugin that expects a <code>videoId</code> param in the query string.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playlist-id</strong></td>
-    <td>The Video Cloud playlist id. For AMP HTML uses a video id will normally be used instead. If both a playlist and a video are specified, the playlist takes precedence.
-
-    This is not used for Perform players by default; use it if you have added a plugin that expects a `playlistId` param in the query string.</td>
+    <td width="40%"><p><strong>data-playlist-id</strong></p></td>
+    <td><p>The Video Cloud playlist id. For AMP HTML uses a video id will normally be used instead. If both a playlist and a video are specified, the playlist takes precedence.</p>
+<p>This is not used for Perform players by default; use it if you have added a plugin that expects a <code>playlistId</code> param in the query string.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-referrer</strong></td>
-    <td>Sets the referrer to be used for the Video Cloud analytics within the player. Requires Brightcove Player version v6.25.0+. This supports AMP varables such as `EXTERNAL_REFERRER`.</td>
+    <td width="40%"><p><strong>data-referrer</strong></p></td>
+    <td><p>Sets the referrer to be used for the Video Cloud analytics within the player. Requires Brightcove Player version v6.25.0+. This supports AMP varables such as <code>EXTERNAL_REFERRER</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-\*</strong></td>
-    <td>All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
-    <br>
-    Keys and values will be URI encoded. Keys will be camel cased.
-    <ul>
-        <li>`data-param-language="de"` becomes `&language=de`</li>
-        <li>`data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`</li>
-    </ul>
-    </td>
+    <td width="40%"><p><strong>data-param-*</strong></p></td>
+    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
+<br>
+Keys and values will be URI encoded. Keys will be camel cased.</p>
+<ul>
+<li>`data-param-language="de"` becomes `&language=de`</li>
+<li>`data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -64,49 +64,49 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-account</strong></p></td>
-    <td><p>The Brightcove Video Cloud or Perform account id.</p></td>
+    <td width="40%"><strong>data-account</strong></td>
+    <td>The Brightcove Video Cloud or Perform account id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-player or data-player-id</strong></p></td>
-    <td><p>The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".<br><code>data-player</code> is preferred. <code>data-player-id</code> is also supported for backwards-compatibility.</p></td>
+    <td width="40%"><strong>data-player or data-player-id</strong></td>
+    <td>The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".<br><code>data-player</code> is preferred. <code>data-player-id</code> is also supported for backwards-compatibility.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-embed</strong></p></td>
-    <td><p>The Brightcove player id. This is a GUID or "default". The default value and most common value is "default".</p></td>
+    <td width="40%"><strong>data-embed</strong></td>
+    <td>The Brightcove player id. This is a GUID or "default". The default value and most common value is "default".</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-video-id</strong></p></td>
-    <td><p>The Video Cloud video id. Most Video Cloud players will need this.<br>This is not used for Perform players by default; use it if you have added a plugin that expects a <code>videoId</code> param in the query string.</p></td>
+    <td width="40%"><strong>data-video-id</strong></td>
+    <td>The Video Cloud video id. Most Video Cloud players will need this.<br>This is not used for Perform players by default; use it if you have added a plugin that expects a <code>videoId</code> param in the query string.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playlist-id</strong></p></td>
+    <td width="40%"><strong>data-playlist-id</strong></td>
     <td><p>The Video Cloud playlist id. For AMP HTML uses a video id will normally be used instead. If both a playlist and a video are specified, the playlist takes precedence.</p>
 <p>This is not used for Perform players by default; use it if you have added a plugin that expects a <code>playlistId</code> param in the query string.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-referrer</strong></p></td>
-    <td><p>Sets the referrer to be used for the Video Cloud analytics within the player. Requires Brightcove Player version v6.25.0+. This supports AMP varables such as <code>EXTERNAL_REFERRER</code>.</p></td>
+    <td width="40%"><strong>data-referrer</strong></td>
+    <td>Sets the referrer to be used for the Video Cloud analytics within the player. Requires Brightcove Player version v6.25.0+. This supports AMP varables such as <code>EXTERNAL_REFERRER</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-*</strong></p></td>
-    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
-  <br>
-  Keys and values will be URI encoded. Keys will be camel cased.</p>
+    <td width="40%"><strong>data-param-*</strong></td>
+    <td>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
+<br>
+Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
   <li>`data-param-language="de"` becomes `&language=de`</li>
   <li>`data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -91,18 +91,18 @@ Example:
   <tr>
     <td width="40%"><p><strong>data-param-*</strong></p></td>
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
-<br>
-Keys and values will be URI encoded. Keys will be camel cased.</p>
+  <br>
+  Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
-<li>`data-param-language="de"` becomes `&language=de`</li>
-<li>`data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`</li>
+  <li>`data-param-language="de"` becomes `&language=de`</li>
+  <li>`data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-byside-content/amp-byside-content.md
+++ b/extensions/amp-byside-content/amp-byside-content.md
@@ -62,28 +62,28 @@ The `width` and `height` attributes determine the aspect ratio of the embedded B
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-webcare-id (required)</strong></p></td>
-    <td><p>The BySide customer account ID.</p></td>
+    <td width="40%"><strong>data-webcare-id (required)</strong></td>
+    <td>The BySide customer account ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-label (required)</strong></p></td>
-    <td><p>The content label as seen in your BySide account.</p></td>
+    <td width="40%"><strong>data-label (required)</strong></td>
+    <td>The content label as seen in your BySide account.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-lang</strong></p></td>
-    <td><p>The language to show the contents in, as specified in the BySide customer account localization. Defaults to Portuguese ("pt").</p></td>
+    <td width="40%"><strong>data-lang</strong></td>
+    <td>The language to show the contents in, as specified in the BySide customer account localization. Defaults to Portuguese ("pt").</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-channel</strong></p></td>
-    <td><p>The channel identifier to use for content validation. Defaults to an empty string.</p></td>
+    <td width="40%"><strong>data-channel</strong></td>
+    <td>The channel identifier to use for content validation. Defaults to an empty string.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-fid</strong></p></td>
-    <td><p>The visitor force id. Use this when a unique visitor identifier is available, usually for authenticated users. Defaults to an empty string.</p></td>
+    <td width="40%"><strong>data-fid</strong></td>
+    <td>The visitor force id. Use this when a unique visitor identifier is available, usually for authenticated users. Defaults to an empty string.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-byside-content/amp-byside-content.md
+++ b/extensions/amp-byside-content/amp-byside-content.md
@@ -62,28 +62,28 @@ The `width` and `height` attributes determine the aspect ratio of the embedded B
 
 <table>
   <tr>
-    <td width="40%"><strong>data-webcare-id (required)</strong></td>
-    <td>The BySide customer account ID.</td>
+    <td width="40%"><p><strong>data-webcare-id (required)</strong></p></td>
+    <td><p>The BySide customer account ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-label (required)</strong></td>
-    <td>The content label as seen in your BySide account.</td>
+    <td width="40%"><p><strong>data-label (required)</strong></p></td>
+    <td><p>The content label as seen in your BySide account.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-lang</strong></td>
-    <td>The language to show the contents in, as specified in the BySide customer account localization. Defaults to Portuguese ("pt").</td>
+    <td width="40%"><p><strong>data-lang</strong></p></td>
+    <td><p>The language to show the contents in, as specified in the BySide customer account localization. Defaults to Portuguese ("pt").</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-channel</strong></td>
-    <td>The channel identifier to use for content validation. Defaults to an empty string.</td>
+    <td width="40%"><p><strong>data-channel</strong></p></td>
+    <td><p>The channel identifier to use for content validation. Defaults to an empty string.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-fid</strong></td>
-    <td>The visitor force id. Use this when a unique visitor identifier is available, usually for authenticated users. Defaults to an empty string.</td>
+    <td width="40%"><p><strong>data-fid</strong></p></td>
+    <td><p>The visitor force id. Use this when a unique visitor identifier is available, usually for authenticated users. Defaults to an empty string.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-call-tracking/amp-call-tracking.md
+++ b/extensions/amp-call-tracking/amp-call-tracking.md
@@ -65,14 +65,14 @@ Each unique CORS endpoint is called only once per page.
   <tr>
     <td width="40%"><p><strong>config (required)</strong></p></td>
     <td><p>Defines a CORS URL. The URL's protocol must be HTTPS. The response must consist
-of a valid JSON object with the following fields:</p>
+  of a valid JSON object with the following fields:</p>
 <ul>
-<li>`phoneNumber` (required): Specifies the phone number to call when the user clicks the link.</li>
-<li>`formattedPhoneNumber` (optional): Specifies the phone number to display. If not specified, the value in `phoneNumber` is used.</li>
+  <li>`phoneNumber` (required): Specifies the phone number to call when the user clicks the link.</li>
+  <li>`formattedPhoneNumber` (optional): Specifies the phone number to display. If not specified, the value in `phoneNumber` is used.</li>
 </ul>
 <p>{% call callout('Important', type='caution') %}
-Your XHR endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
-{% endcall %}</p></td>
+  Your XHR endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
+  {% endcall %}</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-call-tracking/amp-call-tracking.md
+++ b/extensions/amp-call-tracking/amp-call-tracking.md
@@ -63,7 +63,7 @@ Each unique CORS endpoint is called only once per page.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>config (required)</strong></p></td>
+    <td width="40%"><strong>config (required)</strong></td>
     <td><p>Defines a CORS URL. The URL's protocol must be HTTPS. The response must consist
   of a valid JSON object with the following fields:</p>
 <ul>

--- a/extensions/amp-call-tracking/amp-call-tracking.md
+++ b/extensions/amp-call-tracking/amp-call-tracking.md
@@ -63,18 +63,16 @@ Each unique CORS endpoint is called only once per page.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>config (required)</strong></td>
-    <td>
-    Defines a CORS URL. The URL's protocol must be HTTPS. The response must consist
-    of a valid JSON object with the following fields:
-    <ul>
-        <li>`phoneNumber` (required): Specifies the phone number to call when the user clicks the link.</li>
-        <li>`formattedPhoneNumber` (optional): Specifies the phone number to display. If not specified, the value in `phoneNumber` is used.</li>
-    </ul>
-    {% call callout('Important', type='caution') %}
-    Your XHR endpoint must implement the requirements specified in the [CORS Requests in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests) spec.
-    {% endcall %}
-    </td>
+    <td width="40%"><p><strong>config (required)</strong></p></td>
+    <td><p>Defines a CORS URL. The URL's protocol must be HTTPS. The response must consist
+of a valid JSON object with the following fields:</p>
+<ul>
+<li>`phoneNumber` (required): Specifies the phone number to call when the user clicks the link.</li>
+<li>`formattedPhoneNumber` (optional): Specifies the phone number to display. If not specified, the value in `phoneNumber` is used.</li>
+</ul>
+<p>{% call callout('Important', type='caution') %}
+Your XHR endpoint must implement the requirements specified in the <a href="https://www.ampproject.org/docs/fundamentals/amp-cors-requests">CORS Requests in AMP</a> spec.
+{% endcall %}</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -94,8 +94,8 @@ In the following example, we have a carousel of three images with preview button
     <td width="40%"><p><strong>type</strong></p></td>
     <td><p>Specifies the display type for the carousel items, which can be:</p>
 <ul>
-<li>**`carousel`** (default): All slides are shown and are scrollable horizontally. This type  supports only the following layouts: `fixed`, `fixed-height`, and `nodisplay`.</li>
-<li>**`slides`**: Shows a single slide at a time. This type supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.</li>
+  <li>**`carousel`** (default): All slides are shown and are scrollable horizontally. This type supports only the following layouts: `fixed`, `fixed-height`, and `nodisplay`.</li>
+  <li>**`slides`**: Shows a single slide at a time. This type supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.</li>
 </ul></td>
   </tr>
   <tr>
@@ -105,8 +105,8 @@ In the following example, we have a carousel of three images with preview button
   <tr>
     <td width="40%"><p><strong>controls (optional)</strong></p></td>
     <td><p>Permanently displays left and right arrows for the user to navigate carousel items on mobile devices.
-By default, navigational arrows disappear after a few seconds on mobile.
-The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</p></td>
+  By default, navigational arrows disappear after a few seconds on mobile.
+  The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-next-button-aria-label (optional)</strong></p></td>
@@ -123,17 +123,17 @@ The visibility of arrows can also be controlled via styling, and a media query c
   <tr>
     <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
     <td><p>Advances the slide to the next slide without user interaction.<br>
-If present without a value:</p>
+  If present without a value:</p>
 <ul>
-<li>By default, advances a slide in 5000 millisecond intervals (5 seconds); this can be overridden by the `delay` attribute.</li>
-<li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
-<li>Requires at least 2 slides for autoplay to occur.</li>
-<li>Applies only to carousels with `type=slides`.</li>
+  <li>By default, advances a slide in 5000 millisecond intervals (5 seconds); this can be overridden by the `delay` attribute.</li>
+  <li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
+  <li>Requires at least 2 slides for autoplay to occur.</li>
+  <li>Applies only to carousels with `type=slides`.</li>
 </ul>
 <p>If present with a value:</p>
 <ul>
-<li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
-<li>Removes the `loop` attribute after the requisite number of loops are made.</li>
+  <li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
+  <li>Removes the `loop` attribute after the requisite number of loops are made.</li>
 </ul></td>
   </tr>
   <tr>
@@ -146,14 +146,10 @@ If present without a value:</p>
 <p><em>Example: Displays a slides carousel with controls, looping, and delayed autoplay</em></p>
 <!--embedded example - displays in ampproject.org -->
 <div>
-<amp-iframe height="446"
-layout="fixed-height"
-sandbox="allow-scripts allow-forms allow-same-origin"
-resizable
-src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.controls.embed.html">
-<div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-<div placeholder></div>
-</amp-iframe>
+  <amp-iframe height="446" layout="fixed-height" sandbox="allow-scripts allow-forms allow-same-origin" resizable src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.controls.embed.html">
+    <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+    <div placeholder></div>
+  </amp-iframe>
 </div></td>
   </tr>
   <tr>

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -91,37 +91,37 @@ In the following example, we have a carousel of three images with preview button
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>type</strong></p></td>
-    <td><p>Specifies the display type for the carousel items, which can be:</p>
+    <td width="40%"><strong>type</strong></td>
+    <td>Specifies the display type for the carousel items, which can be:</p>
 <ul>
   <li>**`carousel`** (default): All slides are shown and are scrollable horizontally. This type supports only the following layouts: `fixed`, `fixed-height`, and `nodisplay`.</li>
   <li>**`slides`**: Shows a single slide at a time. This type supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>height (required)</strong></p></td>
-    <td><p>Specifies the height of the carousel, in pixels.</p></td>
+    <td width="40%"><strong>height (required)</strong></td>
+    <td>Specifies the height of the carousel, in pixels.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>controls (optional)</strong></p></td>
-    <td><p>Permanently displays left and right arrows for the user to navigate carousel items on mobile devices.
-  By default, navigational arrows disappear after a few seconds on mobile.
-  The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</p></td>
+    <td width="40%"><strong>controls (optional)</strong></td>
+    <td>Permanently displays left and right arrows for the user to navigate carousel items on mobile devices.
+By default, navigational arrows disappear after a few seconds on mobile.
+The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-next-button-aria-label (optional)</strong></p></td>
-    <td><p>Sets the aria-label for the <code>amp-carousel-button-next</code>. If no value is given, the aria-label defaults to 'Next item in carousel'.</p></td>
+    <td width="40%"><strong>data-next-button-aria-label (optional)</strong></td>
+    <td>Sets the aria-label for the <code>amp-carousel-button-next</code>. If no value is given, the aria-label defaults to 'Next item in carousel'.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-prev-button-aria-label (optional)</strong></p></td>
-    <td><p>Sets the aria-label for the <code>amp-carousel-button-prev</code>. If no value is given, the aria-label defaults to 'Previous item in carousel'.</p></td>
+    <td width="40%"><strong>data-prev-button-aria-label (optional)</strong></td>
+    <td>Sets the aria-label for the <code>amp-carousel-button-prev</code>. If no value is given, the aria-label defaults to 'Previous item in carousel'.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-button-count-format (optional)</strong></p></td>
-    <td><p>A format string that looks like <code>(%s of %s)</code>, used as a suffix to the aria-label for <code>amp-carousel-button-next</code>/<code>amp-carousel-button-prev</code>. This provides information to users using a screen reader on their progress through the carousel. If no value is given, this defaults to '(%s of %s)'.</p></td>
+    <td width="40%"><strong>data-button-count-format (optional)</strong></td>
+    <td>A format string that looks like <code>(%s of %s)</code>, used as a suffix to the aria-label for <code>amp-carousel-button-next</code>/<code>amp-carousel-button-prev</code>. This provides information to users using a screen reader on their progress through the carousel. If no value is given, this defaults to '(%s of %s)'.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
+    <td width="40%"><strong>autoplay (optional)</strong></td>
     <td><p>Advances the slide to the next slide without user interaction.<br>
   If present without a value:</p>
 <ul>
@@ -137,11 +137,11 @@ In the following example, we have a carousel of three images with preview button
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>delay (optional)</strong></p></td>
-    <td><p>Specifies the duration (in milliseconds) to delay advancing to the next slide when <code>autoplay</code> is enabled. The <code>delay</code> attribute is only applicable to carousels with <code>type=slides</code>.</p></td>
+    <td width="40%"><strong>delay (optional)</strong></td>
+    <td>Specifies the duration (in milliseconds) to delay advancing to the next slide when <code>autoplay</code> is enabled. The <code>delay</code> attribute is only applicable to carousels with <code>type=slides</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>loop (optional)</strong></p></td>
+    <td width="40%"><strong>loop (optional)</strong></td>
     <td><p>Allows the user to advance past the first item or the final item. There must be at least 3 slides for looping to occur. The <code>loop</code> attribute is only applicable to carousels with <code>type=slides</code>.</p>
 <p><em>Example: Displays a slides carousel with controls, looping, and delayed autoplay</em></p>
 <!--embedded example - displays in ampproject.org -->
@@ -153,8 +153,8 @@ In the following example, we have a carousel of three images with preview button
 </div></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -91,80 +91,74 @@ In the following example, we have a carousel of three images with preview button
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>type</strong></td>
-    <td>
-      Specifies the display type for the carousel items, which can be:
-      <ul>
-          <li>**`carousel`** (default): All slides are shown and are scrollable horizontally. This type  supports only the following layouts: `fixed`, `fixed-height`, and `nodisplay`.</li>
-          <li>**`slides`**: Shows a single slide at a time. This type supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>type</strong></p></td>
+    <td><p>Specifies the display type for the carousel items, which can be:</p>
+<ul>
+<li>**`carousel`** (default): All slides are shown and are scrollable horizontally. This type  supports only the following layouts: `fixed`, `fixed-height`, and `nodisplay`.</li>
+<li>**`slides`**: Shows a single slide at a time. This type supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>height (required)</strong></td>
-    <td>Specifies the height of the carousel, in pixels.</td>
+    <td width="40%"><p><strong>height (required)</strong></p></td>
+    <td><p>Specifies the height of the carousel, in pixels.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>controls (optional)</strong></td>
-    <td>Permanently displays left and right arrows for the user to navigate carousel items on mobile devices.
-    By default, navigational arrows disappear after a few seconds on mobile.
-    The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</td>
+    <td width="40%"><p><strong>controls (optional)</strong></p></td>
+    <td><p>Permanently displays left and right arrows for the user to navigate carousel items on mobile devices.
+By default, navigational arrows disappear after a few seconds on mobile.
+The visibility of arrows can also be controlled via styling, and a media query can be used to only display arrows at certain screen widths. On desktop, arrows are always displayed unless only a single child is present.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-next-button-aria-label (optional)</strong></td>
-    <td>Sets the aria-label for the `amp-carousel-button-next`. If no value is given, the aria-label defaults to 'Next item in carousel'.</td>
+    <td width="40%"><p><strong>data-next-button-aria-label (optional)</strong></p></td>
+    <td><p>Sets the aria-label for the <code>amp-carousel-button-next</code>. If no value is given, the aria-label defaults to 'Next item in carousel'.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-prev-button-aria-label (optional)</strong></td>
-    <td>Sets the aria-label for the `amp-carousel-button-prev`. If no value is given, the aria-label defaults to 'Previous item in carousel'.</td>
+    <td width="40%"><p><strong>data-prev-button-aria-label (optional)</strong></p></td>
+    <td><p>Sets the aria-label for the <code>amp-carousel-button-prev</code>. If no value is given, the aria-label defaults to 'Previous item in carousel'.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-button-count-format (optional)</strong></td>
-    <td>A format string that looks like `(%s of %s)`, used as a suffix to the aria-label for `amp-carousel-button-next`/`amp-carousel-button-prev`. This provides information to users using a screen reader on their progress through the carousel. If no value is given, this defaults to '(%s of %s)'.</td>
+    <td width="40%"><p><strong>data-button-count-format (optional)</strong></p></td>
+    <td><p>A format string that looks like <code>(%s of %s)</code>, used as a suffix to the aria-label for <code>amp-carousel-button-next</code>/<code>amp-carousel-button-prev</code>. This provides information to users using a screen reader on their progress through the carousel. If no value is given, this defaults to '(%s of %s)'.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay (optional)</strong></td>
-    <td>
-      Advances the slide to the next slide without user interaction.<br>
-      If present without a value:
-      <ul>
-          <li>By default, advances a slide in 5000 millisecond intervals (5 seconds); this can be overridden by the `delay` attribute.</li>
-          <li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
-          <li>Requires at least 2 slides for autoplay to occur.</li>
-          <li>Applies only to carousels with `type=slides`.</li>
-      </ul>
-      If present with a value:
-      <ul>
-          <li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
-          <li>Removes the `loop` attribute after the requisite number of loops are made.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>autoplay (optional)</strong></p></td>
+    <td><p>Advances the slide to the next slide without user interaction.<br>
+If present without a value:</p>
+<ul>
+<li>By default, advances a slide in 5000 millisecond intervals (5 seconds); this can be overridden by the `delay` attribute.</li>
+<li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
+<li>Requires at least 2 slides for autoplay to occur.</li>
+<li>Applies only to carousels with `type=slides`.</li>
+</ul>
+<p>If present with a value:</p>
+<ul>
+<li>Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.</li>
+<li>Removes the `loop` attribute after the requisite number of loops are made.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>delay (optional)</strong></td>
-    <td>Specifies the duration (in milliseconds) to delay advancing to the next slide when `autoplay` is enabled. The `delay` attribute is only applicable to carousels with `type=slides`.</td>
+    <td width="40%"><p><strong>delay (optional)</strong></p></td>
+    <td><p>Specifies the duration (in milliseconds) to delay advancing to the next slide when <code>autoplay</code> is enabled. The <code>delay</code> attribute is only applicable to carousels with <code>type=slides</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>loop (optional)</strong></td>
-    <td>Allows the user to advance past the first item or the final item. There must be at least 3 slides for looping to occur. The `loop` attribute is only applicable to carousels with `type=slides`.
-
-    *Example: Displays a slides carousel with controls, looping, and delayed autoplay*
-
-    <!--embedded example - displays in ampproject.org -->
-    <div>
-    <amp-iframe height="446"
-                layout="fixed-height"
-                sandbox="allow-scripts allow-forms allow-same-origin"
-                resizable
-                src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.controls.embed.html">
-      <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-      <div placeholder></div>
-    </amp-iframe>
-    </div></td>
+    <td width="40%"><p><strong>loop (optional)</strong></p></td>
+    <td><p>Allows the user to advance past the first item or the final item. There must be at least 3 slides for looping to occur. The <code>loop</code> attribute is only applicable to carousels with <code>type=slides</code>.</p>
+<p><em>Example: Displays a slides carousel with controls, looping, and delayed autoplay</em></p>
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="446"
+layout="fixed-height"
+sandbox="allow-scripts allow-forms allow-same-origin"
+resizable
+src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.controls.embed.html">
+<div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+<div placeholder></div>
+</amp-iframe>
+</div></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -60,11 +60,11 @@ With responsive layout, the width and height from the example should yield corre
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-<li>the video is automatically muted before autoplay starts</li>
-<li>when the video is scrolled out of view, the video is paused</li>
-<li>when the video is scrolled into view, the video resumes playback</li>
-<li>when the user taps the video, the video is unmuted</li>
-<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+  <li>the video is automatically muted before autoplay starts</li>
+  <li>when the video is scrolled out of view, the video is paused</li>
+  <li>when the video is scrolled into view, the video resumes playback</li>
+  <li>when the user taps the video, the video is unmuted</li>
+  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
 </ul></td>
   </tr>
   <tr>
@@ -75,62 +75,62 @@ With responsive layout, the width and height from the example should yield corre
     <td width="40%"><p><strong>data-mute (optional)</strong></p></td>
     <td><p>Indicates whether to mute the video.</p>
 <ul>
-<li>Value: `"true"` or `"false"`</li>
-<li>Default value: `"false"`</li>
+  <li>Value: `"true"` or `"false"`</li>
+  <li>Default value: `"false"`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-endscreen-enable (optional)</strong></p></td>
     <td><p>Indicates whether to enable the end screen.</p>
 <ul>
-<li>Value: `"true"` or `"false"`</li>
-<li>Default value: `"true"`</li>
+  <li>Value: `"true"` or `"false"`</li>
+  <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-sharing-enable (optional)</strong></p></td>
     <td><p>Indicates whether to display the sharing button.</p>
 <ul>
-<li>Value: `"true"` or `"false"`</li>
-<li>Default value: `"true"`</li>
+  <li>Value: `"true"` or `"false"`</li>
+  <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-start (optional)</strong></p></td>
     <td><p>Specifies the time (in seconds) from which the video should start playing.</p>
 <ul>
-<li>Value: integer (number of seconds). For example, `data-start=45`.</li>
-<li>Default value: `0`</li>
+  <li>Value: integer (number of seconds). For example, `data-start=45`.</li>
+  <li>Default value: `0`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-ui-highlight (optional)</strong></p></td>
     <td><p>Change the default highlight color used in the controls.</p>
 <ul>
-<li>alue: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.</li>
+  <li>alue: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-ui-logo (optional)</strong></p></td>
     <td><p>Indicates whether to display the Dailymotion logo.</p>
 <ul>
-<li>Value: `"true"` or `"false"`</li>
-<li>Default value: `"true"`</li>
+  <li>Value: `"true"` or `"false"`</li>
+  <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-info (optional)</strong></p></td>
     <td><p>Indicates whether to show video information (title and owner) on the start screen.</p>
 <ul>
-<li>Value: `"true"` or `"false"`</li>
-<li>Default value: `"true"`</li>
+  <li>Value: `"true"` or `"false"`</li>
+  <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-param-* (optional)</strong></p></td>
     <td><p>All data-param-* attributes are added as query parameters to the src value of the embedded Dailymotion iframe. You can use this attribute to pass custom values not explicitly declared.<br>Keys and values will be URI encoded.</p>
 <ul>
-<li>`data-param-origin="example.com"`</li>
+  <li>`data-param-origin="example.com"`</li>
 </ul>
 <p>Please read <a href="https://developer.dailymotion.com/player#player-parameters">Dailymotion's video player documentation</a> to know more about parameters and options.</p></td>
   </tr>

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -57,106 +57,86 @@ With responsive layout, the width and height from the example should yield corre
 
 <table>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>
-      If this attribute is present, and the browser supports autoplay:
-      <ul>
-          <li>the video is automatically muted before autoplay starts</li>
-          <li>when the video is scrolled out of view, the video is paused</li>
-          <li>when the video is scrolled into view, the video resumes playback</li>
-          <li>when the user taps the video, the video is unmuted</li>
-          <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+<ul>
+<li>the video is automatically muted before autoplay starts</li>
+<li>when the video is scrolled out of view, the video is paused</li>
+<li>when the video is scrolled into view, the video resumes playback</li>
+<li>when the user taps the video, the video is unmuted</li>
+<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-videoid (required)</strong></td>
-    <td>The Dailymotion video id found in every video page URL. For example, `"x2m8jpp"` is the video id for `https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation`.</td>
+    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
+    <td><p>The Dailymotion video id found in every video page URL. For example, <code>"x2m8jpp"</code> is the video id for <code>https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-mute (optional)</strong></td>
-    <td>
-      Indicates whether to mute the video.
-      <ul>
-          <li>Value: `"true"` or `"false"`</li>
-          <li>Default value: `"false"`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-mute (optional)</strong></p></td>
+    <td><p>Indicates whether to mute the video.</p>
+<ul>
+<li>Value: `"true"` or `"false"`</li>
+<li>Default value: `"false"`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-endscreen-enable (optional)</strong></td>
-    <td>
-      Indicates whether to enable the end screen.
-      <ul>
-          <li>Value: `"true"` or `"false"`</li>
-          <li>Default value: `"true"`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-endscreen-enable (optional)</strong></p></td>
+    <td><p>Indicates whether to enable the end screen.</p>
+<ul>
+<li>Value: `"true"` or `"false"`</li>
+<li>Default value: `"true"`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-sharing-enable (optional)</strong></td>
-    <td>
-      Indicates whether to display the sharing button.
-      <ul>
-          <li>Value: `"true"` or `"false"`</li>
-          <li>Default value: `"true"`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-sharing-enable (optional)</strong></p></td>
+    <td><p>Indicates whether to display the sharing button.</p>
+<ul>
+<li>Value: `"true"` or `"false"`</li>
+<li>Default value: `"true"`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-start (optional)</strong></td>
-    <td>
-      Specifies the time (in seconds) from which the video should start playing.
-      <ul>
-          <li>Value: integer (number of seconds). For example, `data-start=45`.</li>
-          <li>Default value: `0`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-start (optional)</strong></p></td>
+    <td><p>Specifies the time (in seconds) from which the video should start playing.</p>
+<ul>
+<li>Value: integer (number of seconds). For example, `data-start=45`.</li>
+<li>Default value: `0`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-ui-highlight (optional)</strong></td>
-    <td>
-      Change the default highlight color used in the controls.
-      <ul>
-          <li>alue: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-ui-highlight (optional)</strong></p></td>
+    <td><p>Change the default highlight color used in the controls.</p>
+<ul>
+<li>alue: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-ui-logo (optional)</strong></td>
-    <td>
-      Indicates whether to display the Dailymotion logo.
-      <ul>
-          <li>Value: `"true"` or `"false"`</li>
-          <li>Default value: `"true"`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-ui-logo (optional)</strong></p></td>
+    <td><p>Indicates whether to display the Dailymotion logo.</p>
+<ul>
+<li>Value: `"true"` or `"false"`</li>
+<li>Default value: `"true"`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-info (optional)</strong></td>
-    <td>
-      Indicates whether to show video information (title and owner) on the start screen.
-      <ul>
-          <li>Value: `"true"` or `"false"`</li>
-          <li>Default value: `"true"`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-info (optional)</strong></p></td>
+    <td><p>Indicates whether to show video information (title and owner) on the start screen.</p>
+<ul>
+<li>Value: `"true"` or `"false"`</li>
+<li>Default value: `"true"`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-\* (optional)</strong></td>
-    <td>
-      All data-param-* attributes are added as query parameters to the src value of the embedded Dailymotion iframe. You can use this attribute to pass custom values not explicitly declared.<br>Keys and values will be URI encoded.
-      <ul>
-          <li>`data-param-origin="example.com"`</li>
-      </ul>
-      Please read [Dailymotion's video player documentation](https://developer.dailymotion.com/player#player-parameters) to know more about parameters and options.
-    </td>
+    <td width="40%"><p><strong>data-param-* (optional)</strong></p></td>
+    <td><p>All data-param-* attributes are added as query parameters to the src value of the embedded Dailymotion iframe. You can use this attribute to pass custom values not explicitly declared.<br>Keys and values will be URI encoded.</p>
+<ul>
+<li>`data-param-origin="example.com"`</li>
+</ul>
+<p>Please read <a href="https://developer.dailymotion.com/player#player-parameters">Dailymotion's video player documentation</a> to know more about parameters and options.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>
-      This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
-    </td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -57,8 +57,8 @@ With responsive layout, the width and height from the example should yield corre
 
 <table>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
   <li>when the video is scrolled out of view, the video is paused</li>
@@ -68,66 +68,66 @@ With responsive layout, the width and height from the example should yield corre
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
-    <td><p>The Dailymotion video id found in every video page URL. For example, <code>"x2m8jpp"</code> is the video id for <code>https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation</code>.</p></td>
+    <td width="40%"><strong>data-videoid (required)</strong></td>
+    <td>The Dailymotion video id found in every video page URL. For example, <code>"x2m8jpp"</code> is the video id for <code>https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-mute (optional)</strong></p></td>
-    <td><p>Indicates whether to mute the video.</p>
+    <td width="40%"><strong>data-mute (optional)</strong></td>
+    <td>Indicates whether to mute the video.</p>
 <ul>
   <li>Value: `"true"` or `"false"`</li>
   <li>Default value: `"false"`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-endscreen-enable (optional)</strong></p></td>
-    <td><p>Indicates whether to enable the end screen.</p>
+    <td width="40%"><strong>data-endscreen-enable (optional)</strong></td>
+    <td>Indicates whether to enable the end screen.</p>
 <ul>
   <li>Value: `"true"` or `"false"`</li>
   <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-sharing-enable (optional)</strong></p></td>
-    <td><p>Indicates whether to display the sharing button.</p>
+    <td width="40%"><strong>data-sharing-enable (optional)</strong></td>
+    <td>Indicates whether to display the sharing button.</p>
 <ul>
   <li>Value: `"true"` or `"false"`</li>
   <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-start (optional)</strong></p></td>
-    <td><p>Specifies the time (in seconds) from which the video should start playing.</p>
+    <td width="40%"><strong>data-start (optional)</strong></td>
+    <td>Specifies the time (in seconds) from which the video should start playing.</p>
 <ul>
   <li>Value: integer (number of seconds). For example, `data-start=45`.</li>
   <li>Default value: `0`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-ui-highlight (optional)</strong></p></td>
-    <td><p>Change the default highlight color used in the controls.</p>
+    <td width="40%"><strong>data-ui-highlight (optional)</strong></td>
+    <td>Change the default highlight color used in the controls.</p>
 <ul>
   <li>alue: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-ui-logo (optional)</strong></p></td>
-    <td><p>Indicates whether to display the Dailymotion logo.</p>
+    <td width="40%"><strong>data-ui-logo (optional)</strong></td>
+    <td>Indicates whether to display the Dailymotion logo.</p>
 <ul>
   <li>Value: `"true"` or `"false"`</li>
   <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-info (optional)</strong></p></td>
-    <td><p>Indicates whether to show video information (title and owner) on the start screen.</p>
+    <td width="40%"><strong>data-info (optional)</strong></td>
+    <td>Indicates whether to show video information (title and owner) on the start screen.</p>
 <ul>
   <li>Value: `"true"` or `"false"`</li>
   <li>Default value: `"true"`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-* (optional)</strong></p></td>
+    <td width="40%"><strong>data-param-* (optional)</strong></td>
     <td><p>All data-param-* attributes are added as query parameters to the src value of the embedded Dailymotion iframe. You can use this attribute to pass custom values not explicitly declared.<br>Keys and values will be URI encoded.</p>
 <ul>
   <li>`data-param-origin="example.com"`</li>
@@ -135,8 +135,8 @@ With responsive layout, the width and height from the example should yield corre
 <p>Please read <a href="https://developer.dailymotion.com/player#player-parameters">Dailymotion's video player documentation</a> to know more about parameters and options.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-delight-player/amp-delight-player.md
+++ b/extensions/amp-delight-player/amp-delight-player.md
@@ -75,8 +75,8 @@ Example:
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-delight-player/amp-delight-player.md
+++ b/extensions/amp-delight-player/amp-delight-player.md
@@ -69,18 +69,18 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-content-id (Required)</strong></td>
-    <td>The video's content ID.</td>
+    <td width="40%"><p><strong>data-content-id (Required)</strong></p></td>
+    <td><p>The video's content ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-delight-player/amp-delight-player.md
+++ b/extensions/amp-delight-player/amp-delight-player.md
@@ -69,18 +69,18 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-content-id (Required)</strong></p></td>
-    <td><p>The video's content ID.</p></td>
+    <td width="40%"><strong>data-content-id (Required)</strong></td>
+    <td>The video's content ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-embedly-card/amp-embedly-card.md
+++ b/extensions/amp-embedly-card/amp-embedly-card.md
@@ -101,14 +101,14 @@ Within your AMP page, you can include one or multiple `amp-embedly-card` compone
    <tr>
      <td width="40%"><p><strong>data-card-image</strong></p></td>
      <td><p>The URL to an image. Specifies which image to use in article cards when <code>data-url</code> points to an article.
-Not all image URLs are supported, if the image is not loaded, try a different image or domain.</p></td>
+  Not all image URLs are supported, if the image is not loaded, try a different image or domain.</p></td>
    </tr>
    <tr>
      <td width="40%"><p><strong>data-card-controls</strong></p></td>
      <td><p>Enables share icons.</p>
 <ul>
-<li>`0`: Disable share icons.</li>
-<li>`1`: Enable share icons</li>
+  <li>`0`: Disable share icons.</li>
+  <li>`1`: Enable share icons</li>
 </ul>
 <p>The default is <code>1</code>.</p></td>
    </tr>
@@ -120,8 +120,8 @@ Not all image URLs are supported, if the image is not loaded, try a different im
       <td width="40%"><p><strong>data-card-recommend</strong></p></td>
       <td><p>When recommendations are supported, it disables embedly recommendations on video and rich cards.<br>These are recommendations created by embedly.</p>
 <ul>
-<li>`0`: Disables embedly recommendations.</li>
-<li>`1`: Enables embedly recommendations.</li>
+  <li>`0`: Disables embedly recommendations.</li>
+  <li>`1`: Enables embedly recommendations.</li>
 </ul>
 <p>The default value is <code>1</code>.</p></td>
     </tr>

--- a/extensions/amp-embedly-card/amp-embedly-card.md
+++ b/extensions/amp-embedly-card/amp-embedly-card.md
@@ -82,29 +82,29 @@ Within your AMP page, you can include one or multiple `amp-embedly-card` compone
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-url (required)</strong></p></td>
-    <td><p>The URL to retrieve embedding information.</p></td>
+    <td width="40%"><strong>data-url (required)</strong></td>
+    <td>The URL to retrieve embedding information.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-card-via</strong></p></td>
-    <td><p>Specifies the via content in the card. This is a a great way to do attribution. This is an optional attribute.</p></td>
+    <td width="40%"><strong>data-card-via</strong></td>
+    <td>Specifies the via content in the card. This is a a great way to do attribution. This is an optional attribute.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-card-theme</strong></p></td>
-    <td><p>Allows settings the <code>dark</code> theme which changes the background color of the main card container. Use <code>dark</code> to set this theme. For dark backgrounds it's better to specify this. The default is <code>light</code>, which sets no background color of the main card container.</p></td>
+    <td width="40%"><strong>data-card-theme</strong></td>
+    <td>Allows settings the <code>dark</code> theme which changes the background color of the main card container. Use <code>dark</code> to set this theme. For dark backgrounds it's better to specify this. The default is <code>light</code>, which sets no background color of the main card container.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>data-card-embed</strong></p></td>
-     <td><p>The URL to a video or rich media. Use with static embeds like articles, instead of using the static page content in the card, the card will embed the video or rich media.</p>
+     <td width="40%"><strong>data-card-embed</strong></td>
+     <td>The URL to a video or rich media. Use with static embeds like articles, instead of using the static page content in the card, the card will embed the video or rich media.
 </td>
    </tr>
    <tr>
-     <td width="40%"><p><strong>data-card-image</strong></p></td>
-     <td><p>The URL to an image. Specifies which image to use in article cards when <code>data-url</code> points to an article.
-  Not all image URLs are supported, if the image is not loaded, try a different image or domain.</p></td>
+     <td width="40%"><strong>data-card-image</strong></td>
+     <td>The URL to an image. Specifies which image to use in article cards when <code>data-url</code> points to an article.
+Not all image URLs are supported, if the image is not loaded, try a different image or domain.</td>
    </tr>
    <tr>
-     <td width="40%"><p><strong>data-card-controls</strong></p></td>
+     <td width="40%"><strong>data-card-controls</strong></td>
      <td><p>Enables share icons.</p>
 <ul>
   <li>`0`: Disable share icons.</li>
@@ -113,11 +113,11 @@ Within your AMP page, you can include one or multiple `amp-embedly-card` compone
 <p>The default is <code>1</code>.</p></td>
    </tr>
    <tr>
-      <td width="40%"><p><strong>data-card-align</strong></p></td>
-      <td><p>Aligns the card. The possible values are <code>left</code>, <code>center</code> and <code>right</code>. The default value is <code>center</code>.</p></td>
+      <td width="40%"><strong>data-card-align</strong></td>
+      <td>Aligns the card. The possible values are <code>left</code>, <code>center</code> and <code>right</code>. The default value is <code>center</code>.</td>
     </tr>
     <tr>
-      <td width="40%"><p><strong>data-card-recommend</strong></p></td>
+      <td width="40%"><strong>data-card-recommend</strong></td>
       <td><p>When recommendations are supported, it disables embedly recommendations on video and rich cards.<br>These are recommendations created by embedly.</p>
 <ul>
   <li>`0`: Disables embedly recommendations.</li>
@@ -126,8 +126,8 @@ Within your AMP page, you can include one or multiple `amp-embedly-card` compone
 <p>The default value is <code>1</code>.</p></td>
     </tr>
     <tr>
-      <td width="40%"><p><strong>common attributes</strong></p></td>
-      <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+      <td width="40%"><strong>common attributes</strong></td>
+      <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
     </tr>
 </table>
 

--- a/extensions/amp-embedly-card/amp-embedly-card.md
+++ b/extensions/amp-embedly-card/amp-embedly-card.md
@@ -82,56 +82,52 @@ Within your AMP page, you can include one or multiple `amp-embedly-card` compone
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-url (required)</strong></td>
-    <td>The URL to retrieve embedding information.</td>
+    <td width="40%"><p><strong>data-url (required)</strong></p></td>
+    <td><p>The URL to retrieve embedding information.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-card-via</strong></td>
-    <td>Specifies the via content in the card. This is a a great way to do attribution. This is an optional attribute.</td>
+    <td width="40%"><p><strong>data-card-via</strong></p></td>
+    <td><p>Specifies the via content in the card. This is a a great way to do attribution. This is an optional attribute.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-card-theme</strong></td>
-    <td>Allows settings the `dark` theme which changes the background color of the main card container. Use `dark` to set this theme. For dark backgrounds it's better to specify this. The default is `light`, which sets no background color of the main card container.</td>
+    <td width="40%"><p><strong>data-card-theme</strong></p></td>
+    <td><p>Allows settings the <code>dark</code> theme which changes the background color of the main card container. Use <code>dark</code> to set this theme. For dark backgrounds it's better to specify this. The default is <code>light</code>, which sets no background color of the main card container.</p></td>
   </tr>
   <tr>
-     <td width="40%"><strong>data-card-embed</strong></td>
-     <td>The URL to a video or rich media. Use with static embeds like articles, instead of using the static page content in the card, the card will embed the video or rich media.
+     <td width="40%"><p><strong>data-card-embed</strong></p></td>
+     <td><p>The URL to a video or rich media. Use with static embeds like articles, instead of using the static page content in the card, the card will embed the video or rich media.</p>
 </td>
    </tr>
    <tr>
-     <td width="40%"><strong>data-card-image</strong></td>
-     <td>The URL to an image. Specifies which image to use in article cards when `data-url` points to an article.
-     Not all image URLs are supported, if the image is not loaded, try a different image or domain.</td>
+     <td width="40%"><p><strong>data-card-image</strong></p></td>
+     <td><p>The URL to an image. Specifies which image to use in article cards when <code>data-url</code> points to an article.
+Not all image URLs are supported, if the image is not loaded, try a different image or domain.</p></td>
    </tr>
    <tr>
-     <td width="40%"><strong>data-card-controls</strong></td>
-     <td>
-        Enables share icons.
-        <ul>
-            <li>`0`: Disable share icons.</li>
-            <li>`1`: Enable share icons</li>
-        </ul>
-        The default is `1`.
-     </td>
+     <td width="40%"><p><strong>data-card-controls</strong></p></td>
+     <td><p>Enables share icons.</p>
+<ul>
+<li>`0`: Disable share icons.</li>
+<li>`1`: Enable share icons</li>
+</ul>
+<p>The default is <code>1</code>.</p></td>
    </tr>
    <tr>
-      <td width="40%"><strong>data-card-align</strong></td>
-      <td>Aligns the card. The possible values are `left`, `center` and `right`. The default value is `center`.</td>
+      <td width="40%"><p><strong>data-card-align</strong></p></td>
+      <td><p>Aligns the card. The possible values are <code>left</code>, <code>center</code> and <code>right</code>. The default value is <code>center</code>.</p></td>
     </tr>
     <tr>
-      <td width="40%"><strong>data-card-recommend</strong></td>
-      <td>
-        When recommendations are supported, it disables embedly recommendations on video and rich cards.<br>These are recommendations created by embedly.
-        <ul>
-            <li>`0`: Disables embedly recommendations.</li>
-            <li>`1`: Enables embedly recommendations.</li>
-        </ul>
-        The default value is `1`.
-      </td>
+      <td width="40%"><p><strong>data-card-recommend</strong></p></td>
+      <td><p>When recommendations are supported, it disables embedly recommendations on video and rich cards.<br>These are recommendations created by embedly.</p>
+<ul>
+<li>`0`: Disables embedly recommendations.</li>
+<li>`1`: Enables embedly recommendations.</li>
+</ul>
+<p>The default value is <code>1</code>.</p></td>
     </tr>
     <tr>
-      <td width="40%"><strong>common attributes</strong></td>
-      <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+      <td width="40%"><p><strong>common attributes</strong></p></td>
+      <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
     </tr>
 </table>
 

--- a/extensions/amp-facebook-comments/amp-facebook-comments.md
+++ b/extensions/amp-facebook-comments/amp-facebook-comments.md
@@ -66,7 +66,7 @@ You can use the `amp-facebook-comments` component to embed the [Facebook comment
   </tr>
   <tr>
     <td width="40%"><p><strong>data-numposts (optional)</strong></p></td>
-    <td><p>The number of comments to show.  For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
+    <td><p>The number of comments to show. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-order-by (optional)</strong></p></td>

--- a/extensions/amp-facebook-comments/amp-facebook-comments.md
+++ b/extensions/amp-facebook-comments/amp-facebook-comments.md
@@ -57,28 +57,28 @@ You can use the `amp-facebook-comments` component to embed the [Facebook comment
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-href (required)</strong></p></td>
-    <td><p>The URL of the comments page. For example, <code>http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html</code>.</p></td>
+    <td width="40%"><strong>data-href (required)</strong></td>
+    <td>The URL of the comments page. For example, <code>http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
-    <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well. <br><br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
+    <td width="40%"><strong>data-locale (optional)</strong></td>
+    <td>By default, the locale is set to user's system language; however, you can specify a locale as well. <br><br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-numposts (optional)</strong></p></td>
-    <td><p>The number of comments to show. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
+    <td width="40%"><strong>data-numposts (optional)</strong></td>
+    <td>The number of comments to show. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-order-by (optional)</strong></p></td>
-    <td><p>The order to use when displaying comments. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
+    <td width="40%"><strong>data-order-by (optional)</strong></td>
+    <td>The order to use when displaying comments. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-colorscheme (optional)</strong></p></td>
-    <td><p>The color scheme. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
+    <td width="40%"><strong>data-colorscheme (optional)</strong></td>
+    <td>The color scheme. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook-comments/amp-facebook-comments.md
+++ b/extensions/amp-facebook-comments/amp-facebook-comments.md
@@ -57,28 +57,28 @@ You can use the `amp-facebook-comments` component to embed the [Facebook comment
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-href (required)</strong></td>
-    <td>The URL of the comments page. For example, `http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html`.</td>
+    <td width="40%"><p><strong>data-href (required)</strong></p></td>
+    <td><p>The URL of the comments page. For example, <code>http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-locale (optional)</strong></td>
-    <td>By default, the locale is set to user's system language; however, you can specify a locale as well. <br><br> For details on strings accepted here please visit the [Facebook API Localization page](https://developers.facebook.com/docs/internationalization)</td>
+    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
+    <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well. <br><br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-numposts (optional)</strong></td>
-    <td>The number of comments to show.  For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).</td>
+    <td width="40%"><p><strong>data-numposts (optional)</strong></p></td>
+    <td><p>The number of comments to show.  For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-order-by (optional)</strong></td>
-    <td>The order to use when displaying comments. For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).</td>
+    <td width="40%"><p><strong>data-order-by (optional)</strong></p></td>
+    <td><p>The order to use when displaying comments. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-colorscheme (optional)</strong></td>
-    <td>The color scheme. For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).</td>
+    <td width="40%"><p><strong>data-colorscheme (optional)</strong></p></td>
+    <td><p>The color scheme. For details, see the <a href="https://developers.facebook.com/docs/plugins/comments">Facebook comments documentation</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook-like/amp-facebook-like.md
+++ b/extensions/amp-facebook-like/amp-facebook-like.md
@@ -78,7 +78,7 @@ You can use the `amp-facebook-like` component to embed the [Facebook like button
   <tr>
     <td width="40%"><p><strong>data-kd_site  (optional)</strong></p></td>
     <td><p>This attribute is also known as <code>data-kid_directed_site</code> in the Facebook SDK.
-If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is <code>false</code>.</p></td>
+  If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is <code>false</code>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-layout (optional)</strong></p></td>

--- a/extensions/amp-facebook-like/amp-facebook-like.md
+++ b/extensions/amp-facebook-like/amp-facebook-like.md
@@ -60,49 +60,49 @@ You can use the `amp-facebook-like` component to embed the [Facebook like button
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-href (required)</strong></td>
-    <td>The absolute URL of the page that will be liked. For example, `https://www.facebook.com/testesmegadivertidos/`.</td>
+    <td width="40%"><p><strong>data-href (required)</strong></p></td>
+    <td><p>The absolute URL of the page that will be liked. For example, <code>https://www.facebook.com/testesmegadivertidos/</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-locale (optional)</strong></td>
-    <td>By default, the locale is set to user's system language; however, you can specify a locale as well. <br> For details on strings accepted here please visit the [Facebook API Localization page](https://developers.facebook.com/docs/internationalization)</td>
+    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
+    <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well. <br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-action (optional)</strong></td>
-    <td>The verb to display on the button. Can be either `like` or `recommend`. The default is `like`.</td>
+    <td width="40%"><p><strong>data-action (optional)</strong></p></td>
+    <td><p>The verb to display on the button. Can be either <code>like</code> or <code>recommend</code>. The default is <code>like</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-colorscheme (optional)</strong></td>
-    <td>The color scheme used by the plugin for any text outside of the button itself. Can be `light` or `dark`. The default is `light`.</td>
+    <td width="40%"><p><strong>data-colorscheme (optional)</strong></p></td>
+    <td><p>The color scheme used by the plugin for any text outside of the button itself. Can be <code>light</code> or <code>dark</code>. The default is <code>light</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-kd_site  (optional)</strong></td>
-    <td>This attribute is also known as `data-kid_directed_site` in the Facebook SDK.
-    If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is `false`.</td>
+    <td width="40%"><p><strong>data-kd_site  (optional)</strong></p></td>
+    <td><p>This attribute is also known as <code>data-kid_directed_site</code> in the Facebook SDK.
+If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-layout (optional)</strong></td>
-    <td>Selects one of the different layouts that are available for the plugin. Can be one of `standard`, `button_count`, `button` or `box_count`. The default is `standard`.</td>
+    <td width="40%"><p><strong>data-layout (optional)</strong></p></td>
+    <td><p>Selects one of the different layouts that are available for the plugin. Can be one of <code>standard</code>, <code>button_count</code>, <code>button</code> or <code>box_count</code>. The default is <code>standard</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-ref (optional)</strong></td>
-    <td>A label for tracking referrals which must be less than 50 characters and can contain alphanumeric characters and some punctuation.</td>
+    <td width="40%"><p><strong>data-ref (optional)</strong></p></td>
+    <td><p>A label for tracking referrals which must be less than 50 characters and can contain alphanumeric characters and some punctuation.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-share (optional)</strong></td>
-    <td>Specifies whether to include a share button beside the Like button. This only works with the XFBML version. The default is `false`.</td>
+    <td width="40%"><p><strong>data-share (optional)</strong></p></td>
+    <td><p>Specifies whether to include a share button beside the Like button. This only works with the XFBML version. The default is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-show_faces (optional)</strong></td>
-    <td>Specifies whether to display profile photos below the button (standard layout only). You must not enable this on child-directed sites. The default is `false`.</td>
+    <td width="40%"><p><strong>data-show_faces (optional)</strong></p></td>
+    <td><p>Specifies whether to display profile photos below the button (standard layout only). You must not enable this on child-directed sites. The default is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-size (optional)</strong></td>
-    <td>The size of the button, which can be one of two sizes, `large` or `small`. The default is `small`. <br>For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/like-button#settings).</td>
+    <td width="40%"><p><strong>data-size (optional)</strong></p></td>
+    <td><p>The size of the button, which can be one of two sizes, <code>large</code> or <code>small</code>. The default is <code>small</code>. <br>For details, see the <a href="https://developers.facebook.com/docs/plugins/like-button#settings">Facebook comments documentation</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook-like/amp-facebook-like.md
+++ b/extensions/amp-facebook-like/amp-facebook-like.md
@@ -60,49 +60,49 @@ You can use the `amp-facebook-like` component to embed the [Facebook like button
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-href (required)</strong></p></td>
-    <td><p>The absolute URL of the page that will be liked. For example, <code>https://www.facebook.com/testesmegadivertidos/</code>.</p></td>
+    <td width="40%"><strong>data-href (required)</strong></td>
+    <td>The absolute URL of the page that will be liked. For example, <code>https://www.facebook.com/testesmegadivertidos/</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
-    <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well. <br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
+    <td width="40%"><strong>data-locale (optional)</strong></td>
+    <td>By default, the locale is set to user's system language; however, you can specify a locale as well. <br> For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-action (optional)</strong></p></td>
-    <td><p>The verb to display on the button. Can be either <code>like</code> or <code>recommend</code>. The default is <code>like</code>.</p></td>
+    <td width="40%"><strong>data-action (optional)</strong></td>
+    <td>The verb to display on the button. Can be either <code>like</code> or <code>recommend</code>. The default is <code>like</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-colorscheme (optional)</strong></p></td>
-    <td><p>The color scheme used by the plugin for any text outside of the button itself. Can be <code>light</code> or <code>dark</code>. The default is <code>light</code>.</p></td>
+    <td width="40%"><strong>data-colorscheme (optional)</strong></td>
+    <td>The color scheme used by the plugin for any text outside of the button itself. Can be <code>light</code> or <code>dark</code>. The default is <code>light</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-kd_site  (optional)</strong></p></td>
-    <td><p>This attribute is also known as <code>data-kid_directed_site</code> in the Facebook SDK.
-  If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-kd_site  (optional)</strong></td>
+    <td>This attribute is also known as <code>data-kid_directed_site</code> in the Facebook SDK.
+If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-layout (optional)</strong></p></td>
-    <td><p>Selects one of the different layouts that are available for the plugin. Can be one of <code>standard</code>, <code>button_count</code>, <code>button</code> or <code>box_count</code>. The default is <code>standard</code>.</p></td>
+    <td width="40%"><strong>data-layout (optional)</strong></td>
+    <td>Selects one of the different layouts that are available for the plugin. Can be one of <code>standard</code>, <code>button_count</code>, <code>button</code> or <code>box_count</code>. The default is <code>standard</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-ref (optional)</strong></p></td>
-    <td><p>A label for tracking referrals which must be less than 50 characters and can contain alphanumeric characters and some punctuation.</p></td>
+    <td width="40%"><strong>data-ref (optional)</strong></td>
+    <td>A label for tracking referrals which must be less than 50 characters and can contain alphanumeric characters and some punctuation.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-share (optional)</strong></p></td>
-    <td><p>Specifies whether to include a share button beside the Like button. This only works with the XFBML version. The default is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-share (optional)</strong></td>
+    <td>Specifies whether to include a share button beside the Like button. This only works with the XFBML version. The default is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-show_faces (optional)</strong></p></td>
-    <td><p>Specifies whether to display profile photos below the button (standard layout only). You must not enable this on child-directed sites. The default is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-show_faces (optional)</strong></td>
+    <td>Specifies whether to display profile photos below the button (standard layout only). You must not enable this on child-directed sites. The default is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-size (optional)</strong></p></td>
-    <td><p>The size of the button, which can be one of two sizes, <code>large</code> or <code>small</code>. The default is <code>small</code>. <br>For details, see the <a href="https://developers.facebook.com/docs/plugins/like-button#settings">Facebook comments documentation</a>.</p></td>
+    <td width="40%"><strong>data-size (optional)</strong></td>
+    <td>The size of the button, which can be one of two sizes, <code>large</code> or <code>small</code>. The default is <code>small</code>. <br>For details, see the <a href="https://developers.facebook.com/docs/plugins/like-button#settings">Facebook comments documentation</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook-page/amp-facebook-page.md
+++ b/extensions/amp-facebook-page/amp-facebook-page.md
@@ -60,36 +60,36 @@ You can use the `amp-facebook-page` component to embed the [Facebook page plugin
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-href (required)</strong></td>
-    <td>The absolute URL of the Facebook page. For example, `https://www.facebook.com/imdb/`.</td>
+    <td width="40%"><p><strong>data-href (required)</strong></p></td>
+    <td><p>The absolute URL of the Facebook page. For example, <code>https://www.facebook.com/imdb/</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-locale (optional)</strong></td>
-    <td>By default, the locale is set to the user's system language; however, you can specify a locale as well. For details, visit the [Facebook API Localization page](https://developers.facebook.com/docs/internationalization).</td>
+    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
+    <td><p>By default, the locale is set to the user's system language; however, you can specify a locale as well. For details, visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-tabs (optional)</strong></td>
-    <td>Specifies the tabs to render (i.e., `timeline`, `events`, `messages`). Use a comma-separated list to add multiple tabs (e.g., `timeline, events`). By default, the Facebook page plugin shows the timeline activity.</td>
+    <td width="40%"><p><strong>data-tabs (optional)</strong></p></td>
+    <td><p>Specifies the tabs to render (i.e., <code>timeline</code>, <code>events</code>, <code>messages</code>). Use a comma-separated list to add multiple tabs (e.g., <code>timeline, events</code>). By default, the Facebook page plugin shows the timeline activity.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-hide-cover (optional)</strong></td>
-    <td>Hides the cover photo in the header. Default value is `false`.</td>
+    <td width="40%"><p><strong>data-hide-cover (optional)</strong></p></td>
+    <td><p>Hides the cover photo in the header. Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-show-facepile (optional)</strong></td>
-    <td>Shows profile photos of friends who like the page. Default value is `true`.</td>
+    <td width="40%"><p><strong>data-show-facepile (optional)</strong></p></td>
+    <td><p>Shows profile photos of friends who like the page. Default value is <code>true</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-hide-cta (optional)</strong></td>
-    <td>Hides the custom call to action button (if available). Default value is `false`.</td>
+    <td width="40%"><p><strong>data-hide-cta (optional)</strong></p></td>
+    <td><p>Hides the custom call to action button (if available). Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-small-header (optional)</strong></td>
-    <td>Uses the small header instead. Default value is `false`.</td>
+    <td width="40%"><p><strong>data-small-header (optional)</strong></p></td>
+    <td><p>Uses the small header instead. Default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook-page/amp-facebook-page.md
+++ b/extensions/amp-facebook-page/amp-facebook-page.md
@@ -60,36 +60,36 @@ You can use the `amp-facebook-page` component to embed the [Facebook page plugin
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-href (required)</strong></p></td>
-    <td><p>The absolute URL of the Facebook page. For example, <code>https://www.facebook.com/imdb/</code>.</p></td>
+    <td width="40%"><strong>data-href (required)</strong></td>
+    <td>The absolute URL of the Facebook page. For example, <code>https://www.facebook.com/imdb/</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
-    <td><p>By default, the locale is set to the user's system language; however, you can specify a locale as well. For details, visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a>.</p></td>
+    <td width="40%"><strong>data-locale (optional)</strong></td>
+    <td>By default, the locale is set to the user's system language; however, you can specify a locale as well. For details, visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-tabs (optional)</strong></p></td>
-    <td><p>Specifies the tabs to render (i.e., <code>timeline</code>, <code>events</code>, <code>messages</code>). Use a comma-separated list to add multiple tabs (e.g., <code>timeline, events</code>). By default, the Facebook page plugin shows the timeline activity.</p></td>
+    <td width="40%"><strong>data-tabs (optional)</strong></td>
+    <td>Specifies the tabs to render (i.e., <code>timeline</code>, <code>events</code>, <code>messages</code>). Use a comma-separated list to add multiple tabs (e.g., <code>timeline, events</code>). By default, the Facebook page plugin shows the timeline activity.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-hide-cover (optional)</strong></p></td>
-    <td><p>Hides the cover photo in the header. Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-hide-cover (optional)</strong></td>
+    <td>Hides the cover photo in the header. Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-show-facepile (optional)</strong></p></td>
-    <td><p>Shows profile photos of friends who like the page. Default value is <code>true</code>.</p></td>
+    <td width="40%"><strong>data-show-facepile (optional)</strong></td>
+    <td>Shows profile photos of friends who like the page. Default value is <code>true</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-hide-cta (optional)</strong></p></td>
-    <td><p>Hides the custom call to action button (if available). Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-hide-cta (optional)</strong></td>
+    <td>Hides the custom call to action button (if available). Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-small-header (optional)</strong></p></td>
-    <td><p>Uses the small header instead. Default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-small-header (optional)</strong></td>
+    <td>Uses the small header instead. Default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -98,43 +98,40 @@ Renders as:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-href (required)</strong></td>
-    <td>The URL of the Facebook post/video/comment. For example, a post or video will look like `https://www.facebook.com/zuck/posts/10102593740125791`. A comment or comment reply will look like `https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185`. For comments, see the Facebook documentation on [how to get a comment's URL](https://developers.facebook.com/docs/plugins/embedded-comments#how-to-get-a-comments-url).</td>
+    <td width="40%"><p><strong>data-href (required)</strong></p></td>
+    <td><p>The URL of the Facebook post/video/comment. For example, a post or video will look like <code>https://www.facebook.com/zuck/posts/10102593740125791</code>. A comment or comment reply will look like <code>https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185</code>. For comments, see the Facebook documentation on <a href="https://developers.facebook.com/docs/plugins/embedded-comments#how-to-get-a-comments-url">how to get a comment's URL</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-embed-as</strong></td>
-    <td>
-      The value is either `post`, `video` or `comment`.  The default is `post`.
-      <br><br>
-      Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting `data-embed-as="post"` ignores the caption card. This is done to make sure we are zooming in on videos correctly.
-      <br><br>
-      The `comment` value embeds a single comment (or reply to a comment) on a post. This is not to be confused with [amp-facebook-comments](https://ampbyexample.com/components/amp-facebook-comments/).
-      <br><br>
-      Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts), [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player), and [comment embeds](https://developers.facebook.com/docs/plugins/embedded-comments).
-    </td>
+    <td width="40%"><p><strong>data-embed-as</strong></p></td>
+    <td><p>The value is either <code>post</code>, <code>video</code> or <code>comment</code>.  The default is <code>post</code>.
+<br><br>
+Both posts and videos can be embedded as a post. Setting <code>data-embed-as="video"</code> for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting <code>data-embed-as="post"</code> ignores the caption card. This is done to make sure we are zooming in on videos correctly.
+<br><br>
+The <code>comment</code> value embeds a single comment (or reply to a comment) on a post. This is not to be confused with <a href="https://ampbyexample.com/components/amp-facebook-comments/">amp-facebook-comments</a>.
+<br><br>
+Check out the documentation for differences between <a href="https://developers.facebook.com/docs/plugins/embedded-posts">post embeds</a>, <a href="https://developers.facebook.com/docs/plugins/embedded-video-player">video embeds</a>, and <a href="https://developers.facebook.com/docs/plugins/embedded-comments">comment embeds</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-include-comment-parent</strong></td>
-    <td>The value is either `true` or `false`. The default is `false`.
-    <br><br>
-    When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</td>
+    <td width="40%"><p><strong>data-include-comment-parent</strong></p></td>
+    <td><p>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
+<br><br>
+When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</p></td>
   </tr>
   <tr>
-     <td width="40%"><strong>data-align-center</strong></td>
-     <td>The value is either `true` or `false`.  The default is `false`.
-     <br><br>
-     For posts and videos, having this attribute set to true would align the post/video container to center.
-     </td>
+     <td width="40%"><p><strong>data-align-center</strong></p></td>
+     <td><p>The value is either <code>true</code> or <code>false</code>.  The default is <code>false</code>.
+<br><br>
+For posts and videos, having this attribute set to true would align the post/video container to center.</p></td>
    </tr>
    <tr>
-      <td width="40%"><strong>data-locale (optional)</strong></td>
-      <td>By default, the locale is set to user's system language; however, you can specify a locale as well.
-      <br><br>
-      For details on strings accepted here please visit the [Facebook API Localization page](https://developers.facebook.com/docs/internationalization)</td>
+      <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
+      <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well.
+<br><br>
+For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
     </tr>
     <tr>
-       <td width="40%"><strong>common attributes</strong></td>
-       <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+       <td width="40%"><p><strong>common attributes</strong></p></td>
+       <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
      </tr>
 </table>
 

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -98,40 +98,40 @@ Renders as:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-href (required)</strong></p></td>
-    <td><p>The URL of the Facebook post/video/comment. For example, a post or video will look like <code>https://www.facebook.com/zuck/posts/10102593740125791</code>. A comment or comment reply will look like <code>https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185</code>. For comments, see the Facebook documentation on <a href="https://developers.facebook.com/docs/plugins/embedded-comments#how-to-get-a-comments-url">how to get a comment's URL</a>.</p></td>
+    <td width="40%"><strong>data-href (required)</strong></td>
+    <td>The URL of the Facebook post/video/comment. For example, a post or video will look like <code>https://www.facebook.com/zuck/posts/10102593740125791</code>. A comment or comment reply will look like <code>https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185</code>. For comments, see the Facebook documentation on <a href="https://developers.facebook.com/docs/plugins/embedded-comments#how-to-get-a-comments-url">how to get a comment's URL</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-embed-as</strong></p></td>
-    <td><p>The value is either <code>post</code>, <code>video</code> or <code>comment</code>. The default is <code>post</code>.
-  <br><br>
-  Both posts and videos can be embedded as a post. Setting <code>data-embed-as="video"</code> for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting <code>data-embed-as="post"</code> ignores the caption card. This is done to make sure we are zooming in on videos correctly.
-  <br><br>
-  The <code>comment</code> value embeds a single comment (or reply to a comment) on a post. This is not to be confused with <a href="https://ampbyexample.com/components/amp-facebook-comments/">amp-facebook-comments</a>.
-  <br><br>
-  Check out the documentation for differences between <a href="https://developers.facebook.com/docs/plugins/embedded-posts">post embeds</a>, <a href="https://developers.facebook.com/docs/plugins/embedded-video-player">video embeds</a>, and <a href="https://developers.facebook.com/docs/plugins/embedded-comments">comment embeds</a>.</p></td>
+    <td width="40%"><strong>data-embed-as</strong></td>
+    <td>The value is either <code>post</code>, <code>video</code> or <code>comment</code>. The default is <code>post</code>.
+<br><br>
+Both posts and videos can be embedded as a post. Setting <code>data-embed-as="video"</code> for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting <code>data-embed-as="post"</code> ignores the caption card. This is done to make sure we are zooming in on videos correctly.
+<br><br>
+The <code>comment</code> value embeds a single comment (or reply to a comment) on a post. This is not to be confused with <a href="https://ampbyexample.com/components/amp-facebook-comments/">amp-facebook-comments</a>.
+<br><br>
+Check out the documentation for differences between <a href="https://developers.facebook.com/docs/plugins/embedded-posts">post embeds</a>, <a href="https://developers.facebook.com/docs/plugins/embedded-video-player">video embeds</a>, and <a href="https://developers.facebook.com/docs/plugins/embedded-comments">comment embeds</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-include-comment-parent</strong></p></td>
-    <td><p>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
-  <br><br>
-  When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</p></td>
+    <td width="40%"><strong>data-include-comment-parent</strong></td>
+    <td>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
+<br><br>
+When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>data-align-center</strong></p></td>
-     <td><p>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
-  <br><br>
-  For posts and videos, having this attribute set to true would align the post/video container to center.</p></td>
+     <td width="40%"><strong>data-align-center</strong></td>
+     <td>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
+<br><br>
+For posts and videos, having this attribute set to true would align the post/video container to center.</td>
    </tr>
    <tr>
-      <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
-      <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well.
-  <br><br>
-  For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
+      <td width="40%"><strong>data-locale (optional)</strong></td>
+      <td>By default, the locale is set to user's system language; however, you can specify a locale as well.
+<br><br>
+For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></td>
     </tr>
     <tr>
-       <td width="40%"><p><strong>common attributes</strong></p></td>
-       <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+       <td width="40%"><strong>common attributes</strong></td>
+       <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
      </tr>
 </table>
 

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -103,31 +103,31 @@ Renders as:
   </tr>
   <tr>
     <td width="40%"><p><strong>data-embed-as</strong></p></td>
-    <td><p>The value is either <code>post</code>, <code>video</code> or <code>comment</code>.  The default is <code>post</code>.
-<br><br>
-Both posts and videos can be embedded as a post. Setting <code>data-embed-as="video"</code> for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting <code>data-embed-as="post"</code> ignores the caption card. This is done to make sure we are zooming in on videos correctly.
-<br><br>
-The <code>comment</code> value embeds a single comment (or reply to a comment) on a post. This is not to be confused with <a href="https://ampbyexample.com/components/amp-facebook-comments/">amp-facebook-comments</a>.
-<br><br>
-Check out the documentation for differences between <a href="https://developers.facebook.com/docs/plugins/embedded-posts">post embeds</a>, <a href="https://developers.facebook.com/docs/plugins/embedded-video-player">video embeds</a>, and <a href="https://developers.facebook.com/docs/plugins/embedded-comments">comment embeds</a>.</p></td>
+    <td><p>The value is either <code>post</code>, <code>video</code> or <code>comment</code>. The default is <code>post</code>.
+  <br><br>
+  Both posts and videos can be embedded as a post. Setting <code>data-embed-as="video"</code> for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting <code>data-embed-as="post"</code> ignores the caption card. This is done to make sure we are zooming in on videos correctly.
+  <br><br>
+  The <code>comment</code> value embeds a single comment (or reply to a comment) on a post. This is not to be confused with <a href="https://ampbyexample.com/components/amp-facebook-comments/">amp-facebook-comments</a>.
+  <br><br>
+  Check out the documentation for differences between <a href="https://developers.facebook.com/docs/plugins/embedded-posts">post embeds</a>, <a href="https://developers.facebook.com/docs/plugins/embedded-video-player">video embeds</a>, and <a href="https://developers.facebook.com/docs/plugins/embedded-comments">comment embeds</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-include-comment-parent</strong></p></td>
     <td><p>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
-<br><br>
-When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</p></td>
+  <br><br>
+  When you are embedding a comment reply, you can optionally also include the parent comment of the reply.</p></td>
   </tr>
   <tr>
      <td width="40%"><p><strong>data-align-center</strong></p></td>
-     <td><p>The value is either <code>true</code> or <code>false</code>.  The default is <code>false</code>.
-<br><br>
-For posts and videos, having this attribute set to true would align the post/video container to center.</p></td>
+     <td><p>The value is either <code>true</code> or <code>false</code>. The default is <code>false</code>.
+  <br><br>
+  For posts and videos, having this attribute set to true would align the post/video container to center.</p></td>
    </tr>
    <tr>
       <td width="40%"><p><strong>data-locale (optional)</strong></p></td>
       <td><p>By default, the locale is set to user's system language; however, you can specify a locale as well.
-<br><br>
-For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
+  <br><br>
+  For details on strings accepted here please visit the <a href="https://developers.facebook.com/docs/internationalization">Facebook API Localization page</a></p></td>
     </tr>
     <tr>
        <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -107,16 +107,16 @@ In the following example, we specified a `min-font-size` of `40`, which causes t
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>min-font-size</strong></p></td>
-    <td><p>Specifies the minimum font size as an integer that the <code>amp-fit-text</code> can use.</p></td>
+    <td width="40%"><strong>min-font-size</strong></td>
+    <td>Specifies the minimum font size as an integer that the <code>amp-fit-text</code> can use.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>max-font-size</strong></p></td>
-    <td><p>Specifies the maximum font size as an integer that the <code>amp-fit-text</code> can use.</p></td>
+    <td width="40%"><strong>max-font-size</strong></td>
+    <td>Specifies the maximum font size as an integer that the <code>amp-fit-text</code> can use.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -107,16 +107,16 @@ In the following example, we specified a `min-font-size` of `40`, which causes t
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>min-font-size</strong></td>
-    <td>Specifies the minimum font size as an integer that the `amp-fit-text` can use.</td>
+    <td width="40%"><p><strong>min-font-size</strong></p></td>
+    <td><p>Specifies the minimum font size as an integer that the <code>amp-fit-text</code> can use.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>max-font-size</strong></td>
-    <td>Specifies the maximum font size as an integer that the `amp-fit-text` can use.</td>
+    <td width="40%"><p><strong>max-font-size</strong></p></td>
+    <td><p>Specifies the maximum font size as an integer that the <code>amp-fit-text</code> can use.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -82,36 +82,36 @@ The `amp-font` extension accepts the `layout` value:  `nodisplay`
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>font-family</strong></td>
-    <td>The font-family of the custom font being loaded.</td>
+    <td width="40%"><p><strong>font-family</strong></p></td>
+    <td><p>The font-family of the custom font being loaded.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>timeout</strong></td>
-    <td>Time in milliseconds after which the we don't wait for the custom font to be available. This attribute is optional and it's default value is 3000. If the timeout is set to 0 then the amp-font loads the font if it is already in the cache, otherwise the font would not be loaded. If the timeout is has an invalid value then the timeout defaults to 3000.</td>
+    <td width="40%"><p><strong>timeout</strong></p></td>
+    <td><p>Time in milliseconds after which the we don't wait for the custom font to be available. This attribute is optional and it's default value is 3000. If the timeout is set to 0 then the amp-font loads the font if it is already in the cache, otherwise the font would not be loaded. If the timeout is has an invalid value then the timeout defaults to 3000.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>on-load-add-class</strong></td>
-    <td>CSS class that would be added to the document root after making sure that the custom font is available for display. This attribute is optional.</td>
+    <td width="40%"><p><strong>on-load-add-class</strong></p></td>
+    <td><p>CSS class that would be added to the document root after making sure that the custom font is available for display. This attribute is optional.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>on-load-remove-class</strong></td>
-    <td>CSS class that would be removed from the document root after making sure that the custom font is available for display. This attribute is optional.</td>
+    <td width="40%"><p><strong>on-load-remove-class</strong></p></td>
+    <td><p>CSS class that would be removed from the document root after making sure that the custom font is available for display. This attribute is optional.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>on-error-add-class</strong></td>
-    <td>CSS class that would be added to the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</td>
+    <td width="40%"><p><strong>on-error-add-class</strong></p></td>
+    <td><p>CSS class that would be added to the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>on-error-remove-class</strong></td>
-    <td>CSS class that would be removed from the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</td>
+    <td width="40%"><p><strong>on-error-remove-class</strong></p></td>
+    <td><p>CSS class that would be removed from the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>font-weight, font-style, font-variant</strong></td>
-    <td>The attributes above should all behave like they do on standard elements.</td>
+    <td width="40%"><p><strong>font-weight, font-style, font-variant</strong></p></td>
+    <td><p>The attributes above should all behave like they do on standard elements.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>layout</strong></td>
-    <td>Must be `nodisplay`.</td>
+    <td width="40%"><p><strong>layout</strong></p></td>
+    <td><p>Must be <code>nodisplay</code>.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -82,36 +82,36 @@ The `amp-font` extension accepts the `layout` value:  `nodisplay`
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>font-family</strong></p></td>
-    <td><p>The font-family of the custom font being loaded.</p></td>
+    <td width="40%"><strong>font-family</strong></td>
+    <td>The font-family of the custom font being loaded.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>timeout</strong></p></td>
-    <td><p>Time in milliseconds after which the we don't wait for the custom font to be available. This attribute is optional and it's default value is 3000. If the timeout is set to 0 then the amp-font loads the font if it is already in the cache, otherwise the font would not be loaded. If the timeout is has an invalid value then the timeout defaults to 3000.</p></td>
+    <td width="40%"><strong>timeout</strong></td>
+    <td>Time in milliseconds after which the we don't wait for the custom font to be available. This attribute is optional and it's default value is 3000. If the timeout is set to 0 then the amp-font loads the font if it is already in the cache, otherwise the font would not be loaded. If the timeout is has an invalid value then the timeout defaults to 3000.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>on-load-add-class</strong></p></td>
-    <td><p>CSS class that would be added to the document root after making sure that the custom font is available for display. This attribute is optional.</p></td>
+    <td width="40%"><strong>on-load-add-class</strong></td>
+    <td>CSS class that would be added to the document root after making sure that the custom font is available for display. This attribute is optional.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>on-load-remove-class</strong></p></td>
-    <td><p>CSS class that would be removed from the document root after making sure that the custom font is available for display. This attribute is optional.</p></td>
+    <td width="40%"><strong>on-load-remove-class</strong></td>
+    <td>CSS class that would be removed from the document root after making sure that the custom font is available for display. This attribute is optional.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>on-error-add-class</strong></p></td>
-    <td><p>CSS class that would be added to the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</p></td>
+    <td width="40%"><strong>on-error-add-class</strong></td>
+    <td>CSS class that would be added to the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>on-error-remove-class</strong></p></td>
-    <td><p>CSS class that would be removed from the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</p></td>
+    <td width="40%"><strong>on-error-remove-class</strong></td>
+    <td>CSS class that would be removed from the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>font-weight, font-style, font-variant</strong></p></td>
-    <td><p>The attributes above should all behave like they do on standard elements.</p></td>
+    <td width="40%"><strong>font-weight, font-style, font-variant</strong></td>
+    <td>The attributes above should all behave like they do on standard elements.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>layout</strong></p></td>
-    <td><p>Must be <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout</strong></td>
+    <td>Must be <code>nodisplay</code>.</td>
   </tr>
 </table>
 

--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -57,12 +57,12 @@ The following requirements are imposed on `amp-fx-flying-carpet` positioning:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>height</strong></td>
-    <td>The height of the flying carpet's "window".</td>
+    <td width="40%"><p><strong>height</strong></p></td>
+    <td><p>The height of the flying carpet's "window".</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -57,12 +57,12 @@ The following requirements are imposed on `amp-fx-flying-carpet` positioning:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>height</strong></p></td>
-    <td><p>The height of the flying carpet's "window".</p></td>
+    <td width="40%"><strong>height</strong></td>
+    <td>The height of the flying carpet's "window".</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -74,8 +74,8 @@ This extension creates an iframe and displays a [gist from GitHub](https://help.
   <tr>
     <td width="40%"><p><strong>height (required)</strong></p></td>
     <td><p>The initial height of the gist or gist file in pixels.
-<br><br>
-<strong>Note</strong>: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</p></td>
+  <br><br>
+  <strong>Note</strong>: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-file (optional)</strong></p></td>

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -64,22 +64,22 @@ This extension creates an iframe and displays a [gist from GitHub](https://help.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-gistid (required)</strong></td>
-    <td>The ID of the gist to embed.</td>
+    <td width="40%"><p><strong>data-gistid (required)</strong></p></td>
+    <td><p>The ID of the gist to embed.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>layout (required)</strong></td>
-    <td>Currently only supports `fixed-height`.</td>
+    <td width="40%"><p><strong>layout (required)</strong></p></td>
+    <td><p>Currently only supports <code>fixed-height</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>height (required)</strong></td>
-    <td>The initial height of the gist or gist file in pixels.
-    <br><br>
-    **Note**: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</td>
+    <td width="40%"><p><strong>height (required)</strong></p></td>
+    <td><p>The initial height of the gist or gist file in pixels.
+<br><br>
+<strong>Note</strong>: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-file (optional)</strong></td>
-    <td>If specified, display only one file in a gist.</td>
+    <td width="40%"><p><strong>data-file (optional)</strong></p></td>
+    <td><p>If specified, display only one file in a gist.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -64,22 +64,22 @@ This extension creates an iframe and displays a [gist from GitHub](https://help.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-gistid (required)</strong></p></td>
-    <td><p>The ID of the gist to embed.</p></td>
+    <td width="40%"><strong>data-gistid (required)</strong></td>
+    <td>The ID of the gist to embed.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>layout (required)</strong></p></td>
-    <td><p>Currently only supports <code>fixed-height</code>.</p></td>
+    <td width="40%"><strong>layout (required)</strong></td>
+    <td>Currently only supports <code>fixed-height</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>height (required)</strong></p></td>
-    <td><p>The initial height of the gist or gist file in pixels.
-  <br><br>
-  <strong>Note</strong>: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</p></td>
+    <td width="40%"><strong>height (required)</strong></td>
+    <td>The initial height of the gist or gist file in pixels.
+<br><br>
+<strong>Note</strong>: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-file (optional)</strong></p></td>
-    <td><p>If specified, display only one file in a gist.</p></td>
+    <td width="40%"><strong>data-file (optional)</strong></td>
+    <td>If specified, display only one file in a gist.</td>
   </tr>
 </table>
 

--- a/extensions/amp-google-vrview-image/amp-google-vrview-image.md
+++ b/extensions/amp-google-vrview-image/amp-google-vrview-image.md
@@ -72,21 +72,21 @@ VR view supports mono and stereo 360 images. Note:
 
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>The source URL of a stereo image. Must resolve to https. See notes above on what
-    kind of image can be passed here.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>The source URL of a stereo image. Must resolve to https. See notes above on what
+kind of image can be passed here.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>stereo</strong></td>
-    <td>If specified, the image provided by the `src` attribute is considered to be a stereo
-    image (see above), otherwise it's a mono image.</td>
+    <td width="40%"><p><strong>stereo</strong></p></td>
+    <td><p>If specified, the image provided by the <code>src</code> attribute is considered to be a stereo
+image (see above), otherwise it's a mono image.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>yaw</strong></td>
-    <td>Initial yaw of viewer, in degrees. Defaults to 0.</td>
+    <td width="40%"><p><strong>yaw</strong></p></td>
+    <td><p>Initial yaw of viewer, in degrees. Defaults to 0.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>yaw-only</strong></td>
-    <td>Can be specified to restrict motion to yaw only.</td>
+    <td width="40%"><p><strong>yaw-only</strong></p></td>
+    <td><p>Can be specified to restrict motion to yaw only.</p></td>
   </tr>
 </table>

--- a/extensions/amp-google-vrview-image/amp-google-vrview-image.md
+++ b/extensions/amp-google-vrview-image/amp-google-vrview-image.md
@@ -74,12 +74,12 @@ VR view supports mono and stereo 360 images. Note:
   <tr>
     <td width="40%"><p><strong>src</strong></p></td>
     <td><p>The source URL of a stereo image. Must resolve to https. See notes above on what
-kind of image can be passed here.</p></td>
+  kind of image can be passed here.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>stereo</strong></p></td>
     <td><p>If specified, the image provided by the <code>src</code> attribute is considered to be a stereo
-image (see above), otherwise it's a mono image.</p></td>
+  image (see above), otherwise it's a mono image.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>yaw</strong></p></td>

--- a/extensions/amp-google-vrview-image/amp-google-vrview-image.md
+++ b/extensions/amp-google-vrview-image/amp-google-vrview-image.md
@@ -72,21 +72,21 @@ VR view supports mono and stereo 360 images. Note:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>The source URL of a stereo image. Must resolve to https. See notes above on what
-  kind of image can be passed here.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>The source URL of a stereo image. Must resolve to https. See notes above on what
+kind of image can be passed here.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>stereo</strong></p></td>
-    <td><p>If specified, the image provided by the <code>src</code> attribute is considered to be a stereo
-  image (see above), otherwise it's a mono image.</p></td>
+    <td width="40%"><strong>stereo</strong></td>
+    <td>If specified, the image provided by the <code>src</code> attribute is considered to be a stereo
+image (see above), otherwise it's a mono image.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>yaw</strong></p></td>
-    <td><p>Initial yaw of viewer, in degrees. Defaults to 0.</p></td>
+    <td width="40%"><strong>yaw</strong></td>
+    <td>Initial yaw of viewer, in degrees. Defaults to 0.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>yaw-only</strong></p></td>
-    <td><p>Can be specified to restrict motion to yaw only.</p></td>
+    <td width="40%"><strong>yaw-only</strong></td>
+    <td>Can be specified to restrict motion to yaw only.</td>
   </tr>
 </table>

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -54,12 +54,12 @@ Displays a simple embedded <a href="http://www.hulu.com">Hulu</a> video.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-eid</strong></p></td>
-    <td><p>The ID of the video. For example, <code>4Dk5F2PYTtrgciuvloH3UA</code> is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.</p></td>
+    <td width="40%"><strong>data-eid</strong></td>
+    <td>The ID of the video. For example, <code>4Dk5F2PYTtrgciuvloH3UA</code> is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -54,12 +54,12 @@ Displays a simple embedded <a href="http://www.hulu.com">Hulu</a> video.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-eid</strong></td>
-    <td>The ID of the video. For example, `4Dk5F2PYTtrgciuvloH3UA` is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.</td>
+    <td width="40%"><p><strong>data-eid</strong></p></td>
+    <td><p>The ID of the video. For example, <code>4Dk5F2PYTtrgciuvloH3UA</code> is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -92,30 +92,30 @@ The reasons for this policy are that:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
-  source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
-  not already have a fragment.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
+source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+not already have a fragment.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>srcdoc, frameborder, allowfullscreen, allowpaymentrequest, allowtransparency, referrerpolicy</strong></p></td>
-    <td><p>These attributes should all behave like they do on standard iframes.
-  <br>
-  If <code>frameborder</code> is not specified, by default, it will be set to <code>0</code>.</p></td>
+    <td width="40%"><strong>srcdoc, frameborder, allowfullscreen, allowpaymentrequest, allowtransparency, referrerpolicy</strong></td>
+    <td>These attributes should all behave like they do on standard iframes.
+<br>
+If <code>frameborder</code> is not specified, by default, it will be set to <code>0</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>sandbox</strong></p></td>
-    <td><p>Iframes created by <code>amp-iframe</code> always have the <code>sandbox</code> attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed". By setting <code>sandbox</code> values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting <code>sandbox="allow-scripts"</code> allows the iframe to run JavaScript, or <code>sandbox="allow-scripts allow-same-origin"</code> allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
-  <br><br>
-  If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add <code>allow-scripts allow-same-origin</code> to the <code>sandbox</code> attribute and you might need to allow additional capabilities.
-  <br><br>
-  Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with <code>target=_blank</code> (add <code>allow-popups</code> to allow this to happen). Adding <code>allow-popups-to-escape-sandbox</code> to the <code>sandbox</code> attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, <code>allow-popups-to-escape-sandbox</code> is only supported by Chrome.
-  <br><br>
-  See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">docs on MDN</a> for further details on the sandbox attribute.</p></td>
+    <td width="40%"><strong>sandbox</strong></td>
+    <td>Iframes created by <code>amp-iframe</code> always have the <code>sandbox</code> attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed". By setting <code>sandbox</code> values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting <code>sandbox="allow-scripts"</code> allows the iframe to run JavaScript, or <code>sandbox="allow-scripts allow-same-origin"</code> allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
+<br><br>
+If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add <code>allow-scripts allow-same-origin</code> to the <code>sandbox</code> attribute and you might need to allow additional capabilities.
+<br><br>
+Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with <code>target=_blank</code> (add <code>allow-popups</code> to allow this to happen). Adding <code>allow-popups-to-escape-sandbox</code> to the <code>sandbox</code> attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, <code>allow-popups-to-escape-sandbox</code> is only supported by Chrome.
+<br><br>
+See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">docs on MDN</a> for further details on the sandbox attribute.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -92,30 +92,30 @@ The reasons for this policy are that:
 
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>The `src` attribute behaves mainly like on a standard iframe with one exception: the `#amp=1` fragment is added to the URL to allow
-    source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by `src` does
-    not already have a fragment.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
+source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+not already have a fragment.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>srcdoc, frameborder, allowfullscreen, allowpaymentrequest, allowtransparency, referrerpolicy</strong></td>
-    <td>These attributes should all behave like they do on standard iframes.
-    <br>
-    If `frameborder` is not specified, by default, it will be set to `0`.</td>
+    <td width="40%"><p><strong>srcdoc, frameborder, allowfullscreen, allowpaymentrequest, allowtransparency, referrerpolicy</strong></p></td>
+    <td><p>These attributes should all behave like they do on standard iframes.
+<br>
+If <code>frameborder</code> is not specified, by default, it will be set to <code>0</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>sandbox</strong></td>
-    <td>Iframes created by `amp-iframe` always have the `sandbox` attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed". By setting `sandbox` values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting `sandbox="allow-scripts"` allows the iframe to run JavaScript, or `sandbox="allow-scripts allow-same-origin"` allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
-    <br><br>
-    If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add `allow-scripts allow-same-origin` to the `sandbox` attribute and you might need to allow additional capabilities.
-    <br><br>
-    Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with `target=_blank` (add `allow-popups` to allow this to happen). Adding `allow-popups-to-escape-sandbox` to the `sandbox` attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, `allow-popups-to-escape-sandbox` is only supported by Chrome.
-    <br><br>
-    See the [docs on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) for further details on the sandbox attribute.</td>
+    <td width="40%"><p><strong>sandbox</strong></p></td>
+    <td><p>Iframes created by <code>amp-iframe</code> always have the <code>sandbox</code> attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed". By setting <code>sandbox</code> values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting <code>sandbox="allow-scripts"</code> allows the iframe to run JavaScript, or <code>sandbox="allow-scripts allow-same-origin"</code> allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
+<br><br>
+If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add <code>allow-scripts allow-same-origin</code> to the <code>sandbox</code> attribute and you might need to allow additional capabilities.
+<br><br>
+Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with <code>target=_blank</code> (add <code>allow-popups</code> to allow this to happen). Adding <code>allow-popups-to-escape-sandbox</code> to the <code>sandbox</code> attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, <code>allow-popups-to-escape-sandbox</code> is only supported by Chrome.
+<br><br>
+See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">docs on MDN</a> for further details on the sandbox attribute.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -94,24 +94,24 @@ The reasons for this policy are that:
   <tr>
     <td width="40%"><p><strong>src</strong></p></td>
     <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
-source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
-not already have a fragment.</p></td>
+  source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+  not already have a fragment.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>srcdoc, frameborder, allowfullscreen, allowpaymentrequest, allowtransparency, referrerpolicy</strong></p></td>
     <td><p>These attributes should all behave like they do on standard iframes.
-<br>
-If <code>frameborder</code> is not specified, by default, it will be set to <code>0</code>.</p></td>
+  <br>
+  If <code>frameborder</code> is not specified, by default, it will be set to <code>0</code>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>sandbox</strong></p></td>
     <td><p>Iframes created by <code>amp-iframe</code> always have the <code>sandbox</code> attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed". By setting <code>sandbox</code> values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting <code>sandbox="allow-scripts"</code> allows the iframe to run JavaScript, or <code>sandbox="allow-scripts allow-same-origin"</code> allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
-<br><br>
-If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add <code>allow-scripts allow-same-origin</code> to the <code>sandbox</code> attribute and you might need to allow additional capabilities.
-<br><br>
-Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with <code>target=_blank</code> (add <code>allow-popups</code> to allow this to happen). Adding <code>allow-popups-to-escape-sandbox</code> to the <code>sandbox</code> attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, <code>allow-popups-to-escape-sandbox</code> is only supported by Chrome.
-<br><br>
-See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">docs on MDN</a> for further details on the sandbox attribute.</p></td>
+  <br><br>
+  If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add <code>allow-scripts allow-same-origin</code> to the <code>sandbox</code> attribute and you might need to allow additional capabilities.
+  <br><br>
+  Note also, that the sandbox applies to all windows opened from a sandboxed iframe. This includes new windows created by a link with <code>target=_blank</code> (add <code>allow-popups</code> to allow this to happen). Adding <code>allow-popups-to-escape-sandbox</code> to the <code>sandbox</code> attribute, makes those new windows behave like non-sandboxed new windows. This is likely most of the time what you want and expect. Unfortunately, as of this writing, <code>allow-popups-to-escape-sandbox</code> is only supported by Chrome.
+  <br><br>
+  See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">docs on MDN</a> for further details on the sandbox attribute.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -89,7 +89,7 @@ The component HTML accepts the following types of HTML nodes as children:
   <tr>
     <td width="40%"><p><strong>data-poster (optional)</strong></p></td>
     <td><p>An image for the frame to be displayed before video playback has started. By
-default, the first frame is displayed.</p></td>
+  default, the first frame is displayed.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-delay-ad-request (optional)</strong></p></td>
@@ -97,13 +97,13 @@ default, the first frame is displayed.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-ad-label (optional)</strong></p></td>
-    <td><p>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3).  This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</p></td>
+    <td><p>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3). This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>
     <td><p>This element includes
-<a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a>
-extended to AMP components.</p></td>
+  <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a>
+  extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -79,31 +79,31 @@ The component HTML accepts the following types of HTML nodes as children:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-tag (required)</strong></td>
-    <td>The URL for your VAST ad document. A relative URL or a URL that uses https protocol.</td>
+    <td width="40%"><p><strong>data-tag (required)</strong></p></td>
+    <td><p>The URL for your VAST ad document. A relative URL or a URL that uses https protocol.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-src</strong></td>
-    <td>The URL of your video content. A relative URL or a URL that uses https protocol. This attribute is required if no `<source>` children are present.</td>
+    <td width="40%"><p><strong>data-src</strong></p></td>
+    <td><p>The URL of your video content. A relative URL or a URL that uses https protocol. This attribute is required if no <code>&lt;source&gt;</code> children are present.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-poster (optional)</strong></td>
-    <td>An image for the frame to be displayed before video playback has started. By
-    default, the first frame is displayed.</td>
+    <td width="40%"><p><strong>data-poster (optional)</strong></p></td>
+    <td><p>An image for the frame to be displayed before video playback has started. By
+default, the first frame is displayed.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-delay-ad-request (optional)</strong></td>
-    <td>If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.</td>
+    <td width="40%"><p><strong>data-delay-ad-request (optional)</strong></p></td>
+    <td><p>If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-ad-label (optional)</strong></td>
-    <td>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3).  This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</td>
+    <td width="40%"><p><strong>data-ad-label (optional)</strong></p></td>
+    <td><p>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3).  This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes
-    [common attributes](https://www.ampproject.org/docs/reference/common_attributes)
-    extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes
+<a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a>
+extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -79,31 +79,31 @@ The component HTML accepts the following types of HTML nodes as children:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-tag (required)</strong></p></td>
-    <td><p>The URL for your VAST ad document. A relative URL or a URL that uses https protocol.</p></td>
+    <td width="40%"><strong>data-tag (required)</strong></td>
+    <td>The URL for your VAST ad document. A relative URL or a URL that uses https protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-src</strong></p></td>
-    <td><p>The URL of your video content. A relative URL or a URL that uses https protocol. This attribute is required if no <code>&lt;source&gt;</code> children are present.</p></td>
+    <td width="40%"><strong>data-src</strong></td>
+    <td>The URL of your video content. A relative URL or a URL that uses https protocol. This attribute is required if no <code>&lt;source&gt;</code> children are present.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-poster (optional)</strong></p></td>
-    <td><p>An image for the frame to be displayed before video playback has started. By
-  default, the first frame is displayed.</p></td>
+    <td width="40%"><strong>data-poster (optional)</strong></td>
+    <td>An image for the frame to be displayed before video playback has started. By
+default, the first frame is displayed.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-delay-ad-request (optional)</strong></p></td>
-    <td><p>If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.</p></td>
+    <td width="40%"><strong>data-delay-ad-request (optional)</strong></td>
+    <td>If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-ad-label (optional)</strong></p></td>
-    <td><p>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3). This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</p></td>
+    <td width="40%"><strong>data-ad-label (optional)</strong></td>
+    <td>A format string that looks like "Ad (%s of %s)", used to generate the ad disclosure when an ad is playing. The "%s" in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3). This allows users to support ad disclosures in different languages. If no value is given, this defaults to "Ad (%s of %s)".</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes
-  <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a>
-  extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes
+<a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a>
+extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -126,16 +126,16 @@ Optionally, you can display captions at the bottom of the viewport for the image
 
 <table>
   <tr>
-    <td width="40%"><strong>layout (required)</strong></td>
-    <td>Must be set to `nodisplay`.</td>
+    <td width="40%"><p><strong>layout (required)</strong></p></td>
+    <td><p>Must be set to <code>nodisplay</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>id (required)</strong></td>
-    <td>The ID for the lightbox element that's used as a target for the image's `on` action.</td>
+    <td width="40%"><p><strong>id (required)</strong></p></td>
+    <td><p>The ID for the lightbox element that's used as a target for the image's <code>on</code> action.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-close-button-aria-label (optional)</strong></td>
-    <td>An ARIA label that you can use for a close button.</td>
+    <td width="40%"><p><strong>data-close-button-aria-label (optional)</strong></p></td>
+    <td><p>An ARIA label that you can use for a close button.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -126,16 +126,16 @@ Optionally, you can display captions at the bottom of the viewport for the image
 
 <table>
   <tr>
-    <td width="40%"><p><strong>layout (required)</strong></p></td>
-    <td><p>Must be set to <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout (required)</strong></td>
+    <td>Must be set to <code>nodisplay</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>id (required)</strong></p></td>
-    <td><p>The ID for the lightbox element that's used as a target for the image's <code>on</code> action.</p></td>
+    <td width="40%"><strong>id (required)</strong></td>
+    <td>The ID for the lightbox element that's used as a target for the image's <code>on</code> action.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-close-button-aria-label (optional)</strong></p></td>
-    <td><p>An ARIA label that you can use for a close button.</p></td>
+    <td width="40%"><strong>data-close-button-aria-label (optional)</strong></td>
+    <td>An ARIA label that you can use for a close button.</td>
   </tr>
 </table>
 

--- a/extensions/amp-imgur/amp-imgur.md
+++ b/extensions/amp-imgur/amp-imgur.md
@@ -56,20 +56,20 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-imgur-id (required)</strong></p></td>
-    <td><p>The ID of the Imgur post.</p></td>
+    <td width="40%"><strong>data-imgur-id (required)</strong></td>
+    <td>The ID of the Imgur post.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>width (required)</strong></p></td>
-    <td><p>The width of the Imgur post.</p></td>
+    <td width="40%"><strong>width (required)</strong></td>
+    <td>The width of the Imgur post.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>height (required)</strong></p></td>
-    <td><p>The height of the Imgur post.</p></td>
+    <td width="40%"><strong>height (required)</strong></td>
+    <td>The height of the Imgur post.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-imgur/amp-imgur.md
+++ b/extensions/amp-imgur/amp-imgur.md
@@ -56,20 +56,20 @@ Example:
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-imgur-id (required)</strong></td>
-    <td>The ID of the Imgur post.</td>
+    <td width="40%"><p><strong>data-imgur-id (required)</strong></p></td>
+    <td><p>The ID of the Imgur post.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>width (required)</strong></td>
-    <td>The width of the Imgur post.</td>
+    <td width="40%"><p><strong>width (required)</strong></p></td>
+    <td><p>The width of the Imgur post.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>height (required)</strong></td>
-    <td>The height of the Imgur post.</td>
+    <td width="40%"><p><strong>height (required)</strong></p></td>
+    <td><p>The height of the Imgur post.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -71,12 +71,12 @@ When using non-responsive layout you will need to account for the extra space ad
   <tr>
     <td width="40%"><p><strong>data-shortcode</strong></p></td>
     <td><p>The instagram data-shortcode is found in every instagram photo URL.
-<br>
-For example, in https://instagram.com/p/fBwFP, <code>fBwFP</code> is the data-shortcode.</p></td>
+  <br>
+  For example, in https://instagram.com/p/fBwFP, <code>fBwFP</code> is the data-shortcode.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-captioned</strong></p></td>
-    <td><p>Include the Instagram caption.  <code>amp-instagram</code> will attempt to resize to the correct height including the caption.</p></td>
+    <td><p>Include the Instagram caption. <code>amp-instagram</code> will attempt to resize to the correct height including the caption.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -69,18 +69,18 @@ When using non-responsive layout you will need to account for the extra space ad
 
 <table>
   <tr>
-    <td width="40%"><strong>data-shortcode</strong></td>
-    <td>The instagram data-shortcode is found in every instagram photo URL.
-    <br>
-    For example, in https://instagram.com/p/fBwFP, `fBwFP` is the data-shortcode.</td>
+    <td width="40%"><p><strong>data-shortcode</strong></p></td>
+    <td><p>The instagram data-shortcode is found in every instagram photo URL.
+<br>
+For example, in https://instagram.com/p/fBwFP, <code>fBwFP</code> is the data-shortcode.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-captioned</strong></td>
-    <td>Include the Instagram caption.  `amp-instagram` will attempt to resize to the correct height including the caption.</td>
+    <td width="40%"><p><strong>data-captioned</strong></p></td>
+    <td><p>Include the Instagram caption.  <code>amp-instagram</code> will attempt to resize to the correct height including the caption.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -69,18 +69,18 @@ When using non-responsive layout you will need to account for the extra space ad
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-shortcode</strong></p></td>
-    <td><p>The instagram data-shortcode is found in every instagram photo URL.
-  <br>
-  For example, in https://instagram.com/p/fBwFP, <code>fBwFP</code> is the data-shortcode.</p></td>
+    <td width="40%"><strong>data-shortcode</strong></td>
+    <td>The instagram data-shortcode is found in every instagram photo URL.
+<br>
+For example, in https://instagram.com/p/fBwFP, <code>fBwFP</code> is the data-shortcode.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-captioned</strong></p></td>
-    <td><p>Include the Instagram caption. <code>amp-instagram</code> will attempt to resize to the correct height including the caption.</p></td>
+    <td width="40%"><strong>data-captioned</strong></td>
+    <td>Include the Instagram caption. <code>amp-instagram</code> will attempt to resize to the correct height including the caption.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -86,10 +86,10 @@ Example:
      <td width="40%"><p><strong>data-no-service-worker-fallback-url-match</strong></p></td>
      <td><p>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
 <ul>
-<li>`amp.html`</li>
-<li>`.*amp`</li>
-<li>`.*\.amp\.html`</li>
-<li>`.*\/amp---
+  <li>`amp.html`</li>
+  <li>`.*amp`</li>
+  <li>`.*\.amp\.html`</li>
+  <li>`.*\/amp---
 $category@: dynamic-content
 formats:
   - websites

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -67,24 +67,24 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src (required)</strong></p></td>
-    <td><p>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>src (required)</strong></td>
+    <td>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-iframe-src (optional)</strong></p></td>
-    <td><p>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>data-iframe-src (optional)</strong></td>
+    <td>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-scope (optional)</strong></p></td>
-    <td><p>The scope of the service worker to be installed.</p></td>
+    <td width="40%"><strong>data-scope (optional)</strong></td>
+    <td>The scope of the service worker to be installed.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>layout</strong></p></td>
-    <td><p>Must have the value <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout</strong></td>
+    <td>Must have the value <code>nodisplay</code>.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>data-no-service-worker-fallback-url-match</strong></p></td>
-     <td><p>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
+     <td width="40%"><strong>data-no-service-worker-fallback-url-match</strong></td>
+     <td>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
 <ul>
   <li>`amp.html`</li>
   <li>`.*amp`</li>
@@ -158,29 +158,29 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src (required)</strong></p></td>
-    <td><p>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>src (required)</strong></td>
+    <td>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-iframe-src (optional)</strong></p></td>
-    <td><p>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</p></td>
+    <td width="40%"><strong>data-iframe-src (optional)</strong></td>
+    <td>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-scope (optional)</strong></p></td>
-    <td><p>The scope of the service worker to be installed.</p></td>
+    <td width="40%"><strong>data-scope (optional)</strong></td>
+    <td>The scope of the service worker to be installed.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>layout</strong></p></td>
-    <td><p>Must have the value <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout</strong></td>
+    <td>Must have the value <code>nodisplay</code>.</td>
   </tr>
   <tr>
-     <td width="40%"><p><strong>data-no-service-worker-fallback-url-match</strong></p></td>
+     <td width="40%"><strong>data-no-service-worker-fallback-url-match</strong></td>
      <td></li>
 </ul></td>
    </tr>
    <tr>
-     <td width="40%"><p><strong>data-no-service-worker-fallback-shell-url</strong></p></td>
-     <td><p>The URL to the shell to use to rewrite URL navigations for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be an URL on the same origin as the AMP document itself.</p></td>
+     <td width="40%"><strong>data-no-service-worker-fallback-shell-url</strong></td>
+     <td>The URL to the shell to use to rewrite URL navigations for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be an URL on the same origin as the AMP document itself.</td>
    </tr>
 </table>
 

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -84,99 +84,14 @@ Example:
   </tr>
   <tr>
      <td width="40%"><strong>data-no-service-worker-fallback-url-match</strong></td>
-     <td>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
-<ul>
-  <li>`amp.html`</li>
-  <li>`.*amp`</li>
-  <li>`.*\.amp\.html`</li>
-  <li>`.*\/amp---
-$category@: dynamic-content
-formats:
-  - websites
-  - stories
-teaser:
-  text: Installs a ServiceWorker.
----
-<!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
-# amp-install-serviceworker
-
-[TOC]
-
-<table>
-  <tr>
-    <td width="40%"><strong>Description</strong></td>
-    <td>Installs a <a href="https://developers.google.com/web/fundamentals/primers/service-worker/">ServiceWorker</a> for the current page.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js">&lt;/script></code></td>
-  </tr>
-  <tr>
-    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>nodisplay</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-install-serviceworker/">Annotated code example for amp-install-serviceworker</a></td>
-  </tr>
-</table>
-
-## Behavior
-
-Registers the service worker given by the `src` attribute if the AMP document is loaded from the same origin as the given service worker URL. If the `data-iframe-src` is set, loads that URL as an iframe when the AMP document is served from an AMP cache. This allows ServiceWorker installation from the AMP cache, so that the service worker is installed by the time users visit the origin site.
-
-This service worker runs whenever the AMP file is served from the origin where you publish the AMP file. On documents served from an AMP cache, the service worker will be installed in the background but will not execute or affect the page's behavior.
-
-See [this article](https://medium.com/@cramforce/amps-and-websites-in-the-age-of-the-service-worker-8369841dc962) for how ServiceWorkers can help with making the AMP experience awesome with ServiceWorkers.
-
-Example:
-
-```html
-<amp-install-serviceworker
-  src="https://www.your-domain.com/serviceworker.js"
-  data-iframe-src="https://www.your-domain.com/install-serviceworker.html"
-  layout="nodisplay">
-</amp-install-serviceworker>
-```
-
-## Attributes
-
-<table>
-  <tr>
-    <td width="40%"><strong>src (required)</strong></td>
-    <td>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-iframe-src (optional)</strong></td>
-    <td>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-scope (optional)</strong></td>
-    <td>The scope of the service worker to be installed.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>layout</strong></td>
-    <td>Must have the value <code>nodisplay</code>.</td>
-  </tr>
-  <tr>
-     <td width="40%"><strong>data-no-service-worker-fallback-url-match</strong></td>
-     <td></li>
-</ul></td>
+     <td><p>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
+      <ul>
+        <li><code>amp.html</code></li>
+        <li><code>.*amp</code></li>
+        <li><code>.*\.amp\.html</code></li>
+        <li><code>.*\/amp$</code></li>
+      </ul>
+    </td>
    </tr>
    <tr>
      <td width="40%"><strong>data-no-service-worker-fallback-shell-url</strong></td>

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -67,36 +67,120 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>src (required)</strong></td>
-    <td>The URL of the ServiceWorker to register, which must use `https` protocol.</td>
+    <td width="40%"><p><strong>src (required)</strong></p></td>
+    <td><p>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-iframe-src (optional)</strong></td>
-    <td>The URL of an HTML document that installs a ServiceWorker. The URL must use `https` protocol.</td>
+    <td width="40%"><p><strong>data-iframe-src (optional)</strong></p></td>
+    <td><p>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-scope (optional)</strong></td>
-    <td>The scope of the service worker to be installed.</td>
+    <td width="40%"><p><strong>data-scope (optional)</strong></p></td>
+    <td><p>The scope of the service worker to be installed.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>layout</strong></td>
-    <td>Must have the value `nodisplay`.</td>
+    <td width="40%"><p><strong>layout</strong></p></td>
+    <td><p>Must have the value <code>nodisplay</code>.</p></td>
   </tr>
   <tr>
-     <td width="40%"><strong>data-no-service-worker-fallback-url-match</strong></td>
-     <td>
-      The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See [Shell URL rewrite](#shell-url-rewrite) section for more details. The value must be a valid JavaScript RegExp string. For example:
-       <ul>
-           <li>`amp.html`</li>
-           <li>`.*amp`</li>
-           <li>`.*\.amp\.html`</li>
-           <li>`.*\/amp$`</li>
-       </ul>
-     </td>
+     <td width="40%"><p><strong>data-no-service-worker-fallback-url-match</strong></p></td>
+     <td><p>The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be a valid JavaScript RegExp string. For example:</p>
+<ul>
+<li>`amp.html`</li>
+<li>`.*amp`</li>
+<li>`.*\.amp\.html`</li>
+<li>`.*\/amp---
+$category@: dynamic-content
+formats:
+  - websites
+  - stories
+teaser:
+  text: Installs a ServiceWorker.
+---
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-install-serviceworker
+
+[TOC]
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Installs a <a href="https://developers.google.com/web/fundamentals/primers/service-worker/">ServiceWorker</a> for the current page.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>nodisplay</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-install-serviceworker/">Annotated code example for amp-install-serviceworker</a></td>
+  </tr>
+</table>
+
+## Behavior
+
+Registers the service worker given by the `src` attribute if the AMP document is loaded from the same origin as the given service worker URL. If the `data-iframe-src` is set, loads that URL as an iframe when the AMP document is served from an AMP cache. This allows ServiceWorker installation from the AMP cache, so that the service worker is installed by the time users visit the origin site.
+
+This service worker runs whenever the AMP file is served from the origin where you publish the AMP file. On documents served from an AMP cache, the service worker will be installed in the background but will not execute or affect the page's behavior.
+
+See [this article](https://medium.com/@cramforce/amps-and-websites-in-the-age-of-the-service-worker-8369841dc962) for how ServiceWorkers can help with making the AMP experience awesome with ServiceWorkers.
+
+Example:
+
+```html
+<amp-install-serviceworker
+  src="https://www.your-domain.com/serviceworker.js"
+  data-iframe-src="https://www.your-domain.com/install-serviceworker.html"
+  layout="nodisplay">
+</amp-install-serviceworker>
+```
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><p><strong>src (required)</strong></p></td>
+    <td><p>The URL of the ServiceWorker to register, which must use <code>https</code> protocol.</p></td>
+  </tr>
+  <tr>
+    <td width="40%"><p><strong>data-iframe-src (optional)</strong></p></td>
+    <td><p>The URL of an HTML document that installs a ServiceWorker. The URL must use <code>https</code> protocol.</p></td>
+  </tr>
+  <tr>
+    <td width="40%"><p><strong>data-scope (optional)</strong></p></td>
+    <td><p>The scope of the service worker to be installed.</p></td>
+  </tr>
+  <tr>
+    <td width="40%"><p><strong>layout</strong></p></td>
+    <td><p>Must have the value <code>nodisplay</code>.</p></td>
+  </tr>
+  <tr>
+     <td width="40%"><p><strong>data-no-service-worker-fallback-url-match</strong></p></td>
+     <td></li>
+</ul></td>
    </tr>
    <tr>
-     <td width="40%"><strong>data-no-service-worker-fallback-shell-url</strong></td>
-     <td>The URL to the shell to use to rewrite URL navigations for no-service-worker fallback. See [Shell URL rewrite](#shell-url-rewrite) section for more details. The value must be an URL on the same origin as the AMP document itself.</td>
+     <td width="40%"><p><strong>data-no-service-worker-fallback-shell-url</strong></p></td>
+     <td><p>The URL to the shell to use to rewrite URL navigations for no-service-worker fallback. See <a href="#shell-url-rewrite">Shell URL rewrite</a> section for more details. The value must be an URL on the same origin as the AMP document itself.</p></td>
    </tr>
 </table>
 

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -52,28 +52,28 @@ With responsive layout the width and height from the example should yield correc
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
-    <td><p>The ID of the Izlesene video, which can be found in the Izlesene video page URL. For example, in https://www.izlesene.com/video/yayin-yok/7221390, the video ID is <code>7221390</code>.</p></td>
+    <td width="40%"><strong>data-videoid (required)</strong></td>
+    <td>The ID of the Izlesene video, which can be found in the Izlesene video page URL. For example, in https://www.izlesene.com/video/yayin-yok/7221390, the video ID is <code>7221390</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-showrel (optional)</strong></p></td>
-    <td><p>This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.</p>
+    <td width="40%"><strong>data-param-showrel (optional)</strong></td>
+    <td>This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.</p>
 <ul>
   <li>Accepted values: `1` or `0`</li>
   <li>Default value: `1`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-showreplay (optional)</strong></p></td>
-    <td><p>This is an optional attribute that indicates whether to show the replay button at the end of the content.</p>
+    <td width="40%"><strong>data-param-showreplay (optional)</strong></td>
+    <td>This is an optional attribute that indicates whether to show the replay button at the end of the content.</p>
 <ul>
   <li>Accepted values: `1` or `0`</li>
   <li>Default value: `1`</li>
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -59,16 +59,16 @@ With responsive layout the width and height from the example should yield correc
     <td width="40%"><p><strong>data-param-showrel (optional)</strong></p></td>
     <td><p>This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.</p>
 <ul>
-<li>Accepted values: `1` or `0`</li>
-<li>Default value: `1`</li>
+  <li>Accepted values: `1` or `0`</li>
+  <li>Default value: `1`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-param-showreplay (optional)</strong></p></td>
     <td><p>This is an optional attribute that indicates whether to show the replay button at the end of the content.</p>
 <ul>
-<li>Accepted values: `1` or `0`</li>
-<li>Default value: `1`</li>
+  <li>Accepted values: `1` or `0`</li>
+  <li>Default value: `1`</li>
 </ul></td>
   </tr>
   <tr>

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -52,32 +52,28 @@ With responsive layout the width and height from the example should yield correc
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-videoid (required)</strong></td>
-    <td>The ID of the Izlesene video, which can be found in the Izlesene video page URL. For example, in https://www.izlesene.com/video/yayin-yok/7221390, the video ID is `7221390`.</td>
+    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
+    <td><p>The ID of the Izlesene video, which can be found in the Izlesene video page URL. For example, in https://www.izlesene.com/video/yayin-yok/7221390, the video ID is <code>7221390</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-showrel (optional)</strong></td>
-    <td>
-      This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.
-      <ul>
-          <li>Accepted values: `1` or `0`</li>
-          <li>Default value: `1`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-param-showrel (optional)</strong></p></td>
+    <td><p>This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.</p>
+<ul>
+<li>Accepted values: `1` or `0`</li>
+<li>Default value: `1`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-showreplay (optional)</strong></td>
-    <td>
-      This is an optional attribute that indicates whether to show the replay button at the end of the content.
-      <ul>
-          <li>Accepted values: `1` or `0`</li>
-          <li>Default value: `1`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-param-showreplay (optional)</strong></p></td>
+    <td><p>This is an optional attribute that indicates whether to show the replay button at the end of the content.</p>
+<ul>
+<li>Accepted values: `1` or `0`</li>
+<li>Default value: `1`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -82,7 +82,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><p><strong>data-playlist-id</strong></p></td>
-    <td><p>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content/playlists">Playlists</a> section in your JW Player Dashboard.  If both <code>data-playlist-id</code> and <code>data-media-id</code> are specified, <code>data-playlist-id</code> takes precedence.  (<strong>Required if <code>data-media-id</code> is not defined.</strong>)</p></td>
+    <td><p>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content/playlists">Playlists</a> section in your JW Player Dashboard. If both <code>data-playlist-id</code> and <code>data-media-id</code> are specified, <code>data-playlist-id</code> takes precedence. (<strong>Required if <code>data-media-id</code> is not defined.</strong>)</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -73,20 +73,20 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-player-id</strong></p></td>
-    <td><p>JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/players">Players</a> section in your JW Player Dashboard. (<strong>Required</strong>)</p></td>
+    <td width="40%"><strong>data-player-id</strong></td>
+    <td>JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/players">Players</a> section in your JW Player Dashboard. (<strong>Required</strong>)</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-media-id</strong></p></td>
-    <td><p>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content">Content</a> section in your JW Player Dashboard. (<strong>Required if <code>data-playlist-id</code> is not defined.</strong>)</p></td>
+    <td width="40%"><strong>data-media-id</strong></td>
+    <td>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content">Content</a> section in your JW Player Dashboard. (<strong>Required if <code>data-playlist-id</code> is not defined.</strong>)</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playlist-id</strong></p></td>
-    <td><p>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content/playlists">Playlists</a> section in your JW Player Dashboard. If both <code>data-playlist-id</code> and <code>data-media-id</code> are specified, <code>data-playlist-id</code> takes precedence. (<strong>Required if <code>data-media-id</code> is not defined.</strong>)</p></td>
+    <td width="40%"><strong>data-playlist-id</strong></td>
+    <td>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content/playlists">Playlists</a> section in your JW Player Dashboard. If both <code>data-playlist-id</code> and <code>data-media-id</code> are specified, <code>data-playlist-id</code> takes precedence. (<strong>Required if <code>data-media-id</code> is not defined.</strong>)</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -73,20 +73,20 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-player-id</strong></td>
-    <td>JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the [Players](https://dashboard.jwplayer.com/#/players) section in your JW Player Dashboard. (**Required**)</td>
+    <td width="40%"><p><strong>data-player-id</strong></p></td>
+    <td><p>JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/players">Players</a> section in your JW Player Dashboard. (<strong>Required</strong>)</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-media-id</strong></td>
-    <td>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the [Content](https://dashboard.jwplayer.com/#/content) section in your JW Player Dashboard. (**Required if `data-playlist-id` is not defined.**)</td>
+    <td width="40%"><p><strong>data-media-id</strong></p></td>
+    <td><p>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content">Content</a> section in your JW Player Dashboard. (<strong>Required if <code>data-playlist-id</code> is not defined.</strong>)</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playlist-id</strong></td>
-    <td>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the [Playlists](https://dashboard.jwplayer.com/#/content/playlists) section in your JW Player Dashboard.  If both `data-playlist-id` and `data-media-id` are specified, `data-playlist-id` takes precedence.  (**Required if `data-media-id` is not defined.**)</td>
+    <td width="40%"><p><strong>data-playlist-id</strong></p></td>
+    <td><p>The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content/playlists">Playlists</a> section in your JW Player Dashboard.  If both <code>data-playlist-id</code> and <code>data-media-id</code> are specified, <code>data-playlist-id</code> takes precedence.  (<strong>Required if <code>data-media-id</code> is not defined.</strong>)</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -62,31 +62,28 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-partner</strong></td>
-    <td>The Kaltura partner id. This attribute is mandatory.</td>
+    <td width="40%"><p><strong>data-partner</strong></p></td>
+    <td><p>The Kaltura partner id. This attribute is mandatory.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-uiconf</strong></td>
-    <td>The Kaltura player id - uiconf id.</td>
+    <td width="40%"><p><strong>data-uiconf</strong></p></td>
+    <td><p>The Kaltura player id - uiconf id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-entryid</strong></td>
-    <td>The Kaltura entry id.</td>
+    <td width="40%"><p><strong>data-entryid</strong></p></td>
+    <td><p>The Kaltura entry id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-\*</strong></td>
-    <td>
-      All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
-
-      Keys and values will be URI encoded. Keys will be camel cased.
-      <ul>
-          <li>`data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-param-*</strong></p></td>
+    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.</p>
+<p>Keys and values will be URI encoded. Keys will be camel cased.</p>
+<ul>
+<li>`data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -78,7 +78,7 @@ Example:
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
-<li>`data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`</li>
+  <li>`data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`</li>
 </ul></td>
   </tr>
   <tr>

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -62,19 +62,19 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-partner</strong></p></td>
-    <td><p>The Kaltura partner id. This attribute is mandatory.</p></td>
+    <td width="40%"><strong>data-partner</strong></td>
+    <td>The Kaltura partner id. This attribute is mandatory.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-uiconf</strong></p></td>
-    <td><p>The Kaltura player id - uiconf id.</p></td>
+    <td width="40%"><strong>data-uiconf</strong></td>
+    <td>The Kaltura player id - uiconf id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-entryid</strong></p></td>
-    <td><p>The Kaltura entry id.</p></td>
+    <td width="40%"><strong>data-entryid</strong></td>
+    <td>The Kaltura entry id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-*</strong></p></td>
+    <td width="40%"><strong>data-param-*</strong></td>
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
@@ -82,8 +82,8 @@ Example:
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -27,8 +27,8 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays elements in a full-viewport “lightbox” modal.</td>
-  </tr>
+    <td>Displays elements in a full-viewport “lightbox” modal.<p></td>
+</tr></p>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js">&lt;/script></code></td>
@@ -68,34 +68,33 @@ For showing images in a lightbox, there's also the [`<amp-image-lightbox>`](http
 
 <table>
   <tr>
-    <td width="40%"><strong>animate-in (optional)</strong></td>
-    <td>Defines the style of animation for opening the lightbox. By default, this will
-    be set to `fade-in`. Valid values are `fade-in`, `fly-in-bottom` and
-    `fly-in-top`.
-    <br><br>
-    **Note**: The `fly-in-*` animation presets modify the `transform` property of the
-    `amp-lightbox` element. Do not rely on transforming the `amp-lightbox` element
-    directly. If you need to apply a transform, set it on a nested element instead.
-    </td>
+    <td width="40%"><p><strong>animate-in (optional)</strong></p></td>
+    <td><p>Defines the style of animation for opening the lightbox. By default, this will
+be set to <code>fade-in</code>. Valid values are <code>fade-in</code>, <code>fly-in-bottom</code> and
+<code>fly-in-top</code>.
+<br><br>
+<strong>Note</strong>: The <code>fly-in-*</code> animation presets modify the <code>transform</code> property of the
+<code>amp-lightbox</code> element. Do not rely on transforming the <code>amp-lightbox</code> element
+directly. If you need to apply a transform, set it on a nested element instead.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>close-button (required on AMPHTML ads)</strong></td>
-    <td>Renders a close button header at the top of the lightbox. This attribute is only
-    required and valid for use with [AMPHTML Ads](#a4a).</td>
+    <td width="40%"><p><strong>close-button (required on AMPHTML ads)</strong></p></td>
+    <td><p>Renders a close button header at the top of the lightbox. This attribute is only
+required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>id (required)</strong></td>
-    <td>A unique identifer for the lightbox.</td>
+    <td width="40%"><p><strong>id (required)</strong></p></td>
+    <td><p>A unique identifer for the lightbox.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>layout (required)</strong></td>
-    <td>Must be set to `nodisplay`.</td>
+    <td width="40%"><p><strong>layout (required)</strong></p></td>
+    <td><p>Must be set to <code>nodisplay</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>scrollable (optional)</strong></td>
-    <td>When the `scrollable` attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
-    <br><br>
-    **Note**: The `scrollable` attribute is not allowed when using `<amp-lightbox>` inside an AMPHTML ad. For details, read the [Using amp-lightbox in AMPHTML ads](#a4a) section.</td>
+    <td width="40%"><p><p><strong>scrollable (optional)</strong></p></p></td>
+    <td><p>When the <code>scrollable</code> attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
+<br><br>
+<strong>Note</strong>: The <code>scrollable</code> attribute is not allowed when using <code>&lt;amp-lightbox&gt;</code> inside an AMPHTML ad. For details, read the <a href="#a4a">Using amp-lightbox in AMPHTML ads</a> section.</p></td>
   </tr>
   <tr>
     <td width="40%"><strong>scrollable (optional)</strong></td>

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -27,8 +27,10 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays elements in a full-viewport “lightbox” modal.<p></td>
-</tr></p>
+    <td>Displays elements in a full-viewport “lightbox” modal.<p>
+  </td>
+  </tr>
+</p>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js">&lt;/script></code></td>
@@ -70,17 +72,17 @@ For showing images in a lightbox, there's also the [`<amp-image-lightbox>`](http
   <tr>
     <td width="40%"><p><strong>animate-in (optional)</strong></p></td>
     <td><p>Defines the style of animation for opening the lightbox. By default, this will
-be set to <code>fade-in</code>. Valid values are <code>fade-in</code>, <code>fly-in-bottom</code> and
-<code>fly-in-top</code>.
-<br><br>
-<strong>Note</strong>: The <code>fly-in-*</code> animation presets modify the <code>transform</code> property of the
-<code>amp-lightbox</code> element. Do not rely on transforming the <code>amp-lightbox</code> element
-directly. If you need to apply a transform, set it on a nested element instead.</p></td>
+  be set to <code>fade-in</code>. Valid values are <code>fade-in</code>, <code>fly-in-bottom</code> and
+  <code>fly-in-top</code>.
+  <br><br>
+  <strong>Note</strong>: The <code>fly-in-*</code> animation presets modify the <code>transform</code> property of the
+  <code>amp-lightbox</code> element. Do not rely on transforming the <code>amp-lightbox</code> element
+  directly. If you need to apply a transform, set it on a nested element instead.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>close-button (required on AMPHTML ads)</strong></p></td>
     <td><p>Renders a close button header at the top of the lightbox. This attribute is only
-required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</p></td>
+  required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>id (required)</strong></p></td>
@@ -93,8 +95,8 @@ required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</p></td>
   <tr>
     <td width="40%"><p><p><strong>scrollable (optional)</strong></p></p></td>
     <td><p>When the <code>scrollable</code> attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
-<br><br>
-<strong>Note</strong>: The <code>scrollable</code> attribute is not allowed when using <code>&lt;amp-lightbox&gt;</code> inside an AMPHTML ad. For details, read the <a href="#a4a">Using amp-lightbox in AMPHTML ads</a> section.</p></td>
+  <br><br>
+  <strong>Note</strong>: The <code>scrollable</code> attribute is not allowed when using <code>&lt;amp-lightbox&gt;</code> inside an AMPHTML ad. For details, read the <a href="#a4a">Using amp-lightbox in AMPHTML ads</a> section.</p></td>
   </tr>
   <tr>
     <td width="40%"><strong>scrollable (optional)</strong></td>

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -27,10 +27,8 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays elements in a full-viewport “lightbox” modal.<p>
-  </td>
-  </tr>
-</p>
+    <td>Displays elements in a full-viewport “lightbox” modal.</td>
+</tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js">&lt;/script></code></td>
@@ -70,33 +68,33 @@ For showing images in a lightbox, there's also the [`<amp-image-lightbox>`](http
 
 <table>
   <tr>
-    <td width="40%"><p><strong>animate-in (optional)</strong></p></td>
-    <td><p>Defines the style of animation for opening the lightbox. By default, this will
-  be set to <code>fade-in</code>. Valid values are <code>fade-in</code>, <code>fly-in-bottom</code> and
-  <code>fly-in-top</code>.
-  <br><br>
-  <strong>Note</strong>: The <code>fly-in-*</code> animation presets modify the <code>transform</code> property of the
-  <code>amp-lightbox</code> element. Do not rely on transforming the <code>amp-lightbox</code> element
-  directly. If you need to apply a transform, set it on a nested element instead.</p></td>
+    <td width="40%"><strong>animate-in (optional)</strong></td>
+    <td>Defines the style of animation for opening the lightbox. By default, this will
+be set to <code>fade-in</code>. Valid values are <code>fade-in</code>, <code>fly-in-bottom</code> and
+<code>fly-in-top</code>.
+<br><br>
+<strong>Note</strong>: The <code>fly-in-*</code> animation presets modify the <code>transform</code> property of the
+<code>amp-lightbox</code> element. Do not rely on transforming the <code>amp-lightbox</code> element
+directly. If you need to apply a transform, set it on a nested element instead.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>close-button (required on AMPHTML ads)</strong></p></td>
-    <td><p>Renders a close button header at the top of the lightbox. This attribute is only
-  required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</p></td>
+    <td width="40%"><strong>close-button (required on AMPHTML ads)</strong></td>
+    <td>Renders a close button header at the top of the lightbox. This attribute is only
+required and valid for use with <a href="#a4a">AMPHTML Ads</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>id (required)</strong></p></td>
-    <td><p>A unique identifer for the lightbox.</p></td>
+    <td width="40%"><strong>id (required)</strong></td>
+    <td>A unique identifer for the lightbox.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>layout (required)</strong></p></td>
-    <td><p>Must be set to <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout (required)</strong></td>
+    <td>Must be set to <code>nodisplay</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><p><strong>scrollable (optional)</strong></p></p></td>
-    <td><p>When the <code>scrollable</code> attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
-  <br><br>
-  <strong>Note</strong>: The <code>scrollable</code> attribute is not allowed when using <code>&lt;amp-lightbox&gt;</code> inside an AMPHTML ad. For details, read the <a href="#a4a">Using amp-lightbox in AMPHTML ads</a> section.</p></td>
+    <td width="40%"><strong>scrollable (optional)</strong></td>
+    <td>When the <code>scrollable</code> attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
+<br><br>
+<strong>Note</strong>: The <code>scrollable</code> attribute is not allowed when using <code>&lt;amp-lightbox&gt;</code> inside an AMPHTML ad. For details, read the <a href="#a4a">Using amp-lightbox in AMPHTML ads</a> section.</td>
   </tr>
   <tr>
     <td width="40%"><strong>scrollable (optional)</strong></td>

--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -146,15 +146,15 @@ selectors will be set to `display: none` in all child documents.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>The URL of the remote endpoint that returns the JSON that will be used to
-    configure this `amp-next-page` component. This must be a CORS HTTP service.
-    The URL's protocol must be HTTPS.
-    <br><br>
-    {% call callout('Important', type='caution') %} Your endpoint must implement
-    the requirements specified in the CORS Requests in AMP spec. {% endcall %}
-    <br><br>
-    The `src` attribute is required unless a config has been specified inline.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>The URL of the remote endpoint that returns the JSON that will be used to
+configure this <code>amp-next-page</code> component. This must be a CORS HTTP service.
+The URL's protocol must be HTTPS.
+<br><br>
+{% call callout('Important', type='caution') %} Your endpoint must implement
+the requirements specified in the CORS Requests in AMP spec. {% endcall %}
+<br><br>
+The <code>src</code> attribute is required unless a config has been specified inline.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -146,15 +146,15 @@ selectors will be set to `display: none` in all child documents.
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>The URL of the remote endpoint that returns the JSON that will be used to
-  configure this <code>amp-next-page</code> component. This must be a CORS HTTP service.
-  The URL's protocol must be HTTPS.
-  <br><br>
-  {% call callout('Important', type='caution') %} Your endpoint must implement
-  the requirements specified in the CORS Requests in AMP spec. {% endcall %}
-  <br><br>
-  The <code>src</code> attribute is required unless a config has been specified inline.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>The URL of the remote endpoint that returns the JSON that will be used to
+configure this <code>amp-next-page</code> component. This must be a CORS HTTP service.
+The URL's protocol must be HTTPS.
+<br><br>
+{% call callout('Important', type='caution') %} Your endpoint must implement
+the requirements specified in the CORS Requests in AMP spec. {% endcall %}
+<br><br>
+The <code>src</code> attribute is required unless a config has been specified inline.</td>
   </tr>
 </table>
 

--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -148,13 +148,13 @@ selectors will be set to `display: none` in all child documents.
   <tr>
     <td width="40%"><p><strong>src</strong></p></td>
     <td><p>The URL of the remote endpoint that returns the JSON that will be used to
-configure this <code>amp-next-page</code> component. This must be a CORS HTTP service.
-The URL's protocol must be HTTPS.
-<br><br>
-{% call callout('Important', type='caution') %} Your endpoint must implement
-the requirements specified in the CORS Requests in AMP spec. {% endcall %}
-<br><br>
-The <code>src</code> attribute is required unless a config has been specified inline.</p></td>
+  configure this <code>amp-next-page</code> component. This must be a CORS HTTP service.
+  The URL's protocol must be HTTPS.
+  <br><br>
+  {% call callout('Important', type='caution') %} Your endpoint must implement
+  the requirements specified in the CORS Requests in AMP spec. {% endcall %}
+  <br><br>
+  The <code>src</code> attribute is required unless a config has been specified inline.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -60,16 +60,16 @@ With the responsive layout, the width and height from the example should yield c
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-mediaid (required)</strong></p></td>
-    <td><p>Represents the ID of the media you want to play.</p></td>
+    <td width="40%"><strong>data-mediaid (required)</strong></td>
+    <td>Represents the ID of the media you want to play.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-client (required)</strong></p></td>
-    <td><p>Your domain ID.</p></td>
+    <td width="40%"><strong>data-client (required)</strong></td>
+    <td>Your domain ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-streamtype (optional)</strong></p></td>
-    <td><p>Indicates the media streaming type, which can be one of the following:</p>
+    <td width="40%"><strong>data-streamtype (optional)</strong></td>
+    <td>Indicates the media streaming type, which can be one of the following:</p>
 <ul>
   <li>`video` (default)</li>
   <li>`audio`</li>
@@ -80,28 +80,28 @@ With the responsive layout, the width and height from the example should yield c
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-seek-to (optional)</strong></p></td>
-    <td><p>Indicates the starting point of your media (in seconds). For example, video starting 1:30min.</p></td>
+    <td width="40%"><strong>data-seek-to (optional)</strong></td>
+    <td>Indicates the starting point of your media (in seconds). For example, video starting 1:30min.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-mode (optional)</strong></p></td>
-    <td><p>Indicates the data mode, which can be <code>static</code> (default) or <code>api</code>.</p></td>
+    <td width="40%"><strong>data-mode (optional)</strong></td>
+    <td>Indicates the data mode, which can be <code>static</code> (default) or <code>api</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-origin (optional)</strong></p></td>
-    <td><p>Indicates the source from which the embedded domain media is played. By default this is set to <code>https://embed.nexx.cloud/</code>.</p></td>
+    <td width="40%"><strong>data-origin (optional)</strong></td>
+    <td>Indicates the source from which the embedded domain media is played. By default this is set to <code>https://embed.nexx.cloud/</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-disable-ads (optional)</strong></p></td>
-    <td><p>Ads are enabled by default. Set value to 1 to disable.</p></td>
+    <td width="40%"><strong>data-disable-ads (optional)</strong></td>
+    <td>Ads are enabled by default. Set value to 1 to disable.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-streaming-filter (optional)</strong></p></td>
-    <td><p>Set streaming filter e.g. "nxp-bitrate-0750" for max 750kbit max bitrate.</p></td>
+    <td width="40%"><strong>data-streaming-filter (optional)</strong></td>
+    <td>Set streaming filter e.g. "nxp-bitrate-0750" for max 750kbit max bitrate.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -69,7 +69,7 @@ With the responsive layout, the width and height from the example should yield c
   </tr>
   <tr>
     <td width="40%"><strong>data-streamtype (optional)</strong></td>
-    <td>Indicates the media streaming type, which can be one of the following:</p>
+    <td><p>Indicates the media streaming type, which can be one of the following:</p>
 <ul>
   <li>`video` (default)</li>
   <li>`audio`</li>

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -71,17 +71,17 @@ With the responsive layout, the width and height from the example should yield c
     <td width="40%"><p><strong>data-streamtype (optional)</strong></p></td>
     <td><p>Indicates the media streaming type, which can be one of the following:</p>
 <ul>
-<li>`video` (default)</li>
-<li>`audio`</li>
-<li>`playlist`</li>
-<li>`playlist-masked`: A playlist without the option to skip or choose video.</li>
-<li>`live`</li>
-<li>`album`: An audio playlist.</li>
+  <li>`video` (default)</li>
+  <li>`audio`</li>
+  <li>`playlist`</li>
+  <li>`playlist-masked`: A playlist without the option to skip or choose video.</li>
+  <li>`live`</li>
+  <li>`album`: An audio playlist.</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-seek-to (optional)</strong></p></td>
-    <td><p>Indicates the starting point of your media (in seconds).  For example, video starting 1:30min.</p></td>
+    <td><p>Indicates the starting point of your media (in seconds). For example, video starting 1:30min.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-mode (optional)</strong></p></td>

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -60,50 +60,48 @@ With the responsive layout, the width and height from the example should yield c
 
 <table>
   <tr>
-    <td width="40%"><strong>data-mediaid (required)</strong></td>
-    <td>Represents the ID of the media you want to play.</td>
+    <td width="40%"><p><strong>data-mediaid (required)</strong></p></td>
+    <td><p>Represents the ID of the media you want to play.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-client (required)</strong></td>
-    <td>Your domain ID.</td>
+    <td width="40%"><p><strong>data-client (required)</strong></p></td>
+    <td><p>Your domain ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-streamtype (optional)</strong></td>
-    <td>
-      Indicates the media streaming type, which can be one of the following:
-      <ul>
-          <li>`video` (default)</li>
-          <li>`audio`</li>
-          <li>`playlist`</li>
-          <li>`playlist-masked`: A playlist without the option to skip or choose video.</li>
-          <li>`live`</li>
-          <li>`album`: An audio playlist.</li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>data-streamtype (optional)</strong></p></td>
+    <td><p>Indicates the media streaming type, which can be one of the following:</p>
+<ul>
+<li>`video` (default)</li>
+<li>`audio`</li>
+<li>`playlist`</li>
+<li>`playlist-masked`: A playlist without the option to skip or choose video.</li>
+<li>`live`</li>
+<li>`album`: An audio playlist.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-seek-to (optional)</strong></td>
-    <td>Indicates the starting point of your media (in seconds).  For example, video starting 1:30min.</td>
+    <td width="40%"><p><strong>data-seek-to (optional)</strong></p></td>
+    <td><p>Indicates the starting point of your media (in seconds).  For example, video starting 1:30min.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-mode (optional)</strong></td>
-    <td>Indicates the data mode, which can be `static` (default) or `api`.</td>
+    <td width="40%"><p><strong>data-mode (optional)</strong></p></td>
+    <td><p>Indicates the data mode, which can be <code>static</code> (default) or <code>api</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-origin (optional)</strong></td>
-    <td>Indicates the source from which the embedded domain media is played. By default this is set to `https://embed.nexx.cloud/`.</td>
+    <td width="40%"><p><strong>data-origin (optional)</strong></p></td>
+    <td><p>Indicates the source from which the embedded domain media is played. By default this is set to <code>https://embed.nexx.cloud/</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-disable-ads (optional)</strong></td>
-    <td>Ads are enabled by default. Set value to 1 to disable.</td>
+    <td width="40%"><p><strong>data-disable-ads (optional)</strong></p></td>
+    <td><p>Ads are enabled by default. Set value to 1 to disable.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-streaming-filter (optional)</strong></td>
-    <td>Set streaming filter e.g. "nxp-bitrate-0750" for max 750kbit max bitrate.</td>
+    <td width="40%"><p><strong>data-streaming-filter (optional)</strong></p></td>
+    <td><p>Set streaming filter e.g. "nxp-bitrate-0750" for max 750kbit max bitrate.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-o2-player/amp-o2-player.md
+++ b/extensions/amp-o2-player/amp-o2-player.md
@@ -63,28 +63,28 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-pid (required)</strong></p></td>
-    <td><p>The Player ID for the O2Player.</p></td>
+    <td width="40%"><strong>data-pid (required)</strong></td>
+    <td>The Player ID for the O2Player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-bcid (required)</strong></p></td>
-    <td><p>The Buyer Company ID (bcid) for the O2Player.</p></td>
+    <td width="40%"><strong>data-bcid (required)</strong></td>
+    <td>The Buyer Company ID (bcid) for the O2Player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-bid</strong></p></td>
-    <td><p>The Playlist ID (bid) for the O2Player.</p></td>
+    <td width="40%"><strong>data-bid</strong></td>
+    <td>The Playlist ID (bid) for the O2Player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-vid</strong></p></td>
-    <td><p>The Video ID (vid) for the O2Player.</p></td>
+    <td width="40%"><strong>data-vid</strong></td>
+    <td>The Video ID (vid) for the O2Player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-macros</strong></p></td>
-    <td><p>The macros for the O2Player.</p></td>
+    <td width="40%"><strong>data-macros</strong></td>
+    <td>The macros for the O2Player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-o2-player/amp-o2-player.md
+++ b/extensions/amp-o2-player/amp-o2-player.md
@@ -63,28 +63,28 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-pid (required)</strong></td>
-    <td>The Player ID for the O2Player.</td>
+    <td width="40%"><p><strong>data-pid (required)</strong></p></td>
+    <td><p>The Player ID for the O2Player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-bcid (required)</strong></td>
-    <td>The Buyer Company ID (bcid) for the O2Player.</td>
+    <td width="40%"><p><strong>data-bcid (required)</strong></p></td>
+    <td><p>The Buyer Company ID (bcid) for the O2Player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-bid</strong></td>
-    <td>The Playlist ID (bid) for the O2Player.</td>
+    <td width="40%"><p><strong>data-bid</strong></p></td>
+    <td><p>The Playlist ID (bid) for the O2Player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-vid</strong></td>
-    <td>The Video ID (vid) for the O2Player.</td>
+    <td width="40%"><p><strong>data-vid</strong></p></td>
+    <td><p>The Video ID (vid) for the O2Player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-macros</strong></td>
-    <td>The macros for the O2Player.</td>
+    <td width="40%"><p><strong>data-macros</strong></p></td>
+    <td><p>The macros for the O2Player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -52,28 +52,28 @@ Displays an <a href="https://www.ooyala.com/">Ooyala</a> video.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-embedcode (required)</strong></p></td>
-    <td><p>The video embed code from <a href="https://backlot.ooyala.com">Backlot</a>.</p></td>
+    <td width="40%"><strong>data-embedcode (required)</strong></td>
+    <td>The video embed code from <a href="https://backlot.ooyala.com">Backlot</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playerid (required)</strong></p></td>
-    <td><p>The ID of the player to load from <a href="https://backlot.ooyala.com">Backlot</a>.</p></td>
+    <td width="40%"><strong>data-playerid (required)</strong></td>
+    <td>The ID of the player to load from <a href="https://backlot.ooyala.com">Backlot</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-pcode (required)</strong></p></td>
-    <td><p>The provider code for the account owning the embed code and player.</p></td>
+    <td width="40%"><strong>data-pcode (required)</strong></td>
+    <td>The provider code for the account owning the embed code and player.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playerversion (optional)</strong></p></td>
-    <td><p>Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.</p></td>
+    <td width="40%"><strong>data-playerversion (optional)</strong></td>
+    <td>Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-config (optional)</strong></p></td>
-    <td><p>Specifies a skin.json config file URL for player V4.</p></td>
+    <td width="40%"><strong>data-config (optional)</strong></td>
+    <td>Specifies a skin.json config file URL for player V4.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -52,28 +52,28 @@ Displays an <a href="https://www.ooyala.com/">Ooyala</a> video.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-embedcode (required)</strong></td>
-    <td>The video embed code from [Backlot](https://backlot.ooyala.com).</td>
+    <td width="40%"><p><strong>data-embedcode (required)</strong></p></td>
+    <td><p>The video embed code from <a href="https://backlot.ooyala.com">Backlot</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playerid (required)</strong></td>
-    <td>The ID of the player to load from [Backlot](https://backlot.ooyala.com).</td>
+    <td width="40%"><p><strong>data-playerid (required)</strong></p></td>
+    <td><p>The ID of the player to load from <a href="https://backlot.ooyala.com">Backlot</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-pcode (required)</strong></td>
-    <td>The provider code for the account owning the embed code and player.</td>
+    <td width="40%"><p><strong>data-pcode (required)</strong></p></td>
+    <td><p>The provider code for the account owning the embed code and player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playerversion (optional)</strong></td>
-    <td>Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.</td>
+    <td width="40%"><p><strong>data-playerversion (optional)</strong></p></td>
+    <td><p>Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-config (optional)</strong></td>
-    <td>Specifies a skin.json config file URL for player V4.</td>
+    <td width="40%"><p><strong>data-config (optional)</strong></p></td>
+    <td><p>Specifies a skin.json config file URL for player V4.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -62,28 +62,28 @@ The `<amp-pan-zoom>` component takes one child of arbitrary content and enables 
 
 <table>
   <tr>
-    <td width="40%"><strong>max-scale (optional)</strong></td>
-    <td>Specifies a max zoom scale, which should be a positive number from 1 - 9.  The default value is 3.</td>
+    <td width="40%"><p><strong>max-scale (optional)</strong></p></td>
+    <td><p>Specifies a max zoom scale, which should be a positive number from 1 - 9.  The default value is 3.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>initial-scale (optional)</strong></td>
-    <td>Specifies a default zoom scale, which should be a positive number from 1 - 9. The default value is 1.</td>
+    <td width="40%"><p><strong>initial-scale (optional)</strong></p></td>
+    <td><p>Specifies a default zoom scale, which should be a positive number from 1 - 9. The default value is 1.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>initial-x, initial-y (optional)</strong></td>
-    <td>Specifies default translation coordinates, otherwise both are set to 0. The value is expected to be a whole number.</td>
+    <td width="40%"><p><strong>initial-x, initial-y (optional)</strong></p></td>
+    <td><p>Specifies default translation coordinates, otherwise both are set to 0. The value is expected to be a whole number.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>reset-on-resize (optional)</strong></td>
-    <td>Refers to the ability to center  the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</td>
+    <td width="40%"><p><strong>reset-on-resize (optional)</strong></p></td>
+    <td><p>Refers to the ability to center  the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>controls (optional)</strong></td>
-    <td>Shows default controls (zoom in / zoom out button) which can be customized via public CSS classes.</td>
+    <td width="40%"><p><strong>controls (optional)</strong></p></td>
+    <td><p>Shows default controls (zoom in / zoom out button) which can be customized via public CSS classes.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -63,7 +63,7 @@ The `<amp-pan-zoom>` component takes one child of arbitrary content and enables 
 <table>
   <tr>
     <td width="40%"><p><strong>max-scale (optional)</strong></p></td>
-    <td><p>Specifies a max zoom scale, which should be a positive number from 1 - 9.  The default value is 3.</p></td>
+    <td><p>Specifies a max zoom scale, which should be a positive number from 1 - 9. The default value is 3.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>initial-scale (optional)</strong></p></td>
@@ -75,7 +75,7 @@ The `<amp-pan-zoom>` component takes one child of arbitrary content and enables 
   </tr>
   <tr>
     <td width="40%"><p><strong>reset-on-resize (optional)</strong></p></td>
-    <td><p>Refers to the ability to center  the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</p></td>
+    <td><p>Refers to the ability to center the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>controls (optional)</strong></p></td>

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -62,28 +62,28 @@ The `<amp-pan-zoom>` component takes one child of arbitrary content and enables 
 
 <table>
   <tr>
-    <td width="40%"><p><strong>max-scale (optional)</strong></p></td>
-    <td><p>Specifies a max zoom scale, which should be a positive number from 1 - 9. The default value is 3.</p></td>
+    <td width="40%"><strong>max-scale (optional)</strong></td>
+    <td>Specifies a max zoom scale, which should be a positive number from 1 - 9. The default value is 3.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>initial-scale (optional)</strong></p></td>
-    <td><p>Specifies a default zoom scale, which should be a positive number from 1 - 9. The default value is 1.</p></td>
+    <td width="40%"><strong>initial-scale (optional)</strong></td>
+    <td>Specifies a default zoom scale, which should be a positive number from 1 - 9. The default value is 1.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>initial-x, initial-y (optional)</strong></p></td>
-    <td><p>Specifies default translation coordinates, otherwise both are set to 0. The value is expected to be a whole number.</p></td>
+    <td width="40%"><strong>initial-x, initial-y (optional)</strong></td>
+    <td>Specifies default translation coordinates, otherwise both are set to 0. The value is expected to be a whole number.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>reset-on-resize (optional)</strong></p></td>
-    <td><p>Refers to the ability to center the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</p></td>
+    <td width="40%"><strong>reset-on-resize (optional)</strong></td>
+    <td>Refers to the ability to center the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>controls (optional)</strong></p></td>
-    <td><p>Shows default controls (zoom in / zoom out button) which can be customized via public CSS classes.</p></td>
+    <td width="40%"><strong>controls (optional)</strong></td>
+    <td>Shows default controls (zoom in / zoom out button) which can be customized via public CSS classes.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -202,7 +202,7 @@ as clock becomes less than 50% visible.
   </tr>
   <tr>
     <td width="40%"><strong>intersection-ratios (optional)</strong></td>
-    <td><p>Defines how much of the target should be visible in the viewport before <code>&lt;amp-position-observer&gt;</code> triggers any of its events. The value is a number between 0 and 1 (default is 0).<br></p>
+    <td><p>Defines how much of the target should be visible in the viewport before <code>&lt;amp-position-observer&gt;</code> triggers any of its events. The value is a number between 0 and 1 (default is 0).</p>
 <p>You can specify different ratios for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
 <ul>
   <li>`intersection-ratios="0"` means `enter` is triggered as soon as a single pixel of the target comes into viewport and `exit` is triggered as soon as the very last pixel of the target goes out of the viewport.
@@ -217,7 +217,7 @@ as clock becomes less than 50% visible.
   </tr>
   <tr>
     <td width="40%"><strong>viewport-margins (optional)</strong></td>
-    <td><p>A <code>px</code> or <code>vh</code> value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed <code>px</code>. Defaults to 0.<br></p>
+    <td><p>A <code>px</code> or <code>vh</code> value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed <code>px</code>. Defaults to 0.</p>
 <p>You can specify different values for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
 <ul>
   <li>`viewport-margins="100px"` means shrink the viewport by 100px from the top and 100px from the bottom.

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -197,38 +197,32 @@ as clock becomes less than 50% visible.
 
 <table>
   <tr>
-    <td width="40%"><strong>target (optional)</strong></td>
-    <td>Specifies the ID of the element to observe. If **not specified**, the **parent** of `<amp-position-observer>` is used as the target.</td>
+    <td width="40%"><p><strong>target (optional)</strong></p></td>
+    <td><p>Specifies the ID of the element to observe. If <strong>not specified</strong>, the <strong>parent</strong> of <code>&lt;amp-position-observer&gt;</code> is used as the target.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>intersection-ratios (optional)</strong></td>
-    <td>Defines how much of the target should be visible in the viewport before `<amp-position-observer>` triggers any of its events. The value is a number between 0 and 1 (default is 0).<br>
-
-    You can specify different ratios for top vs. bottom by providing two values (`<top> <bottom>`).<br>
-
-    <ul>
-    <li>`intersection-ratios="0"` means `enter` is triggered as soon as a single pixel of the target comes into viewport and `exit` is triggered as soon as the very last pixel of the target goes out of the viewport.
-    </li><li>`intersection-ratios="0.5"` means `enter` is triggered as soon as 50% of the target comes into viewport and `exit` is triggered as soon as less than 50% of the target is in the viewport.
-    </li><li>`intersection-ratios="1"` means `enter` is triggered when target is fully visible and `exit` is triggered as soon as a single pixel goes out of the viewport.
-    </li><li>`intersection-ratios="0 1"` makes the conditions different depending on whether the target is entering/exiting from top (0 will be used) or bottom (1 will be used).
-    </li></ul>
-    </td>
+    <td width="40%"><p><strong>intersection-ratios (optional)</strong></p></td>
+    <td><p>Defines how much of the target should be visible in the viewport before <code>&lt;amp-position-observer&gt;</code> triggers any of its events. The value is a number between 0 and 1 (default is 0).<br></p>
+<p>You can specify different ratios for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
+<ul>
+<li>`intersection-ratios="0"` means `enter` is triggered as soon as a single pixel of the target comes into viewport and `exit` is triggered as soon as the very last pixel of the target goes out of the viewport.
+</li><li>`intersection-ratios="0.5"` means `enter` is triggered as soon as 50% of the target comes into viewport and `exit` is triggered as soon as less than 50% of the target is in the viewport.
+</li><li>`intersection-ratios="1"` means `enter` is triggered when target is fully visible and `exit` is triggered as soon as a single pixel goes out of the viewport.
+</li><li>`intersection-ratios="0 1"` makes the conditions different depending on whether the target is entering/exiting from top (0 will be used) or bottom (1 will be used).
+</li></ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>viewport-margins (optional)</strong></td>
-    <td>A `px` or `vh` value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed `px`. Defaults to 0.<br>
-
-    You can specify different values for top vs. bottom by providing two values (`<top> <bottom>`).<br>
-
-    <ul><li>`viewport-margins="100px"` means shrink the viewport by 100px from the top and 100px from the bottom.
-    </li><li>`viewport-margins="25vh"` means shrink the viewport by 25% from the top and 25% from the bottom. Effectively only considering the middle 50% of the viewport.
-    </li><li>`viewport-margins="100px 10vh"` means shrink the viewport by 100px from the top and 10% from the bottom.
-    </li></ul>
-    </td>
+    <td width="40%"><p><strong>viewport-margins (optional)</strong></p></td>
+    <td><p>A <code>px</code> or <code>vh</code> value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed <code>px</code>. Defaults to 0.<br></p>
+<p>You can specify different values for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
+<ul><li>`viewport-margins="100px"` means shrink the viewport by 100px from the top and 100px from the bottom.
+</li><li>`viewport-margins="25vh"` means shrink the viewport by 25% from the top and 25% from the bottom. Effectively only considering the middle 50% of the viewport.
+</li><li>`viewport-margins="100px 10vh"` means shrink the viewport by 100px from the top and 10% from the bottom.
+</li></ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>once (optional)</strong></td>
-    <td>Only triggers the `enter` and `exit` events once. The `scroll` event will also only perform one iteration.</td>
+    <td width="40%"><p><strong>once (optional)</strong></p></td>
+    <td><p>Only triggers the <code>enter</code> and <code>exit</code> events once. The <code>scroll</code> event will also only perform one iteration.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -205,20 +205,28 @@ as clock becomes less than 50% visible.
     <td><p>Defines how much of the target should be visible in the viewport before <code>&lt;amp-position-observer&gt;</code> triggers any of its events. The value is a number between 0 and 1 (default is 0).<br></p>
 <p>You can specify different ratios for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
 <ul>
-<li>`intersection-ratios="0"` means `enter` is triggered as soon as a single pixel of the target comes into viewport and `exit` is triggered as soon as the very last pixel of the target goes out of the viewport.
-</li><li>`intersection-ratios="0.5"` means `enter` is triggered as soon as 50% of the target comes into viewport and `exit` is triggered as soon as less than 50% of the target is in the viewport.
-</li><li>`intersection-ratios="1"` means `enter` is triggered when target is fully visible and `exit` is triggered as soon as a single pixel goes out of the viewport.
-</li><li>`intersection-ratios="0 1"` makes the conditions different depending on whether the target is entering/exiting from top (0 will be used) or bottom (1 will be used).
-</li></ul></td>
+  <li>`intersection-ratios="0"` means `enter` is triggered as soon as a single pixel of the target comes into viewport and `exit` is triggered as soon as the very last pixel of the target goes out of the viewport.
+  </li>
+  <li>`intersection-ratios="0.5"` means `enter` is triggered as soon as 50% of the target comes into viewport and `exit` is triggered as soon as less than 50% of the target is in the viewport.
+  </li>
+  <li>`intersection-ratios="1"` means `enter` is triggered when target is fully visible and `exit` is triggered as soon as a single pixel goes out of the viewport.
+  </li>
+  <li>`intersection-ratios="0 1"` makes the conditions different depending on whether the target is entering/exiting from top (0 will be used) or bottom (1 will be used).
+  </li>
+</ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>viewport-margins (optional)</strong></p></td>
     <td><p>A <code>px</code> or <code>vh</code> value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed <code>px</code>. Defaults to 0.<br></p>
 <p>You can specify different values for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
-<ul><li>`viewport-margins="100px"` means shrink the viewport by 100px from the top and 100px from the bottom.
-</li><li>`viewport-margins="25vh"` means shrink the viewport by 25% from the top and 25% from the bottom. Effectively only considering the middle 50% of the viewport.
-</li><li>`viewport-margins="100px 10vh"` means shrink the viewport by 100px from the top and 10% from the bottom.
-</li></ul></td>
+<ul>
+  <li>`viewport-margins="100px"` means shrink the viewport by 100px from the top and 100px from the bottom.
+  </li>
+  <li>`viewport-margins="25vh"` means shrink the viewport by 25% from the top and 25% from the bottom. Effectively only considering the middle 50% of the viewport.
+  </li>
+  <li>`viewport-margins="100px 10vh"` means shrink the viewport by 100px from the top and 10% from the bottom.
+  </li>
+</ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>once (optional)</strong></p></td>

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -197,11 +197,11 @@ as clock becomes less than 50% visible.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>target (optional)</strong></p></td>
-    <td><p>Specifies the ID of the element to observe. If <strong>not specified</strong>, the <strong>parent</strong> of <code>&lt;amp-position-observer&gt;</code> is used as the target.</p></td>
+    <td width="40%"><strong>target (optional)</strong></td>
+    <td>Specifies the ID of the element to observe. If <strong>not specified</strong>, the <strong>parent</strong> of <code>&lt;amp-position-observer&gt;</code> is used as the target.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>intersection-ratios (optional)</strong></p></td>
+    <td width="40%"><strong>intersection-ratios (optional)</strong></td>
     <td><p>Defines how much of the target should be visible in the viewport before <code>&lt;amp-position-observer&gt;</code> triggers any of its events. The value is a number between 0 and 1 (default is 0).<br></p>
 <p>You can specify different ratios for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
 <ul>
@@ -216,7 +216,7 @@ as clock becomes less than 50% visible.
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>viewport-margins (optional)</strong></p></td>
+    <td width="40%"><strong>viewport-margins (optional)</strong></td>
     <td><p>A <code>px</code> or <code>vh</code> value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed <code>px</code>. Defaults to 0.<br></p>
 <p>You can specify different values for top vs. bottom by providing two values (<code>&lt;top&gt; &lt;bottom&gt;</code>).<br></p>
 <ul>
@@ -229,8 +229,8 @@ as clock becomes less than 50% visible.
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>once (optional)</strong></p></td>
-    <td><p>Only triggers the <code>enter</code> and <code>exit</code> events once. The <code>scroll</code> event will also only perform one iteration.</p></td>
+    <td width="40%"><strong>once (optional)</strong></td>
+    <td>Only triggers the <code>enter</code> and <code>exit</code> events once. The <code>scroll</code> event will also only perform one iteration.</td>
   </tr>
 </table>
 

--- a/extensions/amp-powr-player/amp-powr-player.md
+++ b/extensions/amp-powr-player/amp-powr-player.md
@@ -58,27 +58,27 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-account (required)</strong></p></td>
-    <td><p>The Powr account id.</p></td>
+    <td width="40%"><strong>data-account (required)</strong></td>
+    <td>The Powr account id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-player (required)</strong></p></td>
-    <td><p>The Powr player id.</p></td>
+    <td width="40%"><strong>data-player (required)</strong></td>
+    <td>The Powr player id.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-video (required if data-terms isn't provided)</strong></p></td>
-    <td><p>The Powr video id. Normally a string if characters.</p></td>
+    <td width="40%"><strong>data-video (required if data-terms isn't provided)</strong></td>
+    <td>The Powr video id. Normally a string if characters.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-terms (required if data-video isn't provided)</strong></p></td>
-    <td><p>A space separated list of keywords that describe the page displaying the player. Used to fetch a playlist relevant to the site content.</p></td>
+    <td width="40%"><strong>data-terms (required if data-video isn't provided)</strong></td>
+    <td>A space separated list of keywords that describe the page displaying the player. Used to fetch a playlist relevant to the site content.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-referrer</strong></p></td>
-    <td><p>Sets the referrer to be used for analytics within the player. This supports AMP variables such as <code>EXTERNAL_REFERRER</code>.</p></td>
+    <td width="40%"><strong>data-referrer</strong></td>
+    <td>Sets the referrer to be used for analytics within the player. This supports AMP variables such as <code>EXTERNAL_REFERRER</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
+    <td width="40%"><strong>data-param-&#42;</strong></td>
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br></p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.<br></p>
 <ul>
@@ -88,14 +88,14 @@ Example:
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-powr-player/amp-powr-player.md
+++ b/extensions/amp-powr-player/amp-powr-player.md
@@ -79,7 +79,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><strong>data-param-&#42;</strong></td>
-    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br></p>
+    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.<br></p>
 <ul>
   <li>`data-param-geo="us"` becomes `&geo=us`

--- a/extensions/amp-powr-player/amp-powr-player.md
+++ b/extensions/amp-powr-player/amp-powr-player.md
@@ -58,46 +58,43 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-account (required)</strong></td>
-    <td>The Powr account id.</td>
+    <td width="40%"><p><strong>data-account (required)</strong></p></td>
+    <td><p>The Powr account id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-player (required)</strong></td>
-    <td>The Powr player id.</td>
+    <td width="40%"><p><strong>data-player (required)</strong></p></td>
+    <td><p>The Powr player id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-video (required if data-terms isn't provided)</strong></td>
-    <td>The Powr video id. Normally a string if characters.</td>
+    <td width="40%"><p><strong>data-video (required if data-terms isn't provided)</strong></p></td>
+    <td><p>The Powr video id. Normally a string if characters.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-terms (required if data-video isn't provided)</strong></td>
-    <td>A space separated list of keywords that describe the page displaying the player. Used to fetch a playlist relevant to the site content.</td>
+    <td width="40%"><p><strong>data-terms (required if data-video isn't provided)</strong></p></td>
+    <td><p>A space separated list of keywords that describe the page displaying the player. Used to fetch a playlist relevant to the site content.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-referrer</strong></td>
-    <td>Sets the referrer to be used for analytics within the player. This supports AMP variables such as `EXTERNAL_REFERRER`.</td>
+    <td width="40%"><p><strong>data-referrer</strong></p></td>
+    <td><p>Sets the referrer to be used for analytics within the player. This supports AMP variables such as <code>EXTERNAL_REFERRER</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-&#42;</strong></td>
-    <td>All `data-param-*`  attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br>
-
-    Keys and values will be URI encoded. Keys will be camel cased.<br>
-
-    <ul>
-    <li>`data-param-geo="us"` becomes `&geo=us`
-    </li><li>`data-param-custom-data="key:value;key2:value2"` becomes `&customData=key%3Avalue%3Bkey2%3Avalue2`</li>
-    </ul>
-    </td>
+    <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
+    <td><p>All <code>data-param-*</code>  attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br></p>
+<p>Keys and values will be URI encoded. Keys will be camel cased.<br></p>
+<ul>
+<li>`data-param-geo="us"` becomes `&geo=us`
+</li><li>`data-param-custom-data="key:value;key2:value2"` becomes `&customData=key%3Avalue%3Bkey2%3Avalue2`</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-powr-player/amp-powr-player.md
+++ b/extensions/amp-powr-player/amp-powr-player.md
@@ -79,18 +79,19 @@ Example:
   </tr>
   <tr>
     <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
-    <td><p>All <code>data-param-*</code>  attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br></p>
+    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.<br></p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.<br></p>
 <ul>
-<li>`data-param-geo="us"` becomes `&geo=us`
-</li><li>`data-param-custom-data="key:value;key2:value2"` becomes `&customData=key%3Avalue%3Bkey2%3Avalue2`</li>
+  <li>`data-param-geo="us"` becomes `&geo=us`
+  </li>
+  <li>`data-param-custom-data="key:value;key2:value2"` becomes `&customData=key%3Avalue%3Bkey2%3Avalue2`</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-reach-player/amp-reach-player.md
+++ b/extensions/amp-reach-player/amp-reach-player.md
@@ -64,12 +64,12 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-embed-id</strong></td>
-    <td>The Reach player embed id found in the "players" section or in the generated embed itself.</td>
+    <td width="40%"><p><strong>data-embed-id</strong></p></td>
+    <td><p>The Reach player embed id found in the "players" section or in the generated embed itself.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p>
 </td>
   </tr>
 </table>

--- a/extensions/amp-reach-player/amp-reach-player.md
+++ b/extensions/amp-reach-player/amp-reach-player.md
@@ -64,12 +64,12 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-embed-id</strong></p></td>
-    <td><p>The Reach player embed id found in the "players" section or in the generated embed itself.</p></td>
+    <td width="40%"><strong>data-embed-id</strong></td>
+    <td>The Reach player embed id found in the "players" section or in the generated embed itself.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.
 </td>
   </tr>
 </table>

--- a/extensions/amp-recaptcha-input/amp-recaptcha-input.md
+++ b/extensions/amp-recaptcha-input/amp-recaptcha-input.md
@@ -84,21 +84,21 @@ grecaptcha.execute('reCAPTCHA_site_key', {action: 'reCAPTCHA_example_action'});
 
 <table>
   <tr>
-    <td width="40%"><strong>layout (required)</strong></td>
-    <td>Required value is `nodisplay`.
+    <td width="40%"><p><strong>layout (required)</strong></p></td>
+    <td><p>Required value is <code>nodisplay</code>.</p>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>name (required)</strong></td>
-    <td>Name of the `<amp-recaptcha-input>`. Will be used as a parameter key in the AMP form body submission.</td>
+    <td width="40%"><p><strong>name (required)</strong></p></td>
+    <td><p>Name of the <code>&lt;amp-recaptcha-input&gt;</code>. Will be used as a parameter key in the AMP form body submission.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-sitekey (required)</strong></td>
-    <td>[reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3) site key for the registered website.</td>
+    <td width="40%"><p><strong>data-sitekey (required)</strong></p></td>
+    <td><p><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> site key for the registered website.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-action (required)</strong></td>
-    <td>[reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3) action to be executed on form submission.</td>
+    <td width="40%"><p><strong>data-action (required)</strong></p></td>
+    <td><p><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> action to be executed on form submission.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-recaptcha-input/amp-recaptcha-input.md
+++ b/extensions/amp-recaptcha-input/amp-recaptcha-input.md
@@ -84,21 +84,21 @@ grecaptcha.execute('reCAPTCHA_site_key', {action: 'reCAPTCHA_example_action'});
 
 <table>
   <tr>
-    <td width="40%"><p><strong>layout (required)</strong></p></td>
-    <td><p>Required value is <code>nodisplay</code>.</p>
+    <td width="40%"><strong>layout (required)</strong></td>
+    <td>Required value is <code>nodisplay</code>.
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>name (required)</strong></p></td>
-    <td><p>Name of the <code>&lt;amp-recaptcha-input&gt;</code>. Will be used as a parameter key in the AMP form body submission.</p></td>
+    <td width="40%"><strong>name (required)</strong></td>
+    <td>Name of the <code>&lt;amp-recaptcha-input&gt;</code>. Will be used as a parameter key in the AMP form body submission.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-sitekey (required)</strong></p></td>
-    <td><p><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> site key for the registered website.</p></td>
+    <td width="40%"><strong>data-sitekey (required)</strong></td>
+    <td><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> site key for the registered website.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-action (required)</strong></p></td>
-    <td><p><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> action to be executed on form submission.</p></td>
+    <td width="40%"><strong>data-action (required)</strong></td>
+    <td><a href="https://developers.google.com/recaptcha/docs/v3">reCAPTCHA v3</a> action to be executed on form submission.</td>
   </tr>
 </table>
 

--- a/extensions/amp-reddit/amp-reddit.md
+++ b/extensions/amp-reddit/amp-reddit.md
@@ -78,32 +78,32 @@ Use the `amp-reddit` component to embed a Reddit post or comment.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-embedtype (required)</strong></p></td>
-    <td><p>The type of embed, either <code>post</code> or <code>comment</code>.</p></td>
+    <td width="40%"><strong>data-embedtype (required)</strong></td>
+    <td>The type of embed, either <code>post</code> or <code>comment</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-src (required)</strong></p></td>
-    <td><p>The permamlink uri for the post or comment.</p></td>
+    <td width="40%"><strong>data-src (required)</strong></td>
+    <td>The permamlink uri for the post or comment.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-uuid</strong></p></td>
-    <td><p>The provided UUID for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
+    <td width="40%"><strong>data-uuid</strong></td>
+    <td>The provided UUID for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-embedcreated</strong></p></td>
-    <td><p>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
+    <td width="40%"><strong>data-embedcreated</strong></td>
+    <td>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-embedparent</strong></p></td>
-    <td><p>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
+    <td width="40%"><strong>data-embedparent</strong></td>
+    <td>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-embedlive</strong></p></td>
-    <td><p>Indicates whether the embedded comment should update if the original comment is updated. Supported when <code>data-embedtype</code> is <code>comment</code>.</p></td>
+    <td width="40%"><strong>data-embedlive</strong></td>
+    <td>Indicates whether the embedded comment should update if the original comment is updated. Supported when <code>data-embedtype</code> is <code>comment</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-reddit/amp-reddit.md
+++ b/extensions/amp-reddit/amp-reddit.md
@@ -78,32 +78,32 @@ Use the `amp-reddit` component to embed a Reddit post or comment.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-embedtype (required)</strong></td>
-    <td>The type of embed, either `post` or `comment`.</td>
+    <td width="40%"><p><strong>data-embedtype (required)</strong></p></td>
+    <td><p>The type of embed, either <code>post</code> or <code>comment</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-src (required)</strong></td>
-    <td>The permamlink uri for the post or comment.</td>
+    <td width="40%"><p><strong>data-src (required)</strong></p></td>
+    <td><p>The permamlink uri for the post or comment.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-uuid</strong></td>
-    <td>The provided UUID for the comment embed. Supported when `data-embedtype` is `comment`. </td>
+    <td width="40%"><p><strong>data-uuid</strong></p></td>
+    <td><p>The provided UUID for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-embedcreated</strong></td>
-    <td>The datetime string for the comment embed. Supported when `data-embedtype` is `comment`. </td>
+    <td width="40%"><p><strong>data-embedcreated</strong></p></td>
+    <td><p>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-embedparent</strong></td>
-    <td>The datetime string for the comment embed. Supported when `data-embedtype` is `comment`. </td>
+    <td width="40%"><p><strong>data-embedparent</strong></p></td>
+    <td><p>The datetime string for the comment embed. Supported when <code>data-embedtype</code> is <code>comment</code>. </p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-embedlive</strong></td>
-    <td> Indicates whether the embedded comment should update if the original comment is updated. Supported when `data-embedtype` is `comment`.</td>
+    <td width="40%"><p><strong>data-embedlive</strong></p></td>
+    <td><p>Indicates whether the embedded comment should update if the original comment is updated. Supported when <code>data-embedtype</code> is <code>comment</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-riddle-quiz/amp-riddle-quiz.md
+++ b/extensions/amp-riddle-quiz/amp-riddle-quiz.md
@@ -53,12 +53,12 @@ This component embeds <a href="https://www.riddle.com/">Riddle</a> content (e.g.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-riddle-id (required)</strong></td>
-    <td>Specifies the unique ID for the Riddle item.</td>
+    <td width="40%"><p><strong>data-riddle-id (required)</strong></p></td>
+    <td><p>Specifies the unique ID for the Riddle item.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP component.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP component.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-riddle-quiz/amp-riddle-quiz.md
+++ b/extensions/amp-riddle-quiz/amp-riddle-quiz.md
@@ -53,12 +53,12 @@ This component embeds <a href="https://www.riddle.com/">Riddle</a> content (e.g.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-riddle-id (required)</strong></p></td>
-    <td><p>Specifies the unique ID for the Riddle item.</p></td>
+    <td width="40%"><strong>data-riddle-id (required)</strong></td>
+    <td>Specifies the unique ID for the Riddle item.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP component.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP component.</td>
   </tr>
 </table>
 

--- a/extensions/amp-skimlinks/amp-skimlinks.md
+++ b/extensions/amp-skimlinks/amp-skimlinks.md
@@ -94,7 +94,7 @@ The final code should like:
 <table>
   <tr>
     <td width="40%"><strong>publisher-code (required)</strong></td>
-    <td><p>Your skimlinks publisher code (also called "site Id").<br></p>
+    <td><p>Your skimlinks publisher code (also called "site Id").</p>
 <p>If you don't know what's your publisher code, you can find it on the <a href="https://hub.skimlinks.com/settings/sites">Skimlinks Hub</a> ("Site ID" column.).<br></p>
 <p>Example:</p>
 <pre><code class="html language-html">&lt;amp-skimlinks
@@ -124,7 +124,7 @@ excluded-domains="samsung.com amazon.com"
     <td width="40%"><strong>link-selector (optional)</strong></td>
     <td><p><code>link-selector</code> allows you to restrict which links amp-skimlinks should affiliate and track. All the links
   not matching the provided selector will simply be ignored.<br>
-  By default, amp-skimlinks affiliate and tracks all the links on the page.<br></p>
+  By default, amp-skimlinks affiliate and tracks all the links on the page.</p>
 <p><code>link-selector</code> value should be a valid <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors">CSS selector</a><br></p>
 <p><strong>WARNING:</strong>
   Don't set this option unless you really need it.
@@ -141,7 +141,7 @@ link-selector="article:not(.no-skimlinks) a"
   </tr>
   <tr>
     <td width="40%"><strong>custom-tracking-id (optional)</strong></td>
-    <td><p>The <code>custom-tracking-id</code> (also <code>called xcust</code>) is an optional parameter used to pass your own internal tracking id through Skimlinks' monetization system allowing you to segment your commission data in the way you want.<br></p>
+    <td><p>The <code>custom-tracking-id</code> (also <code>called xcust</code>) is an optional parameter used to pass your own internal tracking id through Skimlinks' monetization system allowing you to segment your commission data in the way you want.</p>
 <p><code>custom-tracking-id</code> should be &lt;=50 characters.</p></td>
   </tr>
 </table>

--- a/extensions/amp-skimlinks/amp-skimlinks.md
+++ b/extensions/amp-skimlinks/amp-skimlinks.md
@@ -108,10 +108,10 @@ publisher-code="123X456"
   <tr>
     <td width="40%"><p><strong>excluded-domains (optional)</strong></p></td>
     <td><p>A whitespace separated list of domain names.
-All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
-By default amp-skimlinks does not exclude any domains.
-<br>
-Example:</p>
+  All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
+  By default amp-skimlinks does not exclude any domains.
+  <br>
+  Example:</p>
 <pre><code class="html language-html">&lt;amp-skimlinks
 ...
 excluded-domains="samsung.com amazon.com"
@@ -123,12 +123,12 @@ excluded-domains="samsung.com amazon.com"
   <tr>
     <td width="40%"><p><strong>link-selector (optional)</strong></p></td>
     <td><p><code>link-selector</code> allows you to restrict which links amp-skimlinks should affiliate and track. All the links
-not matching the provided selector will simply be ignored.<br>
-By default, amp-skimlinks affiliate and tracks all the links on the page.<br></p>
+  not matching the provided selector will simply be ignored.<br>
+  By default, amp-skimlinks affiliate and tracks all the links on the page.<br></p>
 <p><code>link-selector</code> value should be a valid <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors">CSS selector</a><br></p>
 <p><strong>WARNING:</strong>
-Don't set this option unless you really need it.
-When using this option, always double check that your CSS selector is matching your links. When <code>link-selector</code> is provided, only the links matching the provided CSS selector would be able to generate revenue, any other links would be ignored.<br></p>
+  Don't set this option unless you really need it.
+  When using this option, always double check that your CSS selector is matching your links. When <code>link-selector</code> is provided, only the links matching the provided CSS selector would be able to generate revenue, any other links would be ignored.<br></p>
 <p>(e.g: <code>div.content</code> would not match any links and therefore not generate any revenue while <code>div.content a</code> would)!<br></p>
 <p>Example:</p>
 <pre><code class="html language-html">&lt;amp-skimlinks

--- a/extensions/amp-skimlinks/amp-skimlinks.md
+++ b/extensions/amp-skimlinks/amp-skimlinks.md
@@ -93,67 +93,56 @@ The final code should like:
 
 <table>
   <tr>
-    <td width="40%"><strong>publisher-code (required)</strong></td>
-    <td>Your skimlinks publisher code (also called "site Id").<br>
-
-    If you don't know what's your publisher code, you can find it on the [Skimlinks Hub](https://hub.skimlinks.com/settings/sites) ("Site ID" column.).<br>
-
-    Example:
-    ```html
-        <amp-skimlinks
-            ...
-            publisher-code="123X456"
-        >
-        </amp-skimlinks>
-    ```
+    <td width="40%"><p><strong>publisher-code (required)</strong></p></td>
+    <td><p>Your skimlinks publisher code (also called "site Id").<br></p>
+<p>If you don't know what's your publisher code, you can find it on the <a href="https://hub.skimlinks.com/settings/sites">Skimlinks Hub</a> ("Site ID" column.).<br></p>
+<p>Example:</p>
+<pre><code class="html language-html">&lt;amp-skimlinks
+...
+publisher-code="123X456"
+&gt;
+&lt;/amp-skimlinks&gt;
+</code></pre>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>excluded-domains (optional)</strong></td>
-    <td>A whitespace separated list of domain names.
-    All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
-    By default amp-skimlinks does not exclude any domains.
+    <td width="40%"><p><strong>excluded-domains (optional)</strong></p></td>
+    <td><p>A whitespace separated list of domain names.
+All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
+By default amp-skimlinks does not exclude any domains.
 <br>
-    Example:
-    ```html
-        <amp-skimlinks
-            ...
-            excluded-domains="samsung.com amazon.com"
-        >
-        </amp-skimlinks>
-    ```
+Example:</p>
+<pre><code class="html language-html">&lt;amp-skimlinks
+...
+excluded-domains="samsung.com amazon.com"
+&gt;
+&lt;/amp-skimlinks&gt;
+</code></pre>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>link-selector (optional)</strong></td>
-    <td>`link-selector` allows you to restrict which links amp-skimlinks should affiliate and track. All the links
-    not matching the provided selector will simply be ignored.<br>
-    By default, amp-skimlinks affiliate and tracks all the links on the page.<br>
-
-    `link-selector` value should be a valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)<br>
-
-    **WARNING:**
-    Don't set this option unless you really need it.
-    When using this option, always double check that your CSS selector is matching your links. When `link-selector` is provided, only the links matching the provided CSS selector would be able to generate revenue, any other links would be ignored.<br>
-
-    (e.g: `div.content` would not match any links and therefore not generate any revenue while `div.content a` would)!<br>
-
-
-    Example:
-    ```html
-        <amp-skimlinks
-            ...
-            link-selector="article:not(.no-skimlinks) a"
-        >
-        </amp-skimlinks>
-    ```
+    <td width="40%"><p><strong>link-selector (optional)</strong></p></td>
+    <td><p><code>link-selector</code> allows you to restrict which links amp-skimlinks should affiliate and track. All the links
+not matching the provided selector will simply be ignored.<br>
+By default, amp-skimlinks affiliate and tracks all the links on the page.<br></p>
+<p><code>link-selector</code> value should be a valid <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors">CSS selector</a><br></p>
+<p><strong>WARNING:</strong>
+Don't set this option unless you really need it.
+When using this option, always double check that your CSS selector is matching your links. When <code>link-selector</code> is provided, only the links matching the provided CSS selector would be able to generate revenue, any other links would be ignored.<br></p>
+<p>(e.g: <code>div.content</code> would not match any links and therefore not generate any revenue while <code>div.content a</code> would)!<br></p>
+<p>Example:</p>
+<pre><code class="html language-html">&lt;amp-skimlinks
+...
+link-selector="article:not(.no-skimlinks) a"
+&gt;
+&lt;/amp-skimlinks&gt;
+</code></pre>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>custom-tracking-id (optional)</strong></td>
-    <td>The `custom-tracking-id` (also `called xcust`) is an optional parameter used to pass your own internal tracking id through Skimlinks' monetization system allowing you to segment your commission data in the way you want.<br>
-
-    `custom-tracking-id` should be <=50 characters.</td>
+    <td width="40%"><p><strong>custom-tracking-id (optional)</strong></p></td>
+    <td><p>The <code>custom-tracking-id</code> (also <code>called xcust</code>) is an optional parameter used to pass your own internal tracking id through Skimlinks' monetization system allowing you to segment your commission data in the way you want.<br></p>
+<p><code>custom-tracking-id</code> should be &lt;=50 characters.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-skimlinks/amp-skimlinks.md
+++ b/extensions/amp-skimlinks/amp-skimlinks.md
@@ -93,7 +93,7 @@ The final code should like:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>publisher-code (required)</strong></p></td>
+    <td width="40%"><strong>publisher-code (required)</strong></td>
     <td><p>Your skimlinks publisher code (also called "site Id").<br></p>
 <p>If you don't know what's your publisher code, you can find it on the <a href="https://hub.skimlinks.com/settings/sites">Skimlinks Hub</a> ("Site ID" column.).<br></p>
 <p>Example:</p>
@@ -106,12 +106,12 @@ publisher-code="123X456"
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>excluded-domains (optional)</strong></p></td>
-    <td><p>A whitespace separated list of domain names.
-  All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
-  By default amp-skimlinks does not exclude any domains.
-  <br>
-  Example:</p>
+    <td width="40%"><strong>excluded-domains (optional)</strong></td>
+    <td>A whitespace separated list of domain names.
+All the links belonging to a domain in that list will not be affiliated nor tracked by skimlinks.
+By default amp-skimlinks does not exclude any domains.
+<br>
+Example:</p>
 <pre><code class="html language-html">&lt;amp-skimlinks
 ...
 excluded-domains="samsung.com amazon.com"
@@ -121,7 +121,7 @@ excluded-domains="samsung.com amazon.com"
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>link-selector (optional)</strong></p></td>
+    <td width="40%"><strong>link-selector (optional)</strong></td>
     <td><p><code>link-selector</code> allows you to restrict which links amp-skimlinks should affiliate and track. All the links
   not matching the provided selector will simply be ignored.<br>
   By default, amp-skimlinks affiliate and tracks all the links on the page.<br></p>
@@ -140,7 +140,7 @@ link-selector="article:not(.no-skimlinks) a"
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>custom-tracking-id (optional)</strong></p></td>
+    <td width="40%"><strong>custom-tracking-id (optional)</strong></td>
     <td><p>The <code>custom-tracking-id</code> (also <code>called xcust</code>) is an optional parameter used to pass your own internal tracking id through Skimlinks' monetization system allowing you to segment your commission data in the way you want.<br></p>
 <p><code>custom-tracking-id</code> should be &lt;=50 characters.</p></td>
   </tr>

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -76,23 +76,23 @@ Linkedin is one of the pre-configured providers, so you do not need to provide t
 
 <table>
   <tr>
-    <td width="40%"><p><strong>type (required)</strong></p></td>
-    <td><p>Selects a provider type. This is required for both pre-configured and non-configured providers.</p></td>
+    <td width="40%"><strong>type (required)</strong></td>
+    <td>Selects a provider type. This is required for both pre-configured and non-configured providers.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-target</strong></p></td>
+    <td width="40%"><strong>data-target</strong></td>
     <td><p>Specifies the target in which to open the target. The default is <code>_blank</code> for all cases other than email/SMS on iOS, in which case the target is set to <code>_top</code>.</p>
 <p>Please note that we only suggest using this override for email.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-share-endpoint</strong></p></td>
-    <td><p>This attribute is <strong>required for non-configured providers</strong>.
-  <br>
-  Some popular providers have pre-configured share endpoints. For details, see the <a href="#pre-configured-providers">Pre-configured Providers</a> section. For non-configured providers, you'll need to specify the share endpoint.</p></td>
+    <td width="40%"><strong>data-share-endpoint</strong></td>
+    <td>This attribute is <strong>required for non-configured providers</strong>.
+<br>
+Some popular providers have pre-configured share endpoints. For details, see the <a href="#pre-configured-providers">Pre-configured Providers</a> section. For non-configured providers, you'll need to specify the share endpoint.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-*</strong></p></td>
-    <td><p>All <code>data-param-*</code> prefixed attributes are turned into URL parameters and passed to the share endpoint.</p></td>
+    <td width="40%"><strong>data-param-*</strong></td>
+    <td>All <code>data-param-*</code> prefixed attributes are turned into URL parameters and passed to the share endpoint.</td>
   </tr>
 </table>
 

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -87,8 +87,8 @@ Linkedin is one of the pre-configured providers, so you do not need to provide t
   <tr>
     <td width="40%"><p><strong>data-share-endpoint</strong></p></td>
     <td><p>This attribute is <strong>required for non-configured providers</strong>.
-<br>
-Some popular providers have pre-configured share endpoints. For details, see the <a href="#pre-configured-providers">Pre-configured Providers</a> section.  For non-configured providers, you'll need to specify the share endpoint.</p></td>
+  <br>
+  Some popular providers have pre-configured share endpoints. For details, see the <a href="#pre-configured-providers">Pre-configured Providers</a> section. For non-configured providers, you'll need to specify the share endpoint.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-param-*</strong></p></td>

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -76,24 +76,23 @@ Linkedin is one of the pre-configured providers, so you do not need to provide t
 
 <table>
   <tr>
-    <td width="40%"><strong>type (required)</strong></td>
-    <td>Selects a provider type. This is required for both pre-configured and non-configured providers.</td>
+    <td width="40%"><p><strong>type (required)</strong></p></td>
+    <td><p>Selects a provider type. This is required for both pre-configured and non-configured providers.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-target</strong></td>
-    <td>Specifies the target in which to open the target. The default is `_blank` for all cases other than email/SMS on iOS, in which case the target is set to `_top`.
-
-    Please note that we only suggest using this override for email.</td>
+    <td width="40%"><p><strong>data-target</strong></p></td>
+    <td><p>Specifies the target in which to open the target. The default is <code>_blank</code> for all cases other than email/SMS on iOS, in which case the target is set to <code>_top</code>.</p>
+<p>Please note that we only suggest using this override for email.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-share-endpoint</strong></td>
-    <td>This attribute is **required for non-configured providers**.
+    <td width="40%"><p><strong>data-share-endpoint</strong></p></td>
+    <td><p>This attribute is <strong>required for non-configured providers</strong>.
 <br>
-    Some popular providers have pre-configured share endpoints. For details, see the [Pre-configured Providers](#pre-configured-providers) section.  For non-configured providers, you'll need to specify the share endpoint.</td>
+Some popular providers have pre-configured share endpoints. For details, see the <a href="#pre-configured-providers">Pre-configured Providers</a> section.  For non-configured providers, you'll need to specify the share endpoint.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-*</strong></td>
-    <td>All `data-param-*` prefixed attributes are turned into URL parameters and passed to the share endpoint.</td>
+    <td width="40%"><p><strong>data-param-*</strong></p></td>
+    <td><p>All <code>data-param-*</code> prefixed attributes are turned into URL parameters and passed to the share endpoint.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -64,30 +64,30 @@ Classic Mode:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-trackid</strong></p></td>
-    <td><p>This attribute is required if <code>data-playlistid</code> is not defined.<br />
-  The value for this attribute is the ID of a track, an integer.</p></td>
+    <td width="40%"><strong>data-trackid</strong></td>
+    <td>This attribute is required if <code>data-playlistid</code> is not defined.<br />
+The value for this attribute is the ID of a track, an integer.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-playlistid</strong></p></td>
-    <td><p>This attribute is required if <code>data-trackid</code> is not defined.
-  The value for this attribute is the ID of a playlist, an integer.</p></td>
+    <td width="40%"><strong>data-playlistid</strong></td>
+    <td>This attribute is required if <code>data-trackid</code> is not defined.
+The value for this attribute is the ID of a playlist, an integer.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-secret-token (optional)</strong></p></td>
-    <td><p>The secret token of the track, if it is private.</p></td>
+    <td width="40%"><strong>data-secret-token (optional)</strong></td>
+    <td>The secret token of the track, if it is private.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-visual (optional)</strong></p></td>
-    <td><p>If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.</p></td>
+    <td width="40%"><strong>data-visual (optional)</strong></td>
+    <td>If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-color (optional)</strong></p></td>
-    <td><p>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).</p></td>
+    <td width="40%"><strong>data-color (optional)</strong></td>
+    <td>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>width and height</strong></p></td>
-    <td><p>The layout for <code>amp-soundcloud</code> is set to <code>fixed-height</code> and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.</p></td>
+    <td width="40%"><strong>width and height</strong></td>
+    <td>The layout for <code>amp-soundcloud</code> is set to <code>fixed-height</code> and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.</td>
   </tr>
 </table>
 

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -64,30 +64,30 @@ Classic Mode:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-trackid</strong></td>
-    <td>This attribute is required if `data-playlistid` is not defined.  
-    The value for this attribute is the ID of a track, an integer.</td>
+    <td width="40%"><p><strong>data-trackid</strong></p></td>
+    <td><p>This attribute is required if <code>data-playlistid</code> is not defined.<br />
+The value for this attribute is the ID of a track, an integer.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-playlistid</strong></td>
-    <td>This attribute is required if `data-trackid` is not defined.
-    The value for this attribute is the ID of a playlist, an integer.</td>
+    <td width="40%"><p><strong>data-playlistid</strong></p></td>
+    <td><p>This attribute is required if <code>data-trackid</code> is not defined.
+The value for this attribute is the ID of a playlist, an integer.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-secret-token (optional)</strong></td>
-    <td>The secret token of the track, if it is private.</td>
+    <td width="40%"><p><strong>data-secret-token (optional)</strong></p></td>
+    <td><p>The secret token of the track, if it is private.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-visual (optional)</strong></td>
-    <td>If set to `true`, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is `false`.</td>
+    <td width="40%"><p><strong>data-visual (optional)</strong></p></td>
+    <td><p>If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-color (optional)</strong></td>
-    <td>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., `data-color="e540ff"`).</td>
+    <td width="40%"><p><strong>data-color (optional)</strong></p></td>
+    <td><p>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>width and height</strong></td>
-    <td>The layout for `amp-soundcloud` is set to `fixed-height` and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.</td>
+    <td width="40%"><p><strong>width and height</strong></p></td>
+    <td><p>The layout for <code>amp-soundcloud</code> is set to <code>fixed-height</code> and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -66,12 +66,12 @@ Classic Mode:
   <tr>
     <td width="40%"><p><strong>data-trackid</strong></p></td>
     <td><p>This attribute is required if <code>data-playlistid</code> is not defined.<br />
-The value for this attribute is the ID of a track, an integer.</p></td>
+  The value for this attribute is the ID of a track, an integer.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-playlistid</strong></p></td>
     <td><p>This attribute is required if <code>data-trackid</code> is not defined.
-The value for this attribute is the ID of a playlist, an integer.</p></td>
+  The value for this attribute is the ID of a playlist, an integer.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-secret-token (optional)</strong></p></td>

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -62,32 +62,32 @@ The `width` and `height` attributes determine the aspect ratio of the player emb
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><strong>data-site-id (required)</strong></td>
-    <td>The SpringBoard site ID. Specific to every partner.</td>
+    <td width="40%"><p><strong>data-site-id (required)</strong></p></td>
+    <td><p>The SpringBoard site ID. Specific to every partner.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-mode (required)</strong></td>
-    <td>The SpringBoard player mode: `video` or `playlist`.</td>
+    <td width="40%"><p><strong>data-mode (required)</strong></p></td>
+    <td><p>The SpringBoard player mode: <code>video</code> or <code>playlist</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-content-id (required)</strong></td>
-    <td>The SpringBoard player content ID (video or playlist ID).</td>
+    <td width="40%"><p><strong>data-content-id (required)</strong></p></td>
+    <td><p>The SpringBoard player content ID (video or playlist ID).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-player-id (required)</strong></td>
-    <td>The Springboard player ID.</td>
+    <td width="40%"><p><strong>data-player-id (required)</strong></p></td>
+    <td><p>The Springboard player ID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-domain (required)</strong></td>
-    <td>The Springboard partner domain.</td>
+    <td width="40%"><p><strong>data-domain (required)</strong></p></td>
+    <td><p>The Springboard partner domain.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-items (required)</strong></td>
-    <td>The number of videos in the playlist.</td>
+    <td width="40%"><p><strong>data-items (required)</strong></p></td>
+    <td><p>The number of videos in the playlist.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -62,32 +62,32 @@ The `width` and `height` attributes determine the aspect ratio of the player emb
 ## Attributes
 <table>
   <tr>
-    <td width="40%"><p><strong>data-site-id (required)</strong></p></td>
-    <td><p>The SpringBoard site ID. Specific to every partner.</p></td>
+    <td width="40%"><strong>data-site-id (required)</strong></td>
+    <td>The SpringBoard site ID. Specific to every partner.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-mode (required)</strong></p></td>
-    <td><p>The SpringBoard player mode: <code>video</code> or <code>playlist</code>.</p></td>
+    <td width="40%"><strong>data-mode (required)</strong></td>
+    <td>The SpringBoard player mode: <code>video</code> or <code>playlist</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-content-id (required)</strong></p></td>
-    <td><p>The SpringBoard player content ID (video or playlist ID).</p></td>
+    <td width="40%"><strong>data-content-id (required)</strong></td>
+    <td>The SpringBoard player content ID (video or playlist ID).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-player-id (required)</strong></p></td>
-    <td><p>The Springboard player ID.</p></td>
+    <td width="40%"><strong>data-player-id (required)</strong></td>
+    <td>The Springboard player ID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-domain (required)</strong></p></td>
-    <td><p>The Springboard partner domain.</p></td>
+    <td width="40%"><strong>data-domain (required)</strong></td>
+    <td>The Springboard partner domain.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-items (required)</strong></p></td>
-    <td><p>The number of videos in the playlist.</p></td>
+    <td width="40%"><strong>data-items (required)</strong></td>
+    <td>The number of videos in the playlist.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -74,8 +74,8 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>layout (required)</strong></td>
-    <td>Must be set to `nodisplay`.</td>
+    <td width="40%"><p><strong>layout (required)</strong></p></td>
+    <td><p>Must be set to <code>nodisplay</code>.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -74,8 +74,8 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>layout (required)</strong></p></td>
-    <td><p>Must be set to <code>nodisplay</code>.</p></td>
+    <td width="40%"><strong>layout (required)</strong></td>
+    <td>Must be set to <code>nodisplay</code>.</td>
   </tr>
 </table>
 

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -65,7 +65,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><strong>locale (optional)</strong></td>
-    <td>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br></p>
+    <td><p>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:</p>
 <ul>
   <li>ar (Arabic)</li>
   <li>be (Belarusian)</li>

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -60,12 +60,12 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>datetime (required)</strong></p></td>
-    <td><p>An ISO datetime. E.g. 2017-03-10T01:00:00Z (UTC) <em>or</em> 2017-03-09T20:00:00-05:00 (specifying timezone offset).</p></td>
+    <td width="40%"><strong>datetime (required)</strong></td>
+    <td>An ISO datetime. E.g. 2017-03-10T01:00:00Z (UTC) <em>or</em> 2017-03-09T20:00:00-05:00 (specifying timezone offset).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>locale (optional)</strong></p></td>
-    <td><p>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br></p>
+    <td width="40%"><strong>locale (optional)</strong></td>
+    <td>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br></p>
 <ul>
   <li>ar (Arabic)</li>
   <li>be (Belarusian)</li>
@@ -107,12 +107,12 @@ Example:
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>cutoff (optional)</strong></p></td>
-    <td><p>Display the original date if time distance is older than cutoff (seconds).</p></td>
+    <td width="40%"><strong>cutoff (optional)</strong></td>
+    <td>Display the original date if time distance is older than cutoff (seconds).</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -67,43 +67,43 @@ Example:
     <td width="40%"><p><strong>locale (optional)</strong></p></td>
     <td><p>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br></p>
 <ul>
-<li>ar (Arabic)</li>
-<li>be (Belarusian)</li>
-<li>bg (Bulgarian)</li>
-<li>ca (Catalan)</li>
-<li>da (Danish)</li>
-<li>de (German)</li>
-<li>el (Greek)</li>
-<li>en (English)</li>
-<li>enShort (English - short)</li>
-<li>es (Spanish)</li>
-<li>eu (Basque)</li>
-<li>fi (Finnish)</li>
-<li>fr (French)</li>
-<li>he (Hebrew)</li>
-<li>hu (Hungarian)</li>
-<li>inBG (Bangla)</li>
-<li>inHI (Hindi)</li>
-<li>inID (Malay)</li>
-<li>it (Italian)</li>
-<li>ja (Japanese)</li>
-<li>ko (Korean)</li>
-<li>ml (Malayalam)</li>
-<li>nbNO (Norwegian Bokmål)</li>
-<li>nl (Dutch)</li>
-<li>nnNO (Norwegian Nynorsk)</li>
-<li>pl (Polish)</li>
-<li>ptBR (Portuguese)</li>
-<li>ro (Romanian)</li>
-<li>ru (Russian)</li>
-<li>sv (Swedish)</li>
-<li>ta (Tamil)</li>
-<li>th (Thai)</li>
-<li>tr (Turkish)</li>
-<li>uk (Ukrainian)</li>
-<li>vi (Vietnamese)</li>
-<li>zhCN (Chinese)</li>
-<li>zhTW (Taiwanese)</li>
+  <li>ar (Arabic)</li>
+  <li>be (Belarusian)</li>
+  <li>bg (Bulgarian)</li>
+  <li>ca (Catalan)</li>
+  <li>da (Danish)</li>
+  <li>de (German)</li>
+  <li>el (Greek)</li>
+  <li>en (English)</li>
+  <li>enShort (English - short)</li>
+  <li>es (Spanish)</li>
+  <li>eu (Basque)</li>
+  <li>fi (Finnish)</li>
+  <li>fr (French)</li>
+  <li>he (Hebrew)</li>
+  <li>hu (Hungarian)</li>
+  <li>inBG (Bangla)</li>
+  <li>inHI (Hindi)</li>
+  <li>inID (Malay)</li>
+  <li>it (Italian)</li>
+  <li>ja (Japanese)</li>
+  <li>ko (Korean)</li>
+  <li>ml (Malayalam)</li>
+  <li>nbNO (Norwegian Bokmål)</li>
+  <li>nl (Dutch)</li>
+  <li>nnNO (Norwegian Nynorsk)</li>
+  <li>pl (Polish)</li>
+  <li>ptBR (Portuguese)</li>
+  <li>ro (Romanian)</li>
+  <li>ru (Russian)</li>
+  <li>sv (Swedish)</li>
+  <li>ta (Tamil)</li>
+  <li>th (Thai)</li>
+  <li>tr (Turkish)</li>
+  <li>uk (Ukrainian)</li>
+  <li>vi (Vietnamese)</li>
+  <li>zhCN (Chinese)</li>
+  <li>zhTW (Taiwanese)</li>
 </ul></td>
   </tr>
   <tr>

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -60,60 +60,59 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>datetime (required)</strong></td>
-    <td>An ISO datetime. E.g. 2017-03-10T01:00:00Z (UTC) *or* 2017-03-09T20:00:00-05:00 (specifying timezone offset).</td>
+    <td width="40%"><p><strong>datetime (required)</strong></p></td>
+    <td><p>An ISO datetime. E.g. 2017-03-10T01:00:00Z (UTC) <em>or</em> 2017-03-09T20:00:00-05:00 (specifying timezone offset).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>locale (optional)</strong></td>
-    <td>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br>
-
-    <ul>
-      <li>ar (Arabic)</li>
-      <li>be (Belarusian)</li>
-      <li>bg (Bulgarian)</li>
-      <li>ca (Catalan)</li>
-      <li>da (Danish)</li>
-      <li>de (German)</li>
-      <li>el (Greek)</li>
-      <li>en (English)</li>
-      <li>enShort (English - short)</li>
-      <li>es (Spanish)</li>
-      <li>eu (Basque)</li>
-      <li>fi (Finnish)</li>
-      <li>fr (French)</li>
-      <li>he (Hebrew)</li>
-      <li>hu (Hungarian)</li>
-      <li>inBG (Bangla)</li>
-      <li>inHI (Hindi)</li>
-      <li>inID (Malay)</li>
-      <li>it (Italian)</li>
-      <li>ja (Japanese)</li>
-      <li>ko (Korean)</li>
-      <li>ml (Malayalam)</li>
-      <li>nbNO (Norwegian Bokmål)</li>
-      <li>nl (Dutch)</li>
-      <li>nnNO (Norwegian Nynorsk)</li>
-      <li>pl (Polish)</li>
-      <li>ptBR (Portuguese)</li>
-      <li>ro (Romanian)</li>
-      <li>ru (Russian)</li>
-      <li>sv (Swedish)</li>
-      <li>ta (Tamil)</li>
-      <li>th (Thai)</li>
-      <li>tr (Turkish)</li>
-      <li>uk (Ukrainian)</li>
-      <li>vi (Vietnamese)</li>
-      <li>zhCN (Chinese)</li>
-      <li>zhTW (Taiwanese)</li>
-    </ul></td>
+    <td width="40%"><p><strong>locale (optional)</strong></p></td>
+    <td><p>By default, the local is set to <code>en</code>; however, you can specify one of the following locales:<br></p>
+<ul>
+<li>ar (Arabic)</li>
+<li>be (Belarusian)</li>
+<li>bg (Bulgarian)</li>
+<li>ca (Catalan)</li>
+<li>da (Danish)</li>
+<li>de (German)</li>
+<li>el (Greek)</li>
+<li>en (English)</li>
+<li>enShort (English - short)</li>
+<li>es (Spanish)</li>
+<li>eu (Basque)</li>
+<li>fi (Finnish)</li>
+<li>fr (French)</li>
+<li>he (Hebrew)</li>
+<li>hu (Hungarian)</li>
+<li>inBG (Bangla)</li>
+<li>inHI (Hindi)</li>
+<li>inID (Malay)</li>
+<li>it (Italian)</li>
+<li>ja (Japanese)</li>
+<li>ko (Korean)</li>
+<li>ml (Malayalam)</li>
+<li>nbNO (Norwegian Bokmål)</li>
+<li>nl (Dutch)</li>
+<li>nnNO (Norwegian Nynorsk)</li>
+<li>pl (Polish)</li>
+<li>ptBR (Portuguese)</li>
+<li>ro (Romanian)</li>
+<li>ru (Russian)</li>
+<li>sv (Swedish)</li>
+<li>ta (Tamil)</li>
+<li>th (Thai)</li>
+<li>tr (Turkish)</li>
+<li>uk (Ukrainian)</li>
+<li>vi (Vietnamese)</li>
+<li>zhCN (Chinese)</li>
+<li>zhTW (Taiwanese)</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>cutoff (optional)</strong></td>
-    <td>Display the original date if time distance is older than cutoff (seconds).</td>
+    <td width="40%"><p><strong>cutoff (optional)</strong></p></td>
+    <td><p>Display the original date if time distance is older than cutoff (seconds).</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -102,19 +102,19 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
   <tr>
     <td width="40%"><p><strong>data-tweetid / data-momentid / data-timeline-source-type (required)</strong></p></td>
     <td><p>The ID of the Tweet or Moment, or the source type if a Timeline should be displayed.
-In a URL like https://twitter.com/joemccann/status/640300967154597888,  <code>640300967154597888</code> is the tweet id.
-In a URL like https://twitter.com/i/moments/1009149991452135424, <code>1009149991452135424</code> is the moment id.
-Valid timeline source types include <code>profile</code>, <code>likes</code>, <code>list</code>, <code>collection</code>, <code>url</code>, and <code>widget</code>.</p></td>
+  In a URL like https://twitter.com/joemccann/status/640300967154597888, <code>640300967154597888</code> is the tweet id.
+  In a URL like https://twitter.com/i/moments/1009149991452135424, <code>1009149991452135424</code> is the moment id.
+  Valid timeline source types include <code>profile</code>, <code>likes</code>, <code>list</code>, <code>collection</code>, <code>url</code>, and <code>widget</code>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-timeline-* (optional)</strong></p></td>
     <td><p>When displaying a timeline, further arguments need to be provided in addition to <code>timeline-source-type</code>. For example, <code>data-timeline-screen-name="amphtml"</code> in combination with <code>data-timeline-source-type="profile"</code> will display a timeline of the AMP Twitter account.
-For details on the available arguments, see the "Timelines" section in <a href="https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions">Twitter's JavaScript Factory Functions Guide</a>.</p></td>
+  For details on the available arguments, see the "Timelines" section in <a href="https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions">Twitter's JavaScript Factory Functions Guide</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-* (optional)</strong></p></td>
     <td><p>You can specify options for the Tweet, Moment, or Timeline appearance by setting <code>data-</code> attributes. For example, <code>data-cards="hidden"</code> deactivates Twitter cards.
-For details on the available options, see Twitter's docs <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">for tweets</a>, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0">for moments</a> and <a href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference">for timelines</a>. </p></td>
+  For details on the available options, see Twitter's docs <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">for tweets</a>, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0">for moments</a> and <a href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference">for timelines</a>. </p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -100,25 +100,25 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
 
 <table>
   <tr>
-    <td width="40%"><strong>data-tweetid / data-momentid / data-timeline-source-type (required)</strong></td>
-    <td>The ID of the Tweet or Moment, or the source type if a Timeline should be displayed.
-    In a URL like https://twitter.com/joemccann/status/640300967154597888,  `640300967154597888` is the tweet id.
-    In a URL like https://twitter.com/i/moments/1009149991452135424, `1009149991452135424` is the moment id.
-    Valid timeline source types include `profile`, `likes`, `list`, `collection`, `url`, and `widget`.</td>
+    <td width="40%"><p><strong>data-tweetid / data-momentid / data-timeline-source-type (required)</strong></p></td>
+    <td><p>The ID of the Tweet or Moment, or the source type if a Timeline should be displayed.
+In a URL like https://twitter.com/joemccann/status/640300967154597888,  <code>640300967154597888</code> is the tweet id.
+In a URL like https://twitter.com/i/moments/1009149991452135424, <code>1009149991452135424</code> is the moment id.
+Valid timeline source types include <code>profile</code>, <code>likes</code>, <code>list</code>, <code>collection</code>, <code>url</code>, and <code>widget</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-timeline-* (optional)</strong></td>
-    <td>When displaying a timeline, further arguments need to be provided in addition to `timeline-source-type`. For example, `data-timeline-screen-name="amphtml"` in combination with `data-timeline-source-type="profile"` will display a timeline of the AMP Twitter account.
-    For details on the available arguments, see the "Timelines" section in [Twitter's JavaScript Factory Functions Guide](https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions).</td>
+    <td width="40%"><p><strong>data-timeline-* (optional)</strong></p></td>
+    <td><p>When displaying a timeline, further arguments need to be provided in addition to <code>timeline-source-type</code>. For example, <code>data-timeline-screen-name="amphtml"</code> in combination with <code>data-timeline-source-type="profile"</code> will display a timeline of the AMP Twitter account.
+For details on the available arguments, see the "Timelines" section in <a href="https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions">Twitter's JavaScript Factory Functions Guide</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-* (optional)</strong></td>
-    <td>You can specify options for the Tweet, Moment, or Timeline appearance by setting `data-` attributes. For example, `data-cards="hidden"` deactivates Twitter cards.
-    For details on the available options, see Twitter's docs [for tweets](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference), [for moments](https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0) and [for timelines](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference). </td>
+    <td width="40%"><p><strong>data-* (optional)</strong></p></td>
+    <td><p>You can specify options for the Tweet, Moment, or Timeline appearance by setting <code>data-</code> attributes. For example, <code>data-cards="hidden"</code> deactivates Twitter cards.
+For details on the available options, see Twitter's docs <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">for tweets</a>, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0">for moments</a> and <a href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference">for timelines</a>. </p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -100,25 +100,25 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-tweetid / data-momentid / data-timeline-source-type (required)</strong></p></td>
-    <td><p>The ID of the Tweet or Moment, or the source type if a Timeline should be displayed.
-  In a URL like https://twitter.com/joemccann/status/640300967154597888, <code>640300967154597888</code> is the tweet id.
-  In a URL like https://twitter.com/i/moments/1009149991452135424, <code>1009149991452135424</code> is the moment id.
-  Valid timeline source types include <code>profile</code>, <code>likes</code>, <code>list</code>, <code>collection</code>, <code>url</code>, and <code>widget</code>.</p></td>
+    <td width="40%"><strong>data-tweetid / data-momentid / data-timeline-source-type (required)</strong></td>
+    <td>The ID of the Tweet or Moment, or the source type if a Timeline should be displayed.
+In a URL like https://twitter.com/joemccann/status/640300967154597888, <code>640300967154597888</code> is the tweet id.
+In a URL like https://twitter.com/i/moments/1009149991452135424, <code>1009149991452135424</code> is the moment id.
+Valid timeline source types include <code>profile</code>, <code>likes</code>, <code>list</code>, <code>collection</code>, <code>url</code>, and <code>widget</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-timeline-* (optional)</strong></p></td>
-    <td><p>When displaying a timeline, further arguments need to be provided in addition to <code>timeline-source-type</code>. For example, <code>data-timeline-screen-name="amphtml"</code> in combination with <code>data-timeline-source-type="profile"</code> will display a timeline of the AMP Twitter account.
-  For details on the available arguments, see the "Timelines" section in <a href="https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions">Twitter's JavaScript Factory Functions Guide</a>.</p></td>
+    <td width="40%"><strong>data-timeline-* (optional)</strong></td>
+    <td>When displaying a timeline, further arguments need to be provided in addition to <code>timeline-source-type</code>. For example, <code>data-timeline-screen-name="amphtml"</code> in combination with <code>data-timeline-source-type="profile"</code> will display a timeline of the AMP Twitter account.
+For details on the available arguments, see the "Timelines" section in <a href="https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions">Twitter's JavaScript Factory Functions Guide</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-* (optional)</strong></p></td>
-    <td><p>You can specify options for the Tweet, Moment, or Timeline appearance by setting <code>data-</code> attributes. For example, <code>data-cards="hidden"</code> deactivates Twitter cards.
-  For details on the available options, see Twitter's docs <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">for tweets</a>, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0">for moments</a> and <a href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference">for timelines</a>. </p></td>
+    <td width="40%"><strong>data-* (optional)</strong></td>
+    <td>You can specify options for the Tweet, Moment, or Timeline appearance by setting <code>data-</code> attributes. For example, <code>data-cards="hidden"</code> deactivates Twitter cards.
+For details on the available options, see Twitter's docs <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">for tweets</a>, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0">for moments</a> and <a href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference">for timelines</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -71,8 +71,8 @@ The reasons for this policy are that:
   <tr>
     <td width="40%"><p><strong>src (required)</strong></p></td>
     <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
-source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
-not already have a fragment.</p></td>
+  source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+  not already have a fragment.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>poster (required)</strong></p></td>
@@ -82,8 +82,8 @@ not already have a fragment.</p></td>
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -69,37 +69,37 @@ The reasons for this policy are that:
 
 <table>
   <tr>
-    <td width="40%"><strong>src (required)</strong></td>
-    <td>The `src` attribute behaves mainly like on a standard iframe with one exception: the `#amp=1` fragment is added to the URL to allow
-    source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by `src` does
-    not already have a fragment.</td>
+    <td width="40%"><p><strong>src (required)</strong></p></td>
+    <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
+source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+not already have a fragment.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>poster (required)</strong></td>
-    <td>Points to an image URL that will be displayed while the video loads.
+    <td width="40%"><p><strong>poster (required)</strong></p></td>
+    <td><p>Points to an image URL that will be displayed while the video loads.</p>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>implements-media-session</strong></td>
-    <td>Set this attribute if the document inside the iframe implements the [MediaSession API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API) independently.</td>
+    <td width="40%"><p><strong>implements-media-session</strong></p></td>
+    <td><p>Set this attribute if the document inside the iframe implements the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API">MediaSession API</a> independently.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>implements-rotate-to-fullscreen</strong></td>
-    <td>Set this attribute if the document inside the iframe implements rotate-to-fullscreen independently.</td>
+    <td width="40%"><p><strong>implements-rotate-to-fullscreen</strong></p></td>
+    <td><p>Set this attribute if the document inside the iframe implements rotate-to-fullscreen independently.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>referrerpolicy</strong></td>
-    <td>The [`referrerpolicy`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy) to be set on the iframe element.</td>
+    <td width="40%"><p><strong>referrerpolicy</strong></p></td>
+    <td><p>The <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy"><code>referrerpolicy</code></a> to be set on the iframe element.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -69,37 +69,37 @@ The reasons for this policy are that:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src (required)</strong></p></td>
-    <td><p>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
-  source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
-  not already have a fragment.</p></td>
+    <td width="40%"><strong>src (required)</strong></td>
+    <td>The <code>src</code> attribute behaves mainly like on a standard iframe with one exception: the <code>#amp=1</code> fragment is added to the URL to allow
+source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by <code>src</code> does
+not already have a fragment.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>poster (required)</strong></p></td>
-    <td><p>Points to an image URL that will be displayed while the video loads.</p>
+    <td width="40%"><strong>poster (required)</strong></td>
+    <td>Points to an image URL that will be displayed while the video loads.
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>implements-media-session</strong></p></td>
-    <td><p>Set this attribute if the document inside the iframe implements the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API">MediaSession API</a> independently.</p></td>
+    <td width="40%"><strong>implements-media-session</strong></td>
+    <td>Set this attribute if the document inside the iframe implements the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API">MediaSession API</a> independently.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>implements-rotate-to-fullscreen</strong></p></td>
-    <td><p>Set this attribute if the document inside the iframe implements rotate-to-fullscreen independently.</p></td>
+    <td width="40%"><strong>implements-rotate-to-fullscreen</strong></td>
+    <td>Set this attribute if the document inside the iframe implements rotate-to-fullscreen independently.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>referrerpolicy</strong></p></td>
-    <td><p>The <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy"><code>referrerpolicy</code></a> to be set on the iframe element.</p></td>
+    <td width="40%"><strong>referrerpolicy</strong></td>
+    <td>The <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy"><code>referrerpolicy</code></a> to be set on the iframe element.</td>
   </tr>
 </table>
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -86,15 +86,15 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
   <tr>
     <td width="40%"><p><strong>poster</strong></p></td>
     <td><p>The image for the frame to be displayed before video playback has started. By
-default, the first frame is displayed.
-<br>
-Alternatively, you can present a click-to-play overlay. For details, see the <a href="#click-to-play-overlay">Click-to-Play overlay</a> section below.</p></td>
+  default, the first frame is displayed.
+  <br>
+  Alternatively, you can present a click-to-play overlay. For details, see the <a href="#click-to-play-overlay">Click-to-Play overlay</a> section below.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>controls</strong></p></td>
@@ -123,7 +123,7 @@ to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/am
   <tr>
     <td width="40%"><p><strong>noaudio</strong></p></td>
     <td><p>Annotates the video as having no audio. This hides the equalizer icon that is displayed
-when the video has autoplay.</p></td>
+  when the video has autoplay.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>rotate-to-fullscreen</strong></p></td>

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -80,58 +80,58 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
-    <td><p>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</p></td>
+    <td width="40%"><strong>src</strong></td>
+    <td>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>poster</strong></p></td>
-    <td><p>The image for the frame to be displayed before video playback has started. By
-  default, the first frame is displayed.
-  <br>
-  Alternatively, you can present a click-to-play overlay. For details, see the <a href="#click-to-play-overlay">Click-to-Play overlay</a> section below.</p></td>
+    <td width="40%"><strong>poster</strong></td>
+    <td>The image for the frame to be displayed before video playback has started. By
+default, the first frame is displayed.
+<br>
+Alternatively, you can present a click-to-play overlay. For details, see the <a href="#click-to-play-overlay">Click-to-Play overlay</a> section below.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>controls</strong></p></td>
-    <td><p>This attribute is similar to the <code>controls</code> attribute in the HTML5 <code>video</code>. If this attribute is present, the browser offers controls to allow the user to control video playback.</p></td>
+    <td width="40%"><strong>controls</strong></td>
+    <td>This attribute is similar to the <code>controls</code> attribute in the HTML5 <code>video</code>. If this attribute is present, the browser offers controls to allow the user to control video playback.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>controlsList</strong></p></td>
-    <td><p>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 video element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</p></td>
+    <td width="40%"><strong>controlsList</strong></td>
+    <td>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 video element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>loop</strong></p></td>
-    <td><p>If present, the video will automatically loop back to the start upon reaching the end.</p></td>
+    <td width="40%"><strong>loop</strong></td>
+    <td>If present, the video will automatically loop back to the start upon reaching the end.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>crossorigin</strong></p></td>
-    <td><p>Required if a <code>track</code> resource is hosted on a different origin than the document.</p></td>
+    <td width="40%"><strong>crossorigin</strong></td>
+    <td>Required if a <code>track</code> resource is hosted on a different origin than the document.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>disableremoteplayback</strong></p></td>
-    <td><p>Determines whether the media element is allowed to have a remote playback UI such as Chromecast or AirPlay.</p></td>
+    <td width="40%"><strong>disableremoteplayback</strong></td>
+    <td>Determines whether the media element is allowed to have a remote playback UI such as Chromecast or AirPlay.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>muted (deprecated)</strong></p></td>
-    <td><p>The <code>muted</code> attribute is deprecated and no longer has any effect. The <code>autoplay</code> attribute automatically controls the mute behavior.</p></td>
+    <td width="40%"><strong>muted (deprecated)</strong></td>
+    <td>The <code>muted</code> attribute is deprecated and no longer has any effect. The <code>autoplay</code> attribute automatically controls the mute behavior.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>noaudio</strong></p></td>
-    <td><p>Annotates the video as having no audio. This hides the equalizer icon that is displayed
-  when the video has autoplay.</p></td>
+    <td width="40%"><strong>noaudio</strong></td>
+    <td>Annotates the video as having no audio. This hides the equalizer icon that is displayed
+when the video has autoplay.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>rotate-to-fullscreen</strong></p></td>
-    <td><p>If the video is visible, the video displays fullscreen after the user rotates their device into landscape mode. For more details, see the <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#rotate-to-fullscreen">Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>rotate-to-fullscreen</strong></td>
+    <td>If the video is visible, the video displays fullscreen after the user rotates their device into landscape mode. For more details, see the <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#rotate-to-fullscreen">Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -80,58 +80,58 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
 
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>Required if no `<source>` children are present. Must be HTTPS.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>Required if no <code>&lt;source&gt;</code> children are present. Must be HTTPS.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>poster</strong></td>
-    <td>The image for the frame to be displayed before video playback has started. By
-    default, the first frame is displayed.
+    <td width="40%"><p><strong>poster</strong></p></td>
+    <td><p>The image for the frame to be displayed before video playback has started. By
+default, the first frame is displayed.
 <br>
-    Alternatively, you can present a click-to-play overlay. For details, see the [Click-to-Play overlay](#click-to-play-overlay) section below.</td>
+Alternatively, you can present a click-to-play overlay. For details, see the <a href="#click-to-play-overlay">Click-to-Play overlay</a> section below.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>controls</strong></td>
-    <td>This attribute is similar to the `controls` attribute in the HTML5 `video`. If this attribute is present, the browser offers controls to allow the user to control video playback.</td>
+    <td width="40%"><p><strong>controls</strong></p></td>
+    <td><p>This attribute is similar to the <code>controls</code> attribute in the HTML5 <code>video</code>. If this attribute is present, the browser offers controls to allow the user to control video playback.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>controlsList</strong></td>
-    <td>Same as [controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) attribute of HTML5 video element. Only supported by certain browsers. Please see [https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) for details.</td>
+    <td width="40%"><p><strong>controlsList</strong></p></td>
+    <td><p>Same as <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">controlsList</a> attribute of HTML5 video element. Only supported by certain browsers. Please see <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList">https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList</a> for details.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>loop</strong></td>
-    <td>If present, the video will automatically loop back to the start upon reaching the end.</td>
+    <td width="40%"><p><strong>loop</strong></p></td>
+    <td><p>If present, the video will automatically loop back to the start upon reaching the end.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>crossorigin</strong></td>
-    <td>Required if a `track` resource is hosted on a different origin than the document.</td>
+    <td width="40%"><p><strong>crossorigin</strong></p></td>
+    <td><p>Required if a <code>track</code> resource is hosted on a different origin than the document.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>disableremoteplayback</strong></td>
-    <td>Determines whether the media element is allowed to have a remote playback UI such as Chromecast or AirPlay.</td>
+    <td width="40%"><p><strong>disableremoteplayback</strong></p></td>
+    <td><p>Determines whether the media element is allowed to have a remote playback UI such as Chromecast or AirPlay.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>muted (deprecated)</strong></td>
-    <td>The `muted` attribute is deprecated and no longer has any effect. The `autoplay` attribute automatically controls the mute behavior.</td>
+    <td width="40%"><p><strong>muted (deprecated)</strong></p></td>
+    <td><p>The <code>muted</code> attribute is deprecated and no longer has any effect. The <code>autoplay</code> attribute automatically controls the mute behavior.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>noaudio</strong></td>
-    <td>Annotates the video as having no audio. This hides the equalizer icon that is displayed
-    when the video has autoplay.</td>
+    <td width="40%"><p><strong>noaudio</strong></p></td>
+    <td><p>Annotates the video as having no audio. This hides the equalizer icon that is displayed
+when the video has autoplay.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>rotate-to-fullscreen</strong></td>
-    <td>If the video is visible, the video displays fullscreen after the user rotates their device into landscape mode. For more details, see the [Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#rotate-to-fullscreen).</td>
+    <td width="40%"><p><strong>rotate-to-fullscreen</strong></p></td>
+    <td><p>If the video is visible, the video displays fullscreen after the user rotates their device into landscape mode. For more details, see the <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#rotate-to-fullscreen">Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -57,18 +57,18 @@ With responsive layout, the width and height from the example should yield corre
 
 <table>
   <tr>
-    <td width="40%"><strong>data-videoid (required)</strong></td>
-    <td>The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: `https://vimeo.com/27246366`.</td>
+    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
+    <td><p>The Vimeo video id found in every Vimeo video page URL For example, <code>27246366</code> is the video id for the following url: <code>https://vimeo.com/27246366</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
-    played as soon as it becomes visible. There are some conditions that the component needs to meet
-    to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).</td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -57,18 +57,18 @@ With responsive layout, the width and height from the example should yield corre
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-videoid (required)</strong></p></td>
-    <td><p>The Vimeo video id found in every Vimeo video page URL For example, <code>27246366</code> is the video id for the following url: <code>https://vimeo.com/27246366</code>.</p></td>
+    <td width="40%"><strong>data-videoid (required)</strong></td>
+    <td>The Vimeo video id found in every Vimeo video page URL For example, <code>27246366</code> is the video id for the following url: <code>https://vimeo.com/27246366</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-  played as soon as it becomes visible. There are some conditions that the component needs to meet
-  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -63,8 +63,8 @@ With responsive layout, the width and height from the example should yield corre
   <tr>
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay, the video will be automatically
-played as soon as it becomes visible. There are some conditions that the component needs to meet
-to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
+  played as soon as it becomes visible. There are some conditions that the component needs to meet
+  to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -56,12 +56,12 @@ A Vine simple embed has equal width and height:
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-vineid (required)</strong></p></td>
-    <td><p>The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, <code>MdKjXez002d</code> is the vineID.</p></td>
+    <td width="40%"><strong>data-vineid (required)</strong></td>
+    <td>The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, <code>MdKjXez002d</code> is the vineID.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-vine/validator-amp-vine.protoascii">amp-vine rules</a> in the AMP validator specification.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-vine/validator-amp-vine.protoascii">amp-vine rules</a> in the AMP validator specification.</td>
   </tr>
 </table>
 

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -56,12 +56,12 @@ A Vine simple embed has equal width and height:
 
 <table>
   <tr>
-    <td width="40%"><strong>data-vineid (required)</strong></td>
-    <td>The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, `MdKjXez002d` is the vineID.</td>
+    <td width="40%"><p><strong>data-vineid (required)</strong></p></td>
+    <td><p>The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, <code>MdKjXez002d</code> is the vineID.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>See [amp-vine rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-vine/validator-amp-vine.protoascii) in the AMP validator specification.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-vine/validator-amp-vine.protoascii">amp-vine rules</a> in the AMP validator specification.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-viqeo-player/amp-viqeo-player.md
+++ b/extensions/amp-viqeo-player/amp-viqeo-player.md
@@ -69,17 +69,17 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-<li>the video is automatically muted before autoplay starts</li>
-<li>when the video is scrolled out of view, the video is paused</li>
-<li>when the video is scrolled into view, the video resumes playback</li>
-<li>when the user taps the video, the video is unmuted</li>
-<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+  <li>the video is automatically muted before autoplay starts</li>
+  <li>when the video is scrolled out of view, the video is paused</li>
+  <li>when the video is scrolled into view, the video resumes playback</li>
+  <li>when the user taps the video, the video is unmuted</li>
+  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
 </ul></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>data-profileid</strong></p></td>
     <td><p>Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
-Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br></p>
+  Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br></p>
 <p>To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid &amp; width and height.</p></td>
   </tr>
   <tr>

--- a/extensions/amp-viqeo-player/amp-viqeo-player.md
+++ b/extensions/amp-viqeo-player/amp-viqeo-player.md
@@ -67,7 +67,7 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
 <table>
   <tr>
     <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay:</p>
+    <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
   <li>when the video is scrolled out of view, the video is paused</li>
@@ -79,7 +79,7 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
   <tr>
     <td width="40%"><strong>data-profileid</strong></td>
     <td><p>Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
-  Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br></p>
+  Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p</p>
 <p>To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid &amp; width and height.</p></td>
   </tr>
   <tr>

--- a/extensions/amp-viqeo-player/amp-viqeo-player.md
+++ b/extensions/amp-viqeo-player/amp-viqeo-player.md
@@ -66,8 +66,8 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
 
 <table>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
   <li>when the video is scrolled out of view, the video is paused</li>
@@ -77,17 +77,17 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-profileid</strong></p></td>
+    <td width="40%"><strong>data-profileid</strong></td>
     <td><p>Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
   Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br></p>
 <p>To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid &amp; width and height.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-videoid</strong></p></td>
-    <td><p>The identifier of the video. All videos have unique id, and can be found in Viqeo account after authorisation. Viqeo do not let embed videos by 3rd party websites so only one way to get a data-videoid and other attributes to sign in to Viqeo account.</p></td>
+    <td width="40%"><strong>data-videoid</strong></td>
+    <td>The identifier of the video. All videos have unique id, and can be found in Viqeo account after authorisation. Viqeo do not let embed videos by 3rd party websites so only one way to get a data-videoid and other attributes to sign in to Viqeo account.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>width and height</strong></p></td>
-    <td><p>The width and height attributes are special for the Viqeo embed. Viqeo supports any proportions of videos. Basically Viqeo generates an unique code for each video depending on video size and proportions, but Viqeo user may change proportions in interface. Anyway after pressing 'Get code' button an unique code will be generated.</p></td>
+    <td width="40%"><strong>width and height</strong></td>
+    <td>The width and height attributes are special for the Viqeo embed. Viqeo supports any proportions of videos. Basically Viqeo generates an unique code for each video depending on video size and proportions, but Viqeo user may change proportions in interface. Anyway after pressing 'Get code' button an unique code will be generated.</td>
   </tr>
 </table>

--- a/extensions/amp-viqeo-player/amp-viqeo-player.md
+++ b/extensions/amp-viqeo-player/amp-viqeo-player.md
@@ -66,30 +66,28 @@ The `width` and `height` attributes determine the aspect ratio of the Viqeo embe
 
 <table>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay:
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-    <li>the video is automatically muted before autoplay starts</li>
-    <li>when the video is scrolled out of view, the video is paused</li>
-    <li>when the video is scrolled into view, the video resumes playback</li>
-    <li>when the user taps the video, the video is unmuted</li>
-    <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
-</ul>
-    </td>
+<li>the video is automatically muted before autoplay starts</li>
+<li>when the video is scrolled out of view, the video is paused</li>
+<li>when the video is scrolled into view, the video resumes playback</li>
+<li>when the user taps the video, the video is unmuted</li>
+<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-profileid</strong></td>
-    <td>Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
-    Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br>
-
-    To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid & width and height.</td>
+    <td width="40%"><p><strong>data-profileid</strong></p></td>
+    <td><p>Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
+Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p<br></p>
+<p>To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid &amp; width and height.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-videoid</strong></td>
-    <td>The identifier of the video. All videos have unique id, and can be found in Viqeo account after authorisation. Viqeo do not let embed videos by 3rd party websites so only one way to get a data-videoid and other attributes to sign in to Viqeo account.</td>
+    <td width="40%"><p><strong>data-videoid</strong></p></td>
+    <td><p>The identifier of the video. All videos have unique id, and can be found in Viqeo account after authorisation. Viqeo do not let embed videos by 3rd party websites so only one way to get a data-videoid and other attributes to sign in to Viqeo account.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>width and height</strong></td>
-    <td>The width and height attributes are special for the Viqeo embed. Viqeo supports any proportions of videos. Basically Viqeo generates an unique code for each video depending on video size and proportions, but Viqeo user may change proportions in interface. Anyway after pressing 'Get code' button an unique code will be generated.</td>
+    <td width="40%"><p><strong>width and height</strong></p></td>
+    <td><p>The width and height attributes are special for the Viqeo embed. Viqeo supports any proportions of videos. Basically Viqeo generates an unique code for each video depending on video size and proportions, but Viqeo user may change proportions in interface. Anyway after pressing 'Get code' button an unique code will be generated.</p></td>
   </tr>
 </table>

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -133,7 +133,7 @@ to learn more and play with samples.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>src</strong></p></td>
+    <td width="40%"><strong>src</strong></td>
     <td><p>This attribute can be used to load a Vega specification data file
   from a specified remote URL. The URL must use https scheme.<br></p>
 <p>Alternatively specification data can be included in <code>&lt;script type="application/json"&gt;</code>
@@ -141,7 +141,7 @@ to learn more and play with samples.
 <p>Only either <code>src</code> or <code>&lt;script&gt;</code> should be specified. Using both will result in error.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>use-data-width and use-data-height</strong></p></td>
+    <td width="40%"><strong>use-data-width and use-data-height</strong></td>
     <td><p>To support responsive visualization, by default <code>&lt;amp-viz-vega&gt;</code> overrides <code>width</code>
   and <code>height</code> values defined in the Vega specification data with the actual width
   and height of the <code>&lt;amp-viz-vega&gt;</code> element and re-renders when the size of the

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -135,7 +135,7 @@ to learn more and play with samples.
   <tr>
     <td width="40%"><strong>src</strong></td>
     <td><p>This attribute can be used to load a Vega specification data file
-  from a specified remote URL. The URL must use https scheme.<br></p>
+  from a specified remote URL. The URL must use https scheme.</p>
 <p>Alternatively specification data can be included in <code>&lt;script type="application/json"&gt;</code>
   as the only child of <code>&lt;amp-viz-vega&gt;</code>.<br></p>
 <p>Only either <code>src</code> or <code>&lt;script&gt;</code> should be specified. Using both will result in error.</p></td>
@@ -145,7 +145,7 @@ to learn more and play with samples.
     <td><p>To support responsive visualization, by default <code>&lt;amp-viz-vega&gt;</code> overrides <code>width</code>
   and <code>height</code> values defined in the Vega specification data with the actual width
   and height of the <code>&lt;amp-viz-vega&gt;</code> element and re-renders when the size of the
-  element changes (e.g. going to landscape from portrait on phones).<br></p>
+  element changes (e.g. going to landscape from portrait on phones).</p>
 <p><code>use-data-width</code> and <code>use-data-height</code> attribute can be set to instruct <code>&lt;amp-viz-vega&gt;</code>
   not to override the data-defined width and height values. It is recommended to avoid
   using these attributes as they may result in visualizations that require vertical

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -133,30 +133,27 @@ to learn more and play with samples.
 
 <table>
   <tr>
-    <td width="40%"><strong>src</strong></td>
-    <td>This attribute can be used to load a Vega specification data file
-    from a specified remote URL. The URL must use https scheme.<br>
-
-    Alternatively specification data can be included in `<script type="application/json">`
-    as the only child of `<amp-viz-vega>`.<br>
-
-    Only either `src` or `<script>` should be specified. Using both will result in error.</td>
+    <td width="40%"><p><strong>src</strong></p></td>
+    <td><p>This attribute can be used to load a Vega specification data file
+from a specified remote URL. The URL must use https scheme.<br></p>
+<p>Alternatively specification data can be included in <code>&lt;script type="application/json"&gt;</code>
+as the only child of <code>&lt;amp-viz-vega&gt;</code>.<br></p>
+<p>Only either <code>src</code> or <code>&lt;script&gt;</code> should be specified. Using both will result in error.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>use-data-width and use-data-height</strong></td>
-    <td>To support responsive visualization, by default `<amp-viz-vega>` overrides `width`
-    and `height` values defined in the Vega specification data with the actual width
-    and height of the `<amp-viz-vega>` element and re-renders when the size of the
-    element changes (e.g. going to landscape from portrait on phones).<br>
-
-    `use-data-width` and `use-data-height` attribute can be set to instruct `<amp-viz-vega>`
-    not to override the data-defined width and height values. It is recommended to avoid
-    using these attributes as they may result in visualizations that require vertical
-    and/or horizontal scrolling to be fully viewable. But they can be used in certain
-    cases where it may not be possible for the visualization to scale to fit the given
-    width and height. For example, the *World Map* visualization in the
-    [examples](https://github.com/ampproject/amphtml/blob/master/examples/viz-vega.amp.html)
-    can not realistically scale to the given width and still be usable so it `use-data-width`
-    and allows user to scroll horizontally.</td>
+    <td width="40%"><p><strong>use-data-width and use-data-height</strong></p></td>
+    <td><p>To support responsive visualization, by default <code>&lt;amp-viz-vega&gt;</code> overrides <code>width</code>
+and <code>height</code> values defined in the Vega specification data with the actual width
+and height of the <code>&lt;amp-viz-vega&gt;</code> element and re-renders when the size of the
+element changes (e.g. going to landscape from portrait on phones).<br></p>
+<p><code>use-data-width</code> and <code>use-data-height</code> attribute can be set to instruct <code>&lt;amp-viz-vega&gt;</code>
+not to override the data-defined width and height values. It is recommended to avoid
+using these attributes as they may result in visualizations that require vertical
+and/or horizontal scrolling to be fully viewable. But they can be used in certain
+cases where it may not be possible for the visualization to scale to fit the given
+width and height. For example, the <em>World Map</em> visualization in the
+<a href="https://github.com/ampproject/amphtml/blob/master/examples/viz-vega.amp.html">examples</a>
+can not realistically scale to the given width and still be usable so it <code>use-data-width</code>
+and allows user to scroll horizontally.</p></td>
   </tr>
 </table>

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -135,25 +135,25 @@ to learn more and play with samples.
   <tr>
     <td width="40%"><p><strong>src</strong></p></td>
     <td><p>This attribute can be used to load a Vega specification data file
-from a specified remote URL. The URL must use https scheme.<br></p>
+  from a specified remote URL. The URL must use https scheme.<br></p>
 <p>Alternatively specification data can be included in <code>&lt;script type="application/json"&gt;</code>
-as the only child of <code>&lt;amp-viz-vega&gt;</code>.<br></p>
+  as the only child of <code>&lt;amp-viz-vega&gt;</code>.<br></p>
 <p>Only either <code>src</code> or <code>&lt;script&gt;</code> should be specified. Using both will result in error.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>use-data-width and use-data-height</strong></p></td>
     <td><p>To support responsive visualization, by default <code>&lt;amp-viz-vega&gt;</code> overrides <code>width</code>
-and <code>height</code> values defined in the Vega specification data with the actual width
-and height of the <code>&lt;amp-viz-vega&gt;</code> element and re-renders when the size of the
-element changes (e.g. going to landscape from portrait on phones).<br></p>
+  and <code>height</code> values defined in the Vega specification data with the actual width
+  and height of the <code>&lt;amp-viz-vega&gt;</code> element and re-renders when the size of the
+  element changes (e.g. going to landscape from portrait on phones).<br></p>
 <p><code>use-data-width</code> and <code>use-data-height</code> attribute can be set to instruct <code>&lt;amp-viz-vega&gt;</code>
-not to override the data-defined width and height values. It is recommended to avoid
-using these attributes as they may result in visualizations that require vertical
-and/or horizontal scrolling to be fully viewable. But they can be used in certain
-cases where it may not be possible for the visualization to scale to fit the given
-width and height. For example, the <em>World Map</em> visualization in the
-<a href="https://github.com/ampproject/amphtml/blob/master/examples/viz-vega.amp.html">examples</a>
-can not realistically scale to the given width and still be usable so it <code>use-data-width</code>
-and allows user to scroll horizontally.</p></td>
+  not to override the data-defined width and height values. It is recommended to avoid
+  using these attributes as they may result in visualizations that require vertical
+  and/or horizontal scrolling to be fully viewable. But they can be used in certain
+  cases where it may not be possible for the visualization to scale to fit the given
+  width and height. For example, the <em>World Map</em> visualization in the
+  <a href="https://github.com/ampproject/amphtml/blob/master/examples/viz-vega.amp.html">examples</a>
+  can not realistically scale to the given width and still be usable so it <code>use-data-width</code>
+  and allows user to scroll horizontally.</p></td>
   </tr>
 </table>

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -66,7 +66,7 @@ Clicking the subscription widget pops up a page prompting the user for notificat
   <tr>
     <td width="40%"><p><strong>visibility (required)</strong></p></td>
     <td><p>Describes when the widget is shown. The value can be one of <code>unsubscribed</code>, <code>subscribed</code>, or <code>blocked</code>.<br>
-Widgets are initially hidden while the user's subscription state is computed.</p></td>
+  Widgets are initially hidden while the user's subscription state is computed.</p></td>
   </tr>
 
 </table>

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -64,9 +64,9 @@ Clicking the subscription widget pops up a page prompting the user for notificat
 
 <table>
   <tr>
-    <td width="40%"><strong>visibility (required)</strong></td>
-    <td>Describes when the widget is shown. The value can be one of `unsubscribed`, `subscribed`, or `blocked`.<br>
-    Widgets are initially hidden while the user's subscription state is computed.</td>
+    <td width="40%"><p><strong>visibility (required)</strong></p></td>
+    <td><p>Describes when the widget is shown. The value can be one of <code>unsubscribed</code>, <code>subscribed</code>, or <code>blocked</code>.<br>
+Widgets are initially hidden while the user's subscription state is computed.</p></td>
   </tr>
 
 </table>

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -64,9 +64,9 @@ Clicking the subscription widget pops up a page prompting the user for notificat
 
 <table>
   <tr>
-    <td width="40%"><p><strong>visibility (required)</strong></p></td>
-    <td><p>Describes when the widget is shown. The value can be one of <code>unsubscribed</code>, <code>subscribed</code>, or <code>blocked</code>.<br>
-  Widgets are initially hidden while the user's subscription state is computed.</p></td>
+    <td width="40%"><strong>visibility (required)</strong></td>
+    <td>Describes when the widget is shown. The value can be one of <code>unsubscribed</code>, <code>subscribed</code>, or <code>blocked</code>.<br>
+Widgets are initially hidden while the user's subscription state is computed.</td>
   </tr>
 
 </table>

--- a/extensions/amp-wistia-player/amp-wistia-player.md
+++ b/extensions/amp-wistia-player/amp-wistia-player.md
@@ -50,12 +50,12 @@ Displays a <a href="https://wistia.com">Wistia</a> video.
 
 <table>
   <tr>
-    <td width="40%"><strong>data-media-hashed-id (required)</strong></td>
-    <td>The Wistia media id is found in every Wistia media page URL. If the media page URL is https://support.wistia.com/medias/u8p9wq6mq8, the data-media-hashed-id is `u8p9wq6mq8`.</td>
+    <td width="40%"><p><strong>data-media-hashed-id (required)</strong></p></td>
+    <td><p>The Wistia media id is found in every Wistia media page URL. If the media page URL is https://support.wistia.com/medias/u8p9wq6mq8, the data-media-hashed-id is <code>u8p9wq6mq8</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-wistia-player/amp-wistia-player.md
+++ b/extensions/amp-wistia-player/amp-wistia-player.md
@@ -50,12 +50,12 @@ Displays a <a href="https://wistia.com">Wistia</a> video.
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-media-hashed-id (required)</strong></p></td>
-    <td><p>The Wistia media id is found in every Wistia media page URL. If the media page URL is https://support.wistia.com/medias/u8p9wq6mq8, the data-media-hashed-id is <code>u8p9wq6mq8</code>.</p></td>
+    <td width="40%"><strong>data-media-hashed-id (required)</strong></td>
+    <td>The Wistia media id is found in every Wistia media page URL. If the media page URL is https://support.wistia.com/medias/u8p9wq6mq8, the data-media-hashed-id is <code>u8p9wq6mq8</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-yotpo/amp-yotpo.md
+++ b/extensions/amp-yotpo/amp-yotpo.md
@@ -80,7 +80,7 @@ You can use the `amp-yotpo` extension to display [Yotpo on-site widgets](https:/
   <tr>
     <td width="40%"><p><strong>data-** (optional)</strong></p></td>
     <td><p>Each Yotpo widget has optional data attributes. For example, the reviews widget has an optional attribute named <code>product-id</code>. Refer to <a href="https://support.yotpo.com/en/on-site">Yottpo's documentation</a> for which attributes to specify.<br>
-When using the <code>amp-yotpo</code> extension, for each corresponding Yotpo attribute prepend <code>data</code> to the attribute. For example, the <code>product-id</code> attribute becomes <code>data-product-id</code>.</p></td>
+  When using the <code>amp-yotpo</code> extension, for each corresponding Yotpo attribute prepend <code>data</code> to the attribute. For example, the <code>product-id</code> attribute becomes <code>data-product-id</code>.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>

--- a/extensions/amp-yotpo/amp-yotpo.md
+++ b/extensions/amp-yotpo/amp-yotpo.md
@@ -74,17 +74,17 @@ You can use the `amp-yotpo` extension to display [Yotpo on-site widgets](https:/
 
 <table>
   <tr>
-    <td width="40%"><p><strong>data-app-key (required)</strong></p></td>
-    <td><p>Specifies the account app key. For example, <code>liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5</code>.</p></td>
+    <td width="40%"><strong>data-app-key (required)</strong></td>
+    <td>Specifies the account app key. For example, <code>liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-** (optional)</strong></p></td>
-    <td><p>Each Yotpo widget has optional data attributes. For example, the reviews widget has an optional attribute named <code>product-id</code>. Refer to <a href="https://support.yotpo.com/en/on-site">Yottpo's documentation</a> for which attributes to specify.<br>
-  When using the <code>amp-yotpo</code> extension, for each corresponding Yotpo attribute prepend <code>data</code> to the attribute. For example, the <code>product-id</code> attribute becomes <code>data-product-id</code>.</p></td>
+    <td width="40%"><strong>data-** (optional)</strong></td>
+    <td>Each Yotpo widget has optional data attributes. For example, the reviews widget has an optional attribute named <code>product-id</code>. Refer to <a href="https://support.yotpo.com/en/on-site">Yottpo's documentation</a> for which attributes to specify.<br>
+When using the <code>amp-yotpo</code> extension, for each corresponding Yotpo attribute prepend <code>data</code> to the attribute. For example, the <code>product-id</code> attribute becomes <code>data-product-id</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-yotpo/amp-yotpo.md
+++ b/extensions/amp-yotpo/amp-yotpo.md
@@ -74,18 +74,17 @@ You can use the `amp-yotpo` extension to display [Yotpo on-site widgets](https:/
 
 <table>
   <tr>
-    <td width="40%"><strong>data-app-key (required)</strong></td>
-    <td>Specifies the account app key. For example, `liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5`.</td>
+    <td width="40%"><p><strong>data-app-key (required)</strong></p></td>
+    <td><p>Specifies the account app key. For example, <code>liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-** (optional)</strong></td>
-    <td>Each Yotpo widget has optional data attributes. For example, the reviews widget has an optional attribute named `product-id`. Refer to [Yottpo's documentation](https://support.yotpo.com/en/on-site) for which attributes to specify.<br>
-    When using the `amp-yotpo` extension, for each corresponding Yotpo attribute prepend `data` to the attribute. For example, the `product-id` attribute becomes `data-product-id`.
-    </td>
+    <td width="40%"><p><strong>data-** (optional)</strong></p></td>
+    <td><p>Each Yotpo widget has optional data attributes. For example, the reviews widget has an optional attribute named <code>product-id</code>. Refer to <a href="https://support.yotpo.com/en/on-site">Yottpo's documentation</a> for which attributes to specify.<br>
+When using the <code>amp-yotpo</code> extension, for each corresponding Yotpo attribute prepend <code>data</code> to the attribute. For example, the <code>product-id</code> attribute becomes <code>data-product-id</code>.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -72,8 +72,8 @@ With the responsive layout, the width and height from the example should yield c
 
 <table>
   <tr>
-    <td width="40%"><p><strong>autoplay</strong></p></td>
-    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
   <li>the video is automatically muted before autoplay starts
   </li>
@@ -88,16 +88,16 @@ With the responsive layout, the width and height from the example should yield c
 </ul></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-videoid</strong></p></td>
+    <td width="40%"><strong>data-videoid</strong></td>
     <td><p>The YouTube video id found in every YouTube video page URL.</p>
 <p>For example, in this URL: https://www.youtube.com/watch?v=Z1q71gFeRqM, <code>Z1q71gFeRqM</code> is the video id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-live-channelid</strong></p></td>
-    <td><p>The Youtube channel id that provides a stable livestream url. For example, in this URL: https://www.youtube.com/embed/live_stream?channel=UCB8Kb4pxYzsDsHxzBfnid4Q, <code>UCB8Kb4pxYzsDsHxzBfnid4Q</code> is the channel id. You can provide a <code>data-live-channelid</code> instead of a <code>data-videoid</code> attribute to embed a stable url for a live stream instead of a video. Channels do not come with default placeholders. You can provide a placeholder for the video per example 2 above.</p></td>
+    <td width="40%"><strong>data-live-channelid</strong></td>
+    <td>The Youtube channel id that provides a stable livestream url. For example, in this URL: https://www.youtube.com/embed/live_stream?channel=UCB8Kb4pxYzsDsHxzBfnid4Q, <code>UCB8Kb4pxYzsDsHxzBfnid4Q</code> is the channel id. You can provide a <code>data-live-channelid</code> instead of a <code>data-videoid</code> attribute to embed a stable url for a live stream instead of a video. Channels do not come with default placeholders. You can provide a placeholder for the video per example 2 above.</td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
+    <td width="40%"><strong>data-param-&#42;</strong></td>
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
@@ -107,7 +107,7 @@ With the responsive layout, the width and height from the example should yield c
 </td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>credentials (optional)</strong></p></td>
+    <td width="40%"><strong>credentials (optional)</strong></td>
     <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
 <ul>
   <li>Supported values: `omit`, `include`</li>
@@ -117,8 +117,8 @@ With the responsive layout, the width and height from the example should yield c
   Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><p><strong>common attributes</strong></p></td>
-    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>
 </table>
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -72,57 +72,51 @@ With the responsive layout, the width and height from the example should yield c
 
 <table>
   <tr>
-    <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay:
-      <ul>
-        <li>the video is automatically muted before autoplay starts
-        </li>
-        <li>when the video is scrolled out of view, the video is paused
-        </li>
-        <li>when the video is scrolled into view, the video resumes playback
-        </li>
-        <li>when the user taps the video, the video is unmuted
-        </li>
-        <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
-        </li>
-      </ul>
-    </td>
+    <td width="40%"><p><strong>autoplay</strong></p></td>
+    <td><p>If this attribute is present, and the browser supports autoplay:</p>
+<ul>
+<li>the video is automatically muted before autoplay starts
+</li>
+<li>when the video is scrolled out of view, the video is paused
+</li>
+<li>when the video is scrolled into view, the video resumes playback
+</li>
+<li>when the user taps the video, the video is unmuted
+</li>
+<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+</li>
+</ul></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-videoid</strong></td>
-    <td>The YouTube video id found in every YouTube video page URL.
-
-    For example, in this URL: https://www.youtube.com/watch?v=Z1q71gFeRqM, `Z1q71gFeRqM` is the video id.</td>
+    <td width="40%"><p><strong>data-videoid</strong></p></td>
+    <td><p>The YouTube video id found in every YouTube video page URL.</p>
+<p>For example, in this URL: https://www.youtube.com/watch?v=Z1q71gFeRqM, <code>Z1q71gFeRqM</code> is the video id.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-live-channelid</strong></td>
-    <td>The Youtube channel id that provides a stable livestream url. For example, in this URL: https://www.youtube.com/embed/live_stream?channel=UCB8Kb4pxYzsDsHxzBfnid4Q, `UCB8Kb4pxYzsDsHxzBfnid4Q` is the channel id. You can provide a `data-live-channelid` instead of a `data-videoid` attribute to embed a stable url for a live stream instead of a video. Channels do not come with default placeholders. You can provide a placeholder for the video per example 2 above.</td>
+    <td width="40%"><p><strong>data-live-channelid</strong></p></td>
+    <td><p>The Youtube channel id that provides a stable livestream url. For example, in this URL: https://www.youtube.com/embed/live_stream?channel=UCB8Kb4pxYzsDsHxzBfnid4Q, <code>UCB8Kb4pxYzsDsHxzBfnid4Q</code> is the channel id. You can provide a <code>data-live-channelid</code> instead of a <code>data-videoid</code> attribute to embed a stable url for a live stream instead of a video. Channels do not come with default placeholders. You can provide a placeholder for the video per example 2 above.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>data-param-&#42;</strong></td>
-    <td>All `data-param-*` attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.
-
-    Keys and values will be URI encoded. Keys will be camel cased.
-
-    <ul><li>`data-param-controls=1` becomes `&controls=1`</li></ul>
-
-    See [YouTube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for YouTube.
+    <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
+    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.</p>
+<p>Keys and values will be URI encoded. Keys will be camel cased.</p>
+<ul><li>`data-param-controls=1` becomes `&controls=1`</li></ul>
+<p>See <a href="https://developers.google.com/youtube/player_parameters">YouTube Embedded Player Parameters</a> for more parameter options for YouTube.</p>
 </td>
   </tr>
   <tr>
-    <td width="40%"><strong>credentials (optional)</strong></td>
-    <td>Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
-
-    <ul>
-      <li>Supported values: `omit`, `include`</li>
-      <li>Default: `include`</li>
-    </ul>
-    If you want to use the [YouTube player in privacy-enhanced mode](http://www.google.com/support/youtube/bin/answer.py?answer=141046), pass the value of `omit`.
-    Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.</td>
+    <td width="40%"><p><strong>credentials (optional)</strong></p></td>
+    <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
+<ul>
+<li>Supported values: `omit`, `include`</li>
+<li>Default: `include`</li>
+</ul>
+<p>If you want to use the <a href="http://www.google.com/support/youtube/bin/answer.py?answer=141046">YouTube player in privacy-enhanced mode</a>, pass the value of <code>omit</code>.
+Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.</p></td>
   </tr>
   <tr>
-    <td width="40%"><strong>common attributes</strong></td>
-    <td>This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.</td>
+    <td width="40%"><p><strong>common attributes</strong></p></td>
+    <td><p>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</p></td>
   </tr>
 </table>
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -75,16 +75,16 @@ With the responsive layout, the width and height from the example should yield c
     <td width="40%"><p><strong>autoplay</strong></p></td>
     <td><p>If this attribute is present, and the browser supports autoplay:</p>
 <ul>
-<li>the video is automatically muted before autoplay starts
-</li>
-<li>when the video is scrolled out of view, the video is paused
-</li>
-<li>when the video is scrolled into view, the video resumes playback
-</li>
-<li>when the user taps the video, the video is unmuted
-</li>
-<li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
-</li>
+  <li>the video is automatically muted before autoplay starts
+  </li>
+  <li>when the video is scrolled out of view, the video is paused
+  </li>
+  <li>when the video is scrolled into view, the video resumes playback
+  </li>
+  <li>when the user taps the video, the video is unmuted
+  </li>
+  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+  </li>
 </ul></td>
   </tr>
   <tr>
@@ -100,7 +100,9 @@ With the responsive layout, the width and height from the example should yield c
     <td width="40%"><p><strong>data-param-&#42;</strong></p></td>
     <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.</p>
-<ul><li>`data-param-controls=1` becomes `&controls=1`</li></ul>
+<ul>
+  <li>`data-param-controls=1` becomes `&controls=1`</li>
+</ul>
 <p>See <a href="https://developers.google.com/youtube/player_parameters">YouTube Embedded Player Parameters</a> for more parameter options for YouTube.</p>
 </td>
   </tr>
@@ -108,11 +110,11 @@ With the responsive layout, the width and height from the example should yield c
     <td width="40%"><p><strong>credentials (optional)</strong></p></td>
     <td><p>Defines a <code>credentials</code> option as specified by the <a href="https://fetch.spec.whatwg.org/">Fetch API</a>.</p>
 <ul>
-<li>Supported values: `omit`, `include`</li>
-<li>Default: `include`</li>
+  <li>Supported values: `omit`, `include`</li>
+  <li>Default: `include`</li>
 </ul>
 <p>If you want to use the <a href="http://www.google.com/support/youtube/bin/answer.py?answer=141046">YouTube player in privacy-enhanced mode</a>, pass the value of <code>omit</code>.
-Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.</p></td>
+  Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.</p></td>
   </tr>
   <tr>
     <td width="40%"><p><strong>common attributes</strong></p></td>


### PR DESCRIPTION
After #20684, several attribute tables in extension docs are not rendering properly and showing raw markdown instead, at least on Github.

I went ahead and converted every cell content to from markdown to HTML.