### PR TITLE
✨Request Bank: Fixed AMP CORs and Multipart form data

### DIFF
--- a/build-system/amp-cors.js
+++ b/build-system/amp-cors.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function enableCors(req, res, origin, opt_exposeHeaders) {
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+
+  if(!origin && req.headers.origin) {
+    origin = req.headers.origin
+  }
+
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Expose-Headers',
+    ['AMP-Access-Control-Allow-Source-Origin']
+    .concat(opt_exposeHeaders || []).join(', '));
+  if (req.query.__amp_source_origin) {
+    res.setHeader('AMP-Access-Control-Allow-Source-Origin',
+      req.query.__amp_source_origin);
+  }
+}
+
+module.exports = {
+  enableCors
+};

--- a/build-system/amp-cors.js
+++ b/build-system/amp-cors.js
@@ -17,22 +17,20 @@
 function enableCors(req, res, origin, opt_exposeHeaders) {
   res.setHeader('Access-Control-Allow-Credentials', 'true');
 
-  if(!origin && req.headers.origin) {
-    origin = req.headers.origin
+  if (!origin && req.headers.origin) {
+    origin = req.headers.origin;
   }
 
   if (origin) {
     res.setHeader('Access-Control-Allow-Origin', origin);
   }
   res.setHeader('Access-Control-Expose-Headers',
-    ['AMP-Access-Control-Allow-Source-Origin']
-    .concat(opt_exposeHeaders || []).join(', '));
+      ['AMP-Access-Control-Allow-Source-Origin']
+          .concat(opt_exposeHeaders || []).join(', '));
   if (req.query.__amp_source_origin) {
     res.setHeader('AMP-Access-Control-Allow-Source-Origin',
-      req.query.__amp_source_origin);
+        req.query.__amp_source_origin);
   }
 }
 
-module.exports = {
-  enableCors
-};
+module.exports = enableCors;

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -17,9 +17,14 @@
 
 const app = require('express').Router();
 const minimist = require('minimist');
+const {
+  enableCors,
+} = require('./amp-cors');
 const argv = minimist(
     process.argv.slice(2), {boolean: ['strictBabelTransform']});
+const multer = require('multer');
 
+const upload = multer();
 
 /* eslint-disable max-len */
 
@@ -101,19 +106,23 @@ const bank = {};
  * Deposit a request. An ID has to be specified. Will override previous request
  * if the same ID already exists.
  */
