### PR TITLE
Launch amp-img-auto-sizes to 10% of production

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -58,5 +58,6 @@
   "amp-list-resizable-children": 1,
   "amp-auto-lightbox": 0.5,
   "amp-list-load-more": 1,
-  "amp-ad-ff-adx-ady": 0.01
+  "amp-ad-ff-adx-ady": 0.01,
+  "amp-img-auto-sizes": 0.1
 }


### PR DESCRIPTION
Master issue: https://github.com/ampproject/amphtml/issues/19513. 

Relatedly, we tried out this feature in https://github.com/ampproject/amphtml/issues/17053, and found https://github.com/ampproject/amphtml/issues/21371. It is surfaced due to the change in this experiment but is fundamentally an issue with `layout=INTRINSIC`.  Since workarounds exist, we should be able to launch auto-sizes in parallel. However, if anything here is blocking and needs to be fixed prior to launching this to 10%, please kindly let me know. =) 

/fyi @westonruter 