### PR TITLE
Launch amp-img-auto-sizes to 100% of canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -56,5 +56,6 @@
   "amp-list-viewport-resize": 1,
   "amp-list-resizable-children": 1,
   "amp-auto-lightbox": 1,
-  "adsense-ff-number-delay": 0.01
+  "adsense-ff-number-delay": 0.01,
+  "amp-img-auto-sizes": 1
 }


### PR DESCRIPTION
Launching auto-generated sizes (implementation https://github.com/ampproject/amphtml/pull/20968, reference issue https://github.com/ampproject/amphtml/issues/19513) to 100% of canary. 