### PR TITLE
Visual diff comments and cleanup

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -54,7 +54,7 @@ const HOST = 'localhost';
 const PORT = 8000;
 const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 3000;
-const MAX_PARALLEL_TABS = 10;
+const MAX_PARALLEL_TABS = 20;
 const WAIT_FOR_TABS_MS = 1000;
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -200,13 +200,18 @@ async function launchBrowser() {
  * Opens a new browser tab, resizes its viewport, and returns a Page handler.
  *
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
+ * @param {JsonObject} viewport optional viewport size object with numeric
+ *     fields `width` and `height`.
  */
-async function newPage(browser) {
+async function newPage(browser, viewport = null) {
+  const width = viewport ? viewport.width : VIEWPORT_WIDTH;
+  const height = viewport ? viewport.height : VIEWPORT_HEIGHT;
+
+  log('verbose', 'Creating new page with viewport size of',
+      colors.yellow(`${width}×${height}`));
+
   const page = await browser.newPage();
-  await page.setViewport({
-    width: VIEWPORT_WIDTH,
-    height: VIEWPORT_HEIGHT,
-  });
+  await page.setViewport({width, height});
   page.setDefaultNavigationTimeout(NAVIGATE_TIMEOUT_MS);
   await page.setJavaScriptEnabled(true);
   return page;
@@ -356,18 +361,10 @@ async function snapshotWebpages(percy, browser, webpages) {
         await sleep(WAIT_FOR_TABS_MS);
       }
 
-      const page = await newPage(browser);
       const name = testName ? `${pageName} (${testName})` : pageName;
       log('verbose', 'Visual diff test', colors.yellow(name));
 
-      if (viewport) {
-        log('verbose', 'Setting explicit viewport size of',
-            colors.yellow(`${viewport.width}×${viewport.height}`));
-        await page.setViewport({
-          width: viewport.width,
-          height: viewport.height,
-        });
-      }
+      const page = await newPage(browser, viewport);
       log('verbose', 'Navigating to page', colors.yellow(webpage.url));
 
       // Navigate to an empty page first to support different webpages that only

--- a/build-system/tasks/visual-diff/snippets/remove-amp-scripts.js
+++ b/build-system/tasks/visual-diff/snippets/remove-amp-scripts.js
@@ -1,0 +1,6 @@
+// This file is executed via Puppeteer's page.evaluate on a document to remove
+// all <script> tags that import AMP pages. This makes for cleaner diffs and
+// prevents "double-execution" of AMP scripts when enableJavaScript=true.
+
+document.head.querySelectorAll("script[src]")
+    .forEach(node => node./*OK*/remove());

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -128,12 +128,12 @@
    *   "flaky": true
    * },
    *
-   * Each webpages (or, optionally, each of its tests in the interactive_tests
+   * Each webpage (or, optionally, each of its tests in the interactive_tests
    * file) is processed in a separate headless browser tab, with the test runner
    * performing these tasks in order:
    * - Load the page and waits for network activity to stop (or up to 3 secs)
    * - Wait for the built-in AMP loader dots to disappear from the page, meaning
-   *   all AMP components finished being layed out and all resources, such as
+   *   all AMP components finished being laid out and all resources, such as
    *   images, are displayed (or up to 5 secs)
    * - [if loading_incomplete_selectors is set] wait for all elements that match
    *   these CSS selectors to disappear from the page, i.e., either removed

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -59,14 +59,14 @@
    *
    *   // [optional] CSS selectors for elements that may initially appear on the
    *   // page, but must eventually be removed from it or become invisible.
-   *   "loading_incomplete_css": [
+   *   "loading_incomplete_selectors": [
    *     ".loading-in-progress-css-class",
    *     ".another-loading-in-progress-css-class"
    *   ],
    *
    *   // [optional] CSS selectors for elements that must eventually exist on
    *   // the page and be visible.
-   *   "loading_complete_css": [
+   *   "loading_complete_selectors": [
    *     ".loading-complete-css-class",
    *     ".another-loading-complete-css-class"
    *   ],
@@ -84,7 +84,7 @@
    *   // sent to Percy, and then once again on Percy before the actual snapshot
    *   // occurs. If you wish to execute the code only once, guard against it
    *   // with a CSS class. As an added bonus, this same CSS class can be set as
-   *   // the expected loading_complete_css. e.g., the script can be:
+   *   // the expected loading_complete_selectors. e.g., the script can be:
    *   //   <script>
    *   //     if (!document.body.classList.has('DIRTY_JAVASCRIPT_GUARD')) {
    *   //       do_dom_changing_stuff();
@@ -127,21 +127,42 @@
    *   // snapshot on Percy that demonstrate the flakiness of this test.
    *   "flaky": true
    * },
+   *
+   * Each webpages (or, optionally, each of its tests in the interactive_tests
+   * file) is processed in a separate headless browser tab, with the test runner
+   * performing these tasks in order:
+   * - Load the page and waits for network activity to stop (or up to 3 secs)
+   * - Wait for the built-in AMP loader dots to disappear from the page, meaning
+   *   all AMP components finished being layed out and all resources, such as
+   *   images, are displayed (or up to 5 secs)
+   * - [if loading_incomplete_selectors is set] wait for all elements that match
+   *   these CSS selectors to disappear from the page, i.e., either removed
+   *   entirely or become invisible (or up to 5 secs)
+   * - [if loading_complete_selectors is set] wait for all elements that match
+   *   these CSS selectors to be visible on the page. Note that each defined
+   *   selector MUST match at least ONE element on the page (or up to 5 secs)
+   * - [if loading_complete_delay_ms is set] wait for the defined amount of time
+   * - [if the test is one of the tests defined in interactive_tests] execute
+   *   the code in the interactive test
+   * - Prepare the page for snapshotting by setting snapshot options for Percy
+   *   and, in some cases, modifying the HTML (e.g., when viewport is set, the
+   *   page is wrapped in a fixed-size iframe. See file
+   *   build-system/tasks/visual-diff/index.js for complete implementation)
    */
     {
       "url": "examples/visual-tests/article-access.amp/article-access.amp.html",
       "name": "AMP Article Access",
-      "loading_incomplete_css": [".article-body"],
-      "loading_complete_css": [".login-section"]
+      "loading_incomplete_selectors": [".article-body"],
+      "loading_complete_selectors": [".login-section"]
     },
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",
       "name": "Fonts",
-      "loading_incomplete_css": [
+      "loading_incomplete_selectors": [
         "html.comic-amp-font-loading",
         "html.comic-amp-bold-font-loading"
       ],
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         "html.comic-amp-font-loaded",
         "html.comic-amp-bold-font-loaded"
       ]
@@ -153,7 +174,7 @@
     {
       "url": "examples/visual-tests/article-fade-in.amp.html",
       "name": "fade-in & fade-in-scroll",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".overlay-container",
         ".overflow-window"
       ]
@@ -161,7 +182,7 @@
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".comic-amp-font-missing",
         ".comic-amp-bold-font-missing"
       ],
@@ -170,7 +191,7 @@
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
       "name": "AMP Article",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".article-body",
         ".ad-one div[placeholder].amp-hidden",
         ".ad-two div[placeholder].amp-hidden"
@@ -179,7 +200,7 @@
     {
       "url": "examples/visual-tests/amp-list/amp-list.amp.html",
       "name": "AMP List and Mustache",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".list1",
         ".list2"
       ],
@@ -192,7 +213,7 @@
     {
       "url": "examples/visual-tests/video/rotate-to-fullscreen.html",
       "name": "Video rotate-to-fullscreen",
-      "loading_complete_css": ["video.i-amphtml-replaced-content"]
+      "loading_complete_selectors": ["video.i-amphtml-replaced-content"]
     },
     {
       "url": "examples/visual-tests/amp-sidebar/amp-sidebar.amp.html",
@@ -214,7 +235,7 @@
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
       ],
@@ -225,7 +246,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-fill"
       ]
@@ -234,7 +255,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-vertical"
       ]
@@ -243,7 +264,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-horizontal"
       ]
