### PR TITLE
Add basic e2e tests for amp-list-load-more

### DIFF
--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+describes.endtoend('AMP list load-more=auto', {
+}, async env => {
+  const pageWidth = 800;
+  const pageHeight = 420;
+  let controller;
+  let ampDriver;
+
+  beforeEach(async() => {
+    controller = env.controller;
+    ampDriver = env.ampDriver;
+
+    await controller.navigateTo('http://localhost:8000/test/manual/amp-list/load-more-auto.amp.html');
+    await ampDriver.toggleExperiment('amp-list-load-more', true);
+
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-list/load-more-auto.amp.html');
+  });
+
+  it('should render correctly', async() => {
+    const listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(2);
+
+    const loader = await controller.findElement('[load-more-loading]');
+    expect(loader).to.not.be.null;
+
+    const loaderDisplay = await controller.getElementCssValue(loader,
+        'display');
+    expect(loaderDisplay).to.equal('none');
+
+    const failedIndicator = await controller.findElement('[load-more-failed]');
+    expect(failedIndicator).to.not.be.null;
+    const failedIndicatorDisplay = await controller.getElementCssValue(
+        failedIndicator, 'display');
+    expect(failedIndicatorDisplay).to.equal('none');
+
+    const seeMoreButton = await controller.findElement('[load-more-button]');
+    expect(seeMoreButton).to.not.be.null;
+    const visibility = await controller.getElementCssValue(seeMoreButton,
+        'visibility', 'visible');
+    expect(visibility).to.equal('visible');
+    const display = await controller.getElementCssValue(seeMoreButton,
+        'display');
+    expect(display).to.equal('block');
+
+    await controller.takeScreenshot('screenshots/amp-list-load-more.png');
+  });
+
+  it('should load more items on scroll', async() => {
+    let listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(2);
+
+    const article = await controller.findElement('article');
+    await controller.scroll(article, {top: 10});
+
+    const sixthItem = await controller.findElement(
+        'div.item:nth-child(4)');
+    expect(sixthItem).to.be.not.null;
+    listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(4);
+  });
+
+});

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -39,7 +39,7 @@ describes.endtoend('AMP list load-more=auto', {
 
   it('should render correctly', async() => {
     const listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(2);
+    expect(listItems).to.have.length(2);
 
     const loader = await controller.findElement('[load-more-loading]');
     expect(loader).to.not.be.null;
@@ -68,16 +68,16 @@ describes.endtoend('AMP list load-more=auto', {
 
   it('should load more items on scroll', async() => {
     let listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(2);
+    expect(listItems).to.have.length(2);
 
     const article = await controller.findElement('article');
     await controller.scroll(article, {top: 10});
 
-    const sixthItem = await controller.findElement(
+    const fourthItem = await controller.findElement(
         'div.item:nth-child(4)');
-    expect(sixthItem).to.be.not.null;
+    expect(fourthItem).to.be.not.null;
     listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(4);
+    expect(listItems).to.have.length(4);
   });
 
 });

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -42,20 +42,20 @@ describes.endtoend('AMP list load-more=auto', {
     expect(listItems).to.have.length(2);
 
     const loader = await controller.findElement('[load-more-loading]');
-    expect(loader).to.not.be.null;
+    expect(loader).to.be.ok;
 
     const loaderDisplay = await controller.getElementCssValue(loader,
         'display');
     expect(loaderDisplay).to.equal('none');
 
     const failedIndicator = await controller.findElement('[load-more-failed]');
-    expect(failedIndicator).to.not.be.null;
+    expect(failedIndicator).to.be.ok;
     const failedIndicatorDisplay = await controller.getElementCssValue(
         failedIndicator, 'display');
     expect(failedIndicatorDisplay).to.equal('none');
 
     const seeMoreButton = await controller.findElement('[load-more-button]');
-    expect(seeMoreButton).to.not.be.null;
+    expect(seeMoreButton).to.be.ok;
     const visibility = await controller.getElementCssValue(seeMoreButton,
         'visibility', 'visible');
     expect(visibility).to.equal('visible');
@@ -75,7 +75,7 @@ describes.endtoend('AMP list load-more=auto', {
 
     const fourthItem = await controller.findElement(
         'div.item:nth-child(4)');
-    expect(fourthItem).to.be.not.null;
+    expect(fourthItem).to.be.ok;
     listItems = await controller.findElements('.item');
     expect(listItems).to.have.length(4);
   });

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -39,7 +39,7 @@ describes.endtoend('AMP list load-more=manual', {
 
   it('should render correctly', async() => {
     const listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(2);
+    expect(listItems).to.have.length(2);
     const seeMoreButton = await controller.findElement('[load-more-button]');
 
     // Can we assert its CSS be visible and display block?
@@ -70,7 +70,7 @@ describes.endtoend('AMP list load-more=manual', {
 
   it('should load more items on click', async() => {
     let listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(2);
+    expect(listItems).to.have.length(2);
     const seeMoreButton = await controller.findElement('[load-more-button]');
 
     controller.click(seeMoreButton);
@@ -79,7 +79,7 @@ describes.endtoend('AMP list load-more=manual', {
         'div.item:nth-child(4)');
     expect(fourthItem).to.be.not.null;
     listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(4);
+    expect(listItems).to.have.length(4);
 
     controller.click(seeMoreButton);
 
@@ -87,7 +87,7 @@ describes.endtoend('AMP list load-more=manual', {
         'div.item:nth-child(6)');
     expect(sixthItem).to.be.not.null;
     listItems = await controller.findElements('.item');
-    expect(listItems.length).to.equal(6);
+    expect(listItems).to.have.length(6);
   });
 
 
@@ -111,7 +111,5 @@ describes.endtoend('AMP list load-more=manual', {
     const loaderDisplay = await controller.getElementCssValue(loader,
         'display');
     expect(loaderDisplay).to.equal('none');
-
   });
-
 });

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -15,7 +15,7 @@
  */
 
 
-describes.endtoend('AMP list load-more', {
+describes.endtoend('AMP list load-more=manual', {
 }, async env => {
   const pageWidth = 800;
   const pageHeight = 600;

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 describes.endtoend('AMP list load-more=manual', {
 }, async env => {
   const pageWidth = 800;
@@ -43,7 +42,7 @@ describes.endtoend('AMP list load-more=manual', {
     const seeMoreButton = await controller.findElement('[load-more-button]');
 
     // Can we assert its CSS be visible and display block?
-    expect(seeMoreButton).to.not.be.null;
+    expect(seeMoreButton).to.be.ok;
 
     const visibility = await controller.getElementCssValue(seeMoreButton,
         'visibility', 'visible');
@@ -53,14 +52,14 @@ describes.endtoend('AMP list load-more=manual', {
     expect(display).to.equal('block');
 
     const loader = await controller.findElement('[load-more-loading]');
-    expect(loader).to.not.be.null;
+    expect(loader).to.be.ok;
 
     const loaderDisplay = await controller.getElementCssValue(loader,
         'display');
     expect(loaderDisplay).to.equal('none');
 
     const failedIndicator = await controller.findElement('[load-more-failed]');
-    expect(failedIndicator).to.not.be.null;
+    expect(failedIndicator).to.be.ok;
     const failedIndicatorDisplay = await controller.getElementCssValue(
         failedIndicator, 'display');
     expect(failedIndicatorDisplay).to.equal('none');
@@ -77,7 +76,7 @@ describes.endtoend('AMP list load-more=manual', {
 
     const fourthItem = await controller.findElement(
         'div.item:nth-child(4)');
-    expect(fourthItem).to.be.not.null;
+    expect(fourthItem).to.be.ok;
     listItems = await controller.findElements('.item');
     expect(listItems).to.have.length(4);
 
@@ -85,7 +84,7 @@ describes.endtoend('AMP list load-more=manual', {
 
     const sixthItem = await controller.findElement(
         'div.item:nth-child(6)');
-    expect(sixthItem).to.be.not.null;
+    expect(sixthItem).to.be.ok;
     listItems = await controller.findElements('.item');
     expect(listItems).to.have.length(6);
   });

--- a/extensions/amp-list/0.1/test-e2e/test-load-more.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more.js
@@ -68,4 +68,26 @@ describes.endtoend('AMP list', {
     await controller.takeScreenshot('screenshots/amp-list-load-more.png');
   });
 
+  it('should load more items on click', async() => {
+    let listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(2);
+    const seeMoreButton = await controller.findElement('[load-more-button]');
+
+    controller.click(seeMoreButton);
+
+    const fourthItem = await controller.findElement(
+        'div.item:nth-child(4)');
+    expect(fourthItem).to.be.not.null;
+    listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(4);
+
+    controller.click(seeMoreButton);
+
+    const sixthItem = await controller.findElement(
+        'div.item:nth-child(6)');
+    expect(sixthItem).to.be.not.null;
+    listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(6);
+  });
+
 });

--- a/extensions/amp-list/0.1/test-e2e/test-load-more.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+describes.endtoend('AMP list', {
+}, async env => {
+  const pageWidth = 800;
+  const pageHeight = 600;
+  let controller;
+  let ampDriver;
+
+  beforeEach(async() => {
+    controller = env.controller;
+    ampDriver = env.ampDriver;
+
+    await controller.navigateTo('http://localhost:8000/test/manual/amp-list/load-more-manual.amp.html');
+    await ampDriver.toggleExperiment('amp-list-load-more', true);
+
+    await controller.setWindowRect({
+      width: pageWidth,
+      height: pageHeight,
+    });
+    await controller.navigateTo(
+        'http://localhost:8000/test/manual/amp-list/load-more-manual.amp.html');
+  });
+
+  it('should render correctly', async() => {
+    const listItems = await controller.findElements('.item');
+    expect(listItems.length).to.equal(2);
+    const seeMoreButton = await controller.findElement('[load-more-button]');
+
+    // Can we assert its CSS be visible and display block?
+    expect(seeMoreButton).to.not.be.null;
+
+    const visibility = await controller.getElementCssValue(seeMoreButton,
+        'visibility', 'visible');
+    expect(visibility).to.equal('visible');
+    const display = await controller.getElementCssValue(seeMoreButton,
+        'display');
+    expect(display).to.equal('block');
+
+    const loader = await controller.findElement('[load-more-loading]');
+    expect(loader).to.not.be.null;
+
+    const loaderDisplay = await controller.getElementCssValue(loader,
+        'display');
+    expect(loaderDisplay).to.equal('none');
+
+    const failedIndicator = await controller.findElement('[load-more-failed]');
+    expect(failedIndicator).to.not.be.null;
+    const failedIndicatorDisplay = await controller.getElementCssValue(
+        failedIndicator, 'display');
+    expect(failedIndicatorDisplay).to.equal('none');
+
+    await controller.takeScreenshot('screenshots/amp-list-load-more.png');
+  });
+
+});

--- a/extensions/amp-list/0.1/test-e2e/test-load-more.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more.js
@@ -15,7 +15,7 @@
  */
 
 
-describes.endtoend('AMP list', {
+describes.endtoend('AMP list load-more', {
 }, async env => {
   const pageWidth = 800;
   const pageHeight = 600;
@@ -88,6 +88,30 @@ describes.endtoend('AMP list', {
     expect(sixthItem).to.be.not.null;
     listItems = await controller.findElements('.item');
     expect(listItems.length).to.equal(6);
+  });
+
+
+  it('should show load-more-end when done', async() => {
+    const seeMoreButton = await controller.findElement('[load-more-button]');
+    controller.click(seeMoreButton);
+    await controller.findElement('div.item:nth-child(4)');
+    controller.click(seeMoreButton);
+    await controller.findElement('div.item:nth-child(6)');
+
+    const loadMoreEnd = await controller.findElement('[load-more-end]');
+    const loadEndDisplay = await controller.getElementCssValue(loadMoreEnd,
+        'display');
+    expect(loadEndDisplay).to.equal('block');
+
+    const seeMoreButtonDisplay = await controller.getElementCssValue(
+        seeMoreButton, 'display');
+    expect(seeMoreButtonDisplay).to.equal('none');
+
+    const loader = await controller.findElement('[load-more-loading]');
+    const loaderDisplay = await controller.getElementCssValue(loader,
+        'display');
+    expect(loaderDisplay).to.equal('none');
+
   });
 
 });

--- a/test/manual/amp-list/load-more-auto.amp.html
+++ b/test/manual/amp-list/load-more-auto.amp.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    .footer {
+      width: 100%;
+      height: 50px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+</head>
+<body>
+<article>
+
+  <!-- Do not change this without editing the E2E test -->
+  <amp-list width="auto" height="400"
+    layout="fixed-height"
+    src="/infinite-scroll?items=2&left=1"
+    [src]="data.url"
+    load-more="auto"
+    load-more-bookmark="next">
+    <template type="amp-mustache">
+      <div class="item">
+        <amp-img src="{{imageUrl}}" width="160" height="160"></amp-img>
+        <div class="title">{{title}}</div>
+      </div>
+    </template>
+    <div fallback>
+      FALLBACK
+    </div>
+    <amp-list-load-more load-more-end>
+      The END
+    </amp-list-load-more>
+  </amp-list>
+  <div class="footer"></div>
+</article>
+</body>
+</html>

--- a/test/manual/amp-list/load-more-manual.amp.html
+++ b/test/manual/amp-list/load-more-manual.amp.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+</head>
+<body>
+<article>
+
+  <!-- Do not change this without editing the E2E test -->
+  <amp-list width="auto" height="400"
+    layout="fixed-height"
+    src="/infinite-scroll?items=2&left=20"
+    [src]="data.url"
+    load-more="manual"
+    load-more-bookmark="next">
+    <template type="amp-mustache">
+      <div class="item">
+        <amp-img src="{{imageUrl}}" width="160" height="160"></amp-img>
+        <div class="title">{{title}}</div>
+      </div>
+    </template>
+    <div fallback>
+      FALLBACK
+    </div>
+  </amp-list>
+</article>
+</body>
+</html>

--- a/test/manual/amp-list/load-more-manual.amp.html
+++ b/test/manual/amp-list/load-more-manual.amp.html
@@ -20,7 +20,7 @@
   <!-- Do not change this without editing the E2E test -->
   <amp-list width="auto" height="400"
     layout="fixed-height"
-    src="/infinite-scroll?items=2&left=20"
+    src="/infinite-scroll?items=2&left=2"
     [src]="data.url"
     load-more="manual"
     load-more-bookmark="next">
@@ -33,6 +33,9 @@
     <div fallback>
       FALLBACK
     </div>
+    <amp-list-load-more load-more-end>
+      The END
+    </amp-list-load-more>
   </amp-list>
 </article>
 </body>


### PR DESCRIPTION
Adds two simple fixtures respectively for the manual load-more and automatic load-more cases. Tests that each case successfully renders all items and load-more visuals, and successfully triggers a load-more on click or on scroll. 