### PR TITLE
🐛  amp-video-iframe: add `allow-popups` to sandbox

### DIFF
--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -26,6 +26,7 @@ import {tryParseJson} from './json';
 export const SandboxOptions = {
   ALLOW_SCRIPTS: 'allow-scripts',
   ALLOW_SAME_ORIGIN: 'allow-same-origin',
+  ALLOW_POPUPS: 'allow-popups',
   ALLOW_POPUPS_TO_ESCAPE_SANDBOX: 'allow-popups-to-escape-sandbox',
   ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION:
     'allow-top-navigation-by-user-activation',


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/21179 reminded me that we also need `allow-popups`  in addition to 'allow-popups-to-escape-sandbox' ( 'allow-popups-to-escape-sandbox' is Chrome only)

