### PR TITLE
🐛Accept "ol" as a child of amp-sidebar > nav

### DIFF
--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!-- DO NOT SUBMIT: Fix Page Title. Missing tags? http://go/optional-html -->
+<title>Page Title</title>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!-- DO NOT SUBMIT: Fix Page Title. Missing tags? http://go/optional-html -->
+<title>Page Title</title>
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      margin: 0;
+    }
+
+    .ad-container {
+      display: flex;
+      justify-content: center;
+    }
+
+    .content-container p {
+      line-height: 24px;
+    }
+
+    .article-body {
+      padding: 15px;
+    }
+    h1 {
+      margin: 5px 0;
+      font-weight: normal;
+    }
+
+    hr {
+      margin: 0;
+    }
+
+    amp-sidebar ul {
+      list-style: none;
+    }
+    amp-sidebar li {
+      cursor: pointer;
+      height: 30px;
+    }
+
+    amp-sidebar {
+      width: 50vw;
+    }
+
+    #mybody section{
+      background: red;
+    }
+
+    body#mybody > amp-sidebar {
+      background: grey;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+
+</head>
+<body id="mybody">
+  <amp-sidebar layout="nodisplay" id="sidebar" side="left">
+    <nav id="toolbar" toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="left-target-id">
+        <ol>
+          <li>Nav item 1</li>
+          <li>Nav item 2</li>
+          <li>Nav item 3</li>
+        </ol>
+    </nav>
+  </amp-sidebar>
+
+  <h1>AMP Sidebar Example</h1>
+  <button on='tap:sidebar.toggle'
+    aria-label="Click to toglge sidebar">
+    Toggle sidebar
+  </button>
+  <div id="target-id"></div>
+
+  <article>
+    <div class="content-container">
+      <div class="article-body">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+          luctus nunc ut elit cursus, et imperdiet diam vehicula.
+          Duis et nisi sed urna blandit bibendum et sit amet erat.
+          Suspendisse potenti. Curabitur consequat volutpat arcu nec
+          elementum. Etiam a turpis ac libero varius condimentum.
+          Maecenas sollicitudin felis aliquam tortor vulputate,
+          ac posuere velit semper.
+        </p>
+        <p>
+          Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+          ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+          et lectus. Sed tempus eget enim eget lobortis.
+          Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+          Nullam in libero nisi.
+        </p>
+      </div>
+    </div>
+  </article>
+</body>
+</html>

--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!-- DO NOT SUBMIT: Fix Page Title. Missing tags? http://go/optional-html -->
+<title>Page Title</title>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!-- DO NOT SUBMIT: Fix Page Title. Missing tags? http://go/optional-html -->
+<title>Page Title</title>
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      margin: 0;
+    }
+
+    .ad-container {
+      display: flex;
+      justify-content: center;
+    }
+
+    .content-container p {
+      line-height: 24px;
+    }
+
+    .article-body {
+      padding: 15px;
+    }
+    h1 {
+      margin: 5px 0;
+      font-weight: normal;
+    }
+
+    hr {
+      margin: 0;
+    }
+
+    amp-sidebar ul {
+      list-style: none;
+    }
+    amp-sidebar li {
+      cursor: pointer;
+      height: 30px;
+    }
+
+    amp-sidebar {
+      width: 50vw;
+    }
+
+    #mybody section{
+      background: red;
+    }
+
+    body#mybody > amp-sidebar {
+      background: grey;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+
+</head>
+<body id="mybody">
+  <amp-sidebar layout="nodisplay" id="sidebar" side="left">
+    <nav id="toolbar" toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="left-target-id">
+        <ul>
+          <li>Nav item 1</li>
+          <li>Nav item 2</li>
+          <li>Nav item 3</li>
+        </ul>
+    </nav>
+  </amp-sidebar>
+
+  <h1>AMP Sidebar Example</h1>
+  <button on='tap:sidebar.toggle'
+    aria-label="Click to toglge sidebar">
+    Toggle sidebar
+  </button>
+  <div id="target-id"></div>
+
+  <article>
+    <div class="content-container">
+      <div class="article-body">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+          luctus nunc ut elit cursus, et imperdiet diam vehicula.
+          Duis et nisi sed urna blandit bibendum et sit amet erat.
+          Suspendisse potenti. Curabitur consequat volutpat arcu nec
+          elementum. Etiam a turpis ac libero varius condimentum.
+          Maecenas sollicitudin felis aliquam tortor vulputate,
+          ac posuere velit semper.
+        </p>
+        <p>
+          Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+          ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+          et lectus. Sed tempus eget enim eget lobortis.
+          Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+          Nullam in libero nisi.
+        </p>
+      </div>
+    </div>
+  </article>
+</body>
+</html>

