### PR TITLE
object-fit and object-position attributes for amp-img, amp-video, and amp-anim.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -21,7 +21,7 @@ import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../src/utils/img';
 import {isExperimentOn} from '../src/experiments';
 import {listen} from '../src/event-helper';
 import {registerElement} from '../src/service/custom-element-registry';
-import {setImportantStyles} from '../src/style';
+import {installObjectCropStyles, setImportantStyles} from '../src/style';
 
 /**
  * Attributes to propagate to internal image when changed externally.
@@ -152,6 +152,7 @@ export class AmpImg extends BaseElement {
       this.maybeGenerateSizes_();
     }
     this.applyFillContent(this.img_, true);
+    installObjectCropStyles(this.element, this.img_);
 
     this.element.appendChild(this.img_);
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -18,10 +18,10 @@ import {BaseElement} from '../src/base-element';
 import {Layout, isLayoutSizeDefined} from '../src/layout';
 import {dev} from '../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../src/utils/img';
+import {installObjectCropStyles, setImportantStyles} from '../src/style';
 import {isExperimentOn} from '../src/experiments';
 import {listen} from '../src/event-helper';
 import {registerElement} from '../src/service/custom-element-registry';
-import {installObjectCropStyles, setImportantStyles} from '../src/style';
 
 /**
  * Attributes to propagate to internal image when changed externally.

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -18,9 +18,9 @@ import {BaseElement} from '../src/base-element';
 import {Layout, isLayoutSizeDefined} from '../src/layout';
 import {dev} from '../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../src/utils/img';
-import {installObjectCropStyles, setImportantStyles} from '../src/style';
 import {isExperimentOn} from '../src/experiments';
 import {listen} from '../src/event-helper';
+import {propagateObjectFitStyles, setImportantStyles} from '../src/style';
 import {registerElement} from '../src/service/custom-element-registry';
 
 /**
@@ -152,7 +152,7 @@ export class AmpImg extends BaseElement {
       this.maybeGenerateSizes_();
     }
     this.applyFillContent(this.img_, true);
-    installObjectCropStyles(this.element, this.img_);
+    propagateObjectFitStyles(this.element, this.img_);
 
     this.element.appendChild(this.img_);
   }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -17,8 +17,8 @@
 import * as st from '../../../src/style';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../../../src/utils/img';
-import {installObjectCropStyles} from '../../../src/style';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {propagateObjectFitStyles} from '../../../src/style';
 
 const TAG = 'amp-anim';
 const BUILD_ATTRIBUTES = ['alt', 'aria-label', 'aria-describedby',
@@ -52,7 +52,7 @@ export class AmpAnim extends AMP.BaseElement {
     this.img_.setAttribute('decoding', 'async');
     this.propagateAttributes(BUILD_ATTRIBUTES, this.img_);
     this.applyFillContent(this.img_, true);
-    installObjectCropStyles(this.element, this.img_);
+    propagateObjectFitStyles(this.element, this.img_);
 
     // Remove role=img otherwise this breaks screen-readers focus and
     // only read "Graphic" when using only 'alt'.

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -17,6 +17,7 @@
 import * as st from '../../../src/style';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../../../src/utils/img';
+import {installObjectCropStyles} from '../../../src/style';
 import {isLayoutSizeDefined} from '../../../src/layout';
 
 const TAG = 'amp-anim';
@@ -51,6 +52,7 @@ export class AmpAnim extends AMP.BaseElement {
     this.img_.setAttribute('decoding', 'async');
     this.propagateAttributes(BUILD_ATTRIBUTES, this.img_);
     this.applyFillContent(this.img_, true);
+    installObjectCropStyles(this.element, this.img_);
 
     // Remove role=img otherwise this breaks screen-readers focus and
     // only read "Graphic" when using only 'alt'.

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -81,4 +81,52 @@ describes.realWin('amp-anim', {
     impl.layoutCallback();
     expect(img.getAttribute('src')).to.equal('test.jpg');
   });
+
+  it('should propagate the object-fit attribute', () => {
+    const el = env.win.document.createElement('amp-anim');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('object-fit', 'cover');
+
+    const impl = new AmpAnim(el);
+    impl.buildCallback();
+    impl.layoutCallback();
+    const img = el.querySelector('img');
+    expect(img.style.objectFit).to.equal('cover');
+  });
+
+  it('should not propagate the object-fit attribute if invalid', () => {
+    const el = env.win.document.createElement('amp-anim');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('object-fit', 'foo 80%');
+
+    const impl = new AmpAnim(el);
+    impl.buildCallback();
+    impl.layoutCallback();
+    const img = el.querySelector('img');
+    expect(img.style.objectFit).to.be.empty;
+  });
+
+  it('should propagate the object-position attribute', () => {
+    const el = env.win.document.createElement('amp-anim');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('object-position', '20% 80%');
+
+    const impl = new AmpAnim(el);
+    impl.buildCallback();
+    impl.layoutCallback();
+    const img = el.querySelector('img');
+    expect(img.style.objectPosition).to.equal('20% 80%');
+  });
+
+  it('should not propagate the object-position attribute if invalid', () => {
+    const el = env.win.document.createElement('amp-anim');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('object-position', 'url:("example.com")');
+
+    const impl = new AmpAnim(el);
+    impl.buildCallback();
+    impl.layoutCallback();
+    const img = el.querySelector('img');
+    expect(img.style.objectPosition).to.be.empty;
+  });
 });

--- a/extensions/amp-anim/0.1/test/validator-amp-anim.html
+++ b/extensions/amp-anim/0.1/test/validator-amp-anim.html
@@ -43,7 +43,9 @@
     layout="responsive"
     height="300"
     width="400"
-    src="lemur.gif">
+    src="lemur.gif"
+    object-fit="cover"
+    object-position="left center">
   </amp-anim>
 
   <!-- Invalid: Missing src attribute. -->

--- a/extensions/amp-anim/0.1/test/validator-amp-anim.out
+++ b/extensions/amp-anim/0.1/test/validator-amp-anim.out
@@ -44,13 +44,15 @@ FAIL
 |      layout="responsive"
 |      height="300"
 |      width="400"
-|      src="lemur.gif">
+|      src="lemur.gif"
+|      object-fit="cover"
+|      object-position="left center">
 |    </amp-anim>
 |
 |    <!-- Invalid: Missing src attribute. -->
 |    <amp-anim
 >>   ^~~~~~~~~
-amp-anim/0.1/test/validator-amp-anim.html:50:2 The mandatory attribute 'src' is missing in tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+amp-anim/0.1/test/validator-amp-anim.html:52:2 The mandatory attribute 'src' is missing in tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
 |      layout="responsive"
 |      height="300"
 |      width="400">
@@ -59,7 +61,7 @@ amp-anim/0.1/test/validator-amp-anim.html:50:2 The mandatory attribute 'src' is 
 |    <!-- Invalid: illegal layout. -->
 |    <amp-anim
 >>   ^~~~~~~~~
-amp-anim/0.1/test/validator-amp-anim.html:57:2 The specified layout 'CONTAINER' is not supported by tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_LAYOUT_PROBLEM]
+amp-anim/0.1/test/validator-amp-anim.html:59:2 The specified layout 'CONTAINER' is not supported by tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_LAYOUT_PROBLEM]
 |      layout="container"
 |      height="300"
 |      width="400"

--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -47,6 +47,8 @@ tags: {  # <amp-anim>
   requires_extension: "amp-anim"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-or-srcset"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-anim"
@@ -67,6 +69,8 @@ tags: {  # <amp-anim>
   requires_extension: "amp-anim"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-amp4email"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-anim"

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -40,6 +40,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
 import {
+  installObjectCropStyles,
   setImportantStyles,
   setInitialDisplay,
   setStyles,
@@ -206,6 +207,7 @@ class AmpVideo extends AMP.BaseElement {
         /* opt_removeMissingAttrs */ true);
     this.installEventHandlers_();
     this.applyFillContent(this.video_, true);
