### PR TITLE
🐛 amp-video-iframe: add `allow-popups` to sandbox

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -290,8 +290,8 @@ export class AmpAnimation extends AMP.BaseElement {
     this.triggered_ = true;
     this.hasPositionObserver_ = !!invocation.caller &&
       invocation.caller.tagName === 'AMP-POSITION-OBSERVER';
-    const viewportData = (invocation && invocation.event) ?
-      invocation.event.additionalViewportData : null;
+    const viewportData = (invocation.event && invocation.event.detail) ?
+      invocation.event.detail.additionalViewportData : null;
     return this.createRunnerIfNeeded_(null, viewportData).then(() => {
       this.pause_();
       this.pausedByAction_ = true;

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -27,7 +27,7 @@ import {getFriendlyIframeEmbedOptional}
 import {getParentWindowFrameElement} from '../../../src/service';
 import {installWebAnimationsIfNecessary} from './web-animations-polyfill';
 import {isFiniteNumber} from '../../../src/types';
-import {listen} from '../../../src/event-helper';
+import {getDetail, listen} from '../../../src/event-helper';
 import {setInitialDisplay, setStyles, toggle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
 import {user, userAssert} from '../../../src/log';
@@ -67,9 +67,6 @@ export class AmpAnimation extends AMP.BaseElement {
 
     /** @private {?Pass} */
     this.restartPass_ = null;
-
-    /** @private {boolean} */
-    this.hasPositionObserver_ = false;
   }
 
   /** @override */
@@ -288,11 +285,16 @@ export class AmpAnimation extends AMP.BaseElement {
     // The animation will be triggered (in paused state) and seek will happen
     // regardless of visibility
     this.triggered_ = true;
-    this.hasPositionObserver_ = !!invocation.caller &&
-      invocation.caller.tagName === 'AMP-POSITION-OBSERVER';
-    const viewportData = (invocation.event && invocation.event.detail) ?
-      invocation.event.detail.additionalViewportData : null;
-    return this.createRunnerIfNeeded_(null, viewportData).then(() => {
+
+    let positionObserverData = null;
+    if (invocation.event) {
+      const detail = getDetail(/** @type {!Event} */(invocation.event));
+      if (detail) {
+        positionObserverData = detail['positionObserverData'] || null;
+      }
+    }
+
+    return this.createRunnerIfNeeded_(null, positionObserverData).then(() => {
       this.pause_();
       this.pausedByAction_ = true;
       // time based seek
@@ -407,14 +409,14 @@ export class AmpAnimation extends AMP.BaseElement {
   /**
    * Creates the runner but animations will not start.
    * @param {?JsonObject=} opt_args
-   * @param {?Object=} opt_viewportData
+   * @param {?JsonObject=} opt_positionObserverData
    * @return {!Promise}
    * @private
    */
-  createRunnerIfNeeded_(opt_args, opt_viewportData) {
+  createRunnerIfNeeded_(opt_args, opt_positionObserverData) {
     if (!this.runnerPromise_) {
       this.runnerPromise_ = this.createRunner_(
-          opt_args, opt_viewportData).then(runner => {
+          opt_args, opt_positionObserverData).then(runner => {
         this.runner_ = runner;
         this.runner_.onPlayStateChanged(this.playStateChanged_.bind(this));
         this.runner_.init();
@@ -448,11 +450,11 @@ export class AmpAnimation extends AMP.BaseElement {
 
   /**
    * @param {?JsonObject=} opt_args
-   * @param {?Object=} opt_viewportData
+   * @param {?JsonObject=} opt_positionObserverData
    * @return {!Promise<!./runners/animation-runner.AnimationRunner>}
    * @private
    */
-  createRunner_(opt_args, opt_viewportData) {
+  createRunner_(opt_args, opt_positionObserverData) {
     // Force cast to `WebAnimationDef`. It will be validated during preparation
     // phase.
     const configJson = /** @type {!./web-animation-types.WebAnimationDef} */ (
@@ -475,8 +477,7 @@ export class AmpAnimation extends AMP.BaseElement {
           baseUrl,
           this.getVsync(),
           this.element.getResources());
-      return builder.createRunner(configJson,
-          this.hasPositionObserver_, args, opt_viewportData);
+      return builder.createRunner(configJson, args, opt_positionObserverData);
     });
   }
 

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -22,12 +22,12 @@ import {WebAnimationPlayState} from './web-animation-types';
 import {WebAnimationService} from './web-animation-service';
 import {childElementByTag} from '../../../src/dom';
 import {clamp} from '../../../src/utils/math';
+import {getDetail, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional}
   from '../../../src/friendly-iframe-embed';
 import {getParentWindowFrameElement} from '../../../src/service';
 import {installWebAnimationsIfNecessary} from './web-animations-polyfill';
 import {isFiniteNumber} from '../../../src/types';
-import {getDetail, listen} from '../../../src/event-helper';
 import {setInitialDisplay, setStyles, toggle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
 import {user, userAssert} from '../../../src/log';

--- a/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
+++ b/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
@@ -180,7 +180,7 @@ export class NativeWebAnimationRunner extends AnimationRunner {
    */
   seekToPercent(percent) {
     devAssert(percent >= 0 && percent <= 1);
-    const totalDuration = getTotalDuration(this.requests_);
+    const totalDuration = this.getTotalDuration_();
     const time = totalDuration * percent;
     this.seekTo(time);
   }
@@ -224,5 +224,12 @@ export class NativeWebAnimationRunner extends AnimationRunner {
     }
   }
 
+  /**
+   * @return {number} total duration in milliseconds.
+   * @throws {Error} If timeline is infinite.
+   */
+  getTotalDuration_() {
+    return getTotalDuration(this.requests_);
+  }
 
 }

--- a/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
+++ b/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
@@ -32,7 +32,8 @@ import {
   assertDoesNotContainDisplay,
   setStyles,
 } from '../../../../src/style';
-import {devAssert, userAssert} from '../../../../src/log';
+import {devAssert} from '../../../../src/log';
+import {getTotalDuration} from './utils';
 
 /**
  */
@@ -179,7 +180,7 @@ export class NativeWebAnimationRunner extends AnimationRunner {
    */
   seekToPercent(percent) {
     devAssert(percent >= 0 && percent <= 1);
-    const totalDuration = this.getTotalDuration_();
+    const totalDuration = getTotalDuration(this.requests_);
     const time = totalDuration * percent;
     this.seekTo(time);
   }
@@ -223,28 +224,5 @@ export class NativeWebAnimationRunner extends AnimationRunner {
     }
   }
 
-  /**
-   * @return {number} total duration in milliseconds.
-   * @throws {Error} If timeline is infinite.
-   */
-  getTotalDuration_() {
-    let maxTotalDuration = 0;
-    for (let i = 0; i < this.requests_.length; i++) {
-      const {timing} = this.requests_[i];
 
-      userAssert(isFinite(timing.iterations), 'Animation has infinite ' +
-      'timeline, we can not seek to a relative position within an infinite ' +
-      'timeline. Use "time" for seekTo or remove infinite iterations');
-
-      const iteration = timing.iterations - timing.iterationStart;
-      const totalDuration = (timing.duration * iteration) +
-          timing.delay + timing.endDelay;
-
-      if (totalDuration > maxTotalDuration) {
-        maxTotalDuration = totalDuration;
-      }
-    }
-
-    return maxTotalDuration;
-  }
 }

--- a/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
+++ b/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
@@ -21,6 +21,7 @@ import {
   setStyles,
 } from '../../../../src/style';
 import {dev} from '../../../../src/log';
+import {getTotalDuration} from './utils';
 
 const moduleName = 'amp-animation-worklet';
 let workletModulePromise;
@@ -44,17 +45,13 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
     this.players_ = [];
 
     /** @private {number} */
-    this.topRatio_ = viewportData['top-ratio'];
+    this.startScrollOffset_ = viewportData['start-scroll-offset'];
 
     /** @private {number} */
-    this.bottomRatio_ = viewportData['bottom-ratio'];
+    this.endScrollOffset_ = viewportData['end-scroll-offset'];
 
     /** @private {number} */
-    this.topMargin_ = viewportData['top-margin'];
-
-    /** @private {number} */
-    this.bottomMargin_ =
-      viewportData['bottom-margin'];
+    this.initialInViewPercent_ = viewportData['initial-inview-percent'];
   }
 
   /**
@@ -62,39 +59,35 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
   * Initializes the players but does not change the state.
    */
   init() {
+    const {documentElement} = this.win_.document;
+    const viewportService = Services.viewportForDoc(documentElement);
+    const scrollSource = viewportService.getScrollingElement();
+
+    const timeRange = getTotalDuration(this.requests_);
+    const adjustedTimeRange = (1 - this.initialInViewPercent_) * timeRange;
+    const initialElementOffset = this.initialInViewPercent_ * timeRange;
+
     this.requests_.map(request => {
       // Apply vars.
       if (request.vars) {
         setStyles(request.target,
             assertDoesNotContainDisplay(request.vars));
       }
-      // TODO(nainar): This switches all animations to AnimationWorklet.
-      // Limit only to Scroll based animations for now.
       getOrAddWorkletModule(this.win_).then(() => {
-        const {documentElement} = this.win_.document;
-        const viewportService = Services.viewportForDoc(documentElement);
-
-        const scrollSource = viewportService.getScrollingElement();
-        const elementRect = request.target./*OK*/getBoundingClientRect();
         const scrollTimeline = new this.win_.ScrollTimeline({
           scrollSource,
           orientation: 'block',
-          timeRange: request.timing.duration,
-          startScrollOffset: `${this.topMargin_}px`,
-          endScrollOffset: `${this.bottomMargin_}px`,
-          fill: request.timing.fill,
+          startScrollOffset: `${this.startScrollOffset_}px`,
+          endScrollOffset: `${this.endScrollOffset_}px`,
+          timeRange: adjustedTimeRange,
+          fill: 'both',
         });
         const keyframeEffect = new KeyframeEffect(request.target,
             request.keyframes, request.timing);
         const player = new this.win_.WorkletAnimation(`${moduleName}`,
             [keyframeEffect],
             scrollTimeline, {
-              'time-range': request.timing.duration,
-              'start-offset': this.topMargin_,
-              'end-offset': this.bottomMargin_,
-              'top-ratio': this.topRatio_,
-              'bottom-ratio': this.bottomRatio_,
-              'element-height': elementRect.height,
+              'initial-element-offset': initialElementOffset,
             });
         player.play();
         this.players_.push(player);
@@ -140,46 +133,16 @@ function getOrAddWorkletModule(win) {
   const blob =
  `registerAnimator('${moduleName}', class {
     constructor(options = {
-      'time-range': 0,
-      'start-offset': 0,
-      'end-offset': 0,
-      'top-ratio': 0,
-      'bottom-ratio': 0,
-      'element-height': 0,
+      'current-element-offset': 0
     }) {
       console/*OK*/.info('Using animationWorklet ScrollTimeline');
-      this.timeRange = options['time-range'];
-      this.startOffset = options['start-offset'];
-      this.endOffset = options['end-offset'];
-      this.topRatio = options['top-ratio'];
-      this.bottomRatio = options['bottom-ratio'];
-      this.height = options['element-height'];
+      this.initialElementOffset_ = options['initial-element-offset'];
     }
     animate(currentTime, effect) {
       if (currentTime == NaN) {
         return;
       }
-       // This function mirrors updateVisibility_ in amp-position-observer
-      const currentScrollPos =
-      ((currentTime / this.timeRange) *
-      (this.endOffset - this.startOffset)) +
-      this.startOffset;
-      const halfViewport = (this.startOffset + this.endOffset) / 2;
-      const relativePositionTop = currentScrollPos > halfViewport;
-       const ratioToUse = relativePositionTop ?
-      this.topRatio : this.bottomRatio;
-      const offset = this.height * ratioToUse;
-      let isVisible = false;
-       if (relativePositionTop) {
-        isVisible =
-        currentScrollPos + this.height >= (this.startOffset + offset);
-      } else {
-        isVisible =
-        currentScrollPos <= (this.endOffset - offset);
-      }
-      if (isVisible) {
-        effect.localTime = currentTime;
-      }
+      effect.localTime = currentTime + this.initialElementOffset_;
     }
   });
   `;

--- a/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
+++ b/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
@@ -18,6 +18,7 @@ import {AnimationRunner} from './animation-runner';
 import {Services} from '../../../../src/services';
 import {
   assertDoesNotContainDisplay,
+  px,
   setStyles,
 } from '../../../../src/style';
 import {dev} from '../../../../src/log';
@@ -33,7 +34,7 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
   /**
    * @param {!Window} win
    * @param {!Array<!../web-animation-types.InternalWebAnimationRequestDef>} requests
-   * @param {?Object=} viewportData
+   * @param {!JsonObject} viewportData
    */
   constructor(win, requests, viewportData) {
     super(requests);
@@ -77,8 +78,8 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
         const scrollTimeline = new this.win_.ScrollTimeline({
           scrollSource,
           orientation: 'block',
-          startScrollOffset: `${this.startScrollOffset_}px`,
-          endScrollOffset: `${this.endScrollOffset_}px`,
+          startScrollOffset: `${px(this.startScrollOffset_)}`,
+          endScrollOffset: `${px(this.endScrollOffset_)}`,
           timeRange: adjustedTimeRange,
           fill: 'both',
         });

--- a/extensions/amp-animation/0.1/runners/utils.js
+++ b/extensions/amp-animation/0.1/runners/utils.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {userAssert} from '../../../../src/log';
+
+/**
+ * @param {!Array<!../web-animation-types.InternalWebAnimationRequestDef>} requests
+ * @return {number} total duration in milliseconds.
+ * @throws {Error} If timeline is infinite.
+ */
+export function getTotalDuration(requests) {
+  let maxTotalDuration = 0;
+  for (let i = 0; i < requests.length; i++) {
+    const {timing} = requests[i];
+
+    userAssert(isFinite(timing.iterations), 'Animation has infinite ' +
+    'timeline, we can not seek to a relative position within an infinite ' +
+    'timeline. Use "time" for seekTo or remove infinite iterations');
+
+    const iteration = timing.iterations - timing.iterationStart;
+    const totalDuration = (timing.duration * iteration) +
+        timing.delay + timing.endDelay;
+
+    if (totalDuration > maxTotalDuration) {
+      maxTotalDuration = totalDuration;
+    }
+  }
+
+  return maxTotalDuration;
+}

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -182,7 +182,8 @@ export class Builder {
     /** @private {boolean} */
     this.useAnimationWorklet_ =
       isExperimentOn(this.win_, 'chrome-animation-worklet') &&
-      'animationWorklet' in CSS;
+      'animationWorklet' in CSS &&
+      getMode(win).runtime != 'inabox';
   }
 
   /**

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -185,21 +185,20 @@ export class Builder {
    * Creates the animation runner for the provided spec. Waits for all
    * necessary resources to be loaded before the runner is resolved.
    * @param {!WebAnimationDef|!Array<!WebAnimationDef>} spec
-   * @param {boolean=} hasPositionObserver
    * @param {?WebAnimationDef=} opt_args
-   * @param {?Object=} opt_viewportData
+   * @param {?JsonObject=} opt_positionObserverData
    * @return {!Promise<!./runners/animation-runner.AnimationRunner>}
    */
-  createRunner(spec, hasPositionObserver = false, opt_args,
-    opt_viewportData = null) {
+  createRunner(spec, opt_args,
+    opt_positionObserverData = null) {
     return this.resolveRequests([], spec, opt_args).then(requests => {
       if (getMode().localDev || getMode().development) {
         user().fine(TAG, 'Animation: ', requests);
       }
       return Promise.all(this.loaders_).then(() => {
-        return this.isAnimationWorkletSupported_() && hasPositionObserver ?
+        return this.isAnimationWorkletSupported_() && opt_positionObserverData ?
           new ScrollTimelineWorkletRunner(this.win_, requests,
-              opt_viewportData) :
+              opt_positionObserverData) :
           new NativeWebAnimationRunner(requests);
       });
     });

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -35,7 +35,6 @@ import {NativeWebAnimationRunner} from './runners/native-web-animation-runner';
 import {
   ScrollTimelineWorkletRunner,
 } from './runners/scrolltimeline-worklet-runner';
-import {Services} from '../../../src/services';
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
 import {closestAncestorElementBySelector, matches} from '../../../src/dom';
 import {
@@ -182,7 +181,6 @@ export class Builder {
 
     /** @private {boolean} */
     this.useAnimationWorklet_ =
-      Services.platformFor(this.win_).isChrome() &&
       isExperimentOn(this.win_, 'chrome-animation-worklet') &&
       'animationWorklet' in CSS;
   }

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -37,6 +37,7 @@ import {getServiceForDoc} from '../../../src/service';
 import {
   installPositionObserverServiceForDoc,
 } from '../../../src/service/position-observer/position-observer-impl';
+import {dict} from '../../../src/utils/object';
 
 const TAG = 'amp-position-observer';
 
@@ -237,11 +238,11 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     if (this.isVisible_) {
       this.updateScrollProgress_(positionRect, adjViewportRect);
       const scrolltop = this.viewport_.getScrollTop();
-      const additionalViewportData = {
+      const additionalViewportData = dict({
         'start-scroll-offset': scrolltop,
         'end-scroll-offset': scrolltop + this.remainingScrollToExit_,
         'initial-inview-percent': this.scrollProgress_,
-      };
+      });
       this.triggerScroll_(additionalViewportData);
     }
   }

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -37,7 +37,6 @@ import {getServiceForDoc} from '../../../src/service';
 import {
   installPositionObserverServiceForDoc,
 } from '../../../src/service/position-observer/position-observer-impl';
-import {dict} from '../../../src/utils/object';
 
 const TAG = 'amp-position-observer';
 

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -161,15 +161,20 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * This event is triggered only when position-observer triggers which is
    * at most every animation frame.
    *
-   * @param {?JsonObject} additionalViewportData additional viewport related data to send with the event.
    * @private
    */
-  triggerScroll_(additionalViewportData = null) {
+  triggerScroll_() {
+    const scrolltop = this.viewport_.getScrollTop();
+    const positionObserverData = dict({
+      'start-scroll-offset': scrolltop,
+      'end-scroll-offset': scrolltop + this.remainingScrollToExit_,
+      'initial-inview-percent': this.scrollProgress_,
+    });
     const name = 'scroll';
     const event = createCustomEvent(this.win, `${TAG}.${name}`,
         dict({
           'percent': this.scrollProgress_,
-          'additionalViewportData': additionalViewportData}
+          'positionObserverData': positionObserverData}
         ));
     this.action_.trigger(this.element, name, event, ActionTrust.LOW);
     // TODO(nainar): We want to remove the position observer if the scroll
@@ -236,13 +241,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     // Send scroll progress if visible.
     if (this.isVisible_) {
       this.updateScrollProgress_(positionRect, adjViewportRect);
-      const scrolltop = this.viewport_.getScrollTop();
-      const additionalViewportData = dict({
-        'start-scroll-offset': scrolltop,
-        'end-scroll-offset': scrolltop + this.remainingScrollToExit_,
-        'initial-inview-percent': this.scrollProgress_,
-      });
-      this.triggerScroll_(additionalViewportData);
+      this.triggerScroll_();
     }
   }
 

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -59,11 +59,14 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {boolean} */
-    this.isVisible_ = false;
-
     /** @private {?../../../src/service/position-observer/position-observer-impl.PositionObserver} */
     this.positionObserver_ = null;
+
+    /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = null;
+
+    /** @private {boolean} */
+    this.isVisible_ = false;
 
     /** @private {number} */
     this.topRatio_ = 0;
@@ -95,6 +98,9 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     /** @private {number} */
     this.scrollProgress_ = 0;
 
+    /** @private {number} */
+    this.remainingScrollToExit_ = 0;
+
     /** @private {boolean} */
     this.runOnce_ = false;
 
@@ -119,6 +125,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
   init_() {
     this.parseAttributes_();
     this.action_ = Services.actionServiceForDoc(this.element);
+    this.viewport_ = Services.viewportForDoc(this.element);
     this.maybeInstallPositionObserver_();
     this.getAmpDoc().whenReady().then(() => {
       const scene = this.discoverScene_();
@@ -154,19 +161,16 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * This event is triggered only when position-observer triggers which is
    * at most every animation frame.
    *
-   * @param {!../../../src/layout-rect.LayoutRectDef} adjustedViewportRect viewport rect adjusted for margins.
+   * @param {?JsonObject} additionalViewportData additional viewport related data to send with the event.
    * @private
    */
-  triggerScroll_(adjustedViewportRect) {
+  triggerScroll_(additionalViewportData = null) {
     const name = 'scroll';
     const event = createCustomEvent(this.win, `${TAG}.${name}`,
-        dict({'percent': this.scrollProgress_}));
-    event.additionalViewportData = {
-      'top-ratio': this.topRatio_,
-      'bottom-ratio': this.bottomRatio_,
-      'top-margin': adjustedViewportRect.top,
-      'bottom-margin': adjustedViewportRect.bottom,
-    };
+        dict({
+          'percent': this.scrollProgress_,
+          'additionalViewportData': additionalViewportData}
+        ));
     this.action_.trigger(this.element, name, event, ActionTrust.LOW);
     // TODO(nainar): We want to remove the position observer if the scroll
     // event is only used by the AnimationWorklet codepath of amp-animation.
@@ -215,10 +219,12 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
       this.updateVisibility_(positionRect, adjViewportRect, relPos);
     }
 
+
+
     if (wasVisible && !this.isVisible_) {
       // Send final scroll progress state before exiting to handle fast-scroll.
       this.scrollProgress_ = relPos == RelativePositions.BOTTOM ? 0 : 1;
-      this.triggerScroll_(adjViewportRect);
+      this.triggerScroll_();
       this.triggerExit_();
       this.firstIterationComplete_ = true;
     }
@@ -230,7 +236,13 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     // Send scroll progress if visible.
     if (this.isVisible_) {
       this.updateScrollProgress_(positionRect, adjViewportRect);
-      this.triggerScroll_(adjViewportRect);
+      const scrolltop = this.viewport_.getScrollTop();
+      const additionalViewportData = {
+        'start-scroll-offset': scrolltop,
+        'end-scroll-offset': scrolltop + this.remainingScrollToExit_,
+        'initial-inview-percent': this.scrollProgress_,
+      };
+      this.triggerScroll_(additionalViewportData);
     }
   }
 
@@ -292,6 +304,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
     );
 
     this.scrollProgress_ = topOffset / totalProgress;
+    this.remainingScrollToExit_ = totalProgress - topOffset;
   }
 
   /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -627,5 +627,6 @@ export function whenContentIniLoad(elementOrAmpDoc, hostWin, rect) {
  * @return {boolean}
  */
 export function isInFie(element) {
-  return !!closestAncestorElementBySelector(element, '.i-amphtml-fie');
+  return element.classList.contains('i-amphtml-fie') ||
+    !!closestAncestorElementBySelector(element, '.i-amphtml-fie');
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -812,9 +812,6 @@ export class DeferredEvent {
     /** @type {?Object} */
     this.detail = null;
 
-    /** @type {?Object} */
-    this.additionalViewportData;
-
     cloneWithoutFunctions(event, this);
   }
 }


### PR DESCRIPTION
#21179 reminded me that we also need `allow-popups` in addition to 'allow-popups-to-escape-sandbox' ( 'allow-popups-to-escape-sandbox' is Chrome only)