### PR TITLE
🐛 scopedQuerySelector: support complex selectors

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -76,21 +76,28 @@ function testScopeSelector(el) {
 
 /* eslint-disable quotes, indent */
 const ATTRIBUTE_REGEX = new RegExp(
-  // Consume the opening bracket `[`
+  // Consume the opening bracket ([)
   `\\[` +
   // Consume everything up to the closing bracket, or up to the attribute value
-  // quotes.
+  // quotes
   `[^"'\\]]*` +
-  // Fork here.
+  // Fork here:
   `(?:` +
     // Either there're no quotes and we're at the end of the attribute brackets
     `(?=\\])|` +
 
-    // Or there are quotes. Consume them into Capture Group 1 (CG1)
+    // Or there are quotes. Consume them into Capture Group 1
     `(["'])` +
-    // Consume everything that's not that quote char (CG1)
-    `(?:(?!\\1).)*` +
-    // Consume the end quote (CG1)
+    // Consume all of the following forks:
+    `(?:` +
+      // Consume either a double escapes (\\)
+      `\\\\\\\\|` +
+      // Or a single escape followed by the quote char CG1
+      `\\\\\\1|` +
+      // Or anything that's not the quote char CG1
+      `(?!\\1).` +
+    `)*` +
+    // Consume the end quote CG1
     `\\1` +
     // Consume everything up to the end of the attribute bracket
     `[^\\]]*` +

--- a/src/css.js
+++ b/src/css.js
@@ -147,7 +147,7 @@ export function selectors(selector) {
         // Despite looking useless, we depend on its lastIndex updating
         // side-effect.
         ATTRIBUTE_REGEX.test(selector);
-        i = ATTRIBUTE_REGEX.lastIndex;
+        i = Math.max(i, ATTRIBUTE_REGEX.lastIndex);
         break;
 
       case ',':

--- a/src/dom.js
+++ b/src/dom.js
@@ -503,7 +503,7 @@ export function elementByTag(element, tagName) {
 function scopedQuerySelectionFallback(root, selector) {
   const unique = 'i-amphtml-scoped';
   root.classList.add(unique);
-  const scopedSelector = prependSelectorsWith(selector, `.${unique}`);
+  const scopedSelector = prependSelectorsWith(selector, `.${unique} `);
   const elements = root./*OK*/querySelectorAll(scopedSelector);
   root.classList.remove(unique);
   return elements;
@@ -518,7 +518,7 @@ function scopedQuerySelectionFallback(root, selector) {
  */
 export function scopedQuerySelector(root, selector) {
   if (isScopeSelectorSupported(root)) {
-    return root./*OK*/querySelector(prependSelectorsWith(selector, ':scope'));
+    return root./*OK*/querySelector(prependSelectorsWith(selector, ':scope '));
   }
 
   // Only IE.
@@ -536,7 +536,7 @@ export function scopedQuerySelector(root, selector) {
 export function scopedQuerySelectorAll(root, selector) {
   if (isScopeSelectorSupported(root)) {
     return root./*OK*/querySelectorAll(
-        prependSelectorsWith(selector, ':scope'));
+        prependSelectorsWith(selector, ':scope '));
   }
 
   // Only IE.

--- a/test/unit/test-css.js
+++ b/test/unit/test-css.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {escapeCssSelectorIdent, prependSelectorsWith} from '../../src/css';
+import {
+  escapeCssSelectorIdent,
+  prependSelectorsWith,
+  selectors,
+} from '../../src/css';
 
 describe('CSS', () => {
 
@@ -26,7 +30,6 @@ describe('CSS', () => {
   });
 
   describe('scopeSelector', () => {
-
     it('concats simple', () => {
       expect(prependSelectorsWith('div', '.i-amphtml-scoped '))
           .to.equal('.i-amphtml-scoped div');
@@ -50,6 +53,96 @@ describe('CSS', () => {
     it('does not break psuedo-class selectors with commas', () => {
       expect(prependSelectorsWith('div:is(.first, .second), div', ':scope '))
           .to.equal(':scope div:is(.first, .second),:scope div');
+    });
+  });
+
+  describe('selectors', () => {
+    it('handle simple selector', () => {
+      expect(selectors('div')).to.deep.equal(['div']);
+    });
+
+    it('strips whitespace from simple selector', () => {
+      expect(selectors(' div ')).to.deep.equal(['div']);
+    });
+
+    it('handle multiple selector', () => {
+      expect(selectors('div, ul')).to.deep.equal(['div', 'ul']);
+    });
+
+    it('strips whitespace from multiple selector', () => {
+      expect(selectors(' div , ul ')).to.deep.equal(['div', 'ul']);
+    });
+
+    it('maintains attributes', () => {
+      expect(selectors('div[attr]')).to.deep.equal(['div[attr]']);
+      expect(selectors('div[attr=val]')).to.deep.equal(['div[attr=val]']);
+      expect(selectors('div[attr=val i]')).to.deep.equal(['div[attr=val i]']);
+      expect(selectors('div[attr="val"]')).to.deep.equal(['div[attr="val"]']);
+      expect(selectors('div[attr="val" i]')).to.deep.equal(
+          ['div[attr="val" i]']);
+      expect(selectors('div[attr="val,val2"]')).to.deep.equal(
+          ['div[attr="val,val2"]']);
+      expect(selectors('div[attr="val,val2" i]')).to.deep.equal(
+          ['div[attr="val,val2" i]']);
+      expect(selectors("div[attr='val']")).to.deep.equal(
+          ["div[attr='val']"]);
+      expect(selectors("div[attr='val' i]")).to.deep.equal(
+          ["div[attr='val' i]"]);
+      expect(selectors("div[attr='val,val2']")).to.deep.equal(
+          ["div[attr='val,val2']"]);
+      expect(selectors("div[attr='val,val2' i]")).to.deep.equal(
+          ["div[attr='val,val2' i]"]);
+
+      expect(selectors('div[attr], ul')).to.deep.equal(
+          ['div[attr]', 'ul']);
+      expect(selectors('div[attr=val], ul')).to.deep.equal(
+          ['div[attr=val]', 'ul']);
+      expect(selectors('div[attr=val i], ul')).to.deep.equal(
+          ['div[attr=val i]', 'ul']);
+      expect(selectors('div[attr="val"], ul')).to.deep.equal(
+          ['div[attr="val"]', 'ul']);
+      expect(selectors('div[attr="val" i], ul')).to.deep.equal(
+          ['div[attr="val" i]', 'ul']);
+      expect(selectors('div[attr="val,val2"], ul')).to.deep.equal(
+          ['div[attr="val,val2"]', 'ul']);
+      expect(selectors('div[attr="val,val2" i], ul')).to.deep.equal(
+          ['div[attr="val,val2" i]', 'ul']);
+      expect(selectors("div[attr='val'], ul")).to.deep.equal(
+          ["div[attr='val']", 'ul']);
+      expect(selectors("div[attr='val' i], ul")).to.deep.equal(
+          ["div[attr='val' i]", 'ul']);
+      expect(selectors("div[attr='val,val2'], ul")).to.deep.equal(
+          ["div[attr='val,val2']", 'ul']);
+      expect(selectors("div[attr='val,val2' i], ul")).to.deep.equal(
+          ["div[attr='val,val2' i]", 'ul']);
+    });
+
+    it('maintains psuedo-classes', () => {
+      expect(selectors('div:is(x, y)')).to.deep.equal(
+          ['div:is(x, y)']);
+      expect(selectors('div:is(x, [test="val,val2"])')).to.deep.equal(
+          ['div:is(x, [test="val,val2"])']);
+      expect(selectors('div:is(x, [test=":test("])')).to.deep.equal(
+          ['div:is(x, [test=":test("])']);
+      expect(selectors('div:is(x, :is(y, z))')).to.deep.equal(
+          ['div:is(x, :is(y, z))']);
+      expect(selectors('div:is(x, :is([test="val,val2"], z))')).to.deep.equal(
+          ['div:is(x, :is([test="val,val2"], z))']);
+      expect(selectors('div:is(x, :is([test=":test("], z))')).to.deep.equal(
+          ['div:is(x, :is([test=":test("], z))']);
+
+      expect(selectors('div:is(x, y), ul')).to.deep.equal(
+          ['div:is(x, y)', 'ul']);
+      expect(selectors('div:is(x, [test="val,val2"]), ul')).to.deep.equal(
+          ['div:is(x, [test="val,val2"])', 'ul']);
+      expect(selectors('div:is(x, [test=":test("]), ul')).to.deep.equal(
+          ['div:is(x, [test=":test("])', 'ul']);
+      expect(selectors('div:is(x, :is(y, z)), ul')).to.deep.equal(
+          ['div:is(x, :is(y, z))', 'ul']);
+      expect(selectors('div:is(x, :is([test="val,val2"], z)), ul')).to.deep
+          .equal(['div:is(x, :is([test="val,val2"], z))', 'ul']);
+      expect(selectors('div:is(x, :is([test=":test("], z)), ul')).to.deep.equal(
+          ['div:is(x, :is([test=":test("], z))', 'ul']);
     });
   });
 });

--- a/test/unit/test-css.js
+++ b/test/unit/test-css.js
@@ -28,19 +28,28 @@ describe('CSS', () => {
   describe('scopeSelector', () => {
 
     it('concats simple', () => {
-      expect(prependSelectorsWith('div', '.i-amphtml-scoped'))
+      expect(prependSelectorsWith('div', '.i-amphtml-scoped '))
           .to.equal('.i-amphtml-scoped div');
     });
 
     it('concats multiple selectors (2)', () => {
-      expect(prependSelectorsWith('div,ul', ':scope'))
+      expect(prependSelectorsWith('div,ul', ':scope '))
           .to.equal(':scope div,:scope ul');
     });
 
     it('concats multiple selectors (4)', () => {
-      expect(prependSelectorsWith('div,ul,ol,section', 'div >'))
+      expect(prependSelectorsWith('div,ul,ol,section', 'div > '))
           .to.equal('div > div,div > ul,div > ol,div > section');
     });
 
+    it('does not break attributes with commas', () => {
+      expect(prependSelectorsWith('div[attr="with,comma"], div', ':scope '))
+          .to.equal(':scope div[attr="with,comma"],:scope div');
+    });
+
+    it('does not break psuedo-class selectors with commas', () => {
+      expect(prependSelectorsWith('div:is(.first, .second), div', ':scope '))
+          .to.equal(':scope div:is(.first, .second),:scope div');
+    });
   });
 });


### PR DESCRIPTION
Arbitrary selectors can contain `,` chars in a few locations, but they're still part of a single selector. We need to lex the selectors to find out if a `,` is a selector separator or just part of the single selector.