### PR TITLE
Implement more of the functional-test-controller API

### DIFF
--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -121,7 +121,7 @@ class FunctionalTestController {
    * Retrieves the URL for the current page.
    * {@link https://www.w3.org/TR/webdriver1/#get-current-url}
    *
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
   async getCurrentUrl() {}
 
@@ -129,7 +129,7 @@ class FunctionalTestController {
    * Returns the document title.
    * {@link https://www.w3.org/TR/webdriver1/#get-title}
    *
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
   async getTitle() {}
 
@@ -170,7 +170,7 @@ class FunctionalTestController {
    * Gets the active element of the current browsing context’s document element.
    * {@link https://www.w3.org/TR/webdriver1/#get-active-element}
    *
-   * @return {!Promise<!ElementHandle>}
+   * @return {!ControllerPromise<!ElementHandle>}
    */
   async getActiveElement() {}
 
@@ -259,10 +259,9 @@ class FunctionalTestController {
    * {@link https://www.w3.org/TR/webdriver1/#is-element-selected}
    *
    * @param {!ElementHandle} unusedHandle
-   * @param {boolean=} opt_expect An expected value to wait for
-   * @return {!Promise<boolean>}
+   * @return {!ControllerPromise<boolean>}
    */
-  async isElementSelected(unusedHandle, opt_expect) {}
+  async isElementSelected(unusedHandle) {}
 
   /**
    * Return the value of the given attribute name on the given element.
@@ -271,10 +270,9 @@ class FunctionalTestController {
    *
    * @param {!ElementHandle} unusedHandle
    * @param {string} unusedAttribute
-   * @param {string=} opt_expect An expected value to wait for
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
-  async getElementAttribute(unusedHandle, unusedAttribute, opt_expect) {}
+  async getElementAttribute(unusedHandle, unusedAttribute) {}
 
   /**
    * Return the value of the given property name on the given element.
@@ -282,20 +280,9 @@ class FunctionalTestController {
    *
    * @param {!ElementHandle} unusedHandle
    * @param {string} unusedProperty
-   * @param {string=} opt_expect An expected value to wait for
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
-  async getElementProperty(unusedHandle, unusedProperty, opt_expect) {}
-
-
-  /**
-   * Returns the rect for a given Element.
-   * {@link https://www.w3.org/TR/webdriver1/#get-element-rect}
-   *
-   * @param {!ElementHandle} unusedHandle
-   * @return {!Promise<!{x: number, y: number, height: number. width: number}>}
-   */
-  async getElementRect(unusedHandle) {}
+  async getElementProperty(unusedHandle, unusedProperty) {}
 
   /**
    * Return the value of the given CSS value on the given element.
@@ -303,10 +290,9 @@ class FunctionalTestController {
    *
    * @param {!ElementHandle} unusedHandle
    * @param {string} unusedStyleProperty
-   * @param {string=} opt_expect An expected value to wait for
-   * @return {!Promise<string>} styleProperty
+   * @return {!ControllerPromise<string>} styleProperty
    */
-  async getElementCssValue(unusedHandle, unusedStyleProperty, opt_expect) {}
+  async getElementCssValue(unusedHandle, unusedStyleProperty) {}
 
   /**
    * The Get Element Text command intends to return an element’s text
@@ -315,17 +301,16 @@ class FunctionalTestController {
    * {@link https://www.w3.org/TR/webdriver1/#get-element-text}
    *
    * @param {!ElementHandle} unusedHandle
-   * @param {(string|RegExp)=} opt_expect An expected value to wait for
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
-  async getElementText(unusedHandle, opt_expect) {}
+  async getElementText(unusedHandle) {}
 
   /**
    * Return the value of the tag name for the given element.
    * {@link https://www.w3.org/TR/webdriver1/#get-element-tag-name}
    *
    * @param {!ElementHandle} unusedHandle
-   * @return {!Promise<string>}
+   * @return {!ControllerPromise<string>}
    */
   async getElementTagName(unusedHandle) {}
 
@@ -335,7 +320,7 @@ class FunctionalTestController {
    * {@link https://www.w3.org/TR/webdriver1/#get-element-rect}
    *
    * @param {!ElementHandle} unusedHandle
-   * @return {!Promise<!DOMRectDef>}
+   * @return {!ControllerPromise<!DOMRectDef>}
    */
   async getElementRect(unusedHandle) {}
 
@@ -345,10 +330,9 @@ class FunctionalTestController {
    * {@link https://www.w3.org/TR/webdriver1/#is-element-enabled}
    *
    * @param {!ElementHandle} unusedHandle
-   * @param {boolean=} opt_expect An expected value to wait for
-   * @return {!Promise<boolean>}
+   * @return {!ControllerPromise<boolean>}
    */
-  async isElementEnabled(unusedHandle, opt_expect) {}
+  async isElementEnabled(unusedHandle) {}
 
   /**
    * The Set Window Rect command alters the size and the position of the

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -310,7 +310,7 @@ class FunctionalTestController {
    * {@link https://www.w3.org/TR/webdriver1/#get-element-tag-name}
    *
    * @param {!ElementHandle} unusedHandle
-   * @return {!ControllerPromise<string>}
+   * @return {!Promise<string>}
    */
   async getElementTagName(unusedHandle) {}
 

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -15,8 +15,11 @@
  */
 
 const fs = require('fs');
+const {
+  ControllerPromise,
+  ElementHandle,
+} = require('./functional-test-controller');
 const {By, Condition, Key, until} = require('selenium-webdriver');
-const {ControllerPromise,ElementHandle} = require('./functional-test-controller');
 const {expect} = require('chai');
 
 /**
@@ -135,6 +138,16 @@ class SeleniumWebDriverController {
   }
 
   /**
+   * @return {!Promise<!ElementHandle<!WebElement>>}
+   * @override
+   */
+  async getActiveElement() {
+    const activeElement = await this.driver.executeScript(
+        () => document.activeElement);
+    return new ElementHandle(activeElement);
+  }
+
+  /**
    * @param {string} location
    * @return {!Promise}
    * @override
@@ -173,6 +186,16 @@ class SeleniumWebDriverController {
     return new ControllerPromise(
         webElement.getText(),
         this.getWaitFn_(() => webElement.getText()));
+  }
+
+  /**
+   * @param {!ElementHandle<!WebElement>} handle
+   * @return {!Promise<string>}
+   * @override
+   */
+  getElementTagName(handle) {
+    const webElement = handle.getElement();
+    return webElement.getTagName();
   }
 
   /**
@@ -228,6 +251,30 @@ class SeleniumWebDriverController {
     return new ControllerPromise(
         webElement.getCssValue(styleProperty),
         this.getWaitFn_(() => webElement.getCssValue(styleProperty)));
+  }
+
+  /**
+   * @param {!ElementHandle} handle
+   * @return {!Promise<boolean>}
+   * @override
+   */
+  isElementEnabled(handle) {
+    const webElement = handle.getElement();
+    return new ControllerPromise(
+        webElement.isEnabled(),
+        this.getWaitFn_(() => webElement.isEnabled()));
+  }
+
+  /**
+   * @param {!ElementHandle} handle
+   * @return {!Promise<boolean>}
+   * @override
+   */
+  isElementSelected(handle) {
+    const webElement = handle.getElement();
+    return new ControllerPromise(
+        webElement.isSelected(),
+        this.getWaitFn_(() => webElement.isSelected()));
   }
 
   /**

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -142,8 +142,7 @@ class SeleniumWebDriverController {
    * @override
    */
   async getActiveElement() {
-    const activeElement = await this.driver.executeScript(
-        () => document.activeElement);
+    const activeElement = await this.driver.switchTo().activeElement();
     return new ElementHandle(activeElement);
   }
 


### PR DESCRIPTION
This implements all but three methods of the `FunctionalTestController` interface on the `SeleniumWebdriverController`. The remaining unimplemented methods are

- [ ] `getCurrentUrl`
- [ ] `findElementFromElement`
- [ ] `findElementsFromElement`

This also cleans up out of date method parameters and specifies which methods should return a controllerpromise.