### PR TITLE
Add a method to enable REPL-like debugging on e2e tests

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -19,7 +19,9 @@ require('chromedriver'); // eslint-disable-line no-unused-vars
 const {AmpDriver, AmpdocEnvironment} = require('./amp-driver');
 const {Builder, Capabilities} = require('selenium-webdriver');
 const {clearLastExpectError, getLastExpectError} = require('./expect');
-const {SeleniumWebDriverController} = require('./selenium-webdriver-controller');
+const {installRepl, uninstallRepl} = require('./repl');
+const {SeleniumWebDriverController} = require(
+    './selenium-webdriver-controller');
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
@@ -112,6 +114,9 @@ function describeEnv(factory) {
             }
           }
         });
+        totalPromise = totalPromise.then(() => {
+          installRepl(global, env);
+        });
         return totalPromise;
       });
 
@@ -131,6 +136,8 @@ function describeEnv(factory) {
         for (const key in env) {
           delete env[key];
         }
+
+        uninstallRepl();
       });
 
       after(function() {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -101,23 +101,12 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      beforeEach(() => {
-        let totalPromise = undefined;
+      beforeEach(async() => {
         // Set up all fixtures.
-        fixtures.forEach((fixture, unusedIndex) => {
-          if (totalPromise) {
-            totalPromise = totalPromise.then(() => fixture.setup(env));
-          } else {
-            const res = fixture.setup(env);
-            if (res && typeof res.then == 'function') {
-              totalPromise = res;
-            }
-          }
-        });
-        totalPromise = totalPromise.then(() => {
-          installRepl(global, env);
-        });
-        return totalPromise;
+        for (const fixture of fixtures) {
+          await fixture.setup(env);
+        }
+        installRepl(global, env);
       });
 
       afterEach(function() {

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -65,16 +65,18 @@ function installRepl(global, env) {
   };
 
   function replContinue() {
-    if (replResolve) {
-      replResolve();
-      replResolve = null;
-      replPromise = null;
-      delete global.repl.controller;
-      delete global.repl.env;
-      delete global.repl.continue;
-
-      console./*OK*/log(CONTINUE_MESSAGE);
+    if (!replResolve) {
+      return;
     }
+
+    replResolve();
+    replResolve = null;
+    replPromise = null;
+    delete global.repl.controller;
+    delete global.repl.env;
+    delete global.repl.continue;
+
+    console./*OK*/log(CONTINUE_MESSAGE);
   }
 }
 

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const READY_MESSAGE = 'e2e repl ready';
+const CONTINUE_MESSAGE = 'cleaning up repl';
+
+const REPL_INFINITE_TIMEOUT = 86400000; // milliseconds in a day
+
+/**
+ * Adds a REPL-like debugging experience to E2E tests.
+ * Usage:
+ * 1. In a test, add `await repl(this);` where `this` is mocha's this context.
+ *    This will cause the test to wait indefinitely when you want to execute
+ *    commands in the DevTools console.
+ *    You may have to change `async() => {}` to `async function() {}`
+ * 2. Run gulp with Node debugging enabled:
+ *   `node --inspect-brk $(which gulp) e2e ...`
+ * 3. Open Chrome DevTools and open the Node debugger
+ * 4. Wait for the `READY_MESSAGE` to appear in the console
+ * 5. You are now free to execute code in the console using the controller API.
+ *   `console.log(await repl.controller.getTitle())`
+ * 6. When you're done, call `repl.continue()`
+ *
+ * @param {!Object} global
+ * @param {!Object} env
+ */
+function installRepl(global, env) {
+  let replPromise = null;
+  let replResolve = null;
+
+  /**
+   * Usage: in a test, await repl();
+   * @param {*} mochaThis
+   */
+  global.repl = function(mochaThis) {
+    mochaThis.timeout(REPL_INFINITE_TIMEOUT);
+
+    const {controller} = env;
+    global.repl.controller = controller;
+    global.repl.env = env;
+    global.repl.continue = replContinue;
+
+    if (!replPromise) {
+      replPromise = new Promise(resolve => {
+        replResolve = resolve;
+      });
+    }
+
+    console./*OK*/log(READY_MESSAGE);
+
+    return replPromise;
+  };
+
+  function replContinue() {
+    if (replResolve) {
+      replResolve();
+      replResolve = null;
+      replPromise = null;
+      delete global.repl.controller;
+      delete global.repl.env;
+      delete global.repl.continue;
+
+      console./*OK*/log(CONTINUE_MESSAGE);
+    }
+  }
+}
+
+function uninstallRepl() {
+  delete global.repl;
+}
+
+module.exports = {
+  installRepl,
+  uninstallRepl,
+};


### PR DESCRIPTION
I got sick of debugging and having the test timeout and having to put a debugger statement and then not being able to call methods on the controller.

```js
// before:
it('should do stuff', async() => {
  debugger;
  // even if you called `await controller.getTitle()` in the console, 
  // nothing would happen because test execution is stopped and
  // async calls do not complete. If too much time passes the test will timeout.
});

// after:
it('should do stuff', async function() {
  await repl(this);
  // Now if you called `await controller.getTitle()` in the console,
  // you'll get `"Page Title"`.
});
```

These calls are for debugging only and should not be checked in to the repo.

Demo (internal only): https://drive.google.com/file/d/1KtJjcy8o8oSdax1MChvCWGEpgYJFoco-/view?usp=sharing