### PR TITLE
✅ amp-youtube: add amp=1 to the url

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -180,7 +180,7 @@ class AmpYoutube extends AMP.BaseElement {
       descriptor = 'live_stream?channel='
         + `${encodeURIComponent(this.liveChannelid_ || '')}&`;
     }
-    return `${baseUrl}${descriptor}enablejsapi=1`;
+    return `${baseUrl}${descriptor}enablejsapi=1&amp=1`;
   }
 
   /**

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -21,9 +21,9 @@ import {listenOncePromise} from '../../../../src/event-helper';
 
 const EXAMPLE_VIDEOID = 'mGENRKrdoGY';
 const EXAMPLE_LIVE_CHANNELID = 'UCB8Kb4pxYzsDsHxzBfnid4Q';
-const EXAMPLE_VIDEOID_URL = `https://www.youtube.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&playsinline=1`;
-const EXAMPLE_LIVE_CHANNELID_URL = `https://www.youtube.com/embed/live_stream?channel=${EXAMPLE_LIVE_CHANNELID}&enablejsapi=1&playsinline=1`;
-const EXAMPLE_NO_COOKIE_VIDEOID_URL = `https://www.youtube-nocookie.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&playsinline=1`;
+const EXAMPLE_VIDEOID_URL = `https://www.youtube.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&amp=1&playsinline=1`;
+const EXAMPLE_LIVE_CHANNELID_URL = `https://www.youtube.com/embed/live_stream?channel=${EXAMPLE_LIVE_CHANNELID}&enablejsapi=1&amp=1&playsinline=1`;
+const EXAMPLE_NO_COOKIE_VIDEOID_URL = `https://www.youtube-nocookie.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&amp=1&playsinline=1`;
 
 describes.realWin('amp-youtube', {
   amp: {
@@ -108,6 +108,15 @@ describes.realWin('amp-youtube', {
         expect(iframe.src).to.not.contain('autoplay=1');
         // playsinline should default to 1 if not provided.
         expect(iframe.src).to.contain('playsinline=1');
+      });
+    });
+
+    it('should add amp=1 to the iframe src', () => {
+      return getYt({
+        'data-videoid': datasource,
+      }).then(yt => {
+        const iframe = yt.querySelector('iframe');
+        expect(iframe.src).to.contain('amp=1');
       });
     });
 


### PR DESCRIPTION
Similar to how `amp-iframe` adds `amp=1` so embedders can know if traffic is coming from AMP or not.