### PR TITLE
✨ Allowing custom scope for SW in <amp-web-push>

### DIFF
--- a/extensions/amp-web-push/0.1/amp-web-push-config.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-config.js
@@ -25,6 +25,7 @@ export const WebPushConfigAttributes = {
   HELPER_FRAME_URL: 'helper-iframe-url',
   PERMISSION_DIALOG_URL: 'permission-dialog-url',
   SERVICE_WORKER_URL: 'service-worker-url',
+  SERVICE_WORKER_SCOPE: 'service-worker-scope',
 };
 
 /** @enum {string} */
@@ -71,12 +72,13 @@ export class WebPushConfig extends AMP.BaseElement {
       'helper-iframe-url': null,
       'permission-dialog-url': null,
       'service-worker-url': null,
+      'service-worker-scope': null,
     };
 
     for (const attribute in WebPushConfigAttributes) {
       const value = WebPushConfigAttributes[attribute];
       userAssert(
-          this.element.getAttribute(value),
+          this.element.getAttribute(value) || value === 'service-worker-scope',
           `The ${value} attribute is required for <${CONFIG_TAG}>`
       );
       config[value] = this.element.getAttribute(value);
@@ -113,6 +115,7 @@ export class WebPushConfig extends AMP.BaseElement {
           'to be installed.'
       );
     }
