### PR TITLE
✅ Skip `amp-script` tests on Windows (Edge, Firefox, and Chrome)

### DIFF
--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -23,7 +23,10 @@ function poll(description, condition, opt_onError) {
   return classicPoll(description, condition, opt_onError, TIMEOUT);
 }
 
-describe.configure().skipSinglePass().run('amp-script', function() {
+// TODO(choumx): If possible / desired, make these tests work on Single-pass,
+// and on Windows (Edge, Firefox, and Chrome).
+describe.configure().skipSinglePass().skipWindows().run('amp-' +
+    'script', function() {
   this.timeout(TIMEOUT);
 
   let browser, doc, element;


### PR DESCRIPTION
We recently enabled testing on a few Windows browsers (Edge, Firefox, and Chrome). This PR disables some newly found `amp-script` integration test failures on Windows.

**Edge:** https://travis-ci.org/ampproject/amphtml/jobs/518429019#L2287-L2360
**Firefox:** https://travis-ci.org/ampproject/amphtml/jobs/518429019#L2369-L2457
**Chrome:** https://travis-ci.org/ampproject/amphtml/jobs/518429019#L2460-L2527

Follow up to https://github.com/ampproject/amphtml/pull/21796#issuecomment-481860023