### PR TITLE
✨amp-recaptcha-input: Added Origin Trial Support for the experiment 

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -369,6 +369,8 @@ exports.rules = [
             'src/service/extension-location.js',
       'extensions/amp-list/0.1/amp-list.js->' +
             'src/service/origin-experiments-impl.js',
+      'extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js->' +
+            'src/service/origin-experiments-impl.js',
       // For action macros.
       'extensions/amp-action-macro/0.1/amp-action-macro.js->' +
             'src/service/action-impl.js',

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
@@ -27,13 +27,13 @@ import {
 import {CSS} from '../../../build/amp-recaptcha-input-0.1.css';
 import {Layout} from '../../../src/layout';
 import {
-  installRecaptchaServiceForDoc,
-  recaptchaServiceForDoc,
-} from './amp-recaptcha-service';
-import {
   installOriginExperimentsForDoc,
   originExperimentsForDoc,
 } from '../../../src/service/origin-experiments-impl';
+import {
+  installRecaptchaServiceForDoc,
+  recaptchaServiceForDoc,
+} from './amp-recaptcha-service';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyles, toggle} from '../../../src/style';
 import {user, userAssert} from '../../../src/log';
@@ -64,28 +64,30 @@ export class AmpRecaptchaInput extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    return this._isExperimentEnabled().then(enabled => {
+    return this.isExperimentEnabled_().then(enabled => {
 
       if (!enabled) {
         user().error(TAG, 'Experiment "amp-recaptcha-input" is not enabled.');
-        return;
+        return Promise.reject(
+            'Experiment "amp-recaptcha-input" is not enabled.'
+        );
       }
 
       this.sitekey_ = userAssert(
-        this.element.getAttribute('data-sitekey'),
-        'The data-sitekey attribute is required for <amp-recaptcha-input> %s',
-        this.element);
+          this.element.getAttribute('data-sitekey'),
+          'The data-sitekey attribute is required for <amp-recaptcha-input> %s',
+          this.element);
 
       this.action_ = userAssert(
-        this.element.getAttribute('data-action'),
-        'The data-action attribute is required for <amp-recaptcha-input> %s',
-        this.element);
+          this.element.getAttribute('data-action'),
+          'The data-action attribute is required for <amp-recaptcha-input> %s',
+          this.element);
 
       userAssert(
-        this.element.getAttribute(AsyncInputAttributes.NAME),
-        'The %s attribute is required for <amp-recaptcha-input> %s',
-        AsyncInputAttributes.NAME,
-        this.element);
+          this.element.getAttribute(AsyncInputAttributes.NAME),
+          'The %s attribute is required for <amp-recaptcha-input> %s',
+          AsyncInputAttributes.NAME,
+          this.element);
 
       this.recaptchaService_ = recaptchaServiceForDoc(this.getAmpDoc());
 
@@ -157,20 +159,20 @@ export class AmpRecaptchaInput extends AMP.BaseElement {
    * through origin trial, or AMP.toggleExperiment
    * @return {!Promise<boolean>}
    */
-  _isExperimentEnabled() {
+  isExperimentEnabled_() {
 
     // Check if we are enabled by AMP.toggleExperiment
-    if(isExperimentOn(this.win, 'amp-recaptcha-input')) {
+    if (isExperimentOn(this.win, 'amp-recaptcha-input')) {
       return Promise.resolve(true);
     }
 
     // Check if we are enabled by an origin trial
     installOriginExperimentsForDoc(this.getAmpDoc());
     return originExperimentsForDoc(this.element)
-      .getExperiments()
-      .then(trials => {
-        return trials && trials.includes('amp-recaptcha-input');
-      });
+        .getExperiments()
+        .then(trials => {
+          return trials && trials.includes('amp-recaptcha-input');
+        });
   }
 }
 

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
@@ -30,9 +30,13 @@ import {
   installRecaptchaServiceForDoc,
   recaptchaServiceForDoc,
 } from './amp-recaptcha-service';
+import {
+  installOriginExperimentsForDoc,
+  originExperimentsForDoc,
+} from '../../../src/service/origin-experiments-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyles, toggle} from '../../../src/style';
-import {userAssert} from '../../../src/log';
+import {user, userAssert} from '../../../src/log';
 
 /** @const */
 const TAG = 'amp-recaptcha-input';
@@ -56,52 +60,53 @@ export class AmpRecaptchaInput extends AMP.BaseElement {
 
     /** @private {?Promise} */
     this.registerPromise_ = null;
-
-    /** @private {boolean} */
-    this.isExperimentEnabled_ = isExperimentOn(this.win, 'amp-recaptcha-input');
   }
 
   /** @override */
   buildCallback() {
-    if (!this.isExperimentEnabled_) {
-      return;
-    }
+    return this._isExperimentEnabled().then(enabled => {
 
-    this.sitekey_ = userAssert(
+      if (!enabled) {
+        user().error(TAG, 'Experiment "amp-recaptcha-input" is not enabled.');
+        return;
+      }
+
+      this.sitekey_ = userAssert(
         this.element.getAttribute('data-sitekey'),
         'The data-sitekey attribute is required for <amp-recaptcha-input> %s',
         this.element);
 
-    this.action_ = userAssert(
+      this.action_ = userAssert(
         this.element.getAttribute('data-action'),
         'The data-action attribute is required for <amp-recaptcha-input> %s',
         this.element);
 
-    userAssert(
+      userAssert(
         this.element.getAttribute(AsyncInputAttributes.NAME),
         'The %s attribute is required for <amp-recaptcha-input> %s',
         AsyncInputAttributes.NAME,
         this.element);
 
-    this.recaptchaService_ = recaptchaServiceForDoc(this.getAmpDoc());
+      this.recaptchaService_ = recaptchaServiceForDoc(this.getAmpDoc());
 
-    return this.mutateElement(() => {
-      toggle(this.element);
-      // Add the required AsyncInput class
-      this.element.classList.add(AsyncInputClasses.ASYNC_INPUT);
-      /**
-       * We are applying styles here, to minizime the amp.css file.
-       * These styles will create an in-place element, that is 1x1,
-       * but invisible. Absolute positioning keeps it where it would have
-       * been, without taking up space. Thus, layoutCallback will still
-       * be called at the appropriate time
-       */
-      setStyles(this.element, {
-        'position': 'absolute',
-        'width': '1px',
-        'height': '1px',
-        'overflow': 'hidden',
-        'visibility': 'hidden',
+      return this.mutateElement(() => {
+        toggle(this.element);
+        // Add the required AsyncInput class
+        this.element.classList.add(AsyncInputClasses.ASYNC_INPUT);
+        /**
+         * We are applying styles here, to minizime the amp.css file.
+         * These styles will create an in-place element, that is 1x1,
+         * but invisible. Absolute positioning keeps it where it would have
+         * been, without taking up space. Thus, layoutCallback will still
+         * be called at the appropriate time
+         */
+        setStyles(this.element, {
+          'position': 'absolute',
+          'width': '1px',
+          'height': '1px',
+          'overflow': 'hidden',
+          'visibility': 'hidden',
+        });
       });
     });
   }
@@ -145,6 +150,27 @@ export class AmpRecaptchaInput extends AMP.BaseElement {
         'amp-recaptcha-input requires both the data-sitekey,' +
         ' and data-action attribute'
     ));
+  }
+
+  /**
+   * Function to check if recaptcha experiment is enabled,
+   * through origin trial, or AMP.toggleExperiment
+   * @return {!Promise<boolean>}
+   */
+  _isExperimentEnabled() {
+
+    // Check if we are enabled by AMP.toggleExperiment
+    if(isExperimentOn(this.win, 'amp-recaptcha-input')) {
+      return Promise.resolve(true);
+    }
+
+    // Check if we are enabled by an origin trial
+    installOriginExperimentsForDoc(this.getAmpDoc());
+    return originExperimentsForDoc(this.element)
+      .getExperiments()
+      .then(trials => {
+        return trials && trials.includes('amp-list-load-more');
+      });
   }
 }
 

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js
@@ -169,7 +169,7 @@ export class AmpRecaptchaInput extends AMP.BaseElement {
     return originExperimentsForDoc(this.element)
       .getExperiments()
       .then(trials => {
-        return trials && trials.includes('amp-list-load-more');
+        return trials && trials.includes('amp-recaptcha-input');
       });
   }
 }

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
@@ -60,6 +60,16 @@ describes.realWin('amp-recaptcha-input', {
 
   describe('amp-recaptcha-input', () => {
 
+    it('Rejects because experiment is not enabled', () => {
+      toggleExperiment(win, 'amp-recaptcha-input', false);
+      return allowConsoleError(() => {
+        return getRecaptchaInput()
+          .should.eventually.be.rejectedWith(
+            /Experiment/
+          );
+      });
+    });
+
     it('Rejects because data-name is missing', () => {
 
       const ampRecaptchaInputConfig =

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
@@ -62,11 +62,12 @@ describes.realWin('amp-recaptcha-input', {
 
     it('Rejects because experiment is not enabled', () => {
       toggleExperiment(win, 'amp-recaptcha-input', false);
+
       return allowConsoleError(() => {
         return getRecaptchaInput()
-          .should.eventually.be.rejectedWith(
-            /Experiment/
-          );
+            .should.eventually.be.rejectedWith(
+                /Experiment/
+            );
       });
     });
 


### PR DESCRIPTION
This adds support for origin trials for amp-recaptcha-input, as well as the ability to continue support for manually enabling the experiment with `AMP.toggleExperiment`. Also, adds a test for the experiment, and throws a user error if not enabled for easier debugging 😄 

[Referenced Code Example from amp-list](https://github.com/cathyxz/amphtml/blob/0a2293bf051380b0c38908727318ca1f356e74f2/extensions/amp-list/0.1/amp-list.js#L182)

# Examples

(After modifying the `test/unit/test-origin-experiments` for my desired domain, token, and experiment)

<img width="614" alt="screen shot 2019-02-14 at 2 51 41 pm" src="https://user-images.githubusercontent.com/1448289/52823140-c61c8280-3068-11e9-8a4d-d5ae28f72e5b.png">

(Before AMP.toggleExperiment)

<img width="1440" alt="screen shot 2019-02-14 at 3 30 12 pm" src="https://user-images.githubusercontent.com/1448289/52824604-19450400-306e-11e9-8ab5-63d02dee0aec.png">

(After AMP.toggleExperiment)

<img width="1440" alt="screen shot 2019-02-14 at 3 30 35 pm" src="https://user-images.githubusercontent.com/1448289/52824612-2104a880-306e-11e9-863e-71636e86a6dc.png">
