### PR TITLE
🏗 Altered Safari Preconnect Polyfill Endpoint

### DIFF
--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -308,8 +308,7 @@ class PreconnectService {
     // (read CDNs) to respond more efficiently.
     const cacheBust = now - (now % ACTIVE_CONNECTION_TIMEOUT_MS);
     const url = origin +
-        '/amp_preconnect_polyfill_404_or_other_error_expected.' +
-        '_Do_not_worry_about_it?' + cacheBust;
+        '/robots.txt?_AMP_safari_preconnect_polyfill_cachebust=' + cacheBust;
     const xhr = new XMLHttpRequest();
     xhr.open('HEAD', url, true);
     // We only support credentialed preconnect for now.

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -163,7 +163,7 @@ describe('preconnect', () => {
         expect(open.args[0][1]).to.equal(
             'https://s.preconnect.com/robots.txt?_AMP_safari_' +
             'preconnect_polyfill_cachebust=' +
-            '?1485531180000');
+            '1485531180000');
       });
     });
   });

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -161,8 +161,8 @@ describe('preconnect', () => {
         expect(open).to.be.calledOnce;
         expect(send).to.be.calledOnce;
         expect(open.args[0][1]).to.equal(
-            'https://s.preconnect.com/amp_preconnect_polyfill_404_or' +
-            '_other_error_expected._Do_not_worry_about_it' +
+            'https://s.preconnect.com/robots.txt?_AMP_safari_' +
+            'preconnect_polyfill_cachebust=' +
             '?1485531180000');
       });
     });


### PR DESCRIPTION
Changed the endpoint to use `robots.txt` (and a more descriptive query string), as the current implementation causes some undesirable side-effects (404s in server logs, performance issues, user confusion, etc). 

Fixes #21088.