### PR TITLE
📖 Fix experiment-related sample code in documentation

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -656,7 +656,7 @@ And then protecting your code with a check `isExperimentOn(win,
 
 ```javascript
 import {isExperimentOn} from '../../../src/experiments';
-import {user} from '../../../src/log';
+import {userAssert} from '../../../src/log';
 
 /** @const */
 const EXPERIMENT = 'amp-my-element';
@@ -680,20 +680,16 @@ Class AmpMyElement extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    if (!isExperimentOn(this.win, 'amp-my-element')) {
-      user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
-      return;
-    }
+    userAssert(isExperimentOn(this.win, 'amp-my-element'),
+        `Experiment ${EXPERIMENT} is not turned on.`);
     // get attributes, assertions of values, assign instance variables.
     // build lightweight dom and append to this.element.
   }
 
   /** @override */
   layoutCallback() {
-    if (!isExperimentOn(this.win, 'amp-my-element')) {
-      user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
-      return;
-    }
+    userAssert(isExperimentOn(this.win, 'amp-my-element'),
+        `Experiment ${EXPERIMENT} is not turned on.`);
     // actually load your resource or render more expensive resources.
   }
 }

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -680,20 +680,20 @@ Class AmpMyElement extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    if(!isExperimentOn(this.win, 'amp-my-element')) {
+    if (!isExperimentOn(this.win, 'amp-my-element')) {
       user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
-      return();
-    } 
+      return;
+    }
     // get attributes, assertions of values, assign instance variables.
     // build lightweight dom and append to this.element.
   }
 
   /** @override */
   layoutCallback() {
-    if(!isExperimentOn(this.win, 'amp-my-element')) {
+    if (!isExperimentOn(this.win, 'amp-my-element')) {
       user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
-      return();
-    } 
+      return;
+    }
     // actually load your resource or render more expensive resources.
   }
 }

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -693,7 +693,8 @@ Class AmpMyElement extends AMP.BaseElement {
     if(!isExperimentOn(this.win, 'amp-my-element')) {
       user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
       return();
-    } // actually load your resource or render more expensive resources.
+    } 
+    // actually load your resource or render more expensive resources.
   }
 }
 

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -655,7 +655,8 @@ And then protecting your code with a check `isExperimentOn(win,
 'amp-my-element')` and only execute your code when it is on.
 
 ```javascript
-import {isExperimentOn} from '../src/experiments';
+import {isExperimentOn} from '../../../src/experiments';
+import {userAssert} from '../../../src/log';
 
 /** @const */
 const EXPERIMENT = 'amp-my-element';
@@ -679,20 +680,16 @@ Class AmpMyElement extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
-      user.warn('Experiment %s is not turned on.', EXPERIMENT);
-      return;
-    }
+    userAssert(isExperimentOn(this.win, 'amp-my-element'), 
+        `Experiment ${EXPERIMENT} is not turned on.`);
     // get attributes, assertions of values, assign instance variables.
     // build lightweight dom and append to this.element.
   }
 
   /** @override */
   layoutCallback() {
-    if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
-      user.warn('Experiment %s is not turned on.', EXPERIMENT);
-      return;
-    }
+    userAssert(isExperimentOn(this.win, 'amp-my-element'), 
+        `Experiment ${EXPERIMENT} is not turned on.`);
     // actually load your resource or render more expensive resources.
   }
 }

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -656,7 +656,7 @@ And then protecting your code with a check `isExperimentOn(win,
 
 ```javascript
 import {isExperimentOn} from '../../../src/experiments';
-import {userAssert} from '../../../src/log';
+import {user} from '../../../src/log';
 
 /** @const */
 const EXPERIMENT = 'amp-my-element';
@@ -680,17 +680,20 @@ Class AmpMyElement extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    userAssert(isExperimentOn(this.win, 'amp-my-element'), 
-        `Experiment ${EXPERIMENT} is not turned on.`);
+    if(!isExperimentOn(this.win, 'amp-my-element')) {
+      user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
+      return();
+    } 
     // get attributes, assertions of values, assign instance variables.
     // build lightweight dom and append to this.element.
   }
 
   /** @override */
   layoutCallback() {
-    userAssert(isExperimentOn(this.win, 'amp-my-element'), 
-        `Experiment ${EXPERIMENT} is not turned on.`);
-    // actually load your resource or render more expensive resources.
+    if(!isExperimentOn(this.win, 'amp-my-element')) {
+      user().warn(TAG, `Experiment ${EXPERIMENT} is not turned on.`);
+      return();
+    } // actually load your resource or render more expensive resources.
   }
 }
 


### PR DESCRIPTION
`building-an-amp-extension.md` provides experiment-related code snippets that cause Travis checks to fail.

- Replace forbidden `this.getWin()` with `this.win` and incorrect `user.warn()` with `userAssert()`
- Update imports in sample code
- Replaces `EXPERIMENT` in calls to `isExperimentOn()` with its string literal equivalent (a required change due to check failures)