### PR TITLE
🐛Close opacity layer when sidebar for stories closed via action

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-sidebar.html
+++ b/examples/visual-tests/amp-story/amp-story-sidebar.html
@@ -35,6 +35,7 @@
         poster-landscape-src="https://picsum.photos/1600/900?image=981"
         poster-square-src="https://picsum.photos/1600/1600?image=981">
       <amp-sidebar id="sidebar1" layout="nodisplay" >
+        <button id="close-button" on="tap:sidebar1.close"> close </button>
         <ul>
           <li>Nav item 1</li>
           <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>

--- a/examples/visual-tests/amp-story/amp-story-sidebar.html
+++ b/examples/visual-tests/amp-story/amp-story-sidebar.html
@@ -13,7 +13,7 @@
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       amp-story-page {
-        background: black;
+        background: white;
         color: white;
         font-family: sans-serif;
       }
@@ -47,8 +47,6 @@
       </amp-sidebar>
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="https://picsum.photos/1600/900?image=980">
-          </amp-video>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>
@@ -58,8 +56,6 @@
 
       <amp-story-page id="page-2">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="https://picsum.photos/1600/900?image=981">
-          </amp-video>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>

--- a/examples/visual-tests/amp-story/amp-story-sidebar.js
+++ b/examples/visual-tests/amp-story/amp-story-sidebar.js
@@ -18,11 +18,40 @@
 const {verifySelectorsVisible} = require('../../../build-system/tasks/visual-diff/helpers');
 
 module.exports = {
-  'tapping on sidebar control button should show sidebar ': async (page, name) => {
+  'tapping on sidebar control button should show sidebar and opacity mask': async (page, name) => {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#cover[active]');
     await page.tap('.i-amphtml-story-sidebar-control');
-    await verifySelectorsVisible(page, name, ['amp-sidebar[side][open]']);
+    await verifySelectorsVisible(page, name,
+      [
+        'amp-sidebar[side][open]',
+        '.i-amphtml-story-opacity-mask',
+      ]);
+  },
+  'tapping on element with sidebar close action should close opacity mask ': async(page,name) => {
+    const screen = page.touchscreen;
+    await screen.tap(200, 240);
+    await page.waitFor('amp-story-page#cover[active]');
+    await page.tap('.i-amphtml-story-sidebar-control');
+    await page.waitFor(400);
+    await page.tap('button#close-button');
+    await verifySelectorsVisible(page, name,
+    [
+      'amp-sidebar[hidden]',
+      '.i-amphtml-story-opacity-mask[hidden]',
+    ]);
+  },
+  'tapping on the opacity mask should close sidebar ': async(page,name) => {
+    const screen = page.touchscreen;
+    await screen.tap(200, 240);
+    await page.waitFor('amp-story-page#cover[active]');
+    await page.tap('.i-amphtml-story-sidebar-control');
+    await screen.tap(200, 240);
+    await verifySelectorsVisible(page, name,
+    [
+      'amp-sidebar[hidden]',
+      '.i-amphtml-story-opacity-mask[hidden]',
+    ]);
   },
  };

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1619,14 +1619,14 @@ export class AmpStory extends AMP.BaseElement {
     if (this.win.MutationObserver) {
       if (!this.sidebarObserver_) {
         this.sidebarObserver_ = new this.win.MutationObserver(mutationsList => {
-          if (mutationsList.some(
-              mutation => mutation.attributeName === 'open')) {
-            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
-                this.sidebar_.hasAttribute('open'));
-          } if (mutationsList.some(
-              mutation => mutation.attributeName === 'hidden')) {
-            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
-          }
+          mutationsList.forEach(mutation => {
+            if (mutation.attributeName === 'open') {
+              this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
+                  this.sidebar_.hasAttribute('open'));
+            } else if (mutation.attributeName === 'hidden') {
+              this.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
+            }
+          });
         });
       }
       if (this.sidebar_ && sidebarState) {
@@ -1635,9 +1635,8 @@ export class AmpStory extends AMP.BaseElement {
         actions.execute(this.sidebar_, 'open', /* args */ null,
             /* source */ null, /* caller */ null, /* event */ null,
             ActionTrust.HIGH);
-      } else if (this.sidebar_
-                && !sidebarState
-                && !this.maskElement_.hasAttribute('hidden')) {
+      } else if (this.sidebar_ && !sidebarState &&
+                    !this.maskElement_.hasAttribute('hidden')) {
         this.closeOpacityMask_();
       } else {
         this.sidebarObserver_.disconnect();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1626,8 +1626,7 @@ export class AmpStory extends AMP.BaseElement {
 
           } if (mutationsList.some(
               mutation => mutation.attributeName === 'hidden')) {
-            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
-                this.sidebar_.hasAttribute('open'));
+            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
           }
         });
       }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1623,6 +1623,11 @@ export class AmpStory extends AMP.BaseElement {
               mutation => mutation.attributeName === 'open')) {
             this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
                 this.sidebar_.hasAttribute('open'));
