### PR TITLE
Fix regex to detect ad type

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -892,7 +892,7 @@ function escapeRegExp(string) {
 function elementExtractor(tagName, type) {
   type = escapeRegExp(type);
   return new RegExp(
-      `<${tagName} [^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
+      `<${tagName}[(\\s)][^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
       'gm');
 }
 

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -892,7 +892,7 @@ function escapeRegExp(string) {
 function elementExtractor(tagName, type) {
   type = escapeRegExp(type);
   return new RegExp(
-      `<${tagName}[(\\s)][^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
+      `<${tagName}[\\s][^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
       'gm');
 }
 


### PR DESCRIPTION
This is really tricky. 

Found it from #20534, they used \n to separate `amp-ad` and `width` instead of space. Fix the regex