### PR TITLE
AdSense Fast Fetch experiment - delay request by fixed 3 viewport range

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -97,6 +97,9 @@ export function resetSharedState() {
 /** @type {string} */
 const FORMAT_EXP = 'as-use-attr-for-format';
 
+/** @type {string} */
+const DELAY_NUMBER_EXP = 'adsense-ff-number-delay';
+
 /** @final */
 export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
@@ -235,7 +238,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   delayAdRequestEnabled() {
-    return true;
+    return getExperimentBranch(
+        this.win, DELAY_NUMBER_EXP) == '21063207' ? 3 : true;
   }
 
   /** @override */
@@ -283,6 +287,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
             Number(this.element.getAttribute('width')) > 0 &&
             Number(this.element.getAttribute('height')) > 0,
           branches: ['21062003', '21062004'],
+        },
+        [DELAY_NUMBER_EXP]: {
+          isTrafficEligible: () => true,
+          branches: ['21063206', '21063207'],
         },
       });
     const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -998,6 +998,12 @@ describes.realWin('amp-ad-network-adsense-impl', {
   describe('#delayAdRequestEnabled', () => {
     it('should return true', () =>
       expect(impl.delayAdRequestEnabled()).to.be.true);
+
+    it('should return 3 if in experiment', () => {
+      forceExperimentBranch(impl.win, 'adsense-ff-number-delay', '21063207');
+      impl.divertExperiments();
+      expect(impl.delayAdRequestEnabled()).to.equal(3);
+    });
   });
 
   describe('#preconnect', () => {


### PR DESCRIPTION
Setup client-side diverted experiment for amp-ad type=adsense fast fetch traffic measuring the effect of modifying delayAdRequestEnabled to return 3 instead of true.  Effect is that decision of when to send the request will be based solely off of slot distance relative to viewport instead of current behavior that combines offset and non-AMPHTML creative throttle.