### PR TITLE
✨Expose the `select` event on amp-autocomplete.

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -23,6 +23,7 @@ import {UrlReplacementPolicy,
   batchFetchJsonFor} from '../../../src/batched-json';
 import {childElementsByTag,
   removeChildren} from '../../../src/dom';
+import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user, userAssert} from '../../../src/log';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {includes, startsWith} from '../../../src/string';
@@ -30,7 +31,6 @@ import {isEnumValue} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {toggle} from '../../../src/style';
-import {createCustomEvent} from '../../../src/event-helper';
 
 const EXPERIMENT = 'amp-autocomplete';
 const TAG = 'amp-autocomplete';
@@ -484,18 +484,19 @@ export class AmpAutocomplete extends AMP.BaseElement {
       return;
     }
     this.inputElement_.value = this.userInput_ = element.getAttribute('value');
-    this.fireSelectEvent_(element);
+    this.fireSelectEvent_(this.userInput_);
     this.clearAllItems_();
   }
 
-   /**
-   * Triggers a 'select' event with this.userInput_ as the value emitted.
+  /**
+   * Triggers a 'select' event with the given value as the value emitted.
+   * @param {string} value
    * @private
    */
-  fireSelectEvent_() {
+  fireSelectEvent_(value) {
     const name = 'select';
-    const selectEvent = createCustomEvent(this.win, 
-      `amp-autocomplete.${name}`, this.userInput_);
+    const selectEvent = createCustomEvent(this.win,
+        `amp-autocomplete.${name}`, value);
     this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
   }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-autocomplete-0.1.css';
 import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
@@ -29,6 +30,7 @@ import {isEnumValue} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {toggle} from '../../../src/style';
+import {createCustomEvent} from '../../../src/event-helper';
 
 const EXPERIMENT = 'amp-autocomplete';
 const TAG = 'amp-autocomplete';
@@ -120,6 +122,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
      * @private {?Element}
      */
     this.templateElement_ = null;
+
+    /** @private {?../../../src/service/action-impl.ActionService} */
+    this.action_ = null;
   }
 
   /** @override */
@@ -127,6 +132,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     userAssert(isExperimentOn(this.win, 'amp-autocomplete'),
         `Experiment ${EXPERIMENT} is not turned on.`);
 
+    this.action_ = Services.actionServiceForDoc(this.element);
     const jsonScript =
       this.element.querySelector('script[type="application/json"]');
     if (jsonScript) {
@@ -222,7 +228,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
     container.classList.add('i-amphtml-autocomplete-results');
     container.setAttribute('role', 'list');
     toggle(container, false);
-    this.applyFillContent(container, /* replacedContent */ true);
     return container;
   }
 
@@ -479,7 +484,19 @@ export class AmpAutocomplete extends AMP.BaseElement {
       return;
     }
     this.inputElement_.value = this.userInput_ = element.getAttribute('value');
+    this.fireSelectEvent_(element);
     this.clearAllItems_();
+  }
+
+   /**
+   * Triggers a 'select' event with this.userInput_ as the value emitted.
+   * @private
+   */
+  fireSelectEvent_() {
+    const name = 'select';
+    const selectEvent = createCustomEvent(this.win, 
+      `amp-autocomplete.${name}`, this.userInput_);
+    this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -487,6 +487,20 @@ describes.realWin('amp-autocomplete unit tests', {
     });
   });
 
+  it('should fire select event from selectItem_', () => {
+    const fireEventSpy = sandbox.spy(impl, 'fireSelectEvent_');
+    const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+    const mockEl = doc.createElement('div');
+    return element.layoutCallback().then(() => {
+      impl.toggleResults_(true);
+      mockEl.setAttribute('value', 'test');
+      impl.selectItem_(mockEl);
+      expect(fireEventSpy).to.have.been.calledOnce;
+      expect(fireEventSpy).to.have.been.calledWith('test');
+      expect(triggerSpy).to.have.been.calledOnce;
+    });
+  });
+
   it('should support marking active items', () => {
     let resetSpy;
     return element.layoutCallback().then(() => {

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -62,7 +62,7 @@ Example:
   <amp-autocomplete filter="substring" id="myAutocomplete">
     <input type="text">
     <script type="application/json">
-      { items: ["a", "b", "c"] }
+      { "items": ["a", "b", "c"] }
     </script>
   </amp-autocomplete>
 ```
@@ -79,12 +79,12 @@ Example:
       <li><strong>token-prefix</strong>: if the user input is a prefix of any word in a multi-worded item, then the item gets suggested; example “je” is a token-prefix in “blue jeans”</li>
       <li><strong>fuzzy</strong>: typos in the input field can result in partial match items appearing in the filtered results—need further research</li>
       <li><strong>none</strong>: no client-side rendering; a provided server endpoint will be queried for results</li>
-      <li><strong>custom</strong>: a conditional statement involving an item and a user input to be applied to each item such that evaluating to true implies the item gets suggested; using this filter requires including `amp-bind`; if `filter==custom`, an additional attribute `filter-expr` is required to specify a boolean expression by which to perform the custom filter.</li>
+      <li><strong>custom</strong>: a conditional statement involving an item and a user input to be applied to each item such that evaluating to true implies the item gets suggested; using this filter requires including <code>amp-bind</code> if <code>filter==custom</code>, an additional attribute <code>filter-expr</code> is required to specify a boolean expression by which to perform the custom filter.</li>
     </td>
   </tr>
   <tr>
     <td width="40%"><strong>filter-expr [optional]</strong></td>
-    <td>Required if `filter==custom`</td>
+    <td>Required if <code>filter==custom</code></td>
   </tr>
   <tr>
     <td width="40%"><strong>filter-value [optional]</strong></td>
@@ -105,7 +105,7 @@ Example:
   <tr>
     <td width="40%"><strong>suggest-first [optional]</strong></td>
     <td>
-      Suggest the first entry in the list of results by marking it active; only possible if `filter==prefix` (does nothing otherwise)
+      Suggest the first entry in the list of results by marking it active; only possible if <code>filter==prefix</code> (does nothing otherwise)
     </td>
   </tr>
   <tr>
@@ -126,8 +126,8 @@ Read more about [AMP Actions and Events](../../spec/amp-actions-and-events.md).
 <table>
   <tr>
     <td width="40%"><strong>select</strong></td>
-    <td>`amp-autocomplete` triggers the `select` event when the user selects an option via click, tap, keyboard navigation or accepting typeahead.
-    `event` contains the `value` attribute value of the selected element.
+    <td><code>amp-autocomplete</code> triggers the <code>select</code> event when the user selects an option via click, tap, keyboard navigation or accepting typeahead.
+    <code>event</code> contains the <code>value</code> attribute value of the selected element.</td>
   </tr>
 
 </table>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -115,3 +115,19 @@ Example:
     </td>
   </tr>
 </table>
+
+## Events
+
+Events may trigger actions on other AMP components using the `on` attribute.
+e.g. `on="select: my-tab.show"`
+
+Read more about [AMP Actions and Events](../../spec/amp-actions-and-events.md).
+
+<table>
+  <tr>
+    <td width="40%"><strong>select</strong></td>
+    <td>`amp-autocomplete` triggers the `select` event when the user selects an option via click, tap, keyboard navigation or accepting typeahead.
+    `event` contains the `value` attribute value of the selected element.
+  </tr>
+
+</table>


### PR DESCRIPTION
- Expose the `select` event on amp-autocomplete.
- Add documentation to the `md` file.
- Add a unit test for the new `fireSelectEvent_` method.