### PR TITLE
🐛Avoid Zalgo by forcing expect to always return a Promise

### DIFF
--- a/build-system/tasks/e2e/expect.js
+++ b/build-system/tasks/e2e/expect.js
@@ -145,13 +145,13 @@ function overwriteAlwaysUseSuper(utils) {
       const obj = this._obj;
       const isControllerPromise = obj instanceof ControllerPromise;
       if (!isControllerPromise) {
-        return _super.apply(this, arguments);
+        return Promise.resolve(_super.apply(this, arguments));
       }
       const {waitForValue} = obj;
       if (!waitForValue) {
         const result = await obj;
         flag(this, 'object', result);
-        return _super.apply(this, arguments);
+        return Promise.resolve(_super.apply(this, arguments));
       }
 
       const resultPromise = waitForValue(obj => {


### PR DESCRIPTION
The overwritten expectation methods and properties would return a Promise if passed a ControllerPromise, but not if passed other values. This makes expect always return a Promise.