### PR TITLE
🌐✨ Add fallback message functionality to localization service

### DIFF
--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -162,7 +162,7 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-3a">
+      <amp-story-page id="page-3">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay loop
             width="400"

--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -162,7 +162,7 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-3">
+      <amp-story-page id="page-3a">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay loop
             width="400"

--- a/extensions/amp-story/1.0/_locales/ar.js
+++ b/extensions/amp-story/1.0/_locales/ar.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'وات ساب',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'قم بتوسيع نافذتك لعرض هذه التجربة',
+    fallback: 'قم بتوسيع نافذتك لعرض هذه التجربة',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: '.لعرض هذا المحتوى ،amp-story ،يجب تفعيل تجربة',

--- a/extensions/amp-story/1.0/_locales/de.js
+++ b/extensions/amp-story/1.0/_locales/de.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: ' Vergrößern Sie das Fenster um dieses Erlebnis zu sehen',
+    fallback: ' Vergrößern Sie das Fenster um dieses Erlebnis zu sehen',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Sie müssen das amp-story Experiment aktivieren um den Inhalt zu ' +

--- a/extensions/amp-story/1.0/_locales/en-GB.js
+++ b/extensions/amp-story/1.0/_locales/en-GB.js
@@ -79,7 +79,8 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Expand your window to view this experience',
+    string: 'Expand both the height and width of your window to view this ' +
+        'experience',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'You must enable the amp-story experiment to view this content.',

--- a/extensions/amp-story/1.0/_locales/es-419.js
+++ b/extensions/amp-story/1.0/_locales/es-419.js
@@ -100,7 +100,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Ampliar la ventana para ver esta experiencia',
+    fallback: 'Ampliar la ventana para ver esta experiencia',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Debe habilitar el experimento amp-story para ver este contenido',

--- a/extensions/amp-story/1.0/_locales/es.js
+++ b/extensions/amp-story/1.0/_locales/es.js
@@ -100,7 +100,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Ampliar la ventana para ver esta experiencia',
+    fallback: 'Ampliar la ventana para ver esta experiencia',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Debe habilitar el experimento amp-story para ver este contenido',

--- a/extensions/amp-story/1.0/_locales/fr-CA.js
+++ b/extensions/amp-story/1.0/_locales/fr-CA.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Faire élargir votre fenêtre pour voir cette expérience',
+    fallback: 'Faire élargir votre fenêtre pour voir cette expérience',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Vous devez activer l\'expérience amp-story pour afficher ce ' +

--- a/extensions/amp-story/1.0/_locales/fr.js
+++ b/extensions/amp-story/1.0/_locales/fr.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Agrandissez votre fenêtre pour voir cette expérience',
+    fallback: 'Agrandissez votre fenêtre pour voir cette expérience',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Vous devez activer l\'expérience amp-story pour afficher ce ' +

--- a/extensions/amp-story/1.0/_locales/hi.js
+++ b/extensions/amp-story/1.0/_locales/hi.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'वाट्सऐप',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'इस अनुभव को देखने के लिए अपनी विंडो का विस्तार करें',
+    fallback: 'इस अनुभव को देखने के लिए अपनी विंडो का विस्तार करें',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'आपको इस content को देखने के लिए एमपी-स्टोरी प्रयोग को सक्षम ' +

--- a/extensions/amp-story/1.0/_locales/id.js
+++ b/extensions/amp-story/1.0/_locales/id.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Besarkan browser window anda untuk menggunakan fitur ini',
+    fallback: 'Besarkan browser window anda untuk menggunakan fitur ini',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Anda harus mengaktifkan eksperimen amp-story untuk melihat ' +

--- a/extensions/amp-story/1.0/_locales/it.js
+++ b/extensions/amp-story/1.0/_locales/it.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Espandi la finestra per vedere questo contenuto',
+    fallback: 'Espandi la finestra per vedere questo contenuto',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Devi attivare l\'esperimento amp-story per visualizzare questo ' +

--- a/extensions/amp-story/1.0/_locales/ja.js
+++ b/extensions/amp-story/1.0/_locales/ja.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'これを見るためには、ウィンドウを拡大してください。',
+    fallback: 'これを見るためには、ウィンドウを拡大してください。',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'この内容を見るには、「amp-story」の実験を有効にしてください。',

--- a/extensions/amp-story/1.0/_locales/ko.js
+++ b/extensions/amp-story/1.0/_locales/ko.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'stories는 큰 화면에서만 제공됩니다.',
+    fallback: 'stories는 큰 화면에서만 제공됩니다.',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: '이 콘텐츠를 보시려면 amp-story experiment를 허용하셔야만 합니다',

--- a/extensions/amp-story/1.0/_locales/nl.js
+++ b/extensions/amp-story/1.0/_locales/nl.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Vergroot je venster om deze inhoud te bekijken',
+    fallback: 'Vergroot je venster om deze inhoud te bekijken',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'U moet het amp-story-experiment inschakelen om deze inhoud te ' +

--- a/extensions/amp-story/1.0/_locales/no.js
+++ b/extensions/amp-story/1.0/_locales/no.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Utvid vinduet for å se denne opplevelsen',
+    fallback: 'Utvid vinduet for å se denne opplevelsen',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Du må aktivere amp-story-eksperimentet for å få tilgang til ' +

