### PR TITLE
Use Puppeteer's `networkidle2` heuristic event for page idleness

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -379,13 +379,18 @@ async function snapshotWebpages(percy, browser, webpages) {
       // modify the #anchor name.
       await page.goto('about:blank').then(() => {}, () => {});
 
-      // Puppeteer is flaky when it comes to catching navigation requests, so
-      // ignore timeouts. If this was a real non-loading page, this will be
-      // caught in the resulting Percy build. Also attempt to wait until there
-      // are no more network requests. This method is flaky since Puppeteer
-      // doesn't always understand Chrome's network activity, so ignore timeouts
-      // again.
-      const pagePromise = page.goto(fullUrl, {waitUntil: 'networkidle0'})
+      // Notes:
+      // 1. Puppeteer is flaky when it comes to catching navigation requests, so
+      //    ignore timeouts. If this was a real non-loading page, this will be
+      //    caught in the resulting Percy build.
+      // 2. Await page load by waiting on the `networkidle2` event, which is a
+      //    puppetter heuristic suitable for pages that are expected to have a
+      //    small amount of background network activity.
+      //    Reference: https://github.com/GoogleChrome/puppeteer/issues/1552
+      const pagePromise = page.goto(fullUrl, {
+        timeout: 0,
+        waitUntil: 'networkidle2',
+      })
           .then(() => {}, () => {})
           .then(async() => {
             log('verbose', 'Navigation to page', colors.yellow(name),


### PR DESCRIPTION
The visual tests have been flaky of late due to errors of [this](https://travis-ci.org/ampproject/amphtml/jobs/518428207#L1537-L1552) sort:
```
[18:56:18] ERROR: Error in test amp-story: embed mode 1
[18:56:18] ERROR: Exception thrown: Error: Execution context was destroyed, most likely because of a navigation.
    at rewriteError (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/ExecutionContext.js:144:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at ExecutionContext.<anonymous> (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/helper.js:144:27)
    at _documentPromise._contextPromise.then (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/FrameManager.js:459:38)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at Frame.<anonymous> (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/helper.js:144:27)
    at Page.$$ (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/Page.js:323:29)
    at Page.<anonymous> (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/node_modules/puppeteer/lib/helper.js:145:23)
    at waitForElementVisibility (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/helpers.js:150:44)
    at waitForLoaderDots (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/helpers.js:122:35)
    at page.goto.then.then (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/index.js:404:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)
[18:56:18] FATAL: Some tests have failed locally.
```

This PR uses Puppeteer's `networkidle2` heuristic event for page idleness, which allows for a small amount of background activity. This should hopefully eliminate the case where puppeteer thinks there was a page navigation.

**References:**
- https://github.com/GoogleChrome/puppeteer/issues/3323
- https://github.com/GoogleChrome/puppeteer/issues/1552

Attempted fix for #21056