### PR TITLE
🐛Fix incorrectly sized image viewer images.

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -171,14 +171,22 @@ export class AmpImageViewer extends AMP.BaseElement {
     if (isScaled) {
       return Promise.resolve();
     }
+    // Check to see if have an image that we created already. This is necessary
+    // as we hide the original amp-img, so it will never finish layout again
+    // after the first time we do layout. This ends up preventing Safari from
+    // re-opening a lightbox gallery. This does not affect Chrome as the
+    // image viewer does not seem to unlayout there. This may be related to the
+    // fixed layer logic.
+    // TODO(sparhami, cathyxz) Refactor image viewer once auto sizes lands to
+    // use the amp-img as-is, which means we can simplify this logic to just
+    // wait for the layout signal.
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    const isLaidOut = ampImg.hasAttribute('i-amphtml-layout') ||
-      ampImg.classList.contains('i-amphtml-layout');
-    const laidOutPromise = isLaidOut
+    const haveImg = !!this.image_;
+    const laidOutPromise = haveImg
       ? Promise.resolve()
       : ampImg.signals().whenSignal(CommonSignals.LOAD_END);
 
-    if (!isLaidOut) {
+    if (!haveImg) {
       this.scheduleLayout(ampImg);
     }
 


### PR DESCRIPTION
Change the check to see if we already have an img to be more robust by checking
if we already extracted the `img` from the `amp-img`, which only happens after
the `amp-img` has laid out once.

A variation of this was first attempted in #21483, which was reverted.

Fixes #21481 

/cc @jridgewell It turns out because we are doing weird stuff, we cannot rely on the `LOAD_END` signal from the `amp-img`. It is a bit weird that we didn't encounter the issue on Chrome. This seems to stem from the image viewer getting the unlayout callback on Safari and not on Chrome. This results in Chrome never hitting this code path. Not sure why it isn't happening on Chrome, maybe Safari behaves differently due to fixed layer?