@@ -252,10 +273,10 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds)",
       "viewport": {"width": 320, "height": 480},
-      "loading_incomplete_css": [
+      "loading_incomplete_selectors": [
         "[grid-area]"
       ],
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-thirds"
       ]
@@ -264,7 +285,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#the-one-with-the-cta-layer[active]"
       ],
@@ -275,7 +296,7 @@
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ]
     },
@@ -283,7 +304,7 @@
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ]
     },
@@ -291,7 +312,7 @@
       "url": "examples/visual-tests/amp-story/share-menu.html",
       "name": "amp-story: share menu",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-share-menu"
       ]
@@ -300,7 +321,7 @@
       "url": "examples/visual-tests/amp-story/info-dialog.html",
       "name": "amp-story: info dialog",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-info-dialog"
       ]
@@ -309,7 +330,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-bookend"
       ]
@@ -320,7 +341,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-consent"
       ]
@@ -329,7 +350,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-unsupported-browser-layer.html",
       "name": "amp-story: unsupported browser",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-fallback",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
@@ -338,7 +359,7 @@
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
       ],
@@ -349,7 +370,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill) (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-fill"
       ]
@@ -358,7 +379,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical) (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-vertical"
       ]
@@ -367,7 +388,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal) (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-horizontal"
       ]
