### PR TITLE
✨Add support for setting the slide via an attribute.

### DIFF
--- a/extensions/amp-carousel/0.2/carousel.js
+++ b/extensions/amp-carousel/0.2/carousel.js
@@ -145,6 +145,13 @@ function sum(arr) {
  * half the slides are moved after. This could be a bit smarter and only move
  * as many as are necessary to have a sufficient amount of buffer. When slides
  * are moved, they are positioned on top of an existing spacer.
+ *
+ * Initial index:
+ *
+ * The initial index can be specified, which will make the carousel scroll to
+ * the desired index when it first renders. Since the layout of the slides is
+ * asynchronous, this should be used instead of calling `goToSlide` after
+ * creating the carousel.
  */
 export class Carousel {
   /**
@@ -152,6 +159,7 @@ export class Carousel {
   *   win: !Window,
   *   element: !Element,
   *   scrollContainer: !Element,
+  *   initialIndex: (number|undefined),
   *   runMutate: function(function()),
   * }} config
   */
@@ -159,6 +167,7 @@ export class Carousel {
     win,
     element,
     scrollContainer,
+    initialIndex = 0,
     runMutate,
   }) {
     /** @private @const */
@@ -262,10 +271,7 @@ export class Carousel {
      * restingIndex to currentIndex.
      * @private {number}
      */
-    this.currentIndex_ = 0;
-
-    /** @private {number} */
-    this.initialIndex_ = 0;
+    this.currentIndex_ = initialIndex;
 
     /** @private {boolean} */
     this.loop_ = false;
@@ -372,7 +378,7 @@ export class Carousel {
    * }=} options
    */
   goToSlide(index, {smoothScroll = true, actionSource} = {}) {
-    if (index < 0 || index > this.slides_.length - 1) {
+    if (index < 0 || index > this.slides_.length - 1 || isNaN(index)) {
       return;
     }
 
@@ -437,14 +443,6 @@ export class Carousel {
   }
 
   /**
-   * @param {number} initialIndex The initial index that should be shown.
-   */
-  updateInitialIndex(initialIndex) {
-    this.initialIndex_ = initialIndex;
-    this.updateUi();
-  }
-
-  /**
    * @param {boolean} loop Whether or not the scrollable should loop when
    *    reaching the last slide.
    */
@@ -504,7 +502,7 @@ export class Carousel {
    *
    * @param {boolean} userScrollable Whether or not the carousel can be
    *    scrolled (e.g. via touch). If false, then the carousel can only be
-   *    advanced via next, prev, goToIndex or autoAdvance.
+   *    advanced via next, prev, goToSlide or autoAdvance.
    */
   updateUserScrollable(userScrollable) {
     this.userScrollable_ = userScrollable;
@@ -542,10 +540,6 @@ export class Carousel {
       this.setChildrenSnapAlign_();
       this.hideSpacersAndSlides_();
       this.resetScrollReferencePoint_(/* force */true);
-      this.ignoreNextScroll_ = true;
-      this.scrollSlideIntoView_(this.slides_[this.currentIndex_], {
-        smoothScroll: false,
-      });
     });
   }
 

--- a/extensions/amp-carousel/0.2/test-e2e/test-initial-slide.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-initial-slide.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getSlide,
+} from './helpers';
+
+describes.endtoend('AMP carousel', {
+}, async env => {
+  const pageWidth = 600;
+  const pageHeight = 600;
+  let controller;
+  let ampDriver;
+
+  beforeEach(async() => {
+    controller = env.controller;
+    ampDriver = env.ampDriver;
+
+    await controller.navigateTo('http://localhost:8000/test/manual/amp-carousel-0-2/initial-slide.amp.html');
+    await ampDriver.toggleExperiment('layers', true);
+    await ampDriver.toggleExperiment('amp-carousel-v2', true);
+
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-carousel-0-2/initial-slide.amp.html');
+  });
+
+  it('should render with the correct initial slide', async() => {
+    const thirdSlide = await getSlide(controller, 2);
+
+    // Normally, resizing would cause the position to change. We're testing
+    // that the carousel moves this to the correct position again.
+    await expect(controller.getElementRect(thirdSlide)).to.include({
+      'x': 0,
+      'width': pageWidth,
+    });
+  });
+});

--- a/test/manual/amp-carousel-0-2/bind-slide.amp.html
+++ b/test/manual/amp-carousel-0-2/bind-slide.amp.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Carousel with bound slide</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-state id="carousel">
+    <script type="application/json">
+      {
+        "slide": 0
+      }
+    </script>
+  </amp-state>
+  <h1>Using bind to control the slide</h1>
+  <amp-carousel
+      id="carousel-1"
+      width="300" height="200"
+      layout="responsive"
+      [slide]="carousel.slide">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div>
+      <amp-img src="./img/redgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/greengradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/bluegradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/orangegradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/tealgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/lemonyellowgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/lilacgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+  <button id="slide-0"
+      on="tap:AMP.setState({'carousel': {'slide': 0}})">
+    Set slide to 0
+  </button>
+  <button id="slide-2"
+      on="tap:AMP.setState({'carousel': {'slide': 2}})">
+    Set slide to 2
+  </button>
+  <p>
+    Note: the bound value must change in order for the slide to change.
+  </p>
+</body>
+</html>

--- a/test/manual/amp-carousel-0-2/initial-slide.amp.html
+++ b/test/manual/amp-carousel-0-2/initial-slide.amp.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Initial index carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-custom>
+    amp-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>A carousel with an initial index of "2"</h1>
+  <amp-carousel id="carousel-1" width="300" height="200" layout="responsive"
+      slide="(min-width: 800px) 3, 2">
+    <!-- wrapping divs to workaround https://bugs.webkit.org/show_bug.cgi?id=191816 -->
+    <div>
+      <amp-img src="./img/redgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/greengradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/bluegradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/orangegradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/tealgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/lemonyellowgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+    <div>
+      <amp-img src="./img/lilacgradient.png" width=300 height=200 layout="responsive"></amp-img>
+    </div>
+  </amp-carousel>
+</body>
+</html>


### PR DESCRIPTION
- Remove logic to scroll to the current slide in `updateUi`,
`resetScrollReferencePoint_` already handles it.
- Pass the initial index into the carousel.
- Stringify mutated attribute values, the rest of the logic relies on the
values being strings.
- Refactor the responsive attributes logic to allow getting the matching
value as a one-off.
- Guard against `NaN` for the `goToSlide` method.