### PR TITLE
Revert "🐛Change check to see if amp-img has completed layout. (#21483)"

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -172,13 +172,21 @@ export class AmpImageViewer extends AMP.BaseElement {
       return Promise.resolve();
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    this.scheduleLayout(ampImg);
+    const isLaidOut = ampImg.hasAttribute('i-amphtml-layout') ||
+      ampImg.classList.contains('i-amphtml-layout');
+    const laidOutPromise = isLaidOut
+      ? Promise.resolve()
+      : ampImg.signals().whenSignal(CommonSignals.LOAD_END);
 
-    return ampImg.signals()
-        .whenSignal(CommonSignals.LOAD_END)
+    if (!isLaidOut) {
+      this.scheduleLayout(ampImg);
+    }
+
+    this.loadPromise_ = laidOutPromise
         .then(() => this.init_())
         .then(() => this.resetImageDimensions_())
         .then(() => this.setupGestures_());
+    return this.loadPromise_;
   }
 
   /** @override */


### PR DESCRIPTION
This reverts commit a62890252b6c2875cd5f9bff755f4f9a5c744869.

This breaks re-opening the lightbox gallery after closing it on Safari.

/cc @jridgewell @aghassemi 