### PR TITLE
🐛Fix AMP Experiment Render Block with API Changes, and Removed Bad AMP Story definition

### DIFF
--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import {
+  RenderDelayingService
+} from '../../../src/render-delaying-services';
 import {Services} from '../../../src/services';
-
 
 /**
  * Strips everything but the domain from referrer string.
@@ -150,13 +152,16 @@ function addRuntimeClasses(ampdoc) {
   addViewerClass(ampdoc);
 }
 
+class AmpDynamicCssClasses extends RenderDelayingService {
+  constructor(ampdoc) {
+    super();
+    addRuntimeClasses(ampdoc);
+  }
+}
 
 // Register doc-service factory.
 AMP.extension('amp-dynamic-css-classes', '0.1', AMP => {
   AMP.registerServiceForDoc(
       'amp-dynamic-css-classes',
-      function(ampdoc) {
-        addRuntimeClasses(ampdoc);
-        return {};
-      });
+      AmpDynamicCssClasses);
 });

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -15,7 +15,7 @@
  */
 
 import {
-  RenderDelayingService
+  RenderDelayingService,
 } from '../../../src/render-delaying-services';
 import {Services} from '../../../src/services';
 
@@ -153,6 +153,9 @@ function addRuntimeClasses(ampdoc) {
 }
 
 class AmpDynamicCssClasses extends RenderDelayingService {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
   constructor(ampdoc) {
     super();
     addRuntimeClasses(ampdoc);

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  RenderDelayingService,
-} from '../../../src/render-delaying-services';
 import {Services} from '../../../src/services';
 
 /**
@@ -152,13 +149,23 @@ function addRuntimeClasses(ampdoc) {
   addViewerClass(ampdoc);
 }
 
-class AmpDynamicCssClasses extends RenderDelayingService {
+/** @implements {../../../src/render-delaying-services.RenderDelayingService} */
+class AmpDynamicCssClasses {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
-    super();
     addRuntimeClasses(ampdoc);
+  }
+
+  /**
+   * Function to return a promise for when
+   * it is finished delaying render, and is ready.
+   * Implemented from RenderDelayingService
+   * @return {!Promise}
+   */
+  whenReady() {
+    return Promise.resolve();
   }
 }
 

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -65,7 +65,7 @@ export class Variants {
    * @return {!Promise}
    */
   whenReady() {
-    return this.variantsDeferred_.promise;
+    return this.getVariants();
   }
 }
 

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -15,10 +15,10 @@
  */
 
 import {Deferred} from '../../../src/utils/promise';
-import {Services} from '../../../src/services';
 import {
-  RenderDelayingService
+  RenderDelayingService,
 } from '../../../src/render-delaying-services';
+import {Services} from '../../../src/services';
 import {dev, userAssert} from '../../../src/log';
 import {hasOwn} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -16,6 +16,9 @@
 
 import {Deferred} from '../../../src/utils/promise';
 import {Services} from '../../../src/services';
+import {
+  RenderDelayingService
+} from '../../../src/render-delaying-services';
 import {dev, userAssert} from '../../../src/log';
 import {hasOwn} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';
@@ -27,12 +30,13 @@ const nameValidator = /^[\w-]+$/;
 /**
  * Variants service provides VARIANT variables for the experiment config.
  */
