### PR TITLE
Add extension buffer to registerElement examples

### DIFF
--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -214,7 +214,9 @@ export class ${className} extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement('${name}', ${className});
+AMP.extension('${name}', '0.1', AMP => {
+  AMP.registerElement('${name}', ${className});
+});
 `;
 }
 

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -113,7 +113,9 @@ class AmpMyElement extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement('amp-my-element', AmpMyElement, CSS);
+AMP.extension('amp-my-element', '0.1', AMP => {
+  AMP.registerElement('amp-my-element', AmpMyElement, CSS);
+});
 ```
 
 ### BaseElement callbacks
@@ -287,7 +289,9 @@ AMP; all AMP extensions are prefixed with `amp-`. This is where you
 tell AMP which class to use for this tag name and which CSS to load.
 
 ```javascript
-AMP.registerElement('amp-carousel', CarouselSelector, CSS);
+AMP.extension('amp-carousel', '0.1', AMP => {
+  AMP.registerElement('amp-carousel', CarouselSelector, CSS);
+});
 ```
 
 ## Actions and events
@@ -697,7 +701,9 @@ Class AmpMyElement extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement('amp-my-element', AmpMyElement, CSS);
+AMP.extension('amp-my-element', '0.1', AMP => {
+  AMP.registerElement('amp-my-element', AmpMyElement, CSS);
+});
 ```
 
 ### Enabling and removing your experiment


### PR DESCRIPTION
Resolves #11346

Examples in building-an-amp-extension.md and the `gulp make-extension` script using AMP.registerElement are error-causing. These changes reflect how existing AMP components place the registerElement call in their implementation, universally updated in #11013, #11018, and #11039.

- Update examples in script and documentation to include AMP.extension buffer