### PR TITLE
✨amp-experiment: Mutation Parser for 1.0 format

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -27,11 +27,25 @@
           "variants": {
             "yellow": {
               "weight": 50,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "color: yellow"
+                }
+              ]
             },
             "green": {
               "weight": 50,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "color: green"
+                }
+              ]
             }
           }
         },
@@ -40,11 +54,25 @@
           "variants": {
             "blue": {
               "weight": 20,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "color: blue"
+                }
+              ]
             },
             "red": {
               "weight": 20,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "color: red"
+                }
+              ]
             }
           }
         },
@@ -53,11 +81,25 @@
           "variants": {
             "solid": {
               "weight": 50,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "border: 1px black solid"
+                }
+              ]
             },
             "dashed": {
               "weight": 50,
-              "mutations": [{}]
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "border: 1px black dashed"
+                }
+              ]
             }
           }
         }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -27,6 +27,7 @@ import {
 } from '../../../src/service/origin-experiments-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseJson} from '../../../src/json';
+import {parseMutation} from './mutation-parser';
 
 const TAG = 'amp-experiment';
 
@@ -164,12 +165,16 @@ export class AmpExperiment extends AMP.BaseElement {
   applyMutations_(experimentName, variantObject) {
     const doc = this.getAmpDoc();
     return doc.whenBodyAvailable().then(() => {
-      // TODO (torch2424): Use a mutation service,
-      // and apply mutations
-      // Placehodler to pass linting for code review
-      // and keep PRs small
-      // This is a NOOP
-      variantObject[experimentName] = experimentName;
+
+      // Parse / Validate all of our mutations
+      const mutationOperations = variantObject['mutations'].map(
+          mutation => parseMutation(mutation, this.win.document)
+      );
+
+      // Apply our mutations
+      mutationOperations.forEach(
+          mutationOperation => mutationOperation()
+      );
     });
   }
 

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -23,7 +23,7 @@ import {userAssert} from '../../../src/log';
  * MutationRecord
  * @param {!JsonObject} mutation
  * @param {!Document} document
- * @returns {!Function}
+ * @return {!Function}
  */
 export function parseMutation(mutation, document) {
 
@@ -41,7 +41,9 @@ export function parseMutation(mutation, document) {
   } else if (mutationRecord['type'] === 'characterData') {
     // NOOP for small PRs
     return noopFunction;
-  } else if (mutationRecord['type'] === 'childList') {
+  } else {
+    // childList type of mutation
+
     // NOOP for small PRs
     return noopFunction;
   }
@@ -57,30 +59,30 @@ function assertMutationRecord_(mutation) {
 
   // Assert that the mutation is an object
   userAssert(
-    isObject(mutation),
-    `Mutation ${JSON.stringify(mutation)} must be an object.`);
+      isObject(mutation),
+      `Mutation ${JSON.stringify(mutation)} must be an object.`);
 
   // Assert the mutation type
   userAssert(
-    mutation['type'] !== undefined &&
+      mutation['type'] !== undefined &&
     typeof mutation['type'] === 'string',
-    `Mutation ${JSON.stringify(mutation)} must have a type.`);
+      `Mutation ${JSON.stringify(mutation)} must have a type.`);
 
   // Assert the mutation type is one of the following keys
   const mutationTypes = [
     'attributes',
     'characterData',
-    'childList'
+    'childList',
   ];
   userAssert(
-    mutationTypes.indexOf(mutation['type']) >= 0,
-    `Mutation ${JSON.stringify(mutation)} must have a type.`);
+      mutationTypes.indexOf(mutation['type']) >= 0,
+      `Mutation ${JSON.stringify(mutation)} must have a type.`);
 
   // Assert the mutation target
   userAssert(
-    mutation['target'] !== undefined &&
+      mutation['target'] !== undefined &&
     typeof mutation['target'] === 'string',
-    `Mutation ${JSON.stringify(mutation)} must have a target.`);
+      `Mutation ${JSON.stringify(mutation)} must have a target.`);
 
   return mutation;
 }
