### PR TITLE
🏗✅ Add a blocking check for invalid extension definitions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -198,12 +198,9 @@ function endBuildStep(stepName, targetName, startTime) {
 }
 
 /**
- * Build all the AMP extensions
- *
- * @param {!Object} options
- * @return {!Promise}
+ * Initializes all extensions from bundles.config.js if not already done.
  */
-function buildExtensions(options) {
+function maybeInitializeExtensions() {
   if (Object.keys(extensions).length === 0) {
     verifyExtensionBundles();
     extensionBundles.forEach(c => {
@@ -218,7 +215,16 @@ function buildExtensions(options) {
           c.name, c.version, c.latestVersion, c.options);
     });
   }
+}
 
+/**
+ * Build all the AMP extensions
+ *
+ * @param {!Object} options
+ * @return {!Promise}
+ */
+function buildExtensions(options) {
+  maybeInitializeExtensions();
   if (!!argv.noextensions && !options.compileAll) {
     return Promise.resolve();
   }
@@ -1025,6 +1031,7 @@ function checkTypes() {
   const handlerProcess = createCtrlcHandler('check-types');
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
+  maybeInitializeExtensions();
   // Disabled to improve type check performance, since this provides
   // little incremental value.
   /*buildExperiments({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,11 +35,11 @@ const source = require('vinyl-source-stream');
 const touch = require('touch');
 const watchify = require('watchify');
 const wrappers = require('./build-system/compile-wrappers');
+const {aliasBundles, extensionBundles, verifyExtensionBundles, verifyExtensionAliasBundles} = require('./bundles.config');
 const {applyConfig, removeConfig} = require('./build-system/tasks/prepend-global/index.js');
 const {cleanupBuildDir, closureCompile} = require('./build-system/tasks/compile');
 const {createCtrlcHandler, exitCtrlcHandler} = require('./build-system/ctrlcHandler');
 const {createModuleCompatibleES5Bundle} = require('./build-system/tasks/create-module-compatible-es5-bundle');
-const {extensionBundles, aliasBundles} = require('./bundles.config');
 const {isTravisBuild} = require('./build-system/travis');
 const {jsifyCssAsync} = require('./build-system/tasks/jsify-css');
 const {serve} = require('./build-system/tasks/serve.js');
@@ -83,13 +83,6 @@ const unminifiedRuntimeEsmTarget = 'dist/amp-esm.js';
 const unminified3pTarget = 'dist.3p/current/integration.js';
 
 const maybeUpdatePackages = isTravisBuild() ? [] : ['update-packages'];
-
-extensionBundles.forEach(c => {
-  declareExtension(c.name, c.version, c.latestVersion, c.options);
-});
-aliasBundles.forEach(c => {
-  declareExtensionVersionAlias(c.name, c.version, c.latestVersion, c.options);
-});
 
 /**
  * Tasks that should print the `--nobuild` help text.
@@ -211,6 +204,21 @@ function endBuildStep(stepName, targetName, startTime) {
  * @return {!Promise}
  */
 function buildExtensions(options) {
+  if (Object.keys(extensions).length === 0) {
+    verifyExtensionBundles();
+    extensionBundles.forEach(c => {
+      declareExtension(c.name, c.version, c.latestVersion, c.options);
+    });
+  }
+
+  if (Object.keys(extensionAliasFilePath).length === 0) {
+    verifyExtensionAliasBundles();
+    aliasBundles.forEach(c => {
+      declareExtensionVersionAlias(
+          c.name, c.version, c.latestVersion, c.options);
+    });
+  }
+
   if (!!argv.noextensions && !options.compileAll) {
     return Promise.resolve();
   }


### PR DESCRIPTION
If `gulp` of any of its related commands are run with invalid extension definitions, we currently print a message to the console and continue the build.

This PR makes extension validation a blocking build step, and prints a user-friendly, actionable message to the console when an invalid extension definition is detected, and fails the build. For example:

![image](https://user-images.githubusercontent.com/26553114/53751002-4587bf80-3e79-11e9-8b6a-3a87a4daf9f4.png)


Fixes #16191
Fixes #21172
Partial fix for #21135
