### PR TITLE
🏗 Copy form values from the browser to the HTML snapshot that gets uploaded to Percy for visual-diff tests

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -308,8 +308,14 @@ async function generateSnapshots(percy, webpages) {
       '': async() => {},
     };
     if (webpage.interactive_tests) {
-      Object.assign(webpage.tests_,
-          require(path.resolve(ROOT_DIR, webpage.interactive_tests)));
+      try {
+        Object.assign(webpage.tests_,
+            require(path.resolve(ROOT_DIR, webpage.interactive_tests)));
+      } catch (error) {
+        log('fatal', 'Failed to load interactive test',
+            colors.cyan(webpage.interactive_tests), 'for test',
+            colors.cyan(webpage.name), '\nError:', error);
+      }
     }
   }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -65,6 +65,8 @@ const WRAP_IN_IFRAME_SNIPPET = fs.readFileSync(
     path.resolve(__dirname, 'snippets/iframe-wrapper.js'), 'utf8');
 const REMOVE_AMP_SCRIPTS_SNIPPET = fs.readFileSync(
     path.resolve(__dirname, 'snippets/remove-amp-scripts.js'), 'utf8');
+const FREEZE_FORM_VALUE_SNIPPET = fs.readFileSync(
+    path.resolve(__dirname, 'snippets/freeze-form-values.js'), 'utf8');
 
 let browser_;
 let webServerProcess_;
