### PR TITLE
Add unsubscribe method to store service

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -390,6 +390,24 @@ export class AmpStoryStoreService {
   }
 
   /**
+   * Unsubscribes from a state property mutation.
+   * @param {string} key
+   * @param {!Function} listener
+   */
+  unsubscribe(key, listener) {
+    if (!hasOwn(this.state_, key)) {
+      dev().error(TAG, 'Can\'t unsubscribe from unknown state %s.', key);
+      return;
+    }
+    if (!this.listeners_[key]) {
+      dev().error(TAG, 'Can\'t unsubscribe from state with no listeners %s.',
+          listener);
+      return;
+    }
+    this.listeners_[key].remove(listener);
+  }
+
+  /**
    * Dispatches an action and triggers the listeners for the updated state
    * properties.
    * @param  {!Action} action

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -399,11 +399,7 @@ export class AmpStoryStoreService {
       dev().error(TAG, 'Can\'t unsubscribe from unknown state %s.', key);
       return;
     }
-    if (!this.listeners_[key]) {
-      dev().error(TAG, 'Can\'t unsubscribe from state with no listeners %s.',
-          listener);
-      return;
-    }
+
     this.listeners_[key].remove(listener);
   }
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -399,6 +399,11 @@ export class AmpStoryStoreService {
       dev().error(TAG, 'Can\'t unsubscribe from unknown state %s.', key);
       return;
     }
+    if (!this.listeners_[key]) {
+      dev().error(TAG, 'Can\'t unsubscribe from state with no listeners %s.',
+          listener);
+      return;
+    }
 
     this.listeners_[key].remove(listener);
   }

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -26,6 +26,26 @@ import {EmbedMode, EmbedModeParam} from '../embed-mode';
 describes.fakeWin('amp-story-store-service', {}, env => {
   let storeService;
 
+  class FakeComponent1 {
+    static subscribeTo(state, listener) {
+      storeService.subscribe(state, listener);
+    }
+
+    static unsubscribeFrom(state, listener) {
+      storeService.unsubscribe(state, listener);
+    }
+  }
+
+  class FakeComponent2 {
+    static subscribeTo(state, listener) {
+      storeService.subscribe(state, listener);
+    }
+
+    static unsubscribeFrom(state, listener) {
+      storeService.unsubscribe(state, listener);
+    }
+  }
+
   beforeEach(() => {
     // Making sure we always get a new instance to isolate each test.
     storeService = new AmpStoryStoreService(env.win);
@@ -61,6 +81,20 @@ describes.fakeWin('amp-story-store-service', {}, env => {
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy, true);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
+  });
+
+  it('should unsubscribe from corresponding listener', () => {
+    const listenerSpy = sandbox.spy();
+    const listenerSpy2 = sandbox.spy();
+
+    FakeComponent1.subscribeTo(StateProperty.BOOKEND_STATE, listenerSpy);
+    FakeComponent2.subscribeTo(StateProperty.BOOKEND_STATE, listenerSpy2);
+    FakeComponent1.unsubscribeFrom(StateProperty.BOOKEND_STATE, listenerSpy);
+
+    storeService.dispatch(Action.TOGGLE_BOOKEND, true);
+
+    expect(listenerSpy2).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.callCount(0);
   });
 });
 

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -26,26 +26,6 @@ import {EmbedMode, EmbedModeParam} from '../embed-mode';
 describes.fakeWin('amp-story-store-service', {}, env => {
   let storeService;
 
-  class FakeComponent1 {
-    static subscribeTo(state, listener) {
-      storeService.subscribe(state, listener);
-    }
-
-    static unsubscribeFrom(state, listener) {
-      storeService.unsubscribe(state, listener);
-    }
-  }
-
-  class FakeComponent2 {
-    static subscribeTo(state, listener) {
-      storeService.subscribe(state, listener);
-    }
-
-    static unsubscribeFrom(state, listener) {
-      storeService.unsubscribe(state, listener);
-    }
-  }
-
   beforeEach(() => {
     // Making sure we always get a new instance to isolate each test.
     storeService = new AmpStoryStoreService(env.win);
@@ -82,19 +62,26 @@ describes.fakeWin('amp-story-store-service', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
   });
+  class FakeComponent {
+    constructor(callback) {
+      this.callback_ = callback.bind(this);
+      storeService.subscribe(StateProperty.BOOKEND_STATE, this.callback_);
+    }
+
+    unsubscribe() {
+      storeService.unsubscribe(StateProperty.BOOKEND_STATE, this.callback_);
+    }
+  }
 
   it('should unsubscribe from corresponding listener', () => {
-    const listenerSpy = sandbox.spy();
-    const listenerSpy2 = sandbox.spy();
+    const callbackSpy = sandbox.spy();
 
-    FakeComponent1.subscribeTo(StateProperty.BOOKEND_STATE, listenerSpy);
-    FakeComponent2.subscribeTo(StateProperty.BOOKEND_STATE, listenerSpy2);
-    FakeComponent1.unsubscribeFrom(StateProperty.BOOKEND_STATE, listenerSpy);
+    const instance = new FakeComponent(callbackSpy);
+    instance.unsubscribe();
 
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
 
-    expect(listenerSpy2).to.have.been.calledOnce;
-    expect(listenerSpy).to.have.callCount(0);
+    expect(callbackSpy).to.have.not.been.called;
   });
 });
 

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -62,6 +62,7 @@ describes.fakeWin('amp-story-store-service', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
   });
+
   class FakeComponent {
     constructor(callback) {
       this.callback_ = callback.bind(this);

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,3 +1,5 @@
+import {dev} from './log';
+
 /**
  * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
  *
@@ -58,6 +60,7 @@ export class Observable {
     if (index > -1) {
       this.handlers_.splice(index, 1);
     }
+    dev().error('Can\'t remove nonexistent handler %s.', handler);
   }
 
   /**

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,5 +1,3 @@
-import {dev} from './log';
-
 /**
  * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
  *
@@ -60,7 +58,6 @@ export class Observable {
     if (index > -1) {
       this.handlers_.splice(index, 1);
     }
-    dev().error('Can\'t remove nonexistent handler %s.', handler);
   }
 
   /**


### PR DESCRIPTION
This PR adds an unsubscribe method for a given action and listener.

Context on why we need it: (#20806)
For the embedded components feature (#19213 #16522), there is this case where a user:
1. Expands the embed
2. Plays a video inside it (could be in `amp-twitter` or `amp-youtube`...)
3. Switches to another page.

The video will continue playing until it's over or until the user comes back to the page containing it, expands it, pauses it, and closes it again. This is not the desired UX. What we want is to pause the embed when switching a page.

For this, we can use the methods `schedulePause` and `scheduleResume` from `resources-impl`. With the caveat that `schedulePause` should only be called if `scheduleResume` was called first, and `scheduleResume` should be called after `scheduledPaused` was called.

We also need to call `schedulePause` only once per embed once the page switches, which is why I need this unsubscribe method, so I can subscribe to the `CURRENT_PAGE_ID` with a listener that calls `schedulePause`, and immediately remove it so that it doesn't get called again on the same embed.