### PR TITLE
✨Started a config parser for the amp-experiment 1.0 format

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -10,32 +10,10 @@
   <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <style amp-custom>
-    body[amp-x-background-color-test=yellow] {
-      background-color: yellow;
-    }
-    body[amp-x-background-color-test=green] {
-      background-color: green;
-    }
-    body[amp-x-font-color-test=red] {
-      color: red;
-    }
-    body[amp-x-font-color-test=blue] {
-      color: blue;
-    }
-    body[amp-x-border-test=solid] h1 {
-      border: 1px solid black;
-    }
-    body[amp-x-border-test=dashed] h1 {
-      border: 1px dashed black;
-    }
-    amp-user-notification {
-      background-color: darkgray;
-      padding: 5px;
-    }
   </style>
 </head>
 <body>
-  <h1>Background color is user sticky; text color may change on a refresh</h1>
+  <h1>Title TBD</h1>
 
   <ul>
     <li><a href="#amp-x-background-color-test=yellow" target="_blank">#amp-x-background-color-test=yellow</a></li>
@@ -47,22 +25,40 @@
       {
         "background-color-test": {
           "variants": {
-            "yellow": 50,
-            "green": 50
+            "yellow": {
+              "weight": 50,
+              "mutations": []
+            },
+            "green": {
+              "weight": 50,
+              "mutations": []
+            }
           }
         },
         "font-color-test": {
           "sticky": false,
           "variants": {
-            "blue": 20,
-            "red": 20
+            "blue": {
+              "weight": 20,
+              "mutations": []
+            },
+            "red": {
+              "weight": 20,
+              "mutations": []
+            }
           }
         },
         "border-test": {
           "consentNotificationId": "amp-user-notification",
           "variants": {
-            "solid": 50,
-            "dashed": 50
+            "solid": {
+              "weight": 50,
+              "mutations": []
+            },
+            "dashed": {
+              "weight": 50,
+              "mutations": []
+            }
           }
         }
       }

--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -27,11 +27,11 @@
           "variants": {
             "yellow": {
               "weight": 50,
-              "mutations": []
+              "mutations": [{}]
             },
             "green": {
               "weight": 50,
-              "mutations": []
+              "mutations": [{}]
             }
           }
         },
@@ -40,11 +40,11 @@
           "variants": {
             "blue": {
               "weight": 20,
-              "mutations": []
+              "mutations": [{}]
             },
             "red": {
               "weight": 20,
-              "mutations": []
+              "mutations": [{}]
             }
           }
         },
