### PR TITLE
✨ add multi size macro to aps callout URL

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -91,7 +91,7 @@ export const RTC_VENDORS = {
     disableKeyAppend: true,
   },
   aps: {
-    url: 'https://aax.amazon-adsystem.com/e/dtb/bid?src=PUB_ID&pubid=PUB_UUID&amp=1&u=CANONICAL_URL&slots=%5B%7B%22sd%22%3A%22ATTR(data-slot)%22%2C%22s%22%3A%5B%22ATTR(width)xATTR(height)%22%5D%7D%5D&pj=PARAMS',
+    url: 'https://aax.amazon-adsystem.com/e/dtb/bid?src=PUB_ID&pubid=PUB_UUID&amp=1&u=CANONICAL_URL&slots=%5B%7B%22sd%22%3A%22ATTR(data-slot)%22%2C%22s%22%3A%5B%22ATTR(width)xATTR(height)%22%5D%2C%22ms%22%3A%22ATTR(data-multi-size)%22%7D%5D&pj=PARAMS',
     macros: ['PUB_ID', 'PARAMS', 'PUB_UUID'],
     disableKeyAppend: true,
   },


### PR DESCRIPTION
# Instructions:
Amazon Publishers Services (APS) will now be sent the data-multi-size attribute for the amp-ad tag in our vendor callout URL. 

# Description:
Add the data-multi-size attribute to your amp-ad tag with multiple sizes (comma separated string) in order to send them to APS as valid sizes.  


