### PR TITLE
🖍 amp-consent-ui: Removed iframe border-radius on consent fullscreen and width fix

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -98,7 +98,7 @@ iframe.i-amphtml-consent-ui-fill {
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active {
-  width: 100vw !important;
+  width: 100% !important;
   height: 100vh !important;
   padding: 0px !important;
   margin: 0px !important;

--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -118,6 +118,9 @@ amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen {
   top: 0px !important;
   transform: translate3d(0px, 0px, 0px) !important;
+
+  border-top-left-radius: 0px !important;
+  border-top-right-radius: 0px !important;
 }
 
 amp-consent.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen > .i-amphtml-consent-ui-fill {


### PR DESCRIPTION
relates to: #17742
closes: #21245

# Border Radius

This removes the `border-radius` from the consent modal on fullscreen. Made the following design decisions:

1. The border-radius is not animated, as it can't be hardware accelerated. But, honestly, I don't think it is very noticeable, and isn't "jarring" because it happens on user interaction.

2. The box shadow is not removed. This is because once it hits the full viewport height, it should no longer be visible.

cc @MaximePlancke

# Width

The iframe container was originall set to `width: 100vw !important`. But this makes the width [extend beyond scroll bars](https://developers.google.com/web/updates/2016/12/url-bar-resizing), which is something I originally didn't catch when testing in mobile safari. Which is also a problem with the borders, as the right border wouldn't be shown. This fixes that issue. 😄 

# Example

![consentborderfix](https://user-images.githubusercontent.com/1448289/53927712-8a0f8880-403c-11e9-8e54-0bcaec3729e0.gif)
