### PR TITLE
✨amp-experiment-v1: Created experiment for amp-experiment-v1

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -375,7 +375,9 @@ exports.rules = [
       'extensions/amp-list/0.1/amp-list.js->' +
             'src/service/origin-experiments-impl.js',
       'extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js->' +
-            'src/service/origin-experiments-impl.js',
+        'src/service/origin-experiments-impl.js',
+      'extensions/amp-experiment/1.0/amp-experiment.js->' +
+        'src/service/origin-experiments-impl.js',
       // For action macros.
       'extensions/amp-action-macro/0.1/amp-action-macro.js->' +
             'src/service/action-impl.js',

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -61,7 +61,6 @@ export class AmpExperiment extends AMP.BaseElement {
         );
       }
 
-
       try {
         const config = this.getConfig_();
         const results = Object.create(null);

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -28,7 +28,6 @@ import {
 import {isExperimentOn} from '../../../src/experiments';
 import {parseJson} from '../../../src/json';
 
-
 const TAG = 'amp-experiment';
 
 export class AmpExperiment extends AMP.BaseElement {

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -22,7 +22,6 @@ import {toggleExperiment} from '../../../../src/experiments';
 describes.realWin('amp-experiment', {
   amp: {
     extensions: ['amp-experiment:1.0'],
-
   },
 }, env => {
 
@@ -64,6 +63,7 @@ describes.realWin('amp-experiment', {
   let win, doc;
   let ampdoc;
   let experiment;
+  let el;
 
   beforeEach(() => {
     win = env.win;
@@ -72,7 +72,7 @@ describes.realWin('amp-experiment', {
 
     toggleExperiment(win, 'amp-experiment-1.0', true);
 
-    const el = doc.createElement('amp-experiment');
+    el = doc.createElement('amp-experiment');
     el.ampdoc_ = ampdoc;
     experiment = new AmpExperiment(el);
   });
@@ -83,6 +83,18 @@ describes.realWin('amp-experiment', {
     child.textContent = opt_textContent || JSON.stringify(config);
     experiment.element.appendChild(child);
   }
+
+  it('Rejects because experiment is not enabled', () => {
+    toggleExperiment(win, 'amp-experiment-1.0', false);
+
+    expectAsyncConsoleError(/Experiment/);
+    addConfigElement('script');
+    doc.body.appendChild(el);
+    return experiment.buildCallback()
+        .should.eventually.be.rejectedWith(
+            /Experiment/
+        );
+  });
 
   it('should not throw on valid config', () => {
     expect(() => {

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -17,10 +17,12 @@
 import * as variant from '../variant';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
+import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-experiment', {
   amp: {
     extensions: ['amp-experiment:1.0'],
+
   },
 }, env => {
 
@@ -67,6 +69,9 @@ describes.realWin('amp-experiment', {
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
+
+    toggleExperiment(win, 'amp-experiment-1.0', true);
+
     const el = doc.createElement('amp-experiment');
     el.ampdoc_ = ampdoc;
     experiment = new AmpExperiment(el);


### PR DESCRIPTION
Ironic title 😂 

This creates the experiment check for `amp-experiment-v1` with support for origin trial checking (as I trust we will be going down that path, cc @jeffjose ).

# Examples

**Before Enabling Experiment**

<img width="1439" alt="Screen Shot 2019-04-01 at 3 02 18 PM" src="https://user-images.githubusercontent.com/1448289/55363382-bc70a200-5491-11e9-8b60-3389a39d15ce.png">

**After Enabling Experiment**

<img width="1440" alt="Screen Shot 2019-04-01 at 3 02 55 PM" src="https://user-images.githubusercontent.com/1448289/55363398-c72b3700-5491-11e9-89b8-482151c25f85.png">

