### PR TITLE
amp-bind: Wait for init before scanAndApply

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -381,6 +381,19 @@ export class Bind {
    * @return {!Promise}
    */
   scanAndApply(addedElements, removedElements, timeout = 2000) {
+    return this.initializePromise_.then(() => {
+      return this.rescan_(addedElements, removedElements, timeout);
+    });
+  }
+
+  /**
+   * @param {!Array<!Element>} addedElements
+   * @param {!Array<!Element>} removedElements
+   * @param {number} timeout
+   * @return {!Promise}
+   * @private
+   */
+  rescan_(addedElements, removedElements, timeout) {
     dev().info(TAG, 'rescan:', addedElements, removedElements);
     /**
      * Helper function for cleaning up bindings in removed elements.


### PR DESCRIPTION
Fixes race condition that can result in duplicate binding records e.g. in the case where amp-list renders before amp-bind's tree walk completes.