### PR TITLE
🐛Update Scroll amp-access extension placeholder CSS to match current UI

### DIFF
--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -25,8 +25,8 @@
 }
 
 .amp-access-scroll-placeholder {
-  padding-top: 7px;
-  padding-left: 8px;
+  padding-top: 5px;
+  padding-left: 16px;
   background-color: #fff;
   border-top: 1px solid #eee;
   border-bottom: 1px solid #eee;

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -294,10 +294,10 @@ class ScrollElement {
     placeholder.classList.add('amp-access-scroll-placeholder');
     const img = document.createElement('img');
     img.setAttribute('src',
-        'https://static.scroll.com/assets/icn-scroll-logo.svg');
+        'https://static.scroll.com/assets/icn-scroll-logo32-9f4ceef399905139bbd26b87bfe94542.svg');
     img.setAttribute('layout', 'fixed');
-    img.setAttribute('width', 26);
-    img.setAttribute('height', 26);
+    img.setAttribute('width', 32);
+    img.setAttribute('height', 32);
     placeholder.appendChild(img);
     this.ampdoc_.getBody().appendChild(placeholder);
 


### PR DESCRIPTION
This PR updates the styling of the placeholder rendered by the amp-access-scroll extension to match the content loaded in later (similar to #14993 )

cc @kushal 