### PR TITLE
Removing myself as owner

### DIFF
--- a/extensions/amp-access-laterpay/OWNERS.yaml
+++ b/extensions/amp-access-laterpay/OWNERS.yaml
@@ -1,1 +1,0 @@
-- trodrigues


### PR DESCRIPTION
Removing myself from this file as I today is my last day working for LaterPay. I've notified my coworkers that they'll need to add someone here in the future when new ownership is determined, but for now I'd like to not be list as a public point of contact.