### PR TITLE
✨Support rich content on amp-autocomplete. 

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -228,49 +228,5 @@
             </template>
         </div>
     </form>
-
-    <h3>Rich Text, Script Child Template, Custom Value Property</h3>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
-        <fieldset>
-            <label>
-                <span>Search for</span>
-                <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
-                    <input type="search" name="term" required>
-                    <script type="application/json">
-                        { "items" : [
-                            {
-                                "city" : "Albany",
-                                "state" : "New York", 
-                                "areaCode" : 518,
-                                "population" : 98251
-                            }, {
-                                "city" : "Annapolis",
-                                "state" : "Maryland",
-                                "areaCode" : 410,
-                                "population" : 39321
-                            }, {
-                                "city" : "Trenton",
-                                "state" : "New Jersey",
-                                "areaCode" : 609,
-                                "population" : 84964
-                            }
-                        ] }
-                    </script>
-                    <script type="text/plain" template="amp-mustache">
-                        <div class="city-item" value="{{city}}, {{state}}">
-                            <div>{{city}}, {{state}}</div>
-                            <div class="custom-population">Population: {{population}}</div>        
-                        </div>
-                    </script>
-                </amp-autocomplete>
-            </label>
-            <input type="submit" value="Search">
-        </fieldset>
-        <div submit-success>
-            <template type="amp-mustache">
-                <div>Here are the results for the search: {{term}}</div>
-            </template>
-        </div>
-    </form>
 </body>
 </html>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -10,6 +10,12 @@
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp-custom>
+    .custom-population {
+        padding-top: 4px;
+        font: 8pt 'Courier New', Courier, monospace;
+    }
+  </style>
   <script>
       (self.AMP=self.AMP||[]).push((AMP) => {
         AMP.toggleExperiment('amp-autocomplete', true);
@@ -81,6 +87,7 @@
     </form>
 
     <h2>Search context</h2>
+    <h3>Plain Text</h3>
     <form method="get" action-xhr="/form/search-json/get" target="_blank">
         <fieldset>
             <label>
@@ -90,6 +97,91 @@
                     <script type="application/json">
                         { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
                     </script>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
+
+    <h3>Rich Text</h3>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" min-characters="0">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
+                        { "items" : [
+                            {
+                                "value" : "Albany, New York",
+                                "areaCode" : 518,
+                                "population" : 98251
+                            }, {
+                                "value" : "Annapolis, Maryland",
+                                "areaCode" : 410,
+                                "population" : 39321
+                            }, {
+                                "value" : "Trenton, New Jersey",
+                                "areaCode" : 609,
+                                "population" : 84964
+                            }
+                        ] }
+                    </script>
+                    <template type="amp-mustache" id="amp-template-id">
+                        <div class="city-item" value="{{value}}">
+                            <div>{{value}}</div>
+                            <div class="custom-population">Population: {{population}}</div>        
+                        </div>
+                        </template>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
+
+    <h3>Rich Text: Custom Value</h3>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
+                        { "items" : [
+                            {
+                                "city" : "Albany",
+                                "state" : "New York", 
+                                "areaCode" : 518,
+                                "population" : 98251
+                            }, {
+                                "city" : "Annapolis",
+                                "state" : "Maryland",
+                                "areaCode" : 410,
+                                "population" : 39321
+                            }, {
+                                "city" : "Trenton",
+                                "state" : "New Jersey",
+                                "areaCode" : 609,
+                                "population" : 84964
+                            }
+                        ] }
+                    </script>
+                    <template type="amp-mustache" id="amp-template-id">
+                        <div class="city-item" value="{{city}}, {{state}}">
+                            <div>{{city}}, {{state}}</div>
+                            <div class="custom-population">Population: {{population}}</div>        
+                        </div>
+                        </template>
                 </amp-autocomplete>
             </label>
             <input type="submit" value="Search">

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -108,7 +108,7 @@
         </div>
     </form>
 
-    <h3>Rich Text</h3>
+    <h3>Rich Text, Template Child, Default Value Property</h3>
     <form method="get" action-xhr="/form/search-json/get" target="_blank">
         <fieldset>
             <label>
@@ -132,7 +132,7 @@
                             }
                         ] }
                     </script>
-                    <template type="amp-mustache" id="amp-template-id">
+                    <template type="amp-mustache" id="amp-template-default">
                         <div class="city-item" value="{{value}}">
                             <div>{{value}}</div>
                             <div class="custom-population">Population: {{population}}</div>        
@@ -149,7 +149,7 @@
         </div>
     </form>
 
-    <h3>Rich Text: Custom Value</h3>
+    <h3>Rich Text, Template Child, Custom Value Property</h3>
     <form method="get" action-xhr="/form/search-json/get" target="_blank">
         <fieldset>
             <label>
@@ -176,12 +176,92 @@
                             }
                         ] }
                     </script>
-                    <template type="amp-mustache" id="amp-template-id">
+                    <template type="amp-mustache" id="amp-template-custom">
                         <div class="city-item" value="{{city}}, {{state}}">
                             <div>{{city}}, {{state}}</div>
                             <div class="custom-population">Population: {{population}}</div>        
                         </div>
