### PR TITLE
(draft) autocomplete MVP features under experimental

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -20,7 +20,7 @@
         <fieldset>
             <label>
                 <span>Your name</span>
-                <amp-autocomplete filter="substring" min-characters="0">
+                <amp-autocomplete filter="substring" min-characters="0" max-entries="2">
                     <input type="text" name="name" required>
                     <script type="application/json">
                     { "items" : ["hello a", "hello b", "hello c"] }

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -10,6 +10,11 @@
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script>
+      (self.AMP=self.AMP||[]).push((AMP) => {
+        AMP.toggleExperiment('amp-autocomplete', true);
+      });
+  </script>
 </head>
 <body>
     <h1>Autocomplete</h1>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <title>AMP Autocomplete Demo</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+</head>
+<body>
+    <h1>Autocomplete</h1>
+    <h2>Form context</h2>
+    <form method="post"
+        action-xhr="http://amp.localhost:8000/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your name</span>
+                <amp-autocomplete filter="substring">
+                    <input type="text" name="name" required>
+                    <script type="application/json">
+                    { "items" : ["hello a", "hello b", "hello c"] }
+                    </script>
+                </amp-autocomplete>
+            </label>
+            <label>
+                <span>Your email</span>
+                <amp-autocomplete filter="prefix">
+                    <input type="text" name="email" required>
+                    <script type="application/json">
+                        { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
+                    </script>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit">
+        </fieldset>
+
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
+                to confirm!
+            </template>
+        </div>
+        <div submit-error>
+            <template type="amp-mustache">
+                Oops! {{name}}, We apologies something went wrong. Please try again later.
+            </template>
+        </div>
+    </form>
+
+    <h2>Search context</h2>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
+                        { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
+                    </script>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
+</body>
+</html>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -20,7 +20,7 @@
         <fieldset>
             <label>
                 <span>Your name</span>
-                <amp-autocomplete filter="substring">
+                <amp-autocomplete filter="substring" min-characters="0">
                     <input type="text" name="name" required>
                     <script type="application/json">
                     { "items" : ["hello a", "hello b", "hello c"] }
@@ -29,7 +29,7 @@
             </label>
             <label>
                 <span>Your email</span>
-                <amp-autocomplete filter="prefix">
+                <amp-autocomplete filter="prefix" min-characters="3">
                     <input type="text" name="email" required>
                     <script type="application/json">
                         { "items" : ["apple", "pineapple", "coconut", "pine apple"] }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -34,3 +34,11 @@
     padding: 4px;
     position: relative;
  }
+
+ .i-amphtml-autocomplete-item:hover {   
+   background-color: #d3d3d3;
+}
+
+ .i-amphtml-autocomplete-item-active {
+    background-color: #d3d3d3;
+ }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -13,3 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.i-amphtml-autocomplete {   
+    display: inline-flex;
+    flex-direction: column;
+    align-items: stretch;
+ }
+
+.i-amphtml-autocomplete-input {
+    padding: 4px;
+ }
+
+ .i-amphtml-autocomplete-results {
+    margin-top: 4px;
+ }
+
+ .i-amphtml-autocomplete-item {   
+    background-color: white;
+    border: 1px solid black;
+    padding: 4px;
+    position: relative;
+ }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -241,25 +241,19 @@ export class AmpAutocomplete extends AMP.BaseElement {
       switch (this.filter_) {
         case FilterType.SUBSTRING:
           return item.includes(input);
-          break;
         case FilterType.PREFIX:
           return item.startsWith(input);
-          break;
         case FilterType.TOKEN_PREFIX:
           return item.split(' ').some(token => {
             return token.startsWith(input);
           });
-          break;
         case FilterType.FUZZY:
           throw new Error(`Filter not yet supported: ${this.filter_}`);
-          break;
         case FilterType.CUSTOM:
           throw new Error(`Filter not yet supported: ${this.filter_}`);
-          break;
         case FilterType.NONE:
           // Query server endpoint.
           throw new Error(`Filter not yet supported: ${this.filter_}`);
-          break;
         default:
           throw new Error(`Unexpected filter: ${this.filter_}`);
       }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -16,10 +16,12 @@
 
 import {CSS} from '../../../build/amp-autocomplete-0.1.css';
 import {Layout} from '../../../src/layout';
-import {childElementsByTag} from '../../../src/dom';
+import {childElementsByTag, isJsonScriptTag,
+  removeChildren} from '../../../src/dom';
+import {dev, user, userAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
+import {setStyle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
-import {user, userAssert} from '../../../src/log';
 
 /** @const {string} */
 const EXPERIMENT = 'amp-autocomplete';
@@ -33,16 +35,29 @@ export class AmpAutocomplete extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private {string} */
-    this.myText_ = 'hello world';
-
-    /** @private {?string} */
+    /**
+     * The data extracted from the <script> tag optionally provided
+     * as a child. For use with static data.
+     * @private {?string}
+     */
     this.inlineData_ = null;
 
-    /** @private {?HTMLElement} */
+    /**
+     * The reference to the <input> tag provided as a child.
+     * @private {?HTMLElement}
+     */
     this.inputElement_ = null;
 
-    /** @private {?Element} */
+    /**
+     * The value of the "filter" attribute on <autocomplete>.
+     * @private {?string}
+     */
+    this.filter_ = null;
+
+    /**
+     * The reference to the <div> that contains template-rendered children.
+     * @private {?HTMLElement}
+     */
     this.container_ = null;
   }
 
@@ -52,14 +67,23 @@ export class AmpAutocomplete extends AMP.BaseElement {
         `Experiment ${EXPERIMENT} is not turned on.`);
 
     this.inlineData_ = this.getInlineData_();
+
     const inputElements = childElementsByTag(this.element, 'INPUT');
     userAssert(inputElements.length === 1,
         `${TAG} should contain exactly one <input> child`);
     this.inputElement_ = inputElements[0];
+
+    this.filter_ = this.element.getAttribute('filter');
+    this.container_ = this.createContainer_();
+    this.element.appendChild(this.container_);
   }
 
-  /** Reads the data from the child element. *
-   * @return {?Array} */
+  /**
+   * Reads the 'items' data from the child <script> element.
+   * For use with static local data.
+   * @return {?Array}
+   * @private
+   */
   getInlineData_() {
     const scriptElements = childElementsByTag(this.element, 'SCRIPT');
     if (!scriptElements.length) {
@@ -71,14 +95,134 @@ export class AmpAutocomplete extends AMP.BaseElement {
     userAssert(isJsonScriptTag(scriptElement),
         `${TAG} should be inside a <script> tag with type="application/json"`);
     const json = tryParseJson(scriptElement.textContent,
-        error => {user().error((TAG, 'failed to parse config', error));});
-    return json['items'];
+        error => {user().error((TAG, 'failed to parse inline data', error));});
+    return json.items;
+  }
+
+  /**
+   * Creates and returns <div> that contains the template-rendered children.
+   * @return {?HTMLElement}
+   * @private
+   */
+  createContainer_() {
+    const container = this.element.ownerDocument.createElement('div');
+    container.classList.add('i-amphtml-autocomplete-results');
+    container.setAttribute('role', 'list');
+    setStyle(container, 'visibility', 'hidden');
+    this.applyFillContent(container, /* replacedContent */ true);
+    return container;
   }
 
   /** @override */
   layoutCallback() {
-    // Actually load your resource or render more expensive resources.
+    this.element.classList.add('i-amphtml-autocomplete');
+    this.inputElement_.classList.add('i-amphtml-autocomplete-input');
+    // Disable autofill in browsers.
+    this.inputElement_.setAttribute('autocomplete', 'off');
+
+    // No static local data to filter against.
+    if (!this.inlineData_) {
+      return Promise.resolve();
+    }
+    this.inputElement_.addEventListener('input',
+        this.renderResults_.bind(this));
+    this.inputElement_.addEventListener('focus', this.showResults.bind(this));
+    this.inputElement_.addEventListener('blur', this.hideResults.bind(this));
+    this.renderResults_();
     return Promise.resolve();
+  }
+
+  /**
+   * Create and return <div> element from given plan-text item.
+   * @param {string} item
+   * @return {!HTMLElement}
+   * @private
+   */
+  createElementFromItem_(item) {
+    const element = this.element.ownerDocument.createElement('div');
+    element.classList.add('i-amphtml-autocomplete-item');
+    element.setAttribute('role', 'listitem');
+    element.addEventListener('mousedown', this.selectItem.bind(this));
+    element.textContent = item;
+    return element;
+  }
+
+  /** 
+   * Render filtered results on the current input and update the container_.
+   * @param {?event} event
+   * @private
+   */
+  renderResults_(event) {
+    if (event && event.inputType === 'deleteContentBackward') {
+      // Explore options for caching results to avoid repetitive queries.
+    }
+    const userInput = this.inputElement_.value;
+    const filteredData = this.filter_(this.inlineData_, userInput);
+    this.clearAllItems();
+    filteredData.forEach(item => {
+      this.container_.appendChild(this.createElementFromItem_(item));
+    });
+  }
+
+  /** 
+   * Apply the filter to the given data based on the given input.
+   * @param {!Array<string>} data
+   * @param {string} input
+   * @return {!Array<string>}
+   * @private
+   */
+  filter_(data, input) {
+    return data.filter(item => {
+      switch (this.filter_) {
+        case 'substring':
+          return item.includes(input);
+          break;
+        case 'prefix':
+          return item.startsWith(input);
+          break;
+        case 'token-prefix':
+          return item.split(' ').some(token => {
+            return token.startsWith(input);
+          });
+          break;
+        case 'fuzzy':
+          throw new Error(`Filter not yet supported: ${this.filter_}`);
+          break;
+        case 'custom':
+          throw new Error(`Filter not yet supported: ${this.filter_}`);          
+          break;
+        case 'none':
+          // Query server endpoint.
+          throw new Error(`Filter not yet supported: ${this.filter_}`);
+          break;
+        default:
+          throw new Error(`Unexpected filter: ${this.filter_}`);
+      }
+    });
+  }
+
+  /** Set container_ visibility to visible. */
+  showResults() {
+    setStyle(this.container_, 'visibility', 'visible');
+  }
+
+  /** Set container_ visibility to hidden. */
+  hideResults() {
+    setStyle(this.container_, 'visibility', 'hidden');
+  }
+
+  /** 
+   * Writes the selected value into the input field.
+   * @param {?event} event
+   */
+  selectItem(event) {
+    this.inputElement_.value = event.target.textContent;
+    this.clearAllItems();
+  }
+
+  /** Delete all children to the container_ */
+  clearAllItems() {
+    removeChildren(dev().assertElement(this.container_));
   }
 
   /** @override */

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -56,6 +56,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.filter_ = null;
 
     /**
+     * The value of the "min-characters" attribute on <autocomplete>.
+     * @private {?number}
+     */
+    this.minChars = null;
+
+    /**
      * The index of the active suggested item.
      * @private (!number)
      */
@@ -87,6 +93,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.inputElement_ = inputElements[0];
 
     this.filter_ = this.element.getAttribute('filter');
+    this.minChars = this.element.hasAttribute('min-characters') ?
+      parseInt(this.element.getAttribute('min-characters')) : 1;
+
     this.container_ = this.createContainer_();
     this.element.appendChild(this.container_);
   }
@@ -181,8 +190,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
    */
   renderResults_() {
     const userInput = this.inputElement_.value;
-    const filteredData = this.filterData_(this.inlineData_, userInput);
     this.clearAllItems();
+    if (userInput.length < this.minChars) {
+      return;
+    }
+    const filteredData = this.filterData_(this.inlineData_, userInput);
     filteredData.forEach(item => {
       this.container_.appendChild(this.createElementFromItem_(item));
     });

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -24,12 +24,26 @@ import {getStyle, setStyle} from '../../../src/style';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {tryParseJson} from '../../../src/json';
+import {isEnumValue} from '../../../src/types';
 
 /** @const {string} */
 const EXPERIMENT = 'amp-autocomplete';
 
 /** @const {string} */
 const TAG = 'amp-autocomplete';
+
+/**
+ * Different filtering options.
+ * @const @enum {string}
+ */
+export const FilterType = {
+  SUBSTRING: 'substring',
+  PREFIX: 'prefix',
+  TOKEN_PREFIX: 'token-prefix',
+  FUZZY: 'fuzzy',
+  CUSTOM: 'custom',
+  NONE: 'none',
+}
 
 export class AmpAutocomplete extends AMP.BaseElement {
 
@@ -99,8 +113,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
         `${TAG} should contain exactly one <input> child`);
     this.inputElement_ = inputElements[0];
 
-    this.filter_ = userAssert(this.element.getAttribute('filter')
-        , `${TAG} requires "filter" attribute.`);
+    this.filter_ = userAssert(this.element.getAttribute('filter'),
+      `${TAG} requires "filter" attribute.`);
+    userAssert(isEnumValue(FilterType, this.filter_), 
+      `Unexpected filter: ${this.filter}`);
+
     this.minChars_ = this.element.hasAttribute('min-characters') ?
       parseInt(this.element.getAttribute('min-characters'), 10) : 1;
     this.maxEntries_ = parseInt(this.element.getAttribute('max-entries'), 10);
@@ -222,24 +239,24 @@ export class AmpAutocomplete extends AMP.BaseElement {
   filterData_(data, input) {
     let filteredData = data.filter(item => {
       switch (this.filter_) {
-        case 'substring':
+        case FilterType.SUBSTRING:
           return item.includes(input);
           break;
-        case 'prefix':
+        case FilterType.PREFIX:
           return item.startsWith(input);
           break;
-        case 'token-prefix':
+        case FilterType.TOKEN_PREFIX:
           return item.split(' ').some(token => {
             return token.startsWith(input);
           });
           break;
-        case 'fuzzy':
+        case FilterType.FUZZY:
           throw new Error(`Filter not yet supported: ${this.filter_}`);
           break;
-        case 'custom':
+        case FilterType.CUSTOM:
           throw new Error(`Filter not yet supported: ${this.filter_}`);
           break;
-        case 'none':
+        case FilterType.NONE:
           // Query server endpoint.
           throw new Error(`Filter not yet supported: ${this.filter_}`);
           break;

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -26,15 +26,15 @@ import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {tryParseJson} from '../../../src/json';
 
-/** @const {string} */
+/** @const */
 const EXPERIMENT = 'amp-autocomplete';
 
-/** @const {string} */
+/** @const */
 const TAG = 'amp-autocomplete';
 
 /**
  * Different filtering options.
- * @const @enum {string}
+ * @enum {string}
  */
 export const FilterType = {
   SUBSTRING: 'substring',
@@ -54,7 +54,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     /**
      * The data extracted from the <script> tag optionally provided
      * as a child. For use with static data.
-     * @private {?string}
+     * @private {?Array}
      */
     this.inlineData_ = null;
 
@@ -66,15 +66,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
     /**
      * The value of the "filter" attribute on <autocomplete>.
-     * @private {?string}
+     * @private {string}
      */
-    this.filter_ = null;
+    this.filter_ = '';
 
     /**
      * The value of the "min-characters" attribute on <autocomplete>.
-     * @private {?number}
+     * @private {number}
      */
-    this.minChars_ = null;
+    this.minChars_ = 1;
 
     /**
      * The value of the "max-entries" attribute on <autocomplete>.
@@ -84,13 +84,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
     /**
      * The index of the active suggested item.
-     * @private (!number)
+     * @private {number}
      */
     this.activeIndex_ = -1;
 
     /**
      * The reference to the <div> of the active suggested item.
-     * @private (!number)
+     * @private {?HTMLElement}
      */
     this.activeElement_ = null;
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -21,7 +21,7 @@ import {childElementsByTag, isJsonScriptTag,
 import {dev, user, userAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
-import {setStyle} from '../../../src/style';
+import {setStyle, getStyle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
 
 /** @const {string} */
@@ -249,6 +249,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.activeIndex_ = -1;
   }
 
+  resultsShowing() {
+    return getStyle(this.container_, 'visibility') === 'visible' && 
+      this.container_.children.length;
+  }
+
   /**
    * Selects the target of the event.
    * @param {!event} event
@@ -312,10 +317,14 @@ export class AmpAutocomplete extends AMP.BaseElement {
   keyDownHandler_(event) {
     switch (event.key) {
       case 'ArrowDown':
-        this.updateActiveItem_(1);
+        if (this.resultsShowing()) {
+          this.updateActiveItem_(1);
+        }
         break;
       case 'ArrowUp':
-        this.updateActiveItem_(-1);
+        if (this.resultsShowing()) {
+          this.updateActiveItem_(-1);
+        }
         break;
       case 'Enter':
         if (this.activeElement_) {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -20,7 +20,7 @@ import {Layout} from '../../../src/layout';
 import {childElementsByTag, isJsonScriptTag,
   removeChildren} from '../../../src/dom';
 import {dev, user, userAssert} from '../../../src/log';
-import {getStyle, setStyle} from '../../../src/style';
+import {getStyle, toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
@@ -156,7 +156,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const container = this.element.ownerDocument.createElement('div');
     container.classList.add('i-amphtml-autocomplete-results');
     container.setAttribute('role', 'list');
-    setStyle(container, 'visibility', 'hidden');
+    toggle(container, false);
     this.applyFillContent(container, /* replacedContent */ true);
     return container;
   }
@@ -275,12 +275,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /** Set container_ visibility to visible. */
   showResults() {
-    setStyle(this.container_, 'visibility', 'visible');
+    toggle(this.container_, true);
   }
 
   /** Set container_ visibility to hidden. */
   hideResults() {
-    setStyle(this.container_, 'visibility', 'hidden');
+    toggle(this.container_, false);    
     this.resetActiveElement_();
     this.activeIndex_ = -1;
   }
@@ -365,6 +365,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         break;
       case Keys.ENTER:
         if (this.activeElement_) {
+          // Only prevent if submit-on-enter === false.
           event.preventDefault();
           this.selectItem(this.activeElement_);
           this.resetActiveElement_();

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -280,7 +280,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /** Set container_ visibility to hidden. */
   hideResults() {
-    toggle(this.container_, false);    
+    toggle(this.container_, false);
     this.resetActiveElement_();
     this.activeIndex_ = -1;
   }
@@ -293,10 +293,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /**
    * Returns true if the given element is a suggested item.
-   * @param {HTMLElement} element 
+   * @param {HTMLElement} element
    */
   isItemElement(element) {
-    return element.classList.contains("i-amphtml-autocomplete-item");
+    return element.classList.contains('i-amphtml-autocomplete-item');
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -157,7 +157,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       // Explore options for caching results to avoid repetitive queries.
     }
     const userInput = this.inputElement_.value;
-    const filteredData = this.filter_(this.inlineData_, userInput);
+    const filteredData = this.filterData_(this.inlineData_, userInput);
     this.clearAllItems();
     filteredData.forEach(item => {
       this.container_.appendChild(this.createElementFromItem_(item));
@@ -171,7 +171,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @return {!Array<string>}
    * @private
    */
-  filter_(data, input) {
+  filterData_(data, input) {
     return data.filter(item => {
       switch (this.filter_) {
         case 'substring':

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -62,6 +62,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.minChars = null;
 
     /**
+     * The value of the "max-entries" attribute on <autocomplete>.
+     * @private {?number}
+     */
+    this.maxEntries = null;
+
+    /**
      * The index of the active suggested item.
      * @private (!number)
      */
@@ -94,7 +100,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
     this.filter_ = this.element.getAttribute('filter');
     this.minChars = this.element.hasAttribute('min-characters') ?
-      parseInt(this.element.getAttribute('min-characters')) : 1;
+      parseInt(this.element.getAttribute('min-characters'), 10) : 1;
+    this.maxEntries = parseInt(this.element.getAttribute('max-entries'), 10);
 
     this.container_ = this.createContainer_();
     this.element.appendChild(this.container_);
@@ -208,7 +215,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   filterData_(data, input) {
-    return data.filter(item => {
+    let filteredData = data.filter(item => {
       switch (this.filter_) {
         case 'substring':
           return item.includes(input);
@@ -235,6 +242,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
           throw new Error(`Unexpected filter: ${this.filter_}`);
       }
     });
+    // Truncate to max-entries.
+    if (this.maxEntries && this.maxEntries < filteredData.length) {
+      filteredData = filteredData.slice(0, this.maxEntries);
+    }
+    return filteredData;
   }
 
   /** Set container_ visibility to visible. */

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -21,10 +21,10 @@ import {childElementsByTag, isJsonScriptTag,
   removeChildren} from '../../../src/dom';
 import {dev, user, userAssert} from '../../../src/log';
 import {getStyle, setStyle} from '../../../src/style';
+import {isEnumValue} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {tryParseJson} from '../../../src/json';
-import {isEnumValue} from '../../../src/types';
 
 /** @const {string} */
 const EXPERIMENT = 'amp-autocomplete';
@@ -43,7 +43,7 @@ export const FilterType = {
   FUZZY: 'fuzzy',
   CUSTOM: 'custom',
   NONE: 'none',
-}
+};
 
 export class AmpAutocomplete extends AMP.BaseElement {
 
@@ -114,9 +114,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.inputElement_ = inputElements[0];
 
     this.filter_ = userAssert(this.element.getAttribute('filter'),
-      `${TAG} requires "filter" attribute.`);
-    userAssert(isEnumValue(FilterType, this.filter_), 
-      `Unexpected filter: ${this.filter}`);
+        `${TAG} requires "filter" attribute.`);
+    userAssert(isEnumValue(FilterType, this.filter_),
+        `Unexpected filter: ${this.filter}`);
 
     this.minChars_ = this.element.hasAttribute('min-characters') ?
       parseInt(this.element.getAttribute('min-characters'), 10) : 1;

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -181,6 +181,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
         this.keyDownHandler_.bind(this));
     this.inputElement_.addEventListener('focus', this.showResults.bind(this));
     this.inputElement_.addEventListener('blur', this.hideResults.bind(this));
+    this.container_.addEventListener('mousedown', e => {
+      if (!this.isItemElement(e.target)) {
+        return;
+      }
+      this.selectItem(e.target);
+    });
+
     this.renderResults_();
     return Promise.resolve();
   }
@@ -195,7 +202,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const element = this.element.ownerDocument.createElement('div');
     element.classList.add('i-amphtml-autocomplete-item');
     element.setAttribute('role', 'listitem');
-    element.addEventListener('mousedown', this.mousedownHandler_.bind(this));
     element.textContent = item;
     return element;
   }
@@ -286,16 +292,16 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /**
-   * Selects the target of the mousedown event.
-   * @param {!event} event
+   * Returns true if the given element is a suggested item.
+   * @param {HTMLElement} element 
    */
-  mousedownHandler_(event) {
-    this.selectItem(event.target);
+  isItemElement(element) {
+    return element.classList.contains("i-amphtml-autocomplete-item");
   }
 
   /**
    * Writes the selected value into the input field.
-   * @param {?HTMLElement} element
+   * @param {HTMLElement} element
    */
   selectItem(element) {
     this.inputElement_.value = element.textContent;


### PR DESCRIPTION
This is a draft PR of an autocomplete mvp. [Demo](https://amp-autocomplete.firebaseapp.com/) using `toggleExperiment('amp-autocomplete', true)`.

- Override baseElement callbacks
- Read from child `script` tag
- Create basic filtering function and render filtered data as results
- Show/hide results on focus/blur and esc (sometimes)
- Support "active" item styling on mouse hover or keyboard navigate
- Add keyboard handlers (up, down, enter, esc--note esc has unexpected default behavior when input type="search")
- Support min-characters and max-entries attributes
- Create autocomplete.amp.html example document