### PR TITLE
🏗 Better E2E error logging

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-max-swipe.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-max-swipe.js
@@ -26,14 +26,6 @@ describes.endtoend('AMP carousel max-swipe', {
   let controller;
   let ampDriver;
 
-  function prop(el, name) {
-    return controller.getElementProperty(el, name);
-  }
-
-  function rect(el) {
-    return controller.getElementRect(el);
-  }
-
   beforeEach(async() => {
     controller = env.controller;
     ampDriver = env.ampDriver;
@@ -42,6 +34,7 @@ describes.endtoend('AMP carousel max-swipe', {
         'http://localhost:8000/test/manual/amp-base-carousel/max-swipe-one.amp.html');
     await ampDriver.toggleExperiment('layers', true);
     await ampDriver.toggleExperiment('amp-base-carousel', true);
+    await controller.refresh();
 
     await controller.setWindowRect({
       width: pageWidth,
@@ -50,26 +43,21 @@ describes.endtoend('AMP carousel max-swipe', {
   });
 
   describe('looping', () => {
-    beforeEach(async() => {
-      await controller.navigateTo(
-          'http://localhost:8000/test/manual/amp-base-carousel/max-swipe-one.amp.html');
-    });
-
     it('should only show one slide on each side initially', async() => {
       const el = await getScrollingElement(controller);
       const slides = await getSlides(controller);
 
-      await expect(prop(el, 'scrollLeft')).to.equal(pageWidth);
+      await controller.waitForElementProperty(el, 'scrollLeft', pageWidth);
       // Verify the scroll width to make sure no unexpected spacers are
       // increasing the width,
-      await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * 3);
-      await expect(rect(slides[0])).to.include({x: 0});
-      await expect(rect(slides[1])).to.include({x: pageWidth});
-      await expect(rect(slides[slides.length - 1])).to.include({
-        x: -pageWidth,
-      });
-      await expect(prop(slides[2], 'hidden')).to.equal(true);
-      await expect(prop(slides[slides.length - 2], 'hidden')).to.equal(true);
+      await controller.waitForElementProperty(el, 'scrollWidth', pageWidth * 3);
+      await controller.waitForElementRect(slides[0], {x: 0});
+      await controller.waitForElementRect(slides[1], {x: pageWidth});
+      await controller.waitForElementRect(slides[slides.length - 1],
+          {x: -pageWidth});
+      await controller.waitForElementProperty(slides[2], 'hidden', true);
+      await controller.waitForElementProperty(slides[slides.length - 2],
+          'hidden', true);
     });
 
     it('should show the correct slides after moving right', async() => {
@@ -79,37 +67,38 @@ describes.endtoend('AMP carousel max-swipe', {
       // Move right by 1 slide.
       await controller.scrollBy(el, {left: pageWidth});
       // Wait for scroll position to be reset.
-      await expect(prop(el, 'scrollLeft')).to.equal(pageWidth);
+      await controller.waitForElementProperty(el, 'scrollLeft', pageWidth);
+
       // Verify the scroll width to make sure no unexpected spacers are
       // increasing the width,
-      await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * 3);
-      await expect(rect(slides[0])).to.include({x: -pageWidth});
-      await expect(rect(slides[1])).to.include({x: 0});
-      await expect(rect(slides[2])).to.include({x: pageWidth});
-      await expect(prop(slides[slides.length - 1], 'hidden')).to.equal(true);
-      await expect(prop(slides[3], 'hidden')).to.equal(true);
+      await controller.waitForElementProperty(el, 'scrollWidth', pageWidth * 3);
+      await controller.waitForElementRect(slides[0], {x: -pageWidth});
+      await controller.waitForElementRect(slides[1], {x: 0});
+      await controller.waitForElementRect(slides[2], {x: pageWidth});
+      await controller.waitForElementProperty(slides[slides.length - 1],
+          'hidden', true);
+      await controller.waitForElementProperty(slides[3], 'hidden', true);
     });
 
     it('should show the correct slides after moving left', async() => {
       const el = await getScrollingElement(controller);
       const slides = await getSlides(controller);
-
       // Move left by 1 slide.
       await controller.scrollBy(el, {left: -pageWidth});
+
       // Wait for scroll position to be reset.
-      await expect(prop(el, 'scrollLeft')).to.equal(pageWidth);
+      await controller.waitForElementProperty(el, 'scrollLeft', pageWidth);
+
       // Verify the scroll width to make sure no unexpected spacers are
       // increasing the width,
-      await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * 3);
-      await expect(rect(slides[slides.length - 2])).to.include({
-        x: -pageWidth,
-      });
-      await expect(rect(slides[slides.length - 1])).to.include({
-        x: 0,
-      });
-      await expect(rect(slides[0])).to.include({x: pageWidth});
-      await expect(prop(slides[slides.length - 3], 'hidden')).to.equal(true);
-      await expect(prop(slides[1], 'hidden')).to.equal(true);
+      await controller.waitForElementProperty(el, 'scrollWidth', pageWidth * 3);
+      await controller.waitForElementRect(slides[slides.length - 2],
+          {x: -pageWidth});
+      await controller.waitForElementRect(slides[slides.length - 1], {x: 0});
+      await controller.waitForElementRect(slides[0], {x: pageWidth});
+      await controller.waitForElementProperty(slides[slides.length - 3],
+          'hidden', true);
+      await controller.waitForElementProperty(slides[1], 'hidden', true);
     });
   });
 });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -82,7 +82,7 @@ describes.endtoend('AMP carousel mixed length slides', {
       const slides = await getSlides(controller);
 
       await controller.scrollBy(el, {left: 10});
-      await expect(controller.getElementRect(slides[0])).to.include({x: -10});
+      await controller.waitForElementRect(slides[0], {x: -10});
     });
   });
 
@@ -101,14 +101,16 @@ describes.endtoend('AMP carousel mixed length slides', {
       const slides = await getSlides(controller);
 
       // First slide has width 75%, and viewport is 600 pixels wide
-      await expect(prop(slides[0], 'offsetWidth')).to.equal(slideOneWidth);
-      await expect(controller.getElementRect(slides[0])).to.include({
+      await controller.waitForElementProperty(slides[0], 'offsetWidth',
+          slideOneWidth);
+      await controller.waitForElementRect(slides[0], {
         x: (pageWidth - slideOneWidth) / 2,
       });
       await assertSpacerWidth(0, slideOneWidth);
       // Second slide has width 50%, and viewport is 400 pixels wide
-      await expect(prop(slides[1], 'offsetWidth')).to.equal(slideTwoWidth);
-      await expect(controller.getElementRect(slides[1])).to.include({
+      await controller.waitForElementProperty(slides[1], 'offsetWidth',
+          slideTwoWidth);
+      await controller.waitForElementRect(slides[1], {
         x: slideOneWidth + (pageWidth - slideOneWidth) / 2,
       });
       await assertSpacerWidth(1, slideTwoWidth);
@@ -120,7 +122,7 @@ describes.endtoend('AMP carousel mixed length slides', {
       const scrollAmount = 1 + (slideOneWidth + slideTwoWidth) / 2;
 
       await controller.scrollBy(el, {left: scrollAmount});
-      await expect(controller.getElementRect(slides[1])).to.include({
+      await controller.waitForElementRect(slides[1], {
         x: (pageWidth - slideTwoWidth) / 2,
       });
     });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -42,8 +42,7 @@ describes.endtoend('AMP Carousel responsive attributes', {
       width: 1000,
       height: 600,
     });
-    await controller.navigateTo(
-        'http://localhost:8000/test/manual/amp-base-carousel/responsive.amp.html');
+    await controller.refresh();
   });
 
   it('should layout correctly initially', async() => {
@@ -90,7 +89,7 @@ describes.endtoend('AMP Carousel responsive attributes', {
     const firstSlide = await getSlide(controller, 0);
 
     // 3 slides width width 1000 = 333 width per slide.
-    await expect(controller.getElementRect(firstSlide)).to.include({
+    await controller.waitForElementRect(firstSlide, {
       width: 333,
       x: 0,
     });
@@ -98,7 +97,7 @@ describes.endtoend('AMP Carousel responsive attributes', {
     const btn = await controller.findElement('#responsive-5-4');
     await controller.click(btn);
     // 5 slides width width 1000 = 200 width per slide
-    await expect(controller.getElementRect(firstSlide)).to.include({
+    await controller.waitForElementRect(firstSlide, {
       width: 200,
       x: 0,
     });
@@ -108,7 +107,7 @@ describes.endtoend('AMP Carousel responsive attributes', {
       height: 600,
     });
     // 4 slides width width 600 = 150 width per slide.
-    await expect(controller.getElementRect(firstSlide)).to.include({
+    await controller.waitForElementRect(firstSlide, {
       width: 150,
       x: 0,
     });


### PR DESCRIPTION
Updates vague "timeout exceeded" error messages with specific reasons, i.e. cannot find element by XPath or css selector, timeout waiting for element to have specific rect, and timeout waiting for attribute on element to have specific value.

Updates amp-base-carousel's test-mixed-lengths and test-responsive to use new error logging methods.

Bug fix - fails e2e test if browser fails to resize

