### PR TITLE
🐛 Block initial amp-story render on amp-story layout

### DIFF
--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CommonSignals} from '../../../src/common-signals';
+
+/** @implements {../../../src/render-delaying-services.RenderDelayingService} */
+export class AmpStoryRenderService {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /**
+     * @private {!Element}
+     */
+    this.ampdoc_ = ampdoc; //ampdoc.getRootNode());
+  }
+
+  /**
+   * Function to return a promise for when it is finished delaying render, and
+   * is ready.  Implemented from RenderDelayingService
+   * @return {!Promise}
+   */
+  whenReady() {
+    return this.ampdoc_.whenBodyAvailable().then(body => {
+      const storyEl = body.querySelector('amp-story[standalone]');
+
+      if (!storyEl) {
+        return;
+      }
+
+      return storyEl.signals().whenSignal(CommonSignals.LOAD_END);
+    });
+  }
+}

--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -15,6 +15,7 @@
  */
 
 import {CommonSignals} from '../../../src/common-signals';
+import {whenUpgradedToCustomElement} from '../../../src/dom';
 
 /** @implements {../../../src/render-delaying-services.RenderDelayingService} */
 export class AmpStoryRenderService {
@@ -41,7 +42,8 @@ export class AmpStoryRenderService {
         return;
       }
 
-      return storyEl.signals().whenSignal(CommonSignals.LOAD_END);
+      return whenUpgradedToCustomElement(storyEl).signals()
+          .whenSignal(CommonSignals.LOAD_END);
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -42,7 +42,9 @@ export class AmpStoryRenderService {
         return;
       }
 
-      return whenUpgradedToCustomElement(storyEl).signals()
+      return whenUpgradedToCustomElement(storyEl).then(() => {
+        return storyEl.signals().whenSignal(CommonSignals.LOAD_END);
+      })
           .whenSignal(CommonSignals.LOAD_END);
     });
   }

--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -44,7 +44,7 @@ export class AmpStoryRenderService {
 
       return whenUpgradedToCustomElement(storyEl).then(() => {
         return storyEl.signals().whenSignal(CommonSignals.LOAD_END);
-      })
+      });
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -24,9 +24,9 @@ export class AmpStoryRenderService {
    */
   constructor(ampdoc) {
     /**
-     * @private {!Element}
+     * @private {!../../../src/service/ampdoc-impl.AmpDoc}
      */
-    this.ampdoc_ = ampdoc; //ampdoc.getRootNode());
+    this.ampdoc_ = ampdoc;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-render-service.js
+++ b/extensions/amp-story/1.0/amp-story-render-service.js
@@ -45,7 +45,6 @@ export class AmpStoryRenderService {
       return whenUpgradedToCustomElement(storyEl).then(() => {
         return storyEl.signals().whenSignal(CommonSignals.LOAD_END);
       })
-          .whenSignal(CommonSignals.LOAD_END);
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2360,6 +2360,32 @@ export class AmpStory extends AMP.BaseElement {
   }
 }
 
+/** @implements {../../../src/render-delaying-services.RenderDelayingService} */
+class AmpStoryRender {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /**
+     * @private {!Element}
+     */
+    this.storyEl_ = ampdoc.getRootNode().querySelector('amp-story[standalone]');
+  }
+
+  /**
+   * Function to return a promise for when it is finished delaying render, and
+   * is ready.  Implemented from RenderDelayingService
+   * @return {!Promise}
+   */
+  whenReady() {
+    if (!this.storyEl_) {
+      return Promise.resolve();
+    }
+
+    return this.storyEl_.signals().whenSignal(CommonSignals.LOAD_END);
+  }
+}
+
 AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story', AmpStory, CSS);
   AMP.registerElement('amp-story-access', AmpStoryAccess);
@@ -2369,4 +2395,5 @@ AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story-grid-layer', AmpStoryGridLayer);
   AMP.registerElement('amp-story-page', AmpStoryPage);
   AMP.registerElement('amp-story-page-attachment', AmpStoryPageAttachment);
+  AMP.registerServiceForDoc('amp-story-render', AmpStoryRender);
 });

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -48,6 +48,7 @@ import {AmpStoryGridLayer} from './amp-story-grid-layer';
 import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
 import {AmpStoryPageAttachment} from './amp-story-page-attachment';
+import {AmpStoryRenderService} from './amp-story-render-service';
 import {AmpStoryVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
@@ -501,7 +502,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    this.vsync_.run({
+    return this.vsync_.runPromise({
       measure: state => {
         state.vh = this.activePage_.element./*OK*/clientHeight / 100;
         state.vw = this.activePage_.element./*OK*/clientWidth / 100;
@@ -2360,32 +2361,6 @@ export class AmpStory extends AMP.BaseElement {
   }
 }
 
-/** @implements {../../../src/render-delaying-services.RenderDelayingService} */
-class AmpStoryRender {
-  /**
-   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   */
-  constructor(ampdoc) {
-    /**
-     * @private {!Element}
-     */
-    this.storyEl_ = ampdoc.getRootNode().querySelector('amp-story[standalone]');
-  }
-
-  /**
-   * Function to return a promise for when it is finished delaying render, and
-   * is ready.  Implemented from RenderDelayingService
-   * @return {!Promise}
-   */
-  whenReady() {
-    if (!this.storyEl_) {
-      return Promise.resolve();
-    }
-
-    return this.storyEl_.signals().whenSignal(CommonSignals.LOAD_END);
-  }
-}
-
 AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story', AmpStory, CSS);
   AMP.registerElement('amp-story-access', AmpStoryAccess);
@@ -2395,5 +2370,5 @@ AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story-grid-layer', AmpStoryGridLayer);
   AMP.registerElement('amp-story-page', AmpStoryPage);
   AMP.registerElement('amp-story-page-attachment', AmpStoryPageAttachment);
-  AMP.registerServiceForDoc('amp-story-render', AmpStoryRender);
+  AMP.registerServiceForDoc('amp-story-render', AmpStoryRenderService);
 });

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -39,6 +39,7 @@ import {getServicePromise} from './service';
 const SERVICES = {
   'amp-dynamic-css-classes': '[custom-element=amp-dynamic-css-classes]',
   'variant': 'amp-experiment',
+  'amp-story-render': 'amp-story[standalone]',
 };
 
 /**


### PR DESCRIPTION
Followup to #21193.  This fixes the previously-broken definition for amp-story, so that it may block on it's `layoutCallback` before rendering.

Fixes #21349 