### PR TITLE
📖 Add note about `Vary: Accept`.

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -144,7 +144,11 @@ function filterWhitelistedLinks(markdown) {
 
   // The heroku nightly build page is not always acccessible by the checker.
   filteredMarkdown = filteredMarkdown.replace(
-      /\(http:\/\/amphtml-nightly.herokuapp.com\/\)/g, '');
+      /\(http:\/\/amphtml-nightly\.herokuapp\.com\/\)/g, '');
+
+  // The Googlebot help page is currently only available to signed-in users.
+  filteredMarkdown = filteredMarkdown.replace(
+      /\(https:\/\/support\.google\.com\/webmasters\/answer\/182072\)/g, '');
 
   // After all whitelisting is done, clean up any remaining empty blocks bounded
   // by backticks. Otherwise, `` will be treated as the start of a code block

--- a/spec/amp-cache-transform.md
+++ b/spec/amp-cache-transform.md
@@ -167,6 +167,17 @@ For a given URL, if the server content-negotiates on `AMP-Cache-Transform`, it
 must include `Vary: AMP-Cache-Transform` in all responses, whether signed or
 unsigned.
 
+Note that this also likely means it's negotiating on `Accept`, so it should
+include `Vary: Accept` in these cases, too. The high-entropy nature of `Accept`
+causes cache fragmentation in default setups; publishers may wish to configure
+caches under their control to convert incoming `Accept` headers into
+lower-entropy forms, e.g. by performing the content negotiation (using
+hard-coded knowledge about what variants are available at a given URL) and
+including only the negotiated media-type, without q-values. The publisher may
+also specify
+[Variants](https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html)
+to aid caching proxies that understand that header.
+
 ### URL rewrites
 
 The exact set of rewrites is not yet fully specified; a few


### PR DESCRIPTION
Update amp-cache-transform spec with a note about the likely necessity
to Vary on Accept, and suggestions for how to deal with the resulting
cache fragmentation.