@@ -420,7 +422,7 @@ async function snapshotWebpages(percy, browser, webpages) {
             // prepare it for snapshotting on Percy. See comments inside the
             // snippet files for description of each.
             await page.evaluate(REMOVE_AMP_SCRIPTS_SNIPPET);
-            // TODO(#20630): add a snippet to freeze form inputs
+            await page.evaluate(FREEZE_FORM_VALUE_SNIPPET);
 
             // Create a default set of snapshot options for Percy and modify
             // them based on the test's configuration.

--- a/build-system/tasks/visual-diff/snippets/freeze-form-values.js
+++ b/build-system/tasks/visual-diff/snippets/freeze-form-values.js
@@ -1,0 +1,47 @@
+// This file is executed via Puppeteer's page.evaluate on a document to remove
+// all <script> tags that import AMP pages. This makes for cleaner diffs and
+// prevents "double-execution" of AMP scripts when enableJavaScript=true.
+
+for (const form of document.forms) {
+  for (const formElement of form.elements) {
+    switch (formElement.tagName) {
+      case 'INPUT':
+        // Need to update this? Look at
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties
+        // for inspiration.
+        switch (formElement.type) {
+          case 'file':
+          case 'hidden':
+          case 'image':
+            break;
+
+          case 'checkbox':
+          case 'radio':
+            if (formElement.checked) {
+                formElement.setAttribute('checked', '');
+            } else {
+                formElement.removeAttribute('checked');
+            }
+            break;
+
+          default:
+            formElement.setAttribute('value', formElement.value);
+        }
+        break;
+
+      case 'SELECT':
+        for (const optionElement of formElement.options) {
+          if (optionElement.selected) {
+            optionElement.setAttribute('selected', '');
+          } else {
+            optionElement.removeAttribute('selected');
+          }
+        }
+        break;
+
+      case 'TEXTAREA':
+        formElement.textContent = formElement.value;
+        break;
+    }
+  }
+}

--- a/build-system/tasks/visual-diff/snippets/freeze-form-values.js
+++ b/build-system/tasks/visual-diff/snippets/freeze-form-values.js
@@ -1,6 +1,6 @@
-// This file is executed via Puppeteer's page.evaluate on a document to remove
-// all <script> tags that import AMP pages. This makes for cleaner diffs and
-// prevents "double-execution" of AMP scripts when enableJavaScript=true.
+// This file is executed via Puppeteer's page.evaluate on a document to copy the
+// values of forms into their attributes, so that they will be passed in the
+// snapshots to Percy.
 
 for (const form of document.forms) {
   for (const formElement of form.elements) {

--- a/examples/visual-tests/amp-form/amp-form.amp.html
+++ b/examples/visual-tests/amp-form/amp-form.amp.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Form</title>
+  <link rel="canonical" href="amp-form.amp.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp-custom>
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<form
+  id="form"
+  method="get"
+  action="/form/search-html/get"
+  action-xhr="/form/search-json/get"
+  target="_blank"
+  custom-validation-reporting="show-all-on-submit">
+  <div>
+    <input type="text"
+      id="name"
+      name="name"
+      placeholder="Name..."
+      required
+      pattern="\p{L}+\s\p{L}+">
+    <span visible-when-invalid="valueMissing" validation-for="name"></span>
+    <span visible-when-invalid="patternMismatch" validation-for="name">
+      Please enter your first and last name separated by a space (e.g. Jane Miller)
+    </span>
+  </div>
+  <div>
+    <input type="email"
+      id="email"
+      name="email"
+      placeholder="Email..."
+      required>
+    <span visible-when-invalid="valueMissing" validation-for="email"></span>
+    <span visible-when-invalid="typeMismatch" validation-for="email"></span>
+  </div>
+  <input id="submit" type="submit" value="Submit">
+  <div submit-success>
+    <template type="amp-mustache">
+      Success! Thanks for trying the <code>amp-form</code> demo!
+    </template>
+  </div>
+  <div submit-error>
+    <template type="amp-mustache">
+      Error!
+    </template>
+  </div>
+</form>
+</body>
+</html>

--- a/examples/visual-tests/amp-form/amp-form.js
+++ b/examples/visual-tests/amp-form/amp-form.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const {
+  verifySelectorsVisible,
+} = require('../../../build-system/tasks/visual-diff/helpers');
+
+module.exports = {
+  'try to submit without input': async (page, name) => {
+    await page.tap('#submit');
+    await verifySelectorsVisible(page, name, [
+      '#form.user-invalid',
+      'span[visible-when-invalid="valueMissing"].visible',
+    ]);
+  },
+
+  'try to submit with invalid input': async (page, name) => {
+    await page.tap('#name');
+    await page.keyboard.type('hello');
+    await page.keyboard.press('Tab');
+    await page.keyboard.type('not.an.email.address');
+    await page.tap('#submit');
+    await verifySelectorsVisible(page, name, ['#form.user-invalid']);
+  },
+
+  'try to submit with valid input': async (page, name) => {
+    await page.tap('#name');
+    await page.keyboard.type('Jane Miller');
+    await page.tap('#email');
+    await page.keyboard.type('jane.miller@ampproject.org');
+    await page.tap('#submit');
+    await verifySelectorsVisible(page, name, [
+      '#form.user-valid',
+      'div[submit-success] div[id^="rendered-message-amp-form-"]',
+    ]);
+  },
+
+  'try to submit to a dead server': async (page, name) => {
+    await page.setRequestInterception(true);
+    page.on('request', interceptedRequest => interceptedRequest.abort());
+
+    await page.tap('#name');
+    await page.keyboard.type('Jane Miller');
+    await page.tap('#email');
+    await page.keyboard.type('jane.miller@ampproject.org');
+    await page.tap('#submit');
+    await verifySelectorsVisible(page, name, [
+      '#form.user-valid',
+      'div[submit-error] div[id^="rendered-message-amp-form-"]',
+    ]);
+  }
+};

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -634,6 +634,11 @@
       "interactive_tests": "examples/visual-tests/amp-selector.js",
     },
     {
+      "url": "examples/visual-tests/amp-form/amp-form.amp.html",
+      "name": "amp-form",
+      "interactive_tests": "examples/visual-tests/amp-form/amp-form.js",
+    },
+    {
       "url": "examples/visual-tests/amp-accordion/amp-accordion.html",
       "name": "amp-accordion: page loads",
       "loading_complete_delay_ms": 1000,


### PR DESCRIPTION
This PR:

* Fixes #20630
* Adds an error handler to display what went wrong when `require`ing an interactive test file crashes the visual diff tests runner
* Adds sample `<amp-form>` visual diff tests to show that this really fixes #20630