### PR TITLE
🐛Reset min dimensions on undock

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1717,6 +1717,8 @@ export class VideoDocking {
         resetStyles(el, [
           'transform',
           'transition',
+          'min-width',
+          'min-height',
           'width',
           'height',
           'opacity',


### PR DESCRIPTION
Otherwise the video can be oversized and clipped when docked and resizing the window.