### PR TITLE
🐛 Fix Source maps

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -52,6 +52,7 @@ import {
 } from './3p';
 import {startsWith} from '../src/string.js';
 import {urls} from '../src/config';
+import {version} from '../src/internal-version';
 
 // Disable auto-sorting of imports from here on.
 /* eslint-disable sort-imports-es6-autofix/sort-imports-es6 */
@@ -768,7 +769,7 @@ export function isTagNameAllowed(type, tagName) {
  */
 function lightweightErrorReport(e, isCanary) {
   new Image().src = urls.errorReporting +
-      '?3p=1&v=' + encodeURIComponent('$internalRuntimeVersion$') +
+      '?3p=1&v=' + encodeURIComponent(version()) +
       '&m=' + encodeURIComponent(e.message) +
       '&ca=' + (isCanary ? 1 : 0) +
       '&r=' + encodeURIComponent(document.referrer) +

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -32,6 +32,7 @@ import {getMode} from '../../../src/mode';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
 import {getTimingDataSync} from '../../../src/service/variable-source';
 import {parseJson} from '../../../src/json';
+import {version} from '../../../src/internal-version';
 import {whenUpgradedToCustomElement} from '../../../src/dom';
 
 /** @type {string}  */
@@ -288,7 +289,7 @@ export function googlePageParameters(a4a, startTime) {
           'is_amp': a4a.isXhrAllowed() ?
             AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP :
             AmpAdImplementation.AMP_AD_IFRAME_GET,
-          'amp_v': '$internalRuntimeVersion$',
+          'amp_v': version(),
           'd_imp': '1',
           'c': getCorrelator(win, ampDoc, clientId),
           'ga_cid': win.gaGlobal.cid || null,
@@ -720,7 +721,7 @@ export function addCsiSignalsToAmpAnalyticsConfig(
       `&c=${correlator}&slotId=${slotId}&qqid.${slotId}=${qqid}` +
       `&dt=${initTime}` +
       (eids != 'null' ? `&e.${slotId}=${eids}` : '') +
-      `&rls=$internalRuntimeVersion$&adt.${slotId}=${adType}`;
+      `&rls=${version()}&adt.${slotId}=${adType}`;
   const isAmpSuffix = isVerifiedAmpCreative ? 'Friendly' : 'CrossDomain';
   config['triggers']['continuousVisibleIniLoad'] = {
     'on': 'ini-load',

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -125,6 +125,7 @@ exports.rules = [
       '3p/**->src/observable.js',
       '3p/**->src/amp-events.js',
       '3p/**->src/consent-state.js',
+      '3p/**->src/internal-version.js',
       '3p/polyfills.js->src/polyfills/math-sign.js',
       '3p/polyfills.js->src/polyfills/object-assign.js',
       '3p/polyfills.js->src/polyfills/object-values.js',
@@ -154,6 +155,7 @@ exports.rules = [
       'ads/**->src/string.js',
       'ads/**->src/style.js',
       'ads/**->src/consent-state.js',
+      'ads/**->src/internal-version.js',
       'ads/google/adsense-amp-auto-ads-responsive.js->src/experiments.js',
       'ads/google/doubleclick.js->src/experiments.js',
       // ads/google/a4a doesn't contain 3P ad code and should probably move

--- a/build-system/shorten-license.js
+++ b/build-system/shorten-license.js
@@ -19,6 +19,17 @@ const escape = require('regexp.escape');
 const pumpify = require('pumpify');
 const replace = require('gulp-regexp-sourcemaps');
 
+// Keep the number of lines in the original and replacement the same. Because
+// sourcemaps suck.
+function emptyLines(original, replacement) {
+  const lines = original.split('\n').length;
+  const current = replacement.split('\n').length;
+  for (let l = current; l < lines; l++) {
+    replacement += '\n';
+  }
+  return replacement;
+}
+
 /* eslint-disable */
 const MIT_FULL = [
 'Permission is hereby granted, free of charge, to any person obtaining a copy',
@@ -63,8 +74,8 @@ const BSD_SHORT = [
 /* eslint-enable */
 
 const LICENSES = [
-  [MIT_FULL, MIT_SHORT],
-  [POLYMER_BSD_FULL, BSD_SHORT],
+  [MIT_FULL, emptyLines(MIT_FULL, MIT_SHORT)],
+  [POLYMER_BSD_FULL, emptyLines(POLYMER_BSD_FULL, BSD_SHORT)],
 ];
 
 /*

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -22,6 +22,7 @@ import {hasOwn} from '../../../src/utils/object';
 import {isLongTaskApiSupported} from '../../../src/service/jank-meter';
 import {toggle} from '../../../src/style';
 import {urls} from '../../../src/config';
+import {version} from '../../../src/internal-version';
 
 /** @private @const {string} */
 const TAG_ = 'amp-analytics/iframe-transport';
@@ -51,7 +52,7 @@ export function getIframeTransportScriptUrl(ampWin, opt_forceProdUrl) {
     return `${loc.protocol}//${loc.host}/dist/iframe-transport-client-lib.js`;
   }
   return urls.thirdParty +
-      '/$internalRuntimeVersion$/iframe-transport-client-v0.js';
+      `/${version()}/iframe-transport-client-v0.js`;
 }
 
 /**

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -37,6 +37,7 @@ import {loadPromise} from '../../../src/event-helper';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {urls} from '../../../src/config';
+import {version} from '../../../src/internal-version';
 
 /**
  * @fileoverview
@@ -275,7 +276,7 @@ export class AmpRecaptchaService {
             return '//' + curlsSubdomain +
               '.recaptcha.' + winLocation.host
               + '/dist.3p/' +
-          (getMode().minified ? '$internalRuntimeVersion$/recaptcha'
+          (getMode().minified ? `${version()}/recaptcha`
             : 'current/recaptcha.max') +
           '.html';
           });
@@ -298,7 +299,7 @@ export class AmpRecaptchaService {
 
     return curlsSubdomainPromise.then(curlsSubdomain => {
       const recaptchaFrameSrc = 'https://' + curlsSubdomain +
-        `.recaptcha.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/` +
+        `.recaptcha.${urls.thirdPartyFrameHost}/${version()}/` +
         'recaptcha.html';
       return recaptchaFrameSrc;
     });

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -24,6 +24,7 @@ import {setStyle} from './style';
 import {startsWith} from './string';
 import {tryParseJson} from './json';
 import {urls} from './config';
+import {version} from './internal-version';
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
 let count = {};
@@ -192,7 +193,7 @@ export function preloadBootstrap(win, preconnect, opt_disallowCustom) {
   // fetched by it.
   const scriptUrl = getMode().localDev
     ? getAdsLocalhost(win) + '/dist.3p/current/integration.js'
-    : `${urls.thirdParty}/$internalRuntimeVersion$/f.js`;
+    : `${urls.thirdParty}/${version()}/f.js`;
   preconnect.preload(scriptUrl, 'script');
 }
 
@@ -241,7 +242,7 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
   parentWindow.defaultBootstrapSubDomain =
       parentWindow.defaultBootstrapSubDomain || getSubDomain(parentWindow);
   return 'https://' + parentWindow.defaultBootstrapSubDomain +
-      `.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/` +
+      `.${urls.thirdPartyFrameHost}/${version()}/` +
       `${srcFileBasename}.html`;
 }
 
@@ -254,7 +255,7 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 export function getDevelopmentBootstrapBaseUrl(parentWindow, srcFileBasename) {
   return overrideBootstrapBaseUrl || getAdsLocalhost(parentWindow)
     + '/dist.3p/'
-    + (getMode().minified ? `$internalRuntimeVersion$/${srcFileBasename}`
+    + (getMode().minified ? `${version()}/${srcFileBasename}`
       : `current/${srcFileBasename}.max`)
     + '.html';
 }
@@ -329,7 +330,7 @@ function getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
       '%s (%s) in element %s. See https://github.com/ampproject/amphtml' +
       '/blob/master/spec/amp-iframe-origin-policy.md for details.', url,
   parsed.origin, meta);
-  return url + '?$internalRuntimeVersion$';
+  return url + '?${version()}';
 }
 
 /**

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -330,7 +330,7 @@ function getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
       '%s (%s) in element %s. See https://github.com/ampproject/amphtml' +
       '/blob/master/spec/amp-iframe-origin-policy.md for details.', url,
   parsed.origin, meta);
-  return url + '?${version()}';
+  return `${url}?${version()}`;
 }
 
 /**

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -41,6 +41,7 @@ import {installDocService} from './service/ampdoc-impl';
 import {installPerformanceService} from './service/performance-impl';
 import {isExperimentOn} from './experiments';
 import {stubElementsForDoc} from './service/custom-element-registry';
+import {version} from './internal-version';
 
 // This feature doesn't make sense in shadow mode as it only applies to
 // background rendered iframes;
@@ -92,7 +93,6 @@ if (isExperimentOn(self, 'ampdoc-shell')) {
 // (At least by sophisticated users).
 if (self.console) {
   (console.info || console.log).call(console,
-      'Powered by AMP ⚡ HTML shadows – Version $internalRuntimeVersion$');
+      `Powered by AMP ⚡ HTML shadows – Version ${version()}`);
 }
-self.document.documentElement.setAttribute('amp-version',
-    '$internalRuntimeVersion$');
+self.document.documentElement.setAttribute('amp-version', version());

--- a/src/amp.js
+++ b/src/amp.js
@@ -45,6 +45,7 @@ import {maybeTrackImpression} from './impression';
 import {maybeValidate} from './validator-integration';
 import {startupChunk} from './chunk';
 import {stubElementsForDoc} from './service/custom-element-registry';
+import {version} from './internal-version';
 
 /**
  * self.IS_AMP_ALT (is AMP alternative binary) is undefined by default in the
@@ -139,9 +140,8 @@ if (shouldMainBootstrapRun) {
   // (At least by sophisticated users).
   if (self.console) {
     (console.info || console.log).call(console,
-        'Powered by AMP ⚡ HTML – Version $internalRuntimeVersion$',
+        `Powered by AMP ⚡ HTML – Version ${version()}`,
         self.location.href);
   }
-  self.document.documentElement.setAttribute('amp-version',
-      '$internalRuntimeVersion$');
+  self.document.documentElement.setAttribute('amp-version', version());
 }

--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -20,6 +20,7 @@ import {experimentToggles, isCanary} from './experiments';
 import {getLengthNumeral} from './layout';
 import {getModeObject} from './mode-object';
 import {urls} from './config';
+import {version} from './internal-version';
 
 /**
  * Produces the attributes for the ad template.
@@ -65,9 +66,8 @@ export function getContextMetadata(
   // Please also add new introduced variable
   // name to the extern list.
   attributes['_context'] = dict({
-    'ampcontextVersion': '$internalRuntimeVersion$',
-    'ampcontextFilepath': urls.thirdParty + '/$internalRuntimeVersion$' +
-        '/ampcontext-v0.js',
+    'ampcontextVersion': version(),
+    'ampcontextFilepath': `${urls.thirdParty}/${version()}/ampcontext-v0.js`,
     'sourceUrl': docInfo.sourceUrl,
     'referrer': referrer,
     'canonicalUrl': docInfo.canonicalUrl,

--- a/src/inabox/amp-inabox-lite.js
+++ b/src/inabox/amp-inabox-lite.js
@@ -45,6 +45,7 @@ import {
 import {installViewerServiceForDoc} from '../service/viewer-impl';
 import {registerIniLoadListener} from './utils';
 import {stubElementsForDoc} from '../service/custom-element-registry';
+import {version} from '../internal-version';
 
 import {installActionServiceForDoc} from '../service/action-impl';
 import {installCidService} from '../service/cid-impl';
@@ -114,11 +115,10 @@ installStylesForDoc(ampdoc, fullCss, () => {
 // (At least by sophisticated users).
 if (self.console) {
   (console.info || console.log).call(console,
-      'Powered by AMP ⚡ HTML – Version $internalRuntimeVersion$',
+      `Powered by AMP ⚡ HTML – Version ${version()}`,
       self.location.href);
 }
-self.document.documentElement.setAttribute('amp-version',
-    '$internalRuntimeVersion$');
+self.document.documentElement.setAttribute('amp-version', version());
 
 /**
  * Install ampdoc-level services.

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -46,6 +46,7 @@ import {maybeTrackImpression} from '../impression';
 import {maybeValidate} from '../validator-integration';
 import {startupChunk} from '../chunk';
 import {stubElementsForDoc} from '../service/custom-element-registry';
+import {version} from '../internal-version';
 
 getMode(self).runtime = 'inabox';
 getMode(self).a4aId = getA4AId(self);
@@ -128,8 +129,7 @@ startupChunk(self.document, function initial() {
 // (At least by sophisticated users).
 if (self.console) {
   (console.info || console.log).call(console,
-      'Powered by AMP ⚡ HTML – Version $internalRuntimeVersion$',
+      `Powered by AMP ⚡ HTML – Version ${version()}`,
       self.location.href);
 }
-self.document.documentElement.setAttribute('amp-version',
-    '$internalRuntimeVersion$');
+self.document.documentElement.setAttribute('amp-version', version());

--- a/src/internal-version.js
+++ b/src/internal-version.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns the internal AMP runtime version. Note that this is not the RTV,
+ * which is a prefix and the runtime version.
+ *
+ * This function is replaced at compile time with a constant string.
+ *
+ * @return {string}
+ */
+export function version() {
+  return '$internalRuntimeVersion$';
+}

--- a/src/internal-version.js
+++ b/src/internal-version.js
@@ -18,7 +18,8 @@
  * Returns the internal AMP runtime version. Note that this is not the RTV,
  * which is a prefix and the runtime version.
  *
- * This function is replaced at compile time with a constant string.
+ * TODO: Calling this function should be replaced by a compile-time constant
+ * string. For now, function's return value is compiled, not the call site.
  *
  * @return {string}
  */

--- a/src/mode.js
+++ b/src/mode.js
@@ -134,10 +134,10 @@ function getRtvVersion(win, isLocalDev) {
     return win.AMP_CONFIG.v;
   }
 
-  // Currently `$internalRuntimeVersion$` and thus `mode.version` contain only
+  // Currently `internalRuntimeVersion` and thus `mode.version` contain only
   // major version. The full version however must also carry the minor version.
   // We will default to production default `01` minor version for now.
-  // TODO(erwinmombay): decide whether $internalRuntimeVersion$ should contain
+  // TODO(erwinmombay): decide whether internalRuntimeVersion should contain
   // minor version.
   return `01${version()}`;
 }

--- a/src/mode.js
+++ b/src/mode.js
@@ -15,6 +15,7 @@
  */
 
 import {parseQueryString_} from './url-parse-query-string';
+import {version} from './internal-version';
 
 /**
  * @typedef {{
@@ -33,9 +34,6 @@ import {parseQueryString_} from './url-parse-query-string';
  * }}
  */
 export let ModeDef;
-
-/** @type {string} */
-const version = '$internalRuntimeVersion$';
 
 /**
  * `rtvVersion` is the prefixed version we serve off of the cdn.
@@ -111,7 +109,7 @@ function getMode_(win) {
     lite: searchQuery['amp_lite'] != undefined,
     test: runningTests,
     log: hashQuery['log'],
-    version,
+    version: version(),
     rtvVersion,
     singlePassType,
   };
@@ -129,7 +127,7 @@ function getRtvVersion(win, isLocalDev) {
   // If it's local dev then we won't actually have a full version so
   // just use the version.
   if (isLocalDev) {
-    return version;
+    return version();
   }
 
   if (win.AMP_CONFIG && win.AMP_CONFIG.v) {
@@ -141,7 +139,7 @@ function getRtvVersion(win, isLocalDev) {
   // We will default to production default `01` minor version for now.
   // TODO(erwinmombay): decide whether $internalRuntimeVersion$ should contain
   // minor version.
-  return `01${version}`;
+  return `01${version()}`;
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -85,6 +85,7 @@ import {reportErrorForWin} from './error';
 import {setStyle} from './style';
 import {startupChunk} from './chunk';
 import {stubElementsForDoc} from './service/custom-element-registry';
+import {version} from './internal-version';
 
 initLogConstructor();
 setReportError(reportErrorForWin.bind(null, self));
@@ -920,11 +921,11 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
   if (typeof fnOrStruct == 'function') {
     return false;
   }
-  const version = fnOrStruct.v;
+  const {v} = fnOrStruct;
   // This is non-obvious, but we only care about the release version,
   // not about the full rtv version, because these only differ
   // in the config that is fully determined by the primary binary.
-  if ('$internalRuntimeVersion$' == version) {
+  if (version() == v) {
     return false;
   }
   // The :not is an extra prevention of recursion because it will be

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -45,6 +45,7 @@ import {
   registerServiceBuilderForDoc,
 } from '../service';
 import {tryResolve} from '../utils/promise';
+import {version} from '../internal-version';
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';
@@ -520,7 +521,7 @@ export class GlobalVariableSource extends VariableSource {
     });
 
     // returns the AMP version number
-    this.set('AMP_VERSION', () => '$internalRuntimeVersion$');
+    this.set('AMP_VERSION', () => version());
 
     this.set('BACKGROUND_STATE', () => {
       return Services.viewerForDoc(this.ampdoc).isVisible() ? '0' : '1';


### PR DESCRIPTION
Through a lot of trial and error, I've identified the two areas where our sourcemaps were getting screwed up. Embarrassingly, it's the same two areas from #17251.

It turns out, combining two different modifications into a single sourcemap isn't trivial. So, I'm falling back on more of a hack:

When we shorten the license comments, I'm ensuring that the shortened license has the same number of lines as the original. We waste a couple of bytes, but now there's no issue with lines coming after being mapped to the incorrect line number.

Additionally, I've extracted the `$internalRuntimeVersion$` magic string into a single location. That means only 1 line will have incorrect source mappings (which will only affect the columns). That line happens very early in the file, with other things that cannot throw errors, so we should be pretty safe here. Down the line, we can replace `version$$module$src$internalVersion()` with just the `'1904091426071'` compile-time string and eliminate the search-and-replace, which'll fix the problem entirely.