### PR TITLE
[carousel v2] Support a maximum number of auto advance loops.

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -235,6 +235,7 @@ function createElementRules_() {
       'advance-count': null,
       'auto-advance-count': null,
       'auto-advance-interval': null,
+      'auto-advance-loops': null,
       'auto-advance': null,
       'horizontal': null,
       'initial-index': null,

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -74,6 +74,9 @@ class AmpCarousel extends AMP.BaseElement {
       'auto-advance-interval': newValue => {
         this.carousel_.updateAutoAdvanceInterval(Number(newValue) || 0);
       },
+      'auto-advance-loops': newValue => {
+        this.carousel_.updateAutoAdvanceLoops(Number(newValue) || 0);
+      },
       'horizontal': newValue => {
         this.carousel_.updateHorizontal(newValue == 'true');
       },

--- a/extensions/amp-carousel/0.2/auto-advance.js
+++ b/extensions/amp-carousel/0.2/auto-advance.js
@@ -56,6 +56,9 @@ export class AutoAdvance {
     /** @private @const */
     this.advanceable_ = advanceable;
 
+    /** @private {number} */
+    this.advances_ = 0;
+
     /** @private {boolean} */
     this.autoAdvance_ = false;
 
@@ -70,6 +73,9 @@ export class AutoAdvance {
 
     /** @private {?function()} */
     this.debouncedAdvance_ = null;
+
+    /** @private {number} */
+    this.maxAdvances_ = Number.POSITIVE_INFINITY;
 
     this.createDebouncedAdvance_(this.autoAdvanceInterval_);
     this.scrollContainer_.addEventListener(
@@ -108,6 +114,14 @@ export class AutoAdvance {
   }
 
   /**
+   * @param {number} maxAdvances The maximum number of advances that should be
+   *    performed.
+   */
+  updateMaxAdvances(maxAdvances) {
+    this.maxAdvances_ = maxAdvances;
+  }
+
+  /**
    * Creates a debounced advance function.
    * @param {number} interval
    * @private
@@ -132,6 +146,16 @@ export class AutoAdvance {
   }
 
   /**
+   * @return {boolean} Whether or not autodadvancing should occur.
+   * @private
+   */
+  shouldAutoAdvance_() {
+    return this.autoAdvance_ &&
+        !this.paused_ &&
+        this.advances_ < this.maxAdvances_;
+  }
+
+  /**
    * Handles scroll, resetting the auto advance.
    */
   handleScroll_() {
@@ -139,15 +163,15 @@ export class AutoAdvance {
   }
 
   /**
-   * Advances, as long as auto advance is still enabled and the advancing has
-   * not been paused.
+   * Advances, as long as we should still auto advance.
    */
   advance_() {
-    if (!this.autoAdvance_ || this.paused_) {
+    if (!this.shouldAutoAdvance_()) {
       return;
     }
 
     this.advanceable_.advance(this.autoAdvanceCount_, ActionSource.AUTOPLAY);
+    this.advances_ += this.autoAdvanceCount_;
   }
 
   /**
@@ -155,7 +179,7 @@ export class AutoAdvance {
    * is enabled, it starts a debounced timer for advancing.
    */
   resetAutoAdvance_() {
-    if (!this.autoAdvance_) {
+    if (!this.shouldAutoAdvance_()) {
       return;
     }
 

--- a/extensions/amp-carousel/0.2/carousel.js
+++ b/extensions/amp-carousel/0.2/carousel.js
@@ -188,6 +188,9 @@ export class Carousel {
     /** @private {number} */
     this.advanceCount_ = 1;
 
+    /** @private {number} */
+    this.autoAdvanceLoops_ = Number.POSITIVE_INFINITY;
+
     /** @private {boolean} */
     this.mixedLength_ = false;
 
@@ -428,6 +431,16 @@ export class Carousel {
   }
 
   /**
+   * @param {number} autoAdvanceLoops The number of loops through the carousel
+   *    that should be autoadvanced before stopping. This defaults to infinite
+   *    loops.
+   */
+  updateAutoAdvanceLoops(autoAdvanceLoops) {
+    this.autoAdvanceLoops_ = autoAdvanceLoops;
+    this.updateUi();
+  }
+
+  /**
    * @param {boolean} horizontal Whether the scrollable should lay out
    *    horizontally or vertically.
    */
@@ -538,6 +551,9 @@ export class Carousel {
       if (!this.slides_.length) {
         return;
       }
+
+      this.autoAdvance_.updateMaxAdvances(
+          (this.autoAdvanceLoops_ * this.slides_.length) - 1);
       this.updateSpacers_();
       this.setChildrenSnapAlign_();
       this.hideSpacersAndSlides_();


### PR DESCRIPTION
This was implemented for carousel v1 in #18981.