### PR TITLE
📖 Simplify docking example

### DIFF
--- a/examples/article-with-docked-video.html
+++ b/examples/article-with-docked-video.html
@@ -329,9 +329,12 @@
       `responsive`, the slot will expand to fill the aside's width while
       preserving aspect ratio.
 
-      Additionally, set the `on` attribute to specify the actions that
-      get executed on docking events. In this case, we'll start the `slideSidebarDown`
-      animation on `dock` and run it in reverse on `undock`.-->
+      You should also set the `on` attribute to specify the actions that get executed on docking events.
+      In this case, we'll start the `slideDown` animation on `dock` and run it in reverse on `undock`.
+
+      Note that we're seeting the action on the slot element. If we were to set
+      it in the video itself, it would be triggered for `minimize-to-corner` rather
+      than `minimize-to-slot`.-->
       <amp-layout
           layout="responsive"
           width="16"

--- a/examples/article-with-docked-video.html
+++ b/examples/article-with-docked-video.html
@@ -212,45 +212,20 @@
 </head>
 
 <body>
-  <!-- ## Define animations -->
+  <!-- ## Define animation -->
   <!-- To slide down the content below the docking slot, the vertical offset is
-  changed into a `20px` positive offset to create padding below the slot. -->
+  changed into a `40px` positive offset to create padding below the slot.
+  To slide it up, we'll simply reverse this animation. -->
   <amp-animation layout="nodisplay" id="slideSidebarDown">
     <script type="application/json">
       {
         "selector": ".more-content",
         "duration": "0.5s",
         "fill": "both",
-        "easing": "ease-out",
-        "keyframes": [{
-            "offset": 0,
-            "transform": "translateY(-16.85vw)"
-          },
-          {
-            "offset": 1,
-            "transform": "translateY(40px)"
-          }
-        ]
-      }
-    </script>
-  </amp-animation>
-  <!-- To slide up the content once the video is no longer docked, the animation
-  reverts the aside content's offset to `-16.85vw`. -->
-  <amp-animation layout="nodisplay" id="slideSidebarUp">
-    <script type="application/json">
-      {
-        "selector": ".more-content",
-        "duration": "0.5s",
-        "fill": "both",
-        "easing": "ease-out",
-        "keyframes": [{
-            "offset": 0,
-            "transform": "translateY(40px)"
-          },
-          {
-            "offset": 1,
-            "transform": "translateY(-16.85vw)"
-          }
+        "easing": "ease",
+        "keyframes": [
+          {"transform": "translateY(-16.85vw)"},
+          {"transform": "translateY(40px)"}
         ]
       }
     </script>
@@ -356,14 +331,14 @@
 
       Additionally, set the `on` attribute to specify the actions that
       get executed on docking events. In this case, we'll start the `slideSidebarDown`
-      animation on `dock` and the `slideSidebarUp` animation on `undock`.-->
+      animation on `dock` and run it in reverse on `undock`.-->
       <amp-layout
           layout="responsive"
           width="16"
           height="9"
           id="dock-slot"
           on="dock: slideSidebarDown.start;
-            undock: slideSidebarUp.start;">
+              undock: slideSidebarDown.start, slideSidebarDown.reverse;">
       </amp-layout>
       <!-- ## Define the content under the slot -->
       <!-- This container is negatively offset on the vertical axis to cover


### PR DESCRIPTION
TIL (actually yesterday) of `amp-animation.reverse`. This means we can have only one animation and `reverse` it on `undock`. 

ABE: ampproject/amp-by-example#1835