### PR TITLE
🏗 Clear node require cache when running E2E tests

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -209,7 +209,7 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      beforeEach(async() => {
+      before(async() => {
         // Set up all fixtures.
         for (const fixture of fixtures) {
           await fixture.setup(env);
@@ -217,7 +217,7 @@ function describeEnv(factory) {
         installRepl(global, env);
       });
 
-      afterEach(function() {
+      after(function() {
         clearLastExpectError();
         clearTimeout(asyncErrorTimerId);
         // Tear down all fixtures.
@@ -229,16 +229,7 @@ function describeEnv(factory) {
           fixture.teardown(env);
         });
 
-        // Delete all other keys.
-        for (const key in env) {
-          delete env[key];
-        }
-
         uninstallRepl();
-      });
-
-      after(function() {
-        clearTimeout(asyncErrorTimerId);
       });
 
       describe(SUB, function() {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -209,7 +209,7 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      before(async() => {
+      beforeEach(async() => {
         // Set up all fixtures.
         for (const fixture of fixtures) {
           await fixture.setup(env);
@@ -217,7 +217,7 @@ function describeEnv(factory) {
         installRepl(global, env);
       });
 
-      after(function() {
+      afterEach(function() {
         clearLastExpectError();
         clearTimeout(asyncErrorTimerId);
         // Tear down all fixtures.
@@ -229,7 +229,16 @@ function describeEnv(factory) {
           fixture.teardown(env);
         });
 
+        // Delete all other keys.
+        for (const key in env) {
+          delete env[key];
+        }
+
         uninstallRepl();
+      });
+
+      after(function() {
+        clearTimeout(asyncErrorTimerId);
       });
 
       describe(SUB, function() {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -114,12 +114,14 @@ async function e2e() {
     // specify tests to run
     if (argv.files) {
       glob.sync(argv.files).forEach(file => {
+        delete require.cache[file];
         mocha.addFile(file);
       });
     }
     else {
       config.e2eTestPaths.forEach(path => {
         glob.sync(path).forEach(file => {
+          delete require.cache[file];
           mocha.addFile(file);
         });
       });


### PR DESCRIPTION
The PR is an attempt to fix the inconsistent number of E2E tests being run on Travis.

It's possible that test files are being cached. Mocha will skip test files that are in the node require cache, so this ensures that the cache is cleared.

~~This also attempts to fix this error - `NoSuchSessionError: This driver instance does not have a valid session ID (did you call WebDriver.quit()?) and may no longer be used.` by spinning up a WebDriver instance only once per describes(), instead of for each it().~~ Never mind about this, because some tests assume that a fresh page is spun up for each it()

