### PR TITLE
🐛 Update frontmatter for amp-story documentation.

### DIFF
--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -2,6 +2,7 @@
 $category@: presentation
 formats:
   - websites
+  - stories
 teaser:
   text: A rich, visual storytelling format.
 ---


### PR DESCRIPTION
Fixes ampproject/docs#1724: the amp-story documentation is currently not available when filtering for format stories.

/cc @sebastianbenz, @CrystalOnScript 