### PR TITLE
✨amp-experiment: Base functionality for Demo

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -24,6 +24,7 @@
     <script type="application/json">
       {
         "background-color-test": {
+          "consentNotificationId": "amp-user-notification",
           "variants": {
             "yellow": {
               "weight": 50,
@@ -32,72 +33,43 @@
                   "type": "attributes",
                   "target": "h1",
                   "attributeName": "style",
-                  "value": "color: yellow"
-                }
-              ]
-            },
-            "green": {
-              "weight": 50,
-              "mutations": [
-                {
-                  "type": "attributes",
-                  "target": "h1",
-                  "attributeName": "style",
-                  "value": "color: green"
-                }
-              ]
-            }
-          }
-        },
-        "font-color-test": {
-          "sticky": false,
-          "variants": {
-            "blue": {
-              "weight": 20,
-              "mutations": [
-                {
-                  "type": "attributes",
-                  "target": "h1",
-                  "attributeName": "style",
-                  "value": "color: blue"
+                  "value": "background-color: #FFFF00"
                 }
               ]
             },
             "red": {
-              "weight": 20,
+              "weight": 50,
               "mutations": [
                 {
                   "type": "attributes",
                   "target": "h1",
                   "attributeName": "style",
-                  "value": "color: red"
+                  "value": "background-color: #FF0000"
                 }
               ]
             }
           }
         },
