### PR TITLE
Scrub <script> tags from <head> of ad responses if offsets are missing 

### DIFF
--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -78,13 +78,21 @@ export function getAmpAdMetadata(creative) {
   try {
     const metaDataObj = parseJson(
         creative.slice(metadataStart + metadataString.length, metadataEnd));
-    const ampRuntimeUtf16CharOffsets =
+    let ampRuntimeUtf16CharOffsets =
       metaDataObj['ampRuntimeUtf16CharOffsets'];
     if (!isArray(ampRuntimeUtf16CharOffsets) ||
         ampRuntimeUtf16CharOffsets.length != 2 ||
         typeof ampRuntimeUtf16CharOffsets[0] !== 'number' ||
         typeof ampRuntimeUtf16CharOffsets[1] !== 'number') {
-      throw new Error('Invalid runtime offsets');
+      const headStart = creative.indexOf('<head>');
+      const headEnd = creative.indexOf('</head>');
+      const headSubstring = creative.slice(
+          headStart, headEnd + '</head>'.length);
+      ampRuntimeUtf16CharOffsets = [
+          headStart + headSubstring.indexOf('<script'),
+          headStart + headSubstring.lastIndexOf('</script>') +
+              '</script>'.length
+      ];
     }
     const metaData = {};
     if (metaDataObj['customElementExtensions']) {

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -89,9 +89,9 @@ export function getAmpAdMetadata(creative) {
       const headSubstring = creative.slice(
           headStart, headEnd + '</head>'.length);
       ampRuntimeUtf16CharOffsets = [
-          headStart + headSubstring.indexOf('<script'),
-          headStart + headSubstring.lastIndexOf('</script>') +
-              '</script>'.length
+        headStart + headSubstring.indexOf('<script'),
+        headStart + headSubstring.lastIndexOf('</script>') +
+            '</script>'.length,
       ];
     }
     const metaData = {};

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -32,6 +32,19 @@ describe('getAmpAdMetadata', () => {
     expect(creativeMetadata.images).to.not.be.ok;
   });
 
+  it('should parse metadata despite missing offsets', () => {
+    const creativeMetadata = getAmpAdMetadata(data.reserializedMissingOffset);
+    expect(creativeMetadata).to.be.ok;
+    expect(creativeMetadata.minifiedCreative).to.equal(data.minifiedCreative);
+    expect(creativeMetadata.customElementExtensions.length).to.equal(1);
+    expect(creativeMetadata.customElementExtensions[0]).to.equal('amp-font');
+    expect(creativeMetadata.customStylesheets.length).to.equal(1);
+    expect(creativeMetadata.customStylesheets[0]).to.deep.equal({
+      'href': 'https://fonts.googleapis.com/css?family=Questrial',
+    });
+    expect(creativeMetadata.images).to.not.be.ok;
+  });
+
   it('should return null -- bad offset', () => {
     const creativeMetadata = getAmpAdMetadata(data.reserializedInvalidOffset);
     expect(creativeMetadata).to.be.null;

--- a/extensions/amp-a4a/0.1/test/testdata/valid_css_at_rules_amp.reserialized.js
+++ b/extensions/amp-a4a/0.1/test/testdata/valid_css_at_rules_amp.reserialized.js
@@ -53,6 +53,30 @@ export const data = {
 }
 </script></body></html>`,
 
+  reserializedMissingOffset: `<!doctype html><html ⚡4ads><head><meta charset=utf-8><meta content=width=device-width,minimum-scale=1 name=viewport><script async src=https://cdn.ampproject.org/amp4ads-v0.js></script><script async custom-element=amp-font src=https://cdn.ampproject.org/v0/amp-font-0.1.js></script><link href=https://fonts.googleapis.com/css?family=Questrial rel=stylesheet type=text/css><style amp-custom>
+    amp-user-notification.amp-active {
+      opacity: 0;
+    }
+  </style><style amp4ads-boilerplate>body{visibility:hidden}</style></head><body>Hello, world.
+
+<script amp-ad-metadata type=application/json>
+{
+   "customElementExtensions" : [ "amp-font" ],
+   "customStylesheets" : [
+      {
+         "href" : "https://fonts.googleapis.com/css?family=Questrial"
+      }
+   ],
+   "extensions" : [
+      {
+         "custom-element" : "amp-font",
+         "src" : "https://cdn.ampproject.org/v0/amp-font-0.1.js"
+      }
+   ]
+}
+</script></body></html>`,
+
+
   reserializedMissingScriptTag: `<!doctype html><html ⚡4ads><head><meta charset=utf-8><meta content=width=device-width,minimum-scale=1 name=viewport><script async src=https://cdn.ampproject.org/amp4ads-v0.js></script><script async custom-element=amp-font src=https://cdn.ampproject.org/v0/amp-font-0.1.js></script><link href=https://fonts.googleapis.com/css?family=Questrial rel=stylesheet type=text/css><style amp-custom>
     amp-user-notification.amp-active {
       opacity: 0;


### PR DESCRIPTION
Normally, ad responses contain the offsets that point to the beginning and end of <script> tags included in the tag of creatives so that they can be excised, and if these offsets are missing the creative will not gain preferential rendering. This change will compute the offsets on the client, permitting the <script> tags to be excised even if the offsets are not included in the ad response.

Fixes #21381