### PR TITLE
✨ Add Reppublika as an analytics vendor

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -94,6 +94,7 @@
       <option>pressboard</option>
       <option>quantcast</option>
       <option>rakam</option>
+      <option>reppublika</option>
       <option>retargetly</option>
       <option>segment</option>
       <option>shinystat</option>
@@ -1122,6 +1123,29 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End Quantcast example -->
+
+<!-- Reppublika example -->
+<amp-analytics type="reppublika" id="reppublika">
+<script type="application/json">
+{
+  "vars": {
+    "code": "XX-XXXXX",
+    "type": "1",
+    "service": "YY-YYYYY",
+    "category": "category1",
+    "channel": "channel1",
+    "device": "mobile"
+  },
+  "triggers": {
+    "trackPageview": {
+        "on": "visible",
+        "request": "pageview"
+      }
+    }
+}
+</script>
+</amp-analytics>	
+<!-- End Reppublika example -->
 
 <!-- Retargetly example -->
 <amp-analytics data-credentials="include" type="retargetly" id="retargetly">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -346,6 +346,12 @@
     "pageview": "https://!apiEndpoint/event/pixel?api.api_key=!writeKey&prop._platform=amp&prop._device_id=_client_id_&prop.locale=_browser_language_&prop.path=_canonical_path_&prop.url=_canonical_url_&prop.color_depth=_screen_color_depth_&prop._referrer=_document_referrer_&prop.title=_title_&prop.timezone=_timezone_&prop._time=_timestamp_&prop.resolution=_screen_width_ × _screen_height_&collection=!pageViewName",
     "custom": "https://!apiEndpoint/event/pixel?api.api_key=!writeKey&prop._platform=amp&prop._device_id=_client_id_&prop.locale=_browser_language_&prop.path=_canonical_path_&prop.url=_canonical_url_&prop.color_depth=_screen_color_depth_&prop._referrer=_document_referrer_&prop.title=_title_&prop.timezone=_timezone_&prop._time=_timestamp_&prop.resolution=_screen_width_ × _screen_height_&collection=!collection"
   },
+  "reppublika": {
+	  "host": "https://t5.mindtake.com",
+	  "basePrefix": "/tag/cid/",
+	  "baseSuffix": "Service=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_",
+	  "pageview": "https://t5.mindtake.com/tag/cid/${code}/track.gifService=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_"
+  },
   "retargetly": {
     "host": "https://api.retargetly.com",
     "page": "https://api.retargetly.com/api?id=!accountId&src=!sourceId&url=_source_url_&n=_title_&ref=_document_referrer_&ua=_user_agent_&random=_random_&bl=_browser_language_&source=amp"

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -350,7 +350,7 @@
 	  "host": "https://t5.mindtake.com",
 	  "basePrefix": "/tag/cid/",
 	  "baseSuffix": "Service=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_",
-	  "pageview": "https://t5.mindtake.com/tag/cid/!code/track.gifService=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_"
+	  "pageview": "https://t5.mindtake.com/tag/cid/!code/track.gif?Service=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_"
   },
   "retargetly": {
     "host": "https://api.retargetly.com",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -350,7 +350,7 @@
 	  "host": "https://t5.mindtake.com",
 	  "basePrefix": "/tag/cid/",
 	  "baseSuffix": "Service=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_",
-	  "pageview": "https://t5.mindtake.com/tag/cid/${code}/track.gifService=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_"
+	  "pageview": "https://t5.mindtake.com/tag/cid/!code/track.gifService=!service&Category=!category&Url=_source_url_&Device=!device&uid=_random_"
   },
   "retargetly": {
     "host": "https://api.retargetly.com",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -96,6 +96,7 @@ import {
 import {MOAT_CONFIG} from './vendors/moat';
 import {BG_CONFIG} from './vendors/bg';
 import {UPSCORE_CONFIG} from './vendors/upscore';
+import {REPPUBLIKA_CONFIG} from './vendors/reppublika';
 
 /**
  * @const {!JsonObject}
@@ -229,6 +230,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'quantcast': QUANTCAST_CONFIG,
   'retargetly': RETARGETLY_CONFIG,
   'rakam': RAKAM_CONFIG,
+  'reppublika': REPPUBLIKA_CONFIG,
   'segment': SEGMENT_CONFIG,
   'shinystat': SHINYSTAT_CONFIG,
   'simplereach': SIMPLEREACH_CONFIG,

--- a/extensions/amp-analytics/0.1/vendors/reppublika.js
+++ b/extensions/amp-analytics/0.1/vendors/reppublika.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const REPPUBLIKA_CONFIG = /** @type {!JsonObject} */ ({
+  'requests': {
+    'host': 'https://t5.mindtake.com',
+    'basePrefix': '/tag/cid/',
+    'baseSuffix': 'Service=${service}&Category=${category}&' +
+      'Url=${sourceUrl}&Device=${device}&uid=${random}',
+    'pageview': '${host}${basePrefix}${code}/track.gif?${baseSuffix}',
+  },
+    'transport': {
+    'beacon': false,
+    'xhrpost': false,
+    'image': true,
+  },
+});

--- a/extensions/amp-analytics/0.1/vendors/reppublika.js
+++ b/extensions/amp-analytics/0.1/vendors/reppublika.js
@@ -23,8 +23,8 @@ export const REPPUBLIKA_CONFIG = /** @type {!JsonObject} */ ({
     'pageview': '${host}${basePrefix}${code}/track.gif?${baseSuffix}',
   },
     'transport': {
-    'beacon': false,
-    'xhrpost': false,
-    'image': true,
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
   },
 });

--- a/extensions/amp-analytics/0.1/vendors/reppublika.js
+++ b/extensions/amp-analytics/0.1/vendors/reppublika.js
@@ -22,9 +22,9 @@ export const REPPUBLIKA_CONFIG = /** @type {!JsonObject} */ ({
       'Url=${sourceUrl}&Device=${device}&uid=${random}',
     'pageview': '${host}${basePrefix}${code}/track.gif?${baseSuffix}',
   },
-    'transport': {
-      'beacon': false,
-      'xhrpost': false,
-      'image': true,
+  'transport': {
+    'beacon': false,
+    'xhrpost': false,
+    'image': true,
   },
 });


### PR DESCRIPTION
# Instructions:
Adds [Reppublika](https://reppublika.com/) as an amp-analytics vendor option.
