### PR TITLE
Make changes to support `<amp-inline-gallery>`.

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -219,7 +219,7 @@ class AmpCarousel extends AMP.BaseElement {
   renderContainerDom_() {
     const html = htmlFor(this.element);
     return html`
-      <div>
+      <div class="i-amphtml-carousel-content">
         <div class="i-amphtml-carousel-scroll"></div>
         <div class="i-amphtml-carousel-arrow-next-slot"></div>
         <div class="i-amphtml-carousel-arrow-prev-slot"></div>

--- a/extensions/amp-base-carousel/0.1/carousel.css
+++ b/extensions/amp-base-carousel/0.1/carousel.css
@@ -14,20 +14,27 @@
  * limitations under the License.
  */
 
-.i-amphtml-carousel-scroll {
+ /**
+  * We need a separate container for `position: absolute` for two reasons:
+  *
+  * 1. We do not want to make the scrolling area positioned, so that content
+  *    inside can position relative to the outer container.
+  * 2. Chrome causes the slides to flicker if the scrolling element is
+  *    position: absolute;
+  */
+.i-amphtml-carousel-content {
   position: absolute;
   top: 0;
   left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.i-amphtml-carousel-scroll {
   display: flex;
   width: 100%;
   height: 100%;
   align-items: center;
-
-  /*
-   * Need to force a layer to work around a Chrome bug where scroll position
-   * updates cause a temporary incorrect UI rendering.
-   */
-  transform: translateZ(0);
 
   scroll-behavior: smooth;
   /* Hide scrollbar */

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -721,8 +721,7 @@ export class Carousel {
     });
 
     this.allSpacers_ = this.beforeSpacers_
-        .concat(this.replacementSpacers_)
-        .concat(this.afterSpacers_);
+        .concat(this.replacementSpacers_, this.afterSpacers_);
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -221,6 +221,9 @@ export class Carousel {
     /** @private {!Array<!Element>} */
     this.afterSpacers_ = [];
 
+    /** @private {!Array<!Element>} */
+    this.allSpacers_ = [];
+
     /**
     * Set from sources of programmatic scrolls to avoid doing work associated
     * with regular scrolling.
@@ -716,6 +719,10 @@ export class Carousel {
       this.setElementTransform_(spacer, -1, totalLength);
       this.scrollContainer_.appendChild(spacer);
     });
+
+    this.allSpacers_ = this.beforeSpacers_
+        .concat(this.replacementSpacers_)
+        .concat(this.afterSpacers_);
   }
 
   /**
@@ -809,28 +816,41 @@ export class Carousel {
    * @private
    */
   updateCurrent_() {
+    const {
+      allSpacers_,
+      alignment_,
+      axis_,
+      currentIndex_,
+      element_,
+      loop_,
+      slides_,
+    } = this;
     const totalLength = sum(this.getSlideLengths_());
-    const overlappingIndex = findOverlappingIndex(
-        this.axis_, this.alignment_, this.element_, this.slides_,
-        this.currentIndex_);
+    // When looping, we translate the slides, but the slides might decide to
+    // translate their content instead of the whole slide. As a result, we need
+    // to use the spacers to figure out where we are rather than the slides
+    // themselves.
+    const items = loop_ ? allSpacers_ : slides_;
+    const startIndex = loop_ ? currentIndex_ + slides_.length : currentIndex_;
+    const overlappingIndex =
+        findOverlappingIndex(axis_, alignment_, element_, items, startIndex);
 
     // Currently not over a slide (e.g. on top of overscroll area).
     if (overlappingIndex === undefined) {
       return;
     }
 
-    // Pulled out as a separate variable, since Closure gets confused about
-    // whether it can be undefined pas this point when closed over (in
-    // runMutate).
-    const newIndex = overlappingIndex;
+    // Since we are potentially looking accross all spacers, we need to convert
+    // to a slide index.
+    const newIndex = overlappingIndex % slides_.length;
     // Update the current offset on each scroll so that we have it up to date
     // in case of a resize.
-    const currentElement = this.slides_[newIndex];
-    const dimension = getDimension(this.axis_, currentElement);
+    const currentElement = slides_[newIndex];
+    const dimension = getDimension(axis_, currentElement);
     this.currentElementOffset_ = dimension.start;
 
     // We did not move at all.
-    if (newIndex == this.currentIndex_) {
+    if (newIndex == currentIndex_) {
       return;
     }
 

--- a/extensions/amp-base-carousel/0.1/dimensions.js
+++ b/extensions/amp-base-carousel/0.1/dimensions.js
@@ -15,7 +15,7 @@
  */
 
 import {mod} from '../../../src/utils/math';
-import {setStyle} from '../../../src/style';
+import {setImportantStyles, setStyle} from '../../../src/style';
 
 /**
  * @enum {number}
@@ -117,6 +117,11 @@ export function setTransformTranslateStyle(axis, el, delta) {
   const deltaX = axis == Axis.X ? delta : 0;
   const deltaY = axis == Axis.X ? 0 : delta;
   setStyle(el, 'transform', `translate(${deltaX}px, ${deltaY}px)`);
+  // Set a custom property so that the slide itself can determine how to
+  // translate the content if it so chooses.
+  setImportantStyles(el, {
+    '--content-transform': `translate(${deltaX}px, ${deltaY}px)`,
+  });
 }
 
 /**


### PR DESCRIPTION
This change modifies the base carousel code to allow slides to decide how to position their content with
respect to the carousel. This will be used by slides in `<amp-inline-gallery>` to stick their captions at the bottom like in this jsbin: https://output.jsbin.com/cocetuh

- Move `position: absolute` to a parent of the scrollable area, so slide
content can position relative to it rather than moving with the scroll.
- Set CSS custom properties on the slides in addition to the transform so that they can just translate
part of their content rather than the whole slide.
  * Slides can cancel the transform via CSS. The transform is set explicitly on the slide so that it works when CSS custom properties are not supported.
- Change logic for finding the current overlapping slide to check
against the spacers instead, since the slides themselves might not be in
the expected location.