### PR TITLE
Use `scroll-snap-stop` for amp-base-carousel

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.css
+++ b/extensions/amp-base-carousel/0.1/carousel.css
@@ -91,6 +91,7 @@
   flex-shrink: 0 !important;
   width: 100%;
   height: 100%;
+  scroll-snap-stop: always;
 }
 
 .i-amphtml-carousel-scroll[horizontal="true"][mixed-length="false"] > .i-amphtml-carousel-slotted,


### PR DESCRIPTION
This will result in much more predictable carousel swiping behavior for browsers that support the property.
