### PR TITLE
Avoid bundling DOMPurify into amp-bind, amp-mustache-0.1

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -49,8 +49,7 @@ exports.rules = [
     filesMatching: '**/*.js',
     mustNotDependOn: 'src/sanitizer.js',
     whitelist: [
-      // DEPRECATED! Do not extend this whitelist. Use src/purifier.js instead.
-      // Contact @choumx for questions.
+      // DEPRECATED: Use src/purifier.js instead. @choumx for questions.
       'extensions/amp-mustache/0.1/amp-mustache.js->src/sanitizer.js',
     ],
   },
@@ -58,8 +57,7 @@ exports.rules = [
     filesMatching: '**/*.js',
     mustNotDependOn: 'src/purifier.js',
     whitelist: [
-      'src/sanitizer.js->src/purifier.js',
-      'extensions/amp-bind/0.1/bind-impl.js->src/purifier.js',
+      // WARNING: Importing purifier.js will also bundle DOMPurify (13KB).
       'extensions/amp-mustache/0.2/amp-mustache.js->src/purifier.js',
       'extensions/amp-script/0.1/amp-script.js->src/purifier.js',
     ],

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -33,7 +33,7 @@ import {installServiceInEmbedScope} from '../../../src/service';
 import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
 import {isArray, isFiniteNumber, isObject, toArray} from '../../../src/types';
 import {reportError} from '../../../src/error';
-import {rewriteAttributesForElement} from '../../../src/purifier';
+import {rewriteAttributesForElement} from '../../../src/url-rewrite';
 import {startsWith} from '../../../src/string';
 import {whenDocumentReady} from '../../../src/document-ready';
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -17,6 +17,7 @@
 import {CSS} from '../../../build/amp-script-0.1.css';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
+// TODO(choumx): Avoid bundling an extra copy of DOMPurify here.
 import {addPurifyHooks, purifyConfig} from '../../../src/purifier';
 import {
   calculateExtensionScriptUrl,

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -15,17 +15,17 @@
  */
 
 import {
-  checkCorsUrl,
-  getSourceUrl,
-  isProxyOrigin,
-  parseUrlDeprecated,
-  resolveRelativeUrl,
-} from './url';
-import {dict} from './utils/object';
-import {parseSrcset} from './srcset';
+  BIND_PREFIX,
+  BLACKLISTED_TAGS,
+  TRIPLE_MUSTACHE_WHITELISTED_TAGS,
+  WHITELISTED_ATTRS,
+  WHITELISTED_ATTRS_BY_TAGS,
+  WHITELISTED_TARGETS,
+  isValidAttr,
+} from './sanitation';
 import {remove} from './utils/array';
+import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
-import {urls} from './config';
 import {user} from './log';
 import purify from 'dompurify/dist/purify.es';
 
@@ -39,136 +39,6 @@ const DomPurify = purify(self);
 
 /** @private @const {string} */
 const TAG = 'purifier';
-
-/** @private @const {string} */
-const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
-
-/** @private @const {string} */
-export const BIND_PREFIX = 'data-amp-bind-';
-
-/**
- * @const {!Object<string, boolean>}
- * See https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md
- */
-export const BLACKLISTED_TAGS = {
-  'applet': true,
-  'audio': true,
-  'base': true,
-  'embed': true,
-  'frame': true,
-  'frameset': true,
-  'iframe': true,
-  'img': true,
-  'link': true,
-  'meta': true,
-  'object': true,
-  'style': true,
-  'video': true,
-};
-
-/**
- * Whitelist of tags allowed in triple mustache e.g. {{{name}}}.
- * Very restrictive by design since the triple mustache renders unescaped HTML
- * which, unlike double mustache, won't be processed by the AMP Validator.
- * @const {!Array<string>}
- */
-export const TRIPLE_MUSTACHE_WHITELISTED_TAGS = [
-  'a',
-  'b',
-  'br',
-  'caption',
-  'colgroup',
-  'code',
-  'del',
-  'div',
-  'em',
-  'i',
-  'ins',
-  'li',
-  'mark',
-  'ol',
-  'p',
-  'q',
-  's',
-  'small',
-  'span',
-  'strong',
-  'sub',
-  'sup',
-  'table',
-  'tbody',
-  'time',
-  'td',
-  'th',
-  'thead',
-  'tfoot',
-  'tr',
-  'u',
-  'ul',
-];
-
-/**
- * Tag-agnostic attribute whitelisted used by both Caja and DOMPurify.
- * @const {!Array<string>}
- */
-export const WHITELISTED_ATTRS = [
-  // AMP-only attributes that don't exist in HTML.
-  'amp-fx',
-  'fallback',
-  'heights',
-  'layout',
-  'min-font-size',
-  'max-font-size',
-  'on',
-  'option',
-  'placeholder',
-  // Attributes related to amp-form.
-  'submitting',
-  'submit-success',
-  'submit-error',
-  'validation-for',
-  'verify-error',
-  'visible-when-invalid',
-  // HTML attributes that are scrubbed by Caja but we handle specially.
-  'href',
-  'style',
-  // Attributes for amp-bind that exist in "[foo]" form.
-  'text',
-  // Attributes for amp-subscriptions.
-  'subscriptions-action',
-  'subscriptions-actions',
-  'subscriptions-decorate',
-  'subscriptions-dialog',
-  'subscriptions-display',
-  'subscriptions-section',
-  'subscriptions-service',
-];
-
-/**
- * Attributes that are only whitelisted for specific, non-AMP elements.
- * @const {!Object<string, !Array<string>>}
- */
-export const WHITELISTED_ATTRS_BY_TAGS = {
-  'a': [
-    'rel',
-    'target',
-  ],
-  'div': [
-    'template',
-  ],
-  'form': [
-    'action-xhr',
-    'verify-xhr',
-    'custom-validation-reporting',
-    'target',
-  ],
-  'input': [
-    'mask-output',
-  ],
-  'template': [
-    'type',
-  ],
-};
 
 /**
  * Tags that are only whitelisted for specific values of given attributes.
@@ -184,55 +54,6 @@ const WHITELISTED_TAGS_BY_ATTRS = {
   },
 };
 
-/** @const {!Array<string>} */
-export const WHITELISTED_TARGETS = ['_top', '_blank'];
-
-/** @const {!Array<string>} */
-const BLACKLISTED_ATTR_VALUES = [
-  /*eslint no-script-url: 0*/ 'javascript:',
-  /*eslint no-script-url: 0*/ 'vbscript:',
-  /*eslint no-script-url: 0*/ 'data:',
-  /*eslint no-script-url: 0*/ '<script',
-  /*eslint no-script-url: 0*/ '</script',
-];
-
-/** @const {!Object<string, !Object<string, !RegExp>>} */
-const BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES = dict({
-  'input': {
-    'type': /(?:image|button)/i,
-  },
-});
-
-/** @const {!Array<string>} */
-const BLACKLISTED_FIELDS_ATTR = [
-  'form',
-  'formaction',
-  'formmethod',
-  'formtarget',
-  'formnovalidate',
-  'formenctype',
-];
-
-/** @const {!Object<string, !Array<string>>} */
-const BLACKLISTED_TAG_SPECIFIC_ATTRS = dict({
-  'input': BLACKLISTED_FIELDS_ATTR,
-  'textarea': BLACKLISTED_FIELDS_ATTR,
-  'select': BLACKLISTED_FIELDS_ATTR,
-});
-
-/**
- * Test for invalid `style` attribute values.
- *
- * !important avoids overriding AMP styles, while `position:fixed|sticky` is a
- * FixedLayer limitation (it only scans the style[amp-custom] stylesheet
- * for potential fixed/sticky elements). Note that the latter can be
- * circumvented with CSS comments -- not a big deal.
- *
- * @const {!RegExp}
- */
-const INVALID_INLINE_STYLE_REGEX =
-    /!important|position\s*:\s*fixed|position\s*:\s*sticky/i;
-
 const PURIFY_CONFIG = /** @type {!DomPurifyConfig} */ ({
   USE_PROFILES: {
     html: true,
@@ -240,7 +61,6 @@ const PURIFY_CONFIG = /** @type {!DomPurifyConfig} */ ({
     svgFilters: true,
   },
 });
-
 
 /**
  * Monotonically increasing counter used for keying nodes.
@@ -266,10 +86,11 @@ export function purifyHtml(dirty, diffing = false) {
  * Returns DOMPurify config for normal, escaped templates.
  * Do not use for unescaped templates.
  *
- * NOTE: see that we use DomPurifyConfig found in
+ * NOTE: See that we use DomPurifyConfig found in
  * build-system/dompurify.extern.js as the exact type. This is to prevent
  * closure compiler from optimizing these fields here in this file and in the
  * 3rd party library file. See #19624 for further information.
+ *
  * @return {!DomPurifyConfig}
  */
 export function purifyConfig() {
@@ -518,208 +339,4 @@ export function purifyTagsForTripleMustache(html, doc = self.document) {
   const div = doc.createElement('div');
   div.appendChild(fragment);
   return div./*OK*/innerHTML;
-}
-
-/**
- * Whether the attribute/value is valid.
- * @param {string} tagName Lowercase tag name.
- * @param {string} attrName Lowercase attribute name.
- * @param {string} attrValue
- * @param {boolean} opt_purify Is true, skips some attribute sanitizations
- *     that are already covered by DOMPurify.
- * @return {boolean}
- */
-export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
-  if (!opt_purify) {
-    // "on*" attributes are not allowed.
-    if (startsWith(attrName, 'on') && attrName != 'on') {
-      return false;
-    }
-
-    // No attributes with "javascript" or other blacklisted substrings in them.
-    if (attrValue) {
-      const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
-      for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
-        if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
-          return false;
-        }
-      }
-    }
-  }
-
-  // Don't allow certain inline style values.
-  if (attrName == 'style') {
-    return !INVALID_INLINE_STYLE_REGEX.test(attrValue);
-  }
-
-  // Don't allow CSS class names with internal AMP prefix.
-  if (attrName == 'class' && attrValue && /(^|\W)i-amphtml-/i.test(attrValue)) {
-    return false;
-  }
-
-  // Don't allow '__amp_source_origin' in URLs.
-  if (isUrlAttribute(attrName) && /__amp_source_origin/.test(attrValue)) {
-    return false;
-  }
-
-  // Remove blacklisted attributes from specific tags e.g. input[formaction].
-  const attrNameBlacklist = BLACKLISTED_TAG_SPECIFIC_ATTRS[tagName];
-  if (attrNameBlacklist && attrNameBlacklist.indexOf(attrName) != -1) {
-    return false;
-  }
-
-  // Remove blacklisted values for specific attributes for specific tags
-  // e.g. input[type=image].
-  const attrBlacklist = BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES[tagName];
-  if (attrBlacklist) {
-    const blacklistedValuesRegex = attrBlacklist[attrName];
-    if (blacklistedValuesRegex &&
-        attrValue.search(blacklistedValuesRegex) != -1) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
- * The same as rewriteAttributeValue() but actually updates the element and
- * modifies other related attribute(s) for special cases, i.e. `target` for <a>.
- * @param {!Element} element
- * @param {string} attrName
- * @param {string} attrValue
- * @param {!Location=} opt_location
- * @param {boolean=} opt_updateProperty
- * @return {string}
- */
-export function rewriteAttributesForElement(
-  element, attrName, attrValue, opt_location, opt_updateProperty)
-{
-  const tag = element.tagName.toLowerCase();
-  const attr = attrName.toLowerCase();
-  const rewrittenValue = rewriteAttributeValue(tag, attr, attrValue);
-  // When served from proxy (CDN), changing an <a> tag from a hash link to a
-  // non-hash link requires updating `target` attribute per cache modification
-  // rules. @see amp-cache-modifications.md#url-rewrites
-  const isProxy = isProxyOrigin(opt_location || self.location);
-  if (isProxy && tag === 'a' && attr === 'href') {
-    const oldValue = element.getAttribute(attr);
-    const newValueIsHash = rewrittenValue[0] === '#';
-    const oldValueIsHash = oldValue && oldValue[0] === '#';
-
-    if (newValueIsHash && !oldValueIsHash) {
-      // Save the original value of `target` so it can be restored (if needed).
-      if (!element[ORIGINAL_TARGET_VALUE]) {
-        element[ORIGINAL_TARGET_VALUE] = element.getAttribute('target');
-      }
-      element.removeAttribute('target');
-    } else if (oldValueIsHash && !newValueIsHash) {
-      // Restore the original value of `target` or default to `_top`.
-      element.setAttribute('target', element[ORIGINAL_TARGET_VALUE] || '_top');
-    }
-  }
-  if (opt_updateProperty) {
-    // Must be done first for <input> elements to correctly update the UI for
-    // the first change on Safari and Chrome.
-    element[attr] = rewrittenValue;
-  }
-  element.setAttribute(attr, rewrittenValue);
-  return rewrittenValue;
-}
-
-/**
- * If (tagName, attrName) is a CDN-rewritable URL attribute, returns the
- * rewritten URL value. Otherwise, returns the unchanged `attrValue`.
- * See resolveUrlAttr() for rewriting rules.
- * @param {string} tagName Lowercase tag name.
- * @param {string} attrName Lowercase attribute name.
- * @param {string} attrValue
- * @return {string}
- * @private
- * @visibleForTesting
- */
-export function rewriteAttributeValue(tagName, attrName, attrValue) {
-  if (isUrlAttribute(attrName)) {
-    return resolveUrlAttr(tagName, attrName, attrValue, self.location);
-  }
-  return attrValue;
-}
-
-/**
- * @param {string} attrName Lowercase attribute name.
- * @return {boolean}
- */
-function isUrlAttribute(attrName) {
-  return (attrName == 'src' || attrName == 'href' || attrName == 'srcset');
-}
-
-/**
- * Rewrites the URL attribute values. URLs are rewritten as following:
- * - If URL is absolute, it is not rewritten
- * - If URL is relative, it's rewritten as absolute against the source origin
- * - If resulting URL is a `http:` URL and it's for image, the URL is rewritten
- *   again to be served with AMP Cache (cdn.ampproject.org).
- *
- * @param {string} tagName Lowercase tag name.
- * @param {string} attrName Lowercase attribute name.
- * @param {string} attrValue
- * @param {!Location} windowLocation
- * @return {string}
- * @private
- * @visibleForTesting
- */
-export function resolveUrlAttr(tagName, attrName, attrValue, windowLocation) {
-  checkCorsUrl(attrValue);
-  const isProxyHost = isProxyOrigin(windowLocation);
-  const baseUrl = parseUrlDeprecated(getSourceUrl(windowLocation));
-
-  if (attrName == 'href' && !startsWith(attrValue, '#')) {
-    return resolveRelativeUrl(attrValue, baseUrl);
-  }
-
-  if (attrName == 'src') {
-    if (tagName == 'amp-img') {
-      return resolveImageUrlAttr(attrValue, baseUrl, isProxyHost);
-    }
-    return resolveRelativeUrl(attrValue, baseUrl);
-  }
-
-  if (attrName == 'srcset') {
-    let srcset;
-    try {
-      srcset = parseSrcset(attrValue);
-    } catch (e) {
-      // Do not fail the whole template just because one srcset is broken.
-      // An AMP element will pick it up and report properly.
-      user().error(TAG, 'Failed to parse srcset: ', e);
-      return attrValue;
-    }
-    return srcset.stringify(url => resolveImageUrlAttr(url, baseUrl,
-        isProxyHost));
-  }
-
-  return attrValue;
-}
-
-/**
- * Non-HTTPs image URLs are rewritten via proxy.
- * @param {string} attrValue
- * @param {!Location} baseUrl
- * @param {boolean} isProxyHost
- * @return {string}
- */
-function resolveImageUrlAttr(attrValue, baseUrl, isProxyHost) {
-  const src = parseUrlDeprecated(resolveRelativeUrl(attrValue, baseUrl));
-
-  // URLs such as `data:` or proxy URLs are returned as is. Unsafe protocols
-  // do not arrive here - already stripped by the sanitizer.
-  if (src.protocol == 'data:' || isProxyOrigin(src) || !isProxyHost) {
-    return src.href;
-  }
-
-  // Rewrite as a proxy URL.
-  return `${urls.cdn}/i/` +
-      (src.protocol == 'https:' ? 's/' : '') +
-      encodeURIComponent(src.host) +
-      src.pathname + (src.search || '') + (src.hash || '');
 }

--- a/src/sanitation.js
+++ b/src/sanitation.js
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dict} from './utils/object';
+import {isUrlAttribute} from './url-rewrite';
+import {startsWith} from './string';
+
+/** @private @const {string} */
+export const BIND_PREFIX = 'data-amp-bind-';
+
+/**
+ * @const {!Object<string, boolean>}
+ * See https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md
+ */
+export const BLACKLISTED_TAGS = {
+  'applet': true,
+  'audio': true,
+  'base': true,
+  'embed': true,
+  'frame': true,
+  'frameset': true,
+  'iframe': true,
+  'img': true,
+  'link': true,
+  'meta': true,
+  'object': true,
+  'style': true,
+  'video': true,
+};
+
+/**
+ * Whitelist of tags allowed in triple mustache e.g. {{{name}}}.
+ * Very restrictive by design since the triple mustache renders unescaped HTML
+ * which, unlike double mustache, won't be processed by the AMP Validator.
+ * @const {!Array<string>}
+ */
+export const TRIPLE_MUSTACHE_WHITELISTED_TAGS = [
+  'a',
+  'b',
+  'br',
+  'caption',
+  'colgroup',
+  'code',
+  'del',
+  'div',
+  'em',
+  'i',
+  'ins',
+  'li',
+  'mark',
+  'ol',
+  'p',
+  'q',
+  's',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'time',
+  'td',
+  'th',
+  'thead',
+  'tfoot',
+  'tr',
+  'u',
+  'ul',
+];
+
+/**
+ * Tag-agnostic attribute whitelisted used by both Caja and DOMPurify.
+ * @const {!Array<string>}
+ */
+export const WHITELISTED_ATTRS = [
+  // AMP-only attributes that don't exist in HTML.
+  'amp-fx',
+  'fallback',
+  'heights',
+  'layout',
+  'min-font-size',
+  'max-font-size',
+  'on',
+  'option',
+  'placeholder',
+  // Attributes related to amp-form.
+  'submitting',
+  'submit-success',
+  'submit-error',
+  'validation-for',
+  'verify-error',
+  'visible-when-invalid',
+  // HTML attributes that are scrubbed by Caja but we handle specially.
+  'href',
+  'style',
+  // Attributes for amp-bind that exist in "[foo]" form.
+  'text',
+  // Attributes for amp-subscriptions.
+  'subscriptions-action',
+  'subscriptions-actions',
+  'subscriptions-decorate',
+  'subscriptions-dialog',
+  'subscriptions-display',
+  'subscriptions-section',
+  'subscriptions-service',
+];
+
+/**
+ * Attributes that are only whitelisted for specific, non-AMP elements.
+ * @const {!Object<string, !Array<string>>}
+ */
+export const WHITELISTED_ATTRS_BY_TAGS = {
+  'a': [
+    'rel',
+    'target',
+  ],
+  'div': [
+    'template',
+  ],
+  'form': [
+    'action-xhr',
+    'verify-xhr',
+    'custom-validation-reporting',
+    'target',
+  ],
+  'input': [
+    'mask-output',
+  ],
+  'template': [
+    'type',
+  ],
+};
+
+/** @const {!Array<string>} */
+export const WHITELISTED_TARGETS = ['_top', '_blank'];
+
+/** @const {!Array<string>} */
+const BLACKLISTED_ATTR_VALUES = [
+  /*eslint no-script-url: 0*/ 'javascript:',
+  /*eslint no-script-url: 0*/ 'vbscript:',
+  /*eslint no-script-url: 0*/ 'data:',
+  /*eslint no-script-url: 0*/ '<script',
+  /*eslint no-script-url: 0*/ '</script',
+];
+
+/** @const {!Object<string, !Object<string, !RegExp>>} */
+const BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES = dict({
+  'input': {
+    'type': /(?:image|button)/i,
+  },
+});
+
+/** @const {!Array<string>} */
+const BLACKLISTED_FIELDS_ATTR = [
+  'form',
+  'formaction',
+  'formmethod',
+  'formtarget',
+  'formnovalidate',
+  'formenctype',
+];
+
+/** @const {!Object<string, !Array<string>>} */
+const BLACKLISTED_TAG_SPECIFIC_ATTRS = dict({
+  'input': BLACKLISTED_FIELDS_ATTR,
+  'textarea': BLACKLISTED_FIELDS_ATTR,
+  'select': BLACKLISTED_FIELDS_ATTR,
+});
+
+/**
+ * Test for invalid `style` attribute values.
+ *
+ * !important avoids overriding AMP styles, while `position:fixed|sticky` is a
+ * FixedLayer limitation (it only scans the style[amp-custom] stylesheet
+ * for potential fixed/sticky elements). Note that the latter can be
+ * circumvented with CSS comments -- not a big deal.
+ *
+ * @const {!RegExp}
+ */
+const INVALID_INLINE_STYLE_REGEX =
+    /!important|position\s*:\s*fixed|position\s*:\s*sticky/i;
+
+/**
+ * Whether the attribute/value is valid.
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
+ * @param {string} attrValue
+ * @param {boolean} opt_purify Is true, skips some attribute sanitizations
+ *     that are already covered by DOMPurify.
+ * @return {boolean}
+ */
+export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
+  if (!opt_purify) {
+    // "on*" attributes are not allowed.
+    if (startsWith(attrName, 'on') && attrName != 'on') {
+      return false;
+    }
+
+    // No attributes with "javascript" or other blacklisted substrings in them.
+    if (attrValue) {
+      const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
+      for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
+        if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
+          return false;
+        }
+      }
+    }
+  }
+
+  // Don't allow certain inline style values.
+  if (attrName == 'style') {
+    return !INVALID_INLINE_STYLE_REGEX.test(attrValue);
+  }
+
+  // Don't allow CSS class names with internal AMP prefix.
+  if (attrName == 'class' && attrValue && /(^|\W)i-amphtml-/i.test(attrValue)) {
+    return false;
+  }
+
+  // Don't allow '__amp_source_origin' in URLs.
+  if (isUrlAttribute(attrName) && /__amp_source_origin/.test(attrValue)) {
+    return false;
+  }
+
+  // Remove blacklisted attributes from specific tags e.g. input[formaction].
+  const attrNameBlacklist = BLACKLISTED_TAG_SPECIFIC_ATTRS[tagName];
+  if (attrNameBlacklist && attrNameBlacklist.indexOf(attrName) != -1) {
+    return false;
+  }
+
+  // Remove blacklisted values for specific attributes for specific tags
+  // e.g. input[type=image].
+  const attrBlacklist = BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES[tagName];
+  if (attrBlacklist) {
+    const blacklistedValuesRegex = attrBlacklist[attrName];
+    if (blacklistedValuesRegex &&
+        attrValue.search(blacklistedValuesRegex) != -1) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -22,10 +22,10 @@ import {
   WHITELISTED_ATTRS_BY_TAGS,
   WHITELISTED_TARGETS,
   isValidAttr,
-  rewriteAttributeValue,
-} from './purifier';
+} from './sanitation';
 import {dict} from './utils/object';
 import {htmlSanitizer} from '../third_party/caja/html-sanitizer';
