### PR TITLE
🚮 Just use querySelector in elementByTag

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -318,7 +318,7 @@ export function ancestorElements(child, predicate) {
  * @return {!Array<!Element>}
  */
 export function ancestorElementsByTag(child, tagName) {
-  assertOnlyTagName(tagName);
+  assertIsTagName(tagName);
   tagName = tagName.toUpperCase();
   return ancestorElements(child, el => {
     return el.tagName == tagName;
@@ -402,7 +402,7 @@ export function childNodes(parent, callback) {
  */
 export function childElementByAttr(parent, attr) {
   // Yah, it's supposed to be an attr and not a tag name. But same code.
-  assertOnlyTagName(attr);
+  assertIsTagName(attr);
   return scopedQuerySelector/*OK*/(parent, `> [${attr}]`);
 }
 
@@ -415,7 +415,7 @@ export function childElementByAttr(parent, attr) {
  */
 export function lastChildElementByAttr(parent, attr) {
   // Yah, it's supposed to be an attr and not a tag name. But same code.
-  assertOnlyTagName(attr);
+  assertIsTagName(attr);
   return lastChildElement(parent, el => {
     return el.hasAttribute(attr);
   });
@@ -430,7 +430,7 @@ export function lastChildElementByAttr(parent, attr) {
  */
 export function childElementsByAttr(parent, attr) {
   // Yah, it's supposed to be an attr and not a tag name. But same code.
-  assertOnlyTagName(attr);
+  assertIsTagName(attr);
   return scopedQuerySelectorAll/*OK*/(parent, `> [${attr}]`);
 }
 
@@ -442,7 +442,7 @@ export function childElementsByAttr(parent, attr) {
  * @return {?Element}
  */
 export function childElementByTag(parent, tagName) {
-  assertOnlyTagName(tagName);
+  assertIsTagName(tagName);
   return scopedQuerySelector/*OK*/(parent, `> ${tagName}`);
 }
 
@@ -454,7 +454,7 @@ export function childElementByTag(parent, tagName) {
  * @return {!NodeList<!Element>}
  */
 export function childElementsByTag(parent, tagName) {
-  assertOnlyTagName(tagName);
+  assertIsTagName(tagName);
   return scopedQuerySelectorAll/*OK*/(parent, `> ${tagName}`);
 }
 
@@ -483,7 +483,7 @@ export function matches(el, selector) {
  * @return {?Element}
  */
 export function elementByTag(element, tagName) {
-  assertOnlyTagName(tagName);
+  assertIsTagName(tagName);
   return element./*OK*/querySelector(tagName);
 }
 
@@ -493,7 +493,7 @@ export function elementByTag(element, tagName) {
  * nor ids.
  * @param {string} tagName
  */
-function assertOnlyTagName(tagName) {
+function assertIsTagName(tagName) {
   devAssert(!/[^\w-]/.test(tagName));
 }
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -494,7 +494,7 @@ export function elementByTag(element, tagName) {
  * @param {string} tagName
  */
 function assertIsTagName(tagName) {
-  devAssert(!/[^\w-]/.test(tagName));
+  devAssert(/^[\w-]+$/.test(tagName));
 }
 
 /**

--- a/src/dom.js
+++ b/src/dom.js
@@ -318,6 +318,7 @@ export function ancestorElements(child, predicate) {
  * @return {!Array<!Element>}
  */
 export function ancestorElementsByTag(child, tagName) {
+  assertOnlyTagName(tagName);
   tagName = tagName.toUpperCase();
   return ancestorElements(child, el => {
     return el.tagName == tagName;
@@ -400,6 +401,8 @@ export function childNodes(parent, callback) {
  * @return {?Element}
  */
 export function childElementByAttr(parent, attr) {
+  // Yah, it's supposed to be an attr and not a tag name. But same code.
+  assertOnlyTagName(attr);
   return scopedQuerySelector/*OK*/(parent, `> [${attr}]`);
 }
 
@@ -411,6 +414,8 @@ export function childElementByAttr(parent, attr) {
  * @return {?Element}
  */
 export function lastChildElementByAttr(parent, attr) {
+  // Yah, it's supposed to be an attr and not a tag name. But same code.
+  assertOnlyTagName(attr);
   return lastChildElement(parent, el => {
     return el.hasAttribute(attr);
   });
@@ -424,6 +429,8 @@ export function lastChildElementByAttr(parent, attr) {
  * @return {!NodeList<!Element>}
  */
 export function childElementsByAttr(parent, attr) {
+  // Yah, it's supposed to be an attr and not a tag name. But same code.
+  assertOnlyTagName(attr);
   return scopedQuerySelectorAll/*OK*/(parent, `> [${attr}]`);
 }
 
@@ -435,6 +442,7 @@ export function childElementsByAttr(parent, attr) {
  * @return {?Element}
  */
 export function childElementByTag(parent, tagName) {
+  assertOnlyTagName(tagName);
   return scopedQuerySelector/*OK*/(parent, `> ${tagName}`);
 }
 
@@ -446,6 +454,7 @@ export function childElementByTag(parent, tagName) {
  * @return {!NodeList<!Element>}
  */
 export function childElementsByTag(parent, tagName) {
+  assertOnlyTagName(tagName);
   return scopedQuerySelectorAll/*OK*/(parent, `> ${tagName}`);
 }
 
@@ -474,14 +483,18 @@ export function matches(el, selector) {
  * @return {?Element}
  */
 export function elementByTag(element, tagName) {
-  let elements;
-  // getElementsByTagName() is not supported on ShadowRoot.
-  if (typeof element.getElementsByTagName === 'function') {
-    elements = element.getElementsByTagName(tagName);
-  } else {
-    elements = element./*OK*/querySelectorAll(tagName);
-  }
-  return (elements && elements[0]) || null;
+  assertOnlyTagName(tagName);
+  return element./*OK*/querySelector(tagName);
+}
+
+/**
+ * Asserts that tagName is just an alphanumeric word, and does not contain
+ * advanced CSS selector features like attributes, psuedo-classes, class names,
+ * nor ids.
+ * @param {string} tagName
+ */
+function assertOnlyTagName(tagName) {
+  devAssert(!/[^\w-]/.test(tagName));
 }
 
 /**


### PR DESCRIPTION
[Just as fast](https://jsbench.github.io/#639aa913f9d03e86f75df4665f04da66) and less code.

Also asserts that tagNames passed to `*ByTag` functions are actually just tagNames.