### PR TITLE
🐛 Improve AMP state URL replacement compatibility with PWA (#20853)

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -571,8 +571,9 @@ export class GlobalVariableSource extends VariableSource {
 
     this.setAsync('AMP_STATE', key => {
       // This is safe since AMP_STATE is not an A4A whitelisted variable.
-      const {documentElement} = win.document;
-      return Services.bindForDocOrNull(documentElement).then(bind => {
+      const root = this.ampdoc.getRootNode();
+      const element = /** @type {!Element|!ShadowRoot} */(root.documentElement || root);
+      return Services.bindForDocOrNull(element).then(bind => {
         if (!bind) {
           return '';
         }


### PR DESCRIPTION
Use `ampdoc.getRootNode()` to identify the relevant document/shadow node
for `Services.bindForDocOrNull()` when making URL replacements in a PWA.

Fixes #20853