### PR TITLE
🏗🐛 Assorted bug fixes for PR check code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
   - pip install urllib3[secure]
   - pip install gsutil --user
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 branches:
   only:
     - master

--- a/build-system/pr-check/dist-tests.js
+++ b/build-system/pr-check/dist-tests.js
@@ -49,6 +49,7 @@ function main() {
   const buildTargets = determineBuildTargets();
 
   if (!isTravisPullRequestBuild()) {
+    timedExecOrDie('gulp update-packages');
     downloadDistOutput();
     timedExecOrDie('gulp bundle-size --on_push_build');
     runSinglePassTest_();

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -43,7 +43,7 @@ function main() {
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    timedExecOrDie('gulp test --integration --nobuild --coverage');
+    timedExecOrDie('gulp test --integration --nobuild --headless --coverage');
     timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
     //TODO(estherkim): turn on when stabilized :)
     //timedExecOrDie('gulp e2e --nobuild');

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -44,8 +44,8 @@ async function main() {
   const buildTargets = determineBuildTargets();
 
   if (!isTravisPullRequestBuild()) {
-    downloadBuildOutput(FILENAME);
     downloadDistOutput(FILENAME);
+    timedExecOrDie('gulp update-packages');
 
     await startSauceConnect(FILENAME);
     timedExecOrDie('gulp test --unit --nobuild --saucelabs_lite');

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -43,6 +43,7 @@ function main() {
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
+    timedExecOrDie('gulp update-packages');
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     timedExecOrDie('gulp visual-diff --nobuild --master');
   } else {
@@ -55,6 +56,7 @@ function main() {
         buildTargets.has('FLAG_CONFIG')) {
 
       downloadBuildOutput(FILENAME);
+      timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp visual-diff --nobuild');
     } else {
       timedExecOrDie('gulp visual-diff --nobuild --empty');

--- a/package.json
+++ b/package.json
@@ -198,7 +198,9 @@
       "/node_modules/"
     ],
     "testEnvironment": "node",
-    "setupTestFrameworkScriptFile": "./build-system/babel-plugins/testSetupFile.js",
+    "setupFilesAfterEnv": [
+      "./build-system/babel-plugins/testSetupFile.js"
+    ],
     "transformIgnorePatterns": [
       "/node_modules/"
     ],


### PR DESCRIPTION
This PR fixes a few bugs and makes a few optimizations in `build-system/pr-check/` (that I discovered while doing build cop duties this week).

- Ensures that `gulp update-packages` is called on every job after a `build` or `dist` output is downloaded (fixes errors like [this](https://travis-ci.org/ampproject/amphtml/jobs/499305564#L2366) and [this](https://travis-ci.org/ampproject/amphtml/jobs/499468258#L1409))
- Prints the PR summary at the start (instead of in the middle) during the `Checks` job ([example](https://travis-ci.org/ampproject/amphtml/jobs/499460329#L698))
- Reorganizes the `Checks` job to make sure faster running checks run first, and fixes a few incorrect build target conditions
- Runs all local Chrome tests in `--headless` mode, and removes the step that installs a virtual frame buffer (`xvfb`)
- No longer downloads both the `build` and `dist` output in `remote-tests.js` (they overwrite one another)
- Fixes a deprecation warning in `jest` ([example](https://travis-ci.org/ampproject/amphtml/jobs/499460329#L740))