### PR TITLE
🐛 Fix owners file for `contributing/`

### DIFF
--- a/contributing/OWNERS.yaml
+++ b/contributing/OWNERS.yaml
@@ -1,1 +1,1 @@
-- jrozier
+- mrjoro


### PR DESCRIPTION
It lists `jrozier` instead of `mrjoro`...

https://github.com/ampproject/amphtml/blob/cb92e831d995964bc290072f3c15aff989671679/contributing/OWNERS.yaml#L1

... which is blocking #21280 by `mrjoro` :)

See https://github.com/ampproject/amphtml/pull/21280/checks?check_run_id=73219223