@@ -89,17 +91,16 @@ function assertMutationRecord_(mutation) {
  * Function to set the target element from the
  * target selector to the target selector key,
  * and assert that we found the element.
+ * @param {string} selectorKey
  * @param {!Object} mutationRecord
- * @param {!String} selectorKey
  * @param {!Document} document
- * @param
  */
 function setSelectorToElement_(selectorKey, mutationRecord, document) {
   const targetElement = document.querySelector(mutationRecord[selectorKey]);
 
   userAssert(
-    targetElement !== null,
-    'No element on the document matches the selector, ' +
+      targetElement !== null,
+      'No element on the document matches the selector, ' +
     `${mutationRecord[selectorKey]} .`);
 
   mutationRecord[selectorKey] = targetElement;

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -38,9 +38,9 @@ const MUTATION_TYPES = [
  */
 export function parseMutation(mutation, document) {
 
-  const mutationRecord = assertMutationRecord_(mutation);
+  const mutationRecord = assertMutationRecord(mutation);
 
-  setSelectorToElement_('target', mutationRecord, document);
+  setSelectorToElement('target', mutationRecord, document);
 
   // TODO (torch2424): Remove this NOOP after reviews
   // This is done to allow for small PRS
@@ -48,6 +48,9 @@ export function parseMutation(mutation, document) {
 
   if (mutationRecord['type'] === 'attributes') {
     // NOOP for small PRs
+    // TODO (torch2424): Be sure to validate supported
+    // attributes (e.g style), and their values for
+    // security, and AMP validation (position: fixed).
     return noopFunction;
   } else if (mutationRecord['type'] === 'characterData') {
     // NOOP for small PRs
@@ -66,7 +69,7 @@ export function parseMutation(mutation, document) {
  * @param {!JsonObject} mutation
  * @return {!Object}
  */
-function assertMutationRecord_(mutation) {
+function assertMutationRecord(mutation) {
 
   // Assert that the mutation is an object
   userAssert(
@@ -101,7 +104,7 @@ function assertMutationRecord_(mutation) {
  * @param {!Object} mutationRecord
  * @param {!Document} document
  */
-function setSelectorToElement_(selectorKey, mutationRecord, document) {
+function setSelectorToElement(selectorKey, mutationRecord, document) {
   const targetElement = document.querySelector(mutationRecord[selectorKey]);
 
   userAssert(

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isObject} from '../../../src/types';
+import {userAssert} from '../../../src/log';
+
+/**
+ * Function to find all selectors of the mutation
+ * and return a function to apply the identified
+ * MutationRecord
+ * @param {!JsonObject} mutation
+ * @param {!Document} document
+ * @returns {!Function}
+ */
+export function parseMutation(mutation, document) {
+
+  const mutationRecord = assertMutationRecord_(mutation);
+
+  setSelectorToElement_('target', mutationRecord, document);
+
+  // TODO (torch2424): Remove this NOOP after reviews
+  // This is done to allow for small PRS
+  const noopFunction = () => {};
+
+  if (mutationRecord['type'] === 'attributes') {
+    // NOOP for small PRs
+    return noopFunction;
+  } else if (mutationRecord['type'] === 'characterData') {
+    // NOOP for small PRs
+    return noopFunction;
+  } else if (mutationRecord['type'] === 'childList') {
+    // NOOP for small PRs
+    return noopFunction;
+  }
+}
+
+/**
+ * Function to validate that the mutation
+ * is a mutation record.
+ * @param {!JsonObject} mutation
+ * @return {!Object}
+ */
+function assertMutationRecord_(mutation) {
+
+  // Assert that the mutation is an object
+  userAssert(
+    isObject(mutation),
+    `Mutation ${JSON.stringify(mutation)} must be an object.`);
+
+  // Assert the mutation type
+  userAssert(
+    mutation['type'] !== undefined &&
+    typeof mutation['type'] === 'string',
+    `Mutation ${JSON.stringify(mutation)} must have a type.`);
+
+  // Assert the mutation type is one of the following keys
+  const mutationTypes = [
+    'attributes',
+    'characterData',
+    'childList'
+  ];
+  userAssert(
+    mutationTypes.indexOf(mutation['type']) >= 0,
+    `Mutation ${JSON.stringify(mutation)} must have a type.`);
+
+  // Assert the mutation target
+  userAssert(
+    mutation['target'] !== undefined &&
+    typeof mutation['target'] === 'string',
+    `Mutation ${JSON.stringify(mutation)} must have a target.`);
+
+  return mutation;
+}
+
+/**
+ * Function to set the target element from the
+ * target selector to the target selector key,
+ * and assert that we found the element.
+ * @param {!Object} mutationRecord
+ * @param {!String} selectorKey
+ * @param {!Document} document
+ * @param
+ */
+function setSelectorToElement_(selectorKey, mutationRecord, document) {
+  const targetElement = document.querySelector(mutationRecord[selectorKey]);
+
+  userAssert(
+    targetElement !== null,
+    'No element on the document matches the selector, ' +
+    `${mutationRecord[selectorKey]} .`);
+
+  mutationRecord[selectorKey] = targetElement;
+}

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -74,24 +74,32 @@ function assertMutationRecord(mutation) {
   // Assert that the mutation is an object
   userAssert(
       isObject(mutation),
-      `Mutation ${JSON.stringify(mutation)} must be an object.`);
+      'Mutation %s must be an object.',
+      JSON.stringify(mutation)
+  );
 
   // Assert the mutation type
   userAssert(
       mutation['type'] !== undefined &&
     typeof mutation['type'] === 'string',
-      `Mutation ${JSON.stringify(mutation)} must have a type.`);
+      'Mutation %s must have a type.',
+      JSON.stringify(mutation)
+  );
 
   // Assert the mutation type is one of the following keys
   userAssert(
       MUTATION_TYPES.indexOf(mutation['type']) >= 0,
-      `Mutation ${JSON.stringify(mutation)} must have a type.`);
+      'Mutation %s must have a type.',
+      JSON.stringify(mutation)
+  );
 
   // Assert the mutation target
   userAssert(
       mutation['target'] !== undefined &&
     typeof mutation['target'] === 'string',
-      `Mutation ${JSON.stringify(mutation)} must have a target.`);
+      'Mutation %s must have a target.',
+      JSON.stringify(mutation)
+  );
 
   return mutation;
 }
@@ -109,8 +117,9 @@ function setSelectorToElement(selectorKey, mutationRecord, document) {
 
   userAssert(
       targetElement !== null,
-      'No element on the document matches the selector, ' +
-    `${mutationRecord[selectorKey]} .`);
+      'No element on the document matches the selector, %s .',
+      mutationRecord[selectorKey]
+  );
 
   mutationRecord[selectorKey] = targetElement;
 }

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -18,6 +18,17 @@ import {isObject} from '../../../src/types';
 import {userAssert} from '../../../src/log';
 
 /**
+ * Types of possibile mutations
+ * from the WorkerDOM MutationRecord.
+ * This is the value set to the 'type' key.
+ */
+const MUTATION_TYPES = [
+  'attributes',
+  'characterData',
+  'childList',
+];
+
+/**
  * Function to find all selectors of the mutation
  * and return a function to apply the identified
  * MutationRecord
@@ -69,13 +80,8 @@ function assertMutationRecord_(mutation) {
       `Mutation ${JSON.stringify(mutation)} must have a type.`);
 
   // Assert the mutation type is one of the following keys
-  const mutationTypes = [
-    'attributes',
-    'characterData',
-    'childList',
-  ];
   userAssert(
-      mutationTypes.indexOf(mutation['type']) >= 0,
+      MUTATION_TYPES.indexOf(mutation['type']) >= 0,
       `Mutation ${JSON.stringify(mutation)} must have a type.`);
 
   // Assert the mutation target

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -25,6 +25,8 @@ describes.realWin('amp-experiment', {
   },
 }, env => {
 
+  // Config has empty mutations
+  // As mutation parser tests will handle this
   const config = {
     'experiment-1': {
       variants: {
@@ -155,7 +157,7 @@ describes.realWin('amp-experiment', {
     stub.withArgs(ampdoc, 'experiment-3', config['experiment-3'])
         .returns(Promise.resolve(null));
 
-    const applySpy = sandbox.spy(experiment, 'applyMutations_');
+    const applyStub = sandbox.stub(experiment, 'applyMutations_');
 
     experiment.buildCallback();
     return Services.variantsForDocOrNull(ampdoc.getHeadNode())
@@ -167,7 +169,7 @@ describes.realWin('amp-experiment', {
             'experiment-3': null,
           });
 
-          expect(applySpy).to.be.calledTwice;
+          expect(applyStub).to.be.calledTwice;
         });
   });
 });

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createElementWithAttributes} from '../../../../src/dom';
+import {parseMutation} from '../mutation-parser';
+
+describes.realWin('amp-experiment mutation-parser', {}, env => {
+  let win, doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+
+  function getAttributeMutation() {
+    const targetId = 'mutation-parser-test';
+    const targetElement = createElementWithAttributes(
+      doc,
+      'div',
+      {
+        'id': targetId
+      }
+    );
+
+    doc.body.appendChild(targetElement);
+
+    return {
+      type: "attributes",
+      target: `#${targetId}`,
+      attributeName: "style",
+      value: "color: red"
+    }
+  }
+
+  it('should allow a valid mutation', () => {
+    const mutation = getAttributeMutation();
+    const mutationOperation = parseMutation(mutation, doc);
+    expect(mutationOperation).to.be.ok;
+  });
+
+  it('should error when no mutation', () => {
+    allowConsoleError(() => {
+      expect(() => {
+        parseMutation(undefined, doc)
+      }).to.throw(/object/);
+    });
+  });
+
+  it('should error when no type', () => {
+    const mutation = getAttributeMutation();
+    delete mutation['type'];
+    allowConsoleError(() => {
+      expect(() => {
+        parseMutation(mutation, doc)
+      }).to.throw(/type/);
+    });
+  });
+
+  it('should error when invalid type', () => {
+    const mutation = getAttributeMutation();
+    mutation['type'] = 'test';
+    allowConsoleError(() => {
+      expect(() => {
+        parseMutation(mutation, doc)
+      }).to.throw(/type/);
+    });
+  });
+
+  it('should error when no target', () => {
+    const mutation = getAttributeMutation();
+    delete mutation['target'];
+    allowConsoleError(() => {
+      expect(() => {
+        parseMutation(mutation, doc)
+      }).to.throw(/target/);
+    });
+  });
+
+  it('should error when no target element', () => {
+    const mutation = getAttributeMutation();
+    doc.body.querySelector(mutation['target']).remove();
+    allowConsoleError(() => {
+      expect(() => {
+        parseMutation(mutation, doc)
+      }).to.throw(/selector/);
+    });
+  });
+
+
+});

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -28,21 +28,21 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
   function getAttributeMutation() {
     const targetId = 'mutation-parser-test';
     const targetElement = createElementWithAttributes(
-      doc,
-      'div',
-      {
-        'id': targetId
-      }
+        doc,
+        'div',
+        {
+          'id': targetId,
+        }
     );
 
     doc.body.appendChild(targetElement);
 
     return {
-      type: "attributes",
+      type: 'attributes',
       target: `#${targetId}`,
-      attributeName: "style",
-      value: "color: red"
-    }
+      attributeName: 'style',
+      value: 'color: red',
+    };
   }
 
   it('should allow a valid mutation', () => {
@@ -54,7 +54,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
   it('should error when no mutation', () => {
     allowConsoleError(() => {
       expect(() => {
-        parseMutation(undefined, doc)
+        parseMutation(undefined, doc);
       }).to.throw(/object/);
     });
   });
@@ -64,7 +64,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     delete mutation['type'];
     allowConsoleError(() => {
       expect(() => {
-        parseMutation(mutation, doc)
+        parseMutation(mutation, doc);
       }).to.throw(/type/);
     });
   });
@@ -74,7 +74,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     mutation['type'] = 'test';
     allowConsoleError(() => {
       expect(() => {
-        parseMutation(mutation, doc)
+        parseMutation(mutation, doc);
       }).to.throw(/type/);
     });
   });
@@ -84,7 +84,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     delete mutation['target'];
     allowConsoleError(() => {
       expect(() => {
-        parseMutation(mutation, doc)
+        parseMutation(mutation, doc);
       }).to.throw(/target/);
     });
   });
@@ -94,7 +94,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     doc.body.querySelector(mutation['target']).remove();
     allowConsoleError(() => {
       expect(() => {
-        parseMutation(mutation, doc)
+        parseMutation(mutation, doc);
       }).to.throw(/selector/);
     });
   });


### PR DESCRIPTION
relates to #20225

[Example Config in docs.snippets.json](https://glitch.com/edit/#!/amp-optimize-playground).

This starts the "Mutation Record" parser for `amp-experiment`. This only does the base "Mutation Record", Parsing specific mutations and returning functions to apply these mutations will come in later PRs. Thus, there is specific code that is there to outline how mutations will operate, and meant to demonstrate the API. This will be removed as it is not completed to keep PRs small(er).

**This original PR still requires tests. Let me know when the API looks good and should have tests written.**

cc @calebcordry 

# Example

**Note, this simple returns the mutation records in the console. This code was removed, and was meant for testing purposes.**

<img width="1440" alt="Screen Shot 2019-04-02 at 11 56 28 AM" src="https://user-images.githubusercontent.com/1448289/55429758-09f81800-5541-11e9-9924-6a2da0024b36.png">
