### PR TITLE
✨ Support dynamically added lists and add configuration options

### DIFF
--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
+import {
+  AMP_LIVE_LIST_CUSTOM_SLOT_ID,
+  LiveListManager,
+  liveListManagerForDoc,
+} from './live-list-manager';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
 import {Layout} from '../../../src/layout';
-import {LiveListManager, liveListManagerForDoc} from './live-list-manager';
 import {childElementByAttr} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {user, userAssert} from '../../../src/log';
@@ -39,13 +43,6 @@ const classes = {
  * }}
  */
 let MutateItemsDef;
-
-/**
- * Property used for storing id of custom slot. This custom slot can be used to
- * replace the default "items" and "update" slot.
- * @const {string}
- */
-export const AMP_LIST_CUSTOM_SLOT_ID = 'AMP_LIST_CUSTOM_SLOT_ID';
 
 /**
  * Defines underlying API for LiveList components.
@@ -204,7 +201,7 @@ export class AmpLiveList extends AMP.BaseElement {
 
     this.manager_ = liveListManagerForDoc(this.getAmpDoc());
 
-    this.customSlotId_ = this.element[AMP_LIST_CUSTOM_SLOT_ID];
+    this.customSlotId_ = this.element[AMP_LIVE_LIST_CUSTOM_SLOT_ID];
 
     this.updateSlot_ = userAssert(
         this.getUpdateSlot_(this.element),

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -198,8 +198,10 @@ export class LiveListManager {
     const liveListsWithCustomSlots = Object.keys(this.liveLists_).filter(id =>
       this.liveLists_[id].hasCustomSlot());
 
-    return liveListsWithCustomSlots.map(id =>
-      doc.getElementById(this.liveLists_[id].element[AMP_LIST_CUSTOM_SLOT_ID]));
+    return liveListsWithCustomSlots.map(id => {
+      const customSlotId = this.liveLists_[id].element[AMP_LIST_CUSTOM_SLOT_ID];
+      return doc.getElementById(customSlotId);
+    });
   }
 
   /**

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {AMP_LIST_CUSTOM_SLOT_ID} from './amp-live-list';
 import {Poller} from './poller';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
@@ -31,6 +30,13 @@ import {userAssert} from '../../../src/log';
 const SERVICE_ID = 'liveListManager';
 
 const TRANSFORMED_PREFIX = 'google;v=';
+
+/**
+ * Property used for storing id of custom slot. This custom slot can be used to
+ * replace the default "items" and "update" slot.
+ * @const {string}
+ */
+export const AMP_LIVE_LIST_CUSTOM_SLOT_ID = 'AMP_LIVE_LIST_CUSTOM_SLOT_ID';
 
 /**
  * Manages registered AmpLiveList components.
@@ -199,7 +205,8 @@ export class LiveListManager {
       this.liveLists_[id].hasCustomSlot());
 
     return liveListsWithCustomSlots.map(id => {
-      const customSlotId = this.liveLists_[id].element[AMP_LIST_CUSTOM_SLOT_ID];
+      const customSlotId =
+        this.liveLists_[id].element[AMP_LIVE_LIST_CUSTOM_SLOT_ID];
       return doc.getElementById(customSlotId);
     });
   }

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -133,7 +133,7 @@ describes.realWin('amp-live-list', {
     const child = document.createElement('div');
     elem.querySelector('[items]').appendChild(child);
     buildElement(elem, dftAttrs);
-    const stub = sandbox.stub(liveList, 'validateLiveListItems_');
+    const stub = sandbox.stub(liveList, 'countAndCacheValidItems_');
     expect(stub).to.have.not.been.called;
     liveList.buildCallback();
     expect(stub).to.be.calledOnce;
@@ -143,21 +143,6 @@ describes.realWin('amp-live-list', {
     const child = document.createElement('div');
     elem.querySelector('[items]').appendChild(child);
     buildElement(elem, dftAttrs);
-    allowConsoleError(() => { expect(() => {
-      liveList.validateLiveListItems_(elem.querySelector('[items]'));
-    }).to.throw(/children must have id and data-sort-time/); });
-
-    allowConsoleError(() => { expect(() => {
-      child.setAttribute('id', 'child-id');
-      liveList.buildCallback();
-    }).to.throw(/children must have id and data-sort-time/); });
-
-    child.removeAttribute('id');
-
-    allowConsoleError(() => { expect(() => {
-      child.setAttribute('data-sort-time', Date.now());
-      liveList.buildCallback();
-    }).to.throw(/children must have id and data-sort-time/); });
 
     expect(() => {
       child.setAttribute('id', 'child-id');
@@ -378,11 +363,9 @@ describes.realWin('amp-live-list', {
       updateLiveListItems.setAttribute('items', '');
       update.appendChild(updateLiveListItems);
       updateLiveListItems.appendChild(document.createElement('div'));
-      const stub = sandbox.stub(liveList, 'validateLiveListItems_');
+      const stub = sandbox.stub(liveList, 'countAndCacheValidItems_');
       expect(stub).to.have.not.been.called;
-      allowConsoleError(() => { expect(() => {
-        liveList.update(update);
-      }).to.throw(); });
+      liveList.update(update);
       expect(stub).to.be.calledOnce;
     });
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -139,6 +139,21 @@ describes.realWin('amp-live-list', {
     expect(stub).to.be.calledOnce;
   });
 
+  it('only counts number of valid children', () => {
+    const child = document.createElement('div');
+    child.setAttribute('id', 'child-id');
+    child.setAttribute('data-sort-time', Date.now());
+    elem.querySelector('[items]').appendChild(child);
+
+    const invalidChild = document.createElement('div');
+    elem.querySelector('[items]').appendChild(invalidChild);
+
+    buildElement(elem, dftAttrs);
+    const spy = sandbox.spy(liveList, 'countAndCacheValidItems_');
+    liveList.buildCallback();
+    expect(spy).to.have.returned(1);
+  });
+
   it('validates correctly', () => {
     const child = document.createElement('div');
     elem.querySelector('[items]').appendChild(child);

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import {AMP_LIST_CUSTOM_SLOT_ID} from '../amp-live-list';
 import {LiveListManager, liveListManagerForDoc} from '../live-list-manager';
 import {Services} from '../../../../src/services';
-import { AMP_LIST_CUSTOM_SLOT_ID } from '../amp-live-list';
 
 const XHR_BUFFER_SIZE = 2;
 
@@ -102,7 +102,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     }
 
     hasCustomSlot() {
-      return !!this[AMP_LIST_CUSTOM_SLOT_ID];
+      return !!this.element[AMP_LIST_CUSTOM_SLOT_ID];
     }
   }
 
@@ -171,8 +171,9 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     const fromServer = doc.createElement('div');
     fromServer.appendChild(customSlot);
     fromServer.getElementById = () => {};
-
-    sandbox.stub(fromServer, 'getElementById').returns(customSlot);
+    sandbox.stub(fromServer, 'getElementById').callsFake(id => {
+      return fromServer.querySelector(`#${id}`);
+    });
 
     ready();
     const clientLiveList = getLiveList({
@@ -182,13 +183,11 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       'disable-pagination': '',
       'auto-insert': '',
     }, 'custom-list');
-    clientLiveList[AMP_LIST_CUSTOM_SLOT_ID] = customSlot.id;
+    clientLiveList.element[AMP_LIST_CUSTOM_SLOT_ID] = customSlot.id;
     clientLiveList.buildCallback();
 
-
     return manager.whenDocReady_().then(() => {
-      manager.updateLiveLists_(fromServer);
-      expect(Object.keys(manager.liveLists_)).to.have.length(1);
+      expect(manager.getCustomSlots_(fromServer)).to.have.length(1);
     });
   });
 

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import {AMP_LIST_CUSTOM_SLOT_ID} from '../amp-live-list';
-import {LiveListManager, liveListManagerForDoc} from '../live-list-manager';
+import {
+  AMP_LIVE_LIST_CUSTOM_SLOT_ID,
+  LiveListManager,
+  liveListManagerForDoc,
+} from '../live-list-manager';
 import {Services} from '../../../../src/services';
 
 const XHR_BUFFER_SIZE = 2;
@@ -102,7 +105,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     }
 
     hasCustomSlot() {
-      return !!this.element[AMP_LIST_CUSTOM_SLOT_ID];
+      return !!this.element[AMP_LIVE_LIST_CUSTOM_SLOT_ID];
     }
   }
 
@@ -183,7 +186,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       'disable-pagination': '',
       'auto-insert': '',
     }, 'custom-list');
-    clientLiveList.element[AMP_LIST_CUSTOM_SLOT_ID] = customSlot.id;
+    clientLiveList.element[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = customSlot.id;
     clientLiveList.buildCallback();
 
     return manager.whenDocReady_().then(() => {

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -99,6 +99,10 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     getUpdateTime() {
       return this.updateTime_;
     }
+
+    isDynamic() {
+      return false;
+    }
   }
 
   function getLiveList(attrs = {}, opt_id) {
@@ -248,7 +252,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       expect(liveList.isEnabled()).to.be.true;
       expect(liveList2.isEnabled()).to.be.true;
 
-      manager.getLiveLists_(fromServer1);
+      manager.updateLiveLists_(fromServer1);
 
       // Still polls since at least one live list can still receive updates.
       expect(liveList.isEnabled()).to.be.true;
@@ -261,7 +265,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       fromServer2List1.setAttribute('disabled', '');
       fromServer2.appendChild(fromServer2List1);
 
-      manager.getLiveLists_(fromServer2);
+      manager.updateLiveLists_(fromServer2);
 
       expect(liveList.isEnabled()).to.be.false;
       expect(liveList2.isEnabled()).to.be.false;
@@ -295,7 +299,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     expect(updateSpy1).to.have.not.been.called;
     expect(updateSpy2).to.have.not.been.called;
 
-    manager.getLiveLists_(fromServer1);
+    manager.updateLiveLists_(fromServer1);
 
     expect(updateSpy1).to.be.calledOnce;
     expect(updateSpy2).to.have.not.been.called;
@@ -313,7 +317,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     expect(updateSpy1).to.be.calledOnce;
     expect(updateSpy2).to.have.not.been.called;
 
-    manager.getLiveLists_(fromServer2);
+    manager.updateLiveLists_(fromServer2);
 
     expect(updateSpy1).to.have.callCount(2);
     expect(updateSpy2).to.be.calledOnce;
@@ -559,7 +563,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     list1.buildCallback();
     list2.buildCallback();
     expect(manager.latestUpdateTime_).to.equal(0);
-    manager.getLiveLists_(doc);
+    manager.updateLiveLists_(doc);
     expect(manager.latestUpdateTime_).to.equal(2000);
   });
 


### PR DESCRIPTION
Resolves #21718

Problem: If we dynamically append an amp-live-list in the client at runtime, there will not be a corresponding amp-live-list in the server document. Even though the custom container that we specified in the amp-live-list is indeed in both documents.
 
Proposed solution: Create a relationship between the dynamically added amp-live-list, and the custom slot (could be the element that built the live-list).

Then the manager will be able to query for that element on the server document., and it would compare these two elements by following the same logic amp-live-list currently uses.

Changelog:
* Introduce new attributes to configure amp-live-list:
 ` disable-scrolling`, `disable-pagination`.
* Introduce new `AMP_LIVE_LIST_CUSTOM_SLOT_ID` property, which if present, specifies a custom slot. This slot can be used to replace the default "items slot" or "update slot".
* Amp-live-list can now be dynamically built using the `dynamic-live-list` attribute on another element. This attribute contains the `id` of the `amp-live-list` that will be built.
* Don't throw an error if item does not have `data-sort-time attribute`, simply ignore it.
  * This will allow flexibility for new custom containers, like `amp-story` - which could contain both dynamic elements and non-dynamic elements.