### PR TITLE
🚮 Make clicks in CTA layer trigger tooltip

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -452,7 +452,7 @@ class ManualAdvancement extends AdvancementConfig {
 
   /**
    * For an element to trigger a tooltip it has to be descendant of
-   * amp-story-page but not of amp-story-cta-layer or amp-story-page-attachment.
+   * amp-story-page but not of amp-story-page-attachment.
    * @param {!Event} event
    * @return {boolean}
    * @private
@@ -464,8 +464,7 @@ class ManualAdvancement extends AdvancementConfig {
     return !!closest(dev().assertElement(event.target), el => {
       tagName = el.tagName.toLowerCase();
 
-      if (tagName === 'amp-story-cta-layer' ||
-          tagName === 'amp-story-page-attachment') {
+      if (tagName === 'amp-story-page-attachment') {
         valid = false;
         return false;
       }


### PR DESCRIPTION
(previously introduced in #19287)

Before we wanted to let anything under the `amp-story-cta-layer` not trigger a tooltip. But we have recently decided to not do this anymore.

This essentially makes the `amp-story-cta-layer` obsolete, but we'll keep it to not cause any breaking changes.

Wip:
* remove docs
* test with existing <button> <a> tags under `amp-story-cta-layer`