@@ -53,11 +53,11 @@
           "variants": {
             "solid": {
               "weight": 50,
-              "mutations": []
+              "mutations": [{}]
             },
             "dashed": {
               "weight": 50,
-              "mutations": []
+              "mutations": [{}]
             }
           }
         }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -50,12 +50,12 @@ export class AmpExperiment extends AMP.BaseElement {
             /** @private @const {!Promise<!Object<string, ?string>>} */
             const experimentVariants = Promise.all(variants)
                 .then(() => results)
-                .then(this.applyExperimentVariants_.bind(this, config));
+              .then(this.applyExperimentVariants_.bind(this, config));
 
             variantsService.init(experimentVariants);
           } catch (e) {
             // Ensure downstream consumers don't wait for the promise forever.
-            variantsService.init({});
+            variantsService.init(Promise.resolve({}));
             throw e;
           }
         });

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -50,7 +50,7 @@ export class AmpExperiment extends AMP.BaseElement {
             /** @private @const {!Promise<!Object<string, ?string>>} */
             const experimentVariants = Promise.all(variants)
                 .then(() => results)
-              .then(this.applyExperimentVariants_.bind(this, config));
+                .then(this.applyExperimentVariants_.bind(this, config));
 
             variantsService.init(experimentVariants);
           } catch (e) {

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -95,6 +95,16 @@ export class AmpExperiment extends AMP.BaseElement {
    * Passes the given experiment and variant pairs to the correct handler,
    * to apply the experiment to the document.
    * Experiment with no variant assigned (null) will be skipped.
+   *
+   * For example, the `experimentToVariant` object looks like:
+   * {
+   *   'appliedExperimentName': 'chosenVariantName',
+   *   'anotherAppliedExperimentName': 'chosenVariantName'
+   * }
+   * Which is a simplified version of the config and
+   * represents what variant of each experiment
+   * should be applied.
+   *
    * @param {!JsonObject} config
    * @param {!Object<string, ?string>} experimentToVariant
    * @return {!Promise<!Object<string, ?string>>} a promise of the original
@@ -129,12 +139,13 @@ export class AmpExperiment extends AMP.BaseElement {
    */
   applyMutations_(experimentName, variantObject) {
     const doc = this.getAmpDoc();
-    return doc.whenBodyAvailable().then(body => {
+    return doc.whenBodyAvailable().then(() => {
       // TODO (torch2424): Use a mutation service,
       // and apply mutations
       // Placehodler to pass linting for code review
       // and keep PRs small
-      body.setAttribute(experimentName, JSON.stringify(variantObject));
+      // This is a NOOP
+      variantObject[experimentName] = experimentName;
     });
   }
 }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -96,7 +96,7 @@ export class AmpExperiment extends AMP.BaseElement {
    * to apply the experiment to the document.
    * Experiment with no variant assigned (null) will be skipped.
    * @param {!JsonObject} config
-   * @param {!Object<string, ?string>} experimentResults
+   * @param {!Object<string, ?string>} experimentToVariant
    * @return {!Promise<!Object<string, ?string>>} a promise of the original
    *     param passed in
    * @private

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -61,7 +61,23 @@ export class AmpExperiment extends AMP.BaseElement {
         });
   }
 
-  /** @return {!JsonObject} [description] */
+  /**
+   * The experiment config can be represented as:
+   * const config = {
+   *   experimentObject: {
+   *     // General experiment settings e.g schedule.
+   *     variants: {
+   *       variantObject: {
+   *         // Objects that represent what
+   *         // should change (mutations) when
+   *         // this variant of the experiment is
+   *         // applied (weight)
+   *       }
+   *     }
+   *   }
+   * }
+   * @return {!JsonObject} [description]
+   */
   getConfig_() {
     const {children} = this.element;
     userAssert(
@@ -80,26 +96,27 @@ export class AmpExperiment extends AMP.BaseElement {
    * to apply the experiment to the document.
    * Experiment with no variant assigned (null) will be skipped.
    * @param {!JsonObject} config
-   * @param {!Object<string, ?string>} experiments
+   * @param {!Object<string, ?string>} experimentResults
    * @return {!Promise<!Object<string, ?string>>} a promise of the original
    *     param passed in
    * @private
    */
-  applyExperimentVariants_(config, experiments) {
+  applyExperimentVariants_(config, experimentToVariant) {
 
-    const appliedExperimentVariantPromises = [];
+    const appliedExperimentToVariantPromises = [];
 
-    for (const name in experiments) {
-      if (experiments[name]) {
-        const variantObject = config[name]['variants'][experiments[name]];
-        appliedExperimentVariantPromises.push(
-            this.applyMutations_(name, variantObject)
+    for (const experimentName in experimentToVariant) {
+      const variantName = experimentToVariant[experimentName];
+      if (variantName) {
+        const variantObject = config[experimentName]['variants'][variantName];
+        appliedExperimentToVariantPromises.push(
+            this.applyMutations_(experimentName, variantObject)
         );
       }
     }
 
-    return Promise.all(appliedExperimentVariantPromises)
-        .then(() => experiments);
+    return Promise.all(appliedExperimentToVariantPromises)
+        .then(() => experimentToVariant);
   }
 
   /**

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -29,19 +29,34 @@ describes.realWin('amp-experiment', {
   const config = {
     'experiment-1': {
       variants: {
-        'variant-a': 50,
-        'variant-b': 50,
+        'variant-a': {
+          weight: 50,
+          mutations: [{}]
+        },
+        'variant-b': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     },
     'experiment-2': {
       variants: {
-        'variant-c': 50,
-        'variant-d': 50,
+        'variant-c': {
+          weight: 50,
+          mutations: [{}]
+        },
+        'variant-d': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     },
     'experiment-3': {
       variants: {
-        'variant-e': 1,
+        'variant-e': {
+          weight: 1,
+          mutations: [{}]
+        },
       },
     },
   };
@@ -124,7 +139,7 @@ describes.realWin('amp-experiment', {
     });
   });
 
-  it('should add attributes to body element for the allocated variants', () => {
+  it('should apply the mutations from the variant', () => {
     addConfigElement('script');
     const stub = sandbox.stub(variant, 'allocateVariant');
     stub.withArgs(ampdoc, 'experiment-1', config['experiment-1'])
@@ -132,7 +147,9 @@ describes.realWin('amp-experiment', {
     stub.withArgs(ampdoc, 'experiment-2', config['experiment-2'])
         .returns(Promise.resolve('variant-d'));
     stub.withArgs(ampdoc, 'experiment-3', config['experiment-3'])
-        .returns(Promise.resolve(null));
+      .returns(Promise.resolve(null));
+
+    const applySpy = sandbox.spy(experiment, 'applyMutations_');
 
     experiment.buildCallback();
     return Services.variantsForDocOrNull(ampdoc.getHeadNode())
@@ -143,12 +160,8 @@ describes.realWin('amp-experiment', {
             'experiment-2': 'variant-d',
             'experiment-3': null,
           });
-          expectBodyHasAttributes({
-            'amp-x-experiment-1': 'variant-a',
-            'amp-x-experiment-2': 'variant-d',
-          });
-          expect(doc.body.getAttribute('amp-x-experiment-3'))
-              .to.equal(null);
+
+          expect(applySpy).to.be.calledTwice;
         });
   });
 });

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -17,8 +17,6 @@
 import * as variant from '../variant';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
-import {hasOwn} from '../../../../src/utils/object';
-
 
 describes.realWin('amp-experiment', {
   amp: {
@@ -31,11 +29,11 @@ describes.realWin('amp-experiment', {
       variants: {
         'variant-a': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         'variant-b': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     },
@@ -43,11 +41,11 @@ describes.realWin('amp-experiment', {
       variants: {
         'variant-c': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         'variant-d': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     },
@@ -55,7 +53,7 @@ describes.realWin('amp-experiment', {
       variants: {
         'variant-e': {
           weight: 1,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     },
@@ -79,15 +77,6 @@ describes.realWin('amp-experiment', {
     child.setAttribute('type', opt_type || 'application/json');
     child.textContent = opt_textContent || JSON.stringify(config);
     experiment.element.appendChild(child);
-  }
-
-  function expectBodyHasAttributes(attributes) {
-    for (const attributeName in attributes) {
-      if (hasOwn(attributes, attributeName)) {
-        expect(doc.body.getAttribute(attributeName))
-            .to.equal(attributes[attributeName]);
-      }
-    }
   }
 
   it('should not throw on valid config', () => {
@@ -147,7 +136,7 @@ describes.realWin('amp-experiment', {
     stub.withArgs(ampdoc, 'experiment-2', config['experiment-2'])
         .returns(Promise.resolve('variant-d'));
     stub.withArgs(ampdoc, 'experiment-3', config['experiment-3'])
-      .returns(Promise.resolve(null));
+        .returns(Promise.resolve(null));
 
     const applySpy = sandbox.spy(experiment, 'applyMutations_');
 

--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -107,11 +107,11 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'variant_1': {
             weight: 51,
-            mutations: [{}]
+            mutations: [{}],
           },
           'variant_2': {
             weight: 51,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -122,7 +122,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'negative_percentage': {
             weight: -1,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -133,7 +133,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'too_big_percentage': {
             weight: 101,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -144,7 +144,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'non_number_percentage': {
             weight: '50',
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -155,7 +155,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'variant_1': {
             weight: 50,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -166,7 +166,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'variant_1': {
             weight: 50,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -178,7 +178,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'variant_1': {
             weight: 50,
-            mutations: [{}]
+            mutations: [{}],
           },
         },
       });
@@ -190,7 +190,7 @@ describes.sandboxed('allocateVariant', {}, env => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'variant_1': {
-            weight: 50
+            weight: 50,
           },
         },
       });
@@ -203,7 +203,7 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'variant_1': {
             weight: 50,
-            mutations: []
+            mutations: [],
           },
         },
       });
@@ -216,19 +216,19 @@ describes.sandboxed('allocateVariant', {}, env => {
         variants: {
           'a': {
             weight: 50.1,
-            mutations: [{}]
+            mutations: [{}],
           },
           'b': {
             weight: 40.3,
-            mutations: [{}]
+            mutations: [{}],
           },
           'c': {
             weight: 9.2,
-            mutations: [{}]
+            mutations: [{}],
           },
           'd': {
             weight: 0.4,
-            mutations: [{}]
+            mutations: [{}],
           },
           // They add up to 100.00000000000001​​​ in JS
         },
@@ -242,12 +242,12 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 56.1,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 23.3,
-          mutations: [{}]
-        }
+          mutations: [{}],
+        },
       },
     })).to.eventually.equal('-Variant_2');
   });
@@ -258,12 +258,12 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
-        }
+          mutations: [{}],
+        },
       },
     })).to.eventually.equal('-Variant_2');
   });
@@ -274,15 +274,15 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 2.1,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 23.3,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_3': {
           weight: 20.123,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal(null);
@@ -295,11 +295,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_1');
@@ -312,11 +312,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_2');
@@ -332,11 +332,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_1');
@@ -353,11 +353,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_1');
@@ -374,11 +374,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_1');
@@ -402,11 +402,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal('-Variant_1');
@@ -421,11 +421,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.be.rejectedWith('Notification not found: notif-1');
@@ -446,11 +446,11 @@ describes.sandboxed('allocateVariant', {}, env => {
       variants: {
         '-Variant_1': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
         '-Variant_2': {
           weight: 50,
-          mutations: [{}]
+          mutations: [{}],
         },
       },
     })).to.eventually.equal(null);

--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -84,11 +84,11 @@ describes.sandboxed('allocateVariant', {}, env => {
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {});
-    }).to.throw(/Missing experiment variants config/); });
+    }).to.throw(/Missing variants/); });
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {variants: {}});
-    }).to.throw(/Missing experiment variants config/); });
+    }).to.throw(/Missing variants/); });
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
@@ -101,8 +101,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
-          'variant_1': 50,
-          'variant_2': 51,
+          'variant_1': {
+            weight: 51,
+            mutations: [{}]
+          },
+          'variant_2': {
+            weight: 51,
+            mutations: [{}]
+          },
         },
       });
     }).to.throw(/Total percentage is bigger than 100/); });
@@ -110,31 +116,43 @@ describes.sandboxed('allocateVariant', {}, env => {
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
-          'negative_percentage': -1,
+          'negative_percentage': {
+            weight: -1,
+            mutations: [{}]
+          },
         },
       });
-    }).to.throw(/Invalid percentage/); });
+    }).to.throw(/Invalid weight percentage/); });
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
-          'too_big_percentage': 101,
+          'too_big_percentage': {
+            weight: 101,
+            mutations: [{}]
+          },
         },
       });
-    }).to.throw(/Invalid percentage/); });
+    }).to.throw(/Invalid weight percentage/); });
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
-          'non_number_percentage': '50',
+          'non_number_percentage': {
+            weight: '50',
+            mutations: [{}]
+          },
         },
       });
-    }).to.throw(/Invalid percentage/); });
+    }).to.throw(/must have a number weight/); });
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'invalid_name!', {
         variants: {
-          'variant_1': 50,
+          'variant_1': {
+            weight: 50,
+            mutations: [{}]
+          },
         },
       });
     }).to.throw(/Invalid name/); });
@@ -142,7 +160,10 @@ describes.sandboxed('allocateVariant', {}, env => {
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, '', {
         variants: {
-          'variant_1': 50,
+          'variant_1': {
+            weight: 50,
+            mutations: [{}]
+          },
         },
       });
     }).to.throw(/Invalid name/); });
@@ -151,7 +172,10 @@ describes.sandboxed('allocateVariant', {}, env => {
       allocateVariant(ampdoc, 'name', {
         group: 'invalid_group_name!',
         variants: {
-          'variant_1': 50,
+          'variant_1': {
+            weight: 50,
+            mutations: [{}]
+          },
         },
       });
     }).to.throw(/Invalid name/); });
@@ -161,10 +185,22 @@ describes.sandboxed('allocateVariant', {}, env => {
     expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
-          'a': 50.1,
-          'b': 40.3,
-          'c': 9.2,
-          'd': 0.4,
+          'a': {
+            weight: 50.1,
+            mutations: [{}]
+          },
+          'b': {
+            weight: 40.3,
+            mutations: [{}]
+          },
+          'c': {
+            weight: 9.2,
+            mutations: [{}]
+          },
+          'd': {
+            weight: 0.4,
+            mutations: [{}]
+          },
           // They add up to 100.00000000000001​​​ in JS
         },
       });
@@ -175,8 +211,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       sticky: false,
       variants: {
-        '-Variant_1': 56.1,
-        '-Variant_2': 23.3,
+        '-Variant_1': {
+          weight: 56.1,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 23.3,
+          mutations: [{}]
+        }
       },
     })).to.eventually.equal('-Variant_2');
   });
@@ -185,8 +227,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       sticky: false,
       variants: {
-        '-Variant_2': 50,
-        '-Variant_1': 50,
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        }
       },
     })).to.eventually.equal('-Variant_2');
   });
@@ -195,9 +243,18 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       sticky: false,
       variants: {
-        '-Variant_1': 2.1,
-        '-Variant_2': 23.3,
-        '-Variant_3': 20.123,
+        '-Variant_1': {
+          weight: 2.1,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 23.3,
+          mutations: [{}]
+        },
+        '-Variant_3': {
+          weight: 20.123,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal(null);
   });
@@ -207,8 +264,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'Name', {
       sticky: false,
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_1');
   });
@@ -218,8 +281,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       sticky: false,
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_2');
   });
@@ -232,8 +301,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
     return expect(allocateVariant(ampdoc, 'name', {
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_1');
   });
@@ -247,8 +322,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       cidScope: 'custom-scope',
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_1');
   });
@@ -262,8 +343,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       group: 'custom-group',
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_1');
   });
@@ -284,8 +371,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       consentNotificationId: 'notif-1',
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal('-Variant_1');
   });
@@ -297,8 +390,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       consentNotificationId: 'notif-1',
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.be.rejectedWith('Notification not found: notif-1');
   });
@@ -316,8 +415,14 @@ describes.sandboxed('allocateVariant', {}, env => {
     return expect(allocateVariant(ampdoc, 'name', {
       consentNotificationId: 'notif-1',
       variants: {
-        '-Variant_1': 50,
-        '-Variant_2': 50,
+        '-Variant_1': {
+          weight: 50,
+          mutations: [{}]
+        },
+        '-Variant_2': {
+          weight: 50,
+          mutations: [{}]
+        },
       },
     })).to.eventually.equal(null);
   });

--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -87,6 +87,10 @@ describes.sandboxed('allocateVariant', {}, env => {
     }).to.throw(/Missing variants/); });
 
     allowConsoleError(() => { expect(() => {
+      allocateVariant(ampdoc, 'name', {variants: 52});
+    }).to.throw(/Missing variants/); });
+
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {variants: {}});
     }).to.throw(/Missing variants/); });
 
@@ -179,6 +183,31 @@ describes.sandboxed('allocateVariant', {}, env => {
         },
       });
     }).to.throw(/Invalid name/); });
+  });
+
+  it('should check that mutations exist', () => {
+    allowConsoleError(() => { expect(() => {
+      allocateVariant(ampdoc, 'name', {
+        variants: {
+          'variant_1': {
+            weight: 50
+          },
+        },
+      });
+    }).to.throw(/mutations array/); });
+  });
+
+  it('should check that has at least one mutation', () => {
+    allowConsoleError(() => { expect(() => {
+      allocateVariant(ampdoc, 'name', {
+        variants: {
+          'variant_1': {
+            weight: 50,
+            mutations: []
+          },
+        },
+      });
+    }).to.throw(/one mutation/); });
   });
 
   it('should work around float rounding error', () => {

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -217,7 +217,7 @@ function assertVariant(variant, experimentName, variantName) {
   userAssert(
       variant['weight'] !== undefined &&
     typeof variant['weight'] === 'number',
-      `${experimentName}.variants.${variantName} must have a weight.`);
+      `${experimentName}.variants.${variantName} must have a number weight.`);
 
   // Assert the variant weight is a percentage
   const percentage = variant['weight'];

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -140,7 +140,7 @@ export function allocateVariant(ampdoc, experimentName, experimentObject) {
 function validateExperiment(experimentName, experimentObject) {
   const variants = experimentObject['variants'];
   userAssert(isObject(variants) && Object.keys(variants).length > 0,
-      'Missing variants from experiment.');
+      'Missing variants object from experiment.');
   if (experimentObject['group']) {
     assertName(experimentObject['group']);
   }

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -46,7 +46,9 @@ export class Variants {
    * @restricted
    */
   init(variants) {
-    variants.then(this.variantsDeferred_.resolve);
+    variants.then(result =>
+      this.variantsDeferred_.resolve(result)
+    );
   }
 
   /**
@@ -117,7 +119,7 @@ export function allocateVariant(ampdoc, experimentName, config) {
           // enumeration is implementation (browser) dependent.
           const variantNames = Object.keys(config['variants']).sort();
           for (let i = 0; i < variantNames.length; i++) {
-            upperBound += config['variants'][variantNames[i]].weight;
+            upperBound += config['variants'][variantNames[i]]['weight'];
             if (ticket < upperBound) {
               return variantNames[i];
             }
@@ -153,13 +155,7 @@ function validateConfig(experimentName, config) {
           variantName
       );
 
-      const percentage = variant.weight;
-
-      userAssert(
-          percentage && percentage > 0 && percentage < 100,
-          'Invalid percentage %s:%s.'
-        + ' Has to be greater than 0 and less than 100',
-          variantName, percentage);
+      const percentage = variant['weight'];
       totalPercentage += percentage;
     }
   }
@@ -221,9 +217,26 @@ function assertVariant(variant, experimentName, variantName) {
     typeof variant['weight'] === 'number',
       `${experimentName}.${variantName} must have a weight.`);
 
+  // Assert the variant weight is a percentage
+  const percentage = variant['weight'];
+  userAssert(
+      percentage > 0 && percentage < 100,
+      'Invalid weight percentage %s.'
+    + ` ${experimentName}.${variantName}` +
+    ' Has to be greater than 0 and less than 100',
+      percentage);
+
+
   // Assert the variant mutations
   userAssert(
-      isArray(variant['mutations']),
+      variant['mutations'] && isArray(variant['mutations']),
       `${experimentName}.${variantName} must have a mutations array.`);
+
+  // Assert the variant has mutations
+  userAssert(
+      variant['mutations'].length > 0,
+      `${experimentName}.${variantName} mutations,`
+    + 'must have at least one mutation.');
+
 }
 

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -85,7 +85,7 @@ export function allocateVariant(ampdoc, experimentName, experimentObject) {
   // Variant can be overridden from URL fragment.
   const viewer = Services.viewerForDoc(ampdoc);
   const override = viewer.getParam(ATTR_PREFIX + experimentName);
-  if (override && hasOwn(config['variants'], override)) {
+  if (override && hasOwn(experimentObject['variants'], override)) {
     return Promise.resolve(/** @type {?string} */ (override));
   }
 
@@ -98,10 +98,11 @@ export function allocateVariant(ampdoc, experimentName, experimentObject) {
     const element = ampdoc.getHeadNode();
     hasConsentPromise = Services.userNotificationManagerForDoc(element)
         .then(manager => manager.getNotification(
-          experimentObject['consentNotificationId']))
+            experimentObject['consentNotificationId']))
         .then(userNotification => {
           userAssert(userNotification,
-            `Notification not found: ${experimentObject['consentNotificationId']}`);
+              'Notification not found: ' +
+            `${experimentObject['consentNotificationId']}`);
           return userNotification.isDismissed();
         });
   }
@@ -216,27 +217,27 @@ function assertVariant(variant, experimentName, variantName) {
   userAssert(
       variant['weight'] !== undefined &&
     typeof variant['weight'] === 'number',
-    `${experimentName}.variants.${variantName} must have a weight.`);
+      `${experimentName}.variants.${variantName} must have a weight.`);
 
   // Assert the variant weight is a percentage
   const percentage = variant['weight'];
   userAssert(
-    percentage > 0 && percentage < 100,
-    'Invalid weight percentage %s.'
+      percentage > 0 && percentage < 100,
+      'Invalid weight percentage %s.'
     + ` ${experimentName}.variants.${variantName}` +
     ' Has to be greater than 0 and less than 100',
-    percentage);
+      percentage);
 
 
   // Assert the variant mutations
   userAssert(
       variant['mutations'] && isArray(variant['mutations']),
-    `${experimentName}.variants.${variantName} must have a mutations array.`);
+      `${experimentName}.variants.${variantName} must have a mutations array.`);
 
   // Assert the variant has mutations
   userAssert(
-    variant['mutations'].length > 0,
-    `${experimentName}.variants.${variantName} mutations`
+      variant['mutations'].length > 0,
+      `${experimentName}.variants.${variantName} mutations`
     + ' must have at least one mutation.');
 }
 

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -41,7 +41,7 @@ export class Variants {
   }
 
   /**
-   * @param {!Promise<!Object<string, ?string>>} variants
+   * @param {!Promise<!Object>} variants
    * @package
    * @restricted
    */


### PR DESCRIPTION
relates to #20225
relates to #21484

This starts the config parser for the 1.0 format (see #20225). Most importantly here, this preserves the analytics, but also passes an object down to `applyMutations_()` which can then use a mutation service to start ingestion of mutations (later PR).

* [x] **This still requires tests. Want code approved before writing the tests** 😄 

# Example

**First image had some testing code to show things work**

<img width="1440" alt="Screen Shot 2019-03-14 at 11 39 18 AM" src="https://user-images.githubusercontent.com/1448289/54776434-80625500-4be6-11e9-98a6-7b97e49c21bf.png">

<img width="1440" alt="Screen Shot 2019-03-21 at 2 31 45 PM" src="https://user-images.githubusercontent.com/1448289/54776440-835d4580-4be6-11e9-9736-6c2e202d3d34.png">
