### PR TITLE
🐛 Fix layout type check

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -151,7 +151,7 @@ const videoPlayerTagNameRe = /^amp\-(video|.+player)/i;
  *   the layout string.
  */
 export function parseLayout(s) {
-  if (LAYOUTS.includes(s)) {
+  if (LAYOUTS.indexOf(s) >= 0) {
     return /** @type {!Layout} */ (s);
   }
   return undefined;


### PR DESCRIPTION
[In my attempts to make the bundle smaller,](https://github.com/ampproject/amphtml/commit/0ca116c94cdee2acb483fa201fa4b62937fdeb35#diff-677d382da9f8d81f61d50af24f937b32R28) broke layouts on IE. 

https://github.com/ampproject/amphtml/blob/0ca116c94cdee2acb483fa201fa4b62937fdeb35/src/layout.js#L154

Oops. Using indexOf instead.