### PR TITLE
🐛 Don't wait for implementation to mark node as visited

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -299,8 +299,7 @@ export class Mutation {
    */
   static mutate(ampEl, mutator) {
     return whenUpgradedToCustomElement(ampEl)
-        .then(ampEl => ampEl.getImpl())
-        .then(impl => impl.mutateElement(mutator));
+        .then(ampEl => ampEl.getResources().mutateElement(ampEl, mutator));
   }
 }
 


### PR DESCRIPTION
I don't know if it's even possible to receive a `DOM_UPDATE` before a node's implementation is resolved, but since support for `amp-carousel` is coming, we better not wait for an additional script to load.