### PR TITLE
✅ Skip `inabox` tests on Windows, not just Edge

### DIFF
--- a/test/integration/test-amp-inabox.js
+++ b/test/integration/test-amp-inabox.js
@@ -68,8 +68,8 @@ function unregisterIframe(frame) {
 
 // TODO: Unskip the cross domain tests on Firefox, which broke because localhost
 // subdomains no longer work on version 65.
-// TODO(zombifier): Unskip on Edge once these tests work.
-describe.configure().skipEdge().run('inabox', function() {
+// TODO(zombifier): Unskip on Windows once these tests work.
+describe.configure().skipWindows().run('inabox', function() {
 
   function testAmpComponents() {
     const imgPromise = RequestBank.withdraw('image').then(req => {
@@ -251,8 +251,8 @@ describe.configure().skipEdge().run('inabox', function() {
   });
 });
 
-// TODO(zombifier): Unskip on Edge once these tests work.
-describe.configure().skipEdge().run('inabox with a complex ' +
+// TODO(zombifier): Unskip on Windows once these tests work.
+describe.configure().skipWindows().run('inabox with a complex ' +
     'image ad', function() {
   const {testServerPort} = window.ampTestRuntimeConfig;
 


### PR DESCRIPTION
#21812 skipped some `inabox` tests on Edge, now that we've enabled testing on a few new browsers. It turns out the failures are widespread across all Windows browsers (Edge, Firefox, and Chrome).

**Logs:** https://travis-ci.org/ampproject/amphtml/jobs/518516284#L1574-L1595

This PR skips the tests on Windows. They still continue to be run on Linux and Mac OS.

Follow up to #21812
