### PR TITLE
🐛 Fix replaced-media pointer in MediaPool

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -499,13 +499,13 @@ export class MediaPool {
   swapPoolMediaElementIntoDom_(placeholderEl, poolMediaEl, sources) {
     const ampMediaForPoolEl = ampMediaElementFor(poolMediaEl);
     const ampMediaForDomEl = ampMediaElementFor(placeholderEl);
+    poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = placeholderEl.id;
 
     return this.enqueueMediaElementTask_(poolMediaEl,
         new SwapIntoDomTask(placeholderEl))
         .then(() => {
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
-          poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = placeholderEl.id;
           this.enqueueMediaElementTask_(poolMediaEl,
               new UpdateSourcesTask(sources));
           this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());
@@ -566,12 +566,10 @@ export class MediaPool {
     const placeholderEl = /** @type {!PlaceholderElementDef} */ (
       dev().assertElement(this.placeholderEls_[placeholderElId],
           'No media element to put back into DOM after eviction.'));
+    poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
 
     const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapOutOfDomTask(placeholderEl))
-        .then(() => {
-          poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
-        });
+        new SwapOutOfDomTask(placeholderEl));
 
     this.resetPoolMediaElementSource_(poolMediaEl);
     return swapOutOfDom;

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -499,13 +499,13 @@ export class MediaPool {
   swapPoolMediaElementIntoDom_(placeholderEl, poolMediaEl, sources) {
     const ampMediaForPoolEl = ampMediaElementFor(poolMediaEl);
     const ampMediaForDomEl = ampMediaElementFor(placeholderEl);
-    poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = placeholderEl.id;
 
     return this.enqueueMediaElementTask_(poolMediaEl,
         new SwapIntoDomTask(placeholderEl))
         .then(() => {
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
+          poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = placeholderEl.id;
           this.enqueueMediaElementTask_(poolMediaEl,
               new UpdateSourcesTask(sources));
           this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -67,6 +67,21 @@ describes.realWin('media-pool', {}, env => {
   }
 
   /**
+   * @param {!Array<!HTMLMediaElement>} elements
+   * @return {function(!Element): number} The distance
+   */
+  function arrayOrderDistanceFn(elements) {
+    return (element) => {
+      const index = elements.indexOf(element);
+      if (index < 0) {
+        return 9999;
+      }
+
+      return index;
+    };
+  }
+
+  /**
    * @param {!Object|!Array} poolOrPools
    * @return {!Array<!HTMLMediaElement>}
    */
@@ -123,14 +138,8 @@ describes.realWin('media-pool', {}, env => {
 
   it.skip('should evict the element with the highest distance first', () => {
     const elements = createMediaElements('video', 3);
-    mediaPool = new MediaPool(win, {'video': 2}, element => {
-      const index = elements.indexOf(element);
-      if (index < 0) {
-        return 9999;
-      }
-
-      return index;
-    });
+    mediaPool = new MediaPool(win, {'video': 2},
+        arrayOrderDistanceFn(elements));
 
     elements.forEach(element => mediaPool.register(element));
     elements.forEach(element => mediaPool.play(element));
@@ -142,5 +151,21 @@ describes.realWin('media-pool', {}, env => {
         .to.be.true;
     expect(isElementInPool(mediaPool.allocated['video'], elements[2]))
         .to.be.false;
+  });
+
+  it('should be able to play alot of videos', () => {
+    const alot = 100;
+    const elements = createMediaElements('video', alot);
+    mediaPool = new MediaPool(win, {'video': 2},
+        arrayOrderDistanceFn(elements));
+
+    elements.forEach(element => mediaPool.register(element));
+    elements.forEach(element => {
+      mediaPool.play(element).then(playbackSucceeded => {
+        expect(playbackSucceeded).to.be.true;
+      }, error => {
+        throw error;
+      });
+    });
   });
 });

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -160,6 +160,8 @@ describes.realWin('media-pool', {}, env => {
         arrayOrderDistanceFn(elements));
 
     elements.forEach(element => mediaPool.register(element));
+
+    // Call play() to ensure it doesn't throw.
     elements.forEach(element => mediaPool.play(element));
   });
 });

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -71,7 +71,7 @@ describes.realWin('media-pool', {}, env => {
    * @return {function(!Element): number} The distance
    */
   function arrayOrderDistanceFn(elements) {
-    return (element) => {
+    return element => {
       const index = elements.indexOf(element);
       if (index < 0) {
         return 9999;
@@ -160,12 +160,6 @@ describes.realWin('media-pool', {}, env => {
         arrayOrderDistanceFn(elements));
 
     elements.forEach(element => mediaPool.register(element));
-    elements.forEach(element => {
-      mediaPool.play(element).then(playbackSucceeded => {
-        expect(playbackSucceeded).to.be.true;
-      }, error => {
-        throw error;
-      });
-    });
+    elements.forEach(element => mediaPool.play(element));
   });
 });

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -74,7 +74,7 @@ describes.realWin('media-pool', {}, env => {
     return element => {
       const index = elements.indexOf(element);
       if (index < 0) {
-        return 9999;
+        return Infinity;
       }
 
       return index;


### PR DESCRIPTION
This PR allows MediaPool to play any number of media elements (fixes #13476), by fixing a bug with the `replaced-media` property in MediaPool.  Copying from the bug:

> This affects both audio and video.  If `n` is the size of the MediaPool for the specified media type, then the you will encounter an error once you navigate to the page containing the `2n+1`th media element of that type.
> 
> This is because we delay clear the associated `replaced-media` after the promise from the `SwapOutOfDomTask` resolves:
> 
> https://github.com/ampproject/amphtml/blob/969a0a0ea9d093010f03980cbf61a898970b248a/extensions/amp-story/1.0/media-pool.js#L570-L574
> 
> The `SwapOutOfDomTask` is executed in a microtask.  However, when this media element is being swapped back into the DOM, there is synchronous code that sets the `replaced-media` before the `SwapIntoDomTask` resolves:
> 
> https://github.com/ampproject/amphtml/blob/969a0a0ea9d093010f03980cbf61a898970b248a/extensions/amp-story/1.0/media-pool.js#L502-L514
> 
> As such, we get this order of events:
> 
> 1. `i-amphtml-pool-media-4` is replacing `i-amphtml-placeholder-media-0`
> 2. setting `replaced-media` of `i-amphtml-pool-media-4` to `i-amphtml-placeholder-media-0`
> 3. swapping `i-amphtml-pool-media-4` into DOM complete
> 4. `i-amphtml-placeholder-media-0` is being put back in DOM; `i-amphtml-pool-media-4` is now available for use
> 5. `i-amphtml-pool-media-4` is replacing `i-amphtml-placeholder-media-3`
> 6. setting `replaced-media` of `i-amphtml-pool-media-4` to `i-amphtml-placeholder-media-3`
> 7. swapping `i-amphtml-pool-media-4` out of DOM complete
> 8. clearing `replaced-media` of `i-amphtml-pool-media-4`
> 9. swapping `i-amphtml-pool-media-4` into DOM complete
> 10. ERROR: `i-amphtml-pool-media-4` has no associated placeholder
> 
> As you can see from the logs above, this is problematic because even though the element is swapped out of the DOM (step 4) before it is swapped back in (step 5), the old `replaced-media` value is cleared (step 8) *after* it is set to the new value (step 6).

This PR ensures that `replaced-media` is both set and cleared before the `SwapIntoDomTask` and `SwapOutOfDomTask`s are executed, respectively.