### PR TITLE
✨amp-recaptcha-input: Removed experiment from amp-recaptcha-input

### DIFF
--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
@@ -16,7 +16,6 @@
 
 import '../amp-recaptcha-input';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-recaptcha-input', {
   amp: { /* amp spec */
@@ -30,7 +29,6 @@ describes.realWin('amp-recaptcha-input', {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    toggleExperiment(win, 'amp-recaptcha-input', true);
   });
 
   const ampRecaptchaInputAttributes = {
@@ -59,17 +57,6 @@ describes.realWin('amp-recaptcha-input', {
   }
 
   describe('amp-recaptcha-input', () => {
-
-    it('Rejects because experiment is not enabled', () => {
-      toggleExperiment(win, 'amp-recaptcha-input', false);
-
-      return allowConsoleError(() => {
-        return getRecaptchaInput()
-            .should.eventually.be.rejectedWith(
-                /Experiment/
-            );
-      });
-    });
 
     it('Rejects because data-name is missing', () => {
 


### PR DESCRIPTION
closes #2273 

This removes the experiment for `amp-recaptcha-input`. Thus launching this feature, and making this available to the public! 😄 

This should be **approved before April 8th, 2019**, and **merged on April 8th, 2019**. In order to line up with a certain date 👀 

Also, this should have a paired documentation update to inform users the feature is no longer experimental 😄 After this goes live in PROD (to avoid confusion).

# Example

<img width="1440" alt="Screen Shot 2019-04-01 at 3 25 09 PM" src="https://user-images.githubusercontent.com/1448289/55363886-803e4100-5493-11e9-82bf-df295416dffa.png">
