### PR TITLE
✅ Skip failing `amp-recaptcha-input` tests on Firefox

### DIFF
--- a/test/integration/test-amp-recaptcha-input.js
+++ b/test/integration/test-amp-recaptcha-input.js
@@ -18,7 +18,9 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {Deferred} from '../../src/utils/promise';
 import {poll} from '../../testing/iframe';
 
-describe.configure().skipSinglePass().run('amp-recaptcha-input', function() {
+// TODO(torch2424, #20541): These tests fail on firefox.
+describe.configure().skipSinglePass().skipFirefox().run('amp-recaptcha-' +
+    'input', function() {
 
   describes.integration('with form and amp-mustache', {
   /* eslint-disable max-len */


### PR DESCRIPTION
This PR skips tests (added by #20541) that consistently fail on Firefox.

https://travis-ci.org/ampproject/amphtml/jobs/499342921#L2361-L2381

```
DESCRIBE => amp-recaptcha-input
  DESCRIBE => with form and amp-mustache
    DESCRIBE =>  
      IT => "before each" hook for "should be able to create the bootstrap frame"
        ✗ Timeout waiting for "amp-recaptcha-input" to layout
        poll@/home/travis/build/ampproject/amphtml/testing/iframe.js:425:17 <- /tmp/da69fa273bba714ffd74a4485584a5e7.browserify.js:99079:18
        
  DESCRIBE => request bank GET
    DESCRIBE =>  
      IT => "before each" hook for "should make a request with correct parameters"
        ✗ Timeout waiting for "amp-recaptcha-input" to layout
        poll@/home/travis/build/ampproject/amphtml/testing/iframe.js:425:17 <- /tmp/da69fa273bba714ffd74a4485584a5e7.browserify.js:99079:18
        
  DESCRIBE => request bank POST
    DESCRIBE =>  
      IT => "before each" hook for "should make a request with correct parameters"
        ✗ Timeout waiting for "amp-recaptcha-input" to layout
        poll@/home/travis/build/ampproject/amphtml/testing/iframe.js:425:17 <- /tmp/da69fa273bba714ffd74a4485584a5e7.browserify.js:99079:18
```