### PR TITLE
✨🐛RE_3:Add support for CAaja ads network

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -271,7 +271,6 @@ import {speakol} from '../ads/speakol';
  * @const {!Object<string, boolean>}
  */
 const AMP_EMBED_ALLOWED = {
-  aja: true,
   _ping_: true,
   '24smi': true,
   bringhub: true,

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -269,7 +269,6 @@ export const adConfig = {
   },
 
   'aja': {
-    renderStartImplemented: true,
   },
 
   'appvador': {

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -270,7 +270,6 @@ export const adConfig = {
 
   'aja': {
     renderStartImplemented: true,
-    prefetch: 'https://cdn.as.amanad.adtdp.com/sdk/asot-v2.js',
   },
 
   'appvador': {

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -270,6 +270,7 @@ export const adConfig = {
 
   'aja': {
     renderStartImplemented: true,
+    prefetch: 'https://cdn.as.amanad.adtdp.com/sdk/asot-v2.js',
   },
 
   'appvador': {

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {writeScript, validateData} from '../3p/3p';
+import {validateData, writeScript} from '../3p/3p';
 
 /**
  * @param {!Window} global

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {validateData, writeScript} from '../3p/3p';
+import {validateData} from '../3p/3p';
 
 /**
  * @param {!Window} global
@@ -28,6 +28,16 @@ export function aja(global, data) {
     sspCode: data['sspCode'],
   });
 
-  const url = 'https://static.aja-recommend.com/html/amp.html?ssp_code=' + encodeURIComponent(data['sspCode']);
-  writeScript(global,url);
+  const elStyle = global.document.createElement('iframe');
+  elStyle.setAttribute('id', 'adframe');
+  elStyle.setAttribute('width', data.width);
+  elStyle.setAttribute('height', data.height);
+  elStyle.setAttribute('frameborder', '0');
+  elStyle.setAttribute('marginheight', '0');
+  elStyle.setAttribute('marginwidth', '0');
+  elStyle.setAttribute('allowfullscreen', 'true');
+  elStyle.setAttribute('scrolling', 'no');
+  elStyle.src = 'https://static.aja-recommend.com/html/amp.html?ssp_code=' + encodeURIComponent(data['sspCode']);
+  global.document.body.appendChild(elStyle);
+
 }

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -22,7 +22,7 @@ import {validateData, writeScript} from '../3p/3p';
  */
 export function aja(global, data) {
 
-  validateData(data, ['sspCode'])
+  validateData(data, ['sspCode']);
 
   (global._aja = global._aja || {
     sspCode: data['sspCode'],

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {loadScript, validateData} from '../3p/3p';
+import {writeScript} from '../3p/3p';
 
 /**
  * @param {!Window} global
@@ -22,20 +22,10 @@ import {loadScript, validateData} from '../3p/3p';
  */
 export function aja(global, data) {
 
-  // ensure we have valid widgetIds value
-  validateData(data, ['widgetids']);
-
-  (global._aja = global._aja || {
-    viewId: global.context.pageViewId,
-    widgetIds: data['widgetids'],
-    htmlURL: data['htmlurl'] || global.context.canonicalUrl,
-    ampURL: data['ampurl'] || global.context.sourceUrl,
-    fbk: data['fbk'] || '',
-    testMode: data['testmode'] || 'false',
-    styleFile: data['stylefile'] || '',
-    referrer: data['referrer'] || global.context.referrer,
+  (global._caaja = global._caaja || {
+    sspCode: data['sspCode'],
   });
 
-  // load the Aja AMP JS file
-  loadScript(global, 'https://cdn.as.amanad.adtdp.com/sdk/asot-v2.js');
+  const url = 'https://static.aja-recommend.com/html/amp.html?ssp_code=' + encodeURIComponent(data['sspCode']);
+  writeScript(global,url);
 }

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import {writeScript} from '../3p/3p';
+import {writeScript, validateData} from '../3p/3p';
 
 /**
  * @param {!Window} global
  * @param {!Object} data
  */
 export function aja(global, data) {
+
+  validateData(data, ['sspCode'])
 
   (global._aja = global._aja || {
     sspCode: data['sspCode'],

--- a/ads/aja.js
+++ b/ads/aja.js
@@ -22,7 +22,7 @@ import {writeScript} from '../3p/3p';
  */
 export function aja(global, data) {
 
-  (global._caaja = global._caaja || {
+  (global._aja = global._aja || {
     sspCode: data['sspCode'],
   });
 

--- a/ads/aja.md
+++ b/ads/aja.md
@@ -37,4 +37,4 @@ do not directly install this code with existing widgets.
 Supported parameters:
 
 - SSPCODE
-  - `data-aja-ssp-asi`
+  - `data-ssp-code`

--- a/ads/aja.md
+++ b/ads/aja.md
@@ -21,11 +21,11 @@ limitations under the License.
 ### Basic
 
 ```html
-  <amp-embed width="100" height="100"
+  <amp-ad width="100" height="100"
              type="aja"
              layout="responsive"
              data-media-id="ZZZZZ">
-  </amp-embed>
+  </amp-ad>
 ```
 
 The above code must be accompanied by AMP-enabled widgets delivered by Aja’s Account Management Team,

--- a/ads/aja.md
+++ b/ads/aja.md
@@ -24,7 +24,7 @@ limitations under the License.
   <amp-ad width="100" height="100"
              type="aja"
              layout="responsive"
-             data-media-id="ZZZZZ">
+             data-ssp-code="ZZZZZ">
   </amp-ad>
 ```
 

--- a/ads/aja.md
+++ b/ads/aja.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,26 +24,17 @@ limitations under the License.
   <amp-embed width="100" height="100"
              type="aja"
              layout="responsive"
-             data-widgetIds="AMP_1,AMP_2">
+             data-media-id="ZZZZZ">
   </amp-embed>
 ```
 
 The above code must be accompanied by AMP-enabled widgets delivered by Aja’s Account Management Team,
 do not directly install this code with existing widgets.
 
-## Parameters
 
-- widgetIds *(**mandatory**)* - Widget Id/s Provided by Account Manager.
-- htmlURL *(optional)* - The URL of the standard html version of the page.
-- ampURL *(optional)* - The URL of the AMP version of the page.
-- styleFile *(optional)* - Provide publisher an option to pass CSS file in order to inherit the design for the AMP displayed widget. **Consult with Account Manager regarding CSS options**.
+## Configuration
 
-## Troubleshooting
+Supported parameters:
 
-### Widget is cut off
-
-According to the AMP API, "resizes are honored when the resize will not adjust the content the user is currently reading.  That is, if the ad is above the viewport's contents, it'll resize. Same if it's below. If it's in the viewport, it ignores it."
-
-**Resolution**
-
- You can set an initial height of what the widget height is supposed to be. That is, instead of ```height="100"```, if the widget's final height is 600px, then set ```height="600"```. Setting the initial height ***will not*** finalize the widget height if it's different from the actual. The widget will resize to it's true dimensions after the widget leaves the viewport.
+- SSPCODE
+  - `data-aja-ssp-asi`

--- a/ads/aja.md
+++ b/ads/aja.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -644,16 +644,11 @@
   </amp-ad>
 
   <h2>AJA</h2>
-  <amp-embed width="100" height="100"
+  <amp-ad width="300" height="250"
       type="aja"
       layout="responsive"
-      data-widgetIds="SB_14,SB_13"
-      data-htmlURL="http%3A%2F%2Fedition.cnn.com%2F2015%2F11%2F08%2Fmiddleeast%2Frussian-plane-crash-egypt-sinai%2Findex.html"
-      data-referrer="http%3A%2F%2Fedition.cnn.com"
-      data-ampURL="http%3A%2F%2Famp.cnn.com%2Fpage.html"
-      data-styleFile="http://localhost/style.css"
-      data-testMode="true">
-  </amp-embed>
+      data-ssp-code="zR52u3bkg">
+  </amp-ad>
 
   <h2>AMoAd banner</h2>
   <amp-ad width="300" height="250"


### PR DESCRIPTION
Adds support for CAaja ads network.

Hello.
We are A.J.A., a subsidiary of CyberAgent which provides ad-network service in Japan. (https://www.cyberagent.co.jp/) CA
(https://aja-kk.co.jp/) AJA
We'd like to add support to amp-ad.

Thanks.

previous↓
#21067