### PR TITLE
amp-bind: Fix state/ready race condition

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -69,13 +69,15 @@ export class AmpState extends AMP.BaseElement {
     }
 
     this.registerAction('refresh', () => {
+      userAssert(this.element.hasAttribute('src'),
+          'Can\'t refresh <amp-state> without "src" attribute.');
       this.fetchAndUpdate_(/* isInit */ false, /* opt_refresh */ true);
     }, ActionTrust.HIGH);
   }
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    const viewer = Services.viewerForDoc(this.getAmpDoc());
+    const viewer = Services.viewerForDoc(this.element);
     if (!viewer.hasBeenVisible()) {
       const TAG = this.getName_();
       dev().error(TAG, 'Viewer must be visible before mutation.');
@@ -126,7 +128,6 @@ export class AmpState extends AMP.BaseElement {
    */
   fetch_(ampdoc, element, isInit, opt_refresh) {
     const src = element.getAttribute('src');
-
     // Require opt-in for URL variable replacements on CORS fetches triggered
     // by [src] mutation. @see spec/amp-var-substitutions.md
     let policy = UrlReplacementPolicy.OPT_IN;
@@ -147,7 +148,7 @@ export class AmpState extends AMP.BaseElement {
   fetchAndUpdate_(isInit, opt_refresh) {
     const ampdoc = this.getAmpDoc();
     // Don't fetch in prerender mode.
-    const viewer = Services.viewerForDoc(this.getAmpDoc());
+    const viewer = Services.viewerForDoc(this.element);
     return viewer.whenFirstVisible()
         .then(() => this.fetch_(ampdoc, this.element, isInit, opt_refresh))
         .then(json => this.updateState_(json, isInit));

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -57,10 +57,11 @@ export class AmpState extends AMP.BaseElement {
         bind.addOverridableKey(element.getAttribute('id'));
       });
     }
-    // Parse child script tag and/or fetch JSON from endpoint at `src`
-    // attribute, with the latter taking priority.
+    // Parse child <script> tag and/or fetch JSON from `src` attribute.
+    // The latter is allowed to overwrite the former.
     const {children} = element;
     if (children.length > 0) {
+      // Bind relies on this happening synchronously in buildCallback().
       this.parseAndUpdate_();
     }
     if (this.element.hasAttribute('src')) {

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -54,7 +54,7 @@ export class AmpState extends AMP.BaseElement {
     if (element.hasAttribute('overridable')) {
       Services.bindForDocOrNull(element).then(bind => {
         devAssert(bind);
-        bind.makeStateKeyOverridable(element.getAttribute('id'));
+        bind.addOverridableKey(element.getAttribute('id'));
       });
     }
     // Parse child script tag and/or fetch JSON from endpoint at `src`
@@ -164,7 +164,8 @@ export class AmpState extends AMP.BaseElement {
     const id = userAssert(this.element.id, '<amp-state> must have an id.');
     Services.bindForDocOrNull(this.element).then(bind => {
       devAssert(bind);
-      const state = /** @type {!JsonObject} */ (map({[id]: json}));
+      const state = /** @type {!JsonObject} */ (map());
+      state[id] = json;
       // As a rule, initialization should skip evaluation.
       // If we're not initializing then this must be a mutation, so we must
       // skip <amp-state> evaluation to prevent update cycles.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -487,7 +487,7 @@ export class Bind {
    * @private
    */
   checkReadiness_() {
-    if (this.numberOfAmpStateInits_ <= this.numberOfAmpStateElements_) {
+    if (this.numberOfAmpStateInits_ < this.numberOfAmpStateElements_) {
       return;
     }
     // Use a signal to ensure that onReady_() is only invoked once.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -183,18 +183,15 @@ export class Bind {
           return this.initialize_(root);
         });
 
+    /** @private {?Node} */
+    this.rootNode_ = null;
+
     /** @private {Promise} */
     this.setStatePromise_ = null;
 
     /** @private @const {!../../../src/utils/signals.Signals} */
     this.signals_ = new Signals();
     this.signals_.whenSignal('READY').then(() => this.onReady_());
-
-    /** @private {number} */
-    this.numberOfAmpStateElements_ = Number.POSITIVE_INFINITY;
-
-    /** @private {number} */
-    this.numberOfAmpStateInits_ = 0;
 
     // Install debug tools.
     const g = self.AMP;
@@ -234,7 +231,6 @@ export class Bind {
     dev().info(TAG, 'state:', this.state_);
 
     if (opt_skipEval) {
-      this.numberOfAmpStateInits_++;
       this.checkReadiness_();
       return Promise.resolve();
     }
@@ -455,9 +451,7 @@ export class Bind {
    * @private
    */
   initialize_(root) {
-    dev().info(TAG, 'init');
-
-    this.numberOfAmpStateElements_ = root.querySelectorAll('AMP-STATE').length;
+    this.rootNode_ = root;
 
     // Disallow URL property bindings in AMP4EMAIL.
     const allowUrlProperties = !this.isAmp4Email_();
@@ -487,7 +481,12 @@ export class Bind {
    * @private
    */
   checkReadiness_() {
-    if (this.numberOfAmpStateInits_ < this.numberOfAmpStateElements_) {
+    if (!this.rootNode_) {
+      return;
+    }
+    const unbuilt =
+        this.rootNode_.querySelectorAll('AMP-STATE.i-amphtml-notbuilt');
+    if (unbuilt.length > 0) {
       return;
     }
     // Use a signal to ensure that onReady_() is only invoked once.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -567,7 +567,7 @@ export class Bind {
    * a premutate message from the viewer.
    * @param {string} key
    */
-  makeStateKeyOverridable(key) {
+  addOverridableKey(key) {
     this.overridableKeys_.push(key);
   }
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -308,8 +308,9 @@ describe.configure().ifChrome().run('Bind', function() {
       });
     });
 
-    it('should not send "bindReady" until <amp-state> is initialized', () => {
-      createElement(env, container, '', 'amp-state', true);
+    it('should not send "bindReady" until all <amp-state> are built', () => {
+      const element = createElement(env, container, '', 'amp-state', true);
+      element.classList.add('i-amphtml-notbuilt');
 
       const signals = bind.signals();
       sandbox.spy(signals, 'signal');
@@ -320,7 +321,8 @@ describe.configure().ifChrome().run('Bind', function() {
       return onBindReady(env, bind).then(() => {
         expect(signals.signal).to.not.be.called;
 
-        // Simulate <amp-state> initialization.
+        // Simulate <amp-state> buildCallback().
+        element.classList.remove('i-amphtml-notbuilt');
         bind.setState({}, /* opt_skipEval */ true);
 
         return signals.whenSignal('READY');


### PR DESCRIPTION
In some cases, `bindReady` viewer message can be sent before all `<amp-state>` elements are initialized (local data parsed). Fix this by:

1. Allowing parsing local data (`<script>` child) during prerender mode.
2. Don't send `bindReady` message until all `<amp-state>` are built.