### PR TITLE
Fix amp-audio on the first page of a story.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -721,8 +721,10 @@ export class AmpStoryPage extends AMP.BaseElement {
           const timeStart =
               mediaEl[PLAY_AUDIO_ELEMENT_FROM_TIMESTAMP_PROPERTY_NAME];
           let currentTime = (Date.now() - timeStart) / 1000;
-          mediaEl.duration && (currentTime = currentTime % mediaEl.duration);
-          mediaEl.currentTime = currentTime;
+          if (mediaEl.duration) {
+            currentTime = currentTime % mediaEl.duration;
+          }
+          promises.push(mediaPool.setCurrentTime(mediaEl, currentTime));
           promises.push(mediaPool.play(mediaEl));
         }
 

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -812,7 +812,7 @@ export class MediaPool {
           if (rewindToBeginning) {
             this.enqueueMediaElementTask_(
                 /** @type {!PoolBoundElementDef} */ (poolMediaEl),
-                new SetCurrentTimeTask());
+                new SetCurrentTimeTask({currentTime: 0}));
           }
         });
   }

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -22,7 +22,7 @@ import {
   MuteTask,
   PauseTask,
   PlayTask,
-  RewindTask,
+  SetCurrentTimeTask,
   SwapIntoDomTask,
   SwapOutOfDomTask,
   UnmuteTask,
@@ -812,7 +812,7 @@ export class MediaPool {
           if (rewindToBeginning) {
             this.enqueueMediaElementTask_(
                 /** @type {!PoolBoundElementDef} */ (poolMediaEl),
-                new RewindTask());
+                new SetCurrentTimeTask());
           }
         });
   }
@@ -825,6 +825,18 @@ export class MediaPool {
    *     specified media element has been successfully rewound.
    */
   rewindToBeginning(domMediaEl) {
+    return this.setCurrentTime(domMediaEl, 0 /** currentTime */);
+  }
+
+
+  /**
+   * Sets currentTime for a specified media element in the DOM.
+   * @param {!DomElementDef} domMediaEl The media element.
+   * @param {number} currentTime The time to seek to, in seconds.
+   * @return {!Promise} A promise that is resolved when the
+   *     specified media element has been successfully set to the given time.
+   */
+  setCurrentTime(domMediaEl, currentTime) {
     const mediaType = this.getMediaType_(domMediaEl);
     const poolMediaEl =
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
@@ -833,7 +845,8 @@ export class MediaPool {
       return Promise.resolve();
     }
 
-    return this.enqueueMediaElementTask_(poolMediaEl, new RewindTask());
+    return this.enqueueMediaElementTask_(
+        poolMediaEl, new SetCurrentTimeTask({currentTime}));
   }
 
 

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -143,8 +143,9 @@ function copyAttributes(fromEl, toEl) {
 export class MediaTask {
   /**
    * @param {string} name
+   * @param {!Object=} options
    */
-  constructor(name) {
+  constructor(name, options = {}) {
     /** @private @const {string} */
     this.name_ = name;
 
@@ -152,6 +153,9 @@ export class MediaTask {
 
     /** @private @const {!Promise} */
     this.completionPromise_ = deferred.promise;
+
+    /** @protected @const {!Object} */
+    this.options = options;
 
     /** @private {?function()} */
     this.resolve_ = deferred.resolve;
@@ -300,19 +304,19 @@ export class MuteTask extends MediaTask {
 
 
 /**
- * Seeks the specified media element to the beginning.
+ * Seeks the specified media element to the provided time, in seconds.
  */
-export class RewindTask extends MediaTask {
+export class SetCurrentTimeTask extends MediaTask {
   /**
-   * @public
+   * @param {!Object=} options
    */
-  constructor() {
-    super('rewind');
+  constructor(options = {currentTime: 0}) {
+    super('setCurrentTime', options);
   }
 
   /** @override */
   executeInternal(mediaEl) {
-    mediaEl.currentTime = 0;
+    mediaEl.currentTime = this.options.currentTime;
     return Promise.resolve();
   }
 }

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -18,7 +18,7 @@ import {
   MuteTask,
   PauseTask,
   PlayTask,
-  RewindTask,
+  SetCurrentTimeTask,
   SwapIntoDomTask,
   SwapOutOfDomTask,
   UnmuteTask,
@@ -105,14 +105,23 @@ describes.realWin('media-tasks', {}, () => {
     });
   });
 
-  describe('RewindTask', () => {
-    it('should set currentTime to 0', () => {
+  describe('SetCurrentTimeTask', () => {
+    it('should set currentTime to 0 by default', () => {
       el.currentTime = 1;
       expect(el.currentTime).to.equal(1);
 
-      const task = new RewindTask();
+      const task = new SetCurrentTimeTask();
       task.execute(el);
       expect(el.currentTime).to.equal(0);
+    });
+
+    it('should set currentTime to the passed value', () => {
+      el.currentTime = 1;
+      expect(el.currentTime).to.equal(1);
+
+      const task = new SetCurrentTimeTask({currentTime: 2});
+      task.execute(el);
+      expect(el.currentTime).to.equal(2);
     });
   });
 


### PR DESCRIPTION
Using an `amp-audio` element on the first page of a story has two issues:
- Playing the audio will fail since there was no user intent, and trigger the "Play this video" UI message that's supposed to be for videos only -> we stop triggering this message, and rely on the story unmute button to play the audio
- Unmuting the story will unmute the audio, but not play it -> play the audio if it wasn't playing when it's unmuted

Fixes #21604