+    installObjectCropStyles(this.element, this.video_);
 
     this.createPosterForAndroidBug_();
     element.appendChild(this.video_);

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -33,18 +33,18 @@ import {dev, devAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {
+  installObjectCropStyles,
+  setImportantStyles,
+  setInitialDisplay,
+  setStyles,
+} from '../../../src/style';
+import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
-import {
-  installObjectCropStyles,
-  setImportantStyles,
-  setInitialDisplay,
-  setStyles,
-} from '../../../src/style';
 import {toArray} from '../../../src/types';
 
 const TAG = 'amp-video';

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -33,18 +33,18 @@ import {dev, devAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {
-  installObjectCropStyles,
-  setImportantStyles,
-  setInitialDisplay,
-  setStyles,
-} from '../../../src/style';
-import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
+import {
+  propagateObjectFitStyles,
+  setImportantStyles,
+  setInitialDisplay,
+  setStyles,
+} from '../../../src/style';
 import {toArray} from '../../../src/types';
 
 const TAG = 'amp-video';
@@ -207,7 +207,7 @@ class AmpVideo extends AMP.BaseElement {
         /* opt_removeMissingAttrs */ true);
     this.installEventHandlers_();
     this.applyFillContent(this.video_, true);
-    installObjectCropStyles(this.element, this.video_);
+    propagateObjectFitStyles(this.element, this.video_);
 
     this.createPosterForAndroidBug_();
     element.appendChild(this.video_);

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -437,6 +437,46 @@ describes.realWin('amp-video', {
     });
   });
 
