### PR TITLE
✅ Skip flaky resources unit test on Safari

### DIFF
--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1162,7 +1162,8 @@ describe('Resources discoverWork', () => {
     expect(resources.queue_.tasks_[1].resource).to.equal(resource2);
   });
 
-  it('should NOT rerender anything', () => {
+  // TODO(dvoytenko): Fails on Safari.
+  it.configure().skipSafari('should NOT rerender anything', () => {
     resource1.state_ = ResourceState.LAYOUT_COMPLETE;
     resource2.state_ = ResourceState.LAYOUT_COMPLETE;
     resources.visible_ = true;
@@ -1548,7 +1549,8 @@ describe('Resources discoverWork', () => {
       resources.ampdoc.signals().signal('ready-scan');
     });
 
-    it('should wait until ready-scan', () => {
+    // TODO(dvoytenko): Fails on Safari.
+    it.configure().skipSafari('should wait until ready-scan', () => {
       const rect = layoutRectLtwh(0, 0, 100, 100);
       resources.ampdoc.signals().reset('ready-scan');
       expect(resource1.hasBeenMeasured()).to.be.false;


### PR DESCRIPTION
https://travis-ci.org/ampproject/amphtml/jobs/499363287#L2369-L2377

```
DESCRIBE => Resources discoverWork
  IT => "after each" hook for "should NOT rerender anything"
    ✗ Unexpected call: getRect() at setState@/home/travis/build/ampproject/amphtml/src/finite-state-machine.js:73:14 <- /tmp/9edb5c0bb23451254597640e2df2c428.browserify.js:63054:15
    Unexpected call: getRect() at setState@/home/travis/build/ampproject/amphtml/src/finite-state-machine.js:73:14 <- /tmp/9edb5c0bb23451254597640e2df2c428.browserify.js:63054:15
    Unexpected call: getRect() at setState@/home/travis/build/ampproject/amphtml/src/finite-state-machine.js:73:14 <- /tmp/9edb5c0bb23451254597640e2df2c428.browserify.js:63054:15
    Expectation met: getRect([...]) once
    fail@node_modules/sinon/pkg/sinon.js:1597:34
    verify@node_modules/sinon/pkg/sinon.js:1720:33
    /home/travis/build/ampproject/amphtml/test/unit/test-resources.js:1115:4 <- /tmp/9edb5c0bb23451254597640e2df2c428.browserify.js:152540:24
```

https://travis-ci.org/ampproject/amphtml/jobs/499429132#L2369-L2382

```
DESCRIBE => Resources discoverWork
  DESCRIBE => getResourcesInRect
    IT => should wait until ready-scan
      ✗ expected true to be false
      AssertionError@node_modules/chai/chai.js:9449:22
      assert@node_modules/chai/chai.js:239:31
      node_modules/chai/chai.js:1056:16
      propertyGetter@node_modules/chai/chai.js:7899:33
      doAsserterAsyncAndAddThen@/tmp/node_modules/chai-as-promised/lib/chai-as-promised.js:289 <- /tmp/70cf918aa35ec632d1bd885b819c37db.browserify.js:33742:27
      /tmp/node_modules/chai-as-promised/lib/chai-as-promised.js:280 <- /tmp/70cf918aa35ec632d1bd885b819c37db.browserify.js:33733:68
      overwritingPropertyGetter@node_modules/chai/chai.js:9134:41
      get@[native code]
      proxyGetter@node_modules/chai/chai.js:9247:25
      /home/travis/build/ampproject/amphtml/test/unit/test-resources.js:1554:48 <- /tmp/70cf918aa35ec632d1bd885b819c37db.browserify.js:153156:48
```