### PR TITLE
🐛 Assert that values are never returned from vsync callbacks

### DIFF
--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -79,7 +79,9 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
     }, opt_is3P);
 
     this.applyFillContent(iframe);
-    this.getVsync().mutate(() => this.element.appendChild(iframe));
+    this.getVsync().mutate(() => {
+      this.element.appendChild(iframe);
+    });
 
     this.iframe_ = iframe;
 

--- a/extensions/amp-subscriptions/0.1/dialog.js
+++ b/extensions/amp-subscriptions/0.1/dialog.js
@@ -173,6 +173,7 @@ export class Dialog {
       setImportantStyles(this.wrapper_, {
         transform: 'translateY(100%)',
       });
+    }).then(() => {
       return this.timer_.promise(300);
     }).then(() => {
       return this.vsync_.mutatePromise(() => {

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -459,8 +459,8 @@ function callTaskNoInline(callback, state) {
     try {
       devAssert(ret === undefined);
     } catch (e) {
-      dev().error('VSYNC', 'callback return a value but vsync cannot propogate ' +
-        'it: %s', callback.toString());
+      dev().error('VSYNC', 'callback returned a value but vsync cannot ' +
+        'propogate it: %s', callback.toString());
     }
   } catch (e) {
     rethrowAsync(e);

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -455,7 +455,13 @@ export class Vsync {
 function callTaskNoInline(callback, state) {
   devAssert(callback);
   try {
-    callback(state);
+    const ret = callback(state);
+    try {
+      devAssert(ret === undefined);
+    } catch (e) {
+      dev.error('VSYNC', 'callback return a value but vsync cannot propogate ' +
+        'it: %s', callback.toString());
+    }
   } catch (e) {
     rethrowAsync(e);
     return false;

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -459,7 +459,7 @@ function callTaskNoInline(callback, state) {
     try {
       devAssert(ret === undefined);
     } catch (e) {
-      dev.error('VSYNC', 'callback return a value but vsync cannot propogate ' +
+      dev().error('VSYNC', 'callback return a value but vsync cannot propogate ' +
         'it: %s', callback.toString());
     }
   } catch (e) {

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -33,8 +33,8 @@ let VsyncStateDef;
 
 /**
  * @typedef {{
- *   measure: (function(!VsyncStateDef)|undefined),
- *   mutate: (function(!VsyncStateDef)|undefined)
+ *   measure: (function(!VsyncStateDef):undefined|undefined),
+ *   mutate: (function(!VsyncStateDef):undefined|undefined)
  * }}
  */
 let VsyncTaskSpecDef;
@@ -208,7 +208,7 @@ export class Vsync {
 
   /**
    * Runs the mutate operation via vsync.
-   * @param {function()} mutator
+   * @param {function():undefined} mutator
    */
   mutate(mutator) {
     this.run({
@@ -219,7 +219,7 @@ export class Vsync {
 
   /**
    * Runs `mutate` wrapped in a promise.
-   * @param {function()} mutator
+   * @param {function():undefined} mutator
    * @return {!Promise}
    */
   mutatePromise(mutator) {
@@ -231,7 +231,7 @@ export class Vsync {
 
   /**
    * Runs the measure operation via vsync.
-   * @param {function()} measurer
+   * @param {function():undefined} measurer
    */
   measure(measurer) {
     this.run({
@@ -449,7 +449,7 @@ export class Vsync {
 
 /**
  * For optimization reasons to stop try/catch from blocking optimization.
- * @param {function(!VsyncStateDef)|undefined} callback
+ * @param {function(!VsyncStateDef):undefined|undefined} callback
  * @param {!VsyncStateDef} state
  */
 function callTaskNoInline(callback, state) {

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -456,9 +456,7 @@ function callTaskNoInline(callback, state) {
   devAssert(callback);
   try {
     const ret = callback(state);
-    try {
-      devAssert(ret === undefined);
-    } catch (e) {
+    if (ret !== undefined) {
       dev().error('VSYNC', 'callback returned a value but vsync cannot ' +
         'propogate it: %s', callback.toString());
     }


### PR DESCRIPTION
Vsync does not propogate those values in any way. This is specifically targetting code like:

```js
vsync.measure(() => {
  return el.getBoundingClientRect();
});

// or
vsync.mutatePromise(() => {
  return someOtherPromise;
});
```