+import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';
 

--- a/src/url-rewrite.js
+++ b/src/url-rewrite.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  checkCorsUrl,
+  getSourceUrl,
+  isProxyOrigin,
+  parseUrlDeprecated,
+  resolveRelativeUrl,
+} from './url';
+import {parseSrcset} from './srcset';
+import {startsWith} from './string';
+import {urls} from './config';
+import {user} from './log';
+
+const TAG = 'URL-REWRITE';
+
+/** @private @const {string} */
+const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
+
+/**
+ * The same as rewriteAttributeValue() but actually updates the element and
+ * modifies other related attribute(s) for special cases, i.e. `target` for <a>.
+ * @param {!Element} element
+ * @param {string} attrName
+ * @param {string} attrValue
+ * @param {!Location=} opt_location
+ * @param {boolean=} opt_updateProperty
+ * @return {string}
+ */
+export function rewriteAttributesForElement(
+  element, attrName, attrValue, opt_location, opt_updateProperty)
+{
+  const tag = element.tagName.toLowerCase();
+  const attr = attrName.toLowerCase();
+  const rewrittenValue = rewriteAttributeValue(tag, attr, attrValue);
+  // When served from proxy (CDN), changing an <a> tag from a hash link to a
+  // non-hash link requires updating `target` attribute per cache modification
+  // rules. @see amp-cache-modifications.md#url-rewrites
+  const isProxy = isProxyOrigin(opt_location || self.location);
+  if (isProxy && tag === 'a' && attr === 'href') {
+    const oldValue = element.getAttribute(attr);
+    const newValueIsHash = rewrittenValue[0] === '#';
+    const oldValueIsHash = oldValue && oldValue[0] === '#';
+
+    if (newValueIsHash && !oldValueIsHash) {
+      // Save the original value of `target` so it can be restored (if needed).
+      if (!element[ORIGINAL_TARGET_VALUE]) {
+        element[ORIGINAL_TARGET_VALUE] = element.getAttribute('target');
+      }
+      element.removeAttribute('target');
+    } else if (oldValueIsHash && !newValueIsHash) {
+      // Restore the original value of `target` or default to `_top`.
+      element.setAttribute('target', element[ORIGINAL_TARGET_VALUE] || '_top');
+    }
+  }
+  if (opt_updateProperty) {
+    // Must be done first for <input> elements to correctly update the UI for
+    // the first change on Safari and Chrome.
+    element[attr] = rewrittenValue;
+  }
+  element.setAttribute(attr, rewrittenValue);
+  return rewrittenValue;
+}
+
+/**
+ * If (tagName, attrName) is a CDN-rewritable URL attribute, returns the
+ * rewritten URL value. Otherwise, returns the unchanged `attrValue`.
+ * See resolveUrlAttr() for rewriting rules.
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
+ * @param {string} attrValue
+ * @return {string}
+ * @private
+ * @visibleForTesting
+ */
+export function rewriteAttributeValue(tagName, attrName, attrValue) {
+  if (isUrlAttribute(attrName)) {
+    return resolveUrlAttr(tagName, attrName, attrValue, self.location);
+  }
+  return attrValue;
+}
+
+/**
+ * @param {string} attrName Lowercase attribute name.
+ * @return {boolean}
+ */
+export function isUrlAttribute(attrName) {
+  return (attrName == 'src' || attrName == 'href' || attrName == 'srcset');
+}
+
+/**
+ * Rewrites the URL attribute values. URLs are rewritten as following:
+ * - If URL is absolute, it is not rewritten
+ * - If URL is relative, it's rewritten as absolute against the source origin
+ * - If resulting URL is a `http:` URL and it's for image, the URL is rewritten
+ *   again to be served with AMP Cache (cdn.ampproject.org).
+ *
+ * @param {string} tagName Lowercase tag name.
+ * @param {string} attrName Lowercase attribute name.
+ * @param {string} attrValue
+ * @param {!Location} windowLocation
+ * @return {string}
+ * @private
+ * @visibleForTesting
+ */
+export function resolveUrlAttr(tagName, attrName, attrValue, windowLocation) {
+  checkCorsUrl(attrValue);
+  const isProxyHost = isProxyOrigin(windowLocation);
+  const baseUrl = parseUrlDeprecated(getSourceUrl(windowLocation));
+
+  if (attrName == 'href' && !startsWith(attrValue, '#')) {
+    return resolveRelativeUrl(attrValue, baseUrl);
+  }
+
+  if (attrName == 'src') {
+    if (tagName == 'amp-img') {
+      return resolveImageUrlAttr(attrValue, baseUrl, isProxyHost);
+    }
+    return resolveRelativeUrl(attrValue, baseUrl);
+  }
+
+  if (attrName == 'srcset') {
+    let srcset;
+    try {
+      srcset = parseSrcset(attrValue);
+    } catch (e) {
+      // Do not fail the whole template just because one srcset is broken.
+      // An AMP element will pick it up and report properly.
+      user().error(TAG, 'Failed to parse srcset: ', e);
+      return attrValue;
+    }
+    return srcset.stringify(url => resolveImageUrlAttr(url, baseUrl,
+        isProxyHost));
+  }
+
+  return attrValue;
+}
+
+/**
+ * Non-HTTPs image URLs are rewritten via proxy.
+ * @param {string} attrValue
+ * @param {!Location} baseUrl
+ * @param {boolean} isProxyHost
+ * @return {string}
+ */
+function resolveImageUrlAttr(attrValue, baseUrl, isProxyHost) {
+  const src = parseUrlDeprecated(resolveRelativeUrl(attrValue, baseUrl));
+
+  // URLs such as `data:` or proxy URLs are returned as is. Unsafe protocols
+  // do not arrive here - already stripped by the sanitizer.
+  if (src.protocol == 'data:' || isProxyOrigin(src) || !isProxyHost) {
+    return src.href;
+  }
+
+  // Rewrite as a proxy URL.
+  return `${urls.cdn}/i/` +
+      (src.protocol == 'https:' ? 's/' : '') +
+      encodeURIComponent(src.host) +
+      src.pathname + (src.search || '') + (src.hash || '');
+}

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -17,8 +17,6 @@
 import {
   purifyHtml,
   purifyTagsForTripleMustache,
-  resolveUrlAttr,
-  rewriteAttributesForElement,
 } from '../../src/purifier';
 
 /**
@@ -436,6 +434,13 @@ function runSanitizerTests() {
       // Other elements should NOT have i-amphtml-key-set.
       expect(purify('<p></p>')).to.equal('<p></p>');
     });
+
+    it('should resolve URLs', () => {
+      expect(purify('<a href="/path"></a>')).to.match(/http/);
+      expect(purify('<amp-img src="/path"></amp-img>')).to.match(/http/);
+      expect(purify('<amp-img srcset="/path"></amp-img>'))
+          .to.match(/http/);
+    });
   });
 
   describe('purifyTagsForTripleMustache', () => {
@@ -516,136 +521,3 @@ function runSanitizerTests() {
     });
   });
 }
-
-describe('rewriteAttributesForElement', () => {
-  let location = 'https://pub.com/';
-  it('should not modify `target` on publisher origin', () => {
-    const element = document.createElement('a');
-    element.setAttribute('href', '#hash');
-
-    rewriteAttributesForElement(element, 'href', 'https://not.hash/',
-        location);
-
-    expect(element.getAttribute('href')).to.equal('https://not.hash/');
-    expect(element.hasAttribute('target')).to.equal(false);
-  });
-
-  describe('on CDN origin', () => {
-    beforeEach(() => {
-      location = 'https://cdn.ampproject.org';
-    });
-
-    it('should set `target` when rewrite <a> from hash to non-hash', () => {
-      const element = document.createElement('a');
-      element.setAttribute('href', '#hash');
-
-      rewriteAttributesForElement(
-          element, 'href', 'https://not.hash/', location);
-
-      expect(element.getAttribute('href')).to.equal('https://not.hash/');
-      expect(element.getAttribute('target')).to.equal('_top');
-    });
-
-    it('should remove `target` when rewrite <a> from non-hash to hash', () => {
-      const element = document.createElement('a');
-      element.setAttribute('href', 'https://not.hash/');
-
-      rewriteAttributesForElement(element, 'href', '#hash', location);
-
-      expect(element.getAttribute('href')).to.equal('#hash');
-      expect(element.hasAttribute('target')).to.equal(false);
-    });
-  });
-});
-
-describe('resolveUrlAttr', () => {
-  it('should throw if __amp_source_origin is set', () => {
-    allowConsoleError(() => {
-      expect(() => resolveUrlAttr('a', 'href',
-          '/doc2?__amp_source_origin=https://google.com',
-          'http://acme.org/doc1')).to.throw(/Source origin is not allowed/);
-    });
-  });
-
-  it('should be called by sanitizer', () => {
-    expect(purify('<a href="/path"></a>')).to.match(/http/);
-    expect(purify('<amp-img src="/path"></amp-img>')).to.match(/http/);
-    expect(purify('<amp-img srcset="/path"></amp-img>'))
-        .to.match(/http/);
-  });
-
-  it('should resolve non-hash href', () => {
-    expect(resolveUrlAttr('a', 'href',
-        '/doc2',
-        'http://acme.org/doc1'))
-        .to.equal('http://acme.org/doc2');
-    expect(resolveUrlAttr('a', 'href',
-        '/doc2',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('http://acme.org/doc2');
-    expect(resolveUrlAttr('a', 'href',
-        'http://non-acme.org/doc2',
-        'http://acme.org/doc1'))
-        .to.equal('http://non-acme.org/doc2');
-  });
-
-  it('should ignore hash URLs', () => {
-    expect(resolveUrlAttr('a', 'href',
-        '#hash1',
-        'http://acme.org/doc1'))
-        .to.equal('#hash1');
-  });
-
-  it('should resolve src', () => {
-    expect(resolveUrlAttr('amp-video', 'src',
-        '/video1',
-        'http://acme.org/doc1'))
-        .to.equal('http://acme.org/video1');
-    expect(resolveUrlAttr('amp-video', 'src',
-        '/video1',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('http://acme.org/video1');
-    expect(resolveUrlAttr('amp-video', 'src',
-        'http://non-acme.org/video1',
-        'http://acme.org/doc1'))
-        .to.equal('http://non-acme.org/video1');
-  });
-
-  it('should rewrite image http(s) src', () => {
-    expect(resolveUrlAttr('amp-img', 'src',
-        '/image1?a=b#h1',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1');
-    expect(resolveUrlAttr('amp-img', 'src',
-        'https://acme.org/image1?a=b#h1',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('https://cdn.ampproject.org/i/s/acme.org/image1?a=b#h1');
-  });
-
-  it('should rewrite image http(s) srcset', () => {
-    expect(resolveUrlAttr('amp-img', 'srcset',
-        '/image2?a=b#h1 2x, /image1?a=b#h1 1x',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1 1x, ' +
-            'https://cdn.ampproject.org/i/acme.org/image2?a=b#h1 2x');
-    expect(resolveUrlAttr('amp-img', 'srcset',
-        'https://acme.org/image2?a=b#h1 2x, /image1?a=b#h1 1x',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1 1x, ' +
-            'https://cdn.ampproject.org/i/s/acme.org/image2?a=b#h1 2x');
-  });
-
-  it('should NOT rewrite image http(s) src when not on proxy', () => {
-    expect(resolveUrlAttr('amp-img', 'src',
-        '/image1',
-        'http://acme.org/doc1'))
-        .to.equal('http://acme.org/image1');
-  });
-
-  it('should NOT rewrite image data src', () => {
-    expect(resolveUrlAttr('amp-img', 'src',
-        'data:12345',
-        'https://cdn.ampproject.org/c/acme.org/doc1'))
-        .to.equal('data:12345');
-  });
-});

--- a/test/unit/test-url-rewrite.js
+++ b/test/unit/test-url-rewrite.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  resolveUrlAttr,
+  rewriteAttributesForElement,
+} from '../../src/url-rewrite';
+
+describe('resolveUrlAttr', () => {
+  it('should throw if __amp_source_origin is set', () => {
+    allowConsoleError(() => {
+      expect(() => resolveUrlAttr('a', 'href',
+          '/doc2?__amp_source_origin=https://google.com',
+          'http://acme.org/doc1')).to.throw(/Source origin is not allowed/);
+    });
+  });
+
+  it('should resolve non-hash href', () => {
+    expect(resolveUrlAttr('a', 'href',
+        '/doc2',
+        'http://acme.org/doc1'))
+        .to.equal('http://acme.org/doc2');
+    expect(resolveUrlAttr('a', 'href',
+        '/doc2',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('http://acme.org/doc2');
+    expect(resolveUrlAttr('a', 'href',
+        'http://non-acme.org/doc2',
+        'http://acme.org/doc1'))
+        .to.equal('http://non-acme.org/doc2');
+  });
+
+  it('should ignore hash URLs', () => {
+    expect(resolveUrlAttr('a', 'href',
+        '#hash1',
+        'http://acme.org/doc1'))
+        .to.equal('#hash1');
+  });
+
+  it('should resolve src', () => {
+    expect(resolveUrlAttr('amp-video', 'src',
+        '/video1',
+        'http://acme.org/doc1'))
+        .to.equal('http://acme.org/video1');
+    expect(resolveUrlAttr('amp-video', 'src',
+        '/video1',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('http://acme.org/video1');
+    expect(resolveUrlAttr('amp-video', 'src',
+        'http://non-acme.org/video1',
+        'http://acme.org/doc1'))
+        .to.equal('http://non-acme.org/video1');
+  });
+
+  it('should rewrite image http(s) src', () => {
+    expect(resolveUrlAttr('amp-img', 'src',
+        '/image1?a=b#h1',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1');
+    expect(resolveUrlAttr('amp-img', 'src',
+        'https://acme.org/image1?a=b#h1',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('https://cdn.ampproject.org/i/s/acme.org/image1?a=b#h1');
+  });
+
+  it('should rewrite image http(s) srcset', () => {
+    expect(resolveUrlAttr('amp-img', 'srcset',
+        '/image2?a=b#h1 2x, /image1?a=b#h1 1x',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1 1x, ' +
+            'https://cdn.ampproject.org/i/acme.org/image2?a=b#h1 2x');
+    expect(resolveUrlAttr('amp-img', 'srcset',
+        'https://acme.org/image2?a=b#h1 2x, /image1?a=b#h1 1x',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('https://cdn.ampproject.org/i/acme.org/image1?a=b#h1 1x, ' +
+            'https://cdn.ampproject.org/i/s/acme.org/image2?a=b#h1 2x');
+  });
+
+  it('should NOT rewrite image http(s) src when not on proxy', () => {
+    expect(resolveUrlAttr('amp-img', 'src',
+        '/image1',
+        'http://acme.org/doc1'))
+        .to.equal('http://acme.org/image1');
+  });
+
+  it('should NOT rewrite image data src', () => {
+    expect(resolveUrlAttr('amp-img', 'src',
+        'data:12345',
+        'https://cdn.ampproject.org/c/acme.org/doc1'))
+        .to.equal('data:12345');
+  });
+});
+
+describe('rewriteAttributesForElement', () => {
+  let location = 'https://pub.com/';
+  it('should not modify `target` on publisher origin', () => {
+    const element = document.createElement('a');
+    element.setAttribute('href', '#hash');
+
+    rewriteAttributesForElement(element, 'href', 'https://not.hash/',
+        location);
+
+    expect(element.getAttribute('href')).to.equal('https://not.hash/');
+    expect(element.hasAttribute('target')).to.equal(false);
+  });
+
+  describe('on CDN origin', () => {
+    beforeEach(() => {
+      location = 'https://cdn.ampproject.org';
+    });
+
+    it('should set `target` when rewrite <a> from hash to non-hash', () => {
+      const element = document.createElement('a');
+      element.setAttribute('href', '#hash');
+
+      rewriteAttributesForElement(
+          element, 'href', 'https://not.hash/', location);
+
+      expect(element.getAttribute('href')).to.equal('https://not.hash/');
+      expect(element.getAttribute('target')).to.equal('_top');
+    });
+
+    it('should remove `target` when rewrite <a> from non-hash to hash', () => {
+      const element = document.createElement('a');
+      element.setAttribute('href', 'https://not.hash/');
+
+      rewriteAttributesForElement(element, 'href', '#hash', location);
+
+      expect(element.getAttribute('href')).to.equal('#hash');
+      expect(element.hasAttribute('target')).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #20842.

- Splits code from src/purifier.js to new files src/sanitation.js and src/url-rewrite.js.
- Didn't fix amp-script.js yet since it may make more sense to remove it from worker-dom instead.

Before:
```
54K | amp-bind-0.1.js 
55K | amp-mustache-0.1.js 
31K | amp-mustache-0.2.js 
```

After:
```
41K | amp-bind-0.1.js 
42K | amp-mustache-0.1.js 
31K | amp-mustache-0.2.js 
```

/to @jridgewell 