### PR TITLE
🐛Change check to see if amp-img has completed layout.

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -172,21 +172,13 @@ export class AmpImageViewer extends AMP.BaseElement {
       return Promise.resolve();
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    const hasCompletedLayout = !!ampImg.querySelector(
-        '.i-amphtml-replaced-content');
-    const laidOutPromise = hasCompletedLayout
-      ? Promise.resolve()
-      : ampImg.signals().whenSignal(CommonSignals.LOAD_END);
-
-    if (!hasCompletedLayout) {
-      this.scheduleLayout(ampImg);
-    }
-
-    this.loadPromise_ = laidOutPromise
+    this.scheduleLayout(ampImg);
+    
+    return ampImg.signals()
+        .whenSignal(CommonSignals.LOAD_END)
         .then(() => this.init_())
         .then(() => this.resetImageDimensions_())
         .then(() => this.setupGestures_());
-    return this.loadPromise_;
   }
 
   /** @override */

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -173,7 +173,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
     this.scheduleLayout(ampImg);
-    
+
     return ampImg.signals()
         .whenSignal(CommonSignals.LOAD_END)
         .then(() => this.init_())

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -172,7 +172,8 @@ export class AmpImageViewer extends AMP.BaseElement {
       return Promise.resolve();
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    const hasCompletedLayout = !!ampImg.querySelector('img');
+    const hasCompletedLayout = !!ampImg.querySelector(
+        '.i-amphtml-replaced-content');
     const laidOutPromise = hasCompletedLayout
       ? Promise.resolve()
       : ampImg.signals().whenSignal(CommonSignals.LOAD_END);

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -172,13 +172,12 @@ export class AmpImageViewer extends AMP.BaseElement {
       return Promise.resolve();
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    const isLaidOut = ampImg.hasAttribute('i-amphtml-layout') ||
-      ampImg.classList.contains('i-amphtml-layout');
-    const laidOutPromise = isLaidOut
+    const hasCompletedLayout = !!ampImg.querySelector('img');
+    const laidOutPromise = hasCompletedLayout
       ? Promise.resolve()
       : ampImg.signals().whenSignal(CommonSignals.LOAD_END);
 
-    if (!isLaidOut) {
+    if (!hasCompletedLayout) {
       this.scheduleLayout(ampImg);
     }
 


### PR DESCRIPTION
Instead of looking for the layout class or attribute, check for the
`<img>` element instead. This is a safer check as we can be sure that
the `<amp-img>` has completed its `layoutCallback`.

Fixes #21481
