### PR TITLE
🌐 Get ad attribution label from localization service

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/_locales/en.js
+++ b/extensions/amp-story-auto-ads/0.1/_locales/en.js
@@ -24,6 +24,11 @@ import {
  * @const {!LocalizedStringBundleDef}
  */
 export default /** @const {!LocalizedStringBundleDef} */ ({
+  [LocalizedStringId.AMP_STORY_AUTO_ADS_ATTRIBUTION_LABEL]: {
+    string: 'Ad',
+    description: 'A label that indicates that a piece of content is an ' +
+        'advertisement.',
+  },
   [LocalizedStringId.AMP_STORY_AUTO_ADS_BUTTON_LABEL_APPLY_NOW]: {
     string: 'Apply Now',
     description: 'Button label for an ad call to action button that asks ' +

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -367,7 +367,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     const span = this.win.document.createElement('p');
     span.className = 'i-amphtml-story-ad-attribution';
-    span.textContent = 'Ad';
+    span.textContent = this.localizationService_.getLocalizedString(
+        LocalizedStringId.AMP_STORY_AUTO_ADS_ATTRIBUTION_LABEL);
 
     createShadowRootWithStyle(container, span, attributionCSS);
     this.ampStory_.element.appendChild(container);


### PR DESCRIPTION
Gets the "Ad" attribution label from the localization service.

Note that there are no string translations for this label yet, so until those are committed, it will continue to default to "Ad".