### PR TITLE
🏗 Use gcloud auth for build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
 addons:
   apt:
     packages:
-      - protobuf
       - protobuf-compiler
       - python-protobuf
       - openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
-  - pip install --user gsutil protobuf urllib3[secure]
+  - pip install --user protobuf urllib3[secure]
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
@@ -30,6 +30,7 @@ addons:
       - protobuf-compiler
       - python-protobuf
       - openssl
+      - google-cloud-sdk
   chrome: stable
   hosts:
     - ads.localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
-  - pip install --user protobuf urllib3[secure]
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
@@ -27,6 +26,7 @@ branches:
 addons:
   apt:
     packages:
+      - protobuf
       - protobuf-compiler
       - python-protobuf
       - openssl

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -163,8 +163,8 @@ async function downloadOutput_(functionName, outputFileName) {
   exec('echo travis_fold:start:download_results && echo');
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
-  execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
+      `gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
   exec('echo travis_fold:end:download_results');
 
   console.log(
@@ -202,9 +202,8 @@ async function uploadOutput_(functionName, outputFileName) {
   exec('echo travis_fold:start:upload_results && echo');
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
-  execOrDie(`gsutil -m cp -r ${outputFileName} ` +
-      `${OUTPUT_STORAGE_LOCATION}`);
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
+      `gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
   exec('echo travis_fold:end:upload_results');
 }
 

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -163,12 +163,8 @@ async function downloadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Downloading build output from ` +
       colors.cyan(buildOutputDownloadUrl) + '...');
   exec('echo travis_fold:start:download_results && echo');
-  decryptTravisKey_();
-  execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
-      `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} && ` +
-      'gcloud config set pass_credentials_to_gsutil true && ' +
-      `gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
+  authenticateWithStorageLocation_();
+  execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
   exec('echo travis_fold:end:download_results');
 
   console.log(
@@ -204,13 +200,18 @@ async function uploadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Uploading ` + colors.cyan(outputFileName) + ' to ' +
       colors.cyan(OUTPUT_STORAGE_LOCATION) + '...');
   exec('echo travis_fold:start:upload_results && echo');
+  authenticateWithStorageLocation_();
+  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
+  exec('echo travis_fold:end:upload_results');
+}
+
+function authenticateWithStorageLocation_() {
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
-      `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} && ` +
-      'gcloud config set pass_credentials_to_gsutil true && ' +
-      `gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
-  exec('echo travis_fold:end:upload_results');
+  `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
+  execOrDie(`gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT}`);
+  execOrDie('gcloud config set pass_credentials_to_gsutil true');
+  execOrDie('gcloud config list');
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -211,9 +211,9 @@ async function uploadOutput_(functionName, outputFileName) {
 function authenticateWithStorageLocation_() {
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
-  execOrDie(`gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT}`);
-  execOrDie('gcloud config set pass_credentials_to_gsutil true');
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
+      `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} && ` +
+      'gcloud config set pass_credentials_to_gsutil true');
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -163,8 +163,12 @@ async function downloadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Downloading build output from ` +
       colors.cyan(buildOutputDownloadUrl) + '...');
   exec('echo travis_fold:start:download_results && echo');
-  authenticateWithStorageLocation_();
-  execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
+  decryptTravisKey_();
+  execOrDie('gcloud auth activate-service-account ' +
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
+      `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} && ` +
+      'gcloud config set pass_credentials_to_gsutil true && ' +
+      `gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
   exec('echo travis_fold:end:download_results');
 
   console.log(
@@ -200,20 +204,13 @@ async function uploadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Uploading ` + colors.cyan(outputFileName) + ' to ' +
       colors.cyan(OUTPUT_STORAGE_LOCATION) + '...');
   exec('echo travis_fold:start:upload_results && echo');
-  authenticateWithStorageLocation_();
-  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
-  exec('echo travis_fold:end:upload_results');
-}
-
-/**
- * Uses GCloud SDK to authenticate at storage location with a service account
- */
-function authenticateWithStorageLocation_() {
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
       `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
       `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} && ` +
-      'gcloud config set pass_credentials_to_gsutil true');
+      'gcloud config set pass_credentials_to_gsutil true && ' +
+      `gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
+  exec('echo travis_fold:end:upload_results');
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -35,6 +35,8 @@ const DIST_OUTPUT_FILE =
 const OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
 const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
 const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';
+const OUTPUT_STORAGE_SERVICE_ACCOUNT =
+    'sa-travis@amp-travis-build-storage.iam.gserviceaccount.com';
 
 /**
  * Prints a summary of files changed by, and commits included in the PR.
@@ -161,10 +163,7 @@ async function downloadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Downloading build output from ` +
       colors.cyan(buildOutputDownloadUrl) + '...');
   exec('echo travis_fold:start:download_results && echo');
-  decryptTravisKey_();
-  execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
-  execOrDie('gcloud config set pass_credentials_to_gsutil true');
+  authenticateWithStorageLocation_();
   execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
   exec('echo travis_fold:end:download_results');
 
@@ -201,12 +200,20 @@ async function uploadOutput_(functionName, outputFileName) {
       `${fileLogPrefix} Uploading ` + colors.cyan(outputFileName) + ' to ' +
       colors.cyan(OUTPUT_STORAGE_LOCATION) + '...');
   exec('echo travis_fold:start:upload_results && echo');
+  authenticateWithStorageLocation_();
+  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
+  exec('echo travis_fold:end:upload_results');
+}
+
+/**
+ * Uses GCloud SDK to authenticate at storage location with a service account
+ */
+function authenticateWithStorageLocation_() {
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
       `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
+  execOrDie(`gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT}`);
   execOrDie('gcloud config set pass_credentials_to_gsutil true');
-  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
-  exec('echo travis_fold:end:upload_results');
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -163,8 +163,9 @@ async function downloadOutput_(functionName, outputFileName) {
   exec('echo travis_fold:start:download_results && echo');
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
-      `gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
+  execOrDie('gcloud config set pass_credentials_to_gsutil true');
+  execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
   exec('echo travis_fold:end:download_results');
 
   console.log(
@@ -202,8 +203,9 @@ async function uploadOutput_(functionName, outputFileName) {
   exec('echo travis_fold:start:upload_results && echo');
   decryptTravisKey_();
   execOrDie('gcloud auth activate-service-account ' +
-      `--key-file ${OUTPUT_STORAGE_KEY_FILE} && ` +
-      `gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
+      `--key-file ${OUTPUT_STORAGE_KEY_FILE}`);
+  execOrDie('gcloud config set pass_credentials_to_gsutil true');
+  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
   exec('echo travis_fold:end:upload_results');
 }
 


### PR DESCRIPTION
- Installs `google-cloud-sdk`, which includes `gsutil`, on Travis VMs. This is because authenticating with gcloud did not persist when running `gsutil cp` if you only install gsutil by itself.
- Ensures the service account credentials are being passed along to gsutil method

I'll finally remove public access to gs://amp-travis-builds tomorrow, to let people get latest after this merges.