### PR TITLE
✨ Add additional analytics opt out mechanism. (#21163)

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -413,13 +413,40 @@ export class AmpAnalytics extends AMP.BaseElement {
       return false;
     }
 
-    const props = this.config_['optout'].split('.');
+    // TODO(leeandrew1693): This block is to support backwards compatibility
+    // for GTM. Remove this block once GTM updates.
+    if (typeof this.config_['optout'] === 'string') {
+      const props = this.config_['optout'].split('.');
+      let k = this.win;
+      for (let i = 0; i < props.length; i++) {
+        if (!k) {
+          return false;
+        }
+        k = k[props[i]];
+      }
+      // The actual property being called is controlled by vendor configs only
+      // that are approved in code reviews. User customization of the `optout`
+      // property is not allowed.
+      return k();
+    }
+
+    const elementId = this.config_['optout']['id'];
+    if (elementId && this.win.document.getElementById(elementId)) {
+      return true;
+    }
+
+    const functionName = this.config_['optout']['function'];
+    if (!functionName) {
+      return false;
+    }
+
+    const functionNameComponents = functionName.split('.');
     let k = this.win;
-    for (let i = 0; i < props.length; i++) {
+    for (let i = 0; i < functionNameComponents.length; i++) {
       if (!k) {
         return false;
       }
-      k = k[props[i]];
+      k = k[functionNameComponents[i]];
     }
     // The actual property being called is controlled by vendor configs only
     // that are approved in code reviews. User customization of the `optout`

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -409,44 +409,22 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @return {boolean} true if the user has opted out.
    */
   hasOptedOut_() {
-    if (!this.config_['optout']) {
-      return false;
-    }
-
-    // TODO(leeandrew1693): This block is to support backwards compatibility
-    // for GTM. Remove this block once GTM updates.
-    if (typeof this.config_['optout'] === 'string') {
-      const props = this.config_['optout'].split('.');
-      let k = this.win;
-      for (let i = 0; i < props.length; i++) {
-        if (!k) {
-          return false;
-        }
-        k = k[props[i]];
-      }
-      // The actual property being called is controlled by vendor configs only
-      // that are approved in code reviews. User customization of the `optout`
-      // property is not allowed.
-      return k();
-    }
-
-    const elementId = this.config_['optout']['id'];
+    const elementId = this.config_['optoutElementId'];
     if (elementId && this.win.document.getElementById(elementId)) {
       return true;
     }
 
-    const functionName = this.config_['optout']['function'];
-    if (!functionName) {
+    if (!this.config_['optout']) {
       return false;
     }
 
-    const functionNameComponents = functionName.split('.');
+    const props = this.config_['optout'].split('.');
     let k = this.win;
-    for (let i = 0; i < functionNameComponents.length; i++) {
+    for (let i = 0; i < props.length; i++) {
       if (!k) {
         return false;
       }
-      k = k[functionNameComponents[i]];
+      k = k[props[i]];
     }
     // The actual property being called is controlled by vendor configs only
     // that are approved in code reviews. User customization of the `optout`

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -391,7 +391,9 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
   // that is already being used in the wild.
   userAssert(opt_predefinedConfig
       || !from || !from['optout']
-      || from['optout'] == '_gaUserPrefs.ioo',
+      || from['optout'] == '_gaUserPrefs.ioo'
+      || (from['optout']['function'] == '_gaUserPrefs.ioo'
+        && from['optout']['id'] == '__gaOptOutExtension'),
   'optout property is only available to vendor config.');
 
   for (const property in from) {

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -392,8 +392,7 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
   userAssert(opt_predefinedConfig
       || !from || !from['optout']
       || from['optout'] == '_gaUserPrefs.ioo'
-      || (from['optout']['function'] == '_gaUserPrefs.ioo'
-        && from['optout']['id'] == '__gaOptOutExtension'),
+      || from['optoutElementId'] == '__gaOptOutExtension',
   'optout property is only available to vendor config.');
 
   for (const property in from) {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -734,7 +734,9 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  describe('optout', () => {
+  // TODO(leeandrew1693): This block tests backwards compatible optout code for
+  // GTM. Remove this once GTM updates.
+  describe('optout backwards compatible', () => {
 
     beforeEach(() => {
       sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
@@ -765,13 +767,104 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('works for vendor config when optout returns false', function() {
+    it('works for vendor config when optout returns true', function() {
       win['foo'] = {'bar': function() { return true; }};
       const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
       return waitForNoSendRequest(analytics);
     });
 
     it('works for vendor config when optout is not defined', function() {
+      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
+      return waitForSendRequest(analytics).then(() => {
+        requestVerifier.verifyRequest('https://example.com/bar');
+      });
+    });
+  });
+
+  describe('optout by function', () => {
+
+    beforeEach(() => {
+      sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
+          .returns(Promise.resolve({
+            'requests': {
+              'foo': {
+                baseUrl: 'https://example.com/bar',
+              },
+            },
+            'triggers': {
+              'pageview': {'on': 'visible', 'request': 'foo'},
+            },
+            'transport': {
+              'image': true,
+              'xhrpost': false,
+              'beacon': false,
+            },
+            'vars': {},
+            'optout': {
+              'function': 'foo.bar',
+            },
+          }));
+    });
+
+    it('sends hit when config optout function returns false', function() {
+      win['foo'] = {'bar': () => false};
+      const analytics = getAnalyticsTag(trivialConfig);
+      return waitForSendRequest(analytics).then(() => {
+        requestVerifier.verifyRequest('https://example.com/bar');
+      });
+    });
+
+    it('doesnt send hit when config optout function returns true', function() {
+      win['foo'] = {'bar': function() { return true; }};
+      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
+      return waitForNoSendRequest(analytics);
+    });
+
+    it('sends hit when config optout function is not defined', function() {
+      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
+      return waitForSendRequest(analytics).then(() => {
+        requestVerifier.verifyRequest('https://example.com/bar');
+      });
+    });
+  });
+
+  describe('optout by id', () => {
+
+    beforeEach(() => {
+      sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
+          .returns(Promise.resolve({
+            'requests': {
+              'foo': {
+                baseUrl: 'https://example.com/bar',
+              },
+            },
+            'triggers': {
+              'pageview': {'on': 'visible', 'request': 'foo'},
+            },
+            'transport': {
+              'image': true,
+              'xhrpost': false,
+              'beacon': false,
+            },
+            'vars': {},
+            'optout': {
+              'id': 'elementId',
+            },
+          }));
+    });
+
+    it('doesnt send hit when config optout id is found', function() {
+      const element = doc.createElement('script');
+      element.type = 'text/javascript';
+      element.id = 'elementId';
+      doc.documentElement.insertBefore(
+          element, doc.documentElement.firstChild);
+
+      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
+      return waitForNoSendRequest(analytics);
+    });
+
+    it('sends hit when config optout id is not found', function() {
       const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
       return waitForSendRequest(analytics).then(() => {
         requestVerifier.verifyRequest('https://example.com/bar');

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -734,9 +734,7 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  // TODO(leeandrew1693): This block tests backwards compatible optout code for
-  // GTM. Remove this once GTM updates.
-  describe('optout backwards compatible', () => {
+  describe('optout by function', () => {
 
     beforeEach(() => {
       sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
@@ -781,53 +779,6 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  describe('optout by function', () => {
-
-    beforeEach(() => {
-      sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
-          .returns(Promise.resolve({
-            'requests': {
-              'foo': {
-                baseUrl: 'https://example.com/bar',
-              },
-            },
-            'triggers': {
-              'pageview': {'on': 'visible', 'request': 'foo'},
-            },
-            'transport': {
-              'image': true,
-              'xhrpost': false,
-              'beacon': false,
-            },
-            'vars': {},
-            'optout': {
-              'function': 'foo.bar',
-            },
-          }));
-    });
-
-    it('sends hit when config optout function returns false', function() {
-      win['foo'] = {'bar': () => false};
-      const analytics = getAnalyticsTag(trivialConfig);
-      return waitForSendRequest(analytics).then(() => {
-        requestVerifier.verifyRequest('https://example.com/bar');
-      });
-    });
-
-    it('doesnt send hit when config optout function returns true', function() {
-      win['foo'] = {'bar': function() { return true; }};
-      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
-      return waitForNoSendRequest(analytics);
-    });
-
-    it('sends hit when config optout function is not defined', function() {
-      const analytics = getAnalyticsTag(trivialConfig, {'type': 'testVendor'});
-      return waitForSendRequest(analytics).then(() => {
-        requestVerifier.verifyRequest('https://example.com/bar');
-      });
-    });
-  });
-
   describe('optout by id', () => {
 
     beforeEach(() => {
@@ -847,9 +798,7 @@ describes.realWin('amp-analytics', {
               'beacon': false,
             },
             'vars': {},
-            'optout': {
-              'id': 'elementId',
-            },
+            'optoutElementId': 'elementId',
           }));
     });
 

--- a/extensions/amp-analytics/0.1/vendors/googleanalytics.js
+++ b/extensions/amp-analytics/0.1/vendors/googleanalytics.js
@@ -104,10 +104,8 @@ export const GOOGLEANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'dimension': 'cd',
     'metric': 'cm',
   },
-  'optout': {
-    'function': '_gaUserPrefs.ioo',
-    'id': '__gaOptOutExtension',
-  },
+  'optout': '_gaUserPrefs.ioo',
+  'optoutElementId': '__gaOptOutExtension',
   'linkers': {
     '_gl': {
       'ids': {

--- a/extensions/amp-analytics/0.1/vendors/googleanalytics.js
+++ b/extensions/amp-analytics/0.1/vendors/googleanalytics.js
@@ -104,7 +104,10 @@ export const GOOGLEANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'dimension': 'cd',
     'metric': 'cm',
   },
-  'optout': '_gaUserPrefs.ioo',
+  'optout': {
+    'function': '_gaUserPrefs.ioo',
+    'id': '__gaOptOutExtension',
+  },
   'linkers': {
     '_gl': {
       'ids': {


### PR DESCRIPTION
Modifies the vendor configuration for optout. Vendors currently configure optout by adding the following:
```
'optout': 'function.name'
```
This updates it so that a vendor can specify a function name or an element in the DOM that will cause analytics to be opted out.
```
'optout': {
  'function': 'function.name',
  'id': 'elementId'
}
```

Based on the conversation in the issue, we're leaving backwards compatibility for now, until GTM is able to deploy a change to use the updated optout format. Because of this, there is duplicate code so that it will be an easy to remove the backwards compatibility once the GTM changes roll out. 