-export class Variants {
+export class Variants extends RenderDelayingService {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
+    super();
     /** @const */
     this.ampdoc = ampdoc;
 
@@ -54,6 +58,13 @@ export class Variants {
    * @return {!Promise<!Object<string, ?string>>}
    */
   getVariants() {
+    return this.variantsDeferred_.promise;
+  }
+
+  /**
+   * @override
+   */
+  getPostInstallRenderDelayPromise() {
     return this.variantsDeferred_.promise;
   }
 }

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -64,7 +64,7 @@ export class Variants extends RenderDelayingService {
   /**
    * @override
    */
-  getPostInstallRenderDelayPromise() {
+  getPostRegisterRenderDelayPromise() {
     return this.variantsDeferred_.promise;
   }
 }

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -15,9 +15,6 @@
  */
 
 import {Deferred} from '../../../src/utils/promise';
-import {
-  RenderDelayingService,
-} from '../../../src/render-delaying-services';
 import {Services} from '../../../src/services';
 import {dev, userAssert} from '../../../src/log';
 import {hasOwn} from '../../../src/utils/object';
@@ -29,14 +26,14 @@ const nameValidator = /^[\w-]+$/;
 
 /**
  * Variants service provides VARIANT variables for the experiment config.
+ * @implements {../../../src/render-delaying-services.RenderDelayingService}
  */
-export class Variants extends RenderDelayingService {
+export class Variants {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
-    super();
     /** @const */
     this.ampdoc = ampdoc;
 
@@ -62,9 +59,12 @@ export class Variants extends RenderDelayingService {
   }
 
   /**
-   * @override
+   * Function to return a promise for when
+   * it is finished delaying render, and is ready.
+   * Implemented from RenderDelayingService
+   * @return {!Promise}
    */
-  getPostRegisterRenderDelayPromise() {
+  whenReady() {
     return this.variantsDeferred_.promise;
   }
 }

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -118,10 +118,7 @@ export function hasRenderDelayingServices(win) {
 export function isRenderDelayingService(service) {
   const maybeRenderDelayingService =
     /** @type {!RenderDelayingService}*/ (service);
-  if (typeof maybeRenderDelayingService.whenReady == 'function') {
-    return true;
-  }
-  return false;
+  return typeof maybeRenderDelayingService.whenReady == 'function';
 }
 
 /**

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -82,12 +82,12 @@ export function waitForServices(win) {
         win,
         serviceId
     ).then(service => {
-      if (service && service.whenReady) {
+      if (service && isRenderDelayingService(service)) {
         return service.whenReady().then(() => {
           return service;
         });
       }
-      return Promise.resolve(service);
+      return service;
     });
 
     return Services.timerFor(win).timeoutPromise(
@@ -107,6 +107,21 @@ export function waitForServices(win) {
  */
 export function hasRenderDelayingServices(win) {
   return includedServices(win).length > 0;
+}
+
+/**
+ * Function to determine if the passed
+ * Object is a Render Delaying Service
+ * @param {!Object} service
+ * @return {?RenderDelayingService}
+ */
+export function isRenderDelayingService(service) {
+  const maybeRenderDelayingService =
+    /** @type {!RenderDelayingService}*/ (service);
+  if (typeof maybeRenderDelayingService.whenReady == 'function') {
+    return maybeRenderDelayingService;
+  }
+  return null;
 }
 
 /**

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -113,15 +113,15 @@ export function hasRenderDelayingServices(win) {
  * Function to determine if the passed
  * Object is a Render Delaying Service
  * @param {!Object} service
- * @return {?RenderDelayingService}
+ * @return {boolean}
  */
 export function isRenderDelayingService(service) {
   const maybeRenderDelayingService =
     /** @type {!RenderDelayingService}*/ (service);
   if (typeof maybeRenderDelayingService.whenReady == 'function') {
-    return maybeRenderDelayingService;
+    return true;
   }
-  return null;
+  return false;
 }
 
 /**

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -95,7 +95,7 @@ export function waitForServices(win) {
   });
   return Promise.all(promises).then(services => {
     const postInstallPromises = services.map(service => {
-      if (service.getPostRegisterRenderDelayPromise) {
+      if (service && service.getPostRegisterRenderDelayPromise) {
         return Services.timerFor(win).timeoutPromise(
             POST_REGISTER_TIMEOUT,
             service.getPostRegisterRenderDelayPromise(),

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -58,7 +58,7 @@ export class RenderDelayingService {
    * registered.
    * @returns !Promise
    */
-  getPostInstallRenderDelayPromise() {
+  getPostRegisterRenderDelayPromise() {
     return Promise.resolve();
   }
 }
@@ -74,7 +74,7 @@ const LOAD_TIMEOUT = 3000;
  * tasks before erroring.
  * @const
  */
-const POST_INSTALL_TIMEOUT = 1000;
+const POST_REGISTER_TIMEOUT = 1000;
 
 
 /**
@@ -94,10 +94,10 @@ export function waitForServices(win) {
   })
   return Promise.all(promises).then(services => {
     const postInstallPromises = services.map(service => {
-      if (service.getPostInstallRenderDelayPromise) {
+      if (service.getPostRegisterRenderDelayPromise) {
         return Services.timerFor(win).timeoutPromise(
-          POST_INSTALL_TIMEOUT,
-          service.getPostInstallRenderDelayPromise(),
+          POST_REGISTER_TIMEOUT,
+          service.getPostRegisterRenderDelayPromise(),
           `Render timeout waiting for service ${service} to finish postInstall.`
         );
       }

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -47,7 +47,7 @@ const SERVICES = {
  * is properly handled
  */
 export class RenderDelayingService {
-
+  /** Class Constructor */
   constructor() {}
 
   /**
@@ -56,7 +56,7 @@ export class RenderDelayingService {
    * NOTE: This should be overriden if your
    * service need to perform any logic after being
    * registered.
-   * @returns !Promise
+   * @return {!Promise}
    */
   getPostRegisterRenderDelayPromise() {
     return Promise.resolve();
@@ -89,16 +89,18 @@ export function waitForServices(win) {
     return Services.timerFor(win).timeoutPromise(
         LOAD_TIMEOUT,
         getServicePromise(win, service),
-        `Render timeout waiting for service ${service} to be ready.`
+        `Render timeout waiting for service ${service} ` +
+      'to be ready.'
     );
-  })
+  });
   return Promise.all(promises).then(services => {
     const postInstallPromises = services.map(service => {
       if (service.getPostRegisterRenderDelayPromise) {
         return Services.timerFor(win).timeoutPromise(
-          POST_REGISTER_TIMEOUT,
-          service.getPostRegisterRenderDelayPromise(),
-          `Render timeout waiting for service ${service} to finish postInstall.`
+            POST_REGISTER_TIMEOUT,
+            service.getPostRegisterRenderDelayPromise(),
+            `Render timeout waiting for service ${service} ` +
+          'to finish postInstall.'
         );
       }
       return Promise.resolve();


### PR DESCRIPTION
relates to #20221
relates to #16531

* Implemented a new `RenderDelayingService` Base Class.
* Implemented a `getPostRegisterRenderDelayingPromise` function to delay body after service registered.
* Migrated `amp-experiment` and `amp-dynamic-css-classes` to the new `RenderDelayingService`.
* Fixed bug of showing amp-experiment before finished mutating introduced by #20221 . 
* Removed the non-existant `amp-story` service after discussion with @newmuis . **This will require a follow up PR to actually make amp-story services render blocking. And use this new API**


# Example

**Fix videos have a `debugger` in the function of `style-installer.js` that sets the body styles to visible.**

### Before Fix

![brokenrenderdelay](https://user-images.githubusercontent.com/1448289/53610861-63a3a600-3b81-11e9-8032-19a740a400af.gif)

### After Fix

![fixedrenderdelay](https://user-images.githubusercontent.com/1448289/53610875-6bfbe100-3b81-11e9-9379-6190d3c88ff8.gif)

**Some logging was done not in PR to ensure everything is called int he right order**

![screen shot 2019-02-28 at 5 03 56 pm](https://user-images.githubusercontent.com/1448289/53610888-7c13c080-3b81-11e9-80e8-566997264702.png)

