### PR TITLE
🐛 Fix bad calc()

### DIFF
--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -58,7 +58,7 @@ function flyIn(fxElement, axis, coeff) {
     Services.resourcesForDoc(element).mutateElement(element, () => {
       const style = computedStyle(fxElement.win, element);
       const prop = axisIsX ? 'left' : 'top';
-      const propAsLength = style[prop] === 'auto' ? 0 : style[prop];
+      const propAsLength = style[prop] === 'auto' ? '0px' : style[prop];
       const position =
           style.position === 'static' ?
             'relative' :


### PR DESCRIPTION
Apparently `calc(0 - -10vh)` is an invalid value but `calc(0px - -10px)` isn't. 😑

Partial for #21430.