### PR TITLE
🏗 Reduce number of parallel tabs in visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -54,7 +54,7 @@ const HOST = 'localhost';
 const PORT = 8000;
 const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 3000;
-const MAX_PARALLEL_TABS = 20;
+const MAX_PARALLEL_TABS = 10;
 const WAIT_FOR_TABS_MS = 1000;
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
 


### PR DESCRIPTION
This might be related to #21056