### PR TITLE
🐛amp-mraid: handle non-inabox better

### DIFF
--- a/extensions/amp-mraid/0.1/amp-mraid.js
+++ b/extensions/amp-mraid/0.1/amp-mraid.js
@@ -82,7 +82,7 @@ export class MraidInitializer {
 
     if (getMode().runtime !== 'inabox') {
       dev().fine(TAG, 'Only supported with Inabox');
-      handleMismatch();
+      this.handleMismatch_();
       return;
     }
 

--- a/extensions/amp-mraid/0.1/amp-mraid.js
+++ b/extensions/amp-mraid/0.1/amp-mraid.js
@@ -66,11 +66,6 @@ export class MraidInitializer {
     /** @private {boolean} */
     this.fallback_ = false;
 
-    if (getMode().runtime !== 'inabox') {
-      dev().error(TAG, 'Only supported with Inabox');
-      return;
-    }
-
     const ampMraidScripts = this.ampdoc_.getHeadNode().querySelectorAll(
         'script[host-service="amp-mraid"]');
     if (ampMraidScripts.length > 1) {
@@ -84,6 +79,12 @@ export class MraidInitializer {
     const fallbackOn =
         (element.getAttribute(FALLBACK_ON) || '').split(' ');
     this.fallback_ = fallbackOn.includes(FallbackErrorNames.MISMATCH);
+
+    if (getMode().runtime !== 'inabox') {
+      dev().fine(TAG, 'Only supported with Inabox');
+      handleMismatch();
+      return;
+    }
 
     // It looks like we're initiating a network load for mraid from a relative
     // url, but this will actually be intercepted by the mobile app SDK and


### PR DESCRIPTION
Currently, if we serve amp-mraid to a non-inabox environment it will bail out immediately.  Unfortunately, amp-analytics etc will be stuck waiting for amp-mraid to finish loading.  We should treat this like any other environment mismatch, and fall back if configured to.
