### PR TITLE
Fixed typo in `fixed-elements-in-lightbox` experiment

### DIFF
--- a/examples/amp-lightbox.amp.html
+++ b/examples/amp-lightbox.amp.html
@@ -36,7 +36,7 @@
 <body class="comic-amp-font-loading">
 
 <article>
-<h1 class="fixed" style="background-color: red">Fixed header</h1>
+  <span class="fixed" style="background-color: red">Fixed header</span>
 
   <h2>Scrollable Lightbox</h2>
   <amp-lightbox scrollable id="lightbox-scrollable" layout="nodisplay" animate-in="fly-in-bottom">
@@ -44,7 +44,7 @@
       Close Scrollable Lightbox
     </button>
     <p class="fixed">
-      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
+      <amp-img src="https://ampbyexample.com/img/amp.jpg" width=300 height=200></amp-img>
     </p>
     <p class="lightbox-text">
       Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
@@ -71,6 +71,23 @@
   <button on="tap:lightbox-scrollable">
     Open Scrollable Lightbox
   </button>
+
+  <div id="lipsum">
+      <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sodales lectus, a gravida lacus auctor et. Nullam id urna ut neque euismod vehicula. Mauris scelerisque ullamcorper neque in malesuada. In lobortis placerat leo, eu posuere lectus semper in. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque sed condimentum augue, sit amet porta justo. Integer nec lorem nisi. Phasellus ultrices libero tristique, aliquam neque eleifend, faucibus velit. Morbi vitae pretium augue.
+      </p>
+      <p>
+      Vivamus vel risus vulputate diam malesuada ornare. Nam a urna orci. Vivamus risus tellus, interdum eu turpis ac, tempus viverra sem. In sed leo scelerisque, blandit nibh a, lacinia diam. Maecenas metus arcu, accumsan porta elementum ac, euismod eu leo. Donec ornare risus dui, ut dictum libero imperdiet vitae. Nunc tincidunt velit eu ex dictum posuere. Aliquam interdum orci lectus, et finibus ex bibendum tempor. Phasellus dignissim nibh et maximus ornare. Aliquam ligula lorem, varius non enim ut, imperdiet bibendum magna. Nulla facilisi. Proin pellentesque tristique tellus in egestas. Curabitur laoreet viverra ligula, sit amet finibus arcu. Morbi sed neque sit amet arcu tempus molestie. Mauris aliquam eget nunc eget venenatis. Ut vel mi nec mi mattis ullamcorper vel a enim.
+      </p>
+      <p>
+      Donec ultrices eleifend tristique. Etiam convallis quam lectus, eget tristique elit blandit a. Mauris non tortor et lorem tristique euismod. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse sit amet dui sed ipsum lobortis porttitor interdum nec magna. In et ornare urna, mattis sagittis ipsum. Proin vel felis at urna finibus malesuada eu sit amet mi. Quisque ultrices fringilla est vitae scelerisque. Ut condimentum dui ultrices, venenatis neque at, maximus metus.
+      </p>
+      <p>
+      Praesent elementum sollicitudin risus cursus viverra. In eget scelerisque arcu, tincidunt cursus magna. Cras turpis libero, facilisis sed turpis sed, hendrerit cursus libero. Donec ut sapien ut sem sollicitudin mattis ut ut dui. Phasellus sollicitudin eros vitae venenatis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut molestie nibh semper turpis tempor finibus. Mauris eget sagittis tortor. Fusce interdum enim vitae urna iaculis auctor. Ut volutpat volutpat dignissim. Sed in felis ut nibh faucibus laoreet. Etiam a leo accumsan, efficitur erat non, luctus dui. Vivamus a semper enim, eget luctus dolor. Vestibulum aliquam ullamcorper neque quis bibendum.
+      </p>
+      <p>
+      Proin sit amet lacus nec mi eleifend feugiat tristique ac leo. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Fusce id luctus nisi. Vestibulum viverra auctor nisl, a placerat leo interdum ac. Nullam porttitor auctor ultrices. Etiam tempus lectus urna, sit amet accumsan ante pellentesque eget. Fusce hendrerit scelerisque massa ut venenatis. Vivamus in diam maximus mi ultrices aliquet. Donec lacinia porttitor augue, nec blandit mauris eleifend at. Mauris ante ligula, tincidunt id risus sit amet, laoreet pharetra orci. Aenean id dolor condimentum, mattis libero et, posuere erat. Pellentesque quis magna eu odio pellentesque congue. Sed fringilla massa ut laoreet suscipit.
+      </p></div>
 </article>
 </body>
 </html>

--- a/examples/amp-lightbox.amp.html
+++ b/examples/amp-lightbox.amp.html
@@ -44,7 +44,7 @@
       Close Scrollable Lightbox
     </button>
     <p class="fixed">
