### PR TITLE
🐛 Fix minimum swipe distance

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -695,8 +695,8 @@ export class AmpStory extends AMP.BaseElement {
         }
         return;
       }
-      if (gesture.event && (gesture.event.defaultPrevented ||
-          !this.isSwipeLargeEnoughForHint_(deltaX, deltaY))) {
+      if ((gesture.event && gesture.event.defaultPrevented) ||
+          !this.isSwipeLargeEnoughForHint_(deltaX, deltaY)) {
         return;
       }
 


### PR DESCRIPTION
Fixes #21351.

We weren't honoring the swipe distance because sometimes multiple events get triggered, and if `gesture.event` is `null` (which, sometimes it is), we wouldn't check the minimum swipe distance with the logic before this PR. 