### PR TITLE
🖍 Enable blurry-image placeholder transition experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -59,5 +59,6 @@
   "amp-auto-lightbox": 1,
   "amp-img-auto-sizes": 1,
   "amp-list-load-more": 1,
-  "amp-ad-ff-adx-ady": 0.01
+  "amp-ad-ff-adx-ady": 0.01,
+  "blurry-placeholder": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -59,5 +59,6 @@
   "amp-auto-lightbox": 0.5,
   "amp-list-load-more": 1,
   "amp-ad-ff-adx-ady": 0.01,
-  "amp-img-auto-sizes": 0.1
+  "amp-img-auto-sizes": 0.1,
+  "blurry-placeholder": 1
 }


### PR DESCRIPTION
This is low risk experiment that fades a blurry-image placeholder into the real image when the real image loads.