### PR TITLE
Fix load-more e2e tests

### DIFF
--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -59,7 +59,7 @@ describes.endtoend('AMP list load-more=auto', {
     let listItems = await controller.findElements('.item');
     await expect(listItems).to.have.length(2);
 
-    const article = await controller.findElement('html');
+    const article = await controller.findElement('article');
     await controller.scrollBy(article, {top: 50});
 
     const fourthItem = await controller.findElement('div.item:nth-child(4)');

--- a/test/manual/amp-list/load-more-auto.amp.html
+++ b/test/manual/amp-list/load-more-auto.amp.html
@@ -24,7 +24,6 @@
   <amp-list width="auto" height="400"
     layout="fixed-height"
     src="/list/infinite-scroll?items=2&left=1"
-    [src]="data.url"
     load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">

--- a/test/manual/amp-list/load-more-manual.amp.html
+++ b/test/manual/amp-list/load-more-manual.amp.html
@@ -21,7 +21,6 @@
   <amp-list width="auto" height="400"
     layout="fixed-height"
     src="/list/infinite-scroll?items=2&left=2"
-    [src]="data.url"
     load-more="manual"
     load-more-bookmark="next">
     <template type="amp-mustache">


### PR DESCRIPTION
Remove some unused bindings causing 404s, scroll the `<article>` tag instead of `html`. 

The e2e tests for `amp-list-load-more` are still flaky in the sense that they encounter the `element not interactable` error. Basically there's a race condition where 50% of the time, the click happens before the click listener is registered. I think this was exacerbated by the changes to `findElement` in https://github.com/ampproject/amphtml/pull/21298. I wonder if there is any way to wait a little longer, or to wait until the click listener has been registered. I think Selenium offers a way to [check if an element is clickable](https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html#elementToBeClickable-org.openqa.selenium.By-). I wonder if there is a way to port over similar functionality. 
