### PR TITLE
🏗 Remove `^revert-.*$` branch names from push-build config on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ branches:
     - release
     - canary
     - /^amp-release-.*$/
-    - /^revert-.*$/
 addons:
   apt:
     packages:


### PR DESCRIPTION
Reverting #20749 which had unintended side-effects (e.g., #21636 is a PR that created both a pr build and a push build on Travis)