### PR TITLE
Fix [amp-list-load-more] doesn't work with [amp-state] bug

### DIFF
--- a/build-system/routes/list.js
+++ b/build-system/routes/list.js
@@ -40,7 +40,6 @@ router.use('/vegetable-data/get', (req, res) => {
   });
 });
 
-
 /**
  * Autosuggest endpoint
  */
@@ -72,6 +71,16 @@ const randInt = n => {
 
 const squareImgUrl = width => {
   return `http://picsum.photos/${width}?${randInt(50)}`;
+};
+
+const randomFalsy = () => {
+  const rand = Math.floor(Math.random() * Math.floor(3));
+  switch (rand) {
+    case 1: return null;
+    case 2: return undefined;
+    case 3: return '';
+    default: return false;
+  }
 };
 
 const generateJson = numberOfItems => {
@@ -140,17 +149,6 @@ router.get('/infinite-scroll', function(req, res) {
   const nextUrl = '/list/infinite-scroll?items=' +
     numberOfItems + '&left=' + (pagesLeft - 1) +
     '&latency=' + latency;
-
-  const randomFalsy = () => {
-    const rand = Math.floor(Math.random() * Math.floor(3));
-    switch (rand) {
-      case 1: return null;
-      case 2: return undefined;
-      case 3: return '';
-      default: return false;
-    }
-  };
-
   const next = pagesLeft == 0 ? randomFalsy() : nextUrl;
   const results = next === false ? {items}
     : {items, next,
@@ -163,6 +161,29 @@ router.get('/infinite-scroll', function(req, res) {
   } else {
     res.json(results);
   }
+});
+
+
+const generateJsonWithState = (numberOfItems, pagesLeft) => {
+  const results = generateJson(numberOfItems);
+  results.forEach((e, i) => {
+    e['id'] = pagesLeft * 10 + i;
+    e['count'] = randInt(10);
+    e['favorited'] = randInt(2) == 0 ? 'no' : 'yes';
+  });
+  return results;
+};
+
+router.get('/infinite-scroll-state', function(req, res) {
+  const {query} = req;
+  const numberOfItems = query['items'] || 10;
+  const pagesLeft = query['left'] || 0;
+  const items = generateJsonWithState(numberOfItems, pagesLeft);
+  const results = {
+    items,
+    'next': '/list/infinite-scroll-state?left=' + (pagesLeft - 1),
+  };
+  res.json(results);
 });
 
 module.exports = router;

--- a/build-system/routes/list.js
+++ b/build-system/routes/list.js
@@ -74,7 +74,7 @@ const squareImgUrl = width => {
 };
 
 const randomFalsy = () => {
-  const rand = Math.floor(Math.random() * Math.floor(3));
+  const rand = Math.floor(Math.random() * 4);
   switch (rand) {
     case 1: return null;
     case 2: return undefined;

--- a/build-system/routes/list.js
+++ b/build-system/routes/list.js
@@ -176,12 +176,14 @@ const generateJsonWithState = (numberOfItems, pagesLeft) => {
 
 router.get('/infinite-scroll-state', function(req, res) {
   const {query} = req;
-  const numberOfItems = query['items'] || 10;
+  const numberOfItems = query['items'] || 2;
   const pagesLeft = query['left'] || 0;
   const items = generateJsonWithState(numberOfItems, pagesLeft);
+  const next = '/list/infinite-scroll-state?left=' + (pagesLeft - 1)
+      + '&items=' + numberOfItems;
   const results = {
     items,
-    'next': '/list/infinite-scroll-state?left=' + (pagesLeft - 1),
+    next,
   };
   res.json(results);
 });

--- a/build-system/routes/list.js
+++ b/build-system/routes/list.js
@@ -66,7 +66,7 @@ router.get('/search/countries', function(req, res) {
  * Infinite scroll related endpoints.
  */
 const randInt = n => {
-  return Math.floor(Math.random() * Math.floor(n));
+  return Math.floor(Math.random()) * n;
 };
 
 const squareImgUrl = width => {
@@ -74,7 +74,7 @@ const squareImgUrl = width => {
 };
 
 const randomFalsy = () => {
-  const rand = Math.floor(Math.random() * 4);
+  const rand = randInt(4);
   switch (rand) {
     case 1: return null;
     case 2: return undefined;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -52,6 +52,15 @@ import {
 /** @const {string} */
 const TAG = 'amp-list';
 
+
+/** @typedef {{
+  data:(?JsonObject|string|undefined|!Array),
+  resolver:!Function,
+  rejecter:!Function,
+  append:boolean,
+}} */
+export let RenderItems;
+
 /**
  * The implementation of `amp-list` component. See {@link ../amp-list.md} for
  * the spec.
@@ -82,7 +91,7 @@ export class AmpList extends AMP.BaseElement {
     /**
      * Latest fetched items to render and the promise resolver and rejecter
      * to be invoked on render success or fail, respectively.
-     * @private {?{data:(?JsonObject|string|undefined|!Array), resolver:!Function, rejecter:!Function}}
+     * @private {?RenderItems}
      */
     this.renderItems_ = null;
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -557,7 +557,7 @@ export class AmpList extends AMP.BaseElement {
     const isSSR = this.ssrTemplateHelper_.isSupported();
     let renderPromise = this.ssrTemplateHelper_.renderTemplate(
         this.element, current.data)
-        .then(result => this.updateBindings_(result))
+        .then(result => this.updateBindings_(result, current.append))
         .then(element => this.render_(element, current.append));
     if (!isSSR) {
       const payload = /** @type {!JsonObject} */ (current.payload);
@@ -610,10 +610,11 @@ export class AmpList extends AMP.BaseElement {
    * Ensures that rendered content is up-to-date with the latest bindable state.
    * Can be skipped by setting binding="no" or binding="refresh" attribute.
    * @param {!Array<!Element>|!Element} elementOrElements
+   * @param {boolean} append
    * @return {!Promise<!Array<!Element>>}
    * @private
    */
-  updateBindings_(elementOrElements) {
+  updateBindings_(elementOrElements, append) {
     const elements = /** @type {!Array<!Element>} */
       (isArray(elementOrElements) ? elementOrElements : [elementOrElements]);
 
@@ -623,8 +624,9 @@ export class AmpList extends AMP.BaseElement {
       return Promise.resolve(elements);
     }
     const updateWith = bind => {
+      const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
-      return bind.scanAndApply(elements, [this.container_])
+      return bind.scanAndApply(elements, removedElements)
           .then(() => elements, () => elements);
     };
     // "refresh": Do _not_ block on retrieval of the Bind service before the

--- a/test/manual/amp-list/load-more-state.amp.html
+++ b/test/manual/amp-list/load-more-state.amp.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+
+    body {
+      font-family: Roboto, Sans;
+    }
+
+    article {
+      display: block;
+      margin: 8px;
+    }
+
+    .pin-container {
+      border-radius: 8px;
+      background-color: #fefefe;
+      padding: 8px;
+      margin: 5px;
+    }
+
+    .pin-container:hover {
+       background-color: #eeeeee;
+    }
+
+    amp-img {
+      border-radius: 8px;
+    }
+
+    .title {
+      font-family: Roboto, Sans;
+      margin: 2px;
+    }
+
+    .description {
+      max-width: 160px;
+      font-size: 12px;
+      margin: 2px;
+    }
+
+    div[role="list"] {
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      align-content: flex-start;
+    }
+
+    amp-list {
+      height: auto;
+    }
+
+    .pro-like {
+      width: 100%;
+      height: 80px;
+      background-color: red;
+    }
+
+    .favorite {
+      width: 30px;
+      height: 30px;
+      background-color: blue;
+      cursor: pointer;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+</head>
+<body>
+<article>
+
+  <h1>AMP List</h1>
+
+  <amp-list width="auto" height="400"
+    layout="fixed-height"
+    src="/list/infinite-scroll-state?left=5"
+    load-more="manual"
+    load-more-bookmark="next">
+    <template type="amp-mustache">
+      <amp-state id="fav_state{{id}}" hidden aria-hidden="true">
+          <script type="application/json">
+              {
+                  "count":"{{count}}",
+                  "value":"{{favorited}}"
+              }
+          </script>
+      </amp-state>
+      <div class="pin-container">
+        <amp-img src="{{imageUrl}}" width="160" height="160"></amp-img>
+        <div class="pro-like">
+            <div class="favorite" on="tap:AMP.setState({
+              fav_state{{id}}: {
+                value: fav_state{{id}}.value == 'yes' ? 'no' : 'yes'
+              }
+              })" role="button" tabindex="0">
+            </div>
+            <p [text]="'Favorited: ' + fav_state{{id}}.value"></p>
+        </div>
+      </div>
+    </template>
+    <div fallback>
+      FALLBACK
+    </div>
+  </amp-list>
+</article>
+</body>
+</html>

--- a/test/manual/amp-list/load-more-state.amp.html
+++ b/test/manual/amp-list/load-more-state.amp.html
@@ -83,7 +83,7 @@
 
   <amp-list width="auto" height="400"
     layout="fixed-height"
-    src="/list/infinite-scroll-state?left=5"
+    src="/list/infinite-scroll-state?left=5&items=2"
     load-more="manual"
     load-more-bookmark="next">
     <template type="amp-mustache">


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/21195

Basically, the bug cause here is we're not correctly accounting for the fact that in `load-more` we append items and do not remove the original items in `amp-list` when we pass `removedElements` to `scanAndApply`. This code change fixes the bug, but I'm interested in understanding why we need to special case `amp-list`  in `amp-bind` with this `updateBindings` function and whether we need to continue doing so in the future. 