### PR TITLE
Detect mutations outside of mutation phase

### DIFF
--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -158,7 +158,7 @@ export class Vsync {
         this.ampdocService_.isSingleDoc()) {
       this.mutationObserver_ = new MutationObserver(
           this.mutationHandler_.bind(this));
-      const doc = this.ampdocService_.getAmpDocIfAvailable();
+      const doc = this.win.document;
       this.mutationObserver_.observe(doc, {
         attributes: true,
         characterData: true,
@@ -469,15 +469,17 @@ export class Vsync {
   }
 
   /**
-   * @param {!Array<!MutationRecord>} records
+   * @param {!Array<!MutationRecord>|null} records
    * @private
    */
   mutationHandler_(records) {
+    if (!records) {
+      return;
+    }
     for (let i = 0; i < records.length; i++) {
-      const record = records[i];
-      const {target} = record;
-      dev().error('VSYNC', `Detected ${record.type} mutation on ` +
-        `${target.tagName} outside of mutation phase: %s`, target);
+      const {target, type} = records[i];
+      dev().error('VSYNC', `Detected ${type} mutation on ${target.tagName} ` +
+        'outside of mutation phase: %s', target);
     }
   }
 


### PR DESCRIPTION
A simple change to detect DOM mutations outside of a VSync mutation phase. There are some known violations that we unfortunately can't do anything about (eg, `FixedLayer`'s detection phase). We can associate these known cases into VSync in later PRs.

For now, only runs in local development builds. That's likely not enough to catch bugs, but it gives us a starting point.

This can replace a lot of the black magic PR work I did before. Unfortunately, there's not a nice way to detect measures outside a measure phase...