### PR TITLE
✨ Create a hidden attribute mutation observer service

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -26,14 +26,6 @@ import {
 } from '../refresh-intersection-observer-wrapper';
 import {Services} from '../../../../src/services';
 
-function getTestElement() {
-  const div = window.document.createElement('div');
-  div.setAttribute('style', 'width:1px; height:1px;');
-  div.setAttribute('type', 'doubleclick');
-  div.setAttribute(DATA_ATTR_NAME, '35');
-  return div;
-}
-
 describe('refresh', () => {
 
   let mockA4a;
@@ -43,6 +35,16 @@ describe('refresh', () => {
     totalTimeMin: 0,
     continuousTimeMin: 1,
   };
+
+  function getTestElement() {
+    const div = window.document.createElement('div');
+    div.setAttribute('style', 'width:1px; height:1px;');
+    div.setAttribute('type', 'doubleclick');
+    div.setAttribute(DATA_ATTR_NAME, '35');
+    sandbox.replaceGetter(div, 'isConnected', () => true);
+    return div;
+  }
+
 
   beforeEach(() => {
     sandbox = sinon.sandbox;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -213,6 +213,14 @@ const HIDE_ON_BOOKEND_SELECTOR =
 const DEFAULT_THEME_COLOR = '#202125';
 
 /**
+ * MutationObserverInit options to listen for changes to the `open` attribute.
+ */
+const SIDEBAR_OBSERVER_OPTIONS = {
+  attributes: true,
+  attributeFilter: ['open'],
+};
+
+/**
  * @implements {./media-pool.MediaPoolRoot}
  */
 export class AmpStory extends AMP.BaseElement {
@@ -1653,16 +1661,13 @@ export class AmpStory extends AMP.BaseElement {
     const actions = Services.actionServiceForDoc(this.element);
     if (this.win.MutationObserver) {
       if (!this.sidebarObserver_) {
-        this.sidebarObserver_ = new this.win.MutationObserver(mutationsList => {
-          if (mutationsList.some(
-              mutation => mutation.attributeName === 'open')) {
-            this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
-                this.sidebar_.hasAttribute('open'));
-          }
+        this.sidebarObserver_ = new this.win.MutationObserver(() => {
+          this.storeService_.dispatch(Action.TOGGLE_SIDEBAR,
+              this.sidebar_.hasAttribute('open'));
         });
       }
       if (this.sidebar_ && sidebarState) {
-        this.sidebarObserver_.observe(this.sidebar_, {attributes: true});
+        this.sidebarObserver_.observe(this.sidebar_, SIDEBAR_OBSERVER_OPTIONS);
         this.openOpacityMask_();
         actions.execute(this.sidebar_, 'open', /* args */ null,
             /* source */ null, /* caller */ null, /* event */ null,

--- a/src/inabox/amp-inabox-lite.js
+++ b/src/inabox/amp-inabox-lite.js
@@ -51,6 +51,7 @@ import {installActionServiceForDoc} from '../service/action-impl';
 import {installCidService} from '../service/cid-impl';
 import {installDocumentInfoServiceForDoc} from '../service/document-info-impl';
 import {installGlobalSubmitListenerForDoc} from '../document-submit';
+import {installHiddenObserverForDoc} from '../service/hidden-observer-impl';
 import {installHistoryServiceForDoc} from '../service/history-impl';
 import {installResourcesServiceForDoc} from '../service/resources-impl';
 import {installStandardActionsForDoc} from '../service/standard-actions-impl';
@@ -131,6 +132,7 @@ function installAmpdocServices(ampdoc, opt_initParams) {
   installDocumentInfoServiceForDoc(ampdoc);
   installViewerServiceForDoc(ampdoc, opt_initParams); // TODO: to be simplified
   installInaboxViewportService(ampdoc); // TODO: to be simplified
+  installHiddenObserverForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc); // TODO: to be simplified
   installUrlReplacementsServiceForDoc(ampdoc);

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -298,7 +298,7 @@ export class IntersectionObserverPolyfill {
           ampdoc.win,
           this.handleMutationObserverPass_.bind(this, element)
       );
-      const hiddenObserver = Services.hiddenObserverForDoc(element);
+      const hiddenObserver = Services.hiddenObserverForDoc(ampdoc);
       this.hiddenObserverUnlistener_ = hiddenObserver.add(
           this.handleMutationObserverNotification_.bind(this)
       );

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -298,7 +298,7 @@ export class IntersectionObserverPolyfill {
           ampdoc.win,
           this.handleMutationObserverPass_.bind(this, element)
       );
-      const hiddenObserver = Services.hiddenObserverForDoc(ampdoc);
+      const hiddenObserver = Services.hiddenObserverForDoc(element);
       this.hiddenObserverUnlistener_ = hiddenObserver.add(
           this.handleMutationObserverNotification_.bind(this)
       );

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -60,6 +60,7 @@ import {installDocumentInfoServiceForDoc} from './service/document-info-impl';
 import {installDocumentStateService} from './service/document-state';
 import {installGlobalNavigationHandlerForDoc} from './service/navigation';
 import {installGlobalSubmitListenerForDoc} from './document-submit';
+import {installHiddenObserverForDoc} from './service/hidden-observer-impl';
 import {installHistoryServiceForDoc} from './service/history-impl';
 import {installInputService} from './input';
 import {installPlatformService} from './service/platform-impl';
@@ -122,6 +123,7 @@ export function installAmpdocServices(ampdoc, opt_initParams) {
   installDocumentInfoServiceForDoc(ampdoc);
   installViewerServiceForDoc(ampdoc, opt_initParams);
   installViewportServiceForDoc(ampdoc);
+  installHiddenObserverForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc);
   installUrlReplacementsServiceForDoc(ampdoc);

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -255,7 +255,8 @@ export class FixedLayer {
       return;
     }
 
-    const hiddenObserver = Services.hiddenObserverForDoc(this.ampdoc);
+    const {documentElement} = this.ampdoc.getRootNode();
+    const hiddenObserver = Services.hiddenObserverForDoc(documentElement);
     this.hiddenObserverUnlistener_ = hiddenObserver.add(() => {
       if (!this.updatePass_.isPending()) {
         // Wait one animation frame so that other mutations may arrive.

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -105,8 +105,8 @@ export class FixedLayer {
       this.update();
     });
 
-    /** @private {?MutationObserver} */
-    this.mutationObserver_ = null;
+    /** @private {?function()} */
+    this.hiddenObserverUnlistener_ = null;
 
     /** @private {!Array<string>} */
     this.fixedSelectors_ = [];
@@ -231,60 +231,37 @@ export class FixedLayer {
     if (!isExperimentOn(this.ampdoc.win, 'hidden-mutation-observer')) {
       return;
     }
-    const mo = this.initMutationObserver_();
-    mo.observe(this.ampdoc.getRootNode(), {
-      attributes: true,
-      subtree: true,
-    });
+    this.initHiddenObserver_();
   }
 
   /**
-   * Stop observing changes to the hidden attribute. Does not destroy the
-   * mutation observer.
+   * Stop observing changes to the hidden attribute.
    */
   unobserveHiddenMutations_() {
-    this.clearMutationObserver_();
-    const mo = this.mutationObserver_;
-    if (mo) {
-      mo.disconnect();
-    }
-  }
-
-  /**
-   * Clears the mutation observer and its pass queue.
-   */
-  clearMutationObserver_() {
     this.updatePass_.cancel();
-    const mo = this.mutationObserver_;
-    if (mo) {
-      mo.takeRecords();
+    const unlisten = this.hiddenObserverUnlistener_;
+    if (unlisten) {
+      unlisten();
+      this.hiddenObserverUnlistener_ = null;
     }
   }
 
   /**
-   * @return {!MutationObserver}
+   * Start observing changes to the hidden attribute, if we haven't already
+   * started.
    */
-  initMutationObserver_() {
-    if (this.mutationObserver_) {
-      return this.mutationObserver_;
+  initHiddenObserver_() {
+    if (this.hiddenObserverUnlistener_) {
+      return;
     }
 
-    const mo = new this.ampdoc.win.MutationObserver(mutations => {
-      if (this.updatePass_.isPending()) {
-        return;
-      }
-
-      for (let i = 0; i < mutations.length; i++) {
-        const mutation = mutations[i];
-        if (mutation.attributeName === 'hidden') {
-          // Wait one animation frame so that other mutations may arrive.
-          this.updatePass_.schedule(16);
-          return;
-        }
+    const hiddenObserver = Services.hiddenObserverForDoc(this.ampdoc);
+    this.hiddenObserverUnlistener_ = hiddenObserver.add(() => {
+      if (!this.updatePass_.isPending()) {
+        // Wait one animation frame so that other mutations may arrive.
+        this.updatePass_.schedule(16);
       }
     });
-
-    return this.mutationObserver_ = mo;
   }
 
   /**
@@ -428,8 +405,8 @@ export class FixedLayer {
       return Promise.resolve();
     }
 
-    // Clear out the mutation observer's queue since we're doing the work now.
-    this.clearMutationObserver_();
+    // Clear out the update pass since we're doing the work now.
+    this.updatePass_.cancel();
 
     // Next, the positioning-related properties will be measured. If a
     // potentially fixed/sticky element turns out to be actually fixed/sticky,

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -15,6 +15,7 @@
  */
 
 import {Observable} from '../observable';
+import {devAssert} from '../log';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
@@ -34,8 +35,8 @@ const OBSERVER_OPTIONS = {
  * A document level service that will listen for mutations on the `hidden`
  * attribute and notify listeners. The `hidden` attribute is used to toggle
  * `display: none` on elements.
- * @implements {../../../src/service.EmbeddableService}
- * @implements {../../../src/service.Disposable}
+ * @implements {../service.EmbeddableService}
+ * @implements {../service.Disposable}
  */
 export class HiddenObserver {
   /**
@@ -46,8 +47,10 @@ export class HiddenObserver {
     /** @const {!Document|!ShadowRoot} */
     this.root_ = opt_root || ampdoc.getRootNode();
 
+    const doc = opt_root ? opt_root.ownerDocument : this.root_;
+
     /** @const {!Window} */
-    this.win_ = (opt_root ? opt_root.ownerDocument : this.root_).defaultView;
+    this.win_ = devAssert(doc.defaultView);
 
     /** @private {?MutationObserver} */
     this.mutationObserver_ = null;
@@ -89,7 +92,9 @@ export class HiddenObserver {
     this.observable_ = new Observable();
 
     const mo = new this.win_.MutationObserver(mutations => {
-      this.observable_.fire(mutations);
+      if (mutations) {
+        this.observable_.fire(mutations);
+      }
     });
     this.mutationObserver_ = mo;
     mo.observe(this.root_, OBSERVER_OPTIONS);

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -50,7 +50,7 @@ export class HiddenObserver {
     const doc = opt_root ? opt_root.ownerDocument : this.root_;
 
     /** @const {!Window} */
-    this.win_ = devAssert(doc.defaultView);
+    this.win_ = /** @type {!Window} */(devAssert(doc.defaultView));
 
     /** @private {?MutationObserver} */
     this.mutationObserver_ = null;

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Observable} from '../observable';
+import {
+  installServiceInEmbedScope,
+  registerServiceBuilderForDoc,
+} from '../service';
+
+/**
+ * MutationObserverInit options to listen for mutations to the `hidden`
+ * attribute.
+ */
+const OBSERVER_OPTIONS = {
+  attributes: true,
+  attributeFilter: ['hidden'],
+  subtree: true,
+};
+
+/**
+ * A document level service that will listen for mutations on the `hidden`
+ * attribute and notify listeners. The `hidden` attribute is used to toggle
+ * `display: none` on elements.
+ * @implements {../../../src/service.EmbeddableService}
+ * @implements {../../../src/service.Disposable}
+ */
+export class HiddenObserver {
+  /**
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @param {(!Document|!ShadowRoot)=} opt_root
+   */
+  constructor(ampdoc, opt_root) {
+    /** @const {!Document|!ShadowRoot} */
+    this.root_ = opt_root || ampdoc.getRootNode();
+
+    /** @const {!Window} */
+    this.win_ = (opt_root ? opt_root.ownerDocument : this.root_).defaultView;
+
+    /** @private {?MutationObserver} */
+    this.mutationObserver_ = null;
+
+    /** @private {?Observable<!Array<!MutationRecord>>} */
+    this.observable_ = null;
+  }
+
+  /** @override @nocollapse */
+  static installInEmbedWindow(embedWin, ampdoc) {
+    installServiceInEmbedScope(embedWin, 'hidden-observer',
+        new HiddenObserver(ampdoc, embedWin.document));
+  }
+
+  /**
+   * Adds the observer to this instance.
+   * @param {function(!Array<!MutationRecord>)} handler Observer's handler.
+   * @return {!UnlistenDef}
+   */
+  add(handler) {
+    this.init_();
+
+    const remove = this.observable_.add(handler);
+    return () => {
+      remove();
+      if (this.observable_.getHandlerCount() === 0) {
+        this.dispose();
+      }
+    };
+  }
+
+  /**
+   * Initializes the mutation observer and observable.
+   */
+  init_() {
+    if (this.mutationObserver_) {
+      return;
+    }
+    this.observable_ = new Observable();
+
+    const mo = new this.win_.MutationObserver(mutations => {
+      this.observable_.fire(mutations);
+    });
+    this.mutationObserver_ = mo;
+    mo.observe(this.root_, OBSERVER_OPTIONS);
+  }
+
+  /**
+   * Cleans up the all the mutation observer once the last listener stops
+   * listening, or when the service's doc is disposing.
+   */
+  dispose() {
+    if (!this.mutationObserver_) {
+      return;
+    }
+    this.mutationObserver_.disconnect();
+    this.observable_.removeAll();
+    this.mutationObserver_ = null;
+    this.observable_ = null;
+  }
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ */
+export function installHiddenObserverForDoc(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, 'hidden-observer', HiddenObserver);
+}

--- a/src/services.js
+++ b/src/services.js
@@ -253,6 +253,16 @@ export class Services {
   }
 
   /**
+   * Returns service to listen for `hidden` attribute mutations.
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {!./service/hidden-observer-impl.HiddenObserver}
+   */
+  static hiddenObserverForDoc(elementOrAmpDoc) {
+    return /** @type {!./service/hidden-observer-impl.HiddenObserver} */ (
+      getServiceForDoc(elementOrAmpDoc, 'hidden-observer'));
+  }
+
+  /**
    * Returns service implemented in service/history-impl.
    * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/history-impl.History}

--- a/src/services.js
+++ b/src/services.js
@@ -254,12 +254,12 @@ export class Services {
 
   /**
    * Returns service to listen for `hidden` attribute mutations.
-   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @param {!Element|!ShadowRoot} element
    * @return {!./service/hidden-observer-impl.HiddenObserver}
    */
-  static hiddenObserverForDoc(elementOrAmpDoc) {
+  static hiddenObserverForDoc(element) {
     return /** @type {!./service/hidden-observer-impl.HiddenObserver} */ (
-      getServiceForDoc(elementOrAmpDoc, 'hidden-observer'));
+      getExistingServiceForDocInEmbedScope(element, 'hidden-observer'));
   }
 
   /**

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -19,6 +19,9 @@ import {FakeMutationObserver, FakeWindow} from '../../testing/fake-dom';
 import {FixedLayer} from '../../src/service/fixed-layer';
 import {Services} from '../../src/services';
 import {endsWith} from '../../src/string';
+import {
+  installHiddenObserverForDoc,
+} from '../../src/service/hidden-observer-impl';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {toggle} from '../../src/style';
@@ -160,6 +163,7 @@ describes.sandboxed('FixedLayer', {}, () => {
     };
     documentApi.defaultView.document = documentApi;
     ampdoc = new AmpDocSingle(documentApi.defaultView);
+    installHiddenObserverForDoc(ampdoc);
     installPlatformService(documentApi.defaultView);
     installTimerService(documentApi.defaultView);
     timer = Services.timerFor(documentApi.defaultView);
@@ -1126,10 +1130,13 @@ describes.sandboxed('FixedLayer', {}, () => {
     });
 
     describe('hidden toggle', () => {
+      let mutationObserver;
       beforeEach(() => {
         toggleExperiment(documentApi.defaultView, 'hidden-mutation-observer',
             true);
         fixedLayer.observeHiddenMutations();
+        mutationObserver =
+          Services.hiddenObserverForDoc(ampdoc).mutationObserver_;
       });
 
       it('should trigger an update', () => {
@@ -1149,7 +1156,7 @@ describes.sandboxed('FixedLayer', {}, () => {
         sandbox.stub(timer, 'delay').callsFake(callback => {
           callback();
         });
-        return fixedLayer.mutationObserver_.__mutate({
+        return mutationObserver.__mutate({
           attributeName: 'hidden',
         }).then(() => {
           expect(vsyncTasks).to.have.length(2);
@@ -1477,10 +1484,13 @@ describes.sandboxed('FixedLayer', {}, () => {
     });
 
     describe('hidden toggle', () => {
+      let mutationObserver;
       beforeEach(() => {
         toggleExperiment(documentApi.defaultView, 'hidden-mutation-observer',
             true);
         fixedLayer.observeHiddenMutations();
+        mutationObserver =
+          Services.hiddenObserverForDoc(ampdoc).mutationObserver_;
       });
 
       it('should trigger an update', () => {
@@ -1500,7 +1510,7 @@ describes.sandboxed('FixedLayer', {}, () => {
         sandbox.stub(timer, 'delay').callsFake(callback => {
           callback();
         });
-        return fixedLayer.mutationObserver_.__mutate({
+        return mutationObserver.__mutate({
           attributeName: 'hidden',
         }).then(() => {
           expect(vsyncTasks).to.have.length(2);

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {AmpDocSingle} from '../../src/service/ampdoc-impl';
+import {
+  AmpDocSingle,
+  installDocService,
+} from '../../src/service/ampdoc-impl';
 import {FakeMutationObserver, FakeWindow} from '../../testing/fake-dom';
 import {FixedLayer} from '../../src/service/fixed-layer';
 import {Services} from '../../src/services';
@@ -162,7 +165,8 @@ describes.sandboxed('FixedLayer', {}, () => {
       body: docBody,
     };
     documentApi.defaultView.document = documentApi;
-    ampdoc = new AmpDocSingle(documentApi.defaultView);
+    installDocService(documentApi.defaultView, /* isSingleDoc */ true);
+    ampdoc = Services.ampdocServiceFor(documentApi.defaultView).getAmpDoc();
     installHiddenObserverForDoc(ampdoc);
     installPlatformService(documentApi.defaultView);
     installTimerService(documentApi.defaultView);
@@ -209,6 +213,7 @@ describes.sandboxed('FixedLayer', {}, () => {
     const children = [];
     const elem = {
       id,
+      nodeType: 1,
       ownerDocument: documentApi,
       autoTop: '',
       tagName: id,
@@ -1135,8 +1140,8 @@ describes.sandboxed('FixedLayer', {}, () => {
         toggleExperiment(documentApi.defaultView, 'hidden-mutation-observer',
             true);
         fixedLayer.observeHiddenMutations();
-        mutationObserver =
-          Services.hiddenObserverForDoc(ampdoc).mutationObserver_;
+        mutationObserver = Services.hiddenObserverForDoc(
+            documentApi.documentElement).mutationObserver_;
       });
 
       it('should trigger an update', () => {
@@ -1489,8 +1494,8 @@ describes.sandboxed('FixedLayer', {}, () => {
         toggleExperiment(documentApi.defaultView, 'hidden-mutation-observer',
             true);
         fixedLayer.observeHiddenMutations();
-        mutationObserver =
-          Services.hiddenObserverForDoc(ampdoc).mutationObserver_;
+        mutationObserver = Services.hiddenObserverForDoc(
+            documentApi.documentElement).mutationObserver_;
       });
 
       it('should trigger an update', () => {

--- a/test/unit/test-hidden-observer.js
+++ b/test/unit/test-hidden-observer.js
@@ -35,7 +35,8 @@ describes.fakeWin('HiddenObserver', {
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    hiddenObserver = Services.hiddenObserverForDoc(env.ampdoc);
+    hiddenObserver =
+      Services.hiddenObserverForDoc(env.win.document.documentElement);
   });
 
   it('initializes mutation observer on first listen', () => {

--- a/test/unit/test-hidden-observer.js
+++ b/test/unit/test-hidden-observer.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FakeMutationObserver} from '../../testing/fake-dom';
+import {Services} from '../../src/services';
+
+describes.fakeWin('HiddenObserver', {
+  amp: true,
+}, env => {
+  let hiddenObserver;
+  let sandbox;
+  let MutationObserver;
+
+  function setupSingletonMutationObserver(opt_cb = () => {}) {
+    const mo = new FakeMutationObserver(opt_cb);
+    MutationObserver = sandbox.stub().callsFake(function() {
+      return mo;
+    });
+    env.win.MutationObserver = MutationObserver;
+    return mo;
+  }
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    hiddenObserver = Services.hiddenObserverForDoc(env.ampdoc);
+  });
+
+  it('initializes mutation observer on first listen', () => {
+    const mo = setupSingletonMutationObserver();
+    const observe = sandbox.spy(mo, 'observe');
+
+    hiddenObserver.add(() => {});
+
+    expect(MutationObserver).to.have.been.calledOnce;
+    expect(observe).to.have.been.calledOnceWith(env.win.document);
+  });
+
+  it('keeps mutation observer on second listen', () => {
+    const mo = setupSingletonMutationObserver();
+    const observe = sandbox.spy(mo, 'observe');
+
+    hiddenObserver.add(() => {});
+    hiddenObserver.add(() => {});
+
+    expect(MutationObserver).to.have.been.calledOnce;
+    expect(observe).to.have.been.calledOnce;
+  });
+
+  it('frees mutation observer after last unlisten', () => {
+    const mo = setupSingletonMutationObserver();
+    const disconnect = sandbox.spy(mo, 'disconnect');
+
+    const unlisten = hiddenObserver.add(() => {});
+    unlisten();
+
+    expect(disconnect).to.have.been.calledOnce;
+  });
+
+  it('keeps mutation observer after second-to-last unlisten', () => {
+    const mo = setupSingletonMutationObserver();
+    const disconnect = sandbox.spy(mo, 'disconnect');
+
+    const unlisten = hiddenObserver.add(() => {});
+    const unlisten2 = hiddenObserver.add(() => {});
+
+    unlisten();
+    expect(disconnect).not.to.have.been.called;
+
+    unlisten2();
+    expect(disconnect).to.have.been.calledOnce;
+  });
+
+  it('passes MutationRecords to handler', function*() {
+    const stub = sandbox.stub();
+    const mo = setupSingletonMutationObserver(stub);
+
+    const mutation = {};
+    const mutation2 = {};
+    mo.__mutate(mutation);
+    yield mo.__mutate(mutation2);
+
+    expect(stub).to.have.been.calledOnceWith([mutation, mutation2]);
+  });
+});

--- a/test/unit/test-hidden-observer.js
+++ b/test/unit/test-hidden-observer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/test-intersection-observer-polyfill.js
+++ b/test/unit/test-intersection-observer-polyfill.js
@@ -23,6 +23,9 @@ import {
   intersectionRatio,
 } from '../../src/intersection-observer-polyfill';
 import {Services} from '../../src/services';
+import {
+  installHiddenObserverForDoc,
+} from '../../src/service/hidden-observer-impl';
 import {layoutRectLtwh} from '../../src/layout-rect';
 
 const fakeAmpDoc = {
@@ -30,6 +33,7 @@ const fakeAmpDoc = {
   win: window,
   isSingleDoc: () => {return true;},
 };
+installHiddenObserverForDoc(fakeAmpDoc);
 
 describe('IntersectionObserverApi', () => {
   let sandbox;
@@ -394,23 +398,7 @@ describe('IntersectionObserverPolyfill', () => {
           return layoutRectLtwh(0, 0, 100, 100);
         };
         io.observe(element);
-        expect(io.mutationObserver_).to.be.ok;
-      });
-
-      it('should not create a mutation observer,' +
-        ' if one already exists', () => {
-        io = new IntersectionObserverPolyfill(callbackSpy, {
-          threshold: [0, 1],
-        });
-        element.getLayoutBox = () => {
-          return layoutRectLtwh(0, 0, 100, 100);
-        };
-        io.observe(element);
-        expect(io.mutationObserver_).to.be.ok;
-        const mutationObserver = io.mutationObserver_;
-        io.observe(element);
-        expect(io.mutationObserver_).to.be.ok;
-        expect(io.mutationObserver_).to.be.equal(mutationObserver);
+        expect(io.hiddenObserverUnlistener_).to.be.ok;
       });
 
       it('should remove mutation observer,' +
@@ -422,9 +410,9 @@ describe('IntersectionObserverPolyfill', () => {
           return layoutRectLtwh(0, 0, 100, 100);
         };
         io.observe(element);
-        expect(io.mutationObserver_).to.be.ok;
+        expect(io.hiddenObserverUnlistener_).to.be.ok;
         io.disconnect();
-        expect(io.mutationObserver_).to.not.be.ok;
+        expect(io.hiddenObserverUnlistener_).to.not.be.ok;
       });
     });
 

--- a/test/unit/test-intersection-observer-polyfill.js
+++ b/test/unit/test-intersection-observer-polyfill.js
@@ -86,6 +86,8 @@ describe('IntersectionObserverApi', () => {
       getOwner: () => {return null;},
       getLayoutBox: () => {return layoutRectLtwh(50, 100, 150, 200);},
       win: window,
+      ownerDocument: {defaultView: window},
+      nodeType: 1,
     };
 
     baseElement = {
@@ -325,6 +327,8 @@ describe('IntersectionObserverPolyfill', () => {
       element = {
         isBuilt: () => {return true;},
         getOwner: () => {return null;},
+        ownerDocument: {defaultView: window},
+        nodeType: 1,
       };
     });
 


### PR DESCRIPTION
Creates a shared `hidden` attribute `MutationObserver`, so that we don't have extensions creating redundant MOs.

Fixes https://github.com/ampproject/amphtml/issues/19054