### PR TITLE
✨ Add support for "error" param for amp-viewer-assistance.updateActionState

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -458,8 +458,12 @@ export class AmpList extends AMP.BaseElement {
     }
 
     return fetch.catch(error => {
+      const event = error
+        ? createCustomEvent(this.win, `${TAG}.error`,
+            dict({'response': error.response}))
+        : null;
       const actions = Services.actionServiceForDoc(this.element);
-      actions.trigger(this.element, 'fetch-error', null, ActionTrust.LOW);
+      actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
 
       if (opt_append) {
         throw error;

--- a/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
@@ -212,8 +212,10 @@ export class AmpViewerAssistance {
       return {
         update: {
           actionStatus: 'FAILED_ACTION_STATUS',
-          code: response.status,
-          message: errorMessage,
+          result: {
+            code: response.status,
+            message: errorMessage,
+          },
         },
       };
     });

--- a/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js
@@ -199,8 +199,8 @@ export class AmpViewerAssistance {
    * Transforms an error response object into a suitable updateActionState
    * payload to send to the viewer.
    * @private
-   * @param {?Object} args
-   * @return {!Promise<!Object>}
+   * @param {?JsonObject} args
+   * @return {!Promise<!JsonObject>}
    */
   transformUpdateActionStateArgs_(args) {
     if (args['update']) {

--- a/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
@@ -195,8 +195,10 @@ describes.fakeWin('AmpViewerAssistance', {
         expect(sendMessageStub.firstCall.args[1]).to.deep.equal({
           update: {
             actionStatus: 'FAILED_ACTION_STATUS',
-            code: 500,
-            message: 'error message',
+            result: {
+              code: 500,
+              message: 'error message',
+            },
           },
         });
       });

--- a/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
+++ b/extensions/amp-viewer-assistance/0.1/test/test-amp-viewer-assistance.js
@@ -105,7 +105,7 @@ describes.fakeWin('AmpViewerAssistance', {
       sendMessageStub = service.viewer_.sendMessageAwaitResponse;
     });
 
-    it('should send if params are well-formed', () => {
+    it('should send if "update" params are well-formed', () => {
       const args = {
         'update': {'actionStatus': 'COMPLETED_ACTION_STATUS'},
       };
@@ -127,11 +127,11 @@ describes.fakeWin('AmpViewerAssistance', {
       const invoke = new ActionInvocation(element, 'updateActionState', {});
       invoke.trust = ActionTrust.LOW;
       let actionHandlerPromise;
+      expectAsyncConsoleError('[amp-viewer-assistance] "updateActionState"' +
+          ' action must have an "update" or "error" parameter.', 1);
       return service.start_().then(() => {
         sendMessageStub.resetHistory();
-        allowConsoleError(() => {
-          actionHandlerPromise = service.actionHandler_(invoke);
-        });
+        actionHandlerPromise = service.actionHandler_(invoke);
         expect(actionHandlerPromise).to.be.null;
         return actionHandlerPromise;
       }).then(() => {
@@ -144,11 +144,12 @@ describes.fakeWin('AmpViewerAssistance', {
       const invoke = new ActionInvocation(element, 'updateActionState', args);
       invoke.trust = ActionTrust.LOW;
       let actionHandlerPromise;
+      expectAsyncConsoleError('[amp-viewer-assistance] "updateActionState"' +
+          ' action "update" parameter must contain a valid "actionStatus"' +
+          ' field.', 1);
       return service.start_().then(() => {
         sendMessageStub.resetHistory();
-        allowConsoleError(() => {
-          actionHandlerPromise = service.actionHandler_(invoke);
-        });
+        actionHandlerPromise = service.actionHandler_(invoke);
         expect(actionHandlerPromise).to.be.null;
         return actionHandlerPromise;
       }).then(() => {
@@ -162,17 +163,18 @@ describes.fakeWin('AmpViewerAssistance', {
       };
       const invoke = new ActionInvocation(element, 'updateActionState', args);
       invoke.trust = ActionTrust.LOW;
+      expectAsyncConsoleError('[amp-viewer-assistance] "updateActionState"' +
+          ' action "update" parameter must contain a valid "actionStatus"' +
+          ' field.', 1);
 
       return service.start_().then(() => {
         sendMessageStub.reset();
-        allowConsoleError(() => {
-          expect(service.actionHandler_(invoke)).to.be.null;
-        });
+        expect(service.actionHandler_(invoke)).to.be.null;
         expect(sendMessageStub).to.not.be.called;
       });
     });
 
-    it('should send if "error" param is present', () => {
+    it('should send if "error" param is well-formed', () => {
       const error = {
         text: () => {
           return Promise.resolve('error message');
@@ -201,6 +203,44 @@ describes.fakeWin('AmpViewerAssistance', {
             },
           },
         });
+      });
+    });
+
+    it('should not send if "error" param is invalid', () => {
+      const error = {
+        status: 500,
+      };
+      const args = {
+        'error': error,
+      };
+      const invoke = new ActionInvocation(element, 'updateActionState', args);
+      invoke.trust = ActionTrust.LOW;
+      expectAsyncConsoleError('[amp-viewer-assistance] "updateActionState"' +
+          ' action "error" parameter must contain a valid "response"' +
+          ' object.', 1);
+
+      return service.start_().then(() => {
+        sendMessageStub.resetHistory();
+        expect(service.actionHandler_(invoke)).to.be.null;
+        expect(sendMessageStub).to.not.be.called;
+      });
+    });
+
+    it('should not send if both "update" and "error" params are' +
+        ' present', () => {
+      const args = {
+        'error': {},
+        'update': {},
+      };
+      const invoke = new ActionInvocation(element, 'updateActionState', args);
+      invoke.trust = ActionTrust.LOW;
+      expectAsyncConsoleError('[amp-viewer-assistance] "updateActionState"' +
+          ' must have only one of the parameters "error" and "update".', 1);
+
+      return service.start_().then(() => {
+        sendMessageStub.resetHistory();
+        expect(service.actionHandler_(invoke)).to.be.null;
+        expect(sendMessageStub).to.not.be.called;
       });
     });
   });

--- a/extensions/amp-viewer-assistance/amp-viewer-assistance.md
+++ b/extensions/amp-viewer-assistance/amp-viewer-assistance.md
@@ -63,15 +63,32 @@ The `amp-viewer-assistance` extension currently has two functions that can be in
   </tr>
   <tr>
     <td class="col-fourty"><code>updateActionState</code></td>
-    <td>A function to send a message to the outer viewer representing a state change. Requires an <code>update</code> object parameter of the following format:
-    
-    {
-      "actionStatus": "COMPLETED_ACTION_STATUS" | "ACTIVE_ACTION_STATUS" |
-          "FAILED_ACTION_STATUS",
-      "result": { ... }, // optional field used with COMPLETED_ACTION_STATUS
-    }
+    <td>A function to send a message to the outer viewer representing a state change. Requires either an <code>update</code> or <code>error</code> object parameter
   </tr>
 </table>
+
+### UpdateActionState Payloads
+A valid `amp-viewer-assistance.updateActionState` payload can either be an `update` object of the format:
+```
+{
+  "actionStatus": "COMPLETED_ACTION_STATUS" | "ACTIVE_ACTION_STATUS" |
+      "FAILED_ACTION_STATUS",
+  "result": { ... }, // optional field used with COMPLETED_ACTION_STATUS
+}
+```
+
+or an `error` standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object.
+
+## Handling Errors
+
+In the event of an error with the `amp-list` extension, we can listen to the `fetch-error` event and call `amp-viewer-assistance.updateActionState` to pass the error to the viewer. With an `error` parameter, `amp-viewer-assistance` will transform the parameter into a `FAILED_ACTION_STATUS` payload before sending it to the viewer.
+
+```html
+<amp-list id="my-failing-list"
+    src="failing.xhr.address.com"
+    on="fetch-error:amp-viewer-assistance.updateActionState(error=event.response)">
+</amp-list>
+```
 
 ## Messages Sent
 


### PR DESCRIPTION
With the introduction of #21512, `<amp-list>` now supports the `fetch-error` event. This change allows `amp-viewer-assistance` to report a failed XHR using the `fetch-error` event.

/cc @choumx 