### PR TITLE
✨ Adding 'allow-same-origin' to the consent prompt UI iframe

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -270,11 +270,12 @@ export class ConsentUI {
    */
   createPromptIframeFromSrc_(promptUISrc) {
     const iframe = this.parent_.ownerDocument.createElement('iframe');
-    let sandbox =  'allow-scripts';
+    let sandbox = 'allow-scripts';
     iframe.src = assertHttpsUrl(promptUISrc, this.parent_);
-    const allowSameOrigin = this.allowSameOrigin_(iframe.src, window.location.href)
-    if(allowSameOrigin){
-        sandbox = 'allow-scripts allow-same-origin'
+    const allowSameOrigin = this.allowSameOrigin_(
+        iframe.src, window.location.href);
+    if (allowSameOrigin) {
+      sandbox = 'allow-scripts allow-same-origin';
     }
     iframe.setAttribute('sandbox', sandbox);
     const {classList} = iframe;
@@ -292,11 +293,10 @@ export class ConsentUI {
   allowSameOrigin_(src, containerSrc) {
     const {element} = this;
     const urlService = Services.urlForDoc(element);
-    const url = urlService.parse(src);
-    const {hostname, protocol, origin} = url;
+    const srcUrl = urlService.parse(src);
     const containerUrl = urlService.parse(containerSrc);
 
-    return origin != containerUrl.origin && protocol != 'data:'
+    return srcUrl.origin != containerUrl.origin && srcUrl.protocol != 'data:';
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -272,8 +272,7 @@ export class ConsentUI {
     const iframe = this.parent_.ownerDocument.createElement('iframe');
     let sandbox = 'allow-scripts';
     iframe.src = assertHttpsUrl(promptUISrc, this.parent_);
-    const allowSameOrigin = this.allowSameOrigin_(
-        iframe.src, window.location.href);
+    const allowSameOrigin = this.allowSameOrigin_(iframe.src);
     if (allowSameOrigin) {
       sandbox = 'allow-scripts allow-same-origin';
     }
@@ -287,15 +286,14 @@ export class ConsentUI {
   /**
    * Determines if allow-same-origin should be enabled for the prompt iframe
    * @param {string} src
-   * @param {string} containerSrc
    * @return {boolean}
    */
-  allowSameOrigin_(src, containerSrc) {
+  allowSameOrigin_(src) {
     const urlService = Services.urlForDoc(this.parent_);
     const srcUrl = urlService.parse(src);
-    const containerUrl = urlService.parse(containerSrc);
+    const containerUrl = urlService.parse(this.ampdoc_.getUrl());
 
-    return srcUrl.origin != containerUrl.origin && srcUrl.protocol != 'data:';
+    return srcUrl.origin != containerUrl.origin;
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -291,8 +291,7 @@ export class ConsentUI {
    * @return {boolean}
    */
   allowSameOrigin_(src, containerSrc) {
-    const {element} = this;
-    const urlService = Services.urlForDoc(element);
+    const urlService = Services.urlForDoc(this.parent_);
     const srcUrl = urlService.parse(src);
     const containerUrl = urlService.parse(containerSrc);
 

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -270,12 +270,33 @@ export class ConsentUI {
    */
   createPromptIframeFromSrc_(promptUISrc) {
     const iframe = this.parent_.ownerDocument.createElement('iframe');
+    let sandbox =  'allow-scripts';
     iframe.src = assertHttpsUrl(promptUISrc, this.parent_);
-    iframe.setAttribute('sandbox', 'allow-scripts');
+    const allowSameOrigin = this.allowSameOrigin_(iframe.src, window.location.href)
+    if(allowSameOrigin){
+        sandbox = 'allow-scripts allow-same-origin'
+    }
+    iframe.setAttribute('sandbox', sandbox);
     const {classList} = iframe;
     classList.add(consentUiClasses.fill);
     // Append iframe lazily to save resources.
     return iframe;
+  }
+
+  /**
+   * Determines if allow-same-origin should be enabled for the prompt iframe
+   * @param {string} src
+   * @param {string} containerSrc
+   * @return {boolean}
+   */
+  allowSameOrigin_(src, containerSrc) {
+    const {element} = this;
+    const urlService = Services.urlForDoc(element);
+    const url = urlService.parse(src);
+    const {hostname, protocol, origin} = url;
+    const containerUrl = urlService.parse(containerSrc);
+
+    return origin != containerUrl.origin && protocol != 'data:'
   }
 
   /**


### PR DESCRIPTION
This PR adds the `allow-same-origin` rule to the consent prompt ui iframe, if the iframe src and document origins differ.

This implements the feature requested in https://github.com/ampproject/amphtml/issues/20858

There doesn't appear to be any tests or an example related to this change that needed updating, correct me if I'm wrong.

The `allowSourceOrigin_` method is ultimately a riff of the `assertSource_` method from the amp-iframe code below:

https://github.com/ampproject/amphtml/blob/master/extensions/amp-iframe/0.1/amp-iframe.js#L151-L157
