### PR TITLE
♻ Pass PositionObserver as service builder directly

### DIFF
--- a/src/service/position-observer/position-observer-impl.js
+++ b/src/service/position-observer/position-observer-impl.js
@@ -206,7 +206,5 @@ export class PositionObserver {
  * @param {!../ampdoc-impl.AmpDoc} ampdoc
  */
 export function installPositionObserverServiceForDoc(ampdoc) {
-  registerServiceBuilderForDoc(ampdoc, 'position-observer', () => {
-    return new PositionObserver(ampdoc);
-  });
+  registerServiceBuilderForDoc(ampdoc, 'position-observer', PositionObserver);
 }


### PR DESCRIPTION
`registerServiceBuilderForDoc` already expects constructors so we can pass the classname without a wrapper fn.
