### PR TITLE
🐛 Move responsive font-size declaration to amp-story tag

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -63,6 +63,10 @@ amp-story {
   touch-action: manipulation !important;
 }
 
+html.i-amphtml-story-standalone {
+  font-size: calc(2 * var(--i-amphtml-story-vmax, 8px));
+}
+
 html.i-amphtml-story-standalone,
 html.i-amphtml-story-standalone body {
   font-size: calc(2 * var(--i-amphtml-story-vh, 8px));
@@ -77,28 +81,28 @@ html.i-amphtml-story-standalone body {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
 
-amp-story p,
-amp-story h4 {
+p,
+h4 {
   font-size: 1rem;
 }
 
-amp-story h1 {
+h1 {
   font-size: 2rem;
 }
 
-amp-story h2 {
+h2 {
   font-size: 1.5rem;
 }
 
-amp-story h3 {
+h3 {
   font-size: 1.17rem;
 }
 
-amp-story h5 {
+h5 {
   font-size: 0.83rem;
 }
 
-amp-story h6 {
+h6 {
   font-size: 0.67rem;
 }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -497,7 +497,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   updateViewportSizeStyles_() {
-    if (!this.activePage_) {
+    if (!this.activePage_ || !this.isStandalone_()) {
       return;
     }
 
@@ -509,7 +509,7 @@ export class AmpStory extends AMP.BaseElement {
         state.vmax = Math.max(state.vh, state.vw);
       },
       mutate: state => {
-        this.element.setAttribute('style',
+        this.win.document.documentElement.setAttribute('style',
             `--i-amphtml-story-vh: ${px(state.vh)};` +
             `--i-amphtml-story-vw: ${px(state.vw)};` +
             `--i-amphtml-story-vmin: ${px(state.vmin)};` +


### PR DESCRIPTION
Responsive font units have not worked because of a bug in `amp-story`.  The four custom responsive font units (`--i-amphtml-story-vw`, `--i-amphtml-story-vh`, `--i-amphtml-story-vmin`, and `--i-amphtml-story-vmax`) are calculated and applied to `amp-story`, but the styles using them are targeting the `html` and `body` elements.  Because the `html` and `body` elements are ancestors of the `amp-story` element, the styles for the custom responsive units are not inherited by those elements.  As such, the responsive styles do not work, and default browser styles are applied in every case.

This PR does three things:

1. Move the four custom responsive font units (`--i-amphtml-story-vw`, `--i-amphtml-story-vh`, `--i-amphtml-story-vmin`, and `--i-amphtml-story-vmax`) from `amp-story` to the outermost `html` element, so that these properties may be honored.
2. Lower the specificity of `p`, `h1`, `h2`, `h3`, `h4`, `h5`, and `h6`, so that our styles do not override publisher styles.  This will need to be revisited when if we allow non-standalone stories.
3. Stop setting a duplicate base font size on body.  Setting it on `html` is enough, and this helps lower the specificity for `body` as well.