### PR TITLE
✨amp-experiment: 1.0 Validation, and Regex Updates

### DIFF
--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -35,17 +35,17 @@ const SUPPORTED_ATTRIBUTES = {
   style: value => {
 
     // Do not allow Important or HTML Comments
-    if (value.match(/(!\s*important|<!--)/g)) {
+    if (value.match(/(!\s*important|<!--)/)) {
       return false;
     }
 
     // Allow Color
-    if (value.match(/^color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/g)) {
+    if (value.match(/^color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/)) {
       return true;
     }
 
     // Allow Background color
-    if (value.match(/^background-color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/g)) {
+    if (value.match(/^background-color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/)) {
       return true;
     }
 

--- a/extensions/amp-experiment/1.0/test/validator-amp-experiment.html
+++ b/extensions/amp-experiment/1.0/test/validator-amp-experiment.html
@@ -1,0 +1,71 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests validation for the amp-experiment tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Experiment examples</title>
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-1.0.js"></script>
+     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+<amp-experiment>
+    <script type="application/json">
+        {
+          "background-color-test": {
+            "variants": {
+              "yellow": {
+                "weight": 50,
+                "mutations": [
+                  {
+                    "type": "attributes",
+                    "target": "h1",
+                    "attributeName": "style",
+                    "value": "background-color: #FFFF00"
+                  }
+                ]
+              },
+              "red": {
+                "weight": 50,
+                "mutations": [
+                  {
+                    "type": "attributes",
+                    "target": "h1",
+                    "attributeName": "style",
+                    "value": "background-color: #FF0000"
+                  }
+                ]
+              }
+            }
+          }
+        }
+    </script>
+</amp-experiment>
+
+<amp-experiment>
+    <script type="invalidtype"></script>
+</amp-experiment>
+</body>
+</html>

--- a/extensions/amp-experiment/1.0/test/validator-amp-experiment.out
+++ b/extensions/amp-experiment/1.0/test/validator-amp-experiment.out
@@ -1,0 +1,76 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-experiment tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Experiment examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-1.0.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|
+|  <amp-experiment>
+|      <script type="application/json">
+|          {
+|            "background-color-test": {
+|              "variants": {
+|                "yellow": {
+|                  "weight": 50,
+|                  "mutations": [
+|                    {
+|                      "type": "attributes",
+|                      "target": "h1",
+|                      "attributeName": "style",
+|                      "value": "background-color: #FFFF00"
+|                    }
+|                  ]
+|                },
+|                "red": {
+|                  "weight": 50,
+|                  "mutations": [
+|                    {
+|                      "type": "attributes",
+|                      "target": "h1",
+|                      "attributeName": "style",
+|                      "value": "background-color: #FF0000"
+|                    }
+|                  ]
+|                }
+|              }
+|            }
+|          }
+|      </script>
+|  </amp-experiment>
+|
+|  <amp-experiment>
+>> ^~~~~~~~~
+amp-experiment/1.0/test/validator-amp-experiment.html:67:0 The tag 'amp-experiment' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-experiment) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|      <script type="invalidtype"></script>
+>>     ^~~~~~~~~
+amp-experiment/1.0/test/validator-amp-experiment.html:68:4 Custom JavaScript is not allowed. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|  </amp-experiment>
+|  </body>
+|  </html>

--- a/extensions/amp-experiment/validator-amp-experiment.protoascii
+++ b/extensions/amp-experiment/validator-amp-experiment.protoascii
@@ -22,6 +22,7 @@ tags: {  # amp-experiment
   extension_spec: {
     name: "amp-experiment"
     version: "0.1"
+    version: "1.0"
     version: "latest"
     requires_usage: GRANDFATHERED
     deprecated_allow_duplicates: true


### PR DESCRIPTION
relates to #20225
relates to #21734

This updates the validator to accept the 1.0 version of amp-experiment. As well as adresses a [regex comment on the previous amp-experiment mad by @honeybadgerdontcare ](https://github.com/ampproject/amphtml/pull/21734#discussion_r272765479), that we agreed to implement offline.