--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Description of this file.
+ */
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const {verifySelectorsVisible} = require('../../../build-system/tasks/visual-diff/helpers');
+
+module.exports = {
+  'open sidebar toolbar': async (page, name) => {
+    await page.tap('[on="tap:sidebar.toggle"]');
+    await verifySelectorsVisible(page, name, ['amp-sidebar[open]']);
+    await verifySelectorsVisible(page, name, ['nav[toolbar]']);
+  },
+};

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -49,7 +49,7 @@ amp-sidebar[side] {
   transition: transform 233ms cubic-bezier(0,0,.21,1);
 }
 
-.i-amphtml-toolbar > ul {
+.i-amphtml-toolbar > ul, .i-amphtml-toolbar > ol {
   display: flex;
   justify-content: flex-start;
   flex-wrap: wrap;

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar-autoscroll-valid.html
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar-autoscroll-valid.html
@@ -31,22 +31,42 @@
   <!-- Valid: Example of amp-sidebar usage with autoscroll-->
   <amp-sidebar side="left" layout="nodisplay">
     <ul>
-        <li>Nav item 1</li>
-        <li autoscroll>Nav item 2</li>
-        <li>Nav item 3</li>
-      </ul>
+      <li>Nav item 1</li>
+      <li autoscroll>Nav item 2</li>
+      <li>Nav item 3</li>
+    </ul>
     <amp-img layout="fill" src="img"></amp-img>
   </amp-sidebar>
   <!-- Valid: Example of amp-sidebar with toolbar usage with autoscroll-->
   <amp-sidebar layout="nodisplay">
-      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
-        <ul>
-          <li>Nav item 1</li>
-          <li autoscroll>Nav item 2</li>
-          <li>Nav item 3</li>
-        </ul>
-      </nav>
-      <amp-img layout="fill" src="img"></amp-img>
-    </amp-sidebar>
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ul>
+        <li>Nav item 1</li>
+        <li autoscroll>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ul>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Valid: Example of amp-sidebar usage with ol child autoscroll-->
+  <amp-sidebar side="left" layout="nodisplay">
+    <ol>
+      <li>Nav item 1</li>
+      <li autoscroll>Nav item 2</li>
+      <li>Nav item 3</li>
+    </ol>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Valid: Example of amp-sidebar with ol child and toolbar usage with autoscroll-->
+  <amp-sidebar layout="nodisplay">
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ol>
+        <li>Nav item 1</li>
+        <li autoscroll>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ol>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
 </body>
 </html>

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar-autoscroll-valid.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar-autoscroll-valid.out
@@ -32,22 +32,42 @@ PASS
 |    <!-- Valid: Example of amp-sidebar usage with autoscroll-->
 |    <amp-sidebar side="left" layout="nodisplay">
 |      <ul>
-|          <li>Nav item 1</li>
-|          <li autoscroll>Nav item 2</li>
-|          <li>Nav item 3</li>
-|        </ul>
+|        <li>Nav item 1</li>
+|        <li autoscroll>Nav item 2</li>
+|        <li>Nav item 3</li>
+|      </ul>
 |      <amp-img layout="fill" src="img"></amp-img>
 |    </amp-sidebar>
 |    <!-- Valid: Example of amp-sidebar with toolbar usage with autoscroll-->
 |    <amp-sidebar layout="nodisplay">
-|        <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
-|          <ul>
-|            <li>Nav item 1</li>
-|            <li autoscroll>Nav item 2</li>
-|            <li>Nav item 3</li>
-|          </ul>
-|        </nav>
-|        <amp-img layout="fill" src="img"></amp-img>
-|      </amp-sidebar>
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+|        <ul>
+|          <li>Nav item 1</li>
+|          <li autoscroll>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ul>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Valid: Example of amp-sidebar usage with ol child autoscroll-->
+|    <amp-sidebar side="left" layout="nodisplay">
+|      <ol>
+|        <li>Nav item 1</li>
+|        <li autoscroll>Nav item 2</li>
+|        <li>Nav item 3</li>
+|      </ol>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Valid: Example of amp-sidebar with ol child and toolbar usage with autoscroll-->
+|    <amp-sidebar layout="nodisplay">
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+|        <ol>
+|          <li>Nav item 1</li>
+|          <li autoscroll>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ol>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
 |  </body>
 |  </html>

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.html
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.html
@@ -43,7 +43,7 @@
     </amp-accordion>
     <amp-img layout="fill" src="img"></amp-img>
   </amp-sidebar>
-  <!-- Valid: Example of amp-sidebar with toolbar usage -->
+  <!-- Valid: Example of amp-sidebar with toolbar usage and ul -->
   <amp-sidebar layout="nodisplay">
     <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
       <ul>
@@ -51,6 +51,17 @@
         <li>Nav item 2</li>
         <li>Nav item 3</li>
       </ul>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Valid: Example of amp-sidebar with toolbar usage and ol-->
+  <amp-sidebar layout="nodisplay">
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ol>
+        <li>Nav item 1</li>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ol>
     </nav>
     <amp-img layout="fill" src="img"></amp-img>
   </amp-sidebar>
@@ -67,6 +78,32 @@
     </nav>
     <amp-img layout="fill" src="img"></amp-img>
   </amp-sidebar>
+  <!-- Invalid: more than one <ol> tag -->
+  <amp-sidebar layout="nodisplay">
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ol>
+        <li>Nav item 1</li>
+      </ol>
+      <ol>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ol>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Invalid: both <ul> and <ol> tags -->
+    <amp-sidebar layout="nodisplay">
+      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+        <ul>
+          <li>Nav item 1</li>
+        </ul>
+        <ol>
+          <li>Nav item 2</li>
+          <li>Nav item 3</li>
+        </ol>
+      </nav>
+      <amp-img layout="fill" src="img"></amp-img>
+    </amp-sidebar>
   <!-- Invalid: incorrect side value -->
   <amp-sidebar side="center" layout="nodisplay"></amp-sidebar>
 </body>

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
@@ -44,7 +44,7 @@ FAIL
 |      </amp-accordion>
 |      <amp-img layout="fill" src="img"></amp-img>
 |    </amp-sidebar>
-|    <!-- Valid: Example of amp-sidebar with toolbar usage -->
+|    <!-- Valid: Example of amp-sidebar with toolbar usage and ul -->
 |    <amp-sidebar layout="nodisplay">
 |      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
 |        <ul>
@@ -52,6 +52,17 @@ FAIL
 |          <li>Nav item 2</li>
 |          <li>Nav item 3</li>
 |        </ul>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Valid: Example of amp-sidebar with toolbar usage and ol-->
+|    <amp-sidebar layout="nodisplay">
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+|        <ol>
+|          <li>Nav item 1</li>
+|          <li>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ol>
 |      </nav>
 |      <amp-img layout="fill" src="img"></amp-img>
 |    </amp-sidebar>
@@ -59,7 +70,7 @@ FAIL
 |    <amp-sidebar layout="nodisplay">
 |      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
 >>     ^~~~~~~~~
-amp-sidebar/0.1/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:70:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
 |        <ul>
 |          <li>Nav item 1</li>
 |        </ul>
@@ -70,9 +81,39 @@ amp-sidebar/0.1/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' mus
 |      </nav>
 |      <amp-img layout="fill" src="img"></amp-img>
 |    </amp-sidebar>
+|    <!-- Invalid: more than one <ol> tag -->
+|    <amp-sidebar layout="nodisplay">
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+>>     ^~~~~~~~~
+amp-sidebar/0.1/test/validator-amp-sidebar.html:83:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+|        <ol>
+|          <li>Nav item 1</li>
+|        </ol>
+|        <ol>
+|          <li>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ol>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Invalid: both <ul> and <ol> tags -->
+|      <amp-sidebar layout="nodisplay">
+|        <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+>>       ^~~~~~~~~
+amp-sidebar/0.1/test/validator-amp-sidebar.html:96:6 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+|          <ul>
+|            <li>Nav item 1</li>
+|          </ul>
+|          <ol>
+|            <li>Nav item 2</li>
+|            <li>Nav item 3</li>
+|          </ol>
+|        </nav>
+|        <amp-img layout="fill" src="img"></amp-img>
+|      </amp-sidebar>
 |    <!-- Invalid: incorrect side value -->
 |    <amp-sidebar side="center" layout="nodisplay"></amp-sidebar>
 >>   ^~~~~~~~~
-amp-sidebar/0.1/test/validator-amp-sidebar.html:71:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [DISALLOWED_HTML]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:108:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [DISALLOWED_HTML]
 |  </body>
 |  </html>

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -131,7 +131,7 @@ You can create a `toolbar` element that displays in the `<body>` by specifying t
 - The sidebar may implement toolbars by adding nav elements with the `toolbar` attribute and `toolbar-target` attribute.
 - The nav element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
     - For instance, this would be a valid use of toolbar: `<nav toolbar="(max-width: 1024px)" toolbar-target="target-element">`.
-- The nav containing the toolbar attribute must only contain a single `<ul>` or `ol` element, that contains `<li>` elements.
+- The nav containing the toolbar attribute must only contain a single `<ul>` or `<ol>` element, that contains `<li>` elements.
     - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
 - Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -131,7 +131,7 @@ You can create a `toolbar` element that displays in the `<body>` by specifying t
 - The sidebar may implement toolbars by adding nav elements with the `toolbar` attribute and `toolbar-target` attribute.
 - The nav element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
     - For instance, this would be a valid use of toolbar: `<nav toolbar="(max-width: 1024px)" toolbar-target="target-element">`.
-- The nav containing the toolbar attribute must only contain a single `<ul>` element, that contains `<li>` elements.
+- The nav containing the toolbar attribute must only contain a single `<ul>` or `ol` element, that contains `<li>` elements.
     - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
 - Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
 

--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -92,7 +92,7 @@ tags: {  # amp-sidebar > nav
   }
   child_tags: {
     mandatory_num_child_tags: 1
-    child_tag_name_oneof: "UL"
     child_tag_name_oneof: "OL"
+    child_tag_name_oneof: "UL"
   }
 }

--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -93,5 +93,6 @@ tags: {  # amp-sidebar > nav
   child_tags: {
     mandatory_num_child_tags: 1
     child_tag_name_oneof: "UL"
+    child_tag_name_oneof: "OL"
   }
 }

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -227,6 +227,17 @@
       "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar.js",
     },
     {
+      "url": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html",
+      "name": "amp-sidebar toolbar > ol",
+      "viewport": {"width": 400, "height": 800},
+      "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js",
+    },{
+      "url": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html",
+      "name": "amp-sidebar toolbar > ul",
+      "viewport": {"width": 400, "height": 800},
+      "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js",
+    },
+    {
       "url": "examples/visual-tests/amp-sticky-ad/amp-sticky-ad.amp.html",
       "name": "AMP Sticky Ad",
       "viewport": {


### PR DESCRIPTION
Resolves #20312 

- Validate `ol` as a child of `amp-sidebar > nav`.
- Add additional examples in validator tests