### PR TITLE
🏗🐛 Fix two bugs in PR check

### DIFF
--- a/build-system/pr-check/dist-tests.js
+++ b/build-system/pr-check/dist-tests.js
@@ -50,7 +50,7 @@ function main() {
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
-    downloadDistOutput();
+    downloadDistOutput(FILENAME);
     timedExecOrDie('gulp bundle-size --on_push_build');
     runSinglePassTest_();
   } else {

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -175,7 +175,7 @@ async function downloadOutput_(functionName, outputFileName) {
 
   console.log(fileLogPrefix, 'Verifying extracted files...');
   exec('echo travis_fold:start:verify_unzip_results && echo');
-  execOrDie(`ls -la ${OUTPUT_DIRS}`);
+  execOrDie(`ls -laR ${OUTPUT_DIRS}`);
   exec('echo travis_fold:end:verify_unzip_results');
 }
 


### PR DESCRIPTION
1. There's a missing arg to `downloadDistOutput()` in `dist-tests.js`
2. We're not printing the contents of the `dist/v0/` directory after downloading the output

https://travis-ci.org/ampproject/amphtml/jobs/501748811#L1222