-        "border-test": {
-          "consentNotificationId": "amp-user-notification",
+        "text-content-test": {
+          "sticky": false,
           "variants": {
-            "solid": {
+            "firstVariant": {
               "weight": 50,
               "mutations": [
                 {
-                  "type": "attributes",
+                  "type": "characterData",
                   "target": "h1",
-                  "attributeName": "style",
-                  "value": "border: 1px black solid"
+                  "value": "First characterData Variant"
                 }
               ]
             },
-            "dashed": {
+            "secondVariant": {
               "weight": 50,
               "mutations": [
                 {
-                  "type": "attributes",
+                  "type": "characterData",
                   "target": "h1",
-                  "attributeName": "style",
-                  "value": "border: 1px black dashed"
+                  "value": "Second characterData Variant"
                 }
               ]
             }
@@ -106,11 +78,11 @@
       }
     </script>
   </amp-experiment>
-  <amp-pixel src="https://donot.worry/?background-color-test=VARIANT(background-color-test)&font-color-test=VARIANT(font-color-test)&variants=VARIANTS"></amp-pixel>
+  <amp-pixel src="https://donot.worry/?background-color-test=VARIANT(background-color-test)&text-content-test=VARIANT(text-content-test)&variants=VARIANTS"></amp-pixel>
   <amp-user-notification
       layout=nodisplay
       id="amp-user-notification">
-    Dismiss this notification to see a border around title on your next visit.
+    Dismiss this notification to see a background-color on the title on your next visit.
     <button on="tap:amp-user-notification.dismiss" role="button">I accept</button>
   </amp-user-notification>
 </body>

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -50,10 +50,10 @@ const SUPPORTED_ATTRIBUTES = {
 
     return false;
   },
-  src: () => {
+  src: (value) => {
     return value.match(/^https:\/\//g);
   },
-  href: () => {
+  href: (value) => {
     return value.match(/^https:\/\//g);
   }
 }
@@ -77,7 +77,7 @@ export function parseMutation(mutation, document) {
     assertAttributeMutation(mutationRecord);
 
     return () => {
-      mutationRecord['target'].setAttribute(
+      mutationRecord['targetElement'].setAttribute(
         mutationRecord['attributeName'],
         mutationRecord['value']
       );
@@ -87,7 +87,7 @@ export function parseMutation(mutation, document) {
     assertCharacterDataMutation(mutationRecord);
 
     return () => {
-      mutationRecord['target'].textContent = mutationRecord['value'];
+      mutationRecord['targetElement'].textContent = mutationRecord['value'];
     };
   } else {
     // childList type of mutation
@@ -162,7 +162,7 @@ function setSelectorToElement(selectorKey, mutationRecord, document) {
       mutationRecord[selectorKey]
   );
 
-  mutationRecord[selectorKey] = targetElement;
+  mutationRecord[selectorKey + 'Element'] = targetElement;
 }
 
 /**

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {assertHttpsUrl} from '../../../src/url';
 import {isObject} from '../../../src/types';
 import {user, userAssert} from '../../../src/log';
 
@@ -39,22 +40,22 @@ const SUPPORTED_ATTRIBUTES = {
     }
 
     // Allow Color
-    if (value.match(/^color:\s#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/g)) {
+    if (value.match(/^color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/g)) {
       return true;
     }
 
     // Allow Background color
-    if (value.match(/^background-color:\s#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/g)) {
+    if (value.match(/^background-color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/g)) {
       return true;
     }
 
     return false;
   },
   src: value => {
-    return value.match(/^https:\/\//g);
+    return assertHttpsUrl(value, 'attributes', 'mutation');
   },
   href: value => {
-    return value.match(/^https:\/\//g);
+    return assertHttpsUrl(value, 'attributes', 'mutation');
   },
 };
 

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -25,23 +25,41 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     doc = win.document;
   });
 
-  function getAttributeMutation() {
+  function setupMutationSelector() {
     const targetId = 'mutation-parser-test';
     const targetElement = createElementWithAttributes(
-        doc,
-        'div',
-        {
-          'id': targetId,
-        }
+      doc,
+      'div',
+      {
+        'id': targetId,
+      }
     );
 
     doc.body.appendChild(targetElement);
 
+    return `#${targetId}`;
+  }
+
+  function getAttributeMutation(opt_attributeName, opt_value) {
+
+    const selector = setupMutationSelector();
+
     return {
       type: 'attributes',
-      target: `#${targetId}`,
-      attributeName: 'style',
-      value: 'color: red',
+      target: selector,
+      attributeName: opt_attributeName || 'style',
+      value: opt_value || 'color: #FF0000',
+    };
+  }
+
+  function getCharacterDataMutation(opt_value) {
+
+    const selector = setupMutationSelector();
+
+    return {
+      type: 'characterData',
+      target: selector,
+      value: opt_value || 'Testing...',
     };
   }
 
@@ -99,5 +117,111 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     });
   });
 
+  describe('attributes', () => {
+    it('should allow a valid attributes mutation', () => {
+      const mutation = getAttributeMutation();
+      const mutationOperation = parseMutation(mutation, doc);
+      expect(mutationOperation).to.be.ok;
+    });
 
+    it('should error when no value', () => {
+      const mutation = getAttributeMutation();
+      delete mutation['value'];
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
+    });
+
+    it('should error when no attributeName', () => {
+      const mutation = getAttributeMutation();
+      delete mutation['attributeName'];
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/attributeName/);
+      });
+    });
+
+    it('should error when unallowed attributeName', () => {
+      const mutation = getAttributeMutation('test');
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/attributeName/);
+      });
+    });
+
+    it('should error when unallowed style', () => {
+      const mutation = getAttributeMutation('style', 'position: fixed');
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
+    });
+
+    it('should error when unallowed src', () => {
+      const mutation = getAttributeMutation('src', 'http://amp.dev');
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
+    });
+
+    it('should error when unallowed href', () => {
+      const mutation = getAttributeMutation('href', 'http://amp.dev');
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
+    });
+
+    it('should return an operation that,' +
+      ' changes attribute of selector', () => {
+        const expectedStyle = 'color: #FFF';
+        const mutation = getAttributeMutation('style', expectedStyle);
+        const mutationOperation = parseMutation(mutation, doc);
+
+        mutationOperation();
+
+        expect(
+          doc.querySelector(mutation['target']).getAttribute('style')
+        ).to.be.equal(expectedStyle);
+      });
+  });
+
+  describe('characterData', () => {
+    it('should allow valid characterData mutation', () => {
+      const mutation = getCharacterDataMutation();
+      const mutationOperation = parseMutation(mutation, doc);
+      expect(mutationOperation).to.be.ok;
+    });
+
+    it('should error when no value', () => {
+      const mutation = getCharacterDataMutation();
+      delete mutation['value'];
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
+    });
+
+    it('should return an operation that,' +
+      ' changes textContent of selector', () => {
+      const expectedTextContent = 'Expected';
+      const mutation = getCharacterDataMutation(expectedTextContent);
+      const mutationOperation = parseMutation(mutation, doc);
+
+      mutationOperation();
+
+      expect(
+        doc.querySelector(mutation['target']).textContent
+      ).to.be.equal(expectedTextContent);
+    });
+  });
 });

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -28,11 +28,11 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
   function setupMutationSelector() {
     const targetId = 'mutation-parser-test';
     const targetElement = createElementWithAttributes(
-      doc,
-      'div',
-      {
-        'id': targetId,
-      }
+        doc,
+        'div',
+        {
+          'id': targetId,
+        }
     );
 
     doc.body.appendChild(targetElement);
@@ -182,16 +182,16 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
 
     it('should return an operation that,' +
       ' changes attribute of selector', () => {
-        const expectedStyle = 'color: #FFF';
-        const mutation = getAttributeMutation('style', expectedStyle);
-        const mutationOperation = parseMutation(mutation, doc);
+      const expectedStyle = 'color: #FFF';
+      const mutation = getAttributeMutation('style', expectedStyle);
+      const mutationOperation = parseMutation(mutation, doc);
 
-        mutationOperation();
+      mutationOperation();
 
-        expect(
+      expect(
           doc.querySelector(mutation['target']).getAttribute('style')
-        ).to.be.equal(expectedStyle);
-      });
+      ).to.be.equal(expectedStyle);
+    });
   });
 
   describe('characterData', () => {
@@ -220,7 +220,7 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
       mutationOperation();
 
       expect(
-        doc.querySelector(mutation['target']).textContent
+          doc.querySelector(mutation['target']).textContent
       ).to.be.equal(expectedTextContent);
     });
   });


### PR DESCRIPTION
relates to #20225

This implements some base functionality for amp-experiment for an upcoming initial demo. This includes support for some of the `attributes` type mutations (style with `color` and `background-color`, src, and href), as well as `characterData` mutations 😄 

# Example

![Screen Shot 2019-04-04 at 5 42 25 PM](https://user-images.githubusercontent.com/1448289/55598979-5e022880-570a-11e9-90df-935941cd9276.png)

