### PR TITLE
Undo space reservation after successful height change

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -740,9 +740,13 @@ export class AmpList extends AMP.BaseElement {
             if (this.element.getAttribute('load-more') === 'auto') {
               this.maybeLoadMoreItems_();
             }
+            setStyles(dev().assertElement(this.container_), {
+              'max-height': '',
+            });
           })
           .catch(() => {
             this.resizeFailed_ = true;
+            this.adjustContainerForLoadMoreButton_();
           });
     }
   }


### PR DESCRIPTION
We reserve space for the `load-more-button` on `layoutCallback`. However, we don't need to do this after a successful resize, since the resize will account for the size of the load-more elements. This change clears the `max-height` attribute after a successful resize, and reserves space for it on a failed `attemptChangeSize` callback (i.e. when overflow is triggered). This should mitigate point 3 in https://github.com/ampproject/amphtml/issues/14060#issuecomment-462221486. 