### PR TITLE
always execute yarn with --production=false flag

### DIFF
--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -22,12 +22,7 @@ const log = require('fancy-log');
 const {exec, execOrDie, getStderr} = require('../exec');
 const {isTravisBuild} = require('../travis');
 
-/**
- * NOTE: executing yarn with --production=false prevents having
- * NODE_ENV=production variable set which forces yarn to not install
- * devDependencies. This usually breaks gulp for example.
- */
-const yarnExecutable = 'npx yarn --production=false';
+const yarnExecutable = 'npx yarn';
 
 /**
  * Writes the given contents to the patched file if updated
@@ -187,7 +182,12 @@ function runYarnCheck() {
     const verifyTreeCmd = yarnExecutable + ' check --verify-tree';
     exec(verifyTreeCmd);
     log('Running', colors.cyan('yarn'), 'to update packages...');
-    execOrDie(yarnExecutable); // Stop execution when Ctrl + C is detected.
+    /**
+     * NOTE: executing yarn with --production=false prevents having
+     * NODE_ENV=production variable set which forces yarn to not install
+     * devDependencies. This usually breaks gulp for example.
+     */
+    execOrDie(`${yarnExecutable} install --production=false`); // Stop execution when Ctrl + C is detected.
   } else {
     log(colors.green('All packages in'),
         colors.cyan('node_modules'), colors.green('are up to date.'));

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -22,7 +22,12 @@ const log = require('fancy-log');
 const {exec, execOrDie, getStderr} = require('../exec');
 const {isTravisBuild} = require('../travis');
 
-const yarnExecutable = 'npx yarn';
+/**
+ * NOTE: executing yarn with --production=false prevents having
+ * NODE_ENV=production variable set which forces yarn to not install
+ * devDependencies. This usually breaks gulp for example.
+ */
+const yarnExecutable = 'npx yarn --production=false';
 
 /**
  * Writes the given contents to the patched file if updated


### PR DESCRIPTION
this prevents having NODE_ENV=production variable set which forces yarn to not install devDependencies. This usually breaks gulp for example.