### PR TITLE
🏗 Use `xenial` VMs on Travis for faster bootup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
-  - pip install --user urllib3[secure]
-  - pip install --user gsutil
-  - pip install --user protobuf
+  - pip install --user gsutil protobuf urllib3[secure]
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
@@ -46,7 +44,6 @@ stages:
   - test
 jobs:
   include:
-    # Build stage
     - stage: build
       name: "Build"
       script:
@@ -64,8 +61,6 @@ jobs:
       if: type != pull_request
       script:
         - node build-system/pr-check/dist.js
-
-    # Test stage
     - stage: test
       name: "Dist, Bundle Size, Single Pass Tests"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
+  # Yarn is outdated on Travis (github.com/travis-ci/travis-ci/issues/9445)
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
-  - pip install urllib3[secure] --user
-  - pip install gsutil --user
+  # Python dependencies
+  - pip install --upgrade pip
+  - pip install --user urllib3[secure]
+  - pip install --user gsutil
+  - pip install --user protobuf
 branches:
   only:
     - master
@@ -25,6 +29,11 @@ branches:
     - /^amp-release-.*$/
     - /^revert-.*$/
 addons:
+  apt:
+    packages:
+      - protobuf-compiler
+      - python-protobuf
+  chrome: stable
   hosts:
     - ads.localhost
     - iframe.localhost
@@ -50,15 +59,8 @@ jobs:
         - node build-system/pr-check/checks.js
     - stage: build
       name: "Validator Tests"
-      before_script:
-        - pip install --user protobuf
       script:
         - node build-system/pr-check/validator-tests.js
-      addons:
-        apt:
-          packages:
-            - protobuf-compiler
-            - python-protobuf
     - stage: build
       name: "Dist"
       if: type != pull_request
@@ -66,8 +68,6 @@ jobs:
         - node build-system/pr-check/dist.js
     - stage: test
       name: "Dist, Bundle Size, Single Pass Tests"
-      addons:
-        chrome: stable
       script:
         - node build-system/pr-check/dist-tests.js
     - stage: test
@@ -76,8 +76,6 @@ jobs:
         - node build-system/pr-check/visual-diff-tests.js
     - stage: test
       name: "Local Tests"
-      addons:
-        chrome: stable
       script:
         - node build-system/pr-check/local-tests.js
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,8 @@ jobs:
   fast_finish: true
   #TODO(ampproject/wg-infra): remove when remote tests stabilize
   allow_failures:
-      - script:
-          - node build-system/pr-check/remote-tests.js
+    - script:
+      - node build-system/pr-check/remote-tests.js
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ before_install:
   - pip install --user urllib3[secure]
   - pip install --user gsutil
   - pip install --user protobuf
+  # Xenial uses Java 11 by default (github.com/travis-ci/travis-ci/issues/10290)
+  - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+  - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
-  # Yarn is outdated on Travis (github.com/travis-ci/travis-ci/issues/9445)
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
-  # Python dependencies
   - pip install --user urllib3[secure]
   - pip install --user gsutil
   - pip install --user protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-dist: trusty
+dist: xenial
 node_js:
   - "lts/*"
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
-  - pip install urllib3[secure]
+  - pip install urllib3[secure] --user
   - pip install gsutil --user
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,10 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
   # Python dependencies
-  - pip install --upgrade pip
   - pip install --user urllib3[secure]
   - pip install --user gsutil
   - pip install --user protobuf
-  # Xenial uses Java 11 by default (github.com/travis-ci/travis-ci/issues/10290)
+  # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 branches:
@@ -40,9 +39,8 @@ addons:
   hosts:
     - ads.localhost
     - iframe.localhost
-    # CURLs amp subdomain for amp-recaptcha-input,
-    # integration tests. The hash is the
-    # CURLS subdomain for localhost:9876
+    # CURLs amp subdomain for the amp-recaptcha-input integration test. The hash
+    # is the CURLS subdomain for localhost:9876
     - jgla3zmib2ggq5buc4hwi5taloh6jlvzukddfr4zltz3vay5s5rq.recaptcha.localhost
     # Requested by some tests because they need a valid font host,
     # but should not resolve in tests.
@@ -52,6 +50,7 @@ stages:
   - test
 jobs:
   include:
+    # Build stage
     - stage: build
       name: "Build"
       script:
@@ -69,6 +68,8 @@ jobs:
       if: type != pull_request
       script:
         - node build-system/pr-check/dist.js
+
+    # Test stage
     - stage: test
       name: "Dist, Bundle Size, Single Pass Tests"
       script:
@@ -88,18 +89,19 @@ jobs:
       after_script:
         - build-system/sauce_connect/stop_sauce_connect.sh
   fast_finish: true
-  #TODO(ampproject/wg-infra): remove when remote tests stabilize
+
+  # TODO(ampproject/wg-infra): remove when remote tests stabilize
   allow_failures:
     - script:
       - node build-system/pr-check/remote-tests.js
 cache:
-  yarn: true
   directories:
-    - build-system/tasks/visual-diff/node_modules
     - node_modules
+    - build-system/tasks/visual-diff/node_modules
+    - sauce_connect
     - validator/node_modules
     - validator/nodejs/node_modules
     - validator/webui/node_modules
-    - sauce_connect
   pip: true
   bundler: true
+  yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,5 @@ cache:
     - validator/node_modules
     - validator/nodejs/node_modules
     - validator/webui/node_modules
-  pip: true
-  bundler: true
+    - $HOME/.cache/pip
   yarn: true


### PR DESCRIPTION
This PR switches the Travis VMs we use from Trusty to Xenial.

**Advantages:**
- More recent Linux version (16.04 vs 14.04)
- Fewer unnecessary services are installed by default
- Faster VM bootup time (Xenial: ~20s, Trusty: ~40s)

**References:**
- https://docs.travis-ci.com/user/reference/overview/#virtualization-environments
- https://docs.travis-ci.com/user/reference/xenial/#services-disabled-by-default

**Changes in this PR:**
- Change `dist` in `.travis.yml` from `trusty` to `xenial`
- Consolidate `pip` install of Python modules (in `--user` mode, to work without `sudo`)
- Override Xenial's default Java 11 version (AMP needs Java 8) (https://github.com/travis-ci/travis-ci/issues/10290)
- Consolidate `addons` section
- Remove `bundler` cache (it was used for Ruby gems, and is unnecessary)
- Replace `pip` caching (which [doesn't work](https://docs.travis-ci.com/user/caching/#pip-cache) if `language` is not `python`), with directory-level caching of `$HOME/.cache/pip`
- Remove the `yarn` upgrade step since Xenial [uses the latest version](https://travis-ci.community/t/upgrade-yarn-to-a-newer-version/2135) of yarn (1.13.0 as of today)

Related to #20887