### PR TITLE
🐛 Implemented secure url exception for http://127.0.0.1

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -280,6 +280,7 @@ export function isSecureUrlDeprecated(url) {
   }
   return (url.protocol == 'https:' ||
       url.hostname == 'localhost' ||
+      url.hostname == '127.0.0.1' ||
       endsWith(url.hostname, '.localhost'));
 }
 


### PR DESCRIPTION
Issue: #20543 

This change adds 127.0.0.1 to the exceptions for secure urls.