### PR TITLE
✅ Use non-default slow threshold for e2e tests

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -28,6 +28,7 @@ const {execOrDie, execScriptAsync} = require('../../exec');
 const HOST = 'localhost';
 const PORT = 8000;
 const WEBSERVER_TIMEOUT_RETRIES = 10;
+const SLOW_TEST_THRESHOLD_MS = 2500;
 
 let webServerProcess_;
 
@@ -105,6 +106,10 @@ async function e2e() {
 
   // start up web server
   await launchWebServer_();
+
+  // e2e tests have a different standard for when a test is too slow,
+  // so we set a non-default threshold.
+  mocha.slow(SLOW_TEST_THRESHOLD_MS);
 
   // run tests
   mocha.run(failures => {


### PR DESCRIPTION
The default `75ms` is way too slow. `2500ms` is a good initial value for e2e tests I think, but I'm open to suggestions.

This will make the test output print the number of ms the test took to run in yellow or red if the number exceeds or greatly exceeds the `slow` value.