### PR TITLE
🚀 Story assets preloading improvements.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -862,6 +862,10 @@ amp-story .i-amphtml-loader {
   display: none !important;
 }
 
+amp-story-page:not(:first-of-type):not([distance]):not([active]) {
+  transform: translateY(1000vh) !important;
+}
+
 /**
  * amp-autocomplete to avoid FOUC.
  */

--- a/css/amp.css
+++ b/css/amp.css
@@ -862,8 +862,8 @@ amp-story .i-amphtml-loader {
   display: none !important;
 }
 
-amp-story-page:not(:first-of-type):not([distance]):not([active]) {
-  transform: translateY(1000vh) !important;
+amp-story-page:not(:first-of-type) {
+  transform: translateY(1000vh);
 }
 
 /**

--- a/css/amp.css
+++ b/css/amp.css
@@ -862,8 +862,13 @@ amp-story .i-amphtml-loader {
   display: none !important;
 }
 
-amp-story-page:not(:first-of-type) {
-  transform: translateY(1000vh);
+/**
+ * Uses a selector that stops targeting amp-story-page elements once they have a
+ * [distance] or [active] attribute, so amp-story.css doesn't have to rely on
+ * CSS specificity hacks to override these styles after the JavaScript ran.
+ */
+amp-story-page:not(:first-of-type):not([distance]):not([active]) {
+  transform: translateY(1000vh) !important;
 }
 
 /**

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -218,6 +218,10 @@ amp-story-page:not([active]) {
   transform: translateY(1000vh) !important;
 }
 
+/**
+ * Note: If updating the [active] or [distance] attributes names, please also
+ * update them in the amp.css file.
+ */
 amp-story-page[active],
 amp-story-page[distance="0"],
 amp-story-page[distance="1"] {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -210,8 +210,12 @@ amp-story-page[active] {
  * not be automatically laid out. Max distance is set to 2 (next 2 pages) since
  * we don't want to schedule any further pages. */
 
+amp-story-page:not(:first-of-type):not([distance]):not([active]) {
+  transform: translateY(1000vh) !important;
+}
+
 amp-story-page:not([active]) {
-  transform: translateY(1000%) !important;
+  transform: translateY(1000vh) !important;
 }
 
 amp-story-page[active],


### PR DESCRIPTION
Stories assets preloading is broken in a way that if you have a 10 pages story with an image on each page, these 10 images will get loaded right away.

This PR positions the `amp-story-page` elements far away from the viewport, until the story runtime starts adding `[active]` or `[distance]` attribute and controls when elements should be built and loaded by the AMP runtime.

If the AMP runtime is loaded before the AMP Story runtime, it would start building and loading `amp-img` and `amp-video` elements. To avoid these race conditions, the CSS fix is added to both `amp.css` and `amp-story.css`.

The behavior is the following: it hides all `amp-story-pages` except for the first page, until an `[active]` or `[distance]` attribute is added once the `amp-story.buildCallback/layoutCallback` are executed.
It will start loading the first page even before it is built, and then the N+1 and N+2 pages when the `[distance]` attributes are set.

Performance measured is the time between the `amp-story.js` script onload event, and the "first page assets are loaded" event:

| Connection | Avg first page loaded time before | Avg first page loaded time after | % improvement |
| :-------------: | :-------------: | :-------------: | :-------------: |
| 3G  | 5067ms | 2804ms | -44.66% |
| 4G  | 1875ms | 898ms | -52.11% |

It's also saving a lot of bandwidth when prerendering stories from a viewer, as it only loads what's necessary.

[Demo available here](https://stamp-gmajoulet.firebaseapp.com/examples/s20/body-painting/index.html)