### PR TITLE
AdSense Fast Fetch

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -95,9 +95,6 @@ export function resetSharedState() {
 /** @type {string} */
 const FORMAT_EXP = 'as-use-attr-for-format';
 
-/** @type {string} */
-const DELAY_NUMBER_EXP = 'adsense-ff-number-delay';
-
 /** @final */
 export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
@@ -236,9 +233,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   delayAdRequestEnabled() {
-    if (getExperimentBranch(this.win, DELAY_NUMBER_EXP) != '21063207') {
-      return true;
-    }
     return getAmpAdRenderOutsideViewport(this.element) || 3;
   }
 
@@ -287,10 +281,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
             Number(this.element.getAttribute('width')) > 0 &&
             Number(this.element.getAttribute('height')) > 0,
           branches: ['21062003', '21062004'],
-        },
-        [DELAY_NUMBER_EXP]: {
-          isTrafficEligible: () => true,
-          branches: ['21063206', '21063207'],
         },
       });
     const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -973,19 +973,14 @@ describes.realWin('amp-ad-network-adsense-impl', {
   });
 
   describe('#delayAdRequestEnabled', () => {
-    it('should return true', () =>
-      expect(impl.delayAdRequestEnabled()).to.be.true);
-
-    it('should return 3 if in experiment', () => {
-      forceExperimentBranch(impl.win, 'adsense-ff-number-delay', '21063207');
+    it('should return 3', () => {
       impl.divertExperiments();
       expect(impl.delayAdRequestEnabled()).to.equal(3);
     });
 
-    it('should respect loading strategy in experiment', () => {
+    it('should respect loading strategy', () => {
       impl.element.setAttribute(
           'data-loading-strategy', 'prefer-viewability-over-views');
-      forceExperimentBranch(impl.win, 'adsense-ff-number-delay', '21063207');
       impl.divertExperiments();
       expect(impl.delayAdRequestEnabled()).to.equal(1.25);
     });


### PR DESCRIPTION
Added in #20833, make 3 (or data loading strategy based) viewport the offset for delaying ad request.  Fixes unintended interaction with non-AMP creative throttle rendering.