### PR TITLE
🐛Fix stretched images in lightbox.

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.css
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.css
@@ -16,6 +16,12 @@
 
  .i-amphtml-image-viewer-image {
   position: absolute;
+  /**
+   * The image viewer sizes the image using width/height using the natural
+   * width/height, but falls back to the image viewer size itself. This causes
+   * the image to get stretched, and can occur if the image has not laid out or
+   * loaded yet.
+   */
   object-fit: contain;
 }
 

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.css
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.css
@@ -16,6 +16,7 @@
 
  .i-amphtml-image-viewer-image {
   position: absolute;
+  object-fit: contain;
 }
 
 .i-amphtml-image-viewer {


### PR DESCRIPTION
Add `object-fit: contain` to make sure images are never stretched in the
lightbox. This is a short term fix, since we plan on removing the image
viewer code.
