### PR TITLE
✅ Re-enable tooltip interactive tests

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
@@ -20,34 +20,40 @@ const {verifySelectorsVisible} = require('../../../build-system/tasks/visual-dif
 module.exports = {
   'tapping on a clickable anchor should show the tooltip': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
-    await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(300);
     await page.tap('a.title-small.center');
+    await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping outside tooltip should hide it': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
-    await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(300);
     await page.tap('a.title-small.center');
+    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.tap('.i-amphtml-story-focused-state-layer');
+    await page.waitFor(300);
     await verifySelectorsVisible(
       page, name, ['.i-amphtml-story-focused-state-layer.i-amphtml-hidden']);
   },
   'tapping on tooltip should keep it open': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
-    await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(300);
     await page.tap('a.title-small.center');
+    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.tap('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping arrow when tooltip is open should navigate': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
-    await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(300);
     await page.tap('a.title-small.center');
+    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.tap('button.i-amphtml-story-button-move');
-    await page.waitFor(150);
+    await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['amp-story-page#cover[active]']);
   },
  };

--- a/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
@@ -21,43 +21,43 @@ module.exports = {
   'tapping on a clickable anchor should show the tooltip': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.title-small.center');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping outside tooltip should hide it': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('.i-amphtml-story-focused-state-layer');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await verifySelectorsVisible(
       page, name, ['.i-amphtml-story-focused-state-layer.i-amphtml-hidden']);
   },
   'tapping on tooltip should keep it open': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping arrow when tooltip is open should navigate': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('button.i-amphtml-story-button-move');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await verifySelectorsVisible(page, name, ['amp-story-page#cover[active]']);
   },
  };

--- a/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
@@ -20,6 +20,7 @@ const {verifySelectorsVisible} = require('../../../build-system/tasks/visual-dif
 module.exports = {
   'tapping on a clickable anchor should show the tooltip': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
+    await page.waitFor('amp-story-page#page-2[active]');
     await page.waitFor(300);
     await page.tap('a.title-small.center');
     await page.waitFor(300);
@@ -27,10 +28,11 @@ module.exports = {
   },
   'tapping outside tooltip should hide it': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
+    await page.waitFor('amp-story-page#page-2[active]');
     await page.waitFor(300);
     await page.tap('a.title-small.center');
-    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await page.tap('.i-amphtml-story-focused-state-layer');
     await page.waitFor(300);
     await verifySelectorsVisible(
@@ -38,20 +40,22 @@ module.exports = {
   },
   'tapping on tooltip should keep it open': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
+    await page.waitFor('amp-story-page#page-2[active]');
     await page.waitFor(300);
     await page.tap('a.title-small.center');
-    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await page.tap('a.i-amphtml-story-tooltip');
     await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping arrow when tooltip is open should navigate': async (page, name) => {
     await page.tap('.next-container > button.i-amphtml-story-button-move');
+    await page.waitFor('amp-story-page#page-2[active]');
     await page.waitFor(300);
     await page.tap('a.title-small.center');
-    await page.waitFor(300);
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await page.tap('button.i-amphtml-story-button-move');
     await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['amp-story-page#cover[active]']);

--- a/examples/visual-tests/amp-story/amp-story-tooltip.html
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.html
@@ -55,7 +55,7 @@
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>
           <p>Page two of two</p>
-          <a href="google.com" role="link"  class="title-small center">Click me!</a>
+          <a href="google.com" role="link" data-tooltip-text="Hola" class="title-small center">Click me!</a>
         </amp-story-grid-layer>
       </amp-story-page>
 

--- a/examples/visual-tests/amp-story/amp-story-tooltip.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.js
@@ -22,21 +22,21 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(150);
+    await page.waitFor(150); // For animations to finish.
     await page.tap('a.title-small.center');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping outside tooltip should hide it': async (page, name) => {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(150);
+    await page.waitFor(150); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('.i-amphtml-story-focused-state-layer');
-    await page.waitFor(150);
+    await page.waitFor(150); // For animations to finish.
     await verifySelectorsVisible(
       page, name, ['.i-amphtml-story-focused-state-layer.i-amphtml-hidden']);
   },
@@ -44,8 +44,10 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(150); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300); // For animations to finish.
     await page.tap('a.i-amphtml-story-tooltip');
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
@@ -53,12 +55,12 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(100);
+    await page.waitFor(150); // For animations to finish.
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
-    await page.waitFor(300);
+    await page.waitFor(300); // For animations to finish.
     await page.tap('button.i-amphtml-story-tooltip-nav-button-left');
-    await page.waitFor(150);
+    await page.waitFor(150); // For animations to finish.
     await verifySelectorsVisible(page, name, ['amp-story-page#cover[active]']);
   },
  };

--- a/examples/visual-tests/amp-story/amp-story-tooltip.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.js
@@ -22,16 +22,21 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(150);
     await page.tap('a.title-small.center');
+    await page.waitFor(300);
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping outside tooltip should hide it': async (page, name) => {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(150);
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await page.tap('.i-amphtml-story-focused-state-layer');
+    await page.waitFor(150);
     await verifySelectorsVisible(
       page, name, ['.i-amphtml-story-focused-state-layer.i-amphtml-hidden']);
   },
@@ -48,8 +53,10 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(100);
     await page.tap('a.title-small.center');
     await page.waitFor('a.i-amphtml-story-tooltip');
+    await page.waitFor(300);
     await page.tap('button.i-amphtml-story-tooltip-nav-button-left');
     await page.waitFor(150);
     await verifySelectorsVisible(page, name, ['amp-story-page#cover[active]']);

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -565,26 +565,22 @@
       ],
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/477972351#L762
-      "url": "examples/visual-tests/amp-story/amp-story-embedded-component.html",
+      "url": "examples/visual-tests/amp-story/amp-story-tooltip.html",
       "name": "amp-story: tooltip",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ],
-      "interactive_tests": "examples/visual-tests/amp-story/amp-story-embedded-component.js"
+      "interactive_tests": "examples/visual-tests/amp-story/amp-story-tooltip.js"
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/477972351#L762
-      "url": "examples/visual-tests/amp-story/amp-story-embedded-component.html",
+      "url": "examples/visual-tests/amp-story/amp-story-tooltip.html",
       "name": "amp-story: tooltip desktop",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
         ".i-amphtml-story-loaded"
       ],
-      "interactive_tests": "examples/visual-tests/amp-story/amp-story-embedded-component-desktop.js"
+      "interactive_tests": "examples/visual-tests/amp-story/amp-story-tooltip-desktop.js"
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-pagination-buttons.html",


### PR DESCRIPTION
The tests were failing because 
1. We weren't waiting enough time for the animations to finish before checking taking the snapshot, and
2. At some point I mistakenly edited the file path in the config for a non-existent one. (d'oh!)

I re-ran the tests multiple times to make sure they weren't flaking.