### PR TITLE
cors docs: caches.json is now the canonical source of cache info

### DIFF
--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -140,7 +140,8 @@ When your endpoint receives a CORS request:
 <span id="verify-cors-header"></span>
 
 CORS endpoints receive the requesting origin via the `Origin` HTTP header.
-Endpoints should only allow requests from: (1) the publisher's own origin; and (2) `cacheDomain` origins listed in <https://cdn.ampproject.org/caches.json>. 
+Endpoints should only allow requests from: (1) the publisher's own origin; and
+(2) every `cacheDomain` origin listed in <https://cdn.ampproject.org/caches.json>. 
 
 For example, endpoints should allow requests from:
   *  Google AMP Cache subdomain: `https://<publisher's domain>.cdn.ampproject.org` <br>(for example, `https://nytimes-com.cdn.ampproject.org`)

--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -140,14 +140,11 @@ When your endpoint receives a CORS request:
 <span id="verify-cors-header"></span>
 
 CORS endpoints receive the requesting origin via the `Origin` HTTP header.
-Endpoints should restrict requests to allow only the following origins:
+Endpoints should only allow requests from: (1) the publisher's own origin; and (2) `cacheDomain` origins listed in <https://cdn.ampproject.org/caches.json>. 
 
-*  From AMP caches:
-      *  Google AMP Cache subdomain: `https://<publisher's domain>.cdn.ampproject.org` <br>(for example, `https://nytimes-com.cdn.ampproject.org`)
-      *  Google AMP Cache (legacy): `https://cdn.ampproject.org`
-      *  Cloudflare AMP Cache: `https://<publisher's domain>.amp.cloudflare.com`
-*  From the publisher’s own origins
-
+For example, endpoints should allow requests from:
+  *  Google AMP Cache subdomain: `https://<publisher's domain>.cdn.ampproject.org` <br>(for example, `https://nytimes-com.cdn.ampproject.org`)
+  *  Cloudflare AMP Cache: `https://<publisher's domain>.amp.cloudflare.com`
 
 {% call callout('Read on', type='read') %}
 For information on AMP Cache URL formats, see these resources:


### PR DESCRIPTION
/cc @choumx 