### PR TITLE
🐛 Fix getBoundingClientRect polyfill

### DIFF
--- a/src/get-bounding-client-rect.js
+++ b/src/get-bounding-client-rect.js
@@ -31,12 +31,12 @@ const nativeClientRect = Element.prototype.getBoundingClientRect;
 
 /**
  * Polyfill for Node.getBoundingClientRect API.
- * @param {!Element} el
+ * @this {!Element}
  * @return {!ClientRect|!LayoutRectDef}
  */
-function getBoundingClientRect(el) {
-  if (isConnectedNode(el)) {
-    return nativeClientRect.call(el);
+function getBoundingClientRect() {
+  if (isConnectedNode(this)) {
+    return nativeClientRect.call(this);
   }
 
   return layoutRectLtwh(0, 0, 0, 0);


### PR DESCRIPTION
`getBoundingClientRect` is called with an element as its `this` context,
not as a parameter.

Fixes #20979.
/cc @delima02 