### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-payment-google-inline-async/0.1/test/validator-actions-amp-payment-google-inline-async.html
+++ b/extensions/amp-payment-google-inline-async/0.1/test/validator-actions-amp-payment-google-inline-async.html
@@ -14,7 +14,7 @@
   Test Description: Basic test for amp-payment-google-inline
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ actions>
 <head>
   <meta charset="utf-8">
   <title>amp-payment-google-inline-async: Basic</title>

--- a/extensions/amp-payment-google-inline-async/0.1/test/validator-actions-amp-payment-google-inline-async.out
+++ b/extensions/amp-payment-google-inline-async/0.1/test/validator-actions-amp-payment-google-inline-async.out
@@ -15,7 +15,7 @@ FAIL
 |    Test Description: Basic test for amp-payment-google-inline
 |  -->
 |  <!doctype html>
-|  <html ⚡>
+|  <html ⚡ actions>
 |  <head>
 |    <meta charset="utf-8">
 |    <title>amp-payment-google-inline-async: Basic</title>

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -5216,15 +5216,12 @@ class ParsedValidatorRules {
         this.validateTypeIdentifiers(
             htmlTag.attrs(), ['⚡', 'amp', 'actions'], context,
             validationResult);
-        // TODO(honeybadgerdontcare): require "actions" as a type identifier
-        // when publishers are ready. Uncomment code below and update test.
-        // if (validationResult.typeIdentifier.indexOf("actions") === -1) {
-        //   context.addError(
-        //       amp.validator.ValidationError.Code.MANDATORY_ATTR_MISSING,
-        //       context.getLineCol(), /*params=*/["actions", 'html'],
-        //       'https://www.ampproject.org/docs/reference/spec#required-markup',
-        //       validationResult);
-        // }
+        if (validationResult.typeIdentifier.indexOf('actions') === -1) {
+          context.addError(
+              amp.validator.ValidationError.Code.MANDATORY_ATTR_MISSING,
+              context.getLineCol(), /* params */['actions', 'html'],
+              /* url */'', validationResult);
+        }
         break;
     }
   }

--- a/validator/testdata/actions_feature_tests/type_identifier_missing.out
+++ b/validator/testdata/actions_feature_tests/type_identifier_missing.out
@@ -1,4 +1,4 @@
-PASS
+FAIL
 |  <!--
 |    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |
@@ -20,6 +20,8 @@ PASS
 |  -->
 |  <!doctype html>
 |  <html ⚡>
+>> ^~~~~~~~~
+actions_feature_tests/type_identifier_missing.html:21:0 The mandatory attribute 'actions' is missing in tag 'html'. [DISALLOWED_HTML]
 |  <head>
 |    <meta charset="utf-8">
 |    <link rel="canonical" href="./regular-html-version.html">

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 845
+spec_file_revision: 846
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"


### PR DESCRIPTION
 - cl/238021663 Revision bump for #20497
 - cl/237909151 Require `actions` on html tag for AMP Actions
