### PR TITLE
Reset the page attachment history state when it gets closed.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -24,6 +24,7 @@ import {CSS} from '../../../build/amp-story-page-attachment-header-1.0.css';
 import {
   HistoryState,
   createShadowRootWithStyle,
+  setHistoryState,
 } from './utils';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
@@ -497,5 +498,7 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
       setTimeout(
           () => toggle(dev().assertElement(this.containerEl_), false), 250);
     });
+
+    setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
   }
 }


### PR DESCRIPTION
Reset the page attachment history state when it gets closed. Otherwise, reloading the page would always open the attachment, even if it got closed. :(