--- a/extensions/amp-story/1.0/_locales/pt-BR.js
+++ b/extensions/amp-story/1.0/_locales/pt-BR.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Amplie sua janela para ver esta experiência',
+    fallback: 'Amplie sua janela para ver esta experiência',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Você deve habilitar o experimento amp-story para visualizar ' +

--- a/extensions/amp-story/1.0/_locales/pt.js
+++ b/extensions/amp-story/1.0/_locales/pt.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Amplie sua janela para ver esta experiência',
+    fallback: 'Amplie sua janela para ver esta experiência',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Você deve habilitar o experimento amp-story para visualizar ' +

--- a/extensions/amp-story/1.0/_locales/ru.js
+++ b/extensions/amp-story/1.0/_locales/ru.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Полный просмотр возможен только при развернутом окне браузера',
+    fallback: 'Полный просмотр возможен только при развернутом окне браузера',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Для дальнейшего просмотра вы должны загрузить amp-story ' +

--- a/extensions/amp-story/1.0/_locales/tr.js
+++ b/extensions/amp-story/1.0/_locales/tr.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Bu deneyimi görebilmek için pencerenizi genişletiniz.',
+    fallback: 'Bu deneyimi görebilmek için pencerenizi genişletiniz.',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Bu görünümü açabilmek için amp-story deneyini ' +

--- a/extensions/amp-story/1.0/_locales/vi.js
+++ b/extensions/amp-story/1.0/_locales/vi.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: 'Mở rộng cửa sổ của bạn để xem thử nghiệm này',
+    fallback: 'Mở rộng cửa sổ của bạn để xem thử nghiệm này',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: 'Bạn phải cho phép thử nghiệm amp-story để xem nội dung ' +

--- a/extensions/amp-story/1.0/_locales/zh-TW.js
+++ b/extensions/amp-story/1.0/_locales/zh-TW.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: '請在全屏模式下觀看此體驗',
+    fallback: '請在全屏模式下觀看此體驗',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: '您必須啟用AMP-STORY才能觀看以下內容',

--- a/extensions/amp-story/1.0/_locales/zh.js
+++ b/extensions/amp-story/1.0/_locales/zh.js
@@ -79,7 +79,7 @@ export default /** @const {!LocalizedStringBundleDef} */ ({
     string: 'WhatsApp',
   },
   [LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT]: {
-    string: '请在全屏模式下观看此效果',
+    fallback: '请在全屏模式下观看此效果',
   },
   [LocalizedStringId.AMP_STORY_WARNING_EXPERIMENT_DISABLED_TEXT]: {
     string: '您必须启用AMP-STORY才能观看以下内容',

--- a/extensions/amp-story/1.0/localization.js
+++ b/extensions/amp-story/1.0/localization.js
@@ -133,10 +133,10 @@ function findLocalizedString(localizedStringBundles, languageCodes,
 
   languageCodes.some(languageCode => {
     const localizedStringBundle = localizedStringBundles[languageCode];
-    if (localizedStringBundle && localizedStringBundle[localizedStringId] &&
-        localizedStringBundle[localizedStringId].string) {
-      localizedString = localizedStringBundle[localizedStringId].string;
-      return true;
+    if (localizedStringBundle && localizedStringBundle[localizedStringId]) {
+      localizedString = localizedStringBundle[localizedStringId].string ||
+          localizedStringBundle[localizedStringId].fallback;
+      return !!localizedString;
     }
 
     return false;
@@ -176,6 +176,8 @@ export function createPseudoLocale(localizedStringBundle, localizationFn) {
     /** @type {!LocalizedStringId} */ (localizedStringIdAsStr);
     pseudoLocaleStringBundle[localizedStringId].string =
         localizationFn(localizedStringBundle[localizedStringId].string);
+    pseudoLocaleStringBundle[localizedStringId].fallback =
+        localizationFn(localizedStringBundle[localizedStringId].fallback);
   });
 
   return pseudoLocaleStringBundle;

--- a/extensions/amp-story/1.0/test/test-localization.js
+++ b/extensions/amp-story/1.0/test/test-localization.js
@@ -66,6 +66,31 @@ describes.fakeWin('localization', {}, env => {
           .to.equal('test string content');
     });
 
+    it('should utilize fallback if string is missing', () => {
+      const localizationService = new LocalizationService(env.win);
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          fallback: 'test fallback content',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id'))
+          .to.equal('test fallback content');
+    });
+
+    it('should not utilize fallback if string is present', () => {
+      const localizationService = new LocalizationService(env.win);
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          string: 'test string content',
+          fallback: 'test fallback content',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id'))
+          .to.equal('test string content');
+    });
+
     it('should have language fallbacks', () => {
       expect(getLanguageCodesFromString('de-hi-1')).to
           .deep.equal(['de-hi-1', 'de-hi', 'de', 'default']);


### PR DESCRIPTION
This adds fallback message functionality to the localization service.  If there is no `string` field for a message (i.e. it has not yet been translated), the `fallback` field will be used in its place.  This allows us to track which strings need new translations, without having to remove the old string from the UI.

Additionally, this PR uses the feature for the `AMP_STORY_WARNING_DESKTOP_SIZE_TEXT` string (see #20852).