### PR TITLE
Keep same macro for A4A and inabox

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -197,9 +197,9 @@ app.get('/a4a/:bid', (req, res) => {
             "canonicalUrl": "\${canonicalUrl}",
             "cid": "\${clientId(a)}",
             "img": "\${htmlAttr(amp-img,src)}",
-            "adNavTiming": "\${adNavTiming(requestStart,requestStart)}",
-            "adNavType": "\${adNavType}",
-            "adRedirectCount": "\${adRedirectCount}"
+            "navTiming": "\${navTiming(requestStart,requestStart)}",
+            "navType": "\${navType}",
+            "navRedirectCount": "\${navRedirectCount}"
           }
         }
       }

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -93,15 +93,23 @@ export class A4AVariableSource extends VariableSource {
 
   /** @override */
   initialize() {
-    this.set('AD_NAV_TIMING', (startAttribute, endAttribute) => {
-      userAssert(startAttribute, 'The first argument to AD_NAV_TIMING, the' +
+    // Initiate whitelisted varaibles first in case the resolver function needs
+    // to be overwritten.
+    for (let v = 0; v < WHITELISTED_VARIABLES.length; v++) {
+      const varName = WHITELISTED_VARIABLES[v];
+      const resolvers = this.globalVariableSource_.get(varName);
+      this.set(varName, resolvers.sync).setAsync(varName, resolvers.async);
+    }
+
+    this.set('NAV_TIMING', (startAttribute, endAttribute) => {
+      userAssert(startAttribute, 'The first argument to NAV_TIMING, the' +
           ' start attribute name, is required');
       return getTimingDataSync(
           this.win_,
           /**@type {string}*/(startAttribute),
           /**@type {string}*/(endAttribute));
-    }).setAsync('AD_NAV_TIMING', (startAttribute, endAttribute) => {
-      userAssert(startAttribute, 'The first argument to AD_NAV_TIMING, the' +
+    }).setAsync('NAV_TIMING', (startAttribute, endAttribute) => {
+      userAssert(startAttribute, 'The first argument to NAV_TIMING, the' +
           ' start attribute name, is required');
       return getTimingDataAsync(
           this.win_,
@@ -109,11 +117,11 @@ export class A4AVariableSource extends VariableSource {
           /**@type {string}*/(endAttribute));
     });
 
-    this.set('AD_NAV_TYPE', () => {
+    this.set('NAV_TYPE', () => {
       return getNavigationData(this.win_, 'type');
     });
 
-    this.set('AD_NAV_REDIRECT_COUNT', () => {
+    this.set('NAV_REDIRECT_COUNT', () => {
       return getNavigationData(this.win_, 'redirectCount');
     });
 
@@ -121,12 +129,6 @@ export class A4AVariableSource extends VariableSource {
         /** @type {function(...*)} */(this.htmlAttributeBinding_.bind(this)));
 
     this.set('CLIENT_ID', () => null);
-
-    for (let v = 0; v < WHITELISTED_VARIABLES.length; v++) {
-      const varName = WHITELISTED_VARIABLES[v];
-      const resolvers = this.globalVariableSource_.get(varName);
-      this.set(varName, resolvers.sync).setAsync(varName, resolvers.async);
-    }
   }
 
   /**

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -125,6 +125,31 @@ export class A4AVariableSource extends VariableSource {
       return getNavigationData(this.win_, 'redirectCount');
     });
 
+    // TODO: Remove once the migration to NAV_TIMING is done
+    this.set('AD_NAV_TIMING', (startAttribute, endAttribute) => {
+      userAssert(startAttribute, 'The first argument to AD_NAV_TIMING, the' +
+          ' start attribute name, is required');
+      return getTimingDataSync(
+          this.win_,
+          /**@type {string}*/(startAttribute),
+          /**@type {string}*/(endAttribute));
+    }).setAsync('AD_NAV_TIMING', (startAttribute, endAttribute) => {
+      userAssert(startAttribute, 'The first argument to AD_NAV_TIMING, the' +
+          ' start attribute name, is required');
+      return getTimingDataAsync(
+          this.win_,
+          /**@type {string}*/(startAttribute),
+          /**@type {string}*/(endAttribute));
+    });
+
+    this.set('AD_NAV_TYPE', () => {
+      return getNavigationData(this.win_, 'type');
+    });
+
+    this.set('AD_NAV_REDIRECT_COUNT', () => {
+      return getNavigationData(this.win_, 'redirectCount');
+    });
+
     this.set('HTML_ATTR',
         /** @type {function(...*)} */(this.htmlAttributeBinding_.bind(this)));
 

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -53,19 +53,19 @@ describe('A4AVariableSource', () => {
         .to.equal('https://pinterest.com:8080/pin1');
   });
 
-  it('should replace AD_NAV_TIMING', () => {
-    expect(expandSync('AD_NAV_TIMING', ['navigationStart'])).to.match(/\d+/);
-    return expandAsync('AD_NAV_TIMING', ['navigationStart']).then(val =>
+  it('should replace NAV_TIMING', () => {
+    expect(expandSync('NAV_TIMING', ['navigationStart'])).to.match(/\d+/);
+    return expandAsync('NAV_TIMING', ['navigationStart']).then(val =>
       expect(val).to.match(/\d+/)
     );
   });
 
-  it('should replace AD_NAV_TYPE', () => {
-    expect(expandSync('AD_NAV_TYPE')).to.match(/\d/);
+  it('should replace NAV_TYPE', () => {
+    expect(expandSync('NAV_TYPE')).to.match(/\d/);
   });
 
-  it('should replace AD_NAV_REDIRECT_COUNT', () => {
-    expect(expandSync('AD_NAV_REDIRECT_COUNT')).to.match(/\d/);
+  it('should replace NAV_REDIRECT_COUNT', () => {
+    expect(expandSync('NAV_REDIRECT_COUNT')).to.match(/\d/);
   });
 
   it('should replace HTML_ATTR', () => {
@@ -84,9 +84,6 @@ describe('A4AVariableSource', () => {
   }
 
   // Performance timing info.
-  undefinedVariable('NAV_TIMING');
-  undefinedVariable('NAV_TYPE');
-  undefinedVariable('NAV_REDIRECT_COUNT');
   undefinedVariable('PAGE_LOAD_TIME');
   undefinedVariable('DOMAIN_LOOKUP_TIME');
   undefinedVariable('TCP_CONNECT_TIME');

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -53,6 +53,21 @@ describe('A4AVariableSource', () => {
         .to.equal('https://pinterest.com:8080/pin1');
   });
 
+  it('should replace AD_NAV_TIMING', () => {
+    expect(expandSync('AD_NAV_TIMING', ['navigationStart'])).to.match(/\d+/);
+    return expandAsync('AD_NAV_TIMING', ['navigationStart']).then(val =>
+      expect(val).to.match(/\d+/)
+    );
+  });
+
+  it('should replace AD_NAV_TYPE', () => {
+    expect(expandSync('AD_NAV_TYPE')).to.match(/\d/);
+  });
+
+  it('should replace AD_NAV_REDIRECT_COUNT', () => {
+    expect(expandSync('AD_NAV_REDIRECT_COUNT')).to.match(/\d/);
+  });
+
   it('should replace NAV_TIMING', () => {
     expect(expandSync('NAV_TIMING', ['navigationStart'])).to.match(/\d+/);
     return expandAsync('NAV_TIMING', ['navigationStart']).then(val =>

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -107,7 +107,6 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'transport': {'beacon': true, 'xhrpost': true, 'image': true},
     'vars': {
       'accessReaderId': 'ACCESS_READER_ID',
-      'adRedirectCount': 'AD_NAV_REDIRECT_COUNT', // only available in A4A
       'ampdocHost': 'AMPDOC_HOST',
       'ampdocHostname': 'AMPDOC_HOSTNAME',
       'ampdocUrl': 'AMPDOC_URL',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -107,8 +107,6 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'transport': {'beacon': true, 'xhrpost': true, 'image': true},
     'vars': {
       'accessReaderId': 'ACCESS_READER_ID',
-      'adNavTiming': 'AD_NAV_TIMING', // only available in A4A embeds
-      'adNavType': 'AD_NAV_TYPE', // only available in A4A embeds
       'adRedirectCount': 'AD_NAV_REDIRECT_COUNT', // only available in A4A
       'ampdocHost': 'AMPDOC_HOST',
       'ampdocHostname': 'AMPDOC_HOSTNAME',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -107,6 +107,9 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'transport': {'beacon': true, 'xhrpost': true, 'image': true},
     'vars': {
       'accessReaderId': 'ACCESS_READER_ID',
+      'adNavTiming': 'AD_NAV_TIMING', // only available in A4A embeds
+      'adNavType': 'AD_NAV_TYPE', // only available in A4A embeds
+      'adRedirectCount': 'AD_NAV_REDIRECT_COUNT', // only available in A4A
       'ampdocHost': 'AMPDOC_HOST',
       'ampdocHostname': 'AMPDOC_HOSTNAME',
       'ampdocUrl': 'AMPDOC_URL',

--- a/test/integration/test-amp-ad-fake.js
+++ b/test/integration/test-amp-ad-fake.js
@@ -50,9 +50,9 @@ describe('A4A', function() {
         expect(queries).to.include({
           title: 'AMP TEST', // ${title},
           cid: '', // ${clientId(a)}
-          adNavTiming: '0', // ${adNavTiming(requestStart,requestStart)}
-          adNavType: '0', // ${adNavType}
-          adRedirectCount: '0', // ${adRedirectCount}
+          navTiming: '0', // ${navTiming(requestStart,requestStart)}
+          navType: '0', // ${navType}
+          redirectCount: '0', // ${redirectCount}
         });
         expect(queries['ampdocUrl']).to.contain('http://localhost:9876/amp4test/compose-doc?');
         expect(queries['canonicalUrl']).to.equal('http://nonblocking.io/');

--- a/test/integration/test-amp-ad-fake.js
+++ b/test/integration/test-amp-ad-fake.js
@@ -52,7 +52,7 @@ describe('A4A', function() {
           cid: '', // ${clientId(a)}
           navTiming: '0', // ${navTiming(requestStart,requestStart)}
           navType: '0', // ${navType}
-          redirectCount: '0', // ${redirectCount}
+          navRedirectCount: '0', // ${navRedirectCount}
         });
         expect(queries['ampdocUrl']).to.contain('http://localhost:9876/amp4test/compose-doc?');
         expect(queries['canonicalUrl']).to.equal('http://nonblocking.io/');


### PR DESCRIPTION
As agreed, it doesn't make sense to have special macro for A4a, because they cannot be reused for inabox ad. 

The solution is to override the existing macro resolver function. 


@lannka I didn't find a good testing solution. But I think this is a safe enough change. Let me know if you have any objection. 