### PR TITLE
[amp-list] Fix race condition on access to this.loadMoreService_ 

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -221,13 +221,7 @@ export class AmpList extends AMP.BaseElement {
     }
 
     this.viewport_.onResize(() => {
-      this.loadMoreEnabledPromise_.then(enabled => {
-        if (enabled) {
-          this.attemptToFitLoadMore_(dev().assertElement(this.container_));
-        } else {
-          this.attemptToFit_(dev().assertElement(this.container_));
-        }
-      });
+      this.maybeResizeListToFitItems_();
     });
 
     this.loadMoreEnabledPromise_.then(enabled => {
@@ -246,6 +240,19 @@ export class AmpList extends AMP.BaseElement {
     });
 
     return this.fetchList_();
+  }
+
+  /**
+   * @private
+   */
+  maybeResizeListToFitItems_() {
+    this.loadMoreEnabledPromise_.then(enabled => {
+      if (enabled) {
+        this.attemptToFitLoadMore_(dev().assertElement(this.container_));
+      } else {
+        this.attemptToFit_(dev().assertElement(this.container_));
+      }
+    });
   }
 
   /**
@@ -719,13 +726,7 @@ export class AmpList extends AMP.BaseElement {
       const r = this.element.getResources().getResourceForElement(this.element);
       r.resetPendingChangeSize();
 
-      this.loadMoreEnabledPromise_.then(enabled => {
-        if (enabled) {
-          this.attemptToFitLoadMore_(dev().assertElement(this.container_));
-        } else {
-          this.attemptToFit_(dev().assertElement(this.container_));
-        }
-      });
+      this.maybeResizeListToFitItems_();
     });
   }
 
@@ -754,7 +755,6 @@ export class AmpList extends AMP.BaseElement {
   /**
    *
    * @param {!Element} target
-   * @return {!Promise}
    * @private
    */
   attemptToFitLoadMore_(target) {
@@ -767,11 +767,13 @@ export class AmpList extends AMP.BaseElement {
   /**
    * @param {?Element} element
    * @param {!Element} target
-   * @return {!Promise}
    * @private
    */
   attemptToFitLoadMoreElement_(element, target) {
-    return this.measureElement(() => {
+    if (this.element.getAttribute('layout') == Layout.CONTAINER) {
+      return;
+    }
+    this.measureElement(() => {
       const targetHeight = target./*OK*/scrollHeight;
       const height = this.element./*OK*/offsetHeight;
       const loadMoreHeight = element ? element./*OK*/offsetHeight : 0;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -226,9 +226,8 @@ export class AmpList extends AMP.BaseElement {
 
     this.loadMoreEnabledPromise_.then(enabled => {
       if (enabled) {
-        this.loadMoreService_ = new LoadMoreService(this.element);
         this.mutateElement(() => {
-          this.loadMoreService_.initializeLoadMore();
+          this.getLoadMoreService_().initializeLoadMore();
           const overflowElement = this.getOverflowElement();
           if (overflowElement) {
             toggle(overflowElement, false);
@@ -244,6 +243,17 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * @return {!LoadMoreService}
+   * @private
+   */
+  getLoadMoreService_() {
+    if (!this.loadMoreService_) {
+      this.loadMoreService_ = new LoadMoreService(this.element);
+    }
+    return this.loadMoreService_;
+  }
+
+  /**
    * This function is called at layout time if the amp-list has the
    * load-more attribute. This increases the height of the amp-list by
    * the height of the load-more button and forces the contents to allow
@@ -256,7 +266,7 @@ export class AmpList extends AMP.BaseElement {
     let listHeight;
     return this.measureMutateElement(
         () => {
-          buttonHeight = this.loadMoreService_
+          buttonHeight = this.getLoadMoreService_()
               .getLoadMoreButton()./*OK*/offsetHeight;
           listHeight = this.element./*OK*/offsetHeight;
         },
@@ -593,9 +603,9 @@ export class AmpList extends AMP.BaseElement {
       if (enabled) {
         const promises = [];
         promises.push(this.maybeRenderLoadMoreElement_(
-            this.loadMoreService_.getLoadMoreButton(), data));
+            this.getLoadMoreService_().getLoadMoreButton(), data));
         promises.push(this.maybeRenderLoadMoreElement_(
-            this.loadMoreService_.getLoadMoreEndElement(), data));
+            this.getLoadMoreService_().getLoadMoreEndElement(), data));
         return Promise.all(promises);
       }
     });
@@ -723,8 +733,8 @@ export class AmpList extends AMP.BaseElement {
     this.loadMoreEnabledPromise_.then(enabled => {
       if (enabled) {
         const element = !!this.loadMoreSrc_ ?
-          this.loadMoreService_.getLoadMoreButton() :
-          this.loadMoreService_.getLoadMoreEndElement();
+          this.getLoadMoreService_().getLoadMoreButton() :
+          this.getLoadMoreService_().getLoadMoreEndElement();
         this.attemptToFitLoadMoreElement_(element, target);
       } else {
         this.measureElement(() => {
@@ -862,19 +872,19 @@ export class AmpList extends AMP.BaseElement {
           this.setupLoadMoreAuto_();
         }
         return this.mutateElement(() => {
-          this.loadMoreService_.toggleLoadMoreLoading(false);
+          this.getLoadMoreService_().toggleLoadMoreLoading(false);
           // Set back to visible because there are actually more elements
           // to load. See comment in initializeLoadMoreButton_ for context.
-          setStyles(this.loadMoreService_.getLoadMoreButton(), {
+          setStyles(this.getLoadMoreService_().getLoadMoreButton(), {
             visibility: '',
           });
           this.unlistenLoadMore_ = listen(
-              this.loadMoreService_.getLoadMoreButtonClickable(),
+              this.getLoadMoreService_().getLoadMoreButtonClickable(),
               'click', () => this.loadMoreCallback_());
         });
       } else {
         return this.mutateElement(
-            () => this.loadMoreService_.setLoadMoreEnded());
+            () => this.getLoadMoreService_().setLoadMoreEnded());
       }
     });
   }
@@ -895,7 +905,7 @@ export class AmpList extends AMP.BaseElement {
       return Promise.resolve();
     }
     this.mutateElement(() => {
-      this.loadMoreService_.toggleLoadMoreLoading(true);
+      this.getLoadMoreService_().toggleLoadMoreLoading(true);
     });
     return this.fetchList_(/* opt_append */ true)
         .then(() => {
@@ -905,21 +915,22 @@ export class AmpList extends AMP.BaseElement {
           }
           return this.mutateElement(() => {
             if (this.loadMoreSrc_) {
-              this.loadMoreService_.toggleLoadMoreLoading(false);
+              this.getLoadMoreService_().toggleLoadMoreLoading(false);
             } else {
-              this.loadMoreService_.setLoadMoreEnded();
+              this.getLoadMoreService_().setLoadMoreEnded();
             }
           });
         }).then(() => {
           // Necessary since load-more elements are toggled in the above block
           this.attemptToFit_(dev().assertElement(this.container_));
         }).catch(() => {
-          this.mutateElement(() => this.loadMoreService_.setLoadMoreFailed())
+          this.mutateElement(() =>
+            this.getLoadMoreService_().setLoadMoreFailed())
               .then(() => {
                 this.attemptToFitLoadMoreElement_(
-                    this.loadMoreService_.getLoadMoreFailedElement(),
+                    this.getLoadMoreService_().getLoadMoreFailedElement(),
                     dev().assertElement(this.container_));
-                const loadMoreFailedClickable = this.loadMoreService_
+                const loadMoreFailedClickable = this.getLoadMoreService_()
                     .getLoadMoreFailedClickable();
                 this.unlistenLoadMore_ = listen(
                     loadMoreFailedClickable,
@@ -927,7 +938,6 @@ export class AmpList extends AMP.BaseElement {
               });
         });
   }
-
 
   /**
    * @param {boolean} opt_refresh

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -44,48 +44,46 @@ describes.realWin('amp-list component', {
     sandbox.stub(Services, 'templatesFor').returns(templates);
     sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
 
-    element = doc.createElement('amp-list');
-    element.setAttribute('src', '/list/infinite-scroll?items=2&left=1');
-    element.setAttribute('load-more', 'manual');
-
-    list = new AmpList(element);
-
-    sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
-    sandbox.stub(list, 'getFallback').returns(null);
-
-    sandbox.stub(list, 'mutateElement').callsFake(mutator => {
-      mutator();
-      return Promise.resolve();
-    });
-
-    sandbox.stub(list, 'measureElement').callsFake(measurer => {
-      measurer();
-      return Promise.resolve();
-    });
-
-    sandbox.stub(list, 'measureMutateElement').callsFake(
-        (measurer, mutator) => {
-          measurer();
-          mutator();
-          return Promise.resolve();
-        });
-
     toggleExperiment(win, 'amp-list-load-more', true);
-    expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
-
-    element.style.height = '10px';
-    doc.body.appendChild(element);
-  });
-
-  afterEach(() => {
-
   });
 
   describe('manual', () => {
 
     beforeEach(() => {
       expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
-      sandbox.stub(list, 'getPlaceholder').returns(null);
+
+      element = doc.createElement('amp-list');
+      list = new AmpList(element);
+
+      sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+      sandbox.stub(list, 'getFallback').returns(null);
+
+      sandbox.stub(list, 'mutateElement').callsFake(mutator => {
+        mutator();
+        return Promise.resolve();
+      });
+
+      sandbox.stub(list, 'measureElement').callsFake(measurer => {
+        measurer();
+        return Promise.resolve();
+      });
+
+      sandbox.stub(list, 'measureMutateElement').callsFake(
+          (measurer, mutator) => {
+            measurer();
+            mutator();
+            return Promise.resolve();
+          });
+
+      element.setAttribute('src', '/list/infinite-scroll?items=2&left=1');
+      element.setAttribute('load-more', 'manual');
+      element.setAttribute('layout', 'fixed');
+      element.setAttribute('width', '50');
+      element.setAttribute('height', '10');
+
+      element.style.height = '10px';
+      doc.body.appendChild(element);
+
       sandbox.stub(list, 'getOverflowElement').returns(null);
       sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
       list.element.changeSize = () => {};
@@ -93,6 +91,7 @@ describes.realWin('amp-list component', {
     });
 
     it('should create load-more elements after layout callback', async() => {
+      sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.layoutCallback();
       expect(list.element.querySelector('[load-more-button]')).to.be.ok;
       expect(list.element.querySelector('[load-more-failed]')).to.be.ok;
@@ -100,6 +99,7 @@ describes.realWin('amp-list component', {
     });
 
     it('should hide load-more elements at layout', async() => {
+      sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.layoutCallback();
       const button = list.element.querySelector('[load-more-button]');
       const buttonStyles = win.getComputedStyle(button);
@@ -110,6 +110,16 @@ describes.realWin('amp-list component', {
       expect(failedStyles.display).to.equal('none');
     });
 
+    it('should resize the list to fit a placeholder', async() => {
+      const attemptChangeHeightSpy = sandbox.spy(list, 'attemptChangeHeight');
+      const placeholder = doc.createElement('div');
+      placeholder.setAttribute('placeholder', '');
+      placeholder.style.height = '50px';
+      placeholder.style.width = '50px';
+      list.element.appendChild(placeholder);
+      sandbox.stub(list, 'getPlaceholder').returns(placeholder);
+      await list.layoutCallback();
+      expect(attemptChangeHeightSpy).to.be.calledOnceWith(50);
+    });
   });
-
 });

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpDocService} from '../../../../src/service/ampdoc-impl';
+import {AmpList} from '../amp-list';
+import {Services} from '../../../../src/services';
+import {isExperimentOn, toggleExperiment} from '../../../../src/experiments';
+
+
+describes.realWin('amp-list component', {
+  amp: {
+    ampdoc: 'single',
+    extensions: ['amp-list'],
+  },
+}, env => {
+  let win, doc, ampdoc, sandbox;
+  let element, list;
+  let templates;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    ampdoc = env.ampdoc;
+    sandbox = env.sandbox;
+
+    templates = {
+      findAndSetHtmlForTemplate: sandbox.stub(),
+      findAndRenderTemplate: sandbox.stub(),
+      findAndRenderTemplateArray: sandbox.stub(),
+    };
+    sandbox.stub(Services, 'templatesFor').returns(templates);
+    sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+
+    element = doc.createElement('amp-list');
+    element.setAttribute('src', '/list/infinite-scroll?items=2&left=1');
+    element.setAttribute('load-more', 'manual');
+
+    list = new AmpList(element);
+
+    sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+    sandbox.stub(list, 'getFallback').returns(null);
+
+    sandbox.stub(list, 'mutateElement').callsFake(mutator => {
+      mutator();
+      return Promise.resolve();
+    });
+
+    sandbox.stub(list, 'measureElement').callsFake(measurer => {
+      measurer();
+      return Promise.resolve();
+    });
+
+    sandbox.stub(list, 'measureMutateElement').callsFake(
+        (measurer, mutator) => {
+          measurer();
+          mutator();
+          return Promise.resolve();
+        });
+
+    toggleExperiment(win, 'amp-list-load-more', true);
+    expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
+
+    element.style.height = '10px';
+    doc.body.appendChild(element);
+  });
+
+  afterEach(() => {
+
+  });
+
+  describe('manual', () => {
+
+    beforeEach(() => {
+      expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
+      sandbox.stub(list, 'getPlaceholder').returns(null);
+      sandbox.stub(list, 'getOverflowElement').returns(null);
+      sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+      list.element.changeSize = () => {};
+      list.buildCallback();
+    });
+
+    it('should create load-more elements after layout callback', async() => {
+      await list.layoutCallback();
+      expect(list.element.querySelector('[load-more-button]')).to.be.ok;
+      expect(list.element.querySelector('[load-more-failed]')).to.be.ok;
+      expect(list.element.querySelector('[load-more-end]')).to.be.null;
+    });
+
+    it('should hide load-more elements at layout', async() => {
+      await list.layoutCallback();
+      const button = list.element.querySelector('[load-more-button]');
+      const buttonStyles = win.getComputedStyle(button);
+      expect(buttonStyles.display).to.equal('block');
+      expect(buttonStyles.visibility).to.equal('hidden');
+      const failedElement = list.element.querySelector('[load-more-failed]');
+      const failedStyles = win.getComputedStyle(failedElement);
+      expect(failedStyles.display).to.equal('none');
+    });
+
+  });
+
+});

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -26,7 +26,10 @@ describes.realWin('amp-list component', {
     extensions: ['amp-list'],
   },
 }, env => {
-  let win, doc, ampdoc, sandbox;
+  let win;
+  let doc;
+  let ampdoc;
+  let sandbox;
   let element, list;
   let templates;
 
@@ -93,21 +96,42 @@ describes.realWin('amp-list component', {
     it('should create load-more elements after layout callback', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.layoutCallback();
-      expect(list.element.querySelector('[load-more-button]')).to.be.ok;
-      expect(list.element.querySelector('[load-more-failed]')).to.be.ok;
+
+      expect(list.element.querySelectorAll('[load-more-button]'))
+          .to.have.lengthOf(1);
+      expect(list.element.querySelectorAll('[load-more-failed]'))
+          .to.have.lengthOf(1);
       expect(list.element.querySelector('[load-more-end]')).to.be.null;
     });
 
-    it('should hide load-more elements at layout', async() => {
+    it('should hide load-more-button at layout', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.layoutCallback();
+
       const button = list.element.querySelector('[load-more-button]');
       const buttonStyles = win.getComputedStyle(button);
-      expect(buttonStyles.display).to.equal('block');
-      expect(buttonStyles.visibility).to.equal('hidden');
+      expect(buttonStyles).include({
+        'display': 'block',
+        'visibility': 'hidden',
+      });
+    });
+
+    it('should hide load-more-failed element at layout', async() => {
+      sandbox.stub(list, 'getPlaceholder').returns(null);
+      await list.layoutCallback();
+
       const failedElement = list.element.querySelector('[load-more-failed]');
       const failedStyles = win.getComputedStyle(failedElement);
       expect(failedStyles.display).to.equal('none');
+    });
+
+    it('should hide load-more-loading element at layout', async() => {
+      sandbox.stub(list, 'getPlaceholder').returns(null);
+      await list.layoutCallback();
+
+      const loader = list.element.querySelector('[load-more-loading]');
+      const loaderStyles = win.getComputedStyle(loader);
+      expect(loaderStyles.display).to.equal('none');
     });
 
     it('should resize the list to fit a placeholder', async() => {

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -137,8 +137,8 @@
       FALLBACK
     </div>
     <div placeholder>
-        PLACEHOLDER
-      </div>
+      PLACEHOLDER
+    </div>
     <amp-list-load-more load-more-failed>
 
     </amp-list-load-more>

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -62,6 +62,11 @@
       background-color: red;
     }
 
+    div[placeholder] {
+      height: 100vh;
+      background-color: red;
+    }
+
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -79,7 +84,7 @@
             "items": 8,
             "left": 5,
             "latency": 0,
-            "url": "/list/infinite-scroll?items=8&left=2"
+            "url": "/list/infinite-scroll?items=8&left=5"
           }
         </script>
       </amp-state>
@@ -113,11 +118,11 @@
   <h1>AMP List</h1>
   <p>This is a flexbox amp-list with tiles, something like an infinite image gallery.</p>
 
-  <amp-list width="auto" height="400"
+  <amp-list width="auto" height="200"
     layout="fixed-height"
-    src="/list/infinite-scroll?items=2&left=2"
+    src="/list/infinite-scroll?items=5&left=5"
     [src]="data.url"
-    load-more="manual"
+    load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">
@@ -131,6 +136,9 @@
     <div fallback>
       FALLBACK
     </div>
+    <div placeholder>
+        PLACEHOLDER
+      </div>
     <amp-list-load-more load-more-failed>
 
     </amp-list-load-more>


### PR DESCRIPTION
This fixes a race condition where `attemptToFit_` is called before `loadMoreSrc` is initialized. 

The bug: 
`attemptToFit` is sometimes called before `loadMoreSrc` is initialized (i.e. when the placeholder element is larger than `<amp-list>` and needs to be resized, or if a viewport resize is triggered before layout callback completes). This is slightly more severe on higher latency networks due to the need to wait for load and installation of the origin experiments extension. 