### PR TITLE
🐛Make click event available to ancestors of image viewer.

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -23,6 +23,7 @@ import {
   DoubletapRecognizer,
   PinchRecognizer,
   SwipeXYRecognizer,
+  TapRecognizer,
   TapzoomRecognizer,
 } from '../../../src/gesture-recognizers';
 import {Gestures} from '../../../src/gesture';
@@ -429,6 +430,13 @@ export class AmpImageViewer extends AMP.BaseElement {
       });
     });
 
+    // Propagate click on tap, since the double tap gesture would prevent it
+    // from occurring otherwise. This allows interested parties (e.g. lightbox
+    // gallery) to react to clicks, though there will be a delay.
+    this.gestures_.onGesture(TapRecognizer, gesture => {
+      this.propagateClickEvent_(gesture.data.target);
+    });
+
     this.gestures_.onGesture(TapzoomRecognizer, gesture => {
       const {data} = gesture;
       this.onTapZoom_(data.centerClientX, data.centerClientY,
@@ -479,11 +487,9 @@ export class AmpImageViewer extends AMP.BaseElement {
           }
         });
 
-    this.unlistenOnClickHaltMotion_ = this.gestures_.onPointerDown(event => {
+    this.unlistenOnClickHaltMotion_ = this.gestures_.onPointerDown(() => {
       if (this.motion_) {
         this.motion_.halt();
-      } else {
-        this.propagateClickEvent_(event.target);
       }
     });
   }


### PR DESCRIPTION
Add a tap listener to propagate clicks within the image viewer. Previously, clicks would only be propagated while zoomed in. Additionally, doubling tapping while zoomed in would cause the controls toggle twice (i.e. if they were visible, they would hide, then reshow; if they were hidden, they would show then hide again). Now, tapping will always propagate the click as long as it is not a double tap gesture.

Fixes #21431

/cc @cathyxz 

