### PR TITLE
♻️ Update media pool with clearer IDs and proper pool membership check

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -46,6 +46,12 @@ export const MediaType = {
   VIDEO: 'video',
 };
 
+/** @const @enum {string} */
+const MediaElementOrigin = {
+  PLACEHOLDER: 'placeholder',
+  POOL: 'pool',
+};
+
 /**
  * A marker type to indicate an element that originated in the document that is
  * being swapped for an element from the pool.
@@ -101,6 +107,12 @@ const POOL_MEDIA_ELEMENT_PROPERTY_NAME = '__AMP_MEDIA_POOL_ID__';
  * @const {string}
  */
 const ELEMENT_TASK_QUEUE_PROPERTY_NAME = '__AMP_MEDIA_ELEMENT_TASKS__';
+
+
+/**
+ * @const {string}
+ */
+const MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME = '__AMP_MEDIA_ELEMENT_ORIGIN__';
 
 
 /**
@@ -271,6 +283,7 @@ export class MediaPool {
             (i == 1 ? mediaElSeed : mediaElSeed.cloneNode(/* deep */ true));
         const sources = this.getDefaultSource_(type);
         mediaEl.id = POOL_ELEMENT_ID_PREFIX + poolIdCounter++;
+        mediaEl[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] = MediaElementOrigin.POOL;
         this.enqueueMediaElementTask_(mediaEl,
             new UpdateSourcesTask(sources));
         // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
@@ -322,12 +335,13 @@ export class MediaPool {
 
 
   /**
-   * @param {!PoolBoundElementDef|!PlaceholderElementDef} mediaElement
+   * @param {!DomElementDef} mediaElement
    * @return {boolean}
    * @private
    */
   isPoolMediaElement_(mediaElement) {
-    return mediaElement.classList.contains('i-amphtml-pool-media');
+    return mediaElement[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] ===
+        MediaElementOrigin.POOL;
   }
 
   /**
@@ -709,6 +723,8 @@ export class MediaPool {
     // Since this is not an existing pool media element, we can be certain that
     // it is a placeholder element.
     const placeholderEl = /** @type {!PlaceholderElementDef} */ (domMediaEl);
+    placeholderEl[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] =
+        MediaElementOrigin.PLACEHOLDER;
 
     const id = placeholderEl.id || this.createPlaceholderElementId_();
     if (this.sources_[id] && this.placeholderEls_[id]) {

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -84,7 +84,6 @@ export let ElementDistanceFnDef;
  */
 let ElementTaskDef;
 
-
 /**
  * @const {string}
  */

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -912,7 +912,7 @@ export class MediaPool {
           });
     };
 
-    if (true) {
+    if (task.requiresSynchronousExecution()) {
       executionFn.call(this);
     } else {
       this.timer_.delay(executionFn.bind(this), 0);

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -580,7 +580,8 @@ export class MediaPool {
     const placeholderElId = poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME];
     const placeholderEl = /** @type {!PlaceholderElementDef} */ (
       dev().assertElement(this.placeholderEls_[placeholderElId],
-          `No media element ${placeholderElId} to put back into DOM after eviction.`));
+          `No media element ${placeholderElId} to put back into DOM after` +
+          'eviction.'));
     poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
 
     const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,


### PR DESCRIPTION
This PR adds clearer IDs to pool media:

- Placeholder elements (those specified by the publisher) will get IDs in the form of `i-amphtml-placeholder-media-0` through `i-amphtml-placeholder-media-n` when registered in the media pool
- Pool elements (those created in MediaPool's internal implementation) will get IDs in the form of `i-amphtml-pool-media-0` through `i-amphtml-pool-media-n` when created

This PR also does a proper check for whether an element originated from the media pool; originally we just checked to see if it was in the `allocated` array, but this switches to check the `i-amphtml-pool-media` class name, since we could accidentally put a placeholder video in the `allocated` array.