### PR TITLE
🐛 amp-recaptcha-input: Fixed single pass tests

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -453,8 +453,6 @@ data.bodyBackgroundColor;
 data.data.fontColor;
 data.width;
 data.sitekey;
-data.id;
-data.token;
 data.fortesting;
 
 // 3p code

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -453,6 +453,8 @@ data.bodyBackgroundColor;
 data.data.fontColor;
 data.width;
 data.sitekey;
+data.id;
+data.token;
 data.fortesting;
 
 // 3p code

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -343,20 +343,36 @@ export class AmpRecaptchaService {
 
   /**
    * Function to handle token messages from the recaptcha iframe
+   *
+   * NOTE: Use bracket notation to access message properties,
+   * As the externs were a little too generic.
+   *
    * @param {Object} data
    */
   tokenMessageHandler_(data) {
-    this.executeMap_[data.id].resolve(data.token);
-    delete this.executeMap_[data.id];
+
+    const id = data['id'];
+    const token = data['token'];
+
+    this.executeMap_[id].resolve(token);
+    delete this.executeMap_[id];
   }
 
   /**
    * Function to handle error messages from the recaptcha iframe
+   *
+   * NOTE: Use bracket notation to access message properties,
+   * As the externs were a little too generic.
+   *
    * @param {Object} data
    */
   errorMessageHandler_(data) {
-    this.executeMap_[data.id].reject(new Error(data.error));
-    delete this.executeMap_[data.id];
+
+    const id = data['id'];
+    const error = data['error'];
+
+    this.executeMap_[id].reject(new Error(error));
+    delete this.executeMap_[id];
   }
 }
 

--- a/test/integration/test-amp-recaptcha-input.js
+++ b/test/integration/test-amp-recaptcha-input.js
@@ -19,7 +19,7 @@ import {Deferred} from '../../src/utils/promise';
 import {poll} from '../../testing/iframe';
 
 // TODO(torch2424, #20541): These tests fail on firefox.
-describe.configure().skipSinglePass().skipFirefox().run('amp-recaptcha-' +
+describe.configure().skipFirefox().run('amp-recaptcha-' +
     'input', function() {
 
   describes.integration('with form and amp-mustache', {
@@ -109,7 +109,7 @@ describe.configure().skipSinglePass().skipFirefox().run('amp-recaptcha-' +
       }
     `,
     /* eslint-enable max-len */
-    extensions: ['amp-recaptcha-input', 'amp-form', 'amp-mustache'],
+    extensions: ['amp-recaptcha-input', 'amp-form', 'amp-mustache:0.2'],
     experiments: ['amp-recaptcha-input'],
   }, env => {
     let doc;


### PR DESCRIPTION
closes #21009 
relates to #20541

Simple fix, added data to the externs as mentioned by @erwinmombay 😄 

Also, this bumps the amp-mustache version, to then get the test fully working.

![screen shot 2019-03-04 at 4 15 31 pm](https://user-images.githubusercontent.com/1448289/53771769-c3a78e80-3e98-11e9-897f-0f4d999c641c.png)
