### PR TITLE
Revert "Force the subscriptions dialog into the fixed layer to avoid collisions with border"

### DIFF
--- a/extensions/amp-subscriptions/0.1/dialog.js
+++ b/extensions/amp-subscriptions/0.1/dialog.js
@@ -49,7 +49,6 @@ export class Dialog {
 
     const doc = this.ampdoc_.win.document;
 
-    /** @private @const {!Element} */
     this.wrapper_ = createElementWithAttributes(
         doc,
         'amp-subscriptions-dialog', /** @type {!JsonObject} */ ({
@@ -144,7 +143,8 @@ export class Dialog {
         setImportantStyles(this.wrapper_, {
           transform: 'translateY(0)',
         });
-      }).then(() => this.timer_.promise(300));
+        return this.timer_.promise(300);
+      });
     }).then(() => {
       // Update page layout.
       let offsetHeight;
@@ -154,7 +154,6 @@ export class Dialog {
         },
         mutate: () => {
           this.viewport_.updatePaddingBottom(offsetHeight);
-          this.viewport_.addToFixedLayer(this.wrapper_, true);
         },
       });
     });

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -26,7 +26,7 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
   let dialog;
   let content;
   let vsync, viewport;
-  let addToFixedLayerSpy, updatePaddingSpy;
+  let updatePaddingSpy;
 
   beforeEach(() => {
     win = env.win;
@@ -36,7 +36,6 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     installStylesForDoc(ampdoc, CSS, () => {}, false, 'amp-subscriptions');
     vsync = Services.vsyncFor(ampdoc.win);
     viewport = Services.viewportForDoc(ampdoc);
-    addToFixedLayerSpy = sandbox.stub(viewport, 'addToFixedLayer');
     updatePaddingSpy = sandbox.stub(viewport, 'updatePaddingBottom');
     dialog = new Dialog(ampdoc);
     content = createElementWithAttributes(doc, 'div', {
@@ -74,7 +73,6 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
       expect(styles.transform).to.not.contain('17');
       expect(dialog.closeButton_).to.have.display('none');
       expect(updatePaddingSpy).to.be.calledOnce.calledWith(17);
-      expect(addToFixedLayerSpy).to.be.calledOnce.calledWith(dialog.getRoot());
       expect(dialog.isVisible()).to.be.true;
     });
   });


### PR DESCRIPTION
Reverts ampproject/amphtml#20608

The reason is that the SwG dialogs conflict with other fixed-layer dialogs and elements.