### PR TITLE
♻️Refactor amp-autocomplete to save the partial user input locally

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -28,10 +28,6 @@
   position: relative;
 }
 
-.i-amphtml-autocomplete-item:last-child {
-  display: none;
-}
-
 .i-amphtml-autocomplete-item:hover {
   background-color: #d3d3d3;
 }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -66,6 +66,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.inputElement_ = null;
 
     /**
+     * The partial user input used to generate suggestions.
+     * @private {string}
+     */
+    this.userInput_ = '';
+
+    /**
      * The value of the "filter" attribute on <autocomplete>.
      * @private {string}
      */
@@ -265,6 +271,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   */
   inputHandler_() {
     return this.mutateElement(() => {
+      this.userInput_ = this.inputElement_.value;
       this.renderResults_();
       this.toggleResults_(true);
     });
@@ -289,13 +296,12 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   renderResults_() {
-    const userInput = this.inputElement_.value;
     this.clearAllItems_();
-    if (userInput.length < this.minChars_ || !this.inlineData_) {
+    if (this.userInput_.length < this.minChars_ || !this.inlineData_) {
       return Promise.resolve();
     }
 
-    const filteredData = this.filterData_(this.inlineData_, userInput);
+    const filteredData = this.filterData_(this.inlineData_, this.userInput_);
     let renderPromise = Promise.resolve();
     if (this.templateElement_) {
       renderPromise = this.templates_.renderTemplateArray(this.templateElement_,
@@ -314,10 +320,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
             this.createElementFromItem_(item));
       });
     }
-    return renderPromise.then(() => {
-      // Append the partial user-provided input to navigate back to.
-      this.container_.appendChild(this.createElementFromItem_(userInput));
-    });
+    return renderPromise;
   }
 
   /**
@@ -444,15 +447,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
     if (delta === 0) {
       return Promise.resolve();
     }
-    const index = this.activeIndex_ + delta;
-    let resultsShowing, newActiveElement, newValue, validItem;
+    const keyUpWhenNoneActive = this.activeIndex_ === -1 && delta < 0;
+    const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
+    let resultsShowing, newActiveElement, newValue;
     return this.measureMutateElement(() => {
       resultsShowing = this.resultsShowing_();
       if (resultsShowing) {
         this.activeIndex_ = mod(index, this.container_.children.length);
         newActiveElement = this.container_.children[this.activeIndex_];
         newValue = newActiveElement.getAttribute('value');
-        validItem = this.activeIndex_ !== this.container_.children.length - 1;
       }
     }, () => {
       if (!resultsShowing) {
@@ -460,11 +463,16 @@ export class AmpAutocomplete extends AMP.BaseElement {
       }
       this.inputElement_.value = newValue;
       this.resetActiveElement_();
-      if (validItem) {
-        newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
-        this.activeElement_ = newActiveElement;
-      }
+      newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
+      this.activeElement_ = newActiveElement;
     });
+  }
+
+  /** Displays the user's partial input in the input field. */
+  displayUserInput_() {
+    this.inputElement_.value = this.userInput_;
+    this.resetActiveElement_();
+    this.activeIndex_ = -1;
   }
 
   /**
@@ -498,10 +506,22 @@ export class AmpAutocomplete extends AMP.BaseElement {
     switch (event.key) {
       case Keys.DOWN_ARROW:
         event.preventDefault();
-        return this.updateActiveItem_(1);
+        // Disrupt loop around to display user input.
+        if (this.activeIndex_ === this.container_.children.length - 1) {
+          this.displayUserInput_();
+          return Promise.resolve();
+        } else {
+          return this.updateActiveItem_(1);
+        }
       case Keys.UP_ARROW:
         event.preventDefault();
-        return this.updateActiveItem_(-1);
+        // Disrupt loop around to display user input.
+        if (this.activeIndex_ === 0) {
+          this.displayUserInput_();
+          return Promise.resolve();
+        } else {
+          return this.updateActiveItem_(-1);
+        }
       case Keys.ENTER:
         if (this.activeElement_) {
           // Only prevent if submit-on-enter === false.
@@ -515,8 +535,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       case Keys.ESCAPE:
         // Select user's partial input and hide results.
         return this.mutateElement(() => {
-          this.selectItem_(this.container_.lastElementChild);
-          this.resetActiveElement_();
+          this.displayUserInput_();
           this.toggleResults_(false);
         });
       default:

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -444,26 +444,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   updateActiveItem_(delta) {
-    if (delta === 0) {
+    if (delta === 0 || !this.resultsShowing_()) {
       return Promise.resolve();
     }
     const keyUpWhenNoneActive = this.activeIndex_ === -1 && delta < 0;
     const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
-    let resultsShowing;
-    let newActiveElement;
-    let newValue;
-    return this.measureMutateElement(() => {
-      resultsShowing = this.resultsShowing_();
-      if (resultsShowing) {
-        this.activeIndex_ = mod(index, this.container_.children.length);
-        newActiveElement = this.container_.children[this.activeIndex_];
-        newValue = newActiveElement.getAttribute('value');
-      }
-    }, () => {
-      if (!resultsShowing) {
-        return;
-      }
-      this.inputElement_.value = newValue;
+    this.activeIndex_ = mod(index, this.container_.children.length);
+    const newActiveElement = this.container_.children[this.activeIndex_];
+    this.inputElement_.value = newActiveElement.getAttribute('value');
+    return this.mutateElement(() => {
       this.resetActiveElement_();
       newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
       this.activeElement_ = newActiveElement;

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -459,7 +459,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
     });
   }
 
-  /** Displays the user's partial input in the input field. */
+  /**
+   * Displays the user's partial input in the input field.
+   * @private
+   */
   displayUserInput_() {
     this.inputElement_.value = this.userInput_;
     this.resetActiveElement_();

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -270,8 +270,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
   * @private
   */
   inputHandler_() {
+    this.userInput_ = this.inputElement_.value;
     return this.mutateElement(() => {
-      this.userInput_ = this.inputElement_.value;
       this.renderResults_();
       this.toggleResults_(true);
     });
@@ -449,7 +449,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
     }
     const keyUpWhenNoneActive = this.activeIndex_ === -1 && delta < 0;
     const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
-    let resultsShowing, newActiveElement, newValue;
+    let resultsShowing;
+    let newActiveElement;
+    let newValue;
     return this.measureMutateElement(() => {
       resultsShowing = this.resultsShowing_();
       if (resultsShowing) {
@@ -510,18 +512,16 @@ export class AmpAutocomplete extends AMP.BaseElement {
         if (this.activeIndex_ === this.container_.children.length - 1) {
           this.displayUserInput_();
           return Promise.resolve();
-        } else {
-          return this.updateActiveItem_(1);
         }
+        return this.updateActiveItem_(1);
       case Keys.UP_ARROW:
         event.preventDefault();
         // Disrupt loop around to display user input.
         if (this.activeIndex_ === 0) {
           this.displayUserInput_();
           return Promise.resolve();
-        } else {
-          return this.updateActiveItem_(-1);
         }
+        return this.updateActiveItem_(-1);
       case Keys.ENTER:
         if (this.activeElement_) {
           // Only prevent if submit-on-enter === false.

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -179,39 +179,59 @@ describes.realWin('amp-autocomplete unit tests', {
     });
   });
 
-  it('should call keyDownHandler_() on Down and Up arrow', () => {
+  describe('keyDownHandler_() on arrow keys', () => {
     const event = {key: Keys.DOWN_ARROW, preventDefault: () => {}};
-    const displayInputSpy = sandbox.spy(impl, 'displayUserInput_');
-    const updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
-    const preventSpy = sandbox.spy(event, 'preventDefault');
-    return element.layoutCallback().then(() => {
-      return impl.keyDownHandler_(event);
-    }).then(() => {
-      expect(preventSpy).to.have.been.calledOnce;
-      expect(displayInputSpy).to.have.been.calledOnce;
-      expect(updateActiveSpy).not.to.have.been.called;
-      impl.activeIndex_ = 0;
-      event.key = Keys.UP_ARROW;
-      return impl.keyDownHandler_(event);
-    }).then(() => {
-      expect(preventSpy).to.have.been.calledTwice;
-      expect(displayInputSpy).to.have.been.calledTwice;
-      expect(updateActiveSpy).not.to.have.been.called;
-      impl.activeIndex_ = 1;
-      return impl.keyDownHandler_(event);
-    }).then(() => {
-      expect(displayInputSpy).to.have.been.calledTwice;
-      expect(preventSpy).to.have.been.calledThrice;
-      expect(updateActiveSpy).to.have.been.calledWith(-1);
-      impl.activeIndex_ = 0;
-      event.key = Keys.DOWN_ARROW;
-      return impl.keyDownHandler_(event);
-    })
-        .then(() => {
-          expect(displayInputSpy).to.have.been.calledTwice;
-          expect(preventSpy).to.have.callCount(4);
-          expect(updateActiveSpy).to.have.been.calledWith(1);
-        });
+    let displayInputSpy, updateActiveSpy, eventPreventSpy;
+
+    beforeEach(() => {
+      displayInputSpy = sandbox.spy(impl, 'displayUserInput_');
+      updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
+      eventPreventSpy = sandbox.spy(event, 'preventDefault');
+    });
+
+    it('should updateActiveItem_ on Down arrow', () => {
+      return element.layoutCallback().then(() => {
+        impl.activeIndex_ = 0;
+        return impl.keyDownHandler_(event);
+      }).then(() => {
+        expect(eventPreventSpy).to.have.been.calledOnce;
+        expect(displayInputSpy).not.to.have.been.called;
+        expect(updateActiveSpy).to.have.been.calledWith(1);
+      });
+    });
+
+    it('should displayUserInput_ when looping on Down arrow', () => {
+      return element.layoutCallback().then(() => {
+        return impl.keyDownHandler_(event);
+      }).then(() => {
+        expect(eventPreventSpy).to.have.been.calledOnce;
+        expect(displayInputSpy).to.have.been.calledOnce;
+        expect(updateActiveSpy).not.to.have.been.called;
+      });
+    });
+
+    it('should updateActiveItem_ on Up arrow', () => {
+      return element.layoutCallback().then(() => {
+        event.key = Keys.UP_ARROW;
+        return impl.keyDownHandler_(event);
+      }).then(() => {
+        expect(eventPreventSpy).to.have.been.calledOnce;
+        expect(displayInputSpy).not.to.have.been.called;
+        expect(updateActiveSpy).to.have.been.calledWith(-1);
+      });
+    });
+
+    it('should displayUserInput_ when looping on Up arrow', () => {
+      return element.layoutCallback().then(() => {
+        event.key = Keys.UP_ARROW;
+        impl.activeIndex_ = 0;
+        return impl.keyDownHandler_(event);
+      }).then(() => {
+        expect(eventPreventSpy).to.have.been.calledOnce;
+        expect(displayInputSpy).to.have.been.calledOnce;
+        expect(updateActiveSpy).not.to.have.been.called;
+      });
+    });
   });
 
   it('should call keyDownHandler_() on Enter', () => {


### PR DESCRIPTION
This change is to replace the lastElementChild way of keeping track of the partial user input.
- Refactor amp-autocomplete (and accompanying tests) to save the partial user input locally