### PR TITLE
Add orientation and device attributes on the amp-story element.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -90,7 +90,6 @@ export let InteractiveComponentDef;
  *    hasSidebarState: boolean,
  *    infoDialogState: boolean,
  *    interactiveEmbeddedComponentState: !InteractiveComponentDef,
- *    landscapeState: boolean,
  *    mutedState: boolean,
  *    pageAudioState: boolean,
  *    pausedState: boolean,
@@ -131,7 +130,6 @@ export const StateProperty = {
   HAS_SIDEBAR_STATE: 'hasSidebarState',
   INFO_DIALOG_STATE: 'infoDialogState',
   INTERACTIVE_COMPONENT_STATE: 'interactiveEmbeddedComponentState',
-  LANDSCAPE_STATE: 'landscapeState',
   MUTED_STATE: 'mutedState',
   PAGE_HAS_AUDIO_STATE: 'pageAudioState',
   PAUSED_STATE: 'pausedState',
@@ -170,7 +168,6 @@ export const Action = {
   TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
   TOGGLE_INTERACTIVE_COMPONENT: 'toggleInteractiveComponent',
-  TOGGLE_LANDSCAPE: 'toggleLandscape',
   TOGGLE_MUTED: 'toggleMuted',
   TOGGLE_PAGE_HAS_AUDIO: 'togglePageHasAudio',
   TOGGLE_PAUSED: 'togglePaused',
@@ -261,9 +258,6 @@ const actions = (state, action, data) => {
             [StateProperty.INFO_DIALOG_STATE]: !!data,
             [StateProperty.PAUSED_STATE]: !!data,
           }));
