### PR TITLE
🐛 Do not reset component element on undock

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1708,7 +1708,6 @@ export class VideoDocking {
       this.getControls_().reset();
 
       [
-        element,
         internalElement,
         shadowLayer,
         placeholderBackground,


### PR DESCRIPTION
Otherwise fixed size components can break. No need to reset the direct component element as we don't change its styles.