### PR TITLE
✨ Support dead embeds

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -88,12 +88,6 @@ const LAUNCHABLE_COMPONENTS = {
   },
 };
 
-/** @const {!Array<string>} */
-const INTERACTIVE_ATTR_NAMES = [
-  '[interactive="true"]',
-  '[interactive=""]',
-  '[interactive]'];
-
 /**
  * Union of expandable and launchable components.
  * @private
@@ -105,20 +99,14 @@ const INTERACTIVE_COMPONENTS = Object.assign({}, EXPANDABLE_COMPONENTS,
 /**
  * Gets the list of components with their respective selectors.
  * @param {!Object} components
- * @param {Array<string>=} opt_attrs
  * @return {!Object<string, string>}
  */
-function getComponentSelectors(components, opt_attrs) {
+function getComponentSelectors(components) {
   const componentSelectors = {};
 
   Object.keys(components).forEach(componentName => {
-    let {selector} = components[componentName];
-
-    if (opt_attrs) {
-      selector = opt_attrs.map(attr => selector + attr).join(',');
-    }
-
-    componentSelectors[componentName] = selector;
+    componentSelectors[componentName] = components[componentName].selector +
+      '[interactive]:not([interactive=false])';
   });
 
   return componentSelectors;
@@ -130,7 +118,7 @@ function getComponentSelectors(components, opt_attrs) {
  */
 export function expandableElementsSelectors() {
   // Using indirect invocation to prevent no-export-side-effect issue.
-  return getComponentSelectors(EXPANDABLE_COMPONENTS, INTERACTIVE_ATTR_NAMES);
+  return getComponentSelectors(EXPANDABLE_COMPONENTS);
 }
 
 /**
@@ -138,7 +126,7 @@ export function expandableElementsSelectors() {
  * @type {!Object}
  */
 const interactiveSelectors = Object.assign({},
-    getComponentSelectors(INTERACTIVE_COMPONENTS, INTERACTIVE_ATTR_NAMES),
+    getComponentSelectors(INTERACTIVE_COMPONENTS),
     {EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
     '.i-amphtml-expanded-view-close-button',
     });

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -99,18 +99,23 @@ const INTERACTIVE_COMPONENTS = Object.assign({}, EXPANDABLE_COMPONENTS,
 /**
  * Gets the list of components with their respective selectors.
  * @param {!Object} components
+ * @param {string=} opt_predicate
  * @return {!Object<string, string>}
  */
-function getComponentSelectors(components) {
+function getComponentSelectors(components, opt_predicate) {
   const componentSelectors = {};
 
   Object.keys(components).forEach(componentName => {
-    componentSelectors[componentName] = components[componentName].selector +
-      '[interactive]:not([interactive=false])';
+    componentSelectors[componentName] = opt_predicate ?
+      components[componentName].selector + opt_predicate :
+      components[componentName].selector;
   });
 
   return componentSelectors;
 }
+
+/** @const {string} */
+const INTERACTIVE_ATTR_NAME = '[interactive]:not([interactive=false])';
 
 /**
  * Selectors of elements that can go into expanded view.
@@ -118,7 +123,7 @@ function getComponentSelectors(components) {
  */
 export function expandableElementsSelectors() {
   // Using indirect invocation to prevent no-export-side-effect issue.
-  return getComponentSelectors(EXPANDABLE_COMPONENTS);
+  return getComponentSelectors(EXPANDABLE_COMPONENTS, INTERACTIVE_ATTR_NAME);
 }
 
 /**
@@ -126,7 +131,8 @@ export function expandableElementsSelectors() {
  * @type {!Object}
  */
 const interactiveSelectors = Object.assign({},
-    getComponentSelectors(INTERACTIVE_COMPONENTS),
+    getComponentSelectors(LAUNCHABLE_COMPONENTS),
+    getComponentSelectors(EXPANDABLE_COMPONENTS, INTERACTIVE_ATTR_NAME),
     {EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
     '.i-amphtml-expanded-view-close-button',
     });

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -71,7 +71,7 @@ export const EXPANDABLE_COMPONENTS = {
     '0 78.62 23"/></g></svg>',
     actionIcon: ActionIcon.EXPAND,
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
-    selector: 'amp-twitter',
+    selector: 'amp-twitter[interactive=yes]',
   },
 };
 
@@ -112,22 +112,31 @@ function getComponentSelectors(components) {
 }
 
 /**
+ * Selectors of elements that can go into expanded view.
+ * @return {!Object}
+ */
+export function expandableElementsSelectors() {
+  // Using indirect invocation to prevent no-export-side-effect issue.
+  return getComponentSelectors(EXPANDABLE_COMPONENTS);
+}
+
+/**
  * Contains all interactive component CSS selectors.
  * @type {!Object}
  */
-const interactiveComponentSelectors = Object.assign({},
+const interactiveSelectors = Object.assign({},
     getComponentSelectors(INTERACTIVE_COMPONENTS),
     {EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
     '.i-amphtml-expanded-view-close-button',
     });
 
 /**
- * Selectors that should delegate to AmpStoryEmbeddedComponent.
+ * All selectors that should delegate to the AmpStoryEmbeddedComponent class.
  * @return {!Object}
  */
-export function embeddedComponentSelectors() {
+export function interactiveElementsSelectors() {
   // Using indirect invocation to prevent no-export-side-effect issue.
-  return interactiveComponentSelectors;
+  return interactiveSelectors;
 }
 
 /**
@@ -752,10 +761,8 @@ export class AmpStoryEmbeddedComponent {
         },
         /** mutate */
         () => {
-          element.classList.add('i-amphtml-embedded-component');
-
           elId = elId ? elId : ++embedIds;
-          if (!element.hasAttribute(EMBED_ID_ATTRIBUTE_NAME)) { // First time creating embed style element.
+          if (!element.hasAttribute(EMBED_ID_ATTRIBUTE_NAME)) { // First time creating <style> element for embed.
             const html = htmlFor(pageEl);
             const embedStyleEl = html`<style></style>`;
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -71,7 +71,7 @@ export const EXPANDABLE_COMPONENTS = {
     '0 78.62 23"/></g></svg>',
     actionIcon: ActionIcon.EXPAND,
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
-    selector: 'amp-twitter[interactive=yes]',
+    selector: 'amp-twitter',
   },
 };
 
@@ -88,6 +88,12 @@ const LAUNCHABLE_COMPONENTS = {
   },
 };
 
+/** @const {!Array<string>} */
+const INTERACTIVE_ATTR_NAMES = [
+  '[interactive="true"]',
+  '[interactive=""]',
+  '[interactive]'];
+
 /**
  * Union of expandable and launchable components.
  * @private
@@ -99,16 +105,23 @@ const INTERACTIVE_COMPONENTS = Object.assign({}, EXPANDABLE_COMPONENTS,
 /**
  * Gets the list of components with their respective selectors.
  * @param {!Object} components
+ * @param {Array<string>=} opt_attrs
  * @return {!Object<string, string>}
  */
-function getComponentSelectors(components) {
-  const obj = {};
+function getComponentSelectors(components, opt_attrs) {
+  const componentSelectors = {};
 
-  Object.keys(components).forEach(key => {
-    obj[key] = components[key].selector;
+  Object.keys(components).forEach(componentName => {
+    let {selector} = components[componentName];
+
+    if (opt_attrs) {
+      selector = opt_attrs.map(attr => selector + attr).join(',');
+    }
+
+    componentSelectors[componentName] = selector;
   });
 
-  return obj;
+  return componentSelectors;
 }
 
 /**
@@ -117,7 +130,7 @@ function getComponentSelectors(components) {
  */
 export function expandableElementsSelectors() {
   // Using indirect invocation to prevent no-export-side-effect issue.
-  return getComponentSelectors(EXPANDABLE_COMPONENTS);
+  return getComponentSelectors(EXPANDABLE_COMPONENTS, INTERACTIVE_ATTR_NAMES);
 }
 
 /**
@@ -125,7 +138,7 @@ export function expandableElementsSelectors() {
  * @type {!Object}
  */
 const interactiveSelectors = Object.assign({},
-    getComponentSelectors(INTERACTIVE_COMPONENTS),
+    getComponentSelectors(INTERACTIVE_COMPONENTS, INTERACTIVE_ATTR_NAMES),
     {EXPANDED_VIEW_OVERLAY: '.i-amphtml-story-expanded-view-overflow, ' +
     '.i-amphtml-expanded-view-close-button',
     });

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -35,6 +35,7 @@ import {
   AmpStoryEmbeddedComponent,
   EMBED_ID_ATTRIBUTE_NAME,
   EXPANDABLE_COMPONENTS,
+  expandableElementsSelectors,
 } from './amp-story-embedded-component';
 import {
   AnimationManager,
@@ -100,6 +101,10 @@ const Selectors = {
 /** @private @const {string} */
 const EMBEDDED_COMPONENTS_SELECTORS =
   Object.keys(EXPANDABLE_COMPONENTS).join(', ');
+
+/** @private @const {string} */
+const INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS = Object.values(
+    expandableElementsSelectors()).join(',');
 
 /** @private @const {number} */
 const RESIZE_TIMEOUT_MS = 350;
@@ -471,13 +476,35 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Finds embedded components in page and prepares them for their expanded view
-   * animation.
+   * Finds embedded components in page and prepares them.
    * @param {boolean=} forceResize
    * @private
    */
   findAndPrepareEmbeddedComponents_(forceResize = false) {
-    scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
+    this.addClickShieldToEmbeds_();
+    this.resizeInteractiveEmbeds_(forceResize);
+  }
+
+  /**
+   * Adds a pseudo element on top of the embed to block clicks from going into
+   * the iframe.
+   */
+  addClickShieldToEmbeds_() {
+    scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS).forEach(
+        el => {
+          this.resources_.mutateElement(el, () => {
+            el.classList.add('i-amphtml-embedded-component');
+          });
+        });
+  }
+
+  /**
+   * Resizes interactive embeds to prepare them for their expanded animation.
+   * @param {boolean} forceResize
+   */
+  resizeInteractiveEmbeds_(forceResize) {
+    scopedQuerySelectorAll(this.element,
+        INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS)
         .forEach(el => {
           const debouncePrepareForAnimation =
             debounceEmbedResize(this.win, this.element, this.resources_);
@@ -1001,7 +1028,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   toggleLoadingSpinner_(isActive) {
-    this.getVsync().mutate(() => {
+    this.resources_.mutateElement(this.element, () => {
       if (!this.loadingSpinner_) {
         this.buildAndAppendLoadingSpinner_();
       }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -491,14 +491,11 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   addClickShieldToEmbeds_() {
-    const els = [];
-    scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS).forEach(
-        el => els.push(el));
-
     this.mutateElement(() => {
-      els.forEach(el => {
-        el.classList.add('i-amphtml-embedded-component');
-      });
+      scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
+          .forEach(el => {
+            el.classList.add('i-amphtml-embedded-component');
+          });
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -482,27 +482,32 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   findAndPrepareEmbeddedComponents_(forceResize = false) {
     this.addClickShieldToEmbeds_();
-    this.resizeInteractiveEmbeds_(forceResize);
+    this.resizeInteractiveEmbeddedComponents_(forceResize);
   }
 
   /**
    * Adds a pseudo element on top of the embed to block clicks from going into
    * the iframe.
+   * @private
    */
   addClickShieldToEmbeds_() {
+    const els = [];
     scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS).forEach(
-        el => {
-          this.resources_.mutateElement(el, () => {
-            el.classList.add('i-amphtml-embedded-component');
-          });
-        });
+        el => els.push(el));
+
+    this.mutateElement(() => {
+      els.forEach(el => {
+        el.classList.add('i-amphtml-embedded-component');
+      });
+    });
   }
 
   /**
    * Resizes interactive embeds to prepare them for their expanded animation.
    * @param {boolean} forceResize
+   * @private
    */
-  resizeInteractiveEmbeds_(forceResize) {
+  resizeInteractiveEmbeddedComponents_(forceResize) {
     scopedQuerySelectorAll(this.element,
         INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS)
         .forEach(el => {
@@ -1028,7 +1033,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   toggleLoadingSpinner_(isActive) {
-    this.resources_.mutateElement(this.element, () => {
+    this.mutateElement(() => {
       if (!this.loadingSpinner_) {
         this.buildAndAppendLoadingSpinner_();
       }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -481,7 +481,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   findAndPrepareEmbeddedComponents_(forceResize = false) {
-    this.addClickShieldToEmbeds_();
+    this.addClickShieldToEmbeddedComponents_();
     this.resizeInteractiveEmbeddedComponents_(forceResize);
   }
 
@@ -490,12 +490,18 @@ export class AmpStoryPage extends AMP.BaseElement {
    * the iframe.
    * @private
    */
-  addClickShieldToEmbeds_() {
+  addClickShieldToEmbeddedComponents_() {
+    const componentEls = scopedQuerySelectorAll(this.element,
+        EMBEDDED_COMPONENTS_SELECTORS);
+
+    if (componentEls.length <= 0) {
+      return;
+    }
+
     this.mutateElement(() => {
-      scopedQuerySelectorAll(this.element, EMBEDDED_COMPONENTS_SELECTORS)
-          .forEach(el => {
-            el.classList.add('i-amphtml-embedded-component');
-          });
+      componentEls.forEach(el => {
+        el.classList.add('i-amphtml-embedded-component');
+      });
     });
   }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -26,11 +26,11 @@ import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
-import {
-  embeddedComponentSelectors,
-} from './amp-story-embedded-component';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {hasTapAction, timeStrToMillis} from './utils';
+import {
+  interactiveElementsSelectors,
+} from './amp-story-embedded-component';
 import {listenOnce} from '../../../src/event-helper';
 
 /** @private @const {number} */
@@ -43,7 +43,7 @@ const NEXT_SCREEN_AREA_RATIO = 0.75;
 const PREVIOUS_SCREEN_AREA_RATIO = 0.25;
 
 const EMBEDDED_COMPONENT_SELECTORS = Object.values(
-    embeddedComponentSelectors()).join(',');
+    interactiveElementsSelectors()).join(',');
 
 /** @const {number} */
 export const POLL_INTERVAL_MS = 300;

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -42,7 +42,7 @@ const NEXT_SCREEN_AREA_RATIO = 0.75;
 /** @private @const {number} */
 const PREVIOUS_SCREEN_AREA_RATIO = 0.25;
 
-const EMBEDDED_COMPONENT_SELECTORS = Object.values(
+const INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS = Object.values(
     interactiveElementsSelectors()).join(',');
 
 /** @const {number} */
@@ -484,7 +484,7 @@ class ManualAdvancement extends AdvancementConfig {
     const target = dev().assertElement(event.target);
 
     if (this.canShowTooltip_(event) &&
-      matches(target, EMBEDDED_COMPONENT_SELECTORS)) {
+      matches(target, INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS)) {
       // Clicked element triggers a tooltip, so we dispatch the corresponding
       // event and skip navigation.
       event.preventDefault();

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -53,6 +53,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     win.document.body.appendChild(story);
 
     page = new AmpStoryPage(element);
+    page.element.getResources = () => win.services.resources.obj;
   });
 
   afterEach(() => {


### PR DESCRIPTION
Dead embeds will behave like regular embeds but won't be interactive (i.e. they won't trigger the tooltip). 

This PR makes it so that publishers will have to explicitly opt-in to the interactive mode. They will be able to do this using the `interactive="true"` attribute on the embed.

Follow ups will be sent for validation / visual tests.