### PR TITLE
🐛Pause embeds on page change

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -383,6 +383,9 @@ export class AmpStoryEmbeddedComponent {
    * @private
    */
   scheduleEmbedToPause_(embedEl) {
+    // Resources that previously called `schedulePause` must also call
+    // `scheduleResume`. Calling `scheduleResume` on resources that did not
+    // previously call `schedulePause` has no effect.
     this.resources_.scheduleResume(this.storyEl_, embedEl);
     if (!this.embedsToBePaused_.includes(embedEl)) {
       this.embedsToBePaused_.push(embedEl);
@@ -493,7 +496,7 @@ export class AmpStoryEmbeddedComponent {
     // First time attaching the overlay. Runs only once.
     if (!this.focusedStateOverlay_) {
       this.storyEl_.appendChild(this.buildFocusedState_());
-      this.attachUIListeners_();
+      this.initializeListeners_();
     }
 
     this.updateTooltipBehavior_(component.element);
@@ -514,7 +517,7 @@ export class AmpStoryEmbeddedComponent {
    * Attaches listeners that listen for UI updates.
    * @private
    */
-  attachUIListeners_() {
+  initializeListeners_() {
     this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
       this.onUIStateUpdate_(uiState);
     }, true /** callToInitialize */);

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -73,6 +73,12 @@ export const EXPANDABLE_COMPONENTS = {
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
     selector: 'amp-twitter',
   },
+  'amp-youtube': {
+    selector: 'amp-youtube',
+  },
+  'amp-instagram': {
+    selector: 'amp-instagram',
+  },
 };
 
 /**
@@ -299,6 +305,9 @@ export class AmpStoryEmbeddedComponent {
     /** @private */
     this.expandComponentHandler_ = this.onExpandComponent_.bind(this);
 
+    /** @private */
+    this.onChangePageHandler_ = this.onChangePage_.bind(this);
+
     this.storeService_.subscribe(StateProperty.INTERACTIVE_COMPONENT_STATE,
         /** @param {!InteractiveComponentDef} component */ component => {
           this.onComponentStateUpdate_(component);
@@ -392,6 +401,10 @@ export class AmpStoryEmbeddedComponent {
 
     this.animateExpanded_(devAssert(targetToExpand));
 
+    this.storeService_.subscribe(StateProperty.CURRENT_PAGE_ID,
+        this.onChangePageHandler_);
+
+    this.resources_.scheduleResume(this.storyEl_, this.triggeringTarget_);
     this.expandedViewOverlay_ = this.componentPage_
         .querySelector('.i-amphtml-story-expanded-view-overflow');
     if (!this.expandedViewOverlay_) {
@@ -453,13 +466,6 @@ export class AmpStoryEmbeddedComponent {
       // desktop buttons.
       if (this.state_ === EmbeddedComponentState.FOCUSED) {
         this.close_();
-      }
-
-      // Hide expanded view when page switch is triggered by keyboard or desktop
-      // buttons.
-      if (this.state_ === EmbeddedComponentState.EXPANDED) {
-        this.maybeCloseExpandedView_(null /** target */,
-            true /** forceClose */);
       }
     });
 
@@ -558,6 +564,21 @@ export class AmpStoryEmbeddedComponent {
       this.tooltip_.addEventListener('click', this.expandComponentHandler_,
           true);
     }
+  }
+
+  /**
+   *
+   */
+  onChangePage_() {
+    // Hide expanded view when page switch is triggered by keyboard or desktop
+    // buttons.
+    if (this.state_ === EmbeddedComponentState.EXPANDED) {
+      this.maybeCloseExpandedView_(null /** target */,
+          true /** forceClose */);
+    }
+    this.resources_.schedulePause(this.storyEl_, this.triggeringTarget_);
+    this.storeService_.unsubscribe(StateProperty.CURRENT_PAGE_ID,
+        this.onChangePageHandler_);
   }
 
   /**


### PR DESCRIPTION
Closes #20806

I had previously proposed another approach in #21268, where we would subscribe on change page and unsubscribe once we called `schedulePause` on the embed. But as Gabriel pointed out, this would not work for multiple embeds in one page.

This approach uses a list to push all the embeds that are expanded on a page, and then calls `schedulePause` on all of them whenever a page changes.

I'm also moving the installation of the listeners when we build the tooltip overlay for the first (and only) time to new method.

Demo (go to third page): https://stamp-iframe-support.firebaseapp.com/examples/amp-story/artezan/embeds.html