### PR TITLE
🐛 Update paddingTop after measure cycle

### DIFF
--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -1051,8 +1051,6 @@ export class Viewport {
       lastPaddingTop_: lastPaddingTop,
     } = this;
 
-    this.fixedLayer_.updatePaddingTop(paddingTop, transient);
-
     let doneDeferred;
 
     return this.vsync_.measurePromise(() => {
@@ -1061,6 +1059,8 @@ export class Viewport {
         return def.measure(doneDeferred.promise, lastPaddingTop, paddingTop);
       });
     }).then(animOffsets => {
+      this.fixedLayer_.updatePaddingTop(paddingTop, transient);
+
       if (duration <= 0) {
         return;
       }

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -972,6 +972,7 @@ export class Viewport {
 
   /**
    * @param {!JsonObject} data
+   * @return {!Promise|undefined}
    * @private
    */
   updateOnViewportEvent_(data) {
@@ -996,7 +997,7 @@ export class Viewport {
       return;
     }
 
-    animPromise.then(() => {
+    return animPromise.then(() => {
       this.binding_.showViewerHeader(transient, paddingTop);
     });
   }

--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -530,7 +530,7 @@ describes.fakeWin('Viewport', {}, env => {
     bindingMock.verify();
   });
 
-  it('should update non-transient padding', async () => {
+  it('should update non-transient padding', async() => {
     const bindingMock = sandbox.mock(binding);
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop')
@@ -542,7 +542,7 @@ describes.fakeWin('Viewport', {}, env => {
     fixedLayerMock.verify();
   });
 
-  it('should update padding when viewer wants to hide header', async () => {
+  it('should update padding when viewer wants to hide header', async() => {
     const bindingMock = sandbox.mock(binding);
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop')
@@ -561,18 +561,18 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should update padding for fixed layer when viewer wants to hide header',
-      async () => {
-    const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
-    fixedLayerMock.expects('updatePaddingTop').withArgs(0).once();
-    stubVsyncMeasure();
-    await viewerViewportHandler({
-      paddingTop: 0,
-      duation: 300,
-      curve: 'ease-in',
-      transient: 'true',
-    });
-    fixedLayerMock.verify();
-  });
+      async() => {
+        const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
+        fixedLayerMock.expects('updatePaddingTop').withArgs(0).once();
+        stubVsyncMeasure();
+        await viewerViewportHandler({
+          paddingTop: 0,
+          duation: 300,
+          curve: 'ease-in',
+          transient: 'true',
+        });
+        fixedLayerMock.verify();
+      });
 
   it('should update viewport when entering lightbox mode', () => {
     const requestingEl = document.createElement('div');

--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -530,37 +530,47 @@ describes.fakeWin('Viewport', {}, env => {
     bindingMock.verify();
   });
 
-  it('should update non-transient padding', () => {
+  it('should update non-transient padding', async () => {
     const bindingMock = sandbox.mock(binding);
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop')
         .withExactArgs(/* paddingTop */ 0, /* transient */ undefined)
         .once();
-    viewerViewportHandler({paddingTop: 0});
+    stubVsyncMeasure();
+    await viewerViewportHandler({paddingTop: 0});
     bindingMock.verify();
     fixedLayerMock.verify();
   });
 
-  it('should update padding when viewer wants to hide header', () => {
+  it('should update padding when viewer wants to hide header', async () => {
     const bindingMock = sandbox.mock(binding);
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop')
         .withExactArgs(/* paddingTop */ 0, /* transient */ true)
         .once();
     bindingMock.expects('hideViewerHeader').withArgs(true, 19).once();
-    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in',
-      transient: true});
+    stubVsyncMeasure();
+    await viewerViewportHandler({
+      paddingTop: 0,
+      duation: 300,
+      curve: 'ease-in',
+      transient: true,
+    });
     bindingMock.verify();
     fixedLayerMock.verify();
   });
 
-  it('should update padding for fixed layer when viewer wants to ' +
-      'hide header', () => {
-    viewport.fixedLayer_ = {updatePaddingTop: () => {}};
+  it('should update padding for fixed layer when viewer wants to hide header',
+      async () => {
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop').withArgs(0).once();
-    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in',
-      transient: 'true'});
+    stubVsyncMeasure();
+    await viewerViewportHandler({
+      paddingTop: 0,
+      duation: 300,
+      curve: 'ease-in',
+      transient: 'true',
+    });
     fixedLayerMock.verify();
   });
 


### PR DESCRIPTION
Prevents a flash in viewer header animation.

![](https://user-images.githubusercontent.com/254946/54064916-52d0e100-41ce-11e9-853f-9cd7253a0b50.gif)
