### PR TITLE
Add mini-postmortem to cherry-pick template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -42,6 +42,8 @@ MUST: This issue cannot be closed until the mini-PM is written and its action it
 -->
 # Mini-postmortem
 
+> **TODO:** This postmortem will be written after the cherry-pick deployment and before this issue is closed. Delete this TODO when the postmortem is ready.
+
 ## Summary
 
 <!--

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,14 +1,13 @@
 ---
 name: Cherry-pick template
 about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
-title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE>
-  (Pending)"
+title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
 assignees: cramforce
 ---
 
 <!--
-Replace *everything* in square brackets in the title AND body of this issue.
+Replace *everything* in angle brackets in the title AND body of this issue.
 
 If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
 -->
@@ -23,26 +22,26 @@ Release issues: https://github.com/ampproject/amphtml/labels/Type%3A%20Release
 
 | Issue | PR  | Production? | RC? | Release issue |
 | :---: | :-: | :---------: | :-: | :-----------: |
-| #[_Issue number_] | #[_PR number_] | **[Y/N]** | **[Y/N]** | #[_Release issue_] |
+| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<Y/N>** | **<Y/N>** | #<_RELEASE_ISSUE_> |
 
 ## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
 <!-- Be specific. -->
-[_Your reasons_]
+<_YOUR_REASONS_>
 
 <!--
 IF: Cherry-picking into production but _not_ RC.
 -->
 ## Why is a RC cherry-pick not needed?
 
-[_Your reasons_]
+<_YOUR_REASONS_>
 
 <!-- NOTE: Filling out this mini-PM template is required after the deployment of a production cherry-pick. -->
 # Mini-postmortem
 
 | Users affected | Impact |
 | -------------- | ------ |
-| [_Which users were affected? Roughly how many?_] | [_How were users affected? E.g. partial or complete loss of functionality?_] |
+| <_Which users were affected? Roughly how many?_> | <_How were users affected? E.g. partial or complete loss of functionality?_> |
 
 ## Root Causes
 
@@ -54,7 +53,7 @@ IF: Cherry-picking into production but _not_ RC.
 
 | Action Item | Type | Owner | PR # |
 | ----------- | :--: | :---: | :--: |
-| [_E.g. add integration test_] | [_Investigate/Mitigate/Prevent_] | @[_Username_] | #[_Issue_] |
+| <_E.g. Add integration test_> | <_Investigate/Mitigate/Prevent_> | @<_USERNAME_> | #<_PR_NUMBER_> |
 
 ## Lessons Learned
 

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,52 +1,71 @@
 ---
-name: Cherry pick template
-about: Used to request a cherry pick. See bit.ly/amp-cherry-pick
-title: "\U0001F338 Cherry pick request for <YOUR_ISSUE_NUMBER> into <RELEASE_ISSUE_NUMBER>
+name: Cherry-pick template
+about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
+title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE>
   (Pending)"
 labels: 'Type: Release'
 assignees: cramforce
-
 ---
 
 <!--
-Replace *everything* in angle brackets in the title AND body of this issue. If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
+Replace *everything* in square brackets in the title AND body of this issue.
+
+If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
 -->
 
-
-## GitHub issue your cherry pick is fixing:
-
-Issue #<ISSUE_NUMBER>
-
-
-## PR that you are requesting a cherry pick for:
+# Cherry-pick request
 
 <!--
-Put N/A if you do not yet have a PR with a fix; edit this issue to add it when the PR is ready.
+Cherry-picks into production most likely require a cherry-pick into RC too. Otherwise, your fix will be lost when the RC is promoted.
+
+Release issues: https://github.com/ampproject/amphtml/labels/Type%3A%20Release
 -->
 
-PR #<PR_NUMBER>
+| Issue | PR  | Production? | RC? | Release issue |
+| :---: | :-: | :---------: | :-: | :-----------: |
+| #[_Issue number_] | #[_PR number_] | **[Y/N]** | **[Y/N]** | #[_Release issue_] |
 
-
-## Release(s) you requesting this cherry pick into:
-
-<!--
-Release issues can be found at https://github.com/ampproject/amphtml/labels/Type%3A%20Release
-
-If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost. See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
--->
-
-Production Release? <YES/NO>
-
-<!-- If yes: --> Release Issue #<PRODUCTION_RELEASE_ISSUE>
-
-Canary release? <YES/NO>
-
-<!-- If yes: --> Release Issue #<CANARY_RELEASE_ISSUE>
-<!-- otherwise: --> <WHY_THIS_IS_NOT_NEEDED>
-
-## Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
+## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
 <!-- Be specific. -->