-      <amp-img src="https://ampbyexample.com/img/amp.jpg" width=300 height=200></amp-img>
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
     </p>
     <p class="lightbox-text">
       Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -190,7 +190,7 @@ export class FixedLayer {
           ownerNode.hasAttribute('amp-extension')) {
         continue;
       }
-      // Don't dereference cssRules we need to avoid "Can't access rules"
+      // Don't dereference cssRules early to avoid "Cannot access rules"
       // DOMException due to reading a CORS stylesheet e.g. font.
       this.discoverSelectors_(stylesheet.cssRules);
     }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -43,6 +43,9 @@ const TAG = 'FixedLayer';
 const DECLARED_FIXED_PROP = '__AMP_DECLFIXED';
 const DECLARED_STICKY_PROP = '__AMP_DECLSTICKY';
 
+const LIGHTBOX_MODE_ATTR = 'i-amphtml-lightbox';
+const LIGHTBOX_ELEMENT_CLASS = 'i-amphtml-lightbox-element';
+
 /**
  * @param {!Element} el
  */
@@ -978,9 +981,9 @@ class TransferLayerBody {
       const root = this.getRoot();
       if (this.isLightboxExperimentOn_) {
         if (on) {
-          root.setAttribute('i-amphtml-lightbox', '');
+          root.setAttribute(LIGHTBOX_MODE_ATTR, '');
         } else {
-          root.removeAttribute('i-amphtml-lightbox');
+          root.removeAttribute(LIGHTBOX_MODE_ATTR);
         }
       } else {
         // Legacy behavior is to hide transfer layer when entering lightbox
@@ -1012,7 +1015,7 @@ class TransferLayerBody {
     }
     for (let i = 0; i < layerAttrs.length; i++) {
       const {name} = layerAttrs[i];
-      if (name === 'style' || name === 'i-amphtml-lightbox'
+      if (name === 'style' || name === LIGHTBOX_MODE_ATTR
           || body.hasAttribute(name)) {
         continue;
       }
@@ -1048,7 +1051,7 @@ class TransferLayerBody {
     // Identify lightboxed elements so they can be visible when the transfer
     // layer is "hidden", and hidden with the transfer layer is "visible".
     if (fe.lightboxed) {
-      element.classList.add('i-amphtml-lightbox-element');
+      element.classList.add(LIGHTBOX_ELEMENT_CLASS);
     }
 
     element.parentElement.replaceChild(fe.placeholder, element);
@@ -1076,7 +1079,7 @@ class TransferLayerBody {
     dev().fine(TAG, 'return from fixed:', fe.id, element);
 
     if (fe.lightboxed) {
-      element.classList.remove('i-amphtml-lightbox-element');
+      element.classList.remove(LIGHTBOX_ELEMENT_CLASS);
     }
 
     if (this.doc_.contains(element)) {

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -1012,7 +1012,7 @@ class TransferLayerBody {
     }
     for (let i = 0; i < layerAttrs.length; i++) {
       const {name} = layerAttrs[i];
-      if (name === 'style' || name === 'i-amphtml-lightboxed'
+      if (name === 'style' || name === 'i-amphtml-lightbox'
           || body.hasAttribute(name)) {
         continue;
       }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -181,7 +181,7 @@ export class FixedLayer {
         dev().error(TAG, 'Aborting setup due to null stylesheet.');
         return;
       }
-      const {cssRules, disabled, ownerNode} = stylesheet;
+      const {disabled, ownerNode} = stylesheet;
       if (disabled ||
           !ownerNode ||
           ownerNode.tagName != 'STYLE' ||
@@ -190,7 +190,9 @@ export class FixedLayer {
           ownerNode.hasAttribute('amp-extension')) {
         continue;
       }
-      this.discoverSelectors_(cssRules);
+      // Don't dereference cssRules we need to avoid "Can't access rules"
+      // DOMException due to reading a CORS stylesheet e.g. font.
+      this.discoverSelectors_(stylesheet.cssRules);
     }
 
     this.scanNode_(root);

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -1554,6 +1554,12 @@ describes.sandboxed('FixedLayer', {}, () => {
       body.attributes.push(new FakeAttr('[class]', 'amp-bind'));
       fixedLayer.update();
       expect(layer.getAttribute('[class]')).to.equal('amp-bind');
+
+      // [i-amphtml-lightbox] is an exception and should be preserved.
+      layer.setAttribute('i-amphtml-lightbox', '');
+      fixedLayer.update();
+      expect(layer.hasAttribute('i-amphtml-lightbox')).to.be.true;
+      expect(body.hasAttribute('i-amphtml-lightbox')).to.be.false;
     });
 
     it('should sync invalid-named attributes to layer', () => {


### PR DESCRIPTION
Follow-up to #20954. Fixes a typo and potential DOMException due to reading CORS stylesheet (e.g. fonts).

/to @jridgewell 