### PR TITLE
amp-list-load-more bugfixes

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -933,8 +933,9 @@ export class AmpList extends AMP.BaseElement {
     if (this.resizeFailed_) {
       return;
     }
-    const lastItem = dev().assertElement(this.container_.lastChild);
-    this.viewport_.getClientRectAsync(lastItem)
+    const endoOfListMarker = this.container_.lastChild || this.container_;
+
+    this.viewport_.getClientRectAsync(endoOfListMarker)
         .then(positionRect => {
           const viewportHeight = this.viewport_.getHeight();
           const viewportTop = this.viewport_.getScrollTop();

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -835,7 +835,10 @@ export class AmpList extends AMP.BaseElement {
    */
   maybeSetLoadMore_() {
     return this.loadMoreEnabledPromise_.then(enabled => {
-      if (enabled && this.loadMoreSrc_) {
+      if (!enabled) {
+        return;
+      }
+      if (this.loadMoreSrc_) {
         const autoLoad = this.element.getAttribute('load-more') === 'auto';
         if (autoLoad) {
           this.setupLoadMoreAuto_();
@@ -853,6 +856,9 @@ export class AmpList extends AMP.BaseElement {
         }).then(() => {
           this.attemptToFit_(dev().assertElement(this.container_));
         });
+      } else {
+        return this.mutateElement(
+            () => this.loadMoreService_.setLoadMoreEnded());
       }
     });
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -935,7 +935,7 @@ export class AmpList extends AMP.BaseElement {
     }
     const endoOfListMarker = this.container_.lastChild || this.container_;
 
-    this.viewport_.getClientRectAsync(endoOfListMarker)
+    this.viewport_.getClientRectAsync(dev().assertElement(endoOfListMarker))
         .then(positionRect => {
           const viewportHeight = this.viewport_.getHeight();
           const viewportTop = this.viewport_.getScrollTop();

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -60,16 +60,57 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 </head>
 <body>
 <article>
+
+
+    <amp-state id="data">
+        <script type="application/json">
+          {
+            "items": 8,
+            "left": 5,
+            "latency": 0,
+            "url": "/infinite-scroll?items=8&left=2"
+          }
+        </script>
+      </amp-state>
+
+    <article>
+
+      <div>
+        <span>Items per page: </span>
+        <input type="text" id="items" placeholder="Items per page" value="8"
+             on="change:AMP.setState({data: {items: event.value}})">
+      </div>
+
+      <div>
+        <span>Number of additional pages: </span>
+        <input type="text" id="left" placeholder="Pages left" value="2"
+             on="change:AMP.setState({data: {left: event.value}})">
+      </div>
+
+      <div>
+        <span>Load latency: </span>
+        <input type="text" id="latency" placeholder="Latency" value="0"
+             on="change:AMP.setState({data: {latency: event.value}})">
+      </div>
+
+      <button
+              on="tap:AMP.setState({data: {url: '/infinite-scroll?items='
+                    + data.items + '&left=' + data.left + '&latency=' + data.latency}})">
+        Update
+      </button>
+
   <h1>AMP List</h1>
   <p>This is a flexbox amp-list with tiles, something like an infinite image gallery.</p>
 
   <amp-list width="auto" height="400"
     layout="fixed-height"
     src="/infinite-scroll?items=2&left=20"
+    [src]="data.url"
     load-more="manual"
     load-more-bookmark="next">
     <template type="amp-mustache">
@@ -81,22 +122,10 @@
         </div>
       </div>
     </template>
-    <amp-list-load-more load-more-button>
-      <div>CLICK ME</div>
-    </amp-list-load-more>
-    <amp-list-load-more load-more-loading>
-      <div>LOADING</div>
-    </amp-list-load-more>
-    <amp-list-load-more load-more-failed>
-      <div>OOPS</div>
-    </amp-list-load-more>
     <div fallback>
       FALLBACK
     </div>
   </amp-list>
-
-  <h1>Second List</h1>
-
 </article>
 </body>
 </html>


### PR DESCRIPTION
1. It's possible that the initial load has no more items to load. Account for that case. 
2. It's possible for the amp-list to be empty. Avoid an erroneous null element access in that case. 

Mitigates https://github.com/ampproject/amphtml/issues/14060#issuecomment-463695851. 