-                        </template>
+                    </template>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
+
+    <h3>Rich Text, Template Attribute, Default Value Property</h3>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" min-characters="0"
+                    template="amp-template-default">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
+                        { "items" : [
+                            {
+                                "value" : "Albany, New York",
+                                "areaCode" : 518,
+                                "population" : 98251
+                            }, {
+                                "value" : "Annapolis, Maryland",
+                                "areaCode" : 410,
+                                "population" : 39321
+                            }, {
+                                "value" : "Trenton, New Jersey",
+                                "areaCode" : 609,
+                                "population" : 84964
+                            }
+                        ] }
+                    </script>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
+
+    <h3>Rich Text, Script Child Template, Custom Value Property</h3>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
+                        { "items" : [
+                            {
+                                "city" : "Albany",
+                                "state" : "New York", 
+                                "areaCode" : 518,
+                                "population" : 98251
+                            }, {
+                                "city" : "Annapolis",
+                                "state" : "Maryland",
+                                "areaCode" : 410,
+                                "population" : 39321
+                            }, {
+                                "city" : "Trenton",
+                                "state" : "New Jersey",
+                                "areaCode" : 609,
+                                "population" : 84964
+                            }
+                        ] }
+                    </script>
+                    <script type="text/plain" template="amp-mustache">
+                        <div class="city-item" value="{{city}}, {{state}}">
+                            <div>{{city}}, {{state}}</div>
+                            <div class="custom-population">Population: {{population}}</div>        
+                        </div>
+                    </script>
                 </amp-autocomplete>
             </label>
             <input type="submit" value="Search">

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -267,11 +267,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   selectHandler_(event) {
-    let item;
-    return this.measureMutateElement(() => {
-      item = this.getItemElement_(event.target);
-    }, () => {
-      this.selectItem_(item);
+    return this.mutateElement(() => {
+      this.selectItem_(this.getItemElement_(event.target));
     });
   }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -154,9 +154,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
    */
   getInlineData_() {
     const scripts = childElementsByTag(this.element, 'SCRIPT');
-    if (!scripts.length) {
-      return null;
-    }
+    userAssert(scripts.length,
+        `${TAG} should contain a <script> child or a URL specified in "src".`);
     const jsonScripts = [];
     scripts.forEach(script => { if (isJsonScriptTag(script)) {
       jsonScripts.push(script);

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -133,7 +133,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.templateElement_ =
         this.templates_.findTemplate(this.element,
             'template, script[template]');
-      // Dummy render to verify existence of "vallue" attribute.
+      // Dummy render to verify existence of "value" attribute.
       this.templates_.renderTemplate(this.templateElement_, {}).then(
           renderedEl => {
             userAssert(renderedEl.hasAttribute('value'),
@@ -164,9 +164,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
    */
   getInlineData_(scripts) {
     const jsonScripts = [];
-    scripts.forEach(script => { if (isJsonScriptTag(script)) {
-      jsonScripts.push(script);
-    } });
+    scripts.forEach(script => {
+      if (isJsonScriptTag(script)) {
+        jsonScripts.push(script);
+      }
+    });
     userAssert(jsonScripts.length,
         `${TAG} expected data in a <script type="application/json"> tag.`);
     const json = tryParseJson(jsonScripts[0].textContent,
@@ -403,7 +405,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   /**
    * Returns the nearest ancestor element that is a suggested item.
    * @param {?Element|?EventTarget} element
-   * @return {?Element}
+   * @return {?Element|?EventTarget}
    * @private
    */
   getItemElement_(element) {
@@ -411,7 +413,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       return null;
     }
     if (element.classList.contains('i-amphtml-autocomplete-item')) {
-      return /**@type {!Element} */ (element);
+      return element;
     }
     return this.getItemElement_(element.parentElement);
   }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -55,7 +55,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     /**
      * The data extracted from the <script> tag optionally provided
      * as a child. For use with static data.
-     * @private {?Array<JsonObject|string>}
+     * @private {?Array<!JsonObject|string>}
      */
     this.inlineData_ = null;
 
@@ -130,6 +130,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.templateElement_ =
         this.templates_.findTemplate(this.element,
             'template, script[template]');
+      // Dummy render to verify existence of "vallue" attribute.
+      this.templates_.renderTemplate(this.templateElement_, {}).then(
+        renderedEl => {
+          userAssert(renderedEl.hasAttribute('value'),
+        `${TAG} requires <template> tag to have "value" attribute.`);
+      });
     }
 
     this.filter_ = userAssert(this.element.getAttribute('filter'),
@@ -290,8 +296,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
       renderPromise = this.templates_.renderTemplateArray(this.templateElement_,
           filteredData).then(renderedChildren => {
         renderedChildren.map(child => {
-          userAssert(child.hasAttribute('value'),
-              `${TAG} requires <template value=""> tag`);
           child.classList.add('i-amphtml-autocomplete-item');
           child.setAttribute('role', 'listitem');
           this.container_.appendChild(child);
@@ -313,9 +317,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /**
    * Apply the filter to the given data based on the given input.
-   * @param {!Array<JsonObject|string>} data
+   * @param {!Array<!JsonObject|string>} data
    * @param {string} input
-   * @return {!Array<JsonObject|string>}
+   * @return {!Array<!JsonObject|string>}
    * @private
    */
   filterData_(data, input) {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -117,7 +117,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
         `Experiment ${EXPERIMENT} is not turned on.`);
 
     if (!this.element.hasAttribute('src')) {
-      this.inlineData_ = this.getInlineData_();
+      const scripts = childElementsByTag(this.element, 'SCRIPT');
+      userAssert(scripts.length,
+          `${TAG} expected a <script> child or a URL specified in "src".`);
+      this.inlineData_ = this.getInlineData_(scripts);
     }
 
     const inputElements = childElementsByTag(this.element, 'INPUT');
@@ -132,10 +135,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
             'template, script[template]');
       // Dummy render to verify existence of "vallue" attribute.
       this.templates_.renderTemplate(this.templateElement_, {}).then(
-        renderedEl => {
-          userAssert(renderedEl.hasAttribute('value'),
-        `${TAG} requires <template> tag to have "value" attribute.`);
-      });
+          renderedEl => {
+            userAssert(renderedEl.hasAttribute('value'),
+                `${TAG} requires <template> tag to have "value" attribute.`);
+          });
     }
 
     this.filter_ = userAssert(this.element.getAttribute('filter'),
@@ -155,19 +158,17 @@ export class AmpAutocomplete extends AMP.BaseElement {
   /**
    * Reads the 'items' data from the child <script> element.
    * For use with static local data.
-   * @return {!Array<string>}
+   * @param {!NodeList<!Element>} scripts
+   * @return {!Array<!JsonObject|string>}
    * @private
    */
-  getInlineData_() {
-    const scripts = childElementsByTag(this.element, 'SCRIPT');
-    userAssert(scripts.length,
-        `${TAG} should contain a <script> child or a URL specified in "src".`);
+  getInlineData_(scripts) {
     const jsonScripts = [];
     scripts.forEach(script => { if (isJsonScriptTag(script)) {
       jsonScripts.push(script);
     } });
-    userAssert(jsonScripts.length === 1,
-        `${TAG} expected one <script type="application/json"> child.`);
+    userAssert(jsonScripts.length,
+        `${TAG} expected data in a <script type="application/json"> tag.`);
     const json = tryParseJson(jsonScripts[0].textContent,
         error => {
           throw error;

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -134,7 +134,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
         this.templates_.findTemplate(this.element,
             'template, script[template]');
       // Dummy render to verify existence of "value" attribute.
-      this.templates_.renderTemplate(this.templateElement_, {}).then(
+      this.templates_.renderTemplate(this.templateElement_,
+          /** @type {!JsonObject} */{}).then(
           renderedEl => {
             userAssert(renderedEl.hasAttribute('value'),
                 `${TAG} requires <template> tag to have "value" attribute.`);
@@ -513,11 +514,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
         return Promise.resolve();
       case Keys.ESCAPE:
         // Select user's partial input and hide results.
-        let partialInputChild;
-        return this.measureMutateElement(() => {
-          partialInputChild = this.container_.lastChild;
-        }, () => {
-          this.selectItem_(partialInputChild);
+        return this.mutateElement(() => {
+          this.selectItem_(this.container_.lastElementChild);
           this.resetActiveElement_();
           this.toggleResults_(false);
         });

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -135,7 +135,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
             'template, script[template]');
       // Dummy render to verify existence of "value" attribute.
       this.templates_.renderTemplate(this.templateElement_,
-          /** @type {!JsonObject} */{}).then(
+          /** @type {!JsonObject} */({})).then(
           renderedEl => {
             userAssert(renderedEl.hasAttribute('value'),
                 `${TAG} requires <template> tag to have "value" attribute.`);

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -277,7 +277,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
    */
   selectHandler_(event) {
     return this.mutateElement(() => {
-      this.selectItem_(this.getItemElement_(event.target));
+      const element = dev().assertElement(event.target);
+      this.selectItem_(this.getItemElement_(element));
     });
   }
 
@@ -404,8 +405,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /**
    * Returns the nearest ancestor element that is a suggested item.
-   * @param {?Element|?EventTarget} element
-   * @return {?Element|?EventTarget}
+   * @param {?Element} element
+   * @return {?Element}
    * @private
    */
   getItemElement_(element) {
@@ -420,7 +421,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /**
    * Writes the selected value into the input field.
-   * @param {?Element|?EventTarget} element
+   * @param {?Element} element
    * @private
    */
   selectItem_(element) {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -59,21 +59,22 @@ describes.realWin('amp-autocomplete init', {
   }
 
   it('should render with experiment on', () => {
+    let impl, renderSpy;
     return getAutocomplete({
       'filter': 'substring',
     }).then(ampAutocomplete => {
-      const impl = ampAutocomplete.implementation_;
+      impl = ampAutocomplete.implementation_;
       const expectedItems = ['apple', 'banana', 'orange'];
       expect(impl.inlineData_).to.have.ordered.members(expectedItems);
       expect(impl.inputElement__).not.to.be.null;
       expect(impl.container_).not.to.be.null;
       expect(impl.filter_).to.equal('substring');
 
-      const renderSpy = sandbox.spy(impl, 'renderResults_');
-      return ampAutocomplete.layoutCallback().then(() => {
-        expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
-        expect(renderSpy).to.have.been.calledOnce;
-      });
+      renderSpy = sandbox.spy(impl, 'renderResults_');
+      return ampAutocomplete.layoutCallback();
+    }).then(() => {
+      expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
+      expect(renderSpy).to.have.been.calledOnce;
     });
   });
 

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -65,7 +65,7 @@ describes.realWin('amp-autocomplete unit tests', {
     expect(element.innerText).to.equal('');
   });
 
-  it('renderResults_() should update the container_', () => {
+  it('renderResults_() should update the container_ with plain text', () => {
     expect(impl.container_).not.to.be.null;
     expect(impl.container_.children.length).to.equal(0);
     impl.inputElement_.value = 'ap';
@@ -74,17 +74,57 @@ describes.realWin('amp-autocomplete unit tests', {
 
     // Only clear if input < minChars_
     impl.minChars_ = 3;
-    impl.renderResults_();
-    expect(clearAllItemsSpy).to.have.been.calledOnce;
-    expect(filterDataSpy).not.to.have.been.called;
+    return impl.renderResults_().then(() => {
+      expect(clearAllItemsSpy).to.have.been.calledOnce;
+      expect(filterDataSpy).not.to.have.been.called;
+    }).then(() => {
+      impl.minChars_ = 2;
+      return impl.renderResults_().then(() => {
+        expect(impl.container_.children.length).to.equal(2);
+        expect(impl.container_.children[0].innerText).to.equal('apple');
+        expect(impl.container_.children[1].innerText).to.equal('ap');
+        expect(clearAllItemsSpy).to.have.been.calledTwice;
+        expect(filterDataSpy).to.have.been.calledOnce;
+      });
+    });
+  });
 
-    impl.minChars_ = 2;
-    impl.renderResults_();
-    expect(impl.container_.children.length).to.equal(2);
-    expect(impl.container_.children[0].innerText).to.equal('apple');
-    expect(impl.container_.children[1].innerText).to.equal('ap');
-    expect(clearAllItemsSpy).to.have.been.calledTwice;
-    expect(filterDataSpy).to.have.been.calledOnce;
+  it('renderResults_() should update the container_ with rich text', () => {
+    impl.inlineData_ = [{value: 'apple'}, {value: 'mango'}, {value: 'pear'}];
+    impl.templateElement_ = doc.createElement('template');
+    const renderedChildren = [];
+    impl.inlineData_.forEach(item => {
+      const renderedChild = doc.createElement('div');
+      renderedChild.setAttribute('value', item.value);
+      renderedChildren.push(renderedChild);
+    });
+    sandbox.stub(impl.templates_, 'renderTemplateArray').returns(
+        Promise.resolve(renderedChildren));
+    impl.inputElement_.value = '';
+    const clearAllItemsSpy = sandbox.spy(impl, 'clearAllItems_');
+    const filterDataSpy = sandbox.spy(impl, 'filterData_');
+
+    // Only clear if input < minChars_
+    impl.minChars_ = 3;
+    return impl.renderResults_().then(() => {
+      expect(clearAllItemsSpy).to.have.been.calledOnce;
+      expect(filterDataSpy).not.to.have.been.called;
+    }).then(() => {
+      impl.minChars_ = 0;
+      return impl.renderResults_().then(() => {
+        expect(impl.container_.children.length).to.equal(4);
+        expect(impl.container_.children[0].getAttribute('value')).to.equal(
+            'apple');
+        expect(impl.container_.children[1].getAttribute('value')).to.equal(
+            'mango');
+        expect(impl.container_.children[2].getAttribute('value')).to.equal(
+            'pear');
+        expect(impl.container_.children[3].getAttribute('value')).to.equal(
+            '');
+        expect(clearAllItemsSpy).to.have.been.calledTwice;
+        expect(filterDataSpy).to.have.been.calledOnce;
+      });
+    });
   });
 
   it('filterData_() should filter based on all types', () => {
@@ -119,12 +159,13 @@ describes.realWin('amp-autocomplete unit tests', {
   it('should show and hide results on toggle', () => {
     expect(impl.resultsShowing_()).to.be.false;
     impl.inputElement_.value = 'ap';
-    impl.renderResults_();
-    expect(impl.resultsShowing_()).to.be.false;
-    impl.toggleResults_(true);
-    expect(impl.resultsShowing_()).to.be.true;
-    impl.toggleResults_(false);
-    expect(impl.resultsShowing_()).to.be.false;
+    return impl.renderResults_().then(() => {
+      expect(impl.resultsShowing_()).to.be.false;
+      impl.toggleResults_(true);
+      expect(impl.resultsShowing_()).to.be.true;
+      impl.toggleResults_(false);
+      expect(impl.resultsShowing_()).to.be.false;
+    });
   });
 
   it('should call inputHandler_() on input', () => {
@@ -192,15 +233,16 @@ describes.realWin('amp-autocomplete unit tests', {
     const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
     return element.layoutCallback().then(() => {
       impl.inputElement_.value = 'a';
-      impl.renderResults_();
-      expect(impl.container_.children.length).to.equal(4);
-      impl.toggleResults_(true);
-      expect(impl.resultsShowing_()).to.be.true;
-      return impl.keyDownHandler_(event).then(() => {
-        expect(selectItemSpy).to.have.been.calledOnce;
-        expect(resetSpy).to.have.been.calledOnce;
-        expect(toggleResultsSpy).to.have.been.calledWith(false);
-        expect(impl.resultsShowing_()).to.be.false;
+      return impl.renderResults_().then(() => {
+        expect(impl.container_.children.length).to.equal(4);
+        impl.toggleResults_(true);
+        expect(impl.resultsShowing_()).to.be.true;
+        return impl.keyDownHandler_(event).then(() => {
+          expect(selectItemSpy).to.have.been.calledOnce;
+          expect(resetSpy).to.have.been.calledOnce;
+          expect(toggleResultsSpy).to.have.been.calledWith(false);
+          expect(impl.resultsShowing_()).to.be.false;
+        });
       });
     });
   });
@@ -231,18 +273,18 @@ describes.realWin('amp-autocomplete unit tests', {
   it('should call selectHandler_() on mousedown', () => {
     return element.layoutCallback().then(() => {
       impl.toggleResults_(true);
-      const isItemSpy = sandbox.spy(impl, 'isItemElement_');
+      const getItemSpy = sandbox.spy(impl, 'getItemElement_');
       const selectItemSpy = sandbox.spy(impl, 'selectItem_');
       let mockEl = doc.createElement('div');
       mockEl.textContent = 'test';
       return impl.selectHandler_({target: mockEl}).then(() => {
-        expect(isItemSpy).to.have.been.calledOnce;
-        expect(selectItemSpy).not.to.have.been.called;
+        expect(getItemSpy).to.have.been.calledTwice;
+        expect(selectItemSpy).to.have.been.called;
         expect(impl.inputElement_.value).to.equal('');
       }).then(() => {
         mockEl = impl.createElementFromItem_('abc');
         return impl.selectHandler_({target: mockEl}).then(() => {
-          expect(isItemSpy).to.have.been.calledWith(mockEl);
+          expect(getItemSpy).to.have.been.calledWith(mockEl);
           expect(selectItemSpy).to.have.been.calledWith(mockEl);
           expect(impl.inputElement_.value).to.equal('abc');
         });
@@ -255,59 +297,60 @@ describes.realWin('amp-autocomplete unit tests', {
       expect(impl.activeElement_).to.be.null;
       expect(impl.activeIndex_).to.equal(-1);
       impl.inputElement_.value = 'a';
-      impl.renderResults_();
-      expect(impl.container_.children.length).to.equal(4);
+      return impl.renderResults_().then(() => {
+        expect(impl.container_.children.length).to.equal(4);
 
-      impl.activeElement_ = doc.createElement('div');
-      expect(impl.activeElement_).not.to.be.null;
-      expect(impl.resetActiveElement_()).to.equal();
-      expect(impl.activeElement_).to.be.null;
-
-      impl.toggleResults_(true);
-      const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-      return impl.updateActiveItem_(1).then(() => {
-        expect(resetSpy).to.have.been.calledOnce;
-        expect(impl.activeIndex_).to.equal(0);
+        impl.activeElement_ = doc.createElement('div');
         expect(impl.activeElement_).not.to.be.null;
-        expect(impl.activeElement_).to.have.class(
-            'i-amphtml-autocomplete-item-active');
-        expect(impl.container_.children[1]).not.to.have.class(
-            'i-amphtml-autocomplete-item-active');
-        expect(impl.container_.children[2]).not.to.have.class(
-            'i-amphtml-autocomplete-item-active');
-      }).then(() => {
-        return impl.updateActiveItem_(-1).then(() => {
-          expect(resetSpy).to.have.been.calledTwice;
-          expect(impl.activeIndex_).to.equal(3);
-          expect(impl.activeElement_).to.be.null;
-          expect(impl.container_.children[0]).not.to.have.class(
+        expect(impl.resetActiveElement_()).to.equal();
+        expect(impl.activeElement_).to.be.null;
+
+        impl.toggleResults_(true);
+        const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
+        return impl.updateActiveItem_(1).then(() => {
+          expect(resetSpy).to.have.been.calledOnce;
+          expect(impl.activeIndex_).to.equal(0);
+          expect(impl.activeElement_).not.to.be.null;
+          expect(impl.activeElement_).to.have.class(
               'i-amphtml-autocomplete-item-active');
           expect(impl.container_.children[1]).not.to.have.class(
               'i-amphtml-autocomplete-item-active');
           expect(impl.container_.children[2]).not.to.have.class(
               'i-amphtml-autocomplete-item-active');
-          expect(impl.container_.children[3]).not.to.have.class(
-              'i-amphtml-autocomplete-item-active');
         }).then(() => {
           return impl.updateActiveItem_(-1).then(() => {
-            expect(resetSpy).to.have.been.calledThrice;
-            expect(impl.activeIndex_).to.equal(2);
-            expect(impl.activeElement_).not.to.be.null;
-            expect(impl.activeElement_).to.have.class(
-                'i-amphtml-autocomplete-item-active');
+            expect(resetSpy).to.have.been.calledTwice;
+            expect(impl.activeIndex_).to.equal(3);
+            expect(impl.activeElement_).to.be.null;
             expect(impl.container_.children[0]).not.to.have.class(
                 'i-amphtml-autocomplete-item-active');
             expect(impl.container_.children[1]).not.to.have.class(
                 'i-amphtml-autocomplete-item-active');
+            expect(impl.container_.children[2]).not.to.have.class(
+                'i-amphtml-autocomplete-item-active');
             expect(impl.container_.children[3]).not.to.have.class(
                 'i-amphtml-autocomplete-item-active');
           }).then(() => {
-            return impl.updateActiveItem_(0).then(() => {
+            return impl.updateActiveItem_(-1).then(() => {
               expect(resetSpy).to.have.been.calledThrice;
               expect(impl.activeIndex_).to.equal(2);
               expect(impl.activeElement_).not.to.be.null;
               expect(impl.activeElement_).to.have.class(
                   'i-amphtml-autocomplete-item-active');
+              expect(impl.container_.children[0]).not.to.have.class(
+                  'i-amphtml-autocomplete-item-active');
+              expect(impl.container_.children[1]).not.to.have.class(
+                  'i-amphtml-autocomplete-item-active');
+              expect(impl.container_.children[3]).not.to.have.class(
+                  'i-amphtml-autocomplete-item-active');
+            }).then(() => {
+              return impl.updateActiveItem_(0).then(() => {
+                expect(resetSpy).to.have.been.calledThrice;
+                expect(impl.activeIndex_).to.equal(2);
+                expect(impl.activeElement_).not.to.be.null;
+                expect(impl.activeElement_).to.have.class(
+                    'i-amphtml-autocomplete-item-active');
+              });
             });
           });
         });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -79,13 +79,13 @@ describes.realWin('amp-autocomplete unit tests', {
       expect(filterDataSpy).not.to.have.been.called;
     }).then(() => {
       impl.minChars_ = 2;
-      return impl.renderResults_().then(() => {
-        expect(impl.container_.children.length).to.equal(2);
-        expect(impl.container_.children[0].innerText).to.equal('apple');
-        expect(impl.container_.children[1].innerText).to.equal('ap');
-        expect(clearAllItemsSpy).to.have.been.calledTwice;
-        expect(filterDataSpy).to.have.been.calledOnce;
-      });
+      return impl.renderResults_();
+    }).then(() => {
+      expect(impl.container_.children.length).to.equal(2);
+      expect(impl.container_.children[0].innerText).to.equal('apple');
+      expect(impl.container_.children[1].innerText).to.equal('ap');
+      expect(clearAllItemsSpy).to.have.been.calledTwice;
+      expect(filterDataSpy).to.have.been.calledOnce;
     });
   });
 
@@ -111,19 +111,19 @@ describes.realWin('amp-autocomplete unit tests', {
       expect(filterDataSpy).not.to.have.been.called;
     }).then(() => {
       impl.minChars_ = 0;
-      return impl.renderResults_().then(() => {
-        expect(impl.container_.children.length).to.equal(4);
-        expect(impl.container_.children[0].getAttribute('value')).to.equal(
-            'apple');
-        expect(impl.container_.children[1].getAttribute('value')).to.equal(
-            'mango');
-        expect(impl.container_.children[2].getAttribute('value')).to.equal(
-            'pear');
-        expect(impl.container_.children[3].getAttribute('value')).to.equal(
-            '');
-        expect(clearAllItemsSpy).to.have.been.calledTwice;
-        expect(filterDataSpy).to.have.been.calledOnce;
-      });
+      return impl.renderResults_();
+    }).then(() => {
+      expect(impl.container_.children.length).to.equal(4);
+      expect(impl.container_.children[0].getAttribute('value')).to.equal(
+          'apple');
+      expect(impl.container_.children[1].getAttribute('value')).to.equal(
+          'mango');
+      expect(impl.container_.children[2].getAttribute('value')).to.equal(
+          'pear');
+      expect(impl.container_.children[3].getAttribute('value')).to.equal(
+          '');
+      expect(clearAllItemsSpy).to.have.been.calledTwice;
+      expect(filterDataSpy).to.have.been.calledOnce;
     });
   });
 
@@ -169,15 +169,16 @@ describes.realWin('amp-autocomplete unit tests', {
   });
 
   it('should call inputHandler_() on input', () => {
+    let renderSpy, toggleResultsSpy;
     return element.layoutCallback().then(() => {
-      const renderSpy = sandbox.spy(impl, 'renderResults_');
-      const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
       impl.inputElement_.value = 'a';
-      return impl.inputHandler_().then(() => {
-        expect(renderSpy).to.have.been.calledOnce;
-        expect(toggleResultsSpy).to.have.been.calledWith(true);
-        expect(impl.container_.children.length).to.equal(4);
-      });
+      renderSpy = sandbox.spy(impl, 'renderResults_');
+      toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
+      return impl.inputHandler_();
+    }).then(() => {
+      expect(renderSpy).to.have.been.calledOnce;
+      expect(toggleResultsSpy).to.have.been.calledWith(true);
+      expect(impl.container_.children.length).to.equal(4);
     });
   });
 
@@ -186,16 +187,15 @@ describes.realWin('amp-autocomplete unit tests', {
     const updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
     const preventSpy = sandbox.spy(event, 'preventDefault');
     return element.layoutCallback().then(() => {
-      return impl.keyDownHandler_(event).then(() => {
-        expect(preventSpy).to.have.been.calledOnce;
-        expect(updateActiveSpy).to.have.been.calledWith(1);
-      }).then(() => {
-        event.key = Keys.UP_ARROW;
-        return impl.keyDownHandler_(event).then(() => {
-          expect(preventSpy).to.have.been.calledTwice;
-          expect(updateActiveSpy).to.have.been.calledWith(-1);
-        });
-      });
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(preventSpy).to.have.been.calledOnce;
+      expect(updateActiveSpy).to.have.been.calledWith(1);
+      event.key = Keys.UP_ARROW;
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(preventSpy).to.have.been.calledTwice;
+      expect(updateActiveSpy).to.have.been.calledWith(-1);
     });
   });
 
@@ -205,24 +205,24 @@ describes.realWin('amp-autocomplete unit tests', {
       preventDefault: () => {},
       target: {textContent: 'hello'},
     };
+    let selectItemSpy, resetSpy, clearAllSpy;
     return element.layoutCallback().then(() => {
-      const selectItemSpy = sandbox.spy(impl, 'selectItem_');
-      const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-      const clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
-      return impl.keyDownHandler_(event).then(() => {
-        expect(impl.inputElement_.value).to.equal('');
-        expect(selectItemSpy).not.to.have.been.called;
-        expect(clearAllSpy).not.to.have.been.called;
-        expect(resetSpy).not.to.have.been.called;
-      }).then(() => {
-        impl.activeElement_ = impl.createElementFromItem_('abc');
-        return impl.keyDownHandler_(event).then(() => {
-          expect(impl.inputElement_.value).to.equal('abc');
-          expect(selectItemSpy).to.have.been.calledOnce;
-          expect(clearAllSpy).to.have.been.calledOnce;
-          expect(resetSpy).to.have.been.calledOnce;
-        });
-      });
+      selectItemSpy = sandbox.spy(impl, 'selectItem_');
+      resetSpy = sandbox.spy(impl, 'resetActiveElement_');
+      clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(impl.inputElement_.value).to.equal('');
+      expect(selectItemSpy).not.to.have.been.called;
+      expect(clearAllSpy).not.to.have.been.called;
+      expect(resetSpy).not.to.have.been.called;
+      impl.activeElement_ = impl.createElementFromItem_('abc');
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(impl.inputElement_.value).to.equal('abc');
+      expect(selectItemSpy).to.have.been.calledOnce;
+      expect(clearAllSpy).to.have.been.calledOnce;
+      expect(resetSpy).to.have.been.calledOnce;
     });
   });
 
@@ -233,17 +233,17 @@ describes.realWin('amp-autocomplete unit tests', {
     const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
     return element.layoutCallback().then(() => {
       impl.inputElement_.value = 'a';
-      return impl.renderResults_().then(() => {
-        expect(impl.container_.children.length).to.equal(4);
-        impl.toggleResults_(true);
-        expect(impl.resultsShowing_()).to.be.true;
-        return impl.keyDownHandler_(event).then(() => {
-          expect(selectItemSpy).to.have.been.calledOnce;
-          expect(resetSpy).to.have.been.calledOnce;
-          expect(toggleResultsSpy).to.have.been.calledWith(false);
-          expect(impl.resultsShowing_()).to.be.false;
-        });
-      });
+      return impl.renderResults_();
+    }).then(() => {
+      expect(impl.container_.children.length).to.equal(4);
+      impl.toggleResults_(true);
+      expect(impl.resultsShowing_()).to.be.true;
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(selectItemSpy).to.have.been.calledOnce;
+      expect(resetSpy).to.have.been.calledOnce;
+      expect(toggleResultsSpy).to.have.been.calledWith(false);
+      expect(impl.resultsShowing_()).to.be.false;
     });
   });
 
@@ -255,106 +255,100 @@ describes.realWin('amp-autocomplete unit tests', {
   });
 
   it('should call toggleResultsHandler_()', () => {
+    const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
+    const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
     return element.layoutCallback().then(() => {
-      const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
-      const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-      return impl.toggleResultsHandler_(true).then(() => {
-        expect(toggleResultsSpy).to.have.been.calledOnce;
-        expect(resetSpy).not.to.have.been.called;
-      }).then(() => {
-        return impl.toggleResultsHandler_(false).then(() => {
-          expect(toggleResultsSpy).to.have.been.calledTwice;
-          expect(resetSpy).to.have.been.calledOnce;
-        });
-      });
+      return impl.toggleResultsHandler_(true);
+    }).then(() => {
+      expect(toggleResultsSpy).to.have.been.calledOnce;
+      expect(resetSpy).not.to.have.been.called;
+      return impl.toggleResultsHandler_(false);
+    }).then(() => {
+      expect(toggleResultsSpy).to.have.been.calledTwice;
+      expect(resetSpy).to.have.been.calledOnce;
     });
   });
 
   it('should call selectHandler_() on mousedown', () => {
+    const getItemSpy = sandbox.spy(impl, 'getItemElement_');
+    const selectItemSpy = sandbox.spy(impl, 'selectItem_');
+    let mockEl = doc.createElement('div');
     return element.layoutCallback().then(() => {
       impl.toggleResults_(true);
-      const getItemSpy = sandbox.spy(impl, 'getItemElement_');
-      const selectItemSpy = sandbox.spy(impl, 'selectItem_');
-      let mockEl = doc.createElement('div');
       mockEl.textContent = 'test';
-      return impl.selectHandler_({target: mockEl}).then(() => {
-        expect(getItemSpy).to.have.been.calledTwice;
-        expect(selectItemSpy).to.have.been.called;
-        expect(impl.inputElement_.value).to.equal('');
-      }).then(() => {
-        mockEl = impl.createElementFromItem_('abc');
-        return impl.selectHandler_({target: mockEl}).then(() => {
-          expect(getItemSpy).to.have.been.calledWith(mockEl);
-          expect(selectItemSpy).to.have.been.calledWith(mockEl);
-          expect(impl.inputElement_.value).to.equal('abc');
-        });
-      });
+      return impl.selectHandler_({target: mockEl});
+    }).then(() => {
+      expect(getItemSpy).to.have.been.calledTwice;
+      expect(selectItemSpy).to.have.been.called;
+      expect(impl.inputElement_.value).to.equal('');
+      mockEl = impl.createElementFromItem_('abc');
+      return impl.selectHandler_({target: mockEl});
+    }).then(() => {
+      expect(getItemSpy).to.have.been.calledWith(mockEl);
+      expect(selectItemSpy).to.have.been.calledWith(mockEl);
+      expect(impl.inputElement_.value).to.equal('abc');
     });
   });
 
   it('should support marking active items', () => {
+    let resetSpy;
     return element.layoutCallback().then(() => {
       expect(impl.activeElement_).to.be.null;
       expect(impl.activeIndex_).to.equal(-1);
       impl.inputElement_.value = 'a';
-      return impl.renderResults_().then(() => {
-        expect(impl.container_.children.length).to.equal(4);
-
-        impl.activeElement_ = doc.createElement('div');
-        expect(impl.activeElement_).not.to.be.null;
-        expect(impl.resetActiveElement_()).to.equal();
-        expect(impl.activeElement_).to.be.null;
-
-        impl.toggleResults_(true);
-        const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-        return impl.updateActiveItem_(1).then(() => {
-          expect(resetSpy).to.have.been.calledOnce;
-          expect(impl.activeIndex_).to.equal(0);
-          expect(impl.activeElement_).not.to.be.null;
-          expect(impl.activeElement_).to.have.class(
-              'i-amphtml-autocomplete-item-active');
-          expect(impl.container_.children[1]).not.to.have.class(
-              'i-amphtml-autocomplete-item-active');
-          expect(impl.container_.children[2]).not.to.have.class(
-              'i-amphtml-autocomplete-item-active');
-        }).then(() => {
-          return impl.updateActiveItem_(-1).then(() => {
-            expect(resetSpy).to.have.been.calledTwice;
-            expect(impl.activeIndex_).to.equal(3);
-            expect(impl.activeElement_).to.be.null;
-            expect(impl.container_.children[0]).not.to.have.class(
-                'i-amphtml-autocomplete-item-active');
-            expect(impl.container_.children[1]).not.to.have.class(
-                'i-amphtml-autocomplete-item-active');
-            expect(impl.container_.children[2]).not.to.have.class(
-                'i-amphtml-autocomplete-item-active');
-            expect(impl.container_.children[3]).not.to.have.class(
-                'i-amphtml-autocomplete-item-active');
-          }).then(() => {
-            return impl.updateActiveItem_(-1).then(() => {
-              expect(resetSpy).to.have.been.calledThrice;
-              expect(impl.activeIndex_).to.equal(2);
-              expect(impl.activeElement_).not.to.be.null;
-              expect(impl.activeElement_).to.have.class(
-                  'i-amphtml-autocomplete-item-active');
-              expect(impl.container_.children[0]).not.to.have.class(
-                  'i-amphtml-autocomplete-item-active');
-              expect(impl.container_.children[1]).not.to.have.class(
-                  'i-amphtml-autocomplete-item-active');
-              expect(impl.container_.children[3]).not.to.have.class(
-                  'i-amphtml-autocomplete-item-active');
-            }).then(() => {
-              return impl.updateActiveItem_(0).then(() => {
-                expect(resetSpy).to.have.been.calledThrice;
-                expect(impl.activeIndex_).to.equal(2);
-                expect(impl.activeElement_).not.to.be.null;
-                expect(impl.activeElement_).to.have.class(
-                    'i-amphtml-autocomplete-item-active');
-              });
-            });
-          });
-        });
-      });
+      return impl.renderResults_();
+    }).then(() => {
+      expect(impl.container_.children.length).to.equal(4);
+      impl.activeElement_ = doc.createElement('div');
+      expect(impl.activeElement_).not.to.be.null;
+      expect(impl.resetActiveElement_()).to.equal();
+      expect(impl.activeElement_).to.be.null;
+      impl.toggleResults_(true);
+      resetSpy = sandbox.spy(impl, 'resetActiveElement_');
+      return impl.updateActiveItem_(1);
+    }).then(() => {
+      expect(resetSpy).to.have.been.calledOnce;
+      expect(impl.activeIndex_).to.equal(0);
+      expect(impl.activeElement_).not.to.be.null;
+      expect(impl.activeElement_).to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[1]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[2]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      return impl.updateActiveItem_(-1);
+    }).then(() => {
+      expect(resetSpy).to.have.been.calledTwice;
+      expect(impl.activeIndex_).to.equal(3);
+      expect(impl.activeElement_).to.be.null;
+      expect(impl.container_.children[0]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[1]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[2]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[3]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      return impl.updateActiveItem_(-1);
+    }).then(() => {
+      expect(resetSpy).to.have.been.calledThrice;
+      expect(impl.activeIndex_).to.equal(2);
+      expect(impl.activeElement_).not.to.be.null;
+      expect(impl.activeElement_).to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[0]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[1]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      expect(impl.container_.children[3]).not.to.have.class(
+          'i-amphtml-autocomplete-item-active');
+      return impl.updateActiveItem_(0);
+    }).then(() => {
+      expect(resetSpy).to.have.been.calledThrice;
+      expect(impl.activeIndex_).to.equal(2);
+      expect(impl.activeElement_).not.to.be.null;
+      expect(impl.activeElement_).to.have.class(
+          'i-amphtml-autocomplete-item-active');
     });
   });
 });

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -87,6 +87,10 @@ Example:
     <td>Required if `filter==custom`</td>
   </tr>
   <tr>
+    <td width="40%"><strong>filter-value [optional]</strong></td>
+    <td>If data is an array of JsonObjects, the filter-value is the property name that will be accessed for client side filtering. This attribute is unnecessary if filter is none. Defaults to "value".</td>
+  </tr>
+  <tr>
     <td width="40%"><strong>min-characters [optional]</strong></td>
     <td>
       The min character length of a user input to provide results, default 1


### PR DESCRIPTION
Key decisions made to support rich content have been documented in the [Supporting plain and rich content](https://docs.google.com/document/d/1OOPnKgShbh7BN2D24u7bxa57z2spAiBA8n9o0L5V3qA/edit#heading=h.kd3r11jhzfrz) section of the amp-autocomplete design doc.

- Use template service to find and render templates.
- Create attribute "filter-value" (different name?) to know which property to filter off of when data is an array of JsonObject instead of an array of strings. Limitation: Can only filter off of one property.
- Require template to have "value" attribute that is the text that is inserted in the input field when the item is selected.
- Replaces isItemElement() with getItemElement() since not all elements that can be selected in a template item have the 'i-amphtml-autocomplete-item' class.
- Add example use cases + tests.