+
 
     if (
       parseUrlDeprecated(config['service-worker-url']).origin !==

--- a/extensions/amp-web-push/0.1/test/test-web-push-config.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-config.js
@@ -35,6 +35,8 @@ describes.realWin('web-push-config', {
       'https://a.com/webpush/amp/subscribe?https=1';
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       'https://a.com/service-worker.js?param=value';
+    webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
+      '/';
     return webPushConfig;
   }
 
@@ -51,6 +53,8 @@ describes.realWin('web-push-config', {
         attributes[WebPushConfigAttributes.PERMISSION_DIALOG_URL]);
     element.setAttribute(WebPushConfigAttributes.SERVICE_WORKER_URL,
         attributes[WebPushConfigAttributes.SERVICE_WORKER_URL]);
+    element.setAttribute(WebPushConfigAttributes.SERVICE_WORKER_SCOPE,
+        attributes[WebPushConfigAttributes.SERVICE_WORKER_SCOPE]);
     element.setAttribute('id', TAG);
     win.document.body.appendChild(element);
     return element;
@@ -81,21 +85,23 @@ describes.realWin('web-push-config', {
     });
   });
 
-  it('should fail if any attribute is missing', () => {
+  it('should fail if any mandatory attribute is missing', () => {
     const promises = [];
     for (const attribute in WebPushConfigAttributes) {
       const configName = WebPushConfigAttributes[attribute];
-      const promise = env.ampdoc.whenReady().then(() => {
-        removeAllWebPushConfigElements();
-        webPushConfig = setDefaultWebPushConfig();
-        delete webPushConfig[configName];
-        const element = createConfigElementWithAttributes(webPushConfig);
-        expect(() => {
-          element.implementation_.validate();
-        }).to.throw(
-            new RegExp('must have a valid ' + configName + ' attribute'));
-      });
-      promises.push(promise);
+      if (configName !== WebPushConfigAttributes.SERVICE_WORKER_SCOPE) {
+        const promise = env.ampdoc.whenReady().then(() => {
+          removeAllWebPushConfigElements();
+          webPushConfig = setDefaultWebPushConfig();
+          delete webPushConfig[configName];
+          const element = createConfigElementWithAttributes(webPushConfig);
+          expect(() => {
+            element.implementation_.validate();
+          }).to.throw(
+              new RegExp('must have a valid ' + configName + ' attribute'));
+        });
+        promises.push(promise);
+      }
     }
     return Promise.all(promises);
   });

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -185,6 +185,8 @@ describes.realWin('web-push-service helper frame messaging', {
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
+    webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
+      FAKE_IFRAME_URL;  
   }
 
   function setupHelperIframe() {
@@ -254,6 +256,8 @@ describes.realWin('web-push-service widget visibilities', {
     webPushConfig[WebPushConfigAttributes.PERMISSION_DIALOG_URL] =
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
+      FAKE_IFRAME_URL;
+    webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
       FAKE_IFRAME_URL;
   }
 
@@ -537,6 +541,8 @@ describes.realWin('web-push-service subscribing', {
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
+    webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
+      FAKE_IFRAME_URL;  
   }
 
   function setupHelperIframe() {
@@ -586,10 +592,9 @@ describes.realWin('web-push-service subscribing', {
           .withArgs(
               webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL],
               {
-                scope: '/',
+                scope: webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE],
               })
           .returns(Promise.resolve(true));
-
       return webPush.registerServiceWorker();
     }).then(() => {
       helperFrameSwMessageMock.verify();
@@ -682,6 +687,8 @@ describes.realWin('web-push-service unsubscribing', {
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
+    webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
+      FAKE_IFRAME_URL;  
   }
 
   function setupHelperIframe() {

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -186,7 +186,7 @@ describes.realWin('web-push-service helper frame messaging', {
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
-      FAKE_IFRAME_URL;  
+      FAKE_IFRAME_URL;
   }
 
   function setupHelperIframe() {
@@ -542,7 +542,7 @@ describes.realWin('web-push-service subscribing', {
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
-      FAKE_IFRAME_URL;  
+      FAKE_IFRAME_URL;
   }
 
   function setupHelperIframe() {
@@ -582,6 +582,8 @@ describes.realWin('web-push-service subscribing', {
 
   it('should register service worker', () => {
     let helperFrameSwMessageMock = null;
+    const swUrl = webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL];
+    const swScope = webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE];
 
     return setupHelperIframe().then(() => {
       helperFrameSwMessageMock = sandbox./*OK*/mock(
@@ -589,11 +591,7 @@ describes.realWin('web-push-service subscribing', {
       );
       helperFrameSwMessageMock.expects('register')
           .once()
-          .withArgs(
-              webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL],
-              {
-                scope: webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE],
-              })
+          .withArgs(swUrl, {scope: swScope})
           .returns(Promise.resolve(true));
       return webPush.registerServiceWorker();
     }).then(() => {
@@ -688,7 +686,7 @@ describes.realWin('web-push-service unsubscribing', {
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_URL] =
       FAKE_IFRAME_URL;
     webPushConfig[WebPushConfigAttributes.SERVICE_WORKER_SCOPE] =
-      FAKE_IFRAME_URL;  
+      FAKE_IFRAME_URL;
   }
 
   function setupHelperIframe() {

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -329,14 +329,12 @@ export class WebPushService {
    * @return {Promise<ServiceWorkerRegistrationMessage>}
    */
   registerServiceWorker() {
+
     return this.queryHelperFrame_(
         WindowMessenger.Topics.SERVICE_WORKER_REGISTRATION,
         {
-          workerUrl: this.config_['service-worker-url'],
-          registrationOptions: this.config_.serviceWorkerRegistrationOptions ||
-            {
-              scope: '/',
-            },
+          workerUrl : this.config_['service-worker-url'],
+          registrationOptions : (this.config_['service-worker-scope'] ? {scope : this.config_['service-worker-scope']} : {})
         }
     );
   }

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -329,12 +329,14 @@ export class WebPushService {
    * @return {Promise<ServiceWorkerRegistrationMessage>}
    */
   registerServiceWorker() {
+    const swUrl = this.config_['service-worker-url'];
+    const swScope = this.config_['service-worker-scope'];
 
     return this.queryHelperFrame_(
         WindowMessenger.Topics.SERVICE_WORKER_REGISTRATION,
         {
-          workerUrl : this.config_['service-worker-url'],
-          registrationOptions : (this.config_['service-worker-scope'] ? {scope : this.config_['service-worker-scope']} : {})
+          workerUrl: swUrl,
+          registrationOptions: (swScope ? {scope: swScope} : {}),
         }
     );
   }

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -135,6 +135,14 @@ All properties are <strong>required</strong>, and all URLs must begin with the s
        </p>
     </td>
   </tr>
+  <tr>
+    <td><code>service-worker-scope (optional)</code></td>
+    <td>
+      <p>
+        The scope of the service worker to be installed.
+      </p>
+    </td>
+  </tr>
 </table>
 
 ## Validation


### PR DESCRIPTION
Fixes #19023 

Allows **amp-web-push** to:

- Declare Service Workers in subdirectories.
- Declare custom scopes for Service Workers.

**Instructions to test locally:**

The component requires absolute urls on HTTPS to work. The following steps will allow to test the component locally (a proper test on a public URL is still required after going live).

1. Bypass requirements for public and HTTPS urls, by commenting from [this line](https://github.com/ampproject/amphtml/blob/7b16d1cc109eb77a8e0477dd8eff9501fae638b2/extensions/amp-web-push/0.1/amp-web-push-config.js#L85) to [this line](https://github.com/ampproject/amphtml/blob/7b16d1cc109eb77a8e0477dd8eff9501fae638b2/extensions/amp-web-push/0.1/amp-web-push-config.js#L115) of amp-web-push-config.js.

2. Make sure to compile first with ``gulp dist --fortesting``, so the helper files are built and placed on /dist/v0, where they will by the example.

3. Reuse the current [amp-web-push example](https://github.com/ampproject/amphtml/blob/master/examples/amp-web-push.amp.html), and change the urls for:

```
  <amp-web-push
    id="amp-web-push"
    layout="nodisplay"
    helper-iframe-url="/dist/v0/amp-web-push-helper-frame.html"
    permission-dialog-url="/dist/v0/amp-web-push-permission-dialog.html"
    service-worker-url="/examples/example-sw.js"
  ></amp-web-push>
```

4. Run ``gulp`` and go to: http://localhost:8000/examples/amp-web-push.amp.html.
The Service Worker will be registered whenever the “Subscribe to notifications” button is clicked.

**Note:** Allowing/blocking notifications inside the popup, sets the browser permission. Make sure to click the button next to the address bar on the browser, and turn the “notifications” option back to “Ask” after every test.

5. Test the following scenarios by checking how the SW was installed in CDT->"Application"->"ServiceWorkers".
Make sure to unregister the SW and reload the page after each test:

- No "service-worker-scope" param: should allow to install the SW under /examples/.
- Add service-worker-scope="/examples/". Idem previous step.
- Add service-worker-scope="/examples/ads/". Check that the scope is now "/examples/ads/".

cc // @jridgewell 