### PR TITLE
🐛Make non-script amp-access configs a runtime error

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -28,6 +28,7 @@ import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {isArray} from '../../../src/types';
+import {isJsonScriptTag} from '../../../src/dom';
 import {listenOnce} from '../../../src/event-helper';
 import {startsWith} from '../../../src/string';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
@@ -184,6 +185,9 @@ export class AccessService {
    * @private
    */
   parseConfig_() {
+    userAssert(isJsonScriptTag(this.accessElement_),
+        `${TAG} config should ` +
+        'be inside a <script> tag with type="application/json"');
     const rawContent = tryParseJson(this.accessElement_.textContent, e => {
       throw user().createError('Failed to parse "amp-access" JSON: ' + e);
     });


### PR DESCRIPTION
Fixes #21623

This will prevent document authors from erroneously specifying amp-access configs in non-script tags, which would cause the cache to remove the `amp-access` extension.