### PR TITLE
🖍✨ Display loaders on all video player components

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -118,6 +118,15 @@ export const LOADING_ELEMENTS_ = {
 
 
 /**
+ * All video player components must either have a) "video" or b) "player" in
+ * their name. A few components don't follow this convention for historical
+ * reasons, so they're present in the LOADING_ELEMENTS_ whitelist.
+ * @private @const {!RegExp}
+ */
+const videoPlayerTagNameRe = /^amp\-(video|.+player)/i;
+
+
+/**
  * @param {string} s
  * @return {Layout|undefined} Returns undefined in case of failure to parse
  *   the layout string.
@@ -310,7 +319,7 @@ export function isLoadingAllowed(element) {
  * @return {boolean}
  */
 function isVideoPlayerComponent(tagName) {
-  return /^amp\-(video|.+player)/i.test(tagName);
+  return videoPlayerTagNameRe.test(tagName);
 }
 
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -96,23 +96,24 @@ export const naturalDimensions_ = {
  * @private  Visible for testing only!
  */
 export const LOADING_ELEMENTS_ = {
+  'AMP-AD': true,
   'AMP-ANIM': true,
   'AMP-BRIGHTCOVE': true,
-  'AMP-GOOGLE-DOCUMENT-EMBED': true,
+  'AMP-DAILYMOTION': true,
   'AMP-EMBED': true,
   'AMP-FACEBOOK': true,
   'AMP-FACEBOOK-COMMENTS': true,
   'AMP-FACEBOOK-LIKE': true,
   'AMP-FACEBOOK-PAGE': true,
+  'AMP-GOOGLE-DOCUMENT-EMBED': true,
   'AMP-IFRAME': true,
   'AMP-IMG': true,
   'AMP-INSTAGRAM': true,
   'AMP-LIST': true,
-  'AMP-OOYALA-PLAYER': true,
   'AMP-PINTEREST': true,
   'AMP-PLAYBUZZ': true,
-  'AMP-VIDEO': true,
   'AMP-YOUTUBE': true,
+  'AMP-VIMEO': true,
 };
 
 
@@ -297,10 +298,19 @@ export function getNaturalDimensions(element) {
  */
 export function isLoadingAllowed(element) {
   const tagName = element.tagName.toUpperCase();
-  if (tagName == 'AMP-AD' || tagName == 'AMP-EMBED') {
-    return true;
-  }
-  return LOADING_ELEMENTS_[tagName] || false;
+  return LOADING_ELEMENTS_[tagName] || isVideoPlayerComponent(tagName);
+}
+
+
+/**
+ * All video player components must either have a) "video" or b) "player" in
+ * their name. A few components don't follow this convention for historical
+ * reasons, so they're present in the LOADING_ELEMENTS_ whitelist.
+ * @param {string} tagName
+ * @return {boolean}
+ */
+function isVideoPlayerComponent(tagName) {
+  return /^amp\-(video|.+player)/i.test(tagName);
 }
 
 
@@ -461,7 +471,7 @@ export function applyStaticLayout(element) {
     // i-amphtml-sizer element
     const sizer = htmlFor(element)`
       <i-amphtml-sizer class="i-amphtml-sizer">
-        <img alt="" role="presentation" aria-hidden="true" 
+        <img alt="" role="presentation" aria-hidden="true"
              class="i-amphtml-intrinsic-sizer" />
       </i-amphtml-sizer>`;
     const intrinsicSizer = sizer.firstElementChild;

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -41,19 +41,35 @@ describe('Layout', () => {
       tagName: 'hold',
     };
     const elementsValidTagNames = [
+      // in whitelist.
       'AMP-AD',
       'AMP-ANIM',
       'AMP-BRIGHTCOVE',
+      'AMP-DAILYMOTION',
       'AMP-EMBED',
+      'AMP-FACEBOOK',
+      'AMP-FACEBOOK-COMMENTS',
+      'AMP-FACEBOOK-LIKE',
+      'AMP-FACEBOOK-PAGE',
+      'AMP-GOOGLE-DOCUMENT-EMBED',
       'AMP-IFRAME',
       'AMP-IMG',
       'AMP-INSTAGRAM',
       'AMP-LIST',
-      'AMP-OOYALA-PLAYER',
       'AMP-PINTEREST',
       'AMP-PLAYBUZZ',
-      'AMP-VIDEO',
       'AMP-YOUTUBE',
+      'AMP-VIMEO',
+
+      // matched by video player naming convention (fake)
+      'AMP-FOO-PLAYER',
+      'AMP-VIDEO-FOO',
+
+      // matched by video player naming convention (actual)
+      'AMP-JWPLAYER',
+      'AMP-OOYALA-PLAYER',
+      'AMP-VIDEO',
+      'AMP-VIDEO-IFRAME',
     ];
     elementsValidTagNames.forEach(function(tag) {
       el.tagName = tag;


### PR DESCRIPTION
- Most video player components can be matched by naming convention, use regex for those and remove them from whitelist.
- Add the players that don't match this convention to whitelist.
- Remove special case for `amp-ad` and `amp-embed` when they can be in the whitelist instead.
- Sorted whitelist alphabetically.