### PR TITLE
🐛 Ensure body is available

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -22,9 +22,9 @@ import {
 } from './css';
 import {dev, devAssert} from './log';
 import {dict} from './utils/object';
+import {onDocumentReady} from './document-ready';
 import {startsWith} from './string';
 import {toWin} from './types';
-import {whenDocumentReady} from './document-ready';
 
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
@@ -106,9 +106,7 @@ export function waitForHead(doc, callback) {
  * @return {!Promise}
  */
 export function waitForHeadPromise(doc) {
-  return new Promise(resolve => {
-    waitForHead(doc, resolve);
-  });
+  return new Promise(resolve => waitForHead(doc, resolve));
 }
 
 /**
@@ -119,7 +117,7 @@ export function waitForHeadPromise(doc) {
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  waitForBodyPromise(doc).then(callback);
+  onDocumentReady(doc, () => waitForHead(doc, callback));
 }
 
 
@@ -129,9 +127,7 @@ export function waitForBody(doc, callback) {
  * @return {!Promise}
  */
 export function waitForBodyPromise(doc) {
-  return whenDocumentReady(doc).then(() => {
-    return waitForChildPromise(doc.documentElement, () => !!doc.body);
-  });
+  return new Promise(resolve => waitForBody(doc, resolve));
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -22,9 +22,9 @@ import {
 } from './css';
 import {dev, devAssert} from './log';
 import {dict} from './utils/object';
-import {onDocumentReady, whenDocumentReady} from './document-ready';
 import {startsWith} from './string';
 import {toWin} from './types';
+import {whenDocumentReady} from './document-ready';
 
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
@@ -119,7 +119,7 @@ export function waitForHeadPromise(doc) {
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  return onDocumentReady(doc, callback);
+  waitForBodyPromise(doc).then(callback);
 }
 
 
@@ -129,7 +129,9 @@ export function waitForBody(doc, callback) {
  * @return {!Promise}
  */
 export function waitForBodyPromise(doc) {
-  return whenDocumentReady(doc);
+  return whenDocumentReady(doc).then(() => {
+    return waitForChildPromise(doc.documentElement, () => !!doc.body);
+  });
 }
 
 

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -689,6 +689,38 @@ describes.sandboxed('DOM', {}, env => {
         expect(document.body).to.exist;
       });
     });
+
+    it('should wait for body even if doc is complete', () => {
+      return new Promise((resolve, reject) => {
+        const doc = {
+          readyState: 'complete',
+          body: null,
+          documentElement: {
+            ownerDocument: {
+              defaultView: {
+                setInterval() {
+                  return window.setInterval.apply(window, arguments);
+                },
+                clearInterval() {
+                  return window.clearInterval.apply(window, arguments);
+                },
+              },
+            },
+          },
+        };
+        setTimeout(() => {
+          doc.body = {};
+        }, 50);
+        dom.waitForBody(doc, () => {
+          try {
+            expect(doc.body).to.exist;
+            resolve();
+          } catch (e) {
+            reject(new Error("body doesn't exist"));
+          }
+        });
+      });
+    });
   });
 
   describe('getDataParamsFromAttributes', () => {


### PR DESCRIPTION
This should be impossible, but sometimes the document is ready but the
body is not yet parsed. So, ensure the document has a body before
resolving `waitForBody`.

Fixes #21423.