### PR TITLE
Stories media queries service.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -180,7 +180,8 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 }
 
 .i-amphtml-story-desktop-panels > amp-story-page,
-.i-amphtml-story-desktop-panels .i-amphtml-story-page-sentinel {
+.i-amphtml-story-desktop-panels .i-amphtml-story-page-sentinel,
+.i-amphtml-story-desktop-panels .i-amphtml-story-media-query-matcher {
   left: 50%!important;
   right: auto !important;
   margin: auto !important;

--- a/extensions/amp-story/1.0/amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/amp-story-media-query-service.js
@@ -23,15 +23,15 @@ import {registerServiceBuilder} from '../../../src/service';
  * Util function to retrieve the media query service. Ensures we can retrieve
  * the service synchronously from the amp-story codebase without running into
  * race conditions.
- * @param  {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param  {!Window} win
  * @return {!AmpStoryMediaQueryService}
  */
-export const getMediaQueryService = ampdoc => {
-  let service = Services.storyMediaQueryService(ampdoc);
+export const getMediaQueryService = win => {
+  let service = Services.storyMediaQueryService(win);
 
   if (!service) {
-    service = new AmpStoryMediaQueryService(ampdoc);
-    registerServiceBuilder(ampdoc, 'story-media-query', () => service);
+    service = new AmpStoryMediaQueryService(win);
+    registerServiceBuilder(win, 'story-media-query', () => service);
   }
 
   return service;
@@ -42,27 +42,27 @@ export const getMediaQueryService = ampdoc => {
  */
 export class AmpStoryMediaQueryService {
   /**
-   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Window} win
    */
-  constructor(ampdoc) {
-    /** @private @const {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampdoc_ = ampdoc;
+  constructor(win) {
+    /** @private @const {!Window} */
+    this.win_ = win;
 
-    /** @private {boolean} */
+    /** @private {?Promise} */
     this.initializePromise_ = null;
 
-    /** @private {?HTMLElement} Iframe matcher. */
+    /** @private {?Element} Iframe matcher. */
     this.matcher_ = null;
 
     /** @private @const {!Element} */
     this.storyEl_ = dev().assertElement(
-        this.ampdoc_.getWin().document.querySelector('amp-story'));
+        this.win_.document.querySelector('amp-story'));
   }
 
   /**
    * Registers the media query and triggering the provided callback on match.
    * @param {string} media The media query, ie: '(orientation: portrait)'
-   * @param {!function(boolean)} callback Called when the media query matches.
+   * @param {function(boolean)} callback Called when the media query matches.
    * @return {!Promise<!MediaQueryList>}
    */
   onMediaQueryMatch(media, callback) {
@@ -86,7 +86,7 @@ export class AmpStoryMediaQueryService {
     }
 
     this.initializePromise_ = new Promise(resolve => {
-      this.matcher_ = this.ampdoc_.getWin().document.createElement('iframe');
+      this.matcher_ = this.win_.document.createElement('iframe');
       this.matcher_.classList.add('i-amphtml-story-media-query-matcher');
       this.matcher_.onload = resolve;
       this.storyEl_.appendChild(this.matcher_);

--- a/extensions/amp-story/1.0/amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/amp-story-media-query-service.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../../src/services';
+import {dev} from '../../../src/log';
+import {registerServiceBuilder} from '../../../src/service';
+
+
+/**
+ * Util function to retrieve the media query service. Ensures we can retrieve
+ * the service synchronously from the amp-story codebase without running into
+ * race conditions.
+ * @param  {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {!AmpStoryMediaQueryService}
+ */
+export const getMediaQueryService = ampdoc => {
+  let service = Services.storyMediaQueryService(ampdoc);
+
+  if (!service) {
+    service = new AmpStoryMediaQueryService(ampdoc);
+    registerServiceBuilder(ampdoc, 'story-media-query', () => service);
+  }
+
+  return service;
+};
+
+/**
+ * Media query service.
+ */
+export class AmpStoryMediaQueryService {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private @const {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = ampdoc;
+
+    /** @private {boolean} */
+    this.initializePromise_ = null;
+
+    /** @private {?HTMLElement} Iframe matcher. */
+    this.matcher_ = null;
+
+    /** @private @const {!Element} */
+    this.storyEl_ = dev().assertElement(
+        this.ampdoc_.getWin().document.querySelector('amp-story'));
+  }
+
+  /**
+   * Registers the media query and triggering the provided callback on match.
+   * @param {string} media The media query, ie: '(orientation: portrait)'
+   * @param {!function(boolean)} callback Called when the media query matches.
+   * @return {!Promise<!MediaQueryList>}
+   */
+  onMediaQueryMatch(media, callback) {
+    return this.initialize_().then(() => {
+      const mediaQueryList = this.matcher_.contentWindow.matchMedia(media);
+      mediaQueryList.addListener(event => callback(event.matches));
+      callback(mediaQueryList.matches);
+      return mediaQueryList;
+    });
+  }
+
+  /**
+   * Creates an iframe that is positioned like an amp-story-page, used to match
+   * media queries.
+   * @return {!Promise} Resolves when the iframe is ready.
+   * @private
+   */
+  initialize_() {
+    if (this.initializePromise_) {
+      return this.initializePromise_;
+    }
+
+    this.initializePromise_ = new Promise(resolve => {
+      this.matcher_ = this.ampdoc_.getWin().document.createElement('iframe');
+      this.matcher_.classList.add('i-amphtml-story-media-query-matcher');
+      this.matcher_.onload = resolve;
+      this.storyEl_.appendChild(this.matcher_);
+    });
+
+    return this.initializePromise_;
+  }
+}

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -168,6 +168,7 @@ amp-story .amp-video-eq:not(.amp-video-eq-play) {
 }
 
 /** Page level */
+.i-amphtml-story-media-query-matcher,
 amp-story-page {
   bottom: 0 !important;
   height: auto !important;
@@ -178,6 +179,13 @@ amp-story-page {
   opacity: 1 !important;
   transition: none !important;
   z-index: 0 !important;
+}
+
+.i-amphtml-story-media-query-matcher {
+  height: inherit !important;
+  width: inherit !important;
+  border: 0 !important;
+  z-index: -1 !important;
 }
 
 amp-story-page[active] {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -474,7 +474,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeMediaQueries_(mediaQueryEls) {
-    const service = getMediaQueryService(this.getAmpDoc());
+    const service = getMediaQueryService(this.win);
 
     const onMediaQueryMatch = (matches, className) => {
       this.mutateElement(() => {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -476,21 +476,19 @@ export class AmpStory extends AMP.BaseElement {
   initializeMediaQueries_(mediaQueryEls) {
     const service = getMediaQueryService(this.getAmpDoc());
 
-    const onMediaQueryMatch = (matches, attribute) => {
+    const onMediaQueryMatch = (matches, className) => {
       this.mutateElement(() => {
-        matches ?
-          this.element.setAttribute(attribute, '') :
-          this.element.removeAttribute(attribute);
+        this.element.classList.toggle(className, matches);
       });
     };
 
     mediaQueryEls.forEach(el => {
-      const attribute = el.getAttribute('attribute');
+      const className = el.getAttribute('class-name');
       const media = el.getAttribute('media');
 
-      if (attribute && media) {
+      if (className && media) {
         service.onMediaQueryMatch(
-            media, matches => onMediaQueryMatch(matches, attribute));
+            media, matches => onMediaQueryMatch(matches, className));
       }
     });
   }

--- a/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryMediaQueryService} from '../amp-story-media-query-service';
+import {poll} from '../../../../testing/iframe';
+
+describes.realWin('amp-story-media-query-service', {amp: true}, env => {
+  let mediaQueryService;
+  let storyEl;
+  let styleEl;
+  let win;
+
+  function setMatcherSize(height, width) {
+    styleEl.textContent = `
+        .i-amphtml-story-media-query-matcher {
+          position: absolute;
+          height: ${height}px;
+          width: ${width}px;
+          border: none;
+        }`;
+  };
+
+  function waitForClassName(element, className) {
+    return poll(`className ${className} on ${element.tagName}`, () => {
+      return element.classList.contains(className);
+    }, undefined, 300);
+  };
+
+  beforeEach(() => {
+    win = env.ampdoc.getWin();
+
+    storyEl = win.document.createElement('amp-story');
+    storyEl.setAttribute('foo', 'bar');
+    win.document.body.appendChild(storyEl);
+
+    styleEl = win.document.createElement('style');
+    setMatcherSize(100, 200);
+    storyEl.appendChild(styleEl);
+
+    return new Promise(resolve => {
+      requestAnimationFrame(() => {
+        mediaQueryService = new AmpStoryMediaQueryService(env.ampdoc);
+        resolve();
+      });
+    })
+  });
+
+  afterEach(() => {
+    storyEl.remove();
+    mediaQueryService.matcher_.remove();
+  });
+
+  it('should add the attribute if the media query matches', () => {
+    const spy = sandbox.spy();
+    return mediaQueryService
+        .onMediaQueryMatch('(orientation: landscape)', spy)
+        .then(() => {
+          expect(spy).to.have.been.calledOnceWith(true);
+        });
+  });
+
+  it('should not add the attribute if the media query does not match', () => {
+    const spy = sandbox.spy();
+    return mediaQueryService
+        .onMediaQueryMatch('(orientation: portrait)', spy)
+        .then(() => {
+          expect(spy).to.have.been.calledOnceWith(false);
+        });
+  });
+
+  it('should handle multiple media queries', () => {
+    const spy1 = sandbox.spy();
+    const p1 = mediaQueryService
+        .onMediaQueryMatch('(orientation: landscape)', spy1);
+    const spy2 = sandbox.spy();
+    const p2 = mediaQueryService
+        .onMediaQueryMatch('(min-width: 600px)', spy2);
+    return Promise.all([p1, p2])
+        .then(() => {
+          expect(spy1).to.have.been.calledOnceWith(true);
+          expect(spy2).to.have.been.calledOnceWith(false);
+        });
+  });
+
+  it('should add the className if the media query matches on resize', () => {
+    return mediaQueryService
+        .onMediaQueryMatch('(orientation: portrait)', matches => {
+          storyEl.classList.toggle('portrait', matches);
+        })
+        .then(() => {
+          setMatcherSize(300, 100);
+          return waitForClassName(storyEl, 'portrait');
+        });
+  });
+});

--- a/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
@@ -31,16 +31,16 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
           width: ${width}px;
           border: none;
         }`;
-  };
+  }
 
   function waitForClassName(element, className) {
     return poll(`className ${className} on ${element.tagName}`, () => {
       return element.classList.contains(className);
     }, undefined /** opt_onError */, 300 /** opt_timeout */);
-  };
+  }
 
   beforeEach(() => {
-    win = env.ampdoc.getWin();
+    win = env.win;
 
     storyEl = win.document.createElement('amp-story');
     storyEl.setAttribute('foo', 'bar');
@@ -52,10 +52,10 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
 
     return new Promise(resolve => {
       requestAnimationFrame(() => {
-        mediaQueryService = new AmpStoryMediaQueryService(env.ampdoc);
+        mediaQueryService = new AmpStoryMediaQueryService(win);
         resolve();
       });
-    })
+    });
   });
 
   afterEach(() => {

--- a/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
@@ -23,7 +23,7 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
   let styleEl;
   let win;
 
-  function setMatcherSize(height, width) {
+  function setMatcherSize(width, height) {
     styleEl.textContent = `
         .i-amphtml-story-media-query-matcher {
           position: absolute;
@@ -36,7 +36,7 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
   function waitForClassName(element, className) {
     return poll(`className ${className} on ${element.tagName}`, () => {
       return element.classList.contains(className);
-    }, undefined, 300);
+    }, undefined /** opt_onError */, 300 /** opt_timeout */);
   };
 
   beforeEach(() => {
@@ -47,7 +47,7 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
     win.document.body.appendChild(storyEl);
 
     styleEl = win.document.createElement('style');
-    setMatcherSize(100, 200);
+    setMatcherSize(200, 100);
     storyEl.appendChild(styleEl);
 
     return new Promise(resolve => {
@@ -101,7 +101,7 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
           storyEl.classList.toggle('portrait', matches);
         })
         .then(() => {
-          setMatcherSize(300, 100);
+          setMatcherSize(100, 300);
           return waitForClassName(storyEl, 'portrait');
         });
   });

--- a/src/services.js
+++ b/src/services.js
@@ -388,6 +388,15 @@ export class Services {
   }
 
   /**
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {?../extensions/amp-story/1.0/amp-story-media-query-service.AmpStoryMediaQueryService}
+   */
+  static storyMediaQueryService(elementOrAmpDoc) {
+    return (/** @type {?../extensions/amp-story/1.0/amp-story-media-query-service.AmpStoryMediaQueryService} */
+      (getExistingServiceOrNull(elementOrAmpDoc, 'story-media-query')));
+  }
+
+  /**
    * @param {!Window} win
    * @return {?../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService}
    */

--- a/src/services.js
+++ b/src/services.js
@@ -388,12 +388,12 @@ export class Services {
   }
 
   /**
-   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @param {!Window} win
    * @return {?../extensions/amp-story/1.0/amp-story-media-query-service.AmpStoryMediaQueryService}
    */
-  static storyMediaQueryService(elementOrAmpDoc) {
+  static storyMediaQueryService(win) {
     return (/** @type {?../extensions/amp-story/1.0/amp-story-media-query-service.AmpStoryMediaQueryService} */
-      (getExistingServiceOrNull(elementOrAmpDoc, 'story-media-query')));
+      (getExistingServiceOrNull(win, 'story-media-query')));
   }
 
   /**


### PR DESCRIPTION
Publishers can provide `<media-query>` elements that accept two options: `media` and `className`.
The media query will match against the `amp-story-page` element, and not the viewport, solving media queries for stories.

When the `media` is matched, the `className` will be added as a class on the `amp-story` element, allowing publishers to write custom CSS.

Example:
```
<style amp-custom>
.foo p {
  /* Only triggered when the specified media query matches. */
}

.bar p {
   /* Only triggered when the specified media query matches. */
}
</style>

<amp-story class="foo? bar?">
  <media-query media="(orientation: portrait)" class-name="foo"></media-query>
  <media-query media="(max-width: 600px)" class-name="bar"></media-query>

  <amp-story-page>
    ...
  </amp-story-page>
</amp-story>
```