### PR TITLE
🏗 Add lint rule to enforce that e2e test `expects` are `await`ed

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ dist.3p
 dist.tools
 out
 examples
+firebase
 third_party
 test/coverage
 **/*.extern.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     }
   },
   "rules": {
+    "amphtml-internal/await-expect": 2,
     "amphtml-internal/closure-type-primitives": 2,
     "amphtml-internal/dict-string-keys": 2,
     "amphtml-internal/enforce-private-props": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -172,7 +172,7 @@
       "files": [
         "test/**/*.js",
         "extensions/**/test/**/*.js",
-        "extensions/**/test-e2e/*.js",        
+        "extensions/**/test-e2e/*.js",
         "ads/**/test/**/*.js",
         "testing/**/*.js"
       ],

--- a/build-system/eslint-rules/await-expect.js
+++ b/build-system/eslint-rules/await-expect.js
@@ -15,6 +15,14 @@
  */
 'use strict';
 
+/**
+ * Forces `expect` calls to be preceded by `await` in end-to-end tests.
+ *
+ * Bad:
+ *   expect(actual).to.equal(expected);
+ * Good:
+ *   await expect(actual).to.equal(expected);
+ */
 module.exports = function(context) {
   return {
     CallExpression(node) {

--- a/build-system/eslint-rules/await-expect.js
+++ b/build-system/eslint-rules/await-expect.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function(context) {
+  return {
+    CallExpression(node) {
+      const filename = context.getFilename();
+      if (!/test-e2e|\/test\/e2e\//.test(filename)) {
+        return;
+      }
+
+      const {callee} = node;
+      if (callee.type !== 'Identifier') {
+        return;
+      }
+
+      if (callee.name !== 'expect') {
+        return;
+      }
+
+      if (hasAwaitParent(node)) {
+        return;
+      }
+
+      context.report({
+        node,
+        message: '`expect` in end-to-end tests must use `await`.',
+      });
+    },
+  };
+};
+
+/**
+ * Returns true if the given espree AST node is a child of an `AwaitExpression`.
+ * @param {!Object} node
+ * @return {boolean}
+ */
+function hasAwaitParent(node) {
+  while (node) {
+    if (node.type == 'AwaitExpression') {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
+}
+


### PR DESCRIPTION
This PR should prevent test writers from forgetting to `await` their `expect`s accidentally and having tests succeed when they shouldn't.

This PR also prevents the generated code in the `firebase` directory from getting linted and making the `gulp lint` task take longer