### PR TITLE
:sparkles: Add support for 'data-credentials' attribute for amp-story bookend

### DIFF
--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -25,6 +25,9 @@ import {user, userAssert} from '../../../src/log';
 /** @private @const {string} */
 export const BOOKEND_CONFIG_ATTRIBUTE_NAME = 'src';
 
+/** @private const {string} */
+export const BOOKEND_CREDENTIALS_ATTRIBUTE_NAME = 'data-credentials';
+
 /** @private @const {string} */
 const TAG = 'amp-story-request-service';
 
@@ -63,7 +66,13 @@ export class AmpStoryRequestService {
 
     if (bookendEl.hasAttribute(BOOKEND_CONFIG_ATTRIBUTE_NAME)) {
       const rawUrl = bookendEl.getAttribute(BOOKEND_CONFIG_ATTRIBUTE_NAME);
-      return this.loadJsonFromAttribute_(rawUrl);
+      let credentials = undefined;
+      if (bookendEl.hasAttribute(BOOKEND_CREDENTIALS_ATTRIBUTE_NAME)) {
+        credentials = bookendEl.getAttribute(
+            BOOKEND_CREDENTIALS_ATTRIBUTE_NAME
+        );
+      }
+      return this.loadJsonFromAttribute_(rawUrl, credentials);
     }
 
     // Fallback. Check for an inline json config.
@@ -77,16 +86,21 @@ export class AmpStoryRequestService {
 
   /**
    * @param {string} rawUrl
+   * @param {string=} credentials
    * @return {(!Promise<!JsonObject>|!Promise<null>)}
    * @private
    */
-  loadJsonFromAttribute_(rawUrl) {
+  loadJsonFromAttribute_(rawUrl, credentials) {
     const opts = {};
     opts.requireAmpResponseSourceOrigin = false;
 
     if (!isProtocolValid(rawUrl)) {
       user().error(TAG, 'Invalid config url.');
       return Promise.resolve(null);
+    }
+
+    if (credentials) {
+      opts.credentials = credentials;
     }
 
     return Services.urlReplacementsForDoc(this.storyElement_)

--- a/extensions/amp-story/1.0/test/test-amp-story-request-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-request-service.js
@@ -17,6 +17,7 @@
 import {
   AmpStoryRequestService,
   BOOKEND_CONFIG_ATTRIBUTE_NAME,
+  BOOKEND_CREDENTIALS_ATTRIBUTE_NAME,
 } from '../amp-story-request-service';
 
 
@@ -104,5 +105,31 @@ describes.fakeWin('amp-story-store-service', {amp: true}, env => {
         .then(() => {
           xhrMock.verify();
         });
+  });
+
+  it('should fetch the bookend config with credentials', () => {
+    const bookendUrl = 'https://publisher.com/bookend';
+
+    bookendElement.setAttribute(BOOKEND_CONFIG_ATTRIBUTE_NAME, bookendUrl);
+    bookendElement.setAttribute(BOOKEND_CREDENTIALS_ATTRIBUTE_NAME, 'include');
+    xhrMock.expects('fetchJson')
+        .withExactArgs(
+            bookendUrl,
+            {
+              requireAmpResponseSourceOrigin: false,
+              credentials: 'include',
+            },
+        )
+        .resolves({
+          ok: true,
+          json() {
+            return Promise.resolve();
+          },
+        })
+        .once();
+
+    return requestService.loadBookendConfig().then(() => {
+      xhrMock.verify();
+    });
   });
 });


### PR DESCRIPTION
- Add support for the 'data-credentials' attribute for amp-story bookend.

According to https://www.ampproject.org/docs/fundamentals/amp-cors-requests#utilizing-cookies-for-cors-requests, most components that allow CORS requests allow the developer to optionally set the credentials mode through a 'credentials' or 'data-credentials' attribute. This does not work for amp-story bookend.

Fixes https://github.com/ampproject/amphtml/issues/21598
