### PR TITLE
Adjust `amp-list` container height for both load-end and load-failed elements

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -707,49 +707,53 @@ export class AmpList extends AMP.BaseElement {
     if (this.element.getAttribute('layout') == Layout.CONTAINER) {
       return;
     }
-    this.measureElement(() => {
-      const targetHeight = target./*OK*/scrollHeight;
-      const height = this.element./*OK*/offsetHeight;
-      this.loadMoreEnabledPromise_.then(enabled => {
-        if (enabled) {
-          this.attemptToFitLoadMoreElements_(targetHeight, height);
-        } else {
+    this.loadMoreEnabledPromise_.then(enabled => {
+      if (enabled) {
+        const element = !!this.loadMoreSrc_ ?
+          this.loadMoreService_.getLoadMoreButton() :
+          this.loadMoreService_.getLoadMoreEndElement();
+        this.attemptToFitLoadMoreElement_(element, target);
+      } else {
+        this.measureElement(() => {
+          const targetHeight = target./*OK*/scrollHeight;
+          const height = this.element./*OK*/offsetHeight;
           if (targetHeight > height) {
             this.attemptChangeHeight(targetHeight).catch(() => {});
           }
-        }
-      });
+        });
+      }
     });
   }
 
   /**
-   * @param {number} targetHeight
-   * @param {number} height
+   * @param {?Element} element
+   * @param {!Element} target
    * @private
    */
-  attemptToFitLoadMoreElements_(targetHeight, height) {
-    const loadMoreElement = !!this.loadMoreSrc_ ?
-      this.loadMoreService_.getLoadMoreButton() :
-      this.loadMoreService_.getLoadMoreEndElement();
-    const loadMoreHeight = loadMoreElement./*OK*/offsetHeight;
-    if (targetHeight + loadMoreHeight > height) {
-      this.attemptChangeHeight(targetHeight + loadMoreHeight)
-          .then(() => {
-            this.resizeFailed_ = false;
-            // If there were not enough items to fill the list, consider
-            // automatically loading more if load-more="auto" is enabled
-            if (this.element.getAttribute('load-more') === 'auto') {
-              this.maybeLoadMoreItems_();
-            }
-            setStyles(dev().assertElement(this.container_), {
-              'max-height': '',
+  attemptToFitLoadMoreElement_(element, target) {
+    this.measureElement(() => {
+      const targetHeight = target./*OK*/scrollHeight;
+      const height = this.element./*OK*/offsetHeight;
+      const loadMoreHeight = element ? element./*OK*/offsetHeight : 0;
+      if (targetHeight + loadMoreHeight > height) {
+        this.attemptChangeHeight(targetHeight + loadMoreHeight)
+            .then(() => {
+              this.resizeFailed_ = false;
+              // If there were not enough items to fill the list, consider
+              // automatically loading more if load-more="auto" is enabled
+              if (this.element.getAttribute('load-more') === 'auto') {
+                this.maybeLoadMoreItems_();
+              }
+              setStyles(dev().assertElement(this.container_), {
+                'max-height': '',
+              });
+            })
+            .catch(() => {
+              this.resizeFailed_ = true;
+              this.adjustContainerForLoadMoreButton_();
             });
-          })
-          .catch(() => {
-            this.resizeFailed_ = true;
-            this.adjustContainerForLoadMoreButton_();
-          });
-    }
+      }
+    });
   }
 
   /**
@@ -894,14 +898,18 @@ export class AmpList extends AMP.BaseElement {
             this.unlistenLoadMore_ = null;
           }
         }).catch(() => {
-          this.mutateElement(() => {
-            this.loadMoreService_.setLoadMoreFailed();
-          });
-          const loadMoreFailedClickable = this.loadMoreService_
-              .getLoadMoreFailedClickable();
-          this.unlistenLoadMore_ = listen(
-              loadMoreFailedClickable,
-              'click', () => this.loadMoreCallback_(/*opt_reload*/ true));
+          this.mutateElement(() => this.loadMoreService_.setLoadMoreFailed())
+              .then(() => {
+                this.attemptToFitLoadMoreElement_(
+                    this.loadMoreService_.getLoadMoreFailedElement(),
+                    dev().assertElement(this.container_));
+              }).then(() => {
+                const loadMoreFailedClickable = this.loadMoreService_
+                    .getLoadMoreFailedClickable();
+                this.unlistenLoadMore_ = listen(
+                    loadMoreFailedClickable,
+                    'click', () => this.loadMoreCallback_(/*opt_reload*/ true));
+              });
         });
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -903,7 +903,6 @@ export class AmpList extends AMP.BaseElement {
                 this.attemptToFitLoadMoreElement_(
                     this.loadMoreService_.getLoadMoreFailedElement(),
                     dev().assertElement(this.container_));
-              }).then(() => {
                 const loadMoreFailedClickable = this.loadMoreService_
                     .getLoadMoreFailedClickable();
                 this.unlistenLoadMore_ = listen(

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -728,8 +728,10 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   attemptToFitLoadMoreElements_(targetHeight, height) {
-    const loadMoreHeight = this.loadMoreService_
-        .getLoadMoreButton()./*OK*/offsetHeight;
+    const loadMoreElement = !!this.loadMoreSrc_ ?
+      this.loadMoreService_.getLoadMoreButton() :
+      this.loadMoreService_.getLoadMoreEndElement();
+    const loadMoreHeight = loadMoreElement./*OK*/offsetHeight;
     if (targetHeight + loadMoreHeight > height) {
       this.attemptChangeHeight(targetHeight + loadMoreHeight)
           .then(() => {

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -56,6 +56,12 @@
       height: auto;
     }
 
+    amp-list-load-more[load-more-end] {
+      height: 100vh;
+      width: 100%;
+      background-color: red;
+    }
+
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -109,7 +115,7 @@
 
   <amp-list width="auto" height="400"
     layout="fixed-height"
-    src="/infinite-scroll?items=2&left=20"
+    src="/infinite-scroll?items=2&left=2"
     [src]="data.url"
     load-more="manual"
     load-more-bookmark="next">
@@ -125,6 +131,9 @@
     <div fallback>
       FALLBACK
     </div>
+    <amp-list-load-more load-more-end>
+
+    </amp-list-load-more>
   </amp-list>
 </article>
 </body>

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -56,7 +56,7 @@
       height: auto;
     }
 
-    amp-list-load-more[load-more-end] {
+    amp-list-load-more[load-more-failed] {
       height: 100vh;
       width: 100%;
       background-color: red;
@@ -131,7 +131,7 @@
     <div fallback>
       FALLBACK
     </div>
-    <amp-list-load-more load-more-end>
+    <amp-list-load-more load-more-failed>
 
     </amp-list-load-more>
   </amp-list>


### PR DESCRIPTION
Since it's sometimes the case that the `load-more-button`, `load-more-failed`, and `load-more-end` elements will have different height. 