### PR TITLE
✨ Removing prerender check to include SXG performance marks

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -380,15 +380,13 @@ export class Performance {
     const didStartInPrerender = !this.viewer_.hasBeenVisible();
     let docVisibleTime = didStartInPrerender ? -1 : this.initTime_;
 
-    // This is only relevant if the viewer is in prerender mode.
+    // This will only be relevant if the viewer is in prerender mode.
     // (hasn't been visible yet, ever at this point)
-    if (didStartInPrerender) {
-      this.viewer_.whenFirstVisible().then(() => {
-        docVisibleTime = this.win.Date.now();
-        // Mark this first visible instance in the browser timeline.
-        this.mark('visible');
-      });
-    }
+    this.viewer_.whenFirstVisible().then(() => {
+      docVisibleTime = this.win.Date.now();
+      // Mark this first visible instance in the browser timeline.
+      this.mark('visible');
+    });
 
     this.whenViewportLayoutComplete_().then(() => {
       if (didStartInPrerender) {


### PR DESCRIPTION
Removing the prerender check for the 'visible' performance mark and instead waiting on this.viewer_.whenFirstVisible() in all cases

When measuring the performance of a page using amp signed exchange (SXG) we don't want to wait on the hasBeenVisible since there is no prerender. 

See this document for more details: https://docs.google.com/document/d/1DcnglmBUuZ6pLp_Y3cn0c9StJOIfUAricQtdj--Fbm4/edit?ts=5c8a697e#


