### PR TITLE
🚀  Watch devdash modules for server reload

### DIFF
--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -20,6 +20,7 @@ const colors = require('ansi-colors');
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 const nodemon = require('nodemon');
+const path = require('path');
 
 const host = argv.host || 'localhost';
 const port = argv.port || process.env.PORT || 8000;
@@ -50,6 +51,9 @@ function serve() {
       require.resolve('../app.js'),
       require.resolve('../routes/analytics.js'),
       require.resolve('../server.js'),
+
+      // All devdash routes:
+      path.dirname(require.resolve('../app-index')),
     ],
     env: {
       'NODE_ENV': 'development',


### PR DESCRIPTION
Turns out this is already handled by `nodemon`, we simply need to add the devdash module path to watch and reload server.