### PR TITLE
✨amp-consent: consent-ui Allow Passing Initial styles on ready

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -89,7 +89,7 @@ amp-consent.amp-hidden {
   position: absolute;
   top: 0;
   left: 0;
-  height: 30vh;
+  /* Initial height (Default 30vh) will be set through styles */
   width: 100%;
 }
 
@@ -103,16 +103,18 @@ amp-consent.i-amphtml-consent-ui-iframe-active {
   padding: 0px !important;
   margin: 0px !important;
 
+  transform: translate3d(0px, 100vh, 0px) !important;
+}
+
+amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-default-border {
   border-top-left-radius: 8px !important;
   border-top-right-radius: 8px !important;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
-
-  transform: translate3d(0px, 100vh, 0px) !important;
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
   transition: transform 0.5s ease-out !important;
-  transform: translate3d(0px, calc(100% - 30vh), 0px) !important;
+  /* Initial height transform will be set through styles */
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen {

--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -106,7 +106,7 @@ amp-consent.i-amphtml-consent-ui-iframe-active {
   transform: translate3d(0px, 100vh, 0px) !important;
 }
 
-amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-default-border {
+amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-enable-border {
   border-top-left-radius: 8px !important;
   border-top-right-radius: 8px !important;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -32,7 +32,7 @@ import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
-import {setStyles, setImportantStyles, toggle} from '../../../src/style';
+import {setImportantStyles, setStyles, toggle} from '../../../src/style';
 
 const TAG = 'amp-consent-ui';
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -119,10 +119,10 @@ export class ConsentUI {
     /** @private {?Element} */
     this.placeholder_ = null;
 
-    /** @private {!String} */
+    /** @private {string} */
     this.initialHeight_ = DEFAULT_INITIAL_HEIGHT;
 
-    /** @private {!Boolean} */
+    /** @private {boolean} */
     this.enableBorder_ = DEFAULT_ENABLE_BORDER;
 
     /** @private @const {!Function} */
@@ -300,8 +300,9 @@ export class ConsentUI {
         this.initialHeight_ = `${dataHeight}vh`;
       } else {
         dev().error(
-          TAG,
-          `Inavlid initial height: ${data['initialHeight']}. Must be in 'vh' units. Minimum: 10vh. Maximum: 60vh.`
+            TAG,
+            `Inavlid initial height: ${data['initialHeight']}.` +
+          'Must be in "vh" units. Minimum: 10vh. Maximum: 60vh.'
         );
       }
     }
@@ -466,18 +467,7 @@ export class ConsentUI {
       this.baseInstance_.mutateElement(() => {
         classList.add(consentUiClasses.in);
         this.isIframeVisible_ = true;
-
-        // Apply our initial height and border
-        setStyles(this.ui_, {
-          height: this.initialHeight_
-        });
-        setImportantStyles(this.parent_, {
-          transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`
-        });
-        if (this.enableBorder_) {
-          const {classList} = this.parent_;
-          classList.add(consentUiClasses.enableBorder);
-        }
+        this.applyInitialStyles_();
       });
     });
   }
@@ -510,8 +500,25 @@ export class ConsentUI {
   resetAnimationStyles_() {
     setStyles(this.parent_, {
       transform: '',
-      transition: ''
+      transition: '',
     });
+  }
+
+  /**
+   * Apply styles for ready event
+   */
+  applyInitialStyles_() {
+    // Apply our initial height and border
+    setStyles(this.ui_, {
+      height: this.initialHeight_,
+    });
+    setImportantStyles(this.parent_, {
+      transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
+    });
+    if (this.enableBorder_) {
+      const {classList} = this.parent_;
+      classList.add(consentUiClasses.enableBorder);
+    }
   }
 
   /**

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -304,14 +304,14 @@ export class ConsentUI {
         if (dataHeight >= 10 && dataHeight <= 60) {
           this.initialHeight_ = `${dataHeight}vh`;
         } else {
-          dev().error(
+          user().error(
               TAG,
               `Inavlid initial height: ${data['initialHeight']}.` +
             'Minimum: 10vh. Maximum: 60vh.'
           );
         }
       } else {
-        dev().error(
+        user().error(
             TAG,
             `Inavlid initial height: ${data['initialHeight']}.` +
           'Must be a string in "vh" units.'

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -293,16 +293,26 @@ export class ConsentUI {
     this.enableBorder_ = DEFAULT_ENABLE_BORDER;
 
     // Set our initial height
-    if (data['initialHeight'] && data['initialHeight'].includes('vh')) {
-      const dataHeight = parseInt(data['initialHeight'], 10);
+    if (data['initialHeight']) {
+      if (typeof data['initialHeight'] === 'string' &&
+        data['initialHeight'].indexOf('vh') >= 0) {
 
-      if (dataHeight >= 10 && dataHeight <= 60) {
-        this.initialHeight_ = `${dataHeight}vh`;
+        const dataHeight = parseInt(data['initialHeight'], 10);
+
+        if (dataHeight >= 10 && dataHeight <= 60) {
+          this.initialHeight_ = `${dataHeight}vh`;
+        } else {
+          dev().error(
+              TAG,
+              `Inavlid initial height: ${data['initialHeight']}.` +
+            'Minimum: 10vh. Maximum: 60vh.'
+          );
+        }
       } else {
         dev().error(
             TAG,
             `Inavlid initial height: ${data['initialHeight']}.` +
-          'Must be in "vh" units. Minimum: 10vh. Maximum: 60vh.'
+          'Must be a string in "vh" units.'
         );
       }
     }
@@ -509,9 +519,11 @@ export class ConsentUI {
    */
   applyInitialStyles_() {
     // Apply our initial height and border
-    setStyles(this.ui_, {
-      height: this.initialHeight_,
-    });
+    if (this.ui_) {
+      setStyles(this.ui_, {
+        height: this.initialHeight_,
+      });
+    }
     setImportantStyles(this.parent_, {
       transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
     });
@@ -611,7 +623,7 @@ export class ConsentUI {
     }
 
     if (data['action'] === 'ready') {
-      this.handleReady_(data);
+      this.handleReady_(/** @type {!JsonObject} */(data));
     }
 
     if (data['action'] === 'enter-fullscreen') {

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -261,6 +261,8 @@ export class ConsentUI {
       this.maybeHideOverlay_();
       // Enable the scroll, in case we were fullscreen with no overlay
       this.enableScroll_();
+      // Reset any animation styles set by style attribute
+      this.resetAnimationStyles_();
 
       // NOTE (torch2424): This is very sensitive. Fixed layer applies
       // a `top: calc(0px)` in order to fix some bugs, thus

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -227,6 +227,8 @@ describes.realWin('consent-ui', {
       expect(parent.classList.contains('amp-hidden')).to.be.false;
 
       const showIframeSpy = sandbox.spy(consentUI, 'showIframe_');
+      const applyInitialStylesSpy =
+          sandbox.spy(consentUI, 'applyInitialStyles_');
 
       consentUI.show();
       expect(parent.classList.contains('amp-active')).to.be.true;
@@ -240,6 +242,8 @@ describes.realWin('consent-ui', {
         expect(
             parent.classList.contains(consentUiClasses.iframeActive)
         ).to.be.true;
+
+        return whenCalled(applyInitialStylesSpy);
       });
     });
 
@@ -319,6 +323,93 @@ describes.realWin('consent-ui', {
       yield macroTask();
       expect(consentUI.maskElement_.hasAttribute('hidden')).to.be.ok;
       expect(consentUI.scrollEnabled_).to.be.true;
+    });
+  });
+
+  describe('ready', () => {
+
+    it('should respond to the ready event', () => {
+      return getReadyIframeCmpConsentUi().then(consentUI => {
+        const handleReadyStub = sandbox.stub(consentUI, 'handleReady_');
+
+        consentUI.ui_ = {
+          contentWindow: 'mock-src',
+        };
+        consentUI.handleIframeMessages_({
+          source: 'mock-src',
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+          },
+        });
+
+        expect(handleReadyStub).to.be.calledOnce;
+      });
+    });
+
+    it('should handle a valid initial height', () => {
+      return getReadyIframeCmpConsentUi().then(consentUI => {
+
+        expect(consentUI.initialHeight_).to.be.equal('30vh');
+
+        consentUI.ui_ = {
+          contentWindow: 'mock-src',
+        };
+        consentUI.handleIframeMessages_({
+          source: 'mock-src',
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+            initialHeight: '50vh',
+          },
+        });
+
+        expect(consentUI.initialHeight_).to.be.equal('50vh');
+      });
+    });
+
+    it('should throw an error on an invalid initial height', () => {
+      return getReadyIframeCmpConsentUi().then(consentUI => {
+
+        expect(consentUI.initialHeight_).to.be.equal('30vh');
+
+        return allowConsoleError(() => {
+          consentUI.ui_ = {
+            contentWindow: 'mock-src',
+          };
+          consentUI.handleIframeMessages_({
+            source: 'mock-src',
+            data: {
+              type: 'consent-ui',
+              action: 'ready',
+              initialHeight: '9vh',
+            },
+          });
+
+          expect(consentUI.initialHeight_).to.be.equal('30vh');
+        });
+      });
+    });
+
+    it('should handle a border value', () => {
+      return getReadyIframeCmpConsentUi().then(consentUI => {
+
+        expect(consentUI.enableBorder_).to.be.equal(true);
+
+        consentUI.ui_ = {
+          contentWindow: 'mock-src',
+        };
+        consentUI.handleIframeMessages_({
+          source: 'mock-src',
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+            border: false,
+          },
+        });
+
+        expect(consentUI.enableBorder_).to.be.equal(false);
+      });
     });
   });
 

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -169,7 +169,7 @@ setTimeout(() => {
   // Check if we should randomly do some custom stuff
   const shouldApplyCustom = Math.random() > 0.5;
   if (shouldApplyCustom) {
-    const initialHeight = 10 + Math.floor(Math.random() * 50);
+    const initialHeight = 30 + Math.floor(Math.random() * 30);
     readyObject.initialHeight = `${initialHeight}vh`;
     readyObject.border = Math.random() < 0.5
   }

--- a/test/manual/diy-consent.html
+++ b/test/manual/diy-consent.html
@@ -157,12 +157,26 @@ if (hashMatch) {
   ampWindow = ancestors[depth];
 }
 
-
+// Send our ready event
 setTimeout(() => {
-  parent.postMessage({
+
+  // Our ready object
+  const readyObject = {
     type: 'consent-ui',
     action: 'ready'
-  }, '*');
+  };
+
+  // Check if we should randomly do some custom stuff
+  const shouldApplyCustom = Math.random() > 0.5;
+  if (shouldApplyCustom) {
+    const initialHeight = 10 + Math.floor(Math.random() * 50);
+    readyObject.initialHeight = `${initialHeight}vh`;
+    readyObject.border = Math.random() < 0.5
+  }
+
+  console.log('diy-consent: Sending Ready Message!', readyObject);
+
+  parent.postMessage(readyObject, '*');
 }, 2000);
 
 function registerClickConsentMessage(querySelector, type, action, info, timeout) {


### PR DESCRIPTION
closes #21324

This allows for setting an initial height between `10vh` and `60vh` on iframe ready. As well as optionally removing the border radius and box shadow on the consent iframe container 😄 

# Example

![initialHeightAmpConsent](https://user-images.githubusercontent.com/1448289/54775646-cdddc280-4be4-11e9-8da2-6820531879de.gif)
