### PR TITLE
✨ Create whitelist for amp-viewer-assistance.updateActionState actionStatus

### DIFF
--- a/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
@@ -28,7 +28,7 @@ const TAG = 'amp-viewer-assistance';
 /** @const {string} */
 const GSI_TOKEN_PROVIDER = 'actions-on-google-gsi';
 
-/** @const {Array<string>} */
+/** @const {!Array<string>} */
 const ACTION_STATUS_WHITELIST = [
   'ACTIVE_ACTION_STATUS',
   'FAILED_ACTION_STATUS',
@@ -77,11 +77,13 @@ export class AmpViewerAssistance {
    */
   actionHandler_(invocation) {
     const {method, args} = invocation;
-    if (method == 'updateActionState' && args
-        && this.isValidActionStatusArgs_(args)) {
-      this.viewer_./*OK*/sendMessageAwaitResponse(method, args).catch(error => {
-        user().error(TAG, error.toString());
-      });
+    if (method == 'updateActionState') {
+      if (args && this.isValidActionStatusArgs_(args)) {
+        this.viewer_./*OK*/sendMessageAwaitResponse(method, args)
+            .catch(error => {
+              user().error(TAG, error.toString());
+            });
+      }
     } else if (method == 'signIn') {
       this.requestSignIn_();
     }
@@ -166,19 +168,20 @@ export class AmpViewerAssistance {
    */
   isValidActionStatusArgs_(args) {
     const update = args['update'];
-    if (!update || !update['actionStatus']) {
+    const actionStatus = update ? update['actionStatus'] : undefined;
+    if (!update || !actionStatus) {
       user().error(TAG, 'Invalid arguments for updateActionState! Must have' +
           ' an "update" object with an "actionStatus" field.');
       return false;
     }
 
-    if (!ACTION_STATUS_WHITELIST.includes(update['actionStatus'])) {
+    if (!ACTION_STATUS_WHITELIST.includes(actionStatus)) {
       user().error(TAG, 'Invalid actionStatus for updateActionState! '
-          + update['actionStatus']);
+          + actionStatus);
       return false;
     }
 
-    user().info(TAG, 'Sending actionStatus: ' + update['actionStatus']);
+    user().info(TAG, 'Sending actionStatus: ' + actionStatus);
     return true;
   }
 

--- a/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
@@ -90,39 +90,83 @@ describes.fakeWin('AmpViewerAssistance', {
     });
   });
 
-  it('should send updateActionState to the viewer', () => {
-    const config = {
-      'providerId': 'foo-bar',
-    };
-    element.textContent = JSON.stringify(config);
-    const service = new AmpViewerAssistance(ampdoc);
-    const sendMessageStub = service.viewer_.sendMessageAwaitResponse;
-    const invocationArgs = {
-      'foo': 'bar',
-    };
-    return service.start_().then(() => {
-      sendMessageStub.resetHistory();
-      const invocation = new ActionInvocation(
-          element, 'updateActionState', invocationArgs);
-      service.actionHandler_(invocation);
-      expect(sendMessageStub).to.be.calledOnce;
-      expect(sendMessageStub.firstCall.args[0]).to.equal('updateActionState');
-      expect(sendMessageStub.firstCall.args[1]).to.deep.equal(invocationArgs);
+  describe('updateActionState', () => {
+    it('should send updateActionState to the viewer', () => {
+      const config = {
+        'providerId': 'foo-bar',
+      };
+      element.textContent = JSON.stringify(config);
+      const service = new AmpViewerAssistance(ampdoc);
+      const sendMessageStub = service.viewer_.sendMessageAwaitResponse;
+      const invocationArgs = {
+        'update': {'actionStatus': 'COMPLETED_ACTION_STATUS'},
+      };
+      return service.start_().then(() => {
+        sendMessageStub.resetHistory();
+        const invocation = new ActionInvocation(
+            element, 'updateActionState', invocationArgs);
+        service.actionHandler_(invocation);
+        expect(sendMessageStub).to.be.calledOnce;
+        expect(sendMessageStub.firstCall.args[0]).to.equal('updateActionState');
+        expect(sendMessageStub.firstCall.args[1]).to.deep.equal(invocationArgs);
+      });
     });
-  });
 
-  it('should fail to send updateActionState if args are missing', () => {
-    const config = {
-      'providerId': 'foo-bar',
-    };
-    element.textContent = JSON.stringify(config);
-    const service = new AmpViewerAssistance(ampdoc);
-    const sendMessageStub = service.viewer_.sendMessage;
-    return service.start_().then(() => {
-      sendMessageStub.reset();
-      const invocation = new ActionInvocation(element, 'updateActionState');
-      service.actionHandler_(invocation);
-      expect(sendMessageStub).to.not.be.called;
+    it('should fail to send updateActionState if args are missing', () => {
+      const config = {
+        'providerId': 'foo-bar',
+      };
+      element.textContent = JSON.stringify(config);
+      const service = new AmpViewerAssistance(ampdoc);
+      const sendMessageStub = service.viewer_.sendMessageAwaitResponse;
+      return service.start_().then(() => {
+        sendMessageStub.resetHistory();
+        const invocation = new ActionInvocation(element, 'updateActionState');
+        service.actionHandler_(invocation);
+        expect(sendMessageStub).to.not.be.called;
+      });
+    });
+
+    it('should fail to send updateActionState if args is missing update ' +
+        'object', () => {
+      const config = {
+        'providerId': 'foo-bar',
+      };
+      element.textContent = JSON.stringify(config);
+      const service = new AmpViewerAssistance(ampdoc);
+      const sendMessageStub = service.viewer_.sendMessageAwaitResponse;
+      return service.start_().then(() => {
+        sendMessageStub.reset();
+        const invocationArgs = {'update': {}};
+        const invocation = new ActionInvocation(element, 'updateActionState',
+            invocationArgs);
+        allowConsoleError(() => {
+          service.actionHandler_(invocation);
+        });
+        expect(sendMessageStub).to.not.be.called;
+      });
+    });
+
+    it('should fail to send updateActionState if args has an invalid ' +
+        'actionStatus', () => {
+      const config = {
+        'providerId': 'foo-bar',
+      };
+      element.textContent = JSON.stringify(config);
+      const service = new AmpViewerAssistance(ampdoc);
+      const sendMessageStub = service.viewer_.sendMessageAwaitResponse;
+      return service.start_().then(() => {
+        sendMessageStub.reset();
+        const invocationArgs = {
+          'update': {'actionStatus': 'INVALID_ACTION_STATUS'},
+        };
+        const invocation = new ActionInvocation(element, 'updateActionState',
+            invocationArgs);
+        allowConsoleError(() => {
+          service.actionHandler_(invocation);
+        });
+        expect(sendMessageStub).to.not.be.called;
+      });
     });
   });
 

--- a/extensions/amp-viewer-assistance/amp-viewer-assistance.md
+++ b/extensions/amp-viewer-assistance/amp-viewer-assistance.md
@@ -63,7 +63,7 @@ The `amp-viewer-assistance` extension currently has two functions that can be in
   </tr>
   <tr>
     <td class="col-fourty"><code>updateActionState</code></td>
-    <td>A function to send a message to the outer viewer representing a state change. Should contain an argument of the resulting state change.</td>
+    <td>A function to send a message to the outer viewer representing a state change. Should contain an <code>update</code> object as well as an <code>actionStatus</code> field denoting the resulting state change. Supported <code>actionStatus</code> strings are <code>ACTIVE_ACTION_STATUS</code>, <code>FAILED_ACTION_STATUS</code>, and <code>COMPLETED_ACTION_STATUS</code>.</td>
   </tr>
 </table>
 

--- a/extensions/amp-viewer-assistance/amp-viewer-assistance.md
+++ b/extensions/amp-viewer-assistance/amp-viewer-assistance.md
@@ -63,7 +63,13 @@ The `amp-viewer-assistance` extension currently has two functions that can be in
   </tr>
   <tr>
     <td class="col-fourty"><code>updateActionState</code></td>
-    <td>A function to send a message to the outer viewer representing a state change. Should contain an <code>update</code> object as well as an <code>actionStatus</code> field denoting the resulting state change. Supported <code>actionStatus</code> strings are <code>ACTIVE_ACTION_STATUS</code>, <code>FAILED_ACTION_STATUS</code>, and <code>COMPLETED_ACTION_STATUS</code>.</td>
+    <td>A function to send a message to the outer viewer representing a state change. Requires an <code>update</code> object parameter of the following format:
+    
+    {
+      "actionStatus": "COMPLETED_ACTION_STATUS" | "ACTIVE_ACTION_STATUS" |
+          "FAILED_ACTION_STATUS",
+      "result": { ... }, // optional field used with COMPLETED_ACTION_STATUS
+    }
   </tr>
 </table>
 


### PR DESCRIPTION
In response to [this discussion comment](https://github.com/ampproject/amphtml/pull/21512/files/bc39a41be26b7510b29a037419f7800a878ed97f#r268412642), I created a whitelist for valid action statuses that can be passed via `amp-viewer-assistance` and `updateActionState`.

/cc @choumx 