-app.use('/request-bank/:bid/deposit/:id/', (req, res) => {
-  if (!bank[req.params.bid]) {
-    bank[req.params.bid] = {};
-  }
-  const key = req.params.id;
-  log('SERVER-LOG [DEPOSIT]: ', key);
-  if (typeof bank[req.params.bid][key] === 'function') {
-    bank[req.params.bid][key](req);
-  } else {
-    bank[req.params.bid][key] = req;
-  }
-  res.end();
-});
+app.use(
+    '/request-bank/:bid/deposit/:id/',
+    upload.array(),
+    (req, res) => {
+      enableCors(req, res);
+      if (!bank[req.params.bid]) {
+        bank[req.params.bid] = {};
+      }
+      const key = req.params.id;
+      log('SERVER-LOG [DEPOSIT]: ', key);
+      if (typeof bank[req.params.bid][key] === 'function') {
+        bank[req.params.bid][key](req);
+      } else {
+        bank[req.params.bid][key] = req;
+      }
+      res.end();
+    });
 
 /**
  * Withdraw a request. If the request of the given ID is already in the bank,
@@ -121,6 +130,7 @@ app.use('/request-bank/:bid/deposit/:id/', (req, res) => {
  * The same request cannot be withdrawn twice at the same time.
  */
 app.use('/request-bank/:bid/withdraw/:id/', (req, res) => {
+  enableCors(req, res);
   if (!bank[req.params.bid]) {
     bank[req.params.bid] = {};
   }

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -16,10 +16,8 @@
 'use strict';
 
 const app = require('express').Router();
+const enableCors = require('./amp-cors');
 const minimist = require('minimist');
-const {
-  enableCors,
-} = require('./amp-cors');
 const argv = minimist(
     process.argv.slice(2), {boolean: ['strictBabelTransform']});
 const multer = require('multer');

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -30,13 +30,16 @@ const jsdom = require('jsdom');
 const multer = require('multer');
 const path = require('path');
 const request = require('request');
+const {
+  enableCors,
+} = require('./amp-cors');
 const pc = process;
 const countries = require('../examples/countries.json');
 const runVideoTestBench = require('./app-video-testbench');
 const {
   recaptchaFrameRequestHandler,
   recaptchaRouter,
-} = require('./recaptcha-router.js');
+} = require('./recaptcha-router');
 const {renderShadowViewer} = require('./shadow-viewer');
 const {replaceUrls} = require('./app-utils');
 
@@ -1384,18 +1387,6 @@ function addQueryParam(url, param, value) {
     url += '&' + paramValue;
   }
   return url;
-}
-
-function enableCors(req, res, origin, opt_exposeHeaders) {
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', origin);
-  res.setHeader('Access-Control-Expose-Headers',
-      ['AMP-Access-Control-Allow-Source-Origin']
-          .concat(opt_exposeHeaders || []).join(', '));
-  if (req.query.__amp_source_origin) {
-    res.setHeader('AMP-Access-Control-Allow-Source-Origin',
-        req.query.__amp_source_origin);
-  }
 }
 
 function assertCors(req, res, opt_validMethods, opt_exposeHeaders,

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -24,15 +24,13 @@ const bacon = require('baconipsum');
 const BBPromise = require('bluebird');
 const bodyParser = require('body-parser');
 const devDashboard = require('./app-index/index');
+const enableCors = require('./amp-cors');
 const formidable = require('formidable');
 const fs = BBPromise.promisifyAll(require('fs'));
 const jsdom = require('jsdom');
 const multer = require('multer');
 const path = require('path');
 const request = require('request');
-const {
-  enableCors,
-} = require('./amp-cors');
 const pc = process;
 const countries = require('../examples/countries.json');
 const runVideoTestBench = require('./app-video-testbench');

--- a/build-system/recaptcha-router.js
+++ b/build-system/recaptcha-router.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-const {
-  enableCors,
-} = require('./amp-cors');
+const enableCors = require('./amp-cors');
 const pc = process;
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));

--- a/build-system/recaptcha-router.js
+++ b/build-system/recaptcha-router.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+const {
+  enableCors,
+} = require('./amp-cors');
 const pc = process;
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));
@@ -48,10 +51,7 @@ recaptchaRouter.post(
     '/submit',
     upload.array(),
     (req, res) => {
-      const sourceOrigin = req.query['__amp_source_origin'];
-      if (sourceOrigin) {
-        res.setHeader('AMP-Access-Control-Allow-Source-Origin', sourceOrigin);
-      }
+      enableCors(req, res);
 
       const responseJson = {
         message: 'Success!',


### PR DESCRIPTION
closes #20868 
closes #20869 
relates to #20541 

This adds [multipart form data parsing into the request body](https://stackoverflow.com/questions/37630419/how-to-handle-formdata-from-express-4), which AMP Form uses, to the RequestBank Express Middleware, as well as, enables AMP Cors on request bank (which included some refactoring in other places).

# Example Requests

**These examples are made from just switching around the endpoint of the POST request on the recaptcha example**

## Submitting to a standard endpoint on the dev server

<img width="652" alt="screen shot 2019-02-14 at 5 46 00 pm" src="https://user-images.githubusercontent.com/1448289/52830283-05f16300-3085-11e9-80d9-bcdb81e015d1.png">
<img width="651" alt="screen shot 2019-02-14 at 5 46 19 pm" src="https://user-images.githubusercontent.com/1448289/52830284-0689f980-3085-11e9-9113-31f4ffe2dd2d.png">

## Depositing to request bank

<img width="652" alt="screen shot 2019-02-14 at 6 11 26 pm" src="https://user-images.githubusercontent.com/1448289/52830286-07229000-3085-11e9-9f91-12ca9b34ead4.png">
<img width="651" alt="screen shot 2019-02-14 at 6 11 46 pm" src="https://user-images.githubusercontent.com/1448289/52830287-07229000-3085-11e9-88b1-0ddae40031ee.png">

## Withdrawing from request bank

<img width="1127" alt="screen shot 2019-02-14 at 6 11 16 pm" src="https://user-images.githubusercontent.com/1448289/52830285-0689f980-3085-11e9-821c-10a7df593f7c.png">

