### PR TITLE
Stories default animations curves and duration.

### DIFF
--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -86,8 +86,8 @@ export const getPresetDef = (name, options) => {
   switch (name) {
     case 'pulse':
       return {
-        duration: 500,
-        easing: 'linear',
+        duration: 400,
+        easing: 'cubic-bezier(0.4, 0.0, 0.2, 1)',
         keyframes: [
           {
             offset: 0,
@@ -109,8 +109,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'fly-in-left':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = -(dimensions.targetX + dimensions.targetWidth);
           return translate2d(offsetX, 0, 0, 0);
@@ -118,8 +118,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'fly-in-right':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = dimensions.pageWidth - dimensions.targetX;
           return translate2d(offsetX, 0, 0, 0);
@@ -127,8 +127,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'fly-in-top':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetY = -(dimensions.targetY + dimensions.targetHeight);
           return translate2d(0, offsetY, 0, 0);
@@ -136,8 +136,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'fly-in-bottom':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetY = dimensions.pageHeight - dimensions.targetY;
           return translate2d(0, offsetY, 0, 0);
@@ -145,8 +145,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'rotate-in-left':
       return {
-        duration: 700,
-        easing: 'ease-out',
+        duration: 600,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = -(dimensions.targetX + dimensions.targetWidth);
           return rotateAndTranslate(offsetX, 0, 0, 0, -1);
@@ -154,8 +154,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'rotate-in-right':
       return {
-        duration: 700,
-        easing: 'ease-out',
+        duration: 600,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = dimensions.pageWidth - dimensions.targetX;
           return rotateAndTranslate(offsetX, 0, 0, 0, 1);
@@ -163,8 +163,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'fade-in':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes: [
           {
             opacity: 0,
@@ -232,8 +232,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'whoosh-in-left':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = -(dimensions.targetX + dimensions.targetWidth);
           return whooshIn(offsetX, 0, 0, 0);
@@ -241,8 +241,8 @@ export const getPresetDef = (name, options) => {
       };
     case 'whoosh-in-right':
       return {
-        duration: 500,
-        easing: 'ease-out',
+        duration: 400,
+        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
         keyframes(dimensions) {
           const offsetX = dimensions.pageWidth - dimensions.targetX;
           return whooshIn(offsetX, 0, 0, 0);

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -46,6 +46,8 @@ const ANIMATE_IN_DELAY_ATTRIBUTE_NAME = 'animate-in-delay';
 /** const {string} */
 const ANIMATE_IN_AFTER_ATTRIBUTE_NAME = 'animate-in-after';
 /** const {string} */
+const ANIMATE_IN_TIMING_FUNCTION_ATTRIBUTE_NAME = 'animate-in-timing-function';
+/** const {string} */
 const ANIMATABLE_ELEMENTS_SELECTOR = `[${ANIMATE_IN_ATTRIBUTE_NAME}]`;
 /** const {string} */
 const SCALE_START_ATTRIBUTE_NAME = 'scale-start';
@@ -116,6 +118,10 @@ class AnimationRunner {
 
     /** @private @const */
     this.duration_ = animationDef.duration || this.presetDef_.duration || 0;
+
+    /** @private @const */
+    this.easing_ = animationDef.easing || this.presetDef_.easing ||
+        'cubic-bezier(0.4, 0.0, 0.2, 1)';
 
     /**
      * @private @const {!Promise<
@@ -191,7 +197,7 @@ class AnimationRunner {
       keyframes,
       target: this.target_,
       duration: `${this.duration_}ms`,
-      easing: this.presetDef_.easing,
+      easing: this.easing_,
       fill: 'forwards',
     }));
   }
@@ -545,6 +551,11 @@ export class AnimationManager {
 
       animationDef.startAfterId =
           el.getAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME);
+    }
+
+    if (el.hasAttribute(ANIMATE_IN_TIMING_FUNCTION_ATTRIBUTE_NAME)) {
+      animationDef.easing =
+          el.getAttribute(ANIMATE_IN_TIMING_FUNCTION_ATTRIBUTE_NAME);
     }
 
     return animationDef;

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -57,6 +57,8 @@ const SCALE_END_ATTRIBUTE_NAME = 'scale-end';
 const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
 /** const {string} */
 const TRANSLATE_Y_ATTRIBUTE_NAME = 'translate-y';
+/** const {string} */
+const DEFAULT_EASING = 'cubic-bezier(0.4, 0.0, 0.2, 1)';
 
 /**
  * @param {!Element} element
@@ -121,7 +123,7 @@ class AnimationRunner {
 
     /** @private @const */
     this.easing_ = animationDef.easing || this.presetDef_.easing ||
-        'cubic-bezier(0.4, 0.0, 0.2, 1)';
+        DEFAULT_EASING;
 
     /**
      * @private @const {!Promise<


### PR DESCRIPTION
Updating the default stories animations curves and duration so they respect the material guidelines.
Animations are actually still slower than what's recommended but I don't want to introduce too big of a change.

Publishers could already override the animation duration, but this PR also introduces a way to provide their own timing function:
```
<p animate-in="fly-in-right" animate-in-duration="600" animate-in-timing-function="linear">
  ...
</p>
```