### PR TITLE
 🏗 Fix launching IE when running integration tests locally

### DIFF
--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -59,7 +59,13 @@ function getConfig() {
     return Object.assign({}, karmaDefault, {browsers: ['Edge']});
   }
   if (argv.ie) {
-    return Object.assign({}, karmaDefault, {browsers: ['IE']});
+    return Object.assign({}, karmaDefault, {browsers: ['IE_no_addons'],
+    customLaunchers: {
+      IE_no_addons: {
+        base:  'IE',
+        flags: ['-extoff']
+      }
+    }});
   }
   if (argv.chrome_canary && !argv.chrome_flags) {
     return Object.assign({}, karmaDefault, {browsers: ['ChromeCanary']});

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -59,13 +59,13 @@ function getConfig() {
     return Object.assign({}, karmaDefault, {browsers: ['Edge']});
   }
   if (argv.ie) {
-    return Object.assign({}, karmaDefault, {browsers: ['IE_no_addons'],
-    customLaunchers: {
-      IE_no_addons: {
-        base:  'IE',
-        flags: ['-extoff']
-      }
-    }});
+    return Object.assign({}, karmaDefault, {browsers: ['IE'],
+      customLaunchers: {
+        IeNoAddOns: {
+          base: 'IE',
+          flags: ['-extoff'],
+        },
+      }});
   }
   if (argv.chrome_canary && !argv.chrome_flags) {
     return Object.assign({}, karmaDefault, {browsers: ['ChromeCanary']});


### PR DESCRIPTION
Fixes bug when running integration tests on local IE browser, e.g. `gulp test --integration --nobuild --ie`

Bug is that IE fails to launch. Uses `IE_no_addons` custom launcher as default, which disables IE extensions as instructed here:
https://github.com/karma-runner/karma-ie-launcher#running-ie-in-no-add-ons-mode