### PR TITLE
🐛 Fix selectUp off-by-one bug in amp-selector.

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -430,7 +430,12 @@ export class AmpSelector extends AMP.BaseElement {
     // The selection should loop around if the user attempts to go one
     // past the beginning or end.
     const previousIndex = this.elements_.indexOf(this.selectedElements_[0]);
-    const index = previousIndex + delta;
+
+    // If previousIndex === -1 is true, then a negative delta will be offset 
+    // one more than is wanted when looping back around in the options. This occurs when 
+    // no options are selected and "selectUp" is called.
+    const selectUpWhenNoneSelected = previousIndex === -1 && delta < 0;
+    const index = selectUpWhenNoneSelected ? delta : previousIndex + delta;
     const normalizedIndex = mod(index, this.elements_.length);
 
     this.setSelection_(this.elements_[normalizedIndex]);

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -431,9 +431,9 @@ export class AmpSelector extends AMP.BaseElement {
     // past the beginning or end.
     const previousIndex = this.elements_.indexOf(this.selectedElements_[0]);
 
-    // If previousIndex === -1 is true, then a negative delta will be offset 
-    // one more than is wanted when looping back around in the options. This occurs when 
-    // no options are selected and "selectUp" is called.
+    // If previousIndex === -1 is true, then a negative delta will be offset
+    // one more than is wanted when looping back around in the options.
+    // This occurs when no options are selected and "selectUp" is called.
     const selectUpWhenNoneSelected = previousIndex === -1 && delta < 0;
     const index = selectUpWhenNoneSelected ? delta : previousIndex + delta;
     const normalizedIndex = mod(index, this.elements_.length);


### PR DESCRIPTION
- Add logic to handle selectUp when called with no elements selected. Before this change, calling selectUp() with no elements selected would select the second to last item, not the last item. 
