### PR TITLE
🏗 Reenable Edge and Chrome on Remote Tests (Sauce Labs) job

### DIFF
--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -107,11 +107,11 @@ function getConfig() {
     saucelabsBrowsers = argv.saucelabs ?
     // With --saucelabs, integration tests are run on this set of browsers.
       [
-        //'SL_Chrome',
+        'SL_Chrome',
         'SL_Firefox',
         // TODO(amp-infra): Restore this once tests are stable again.
         // 'SL_Safari_11',
-        //'SL_Edge_17',
+        'SL_Edge_17',
         'SL_Safari_12',
         // TODO(amp-infra): Evaluate and add more platforms here.
         //'SL_Chrome_Android_7',


### PR DESCRIPTION
Follow up to #20574 where Chrome and Edge were disabled on integration tests.