+
+          } if (mutationsList.some(
+              mutation => mutation.attributeName === 'hidden')) {
+            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
+                this.sidebar_.hasAttribute('open'));
           }
         });
       }
@@ -1632,6 +1637,10 @@ export class AmpStory extends AMP.BaseElement {
         actions.execute(this.sidebar_, 'open', /* args */ null,
             /* source */ null, /* caller */ null, /* event */ null,
             ActionTrust.HIGH);
+      } else if (this.sidebar_
+                && !sidebarState
+                && !this.maskElement_.hasAttribute('hidden')) {
+        this.closeOpacityMask_();
       } else {
         this.sidebarObserver_.disconnect();
       }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1623,7 +1623,6 @@ export class AmpStory extends AMP.BaseElement {
               mutation => mutation.attributeName === 'open')) {
             this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
                 this.sidebar_.hasAttribute('open'));
-
           } if (mutationsList.some(
               mutation => mutation.attributeName === 'hidden')) {
             this.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1619,14 +1619,11 @@ export class AmpStory extends AMP.BaseElement {
     if (this.win.MutationObserver) {
       if (!this.sidebarObserver_) {
         this.sidebarObserver_ = new this.win.MutationObserver(mutationsList => {
-          mutationsList.forEach(mutation => {
-            if (mutation.attributeName === 'open') {
-              this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
-                  this.sidebar_.hasAttribute('open'));
-            } else if (mutation.attributeName === 'hidden') {
-              this.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
-            }
-          });
+          if (mutationsList.some(
+              mutation => mutation.attributeName === 'open')) {
+            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
+                this.sidebar_.hasAttribute('open'));
+          }
         });
       }
       if (this.sidebar_ && sidebarState) {
@@ -1635,10 +1632,8 @@ export class AmpStory extends AMP.BaseElement {
         actions.execute(this.sidebar_, 'open', /* args */ null,
             /* source */ null, /* caller */ null, /* event */ null,
             ActionTrust.HIGH);
-      } else if (this.sidebar_ && !sidebarState &&
-                    !this.maskElement_.hasAttribute('hidden')) {
-        this.closeOpacityMask_();
       } else {
+        this.closeOpacityMask_();
         this.sidebarObserver_.disconnect();
       }
     } else if (this.sidebar_ && sidebarState) {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -755,6 +755,23 @@ describes.realWin('amp-story', {
                 .to.be.false;
           });
     });
+
+    it('should close sidebar mask with close action', () => {
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      const sidebar = win.document.createElement('amp-sidebar');
+      story.element.appendChild(sidebar);
+
+      story.buildCallback();
+      return story.layoutCallback()
+          .then(() => {
+            story.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
+          }).then(() => {
+            const mask = story.element.querySelector(
+                '.i-amphtml-story-opacity-mask');
+            expect(mask.hasAttribute('hidden')).to.be.true;
+          });
+    });
   });
 
   describe('desktop attributes', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -769,7 +769,7 @@ describes.realWin('amp-story', {
           }).then(() => {
             const mask = story.element.querySelector(
                 '.i-amphtml-story-opacity-mask');
-            expect(mask.hasAttribute('hidden')).to.be.true;
+            expect(mask).to.have.attribute('hidden');
           });
     });
   });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -755,23 +755,6 @@ describes.realWin('amp-story', {
                 .to.be.false;
           });
     });
-
-    it('should close sidebar mask with close action', () => {
-      createPages(story.element, 2, ['cover', 'page-1']);
-
-      const sidebar = win.document.createElement('amp-sidebar');
-      story.element.appendChild(sidebar);
-
-      story.buildCallback();
-      return story.layoutCallback()
-          .then(() => {
-            story.storeService_.dispatch(Action.TOGGLE_SIDEBAR, false);
-          }).then(() => {
-            const mask = story.element.querySelector(
-                '.i-amphtml-story-opacity-mask');
-            expect(mask).to.have.attribute('hidden');
-          });
-    });
   });
 
   describe('desktop attributes', () => {


### PR DESCRIPTION
Resolves #21050

When sidebar for stories closes via an amp action, the story opacity mask should also close. 

Because the opacity mask was created for the use of sidebar specifically in stories, closing/opening the story mask is not bound to the sidebar's closing/opening. We solve this issue by directly toggling the mask when the sidebar's state is changed.


