### PR TITLE
✅  Re-enable embedded component desktop tests

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
@@ -23,7 +23,7 @@ module.exports = {
     await page.waitFor('amp-story-page#page-2[active]');
     await page.waitFor(300); // For animations to finish.
     await page.tap('a.title-small.center');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping outside tooltip should hide it': async (page, name) => {
@@ -34,7 +34,7 @@ module.exports = {
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.waitFor(300); // For animations to finish.
     await page.tap('.i-amphtml-story-focused-state-layer');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsVisible(
       page, name, ['.i-amphtml-story-focused-state-layer.i-amphtml-hidden']);
   },
@@ -46,7 +46,7 @@ module.exports = {
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.waitFor(300); // For animations to finish.
     await page.tap('a.i-amphtml-story-tooltip');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsVisible(page, name, ['a.i-amphtml-story-tooltip']);
   },
   'tapping arrow when tooltip is open should navigate': async (page, name) => {
@@ -57,7 +57,7 @@ module.exports = {
     await page.waitFor('a.i-amphtml-story-tooltip');
     await page.waitFor(300); // For animations to finish.
     await page.tap('.next-container > button.i-amphtml-story-button-move');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsVisible(page, name, ['amp-story-page#page-3[active]']);
   },
   'tapping on embed tooltip should expand the component': async (page, name) => {
@@ -67,7 +67,7 @@ module.exports = {
     await page.tap('amp-twitter.interactive-embed');
     await page.waitFor(300); // For animations to finish.
     await page.tap('a.i-amphtml-story-tooltip');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsVisible(page, name, ['amp-story-page.i-amphtml-expanded-mode']);
   },
   'tapping on non-interactive embed should not show tooltip or block navigation': async (page, name) => {
@@ -78,7 +78,7 @@ module.exports = {
     await page.waitFor('amp-story-page#page-3[active]');
     await page.waitFor(300); // For animations to finish.
     await page.tap('amp-twitter.non-interactive-embed');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await verifySelectorsInvisible(page, name, ['a.i-amphtml-story-tooltip']);
     await verifySelectorsVisible(page, name, ['amp-story-page#page-4[active]']);
   },
@@ -90,7 +90,7 @@ module.exports = {
     await page.waitFor(300); // For animations to finish.
     await page.tap('a.i-amphtml-story-tooltip');
     await page.waitFor('amp-story-page.i-amphtml-expanded-mode');
-    await page.waitFor(300); // For animations to finish.
+    await page.waitFor(800); // For animations to finish.
     await page.tap('span.i-amphtml-expanded-view-close-button');
     await verifySelectorsInvisible(page, name, ['amp-story-page.i-amphtml-expanded-mode']);
   },

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -585,7 +585,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-tooltip.js"
     },
     {
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-tooltip.html",
       "name": "amp-story: tooltip desktop",
       "viewport": {"width": 1440, "height": 900},


### PR DESCRIPTION
Closes #21665

Ran tests repeatedly (20+ times/variation) and 800ms seemed to be the sweet spot.