### PR TITLE
AmpAd Fast Fetch Launch layoutcallback immediate resolve for FIE

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -44,8 +44,6 @@ import {
   incrementLoadingAds,
   is3pThrottled,
 } from '../../amp-ad/0.1/concurrent-load';
-import {getBinaryType, isExperimentOn} from '../../../src/experiments';
-import {getBinaryTypeNumericalCode} from '../../../ads/google/a4a/utils';
 import {getConsentPolicyState} from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 import {getMode} from '../../../src/mode';
@@ -59,6 +57,7 @@ import {
 } from '../../../src/service/url-replacements-impl';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
 import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
 import {signingServerURLs} from '../../../ads/_a4a-config';
@@ -314,13 +313,6 @@ export class AmpA4A extends AMP.BaseElement {
 
     /** @protected {boolean} */
     this.isRelayoutNeededFlag = false;
-
-    /**
-     * Used as a signal in some of the CSI pings.
-     * @private @const {string}
-     */
-    this.releaseType_ = getBinaryTypeNumericalCode(getBinaryType(this.win)) ||
-        '-1';
 
     /**
      * Mapping of feature name to value extracted from ad response header
@@ -1413,15 +1405,10 @@ export class AmpA4A extends AMP.BaseElement {
         dev().error(TAG, this.element.getAttribute('type'),
             'Error executing onCreativeRender', err);
       })(creativeMetaData, friendlyIframeEmbed.whenWindowLoaded());
-      const iniLoadPromise = friendlyIframeEmbed.whenIniLoaded().then(() => {
+      friendlyIframeEmbed.whenIniLoaded().then(() => {
         checkStillCurrent();
         this.maybeTriggerAnalyticsEvent_('friendlyIframeIniLoad');
       });
-      const isIniLoadFixExpr = !!frameDoc.querySelector(
-          'meta[name="amp-experiments-opt-in"][content*="fie_ini_load_fix"]');
-      if (!isIniLoadFixExpr) {
-        return iniLoadPromise;
-      }
 
       // There's no need to wait for all resources to load.
       // StartRender is enough

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -422,33 +422,6 @@ describe('amp-a4a', () => {
       });
     });
 
-    // TODO: Remove after launch fie_ini_load_fix to 100%
-    it('for A4A FIE should wait for initial layout', () => {
-      let iniLoadResolver;
-      const iniLoadPromise = new Promise(resolve => {
-        iniLoadResolver = resolve;
-      });
-      const whenIniLoadedStub = sandbox.stub(
-          FriendlyIframeEmbed.prototype,
-          'whenIniLoaded').callsFake(
-          () => iniLoadPromise);
-      a4a.buildCallback();
-      const lifecycleEventStub = sandbox.stub(
-          a4a, 'maybeTriggerAnalyticsEvent_');
-      a4a.onLayoutMeasure();
-      const layoutPromise = a4a.layoutCallback();
-      return Promise.resolve().then(() => {
-        expect(whenIniLoadedStub).to.not.be.called;
-        iniLoadResolver();
-        return layoutPromise;
-      }).then(() => {
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        expect(a4a.friendlyIframeEmbed_.host).to.equal(a4a.element);
-        expect(whenIniLoadedStub).to.be.calledOnce;
-        expect(lifecycleEventStub).to.be.calledWith('friendlyIframeIniLoad');
-      });
-    });
-
     it('for A4A layout should resolve once FIE is created', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
@@ -456,11 +429,7 @@ describe('amp-a4a', () => {
       // Never resolve
       sandbox.stub/*OK*/(FriendlyIframeEmbed.prototype,'whenIniLoaded')
           .callsFake(() => {return new Promise(() => {});});
-      let creativeString = buildCreativeString();
-      // TODO: Remove after launch fie_ini_load_fix to 100%
-      creativeString = creativeString.replace('<body>',
-          '<body>' +
-          '<meta name=amp-experiments-opt-in content=a,fie_ini_load_fix,b>');
+      const creativeString = buildCreativeString();
       const metaData = a4a.getAmpAdMetadata(creativeString);
       return a4a.renderAmpCreative_(metaData).then(() => {
         expect(a4a.friendlyIframeEmbed_).to.exist;


### PR DESCRIPTION
Change introduced in #19738 but behind meta tag experiment control.  Launch to all Fast Fetch traffic (inclusion of meta tag on all Google traffic launched yesterday).