### PR TITLE
✅ Skip some tests that fail on Edge now that we're running tests on the browser

### DIFF
--- a/test/integration/test-amp-inabox.js
+++ b/test/integration/test-amp-inabox.js
@@ -68,7 +68,8 @@ function unregisterIframe(frame) {
 
 // TODO: Unskip the cross domain tests on Firefox, which broke because localhost
 // subdomains no longer work on version 65.
-describe('inabox', function() {
+// TODO(zombifier): Unskip on Edge once these tests work.
+describe.configure().skipEdge().run('inabox', function() {
 
   function testAmpComponents() {
     const imgPromise = RequestBank.withdraw('image').then(req => {
@@ -250,7 +251,9 @@ describe('inabox', function() {
   });
 });
 
-describe('inabox with a complex image ad', function() {
+// TODO(zombifier): Unskip on Edge once these tests work.
+describe.configure().skipEdge().run('inabox with a complex ' +
+    'image ad', function() {
   const {testServerPort} = window.ampTestRuntimeConfig;
 
   // The image ad as seen in examples/inabox.gpt.html,

--- a/test/integration/test-amp-recaptcha-input.js
+++ b/test/integration/test-amp-recaptcha-input.js
@@ -18,8 +18,8 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {Deferred} from '../../src/utils/promise';
 import {poll} from '../../testing/iframe';
 
-// TODO(torch2424, #20541): These tests fail on firefox.
-describe.configure().skipFirefox().run('amp-recaptcha-' +
+// TODO(torch2424, #20541): These tests fail on firefox and Edge.
+describe.configure().skipFirefox().skipEdge().run('amp-recaptcha-' +
     'input', function() {
 
   describes.integration('with form and amp-mustache', {


### PR DESCRIPTION
We recently re-enabled testing on Edge. This PR skips a few tests that don't work on the browser.

Logs: https://travis-ci.org/ampproject/amphtml/jobs/518345369#L1599-L1654

Follow up to https://github.com/ampproject/amphtml/pull/21796#issuecomment-481860023