### PR TITLE
🐛 Amp-viqeo-player: fixing placeholder url

### DIFF
--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -205,7 +205,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
       placeholder.setAttribute('alt', 'Loading video');
     }
     placeholder.setAttribute('src',
-        `http://cdn.viqeo.tv/preview/${encodeURIComponent(this.videoId_)}.jpg`);
+        `https://cdn.viqeo.tv/preview/${encodeURIComponent(this.videoId_)}.jpg`);
     placeholder.setAttribute('layout', 'fill');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -102,7 +102,7 @@ describes.realWin('amp-viqeo-player', {
         const img = p.viqeoElement.querySelector('amp-img');
         expect(img).to.not.be.null;
         expect(img.getAttribute('src')).to.equal(
-            'http://cdn.viqeo.tv/preview/922d04f30b66f1a32eb2.jpg');
+            'https://cdn.viqeo.tv/preview/922d04f30b66f1a32eb2.jpg');
         expect(img.getAttribute('layout')).to.equal('fill');
         expect(img.hasAttribute('placeholder')).to.be.true;
         expect(img.getAttribute('referrerpolicy')).to.equal('origin');


### PR DESCRIPTION
Replaced http to https in placeholder url.