### PR TITLE
Don't warn for missing overflow in amp-list-load-more

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -223,6 +223,7 @@ export class AmpList extends AMP.BaseElement {
           if (overflowElement) {
             toggle(overflowElement, false);
           }
+          this.element.warnOnMissingOverflow = false;
         }).then(() => {
           this.adjustContainerForLoadMoreButton_();
         });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -852,8 +852,6 @@ export class AmpList extends AMP.BaseElement {
           this.unlistenLoadMore_ = listen(
               this.loadMoreService_.getLoadMoreButtonClickable(),
               'click', () => this.loadMoreCallback_());
-        }).then(() => {
-          this.attemptToFit_(dev().assertElement(this.container_));
         });
       } else {
         return this.mutateElement(


### PR DESCRIPTION
We disable the overflow element intentionally in `amp-list-load-more` since we override this functionality so there is no need for a user warning. Addresses comment in https://github.com/ampproject/amphtml/issues/14060#issuecomment-465919432. 