### PR TITLE
Make is-my-pr-in-production-yet more prominent in our docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The best place to get help with **questions about using AMP** on your site is [S
 ## Further reading
 
 * [Component reference](https://www.ampproject.org/docs/reference/components)
-* [Release schedule](contributing/release-schedule.md)
+* [Release schedule](contributing/release-schedule.md) or [is my PR in production yet?](contributing/release-schedule.md#determining-if-your-change-is-in-production)
 * [Format specification](spec/amp-html-format.md)
 * [Custom element specification](spec/amp-html-components.md)
 


### PR DESCRIPTION
We actually have pretty great documentation on this already, but based on the number of issues / questions we get on the subject, it seems like this isn't very easy for people to find. This PR links to it from our project README. I'm also adding a link to this in our release slack channel description. 