-    case Action.TOGGLE_LANDSCAPE:
-      return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.LANDSCAPE_STATE]: !!data}));
     // Shows or hides the audio controls.
     case Action.TOGGLE_STORY_HAS_AUDIO:
       return /** @type {!State} */ (Object.assign(
@@ -440,7 +434,6 @@ export class AmpStoryStoreService {
       [StateProperty.INTERACTIVE_COMPONENT_STATE]: {
         state: EmbeddedComponentState.HIDDEN,
       },
-      [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.PAGE_HAS_AUDIO_STATE]: false,
       [StateProperty.PAUSED_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -90,6 +90,7 @@ export let InteractiveComponentDef;
  *    hasSidebarState: boolean,
  *    infoDialogState: boolean,
  *    interactiveEmbeddedComponentState: !InteractiveComponentDef,
+ *    landscapeState: boolean,
  *    mutedState: boolean,
  *    pageAudioState: boolean,
  *    pausedState: boolean,
@@ -130,6 +131,7 @@ export const StateProperty = {
   HAS_SIDEBAR_STATE: 'hasSidebarState',
   INFO_DIALOG_STATE: 'infoDialogState',
   INTERACTIVE_COMPONENT_STATE: 'interactiveEmbeddedComponentState',
+  LANDSCAPE_STATE: 'landscapeState',
   MUTED_STATE: 'mutedState',
   PAGE_HAS_AUDIO_STATE: 'pageAudioState',
   PAUSED_STATE: 'pausedState',
@@ -165,15 +167,16 @@ export const Action = {
   TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_BOOKEND: 'toggleBookend',
+  TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
   TOGGLE_INTERACTIVE_COMPONENT: 'toggleInteractiveComponent',
+  TOGGLE_LANDSCAPE: 'toggleLandscape',
   TOGGLE_MUTED: 'toggleMuted',
   TOGGLE_PAGE_HAS_AUDIO: 'togglePageHasAudio',
   TOGGLE_PAUSED: 'togglePaused',
   TOGGLE_RTL: 'toggleRtl',
   TOGGLE_SHARE_MENU: 'toggleShareMenu',
   TOGGLE_SIDEBAR: 'toggleSidebar',
-  TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_SUPPORTED_BROWSER: 'toggleSupportedBrowser',
   TOGGLE_STORY_HAS_AUDIO: 'toggleStoryHasAudio',
   TOGGLE_STORY_HAS_BACKGROUND_AUDIO: 'toggleStoryHasBackgroundAudio',
@@ -258,6 +261,9 @@ const actions = (state, action, data) => {
             [StateProperty.INFO_DIALOG_STATE]: !!data,
             [StateProperty.PAUSED_STATE]: !!data,
           }));
+    case Action.TOGGLE_LANDSCAPE:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.LANDSCAPE_STATE]: !!data}));
     // Shows or hides the audio controls.
     case Action.TOGGLE_STORY_HAS_AUDIO:
       return /** @type {!State} */ (Object.assign(
@@ -434,6 +440,7 @@ export class AmpStoryStoreService {
       [StateProperty.INTERACTIVE_COMPONENT_STATE]: {
         state: EmbeddedComponentState.HIDDEN,
       },
+      [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.PAGE_HAS_AUDIO_STATE]: false,
       [StateProperty.PAUSED_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1453,9 +1453,11 @@ export class AmpStory extends AMP.BaseElement {
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
     const isLandscape = this.isLandscape_();
-    this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, isLandscape);
+    const isLandscapeSupported = this.isLandscapeSupported_();
+    this.storeService_.dispatch(
+        Action.TOGGLE_LANDSCAPE, isLandscapeSupported && isLandscape);
 
-    if (uiState !== UIType.MOBILE || this.isLandscapeSupported_()) {
+    if (uiState !== UIType.MOBILE || isLandscapeSupported) {
       // Hides the UI that prevents users from using the LANDSCAPE orientation.
       this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, false);
       return;
@@ -1524,7 +1526,6 @@ export class AmpStory extends AMP.BaseElement {
     switch (uiState) {
       case UIType.MOBILE:
         this.vsync_.mutate(() => {
-          this.element.setAttribute('mobile', '');
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
@@ -1535,7 +1536,6 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
-          this.element.removeAttribute('mobile');
           this.element.classList.add('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
@@ -1552,7 +1552,6 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
-          this.element.removeAttribute('mobile');
           this.element.classList.add('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
         });

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1473,6 +1473,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   setOrientationAttribute_(isLandscape, isLandscapeSupported) {
+    // TODO(#20832) base this check on the size of the amp-story-page, once it
+    // is stored as a store state.
     this.mutateElement(() => {
       this.element.setAttribute(
           Attributes.ORIENTATION,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -633,10 +633,6 @@ export class AmpStory extends AMP.BaseElement {
       this.onCurrentPageIdUpdate_(pageId);
     });
 
-    this.storeService_.subscribe(StateProperty.LANDSCAPE_STATE, isLandscape => {
-      this.onLandscapeStateUpdate_(isLandscape);
-    }, true /** callToInitialize */);
-
     this.storeService_.subscribe(StateProperty.PAUSED_STATE, isPaused => {
       this.onPausedStateUpdate_(isPaused);
     });
@@ -1454,8 +1450,8 @@ export class AmpStory extends AMP.BaseElement {
 
     const isLandscape = this.isLandscape_();
     const isLandscapeSupported = this.isLandscapeSupported_();
-    this.storeService_.dispatch(
-        Action.TOGGLE_LANDSCAPE, isLandscapeSupported && isLandscape);
+
+    this.setOrientationAttribute_(isLandscape, isLandscapeSupported);
 
     if (uiState !== UIType.MOBILE || isLandscapeSupported) {
       // Hides the UI that prevents users from using the LANDSCAPE orientation.
@@ -1466,6 +1462,22 @@ export class AmpStory extends AMP.BaseElement {
     // Only called when the desktop media query is not matched and the landscape
     // mode is not enabled.
     this.maybeTriggerViewportWarning_(isLandscape);
+  }
+
+  /**
+   * Adds an orientation=landscape|portrait attribute.
+   * If the story doesn't explicitly support landscape via the opt-in attribute,
+   * it is always in a portrait orientation.
+   * @param {boolean} isLandscape Whether the viewport is landscape or portrait
+   * @param {boolean} isLandscapeSupported Whether the story supports landscape
+   * @private
+   */
+  setOrientationAttribute_(isLandscape, isLandscapeSupported) {
+    this.mutateElement(() => {
+      this.element.setAttribute(
+          Attributes.ORIENTATION,
+          isLandscapeSupported && isLandscape ? 'landscape' : 'portrait');
+    });
   }
 
   /**
@@ -1611,18 +1623,6 @@ export class AmpStory extends AMP.BaseElement {
    */
   isLandscapeSupported_() {
     return this.element.hasAttribute(Attributes.SUPPORTS_LANDSCAPE);
-  }
-
-  /**
-   * Reacts to landscape state updates.
-   * @param {boolean} isLandscape
-   * @private
-   */
-  onLandscapeStateUpdate_(isLandscape) {
-    this.mutateElement(() => {
-      this.element.setAttribute(
-          Attributes.ORIENTATION, isLandscape ? 'landscape' : 'portrait');
-    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -141,17 +141,18 @@ const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;
 
 /** @enum {string} */
 const Attributes = {
-  STANDALONE: 'standalone',
+  AD_SHOWING: 'ad-showing',
   ADVANCE_TO: 'i-amphtml-advance-to',
+  AUTO_ADVANCE_AFTER: 'auto-advance-after',
+  AUTO_ADVANCE_TO: 'auto-advance-to',
+  DESKTOP_POSITION: 'i-amphtml-desktop-position',
+  ORIENTATION: 'orientation',
   PUBLIC_ADVANCE_TO: 'advance-to',
   RETURN_TO: 'i-amphtml-return-to',
-  AUTO_ADVANCE_TO: 'auto-advance-to',
-  AD_SHOWING: 'ad-showing',
-  // Attributes that desktop css looks for to decide where pages will be placed
-  DESKTOP_POSITION: 'i-amphtml-desktop-position',
-  VISITED: 'i-amphtml-visited', // stacked offscreen to left
-  AUTO_ADVANCE_AFTER: 'auto-advance-after',
+  STANDALONE: 'standalone',
   SUPPORTS_LANDSCAPE: 'supports-landscape',
+  // Attributes that desktop css looks for to decide where pages will be placed
+  VISITED: 'i-amphtml-visited', // stacked offscreen to left
 };
 
 /**
@@ -288,6 +289,10 @@ export class AmpStory extends AMP.BaseElement {
     this.canRotateToDesktopMedia_ = this.win.matchMedia(
         `(min-width: ${DESKTOP_HEIGHT_THRESHOLD}px) and ` +
         `(min-height: ${DESKTOP_WIDTH_THRESHOLD}px)`);
+
+    /** @private @const */
+    this.landscapeOrientationMedia_ =
+        this.win.matchMedia('(orientation: landscape)');
 
     /** @private {?AmpStoryBackground} */
     this.background_ = null;
@@ -627,6 +632,10 @@ export class AmpStory extends AMP.BaseElement {
     this.storeService_.subscribe(StateProperty.CURRENT_PAGE_ID, pageId => {
       this.onCurrentPageIdUpdate_(pageId);
     });
+
+    this.storeService_.subscribe(StateProperty.LANDSCAPE_STATE, isLandscape => {
+      this.onLandscapeStateUpdate_(isLandscape);
+    }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.PAUSED_STATE, isPaused => {
       this.onPausedStateUpdate_(isPaused);
@@ -1443,39 +1452,43 @@ export class AmpStory extends AMP.BaseElement {
     const uiState = this.getUIType_();
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 
+    const isLandscape = this.isLandscape_();
+    this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, isLandscape);
+
     if (uiState !== UIType.MOBILE || this.isLandscapeSupported_()) {
       // Hides the UI that prevents users from using the LANDSCAPE orientation.
       this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, false);
       return;
     }
 
-    // On mobile, maybe display the landscape overlay warning and pause the
-    // story.
-    this.vsync_.run({
-      measure: state => {
-        const {offsetWidth, offsetHeight} = this.element;
-        state.isLandscape = offsetWidth > offsetHeight;
-      },
-      mutate: state => {
-        const viewportWarningState =
-            this.storeService_.get(StateProperty.VIEWPORT_WARNING_STATE);
+    // Only called when the desktop media query is not matched and the landscape
+    // mode is not enabled.
+    this.maybeTriggerViewportWarning_(isLandscape);
+  }
 
-        if (viewportWarningState === state.isLandscape) {
-          return;
-        }
+  /**
+   * Maybe triggers the viewport warning overlay.
+   * @param {boolean} isLandscape
+   * @private
+   */
+  maybeTriggerViewportWarning_(isLandscape) {
+    if (isLandscape ===
+        this.storeService_.get(StateProperty.VIEWPORT_WARNING_STATE)) {
+      return;
+    }
 
-        if (state.isLandscape) {
-          this.pausedStateToRestore_ =
-              !!this.storeService_.get(StateProperty.PAUSED_STATE);
-          this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
-          this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, true);
-        } else {
-          this.storeService_
-              .dispatch(Action.TOGGLE_PAUSED, this.pausedStateToRestore_);
-          this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, false);
-        }
-      },
-    }, {});
+    this.mutateElement(() => {
+      if (isLandscape) {
+        this.pausedStateToRestore_ =
+            !!this.storeService_.get(StateProperty.PAUSED_STATE);
+        this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+        this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, true);
+      } else {
+        this.storeService_
+            .dispatch(Action.TOGGLE_PAUSED, this.pausedStateToRestore_);
+        this.storeService_.dispatch(Action.TOGGLE_VIEWPORT_WARNING, false);
+      }
+    });
   }
 
   /**
@@ -1511,6 +1524,7 @@ export class AmpStory extends AMP.BaseElement {
     switch (uiState) {
       case UIType.MOBILE:
         this.vsync_.mutate(() => {
+          this.element.setAttribute('mobile', '');
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
@@ -1521,6 +1535,7 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
+          this.element.removeAttribute('mobile');
           this.element.classList.add('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
@@ -1537,6 +1552,7 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
+          this.element.removeAttribute('mobile');
           this.element.classList.add('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
         });
@@ -1572,6 +1588,14 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
+   * @return {boolean} True if the screen orientation is landscape.
+   * @private
+   */
+  isLandscape_() {
+    return this.landscapeOrientationMedia_.matches;
+  }
+
+  /**
    * @return {boolean} true if this is a standalone story (i.e. this story is
    *     the only content of the document).
    * @private
@@ -1588,6 +1612,18 @@ export class AmpStory extends AMP.BaseElement {
    */
   isLandscapeSupported_() {
     return this.element.hasAttribute(Attributes.SUPPORTS_LANDSCAPE);
+  }
+
+  /**
+   * Reacts to landscape state updates.
+   * @param {boolean} isLandscape
+   * @private
+   */
+  onLandscapeStateUpdate_(isLandscape) {
+    this.mutateElement(() => {
+      this.element.setAttribute(
+          Attributes.ORIENTATION, isLandscape ? 'landscape' : 'portrait');
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -483,9 +483,9 @@ describes.realWin('amp-story', {
   it('should set the orientation portrait attribute on render', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
 
-    const landscapeOrientationMedia = story.landscapeOrientationMedia_;
     story.landscapeOrientationMedia_ = {matches: false};
     story.element.setAttribute('standalone', '');
+    story.element.setAttribute('supports-landscape', '');
 
     story.buildCallback();
 
@@ -494,14 +494,29 @@ describes.realWin('amp-story', {
           expect(story.element).to.have.attribute('orientation');
           expect(story.element.getAttribute('orientation'))
               .to.equal('portrait');
-          story.landscapeOrientationMedia_ = landscapeOrientationMedia;
         });
   });
 
   it('should set the orientation landscape attribute on render', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
 
-    const landscapeOrientationMedia = story.landscapeOrientationMedia_;
+    story.landscapeOrientationMedia_ = {matches: true};
+    story.element.setAttribute('standalone', '');
+    story.element.setAttribute('supports-landscape', '');
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.element).to.have.attribute('orientation');
+          expect(story.element.getAttribute('orientation'))
+              .to.equal('landscape');
+        });
+  });
+
+  it('should not set orientation landscape if no supports-landscape', () => {
+    createPages(story.element, 2, ['cover', 'page-1']);
+
     story.landscapeOrientationMedia_ = {matches: true};
     story.element.setAttribute('standalone', '');
 
@@ -511,8 +526,7 @@ describes.realWin('amp-story', {
         .then(() => {
           expect(story.element).to.have.attribute('orientation');
           expect(story.element.getAttribute('orientation'))
-              .to.equal('landscape');
-          story.landscapeOrientationMedia_ = landscapeOrientationMedia;
+              .to.equal('portrait');
         });
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -444,6 +444,32 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should add a desktop attribute', () => {
+    createPages(story.element, 2, ['cover', '1']);
+
+    story.desktopMedia_ = {matches: true};
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.element).to.have.attribute('desktop');
+        });
+  });
+
+  it('should add a mobile attribute', () => {
+    createPages(story.element, 2, ['cover', '1']);
+
+    story.desktopMedia_ = {matches: false};
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.element).to.have.attribute('mobile');
+        });
+  });
+
   it('should have a meta tag that sets the theme color', () => {
     createPages(story.element, 2);
     story.buildCallback();
@@ -452,6 +478,54 @@ describes.realWin('amp-story', {
           const metaTag = win.document.querySelector('meta[name=theme-color]');
           expect(metaTag).to.not.be.null;
         });
+  });
+
+  it('should set the orientation portrait attribute on render', () => {
+    createPages(story.element, 2, ['cover', 'page-1']);
+
+    const landscapeOrientationMedia = story.landscapeOrientationMedia_;
+    story.landscapeOrientationMedia_ = {matches: false};
+    story.element.setAttribute('standalone', '');
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.element).to.have.attribute('orientation');
+          expect(story.element.getAttribute('orientation'))
+              .to.equal('portrait');
+          story.landscapeOrientationMedia_ = landscapeOrientationMedia;
+        });
+  });
+
+  it('should set the orientation landscape attribute on render', () => {
+    createPages(story.element, 2, ['cover', 'page-1']);
+
+    const landscapeOrientationMedia = story.landscapeOrientationMedia_;
+    story.landscapeOrientationMedia_ = {matches: true};
+    story.element.setAttribute('standalone', '');
+
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(story.element).to.have.attribute('orientation');
+          expect(story.element.getAttribute('orientation'))
+              .to.equal('landscape');
+          story.landscapeOrientationMedia_ = landscapeOrientationMedia;
+        });
+  });
+
+  it('should update the orientation landscape attribute', () => {
+    createPages(story.element, 2, ['cover', 'page-1']);
+
+    story.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, true);
+
+    return story.mutateElement(() => {
+      expect(story.element).to.have.attribute('orientation');
+      expect(story.element.getAttribute('orientation'))
+          .to.equal('landscape');
+    });
   });
 
   describe('amp-story consent', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -457,19 +457,6 @@ describes.realWin('amp-story', {
         });
   });
 
-  it('should add a mobile attribute', () => {
-    createPages(story.element, 2, ['cover', '1']);
-
-    story.desktopMedia_ = {matches: false};
-
-    story.buildCallback();
-
-    return story.layoutCallback()
-        .then(() => {
-          expect(story.element).to.have.attribute('mobile');
-        });
-  });
-
   it('should have a meta tag that sets the theme color', () => {
     createPages(story.element, 2);
     story.buildCallback();
@@ -533,13 +520,23 @@ describes.realWin('amp-story', {
   it('should update the orientation landscape attribute', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
 
-    story.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, true);
+    story.landscapeOrientationMedia_ = {matches: true};
+    story.element.setAttribute('standalone', '');
+    story.element.setAttribute('supports-landscape', '');
+    sandbox.stub(story, 'mutateElement').callsFake(fn => fn());
 
-    return story.mutateElement(() => {
-      expect(story.element).to.have.attribute('orientation');
-      expect(story.element.getAttribute('orientation'))
-          .to.equal('landscape');
-    });
+    story.buildCallback();
+
+    return story.layoutCallback()
+        .then(() => {
+          story.landscapeOrientationMedia_ = {matches: false};
+          story.onResize();
+        })
+        .then(() => {
+          expect(story.element).to.have.attribute('orientation');
+          expect(story.element.getAttribute('orientation'))
+              .to.equal('portrait');
+        });
   });
 
   describe('amp-story consent', () => {


### PR DESCRIPTION
Adds a `[orientation=landscape|portrait]` attributes on the `<amp-story>` element, meant to make CSS styling across experiences and orientations easier for publishers.
This orientation attribute describes how the story is displayed, and not the viewport, like would a CSS media query. Eg: for the desktop three panels UI, the orientation will be `portrait`, when the viewport is actually `landscape`.

Part of #21661