-<YOUR_REASONS>
+[_Your reasons_]
+
+<!--
+IF: Cherry-picking into production but _not_ RC.
+-->
+## Why is a RC cherry-pick not needed?
+
+[_Your reasons_]
+
+<!-- NOTE: Filling out this mini-PM template is required after the deployment of a production cherry-pick. -->
+# Mini-postmortem
+
+| Users affected | Impact |
+| -------------- | ------ |
+| [_Which users were affected? Roughly how many?_] | [_How were users affected? E.g. partial or complete loss of functionality?_] |
+
+## Root Causes
+
+1.
+2.
+3.
+
+## Action Items
+
+| Action Item | Type | Owner | PR # |
+| ----------- | :--: | :---: | :--: |
+| [_E.g. add integration test_] | [_Investigate/Mitigate/Prevent_] | @[_Username_] | #[_Issue_] |
+
+## Lessons Learned
+
+### Things that went well
+
+-
+
+### Things that went wrong
+
+-
+
+---
 
 /cc @cramforce

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -19,7 +19,7 @@ TIP: Cherry-picks into production most likely require a cherry-pick into RC too.
 
 | Issue | PR  | Production? | RC? | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
 | :---: | :-: | :---------: | :-: | :-----------: |
-| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<Y/N>** | **<Y/N>** | #<_RELEASE_ISSUE_> |
+| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<YES/NO>** | **<YES/NO>** | #<_RELEASE_ISSUE_> |
 
 ## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
@@ -36,7 +36,9 @@ CONDITION: Cherry-picking into production but _not_ RC. Otherwise, delete.
 <_YOUR_REASONS_>
 
 <!--
-NOTE: Filling out this mini-PM template is required after the deployment of a production cherry-pick.
+MUST: Filling out the mini-PM template is required _after_ the deployment of a production cherry-pick. If this cherry-pick does not include production, the mini-PM section can be deleted.
+
+MUST: This issue cannot be closed until the mini-PM is written and its action items are completed.
 -->
 # Mini-postmortem
 
@@ -54,8 +56,6 @@ TIP: A few sentences summarizing the problem and impact.
 ## Root Causes
 
 1.
-2.
-3.
 
 ## Action Items
 

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -7,37 +7,45 @@ assignees: cramforce
 ---
 
 <!--
-Replace *everything* in angle brackets in the title AND body of this issue.
+MUST: Replace *everything* in angle brackets in the title AND body of this issue.
 
 If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
 -->
-
 # Cherry-pick request
 
 <!--
-Cherry-picks into production most likely require a cherry-pick into RC too. Otherwise, your fix will be lost when the RC is promoted.
-
-Release issues: https://github.com/ampproject/amphtml/labels/Type%3A%20Release
+TIP: Cherry-picks into production most likely require a cherry-pick into RC too. Otherwise, your fix will be lost when the RC is promoted.
 -->
 
-| Issue | PR  | Production? | RC? | Release issue |
+| Issue | PR  | Production? | RC? | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
 | :---: | :-: | :---------: | :-: | :-----------: |
 | #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<Y/N>** | **<Y/N>** | #<_RELEASE_ISSUE_> |
 
 ## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
-<!-- Be specific. -->
+<!--
+TIP: Be specific.
+-->
 <_YOUR_REASONS_>
 
 <!--
-IF: Cherry-picking into production but _not_ RC.
+CONDITION: Cherry-picking into production but _not_ RC. Otherwise, delete.
 -->
 ## Why is a RC cherry-pick not needed?
 
 <_YOUR_REASONS_>
 
-<!-- NOTE: Filling out this mini-PM template is required after the deployment of a production cherry-pick. -->
+<!--
+NOTE: Filling out this mini-PM template is required after the deployment of a production cherry-pick.
+-->
 # Mini-postmortem
+
+## Summary
+
+<!--
+TIP: A few sentences summarizing the problem and impact.
+-->
+<_YOUR_SUMMARY_>
 
 | Users affected | Impact |
 | -------------- | ------ |


### PR DESCRIPTION
Suggested guidelines:
- The mini-PM should be written soon after the cherry-pick is deployed.
- A mini-PM is required for production cherry-picks, but optional for RC-only cherry-picks.
- If required, the mini-PM must be written and its action items completed before the cherry-pick issue can be closed.

/to @mrjoro 