### PR TITLE
🐛 amp-geo: Target AMP body with class changes (#20946)

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -321,7 +321,7 @@ export class AmpGeo extends AMP.BaseElement {
           classesToAdd.push(COUNTRY_PREFIX + this.country_);
 
           // Let the runtime know we're mutating the AMP body
-          // Actual change happens in callback to runtime can
+          // Actual change happens in callback so runtime can
           // optimize dom mutations.
           self.mutateElement(() => {
             const {classList} = body;


### PR DESCRIPTION
Use `getAmpDoc` method to obtain `document` and `body`, fixing compatibility
with PWAs, where the body is not simply `window.document.body`.

Fixes #20946