### PR TITLE
Launch amp-img-auto-sizes to 100% of production

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -57,7 +57,7 @@
   "amp-auto-lightbox": 1,
   "amp-list-load-more": 1,
   "amp-ad-ff-adx-ady": 0.01,
-  "amp-img-auto-sizes": 0.5,
+  "amp-img-auto-sizes": 1,
   "blurry-placeholder": 1,
   "flexAdSlots": 0.01
 }


### PR DESCRIPTION
This PR should merge **after** canary cut on April 9, 2019 and **before** canary cut on April 16, 2019. 