### PR TITLE
🐛 Experiment guard dirtyElement call in collapseElement

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1092,7 +1092,12 @@ export class Resources {
     const box = this.viewport_.getLayoutRect(element);
     const resource = Resource.forElement(element);
     if (box.width != 0 && box.height != 0) {
-      this.dirtyElement(element);
+      if (isExperimentOn(this.win, 'dirty-collapse-element') ||
+          this.useLayers_) {
+        this.dirtyElement(element);
+      } else {
+        this.setRelayoutTop_(box.top);
+      }
     }
     resource.completeCollapse();
     this.schedulePass(FOUR_FRAME_DELAY_);


### PR DESCRIPTION
This is a partial revert of #21128, since it may have caused a ads
metrics regression. I'm still confident that calling `dirtyElement` is
the correct behavior, but let's see...