### PR TITLE
🐛Include the submit button clicked in POST responses

### DIFF
--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -129,7 +129,7 @@ describes.repeated('', {
     }
 
     function getVerificationForm() {
-      const form = getForm();
+      const form = getForm(/*button1*/ false);
       form.setAttribute('verify-xhr', '');
 
       const noVerifyInput = createElement('input');

--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -15,7 +15,10 @@
  */
 
 import {Services} from './services';
-import {getFormAsObject} from './form';
+import {
+  getFormAsObject,
+  getSubmitButtonUsed,
+} from './form';
 import {iterateCursor} from './dom';
 import {map} from './utils/object';
 
@@ -144,8 +147,8 @@ class NativeFormDataWrapper {
 
   /**
    * If a submit button is focused (because it was used to submit the form),
-   * add its name and value to the `FormData`, since publishers expect the
-   * submit button to be present.
+   * or was the first submit button present, add its name and value to the
+   * `FormData`, since publishers expect the submit button to be present.
    * @param {!HTMLFormElement=} opt_form
    * @private
    */
@@ -156,31 +159,9 @@ class NativeFormDataWrapper {
       return;
     }
 
-    // If the focused element is not a submit button or does not have a name,
-    // then it does not need to be included in the `FormData`
-    const {activeElement} = opt_form.ownerDocument;
-    const {
-      name,
-      tagName,
-      type,
-    } = activeElement;
-    if (!name) {
-      return;
-    }
-    if (tagName != 'BUTTON' && type != 'submit') {
-      return;
-    }
-
-    // Finally, if the focused element is a field of the form,
-    // then it must be added to the `FormData`.
-    const {elements} = opt_form;
-    const {length} = elements;
-    for (let i = 0; i < length; i++) {
-      const element = elements[i];
-      if (element === activeElement) {
-        this.append(element.name, element.value);
-        break;
-      }
+    const button = getSubmitButtonUsed(opt_form);
+    if (button) {
+      this.append(button.name, button.value);
     }
   }
 

--- a/src/form.js
+++ b/src/form.js
@@ -45,14 +45,14 @@ export function setFormForElement(element, form) {
  * @return {!JsonObject}
  */
 export function getFormAsObject(form) {
-  const {
-    elements,
-    ownerDocument,
-  } = form;
+  const {elements} = form;
   const data = /** @type {!JsonObject} */ ({});
-  const submittableTagsRegex = /^(?:input|select|textarea|button)$/i;
-  const unsubmittableTypesRegex = /^(?:button|image|file|reset)$/i;
+  // <button> is handled separately
+  const submittableTagsRegex = /^(?:input|select|textarea)$/i;
+  // type=submit is handled separately
+  const unsubmittableTypesRegex = /^(?:submit|button|image|file|reset)$/i;
   const checkableType = /^(?:checkbox|radio)$/i;
+
   for (let i = 0; i < elements.length; i++) {
     const input = elements[i];
     const {
@@ -83,20 +83,16 @@ export function getFormAsObject(form) {
       });
       continue;
     }
-
-    // In a form, the button's value is only submitted if the button itself was
-    // used to submit the form. We can detect that using the document focus.
-    // Browsers vary on the conditions that focus the form submit button.
-    // Generally, the button is only focused if the user triggers the button
-    // itself. If a script calls `button.click` or `form.submit` the button
-    // will not be focused. If the user presses enter inside a field, the button
-    // will not be focused.
-    if ((type == 'submit' || tagName == 'BUTTON')
-        && input != ownerDocument.activeElement) {
-      continue;
-    }
-
     data[name].push(value);
+  }
+
+  const submitButton = getSubmitButtonUsed(form);
+  if (submitButton && submitButton.name) {
+    const {name} = submitButton;
+    if (data[name] === undefined) {
+      data[name] = [];
+    }
+    data[submitButton.name].push(submitButton.value);
   }
 
   // Wait until the end to remove the empty values, since
@@ -112,6 +108,52 @@ export function getFormAsObject(form) {
   });
 
   return data;
+}
+
+/**
+ * Gets the submit button used to submit the form.
+ * This searches through the form elements to find:
+ * 1. The first submit button element OR
+ * 2. a focused submit button, indicating it was specifically used to submit.
+ * 3. null, if neither of the above is found.
+ * @param {!HTMLFormElement} form
+ * @return {?Element}
+ */
+export function getSubmitButtonUsed(form) {
+  const {elements} = form;
+  const {length} = elements;
+  const {activeElement} = form.ownerDocument;
+  let firstSubmitButton = null;
+
+  for (let i = 0; i < length; i++) {
+    const element = elements[i];
+
+    if (!isSubmitButton(element)) {
+      continue;
+    }
+
+    if (!firstSubmitButton) {
+      firstSubmitButton = element;
+    }
+
+    if (activeElement == element) {
+      return activeElement;
+    }
+  }
+  return firstSubmitButton;
+}
+
+/**
+ * True if the given button can submit a form.
+ * @param {!Element} element
+ * @return {boolean}
+ */
+function isSubmitButton(element) {
+  const {
+    tagName,
+    type,
+  } = element;
+  return tagName == 'BUTTON' || type == 'submit';
 }
 
 /**

--- a/test/unit/test-form-data-wrapper.js
+++ b/test/unit/test-form-data-wrapper.js
@@ -50,7 +50,7 @@ describes.realWin('FormDataWrapper', {}, env => {
         description: 'when native `entries` is available',
 
         beforeEach() {
-          // Do nothing as `FormData.prototype` already has `entires`.
+          // Do nothing as `FormData.prototype` already has `entries`.
         },
 
         afterEach() {
@@ -299,6 +299,55 @@ describes.realWin('FormDataWrapper', {}, env => {
             ['foo2', 'bar'],
             ['foo1', 'baz'],
             ['42', 'bang'],
+          ]);
+        });
+
+        it('includes the focused submit input at submit-time', () => {
+          const form = env.win.document.createElement('form');
+
+          const input = env.win.document.createElement('input');
+          input.type = 'text';
+          input.name = 'foo1';
+          input.value = 'bar';
+
+          const submit = env.win.document.createElement('input');
+          submit.type = 'submit';
+          submit.name = 'foo2';
+          submit.value = 'baz';
+
+          form.appendChild(input);
+          form.appendChild(submit);
+          env.win.document.body.appendChild(form);
+
+          submit.focus();
+          const formData = createFormDataWrapper(env.win, form);
+          expect(fromIterator(formData.entries())).to.have.deep.members([
+            ['foo1', 'bar'],
+            ['foo2', 'baz'],
+          ]);
+        });
+
+        it('includes the focused submit button at submit-time', () => {
+          const form = env.win.document.createElement('form');
+
+          const input = env.win.document.createElement('input');
+          input.type = 'text';
+          input.name = 'foo1';
+          input.value = 'bar';
+
+          const submit = env.win.document.createElement('button');
+          submit.name = 'foo2';
+          submit.innerText = 'baz';
+
+          form.appendChild(input);
+          form.appendChild(submit);
+          env.win.document.body.appendChild(form);
+
+          submit.focus();
+          const formData = createFormDataWrapper(env.win, form);
+          expect(fromIterator(formData.entries())).to.have.deep.members([
+            ['foo1', 'bar'],
+            ['foo2', ''],
           ]);
         });
       });

--- a/test/unit/test-form-data-wrapper.js
+++ b/test/unit/test-form-data-wrapper.js
@@ -350,6 +350,30 @@ describes.realWin('FormDataWrapper', {}, env => {
             ['foo2', ''],
           ]);
         });
+
+        it('includes the first submit button at submit-time if' +
+            ' none is focused', () => {
+          const form = env.win.document.createElement('form');
+
+          const input = env.win.document.createElement('input');
+          input.type = 'text';
+          input.name = 'foo1';
+          input.value = 'bar';
+
+          const submit = env.win.document.createElement('button');
+          submit.name = 'foo2';
+          submit.innerText = 'baz';
+
+          form.appendChild(input);
+          form.appendChild(submit);
+          env.win.document.body.appendChild(form);
+
+          const formData = createFormDataWrapper(env.win, form);
+          expect(fromIterator(formData.entries())).to.have.deep.members([
+            ['foo1', 'bar'],
+            ['foo2', ''],
+          ]);
+        });
       });
     });
 

--- a/test/unit/test-form.js
+++ b/test/unit/test-form.js
@@ -217,17 +217,59 @@ describes.realWin('getFormAsObject', {}, env => {
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar', 'bang']});
   });
 
+  it('returns the first submit input entries if none focused', () => {
+    const input = env.win.document.createElement('input');
+    input.type = 'submit';
+    input.name = 'foo';
+    input.value = 'bar';
+    form.appendChild(input);
+
+    const input2 = env.win.document.createElement('input');
+    input2.type = 'submit';
+    input2.name = 'baz';
+    input2.value = 'quux';
+    form.appendChild(input2);
+
+    Object.defineProperty(form, 'ownerDocument', {get() {
+      return {activeElement: input};
+    }});
+    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
+  });
+
   it('returns focused submit input entries', () => {
     const input = env.win.document.createElement('input');
     input.type = 'submit';
     input.name = 'foo';
     input.value = 'bar';
-
     form.appendChild(input);
-    expect(getFormAsObject(form)).to.deep.equal({});
+
+    const input2 = env.win.document.createElement('input');
+    input2.type = 'submit';
+    input2.name = 'baz';
+    input2.value = 'quux';
+    form.appendChild(input2);
+
+    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
 
     Object.defineProperty(form, 'ownerDocument', {get() {
-      return {activeElement: input};
+      return {activeElement: input2};
+    }});
+    expect(getFormAsObject(form)).to.deep.equal({'baz': ['quux']});
+  });
+
+  it('returns the first submit button entries if none focused', () => {
+    const input = env.win.document.createElement('button');
+    input.name = 'foo';
+    input.value = 'bar';
+    form.appendChild(input);
+
+    const input2 = env.win.document.createElement('button');
+    input2.name = 'baz';
+    input2.value = 'quux';
+    form.appendChild(input2);
+
+    Object.defineProperty(form, 'ownerDocument', {get() {
+      return {activeElement: env.win.document.body};
     }});
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
   });
@@ -236,14 +278,19 @@ describes.realWin('getFormAsObject', {}, env => {
     const input = env.win.document.createElement('button');
     input.name = 'foo';
     input.value = 'bar';
-
     form.appendChild(input);
-    expect(getFormAsObject(form)).to.deep.equal({});
+
+    const input2 = env.win.document.createElement('button');
+    input2.name = 'baz';
+    input2.value = 'quux';
+    form.appendChild(input2);
+
+    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
 
     Object.defineProperty(form, 'ownerDocument', {get() {
-      return {activeElement: input};
+      return {activeElement: input2};
     }});
-    expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
+    expect(getFormAsObject(form)).to.deep.equal({'baz': ['quux']});
   });
 
   it('returns multiple form entries', () => {


### PR DESCRIPTION
Resolves #21498

GET form submits and POST form submits in browsers without `FormData.prototype.entries` support followed a code path that used `getFormAsObject` which was addressed by #18785

This PR adds the button used to submit the form to the `NativeFormDataWrapper` to add the value to `FormData` for all submit code paths. Includes regression tests.

/to @cathyxz @alanorozco 
/cc @aghassemi 