### PR TITLE
Release amp-img-auto-sizes to 1% of production

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -56,5 +56,6 @@
   "amp-list-viewport-resize": 1,
   "amp-list-resizable-children": 1,
   "adsense-ff-number-delay": 0.01,
-  "amp-auto-lightbox": 0.05
+  "amp-auto-lightbox": 0.05,
+  "amp-img-auto-sizes": 0.01
 }


### PR DESCRIPTION
Launching auto-generated sizes (implementation #20968, reference issue #19513) to 1% of production.