### PR TITLE
✨Added support for "config" parameter in purch amp-ad adapter.

### DIFF
--- a/ads/purch.js
+++ b/ads/purch.js
@@ -25,7 +25,7 @@ import {
  */
 export function purch(global, data) {
   validateData(data, [],
-      ['pid', 'divid']);
+      ['pid', 'divid', 'config']);
   global.data = data;
 
   const adsrc = 'https://ramp.purch.com/serve/creative_amp.js';

--- a/ads/purch.md
+++ b/ads/purch.md
@@ -22,7 +22,8 @@ limitations under the License.
 <amp-ad width="300" height="250"
   type="purch"
   data-pid="2882"
-  data-divid="rightcol_top">
+  data-divid="rightcol_top"
+  data-config='{"targeting":{"key1":"value1", "key2":"value2"}}'>
 </amp-ad>
 ```
 
@@ -34,3 +35,5 @@ Supported parameters:
 
 - `data-pid`: placement id
 - `data-divid`: div id of unit
+- `data-config`: Optinal parameter to control the ad behaviour.
+- `data-config.targeting`: Optinal config parameter to pass key-values to DFP/GAM.


### PR DESCRIPTION
Added support for "config" parameter in purch amp-ad adapter.
Tag format data-config='{"targeting":{"key1":"value1", "key2":"value2"}}'
This change is trivial, totally isolated to the purch amp-ad adapter and is totally backward compatible.
