### PR TITLE
♻️ Disable Layers prioritization code

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -216,6 +216,10 @@ export class Resource {
 
     /** @private @const {boolean} */
     this.useLayers_ = isExperimentOn(this.hostWin, 'layers');
+
+    /** @private @const {boolean} */
+    this.useLayersPrioritization_ = isExperimentOn(this.hostWin,
+        'layers-prioritization');
   }
 
   /**
@@ -709,9 +713,7 @@ export class Resource {
 
   /** @return {!ViewportRatioDef} */
   getDistanceViewportRatio() {
-    // TODO(jridgewell): Temporarily disabling layers prioritization code to
-    // determine if it causes the metrics regression.
-    if (false && this.useLayers_) {
+    if (this.useLayers_ && this.useLayersPrioritization_) {
       const {element} = this;
       return {
         distance: element.getLayers().iterateAncestry(element,
@@ -769,9 +771,7 @@ export class Resource {
     }
     const {distance, scrollPenalty, viewportHeight} =
       opt_viewportRatio || this.getDistanceViewportRatio();
-    // TODO(jridgewell): Temporarily disabling layers prioritization code to
-    // determine if it causes the metrics regression.
-    if (false && this.useLayers_) {
+    if (this.useLayers_ && this.useLayersPrioritization_) {
       return dev().assertNumber(distance) < multiplier;
     }
     if (typeof distance == 'boolean') {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -709,7 +709,9 @@ export class Resource {
 
   /** @return {!ViewportRatioDef} */
   getDistanceViewportRatio() {
-    if (this.useLayers_) {
+    // TODO(jridgewell): Temporarily disabling layers prioritization code to
+    // determine if it causes the metrics regression.
+    if (false && this.useLayers_) {
       const {element} = this;
       return {
         distance: element.getLayers().iterateAncestry(element,
@@ -767,7 +769,9 @@ export class Resource {
     }
     const {distance, scrollPenalty, viewportHeight} =
       opt_viewportRatio || this.getDistanceViewportRatio();
-    if (this.useLayers_) {
+    // TODO(jridgewell): Temporarily disabling layers prioritization code to
+    // determine if it causes the metrics regression.
+    if (false && this.useLayers_) {
       return dev().assertNumber(distance) < multiplier;
     }
     if (typeof distance == 'boolean') {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -174,7 +174,9 @@ export class Resources {
     this.useLayers_ = isExperimentOn(this.win, 'layers');
 
     let boundScorer;
-    if (this.useLayers_) {
+    // TODO(jridgewell): Temporarily disabling layers prioritization code to
+    // determine if it causes the metrics regression.
+    if (false && this.useLayers_) {
       boundScorer = this.calcTaskScoreLayers_.bind(this);
     } else {
       boundScorer = this.calcTaskScore_.bind(this);
@@ -239,10 +241,6 @@ export class Resources {
 
       /** @private @const {!./layers-impl.LayoutLayers} */
       this.layers_ = layers;
-
-      layers.onScroll((/* elements */) => {
-        this.schedulePass();
-      });
 
       /** @private @const {function((number|undefined), !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
       this.boundCalcLayoutScore_ = this.calcLayoutScore_.bind(this);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -173,10 +173,12 @@ export class Resources {
     /** @private @const {boolean} */
     this.useLayers_ = isExperimentOn(this.win, 'layers');
 
+    /** @private @const {boolean} */
+    this.useLayersPrioritization_ = isExperimentOn(this.win,
+        'layers-prioritization');
+
     let boundScorer;
-    // TODO(jridgewell): Temporarily disabling layers prioritization code to
-    // determine if it causes the metrics regression.
-    if (false && this.useLayers_) {
+    if (this.useLayers_ && this.useLayersPrioritization_) {
       boundScorer = this.calcTaskScoreLayers_.bind(this);
     } else {
       boundScorer = this.calcTaskScore_.bind(this);


### PR DESCRIPTION
This splits layers into two parts:

1. Bounding box measurements and scrollbox support
2. A new element prioritization algorithm

To test where the metrics regression is coming from, we're just launching the bounding box measurements in canary. If we can confirm this fixes the metrics, we begin digging into why the prioritization algorithm is affecting the metrics so much.

Additionally, reviewed all code between the Resource measurement and Layers measurement, to ensure the both do the same _exact_ same thing outside of the specific measurements.