### PR TITLE
add single pass experiment IDs when needed.

### DIFF
--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -42,6 +42,17 @@ export let A4aExperimentBranches;
 /** @type {string} @private */
 export const MANUAL_EXPERIMENT_ID = '117152632';
 
+
+/**
+ * Experiment IDs used to identify single pass experiments.
+ *
+ * @enum {string}
+ */
+export const SINGLE_PASS_EXPERIMENT_IDS = {
+  SINGLE_PASS: '21063530',
+  MULTI_PASS: '21063529',
+};
+
 /**
  * @param {!Window} win
  * @param {!Element} element Ad tag Element.

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -49,8 +49,8 @@ export const MANUAL_EXPERIMENT_ID = '117152632';
  * @enum {string}
  */
 export const SINGLE_PASS_EXPERIMENT_IDS = {
-  SINGLE_PASS: '21063530',
   MULTI_PASS: '21063529',
+  SINGLE_PASS: '21063530',
 };
 
 /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -19,6 +19,10 @@ import {
   CONSENT_POLICY_STATE, // eslint-disable-line no-unused-vars
 } from '../../../src/consent-state';
 import {Layout, LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
+import {
+  SINGLE_PASS_EXPERIMENT_IDS,
+  addExperimentIdToElement,
+} from '../../../ads/google/a4a/traffic-experiments';
 import {Services} from '../../../src/services';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {
@@ -1765,6 +1769,22 @@ export class AmpA4A extends AMP.BaseElement {
    */
   isVerifiedAmpCreative() {
     return this.isVerifiedAmpCreative_;
+  }
+
+
+  /**
+   * Adds single pass experiment IDs if the javascript binary has
+   * "singlePassType" mode.
+   */
+  maybeAddSinglePassExperiment() {
+    const type = getMode().singlePassType;
+    if (type === 'sp') {
+      addExperimentIdToElement(SINGLE_PASS_EXPERIMENT_IDS.SINGLE_PASS,
+          this.element);
+    } else if (type === 'mp') {
+      addExperimentIdToElement(SINGLE_PASS_EXPERIMENT_IDS.MULTI_PASS,
+          this.element);
+    }
   }
 }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -45,6 +45,10 @@ import {MockA4AImpl, TEST_URL} from './utils';
 import {
   RealTimeConfigManager,
 } from '../real-time-config-manager';
+import {
+  SINGLE_PASS_EXPERIMENT_IDS,
+  isInExperiment,
+} from '../../../../ads/google/a4a/traffic-experiments';
 import {Services} from '../../../../src/services';
 import {Signals} from '../../../../src/utils/signals';
 import {Viewer} from '../../../../src/service/viewer-impl';
@@ -52,6 +56,7 @@ import {cancellation} from '../../../../src/error';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {createIframePromise} from '../../../../testing/iframe';
 import {dev, user} from '../../../../src/log';
+import {getMode} from '../../../../src/mode';
 import {
   incrementLoadingAds,
   is3pThrottled,
@@ -2569,6 +2574,51 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
     it('should return true if experiment disabled', () => {
       toggleExperiment(a4a.win, 'sandbox-ads', false);
       expect(a4a.sandboxHTMLCreativeFrame()).to.be.false;
+    });
+  });
+
+  describe('single pass experiments', () => {
+    it('should add single pass id', () => {
+      getMode().singlePassType = 'sp';
+      a4a.maybeAddSinglePassExperiment();
+
+      const isInSinglePass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.SINGLE_PASS);
+      const isInMultiPass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.MULTI_PASS);
+
+      expect(isInSinglePass).to.be.true;
+      expect(isInMultiPass).to.be.false;
+
+      getMode().singlePassType = '';
+    });
+
+    it('should add multi pass id', () => {
+      getMode().singlePassType = 'mp';
+      a4a.maybeAddSinglePassExperiment();
+
+      const isInSinglePass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.SINGLE_PASS);
+      const isInMultiPass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.MULTI_PASS);
+
+      expect(isInSinglePass).to.be.false;
+      expect(isInMultiPass).to.be.true;
+
+      getMode().singlePassType = '';
+    });
+
+    it('should not add any single pass experiment ids', () => {
+      getMode().singlePassType = '';
+      a4a.maybeAddSinglePassExperiment();
+
+      const isInSinglePass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.SINGLE_PASS);
+      const isInMultiPass = isInExperiment(
+          a4a.element, SINGLE_PASS_EXPERIMENT_IDS.MULTI_PASS);
+
+      expect(isInSinglePass).to.be.false;
+      expect(isInMultiPass).to.be.false;
     });
   });
 });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2609,7 +2609,7 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
     });
 
     it('should not add any single pass experiment ids', () => {
-      getMode().singlePassType = '';
+      getMode().singlePassType = undefined;
       a4a.maybeAddSinglePassExperiment();
 
       const isInSinglePass = isInExperiment(

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -260,6 +260,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     // This should happen last, as some diversion criteria rely on some of the
     // preceding logic (specifically responsive logic).
     this.divertExperiments();
+    this.maybeAddSinglePassExperiment();
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -457,6 +457,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.isFluidRequest_ = !!multiSizeStr &&
           multiSizeStr.indexOf('fluid') != -1;
     }
+    this.maybeAddSinglePassExperiment();
   }
 
   /** @override */


### PR DESCRIPTION
To isolate single pass and its controls performance characteristics, we need to send the experiment ids to be able to filter them.