### PR TITLE
Prerender elements in document order.

### DIFF
--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -50,4 +50,9 @@ export const CommonSignals = {
    * The element has been unlaid out.
    */
   UNLOAD: 'unload',
+
+  /**
+   * The element upgrade has completed.
+   */
+  UPGRADED: 'upgraded',
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -432,6 +432,7 @@ function createBaseCustomElementClass(win) {
       this.implementation_.firstAttachedCallback();
       this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
       this.getResources().upgraded(this);
+      this.signals_.signal(CommonSignals.UPGRADED);
     }
 
     /** @private */
@@ -466,6 +467,15 @@ function createBaseCustomElementClass(win) {
      */
     whenBuilt() {
       return this.signals_.whenSignal(CommonSignals.BUILT);
+    }
+
+    /**
+     * Returns the promise that's resolved when the element has been upgraded.
+     * If the upgrades fails, the resulting promise is rejected.
+     * @return {!Promise}
+     */
+    whenUpgradeCompleted() {
+      return this.signals_.whenSignal(CommonSignals.UPGRADED);
     }
 
     /**
@@ -879,6 +889,8 @@ function createBaseCustomElementClass(win) {
           this.completeUpgrade_(upgrade || impl, startTime);
         }).catch(reason => {
           this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
+          this.signals_.rejectSignal(
+              CommonSignals.UPGRADED, /** @type {!Error} */ (reason));
           rethrowAsync(reason);
         });
       } else {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -601,6 +601,14 @@ export class Resources {
 
   /**
    * Builds resources in document order during prerendering.
+   * This method is called every time an AMP element is attached to the DOM
+   * during prerendering. It traverses the DOM tree in document order to
+   * discover AMP elements to build. Because the DOM might still be
+   * streaming/parsing the first time the it is traversed, we rely on the
+   * element upgrade to resume the traversing, and discover new elements to
+   * prerender.
+   * If enough elements were already prerendered or the DOM is fully traversed,
+   * this is a no-op.
    * @private
    */
   prerenderElements_() {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -558,7 +558,8 @@ export class Resources {
     // Most documents have 10 or less AMP tags. By building 20 we should not
     // change the behavior for the vast majority of docs, and almost always
     // catch everything in the first viewport.
-    return this.buildAttemptsCount_++ < MAX_BUILDS_IN_PRERENDER ||
+    return (this.useDocumentOrderPrerendering_ ||
+        this.buildAttemptsCount_++ < MAX_BUILDS_IN_PRERENDER) ||
         this.viewer_.hasBeenVisible();
   }
 
@@ -627,8 +628,7 @@ export class Resources {
       whenUpgradedToCustomElement(el)
           .then(() => el.whenUpgradeCompleted())
           .then(() => {
-            if (this.viewer_.getVisibilityState() !==
-                VisibilityState.PRERENDER) {
+            if (this.viewer_.hasBeenVisible()) {
               return;
             }
             const r = Resource.forElement(el);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -426,6 +426,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/19869',
     cleanupIssue: 'TODO',
   },
+  {
+    id: 'amp-prerender-in-document-order',
+    name: 'Prerenders the AMP elements in document order.',
+    spec: 'https://github.com/ampproject/amphtml/issues/21791',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/21792',
+  },
 ];
 
 if (getMode().localDev) {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -427,7 +427,7 @@ const EXPERIMENTS = [
     cleanupIssue: 'TODO',
   },
   {
-    id: 'amp-prerender-in-document-order',
+    id: 'amp-document-order-prerender',
     name: 'Prerenders the AMP elements in document order.',
     spec: 'https://github.com/ampproject/amphtml/issues/21791',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/21792',


### PR DESCRIPTION
Prerendering the first 20 elements in document order.
Full context and design are available here: https://github.com/ampproject/amphtml/issues/21791

The code lives behind the `amp-prerender-in-document-order` experiment.

Fixes #21791, #21432