### PR TITLE
Remove pointer-events from story ads UI.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -65,6 +65,7 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   height: 24px !important;
   left: 0 !important;
   padding: 14px 0 0 !important;
+  pointer-events: none !important;
   position: absolute !important;
   top: 0 !important;
   z-index: 100001 !important;


### PR DESCRIPTION
This PR removes pointer-events from story ads UI. They prevent users from clicking the page to navigate, and also happen to come on top of the button to close the page attachment.

![image](https://user-images.githubusercontent.com/1492044/53514291-688b2b80-3a95-11e9-9528-875544cd9e85.png)