@@ -376,10 +397,10 @@
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds) (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_incomplete_css": [
+      "loading_incomplete_selectors": [
         "[grid-area]"
       ],
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-grid-template-thirds"
       ]
@@ -388,7 +409,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#the-one-with-the-cta-layer[active]"
       ],
@@ -399,7 +420,7 @@
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ]
     },
@@ -407,7 +428,7 @@
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
       ]
     },
@@ -415,7 +436,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-bookend"
       ]
@@ -426,7 +447,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-consent"
       ]
@@ -435,7 +456,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-unsupported-browser-layer.html",
       "name": "amp-story: unsupported browser (desktop)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-fallback",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
@@ -444,7 +465,7 @@
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (rtl)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
       ],
@@ -455,7 +476,7 @@
       "url": "examples/visual-tests/amp-story/share-menu.rtl.html",
       "name": "amp-story: share menu (rtl)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-share-menu"
       ]
@@ -464,7 +485,7 @@
       "url": "examples/visual-tests/amp-story/info-dialog.rtl.html",
       "name": "amp-story: info dialog (rtl)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-info-dialog"
       ]
@@ -473,7 +494,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (rtl)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-bookend"
       ]
@@ -484,7 +505,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (rtl)",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-consent"
       ]
@@ -493,7 +514,7 @@
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
       ],
@@ -504,7 +525,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-bookend"
       ]
@@ -515,7 +536,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-consent"
       ]
@@ -526,14 +547,14 @@
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: rotation overlay",
       "viewport": {"width": 480, "height": 320},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-no-rotation-overlay"
       ]
     },
     {
       "url": "examples/visual-tests/amp-inabox/amp-inabox-gpt.html",
       "name": "AMP Inabox GPT Ad",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".slot-render-ended",
         ".slot-onload",
       ],
@@ -544,7 +565,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-embedded-component.html",
       "name": "amp-story: tooltip",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-embedded-component.js"
@@ -555,7 +576,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-embedded-component.html",
       "name": "amp-story: tooltip desktop",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-embedded-component-desktop.js"
@@ -564,7 +585,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-pagination-buttons.html",
       "name": "amp-story: pagination-buttons desktop",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-pagination-buttons.js"
@@ -573,7 +594,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-sidebar.html",
       "name": "amp-story: sidebar",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-sidebar-control.i-amphtml-story-button"
       ],
@@ -583,7 +604,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-page-attachment.html",
       "name": "amp-story: page attachment",
       "viewport": {"width": 320, "height": 480},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
@@ -592,7 +613,7 @@
       "url": "examples/visual-tests/amp-story/amp-story-page-attachment.html",
       "name": "amp-story: page attachment desktop",
       "viewport": {"width": 1440, "height": 900},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment-desktop.js"
@@ -602,7 +623,7 @@
       // See https://percy.io/ampproject/amphtml/builds/1434487/view/95137509/375?browser=firefox&mode=diff
       "url": "examples/visual-tests/amp-date-picker/amp-date-picker.amp.html",
       "name": "amp-date-picker",
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         ".i-amphtml-date-picker-container",
       ],
       "interactive_tests": "examples/visual-tests/amp-date-picker/amp-date-picker.js"
@@ -622,7 +643,7 @@
       "url": "examples/visual-tests/amp-user-notification/amp-user-notification.amp.html",
       "name": "amp-user-notification",
       "viewport": {"width": 400, "height": 600},
-      "loading_complete_css": [
+      "loading_complete_selectors": [
         "amp-user-notification.amp-active",
       ],
       "interactive_tests": "examples/visual-tests/amp-user-notification/amp-user-notification.js"


### PR DESCRIPTION
* Added comments to `visual-diff/index.js` explaining what happens inside that giant function that was extremely opaque until now
* Moved code-in-string to an external file
* Removed unnecessary viewport resizing after wrapping the test inside an iframe
* Doubled the number of parallel tabs. I tried various values and 20 seem to get the optimal result (more than that doesn't make things faster on my local machine, but on Travis it might be different... I could experiment with this more if we start seeing a surge in test numbers ,but for now it runs in ~1m and that's fine)
* Simpler viewport sizing logic
* Renamed `loading_[in]complete_css => loading_[in]complete_selectors` (because they are css **selectors**, not css **code**)
* Added detailed explanation on order of execution of tests to `visual-tests` file