### PR TITLE
🖍 Tooltip UI enhancements

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -145,10 +145,22 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
 const MIN_VERTICAL_SPACE = 48;
 
 /**
- * Padding between tooltip and edges of screen.
+ * Padding between tooltip and vertical edges of screen.
  * @const {number}
  */
-const EDGE_PADDING = 8;
+const VERTICAL_EDGE_PADDING = 24;
+
+/**
+ * Padding between tooltip and horizontal edges of screen.
+ * @const {number}
+ */
+const HORIZONTAL_EDGE_PADDING = 32;
+
+/**
+ * Padding between tooltip arrow and right edge of the tooltip.
+ * @const {number}
+ */
+const TOOLTIP_ARROW_RIGHT_PADDING = 24;
 
 /**
  * Blank icon when no data-tooltip-icon src is specified.
@@ -656,7 +668,7 @@ export class AmpStoryEmbeddedComponent {
    */
   verticalPositioning_(component, pageRect, state) {
     const tooltipHeight = this.tooltip_./*OK*/offsetHeight;
-    const verticalOffset = EDGE_PADDING * 3;
+    const verticalOffset = VERTICAL_EDGE_PADDING ;
 
     state.tooltipTop = component.clientY - tooltipHeight - verticalOffset;
     if (state.tooltipTop < pageRect.top + MIN_VERTICAL_SPACE) {
@@ -677,22 +689,21 @@ export class AmpStoryEmbeddedComponent {
   horizontalPositioning_(component, pageRect, state) {
     const tooltipWidth = this.tooltip_./*OK*/offsetWidth;
     state.tooltipLeft = component.clientX - (tooltipWidth / 2);
-    const maxHorizontalLeft = pageRect.left + pageRect.width -
-      tooltipWidth - EDGE_PADDING;
+    const maxLeft =
+      pageRect.left + pageRect.width - HORIZONTAL_EDGE_PADDING - tooltipWidth;
+    const minLeft = pageRect.left + HORIZONTAL_EDGE_PADDING;
 
     // Make sure tooltip is inside bounds of the page.
-    state.tooltipLeft = Math.min(state.tooltipLeft, maxHorizontalLeft);
-    state.tooltipLeft = Math.max(state.tooltipLeft,
-        pageRect.left + EDGE_PADDING);
+    state.tooltipLeft = Math.min(state.tooltipLeft, maxLeft);
+    state.tooltipLeft = Math.max(state.tooltipLeft, minLeft);
 
     state.arrowLeftOffset = Math.abs(component.clientX - state.tooltipLeft -
         this.tooltipArrow_./*OK*/offsetWidth / 2);
 
     // Make sure tooltip arrow is inside bounds of the tooltip.
-    state.arrowLeftOffset =
-      Math.min(state.arrowLeftOffset, tooltipWidth - EDGE_PADDING * 3);
-    state.arrowLeftOffset =
-      Math.max(state.arrowLeftOffset, 0);
+    state.arrowLeftOffset = Math.min(state.arrowLeftOffset,
+        tooltipWidth - TOOLTIP_ARROW_RIGHT_PADDING);
+    state.arrowLeftOffset = Math.max(state.arrowLeftOffset, 0);
   }
 
   /**
@@ -736,7 +747,8 @@ export class AmpStoryEmbeddedComponent {
     const html = htmlFor(doc);
     const tooltipOverlay =
         html`
-        <section class="i-amphtml-story-focused-state-layer i-amphtml-hidden">
+        <section class="i-amphtml-story-focused-state-layer
+            i-amphtml-story-system-reset i-amphtml-hidden">
           <div class="i-amphtml-story-focused-state-layer-nav-button-container
               i-amphtml-story-tooltip-nav-button-left">
             <button role="button" ref="buttonLeft"

--- a/extensions/amp-story/1.0/amp-story-tooltip.css
+++ b/extensions/amp-story/1.0/amp-story-tooltip.css
@@ -23,8 +23,7 @@
   position: absolute !important;
 }
 
-.i-amphtml-story-focused-state-layer.i-amphtml-hidden,
-.i-amphtml-story-focused-state-layer.i-amphtml-hidden::before {
+.i-amphtml-story-focused-state-layer.i-amphtml-hidden {
   opacity: 0 !important;
   pointer-events: none !important;
   transition: opacity 0.1s cubic-bezier(0.4, 0.0, 1, 1) !important;

--- a/extensions/amp-story/1.0/amp-story-tooltip.css
+++ b/extensions/amp-story/1.0/amp-story-tooltip.css
@@ -23,23 +23,11 @@
   position: absolute !important;
 }
 
-.i-amphtml-story-focused-state-layer::before {
-  content: '' !important;
-  position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100% !important;
-  height: 100% !important;
-  background-color: black !important;
-  opacity: 0.55 !important;
-  transition: opacity 0.225s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
-}
-
 .i-amphtml-story-focused-state-layer.i-amphtml-hidden,
 .i-amphtml-story-focused-state-layer.i-amphtml-hidden::before {
   opacity: 0 !important;
   pointer-events: none !important;
-  transition: opacity 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
+  transition: opacity 0.1s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
 .i-amphtml-story-focused-state-layer-nav-button-container {
@@ -52,12 +40,12 @@
 }
 
 .i-amphtml-story-focused-state-layer-nav-button-container.i-amphtml-story-tooltip-nav-button-left {
-  background-image: linear-gradient(90deg, rgba(33, 33, 33, 0.30) 2%, rgba(33, 33, 33, 0) 100%) !important;
+  background-image: linear-gradient(90deg, rgba(33, 33, 33, 0.15) 2%, rgba(33, 33, 33, 0) 100%) !important;
   left: 0 !important;
 }
 
 .i-amphtml-story-focused-state-layer-nav-button-container.i-amphtml-story-tooltip-nav-button-right {
-  background-image: linear-gradient(90deg, rgba(33, 33, 33, 0) 2%, rgba(33, 33, 33, 0.30) 100%) !important;
+  background-image: linear-gradient(90deg, rgba(33, 33, 33, 0) 2%, rgba(33, 33, 33, 0.15) 100%) !important;
   right: 0 !important;
 }
 
@@ -71,7 +59,8 @@
   padding: 0 !important;
   border: 0 !important;
   background-color: transparent !important;
-  transition: transform 0.225s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+  filter: drop-shadow(0px 0px 16px rgba(0, 0, 0, 0.5)) !important;
+  transition: transform 0.2s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
 .i-amphtml-story-focused-state-layer-nav-button.i-amphtml-story-tooltip-nav-button-left {
@@ -81,7 +70,7 @@
 
 .i-amphtml-hidden .i-amphtml-story-focused-state-layer-nav-button.i-amphtml-story-tooltip-nav-button-left {
   transform: translate3d(8px, 0, 0);
-  transition: transform 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
+  transition: transform 0s linear .1s !important;
 }
 
 .i-amphtml-story-focused-state-layer-nav-button.i-amphtml-story-tooltip-nav-button-right {
@@ -91,7 +80,7 @@
 
 .i-amphtml-hidden .i-amphtml-story-focused-state-layer-nav-button.i-amphtml-story-tooltip-nav-button-right {
   transform: translate3d(-8px, 0, 0);
-  transition: transform 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
+  transition: transform 0s linear .1s !important;
 }
 
 [desktop] .i-amphtml-story-focused-state-layer-nav-button-container {
@@ -101,7 +90,7 @@
 .i-amphtml-hidden > .i-amphtml-story-tooltip,
 .i-amphtml-hidden > .i-amphtml-story-tooltip.i-amphtml-tooltip-arrow-on-top {
   transform: translate3d(0, 0, 0) !important;
-  transition: transform 0s linear 0.15s !important;
+  transition: transform 0s linear 0.1s !important;
 }
 
 .i-amphtml-story-tooltip {
@@ -112,13 +101,15 @@
   position: absolute !important;
   box-sizing: border-box !important;
   text-decoration: none !important;
+  text-shadow: none !important;
+  font-weight: 500 !important;
   display: flex !important;
   justify-content: space-between !important;
   align-items: center !important;
   background: white !important;
-  box-shadow: 0 1px 3px 1px rgba(0,0,0,0.24) !important;
+  box-shadow: 0px 6px 16px rgba(0,0,0,0.16) !important;
   transform: translate3d(0, -16px, 0) !important;
-  transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+  transition: transform 0.2s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
 .i-amphtml-story-tooltip.i-amphtml-tooltip-arrow-on-top {
@@ -141,6 +132,7 @@
 .i-amphtml-story-tooltip-icon {
   width: 24px !important;
   height: 24px !important;
+  filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.08)) !important;
 }
 
 .i-amphtml-story-tooltip-icon.i-amphtml-hidden {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -49,6 +49,7 @@ amp-consent {
   margin: 0 !important;
   padding: 0 !important;
   text-align: start !important;
+  text-shadow: none !important;
   width: auto !important;
 }
 


### PR DESCRIPTION
### Navigation arrows
1. Address edge case where tooltip covers navigation arrows.
  Expanding side margins to 32px each
2. Change background opacity to .15.
3. Add box shadow
x:0 y:0 blur:16px color: 0.5 #000000

### Text 
1. Font weight to 500 (from regular to medium)
2. Adds `i-amphtml-story-system-reset` and adds `text-shadow: none` to remove text shadow, which closes #21102.

### Tooltip & icons 
1. Add light shadow to custom icons.
x: 0, y: 0, blur value: 8px, color 0.08 #000000
2. Change shadow box of tooltip.
x:0 y:6 blur:16px color: 0.16 #000000

### Animation
1. Shorten animation for tooltip + opacity layer: 
    Tooltip box opacity and side arrow opacity duration:100ms
    Other tooltip position and side arrows position: 200ms
    Opacity animation style: linear
    Position change animation style: 0,0,0.2,1
2. Remove movement on exiting tooltip & shorten duration.
    Animation out: no position change for both tooltip and side arrows.
    Opacity change 100% to 0%, duration:100ms.

### Overlay
1. Remove overlay 😈
