### PR TITLE
✨ mraid: change default for fallback, and simplify configuration

### DIFF
--- a/examples/mraid/inabox-mraid.html
+++ b/examples/mraid/inabox-mraid.html
@@ -7,6 +7,7 @@
   <meta name="amp4ads-id" content="vendor=doubleclick,type=impression-id,value=12345">
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async host-service="amp-mraid" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>
+  <!--  <script async host-service="amp-mraid" no-fallback src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script> -->
   <!-- <script async src="https://cdn.ampproject.org/v0.js"></script> -->
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <style amp-custom>

--- a/extensions/amp-mraid/0.1/amp-mraid.js
+++ b/extensions/amp-mraid/0.1/amp-mraid.js
@@ -157,7 +157,6 @@ export class MraidInitializer {
    * Called when we determine that MRAID isn't available.
    */
   handleMismatch_() {
-    console.log("handling mismatch: fallback="+ this.fallback_);
     HostServices.rejectVisibilityServiceForDoc(
         this.ampdoc_, {fallback: this.fallback_});
     HostServices.rejectExitServiceForDoc(

--- a/extensions/amp-mraid/0.1/amp-mraid.js
+++ b/extensions/amp-mraid/0.1/amp-mraid.js
@@ -21,7 +21,17 @@
  * Example:
  * <code>
  * <script async host-service="amp-mraid"
- *         fallback-on="mismatch"></script>
+ *         src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>
+ * <code>
+ *
+ * By default, if amp-mraid determines its not running in a mobile app it falls
+ * back to standard web APIs for determining visibility and collapse/expand.  If
+ * you are sure you're serving to a mobile app and want to disable this
+ * behavior, you can specify no-fallback:
+ *
+ * <code>
+ * <script async host-service="amp-mraid" no-fallback
+ *         src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>
  * </code>
  *
  */
@@ -32,18 +42,7 @@ import {dev} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 
 const TAG = 'amp-mraid';
-const FALLBACK_ON = 'fallback-on';
-
-/**
- * String representations of the HostServicesErrors that can be used in the
- * 'fallback-on' attribute.
- *
- * @const @enum {string}
- */
-const FallbackErrorNames = {
-  MISMATCH: 'mismatch',
-  UNSUPPORTED: 'unsupported',
-};
+const NO_FALLBACK = 'no-fallback';
 
 /**
  * Loads mraid.js if available, and once it's loaded looks good, configures an
@@ -64,7 +63,7 @@ export class MraidInitializer {
     this.mraid_ = null;
 
     /** @private {boolean} */
-    this.fallback_ = false;
+    this.fallback_ = true;
 
     if (getMode().runtime !== 'inabox') {
       dev().error(TAG, 'Only supported with Inabox');
@@ -81,9 +80,9 @@ export class MraidInitializer {
       return;
     }
     const element = ampMraidScripts[0];
-    const fallbackOn =
-        (element.getAttribute(FALLBACK_ON) || '').split(' ');
-    this.fallback_ = fallbackOn.includes(FallbackErrorNames.MISMATCH);
+    if (element.getAttribute(NO_FALLBACK) != null) {
+      this.fallback_ = false;
+    }
 
     // It looks like we're initiating a network load for mraid from a relative
     // url, but this will actually be intercepted by the mobile app SDK and
@@ -158,6 +157,7 @@ export class MraidInitializer {
    * Called when we determine that MRAID isn't available.
    */
   handleMismatch_() {
+    console.log("handling mismatch: fallback="+ this.fallback_);
     HostServices.rejectVisibilityServiceForDoc(
         this.ampdoc_, {fallback: this.fallback_});
     HostServices.rejectExitServiceForDoc(


### PR DESCRIPTION
Initially the design for amp-mraid was that there were multiple situations in which it would need to decide whether to fall back to standard web apis, and we wanted to allow the author to choose how amp-mraid should handle that situation.  It's now clear that this was too complicated, and the only decision amp-mraid needs the author to make is how it should handle the case where it doesn't look like its running in a mobile app.

Additionally, when a creative author decides to include mraid support in a creative they're generally going to want the fallback behavior.  They don't know what environment they will be serving into, and want reasonable behavior everywhere.  Make fallback the default.  Ad networks that know at serving time that they're serving to mobile apps can use no-fallback to ensure that an error with mraid.js doesn't result in incorrect usage of web apis.

Usage changes:

* `<script async host-service="amp-mraid" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>` becomes `<script async host-service="amp-mraid" no-fallback src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>`

* `<script async host-service="amp-mraid" fallback-on="mismatch" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>` becomes `<script async host-service="amp-mraid" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>`

* `<script async host-service="amp-mraid" fallback-on="unsupported" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js"></script>` didn't do anything and has been removed.