+  it('should propagate the object-fit attribute', () => {
+    return getVideo({
+      src: 'video.mp4',
+      'object-fit': 'cover',
+    }).then(v => {
+      const video = v.querySelector('video');
+      expect(video.style.objectFit).to.equal('cover');
+    });
+  });
+
+  it('should not propagate the object-fit attribute if invalid', () => {
+    return getVideo({
+      src: 'video.mp4',
+      'object-fit': 'foo 80%',
+    }).then(v => {
+      const video = v.querySelector('video');
+      expect(video.style.objectFit).to.be.empty;
+    });
+  });
+
+  it('should propagate the object-position attribute', () => {
+    return getVideo({
+      src: 'video.mp4',
+      'object-position': '20% 80%',
+    }).then(v => {
+      const video = v.querySelector('video');
+      expect(video.style.objectPosition).to.equal('20% 80%');
+    });
+  });
+
+  it('should not propagate the object-position attribute if invalid', () => {
+    return getVideo({
+      src: 'video.mp4',
+      'object-position': 'url("example.com")',
+    }).then(v => {
+      const video = v.querySelector('video');
+      expect(video.style.objectPosition).to.be.empty;
+    });
+  });
+
   // TODO: unskip the tests in this file #19664
   it.skip('should forward certain events from video to the amp element', () => {
     return getVideo({

--- a/extensions/amp-video/0.1/test/validator-amp-video.html
+++ b/extensions/amp-video/0.1/test/validator-amp-video.html
@@ -33,7 +33,9 @@
     width="640"
     height="360"
     layout="responsive"
-    poster="images/kitten-playing.png">
+    poster="images/kitten-playing.png"
+    object-fit="cover"
+    object-position="left center">
     <source src="videos/kitten-playing.webm"
       type="video/webm" />
     <source src="videos/kitten-playing.mp4"

--- a/extensions/amp-video/0.1/test/validator-amp-video.out
+++ b/extensions/amp-video/0.1/test/validator-amp-video.out
@@ -34,7 +34,9 @@ FAIL
 |      width="640"
 |      height="360"
 |      layout="responsive"
-|      poster="images/kitten-playing.png">
+|      poster="images/kitten-playing.png"
+|      object-fit="cover"
+|      object-position="left center">
 |      <source src="videos/kitten-playing.webm"
 |        type="video/webm" />
 |      <source src="videos/kitten-playing.mp4"
@@ -47,9 +49,9 @@ FAIL
 |    <!-- Invalid: Incorrect attribute value for autoplay -->
 |    <amp-video autoplay=true layout=fill width=300 height=500
 >>   ^~~~~~~~~
-amp-video/0.1/test/validator-amp-video.html:47:2 The attribute 'autoplay' in tag 'amp-video' is set to the invalid value 'true'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
+amp-video/0.1/test/validator-amp-video.html:49:2 The attribute 'autoplay' in tag 'amp-video' is set to the invalid value 'true'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-video/0.1/test/validator-amp-video.html:47:2 The attribute 'loop' in tag 'amp-video' is set to the invalid value '1'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
+amp-video/0.1/test/validator-amp-video.html:49:2 The attribute 'loop' in tag 'amp-video' is set to the invalid value '1'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
 |      loop="1" preload="metadata" controls="controls"></amp-video>
 |
 |    <!-- Valid: Correct attribute value for rotate-to-fullscreen -->
@@ -59,12 +61,12 @@ amp-video/0.1/test/validator-amp-video.html:47:2 The attribute 'loop' in tag 'am
 |    <!-- Invalid: `dock` without `amp-video-docking` extension. -->
 |    <amp-video dock layout=fill width=300 height=500 controls></amp-video>
 >>   ^~~~~~~~~
-amp-video/0.1/test/validator-amp-video.html:55:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-video/0.1/test/validator-amp-video.html:57:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |
 |    <!-- Invalid: Incorrect attribute value for rotate-to-fullscreen -->
 |    <amp-video rotate-to-fullscreen=true layout=fill width=300 height=500
 >>   ^~~~~~~~~
-amp-video/0.1/test/validator-amp-video.html:58:2 The attribute 'rotate-to-fullscreen' in tag 'amp-video' is set to the invalid value 'true'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
+amp-video/0.1/test/validator-amp-video.html:60:2 The attribute 'rotate-to-fullscreen' in tag 'amp-video' is set to the invalid value 'true'. (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML]
 |      loop preload="metadata" controls></amp-video>
 |  </body>
 |  </html>

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -69,6 +69,8 @@ attr_lists: {
     name: "noaudio"
     value: ""
   }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
   attrs: {
     name: "preload"

--- a/src/style.js
+++ b/src/style.js
@@ -335,3 +335,20 @@ export function resetStyles(element, properties) {
     setStyle(element, properties[i], null);
   }
 }
+
+/**
+ * Propagates the object-fit/position element attributes as styles on the
+ * childElement.
+ * @param {!Element} element ie: amp-img
+ * @param {!Element} childElement ie: the img within amp-img
+ */
+export function installObjectCropStyles(element, childElement) {
+  if (element.hasAttribute('object-fit')) {
+    setStyle(childElement, 'object-fit', element.getAttribute('object-fit'));
+  }
+
+  if (element.hasAttribute('object-position')) {
+    setStyle(childElement, 'object-position',
+        element.getAttribute('object-position'));
+  }
+}

--- a/src/style.js
+++ b/src/style.js
@@ -337,18 +337,16 @@ export function resetStyles(element, properties) {
 }
 
 /**
- * Propagates the object-fit/position element attributes as styles on the
- * childElement.
- * @param {!Element} element ie: amp-img
- * @param {!Element} childElement ie: the img within amp-img
+ * Propagates the object-fit/position element attributes as styles.
+ * @param {!Element} fromEl ie: amp-img
+ * @param {!Element} toEl ie: the img within amp-img
  */
-export function propagateObjectFitStyles(element, childElement) {
-  if (element.hasAttribute('object-fit')) {
-    setStyle(childElement, 'object-fit', element.getAttribute('object-fit'));
+export function propagateObjectFitStyles(fromEl, toEl) {
+  if (fromEl.hasAttribute('object-fit')) {
+    setStyle(toEl, 'object-fit', fromEl.getAttribute('object-fit'));
   }
 
-  if (element.hasAttribute('object-position')) {
-    setStyle(childElement, 'object-position',
-        element.getAttribute('object-position'));
+  if (fromEl.hasAttribute('object-position')) {
+    setStyle(toEl, 'object-position', fromEl.getAttribute('object-position'));
   }
 }

--- a/src/style.js
+++ b/src/style.js
@@ -342,7 +342,7 @@ export function resetStyles(element, properties) {
  * @param {!Element} element ie: amp-img
  * @param {!Element} childElement ie: the img within amp-img
  */
-export function installObjectCropStyles(element, childElement) {
+export function propagateObjectFitStyles(element, childElement) {
   if (element.hasAttribute('object-fit')) {
     setStyle(childElement, 'object-fit', element.getAttribute('object-fit'));
   }

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -379,6 +379,46 @@ describe('amp-img', () => {
     impl.unlayoutCallback();
   });
 
+  it('should propagate the object-fit attribute', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      'object-fit': 'cover',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.style.objectFit).to.equal('cover');
+    });
+  });
+
+  it('should not propagate the object-fit attribute if invalid', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      'object-fit': 'foo 80%',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.style.objectFit).to.be.empty;
+    });
+  });
+
+  it('should propagate the object-position attribute', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      'object-position': '20% 80%',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.style.objectPosition).to.equal('20% 80%');
+    });
+  });
+
+  it('should not propagate the object-position attribute if invalid', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      'object-position': 'url("example.com")',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.style.objectPosition).to.be.empty;
+    });
+  });
+
   describe('blurred image placeholder', () => {
     beforeEach(() => {
       toggleExperiment(window, 'blurry-placeholder', true, true);

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5065,6 +5065,8 @@ tags: {  # <amp-img>
   tag_name: "AMP-IMG"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
   # <amp-bind>
   attrs: { name: "[alt]" }
@@ -5092,6 +5094,8 @@ tags: {  # <amp-img>
   spec_name: "AMP-IMG (AMP4EMAIL)"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-amp4email"


### PR DESCRIPTION
This PR introduces a helper that retrieves the `object-fit` and `object-position` attributes of the element (ie: `<amp-img>`), and if they exist, sets inline styles on the childElement (ie: `<img>`). These inline styles are not marked as `!important`, so they can still be overridden by AMP extensions CSS if needed.

It gives better control to publishers over how their assets are displayed, by making it easier to select what part of the image should always be visible, or how the image should fit its container.

This helper is used for `amp-img`, `amp-video`, and `amp-anim`.

These styles are added right before the child element is appended to the DOM, so assets are rendered with the expected positions.
Since publishers have to explicitly write these attributes, this is not a breaking change. However, if they decide to use these attributes, it will likely override their existing CSS, because the specificity of inline styles is hard to top.

Fixes #4988 
Part of #21661