### PR TITLE
📖Clarify custom-validation-reporting documentation

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -428,6 +428,10 @@ For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 
 For validation messages, if your element contains no text content inside, AMP will fill it out with the browser's default validation message. In the example above, when the `name5` input is empty and validation is kicked off (i.e., user tried to submit the form) AMP will fill `<span visible-when-invalid="valueMissing" validation-for="name5"></span>` with the browser's validation message and show that `span` to the user.
 
+{% call callout('Important', type='caution') %}
+You must provide your own validation UI for each kind of invalid state that the input could have. If these are not present, users will not see any `custom-validation-reporting` for the missing error state. The validity states can be found in the [official W3C HTML validation reporting documentation](https://www.w3.org/TR/html50/forms.html#validitystate).
+{% endcall %}
+
 ### Reporting strategies
 
 Specify one of the following reporting options for the `custom-validation-reporting` attribute:


### PR DESCRIPTION
Addresses concern from #20985

This warns document authors that they need to provide custom messages to use custom-validity-reporting.

/to @CrystalOnScript 