### PR TITLE
Revert "Force the subscriptions dialog into the fixed layer to avoid collisions with border"

### DIFF
--- a/extensions/amp-subscriptions/0.1/dialog.js
+++ b/extensions/amp-subscriptions/0.1/dialog.js
@@ -154,7 +154,9 @@ export class Dialog {
         },
         mutate: () => {
           this.viewport_.updatePaddingBottom(offsetHeight);
-          this.viewport_.addToFixedLayer(this.wrapper_, true);
+          // TODO(dvoytenko, #20608): add to fixed layer, once the SwG/FL
+          // conflict is resolved.
+          // this.viewport_.addToFixedLayer(this.wrapper_, true);
         },
       });
     });

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -76,7 +76,8 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
       expect(updatePaddingSpy).to.be.calledOnce.calledWith(17);
       // TODO(dvoytenko, #20608): add to fixed layer, once the SwG/FL
       // conflict is resolved.
-      // expect(addToFixedLayerSpy).to.be.calledOnce.calledWith(dialog.getRoot());
+      // expect(addToFixedLayerSpy).to.be.calledOnce
+      //     .calledWith(dialog.getRoot());
       expect(addToFixedLayerSpy).to.not.be.called;
       expect(dialog.isVisible()).to.be.true;
     });

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -74,7 +74,10 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
       expect(styles.transform).to.not.contain('17');
       expect(dialog.closeButton_).to.have.display('none');
       expect(updatePaddingSpy).to.be.calledOnce.calledWith(17);
-      expect(addToFixedLayerSpy).to.be.calledOnce.calledWith(dialog.getRoot());
+      // TODO(dvoytenko, #20608): add to fixed layer, once the SwG/FL
+      // conflict is resolved.
+      // expect(addToFixedLayerSpy).to.be.calledOnce.calledWith(dialog.getRoot());
+      expect(addToFixedLayerSpy).to.not.be.called;
       expect(dialog.isVisible()).to.be.true;
     });
   });


### PR DESCRIPTION
Reverts #20608

The reason is that the SwG dialogs conflict with other fixed-layer dialogs and elements.