### PR TITLE
Only allowing amp-audio layout=nodisplay within amp-story.

### DIFF
--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -89,13 +89,6 @@ tags: {  # <amp-audio> for AMP, amp-story (autoplay attribute mandatory)
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-audio"
   amp_layout {
-    defines_default_height: true
-    # TODO(johannes): in the longer run, defines_default_width should
-    # be false, to make it a fixed height layout per default, rather
-    # than a fixed one.
-    defines_default_width: true
-    supported_layouts: FIXED
-    supported_layouts: FIXED_HEIGHT
     supported_layouts: NODISPLAY
   }
 }


### PR DESCRIPTION
Forcing `amp-audio` within `amp-story` to use `layout="nodisplay"`.

Using it with any other display breaks in different ways:
- The underlying `<audio>` element is created at a different time, potentially creating a race condition that results in the audio element not being handled by `amp-story`. It'd play when it's not supposed to, and not react to the story mute/unmute buttons.
- The audio element would be visible, but trying to interact with its controls would just navigate to the previous/next page instead of playing the audio.