### PR TITLE
🏗 Change disconnect / no activity timeouts for Sauce Labs

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -251,10 +251,16 @@ module.exports = {
   },
 
   singleRun: true,
-  browserDisconnectTimeout: 4 * 60 * 1000,
-  browserNoActivityTimeout: 4 * 60 * 1000,
   captureTimeout: 4 * 60 * 1000,
   failOnEmptyTestSuite: false,
+
+  // AMP tests on Sauce take ~9 minutes, so don't fail if the browser doesn't
+  // communicate with the proxy for up to 10 minutes.
+  // TODO(rsimha): Reduce this number once keepalives are implemented by
+  // karma-sauce-launcher.
+  // See https://github.com/karma-runner/karma-sauce-launcher/pull/161.
+  browserDisconnectTimeout: 10 * 60 * 1000,
+  browserNoActivityTimeout: 10 * 60 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,


### PR DESCRIPTION
We frequently see disconnect failures [of this sort](https://travis-ci.org/ampproject/amphtml/jobs/518812129#L2245-L2250) on Sauce Labs, even when tests pass:

```
Safari 12.0.0 (Mac OS X 10.13.6) ERROR
  Disconnected, because no message in 240000 ms.
[15:51:38] Safari 12.0.0 (Mac OS X 10.13.6): Executed 38 of 517 (Skipped 62) SUCCESS
11 04 2019 15:51:38.676:ERROR [reporter.sauce]: ✖ Test Disconnected
```

Our tests take ~9 minutes for normal execution. This PR increases the values of `browserDisconnectTimeout` and `browserNoActivityTimeout` to 10 minutes each so that test runs don't fail if the browser doesn't communicate for that period (Safari in particular is known to stay silent while running tests). Once keepalives are implemented in `karma-sauce-launcher`, we can reduce these timeouts to the keepalive period. See https://github.com/karma-runner/karma-sauce-launcher/pull/161

Follow up to #21578