### PR TITLE
🐛 amp-video-iframe: add `allow-popups` to sandbox

### DIFF
--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -53,6 +53,7 @@ const ANALYTICS_EVENT_TYPE_PREFIX = 'video-custom-';
 const SANDBOX = [
   SandboxOptions.ALLOW_SCRIPTS,
   SandboxOptions.ALLOW_SAME_ORIGIN,
+  SandboxOptions.ALLOW_POPUPS,
   SandboxOptions.ALLOW_POPUPS_TO_ESCAPE_SANDBOX,
   SandboxOptions.ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION,
 ];

--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -26,6 +26,7 @@ import {tryParseJson} from './json';
 export const SandboxOptions = {
   ALLOW_SCRIPTS: 'allow-scripts',
   ALLOW_SAME_ORIGIN: 'allow-same-origin',
+  ALLOW_POPUPS: 'allow-popups',
   ALLOW_POPUPS_TO_ESCAPE_SANDBOX: 'allow-popups-to-escape-sandbox',
   ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION:
     'allow-top-navigation-by-user-activation',


### PR DESCRIPTION
#21179 reminded me that we also need `allow-popups` in addition to 'allow-popups-to-escape-sandbox' ( 'allow-popups-to-escape-sandbox' is Chrome only)