### PR TITLE
✅ Skip flaky amp-base-carousel e2e tests

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -30,6 +30,8 @@ describes.endtoend('AMP carousel arrows when non-looping', {
   testUrl: 'http://localhost:8000/test/manual/amp-base-carousel/non-looping.amp.html',
   experiments: ['amp-base-carousel', 'layers'],
   initialRect: {width: pageWidth, height: pageHeight},
+  //TODO(spaharmi): fails on shadow demo
+  environments: ['single', 'viewer-demo'],
 }, async env => {
   let controller;
   let nextArrow;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
@@ -26,6 +26,8 @@ const SLIDE_COUNT = 7;
 describes.endtoend('AMP carousel arrows with custom arrows', {
   testUrl: 'http://localhost:8000/test/manual/amp-base-carousel/custom-arrows.amp.html',
   experiments: ['amp-base-carousel', 'layers'],
+  //TODO(spaharmi): fails on shadow demo
+  environments: ['single', 'viewer-demo'],
 }, async function(env) {
   let controller;
   let prevArrow;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -27,6 +27,8 @@ describes.endtoend('AMP carousel', {
   testUrl: 'http://localhost:8000/test/manual/amp-base-carousel/basic.amp.html',
   experiments: ['amp-base-carousel', 'layers'],
   initialRect: {width: pageWidth, height: pageHeight},
+  //TODO(spaharmi): fails on shadow demo
+  environments: ['single', 'viewer-demo'],
 }, async env => {
   /** The total number of slides in the carousel */
   const SLIDE_COUNT = 7;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
@@ -35,55 +35,52 @@ describes.endtoend('AMP carousel grouping', {
     return controller.getElementRect(el);
   }
 
-  beforeEach(async() => {
+  beforeEach(function() {
     controller = env.controller;
+    this.timeout(3 * 1000);
   });
 
-  describe('snapping', () => {
-    it('should snap on next group when past the midpoint', async() => {
-      const el = await getScrollingElement(controller);
-      const slides = await getSlides(controller);
+  it('should snap on next group when past the midpoint', async() => {
+    const el = await getScrollingElement(controller);
+    const slides = await getSlides(controller);
 
-      await controller.scrollBy(el, {left: slideWidth + 1});
-      await expect(rect(slides[2])).to.include({x: 0});
-    });
-
-    // TODO(sparhami) It seems like scrolling by even 1 pixel using scrollBy
-    // causes snap now. Need touch event support to actually simulate the  user
-    // scrolling.
-    it.skip('should snap on current group when before the midpoint',
-        async() => {
-          const el = await getScrollingElement(controller);
-          const slides = await getSlides(controller);
-
-          await controller.scrollBy(el, {left: slideWidth - 1});
-          await expect(rect(slides[0])).to.include({x: 0});
-        });
+    await controller.scrollBy(el, {left: slideWidth + 1});
+    await expect(rect(slides[2])).to.include({x: 0});
   });
 
-  describe('advancing', () => {
-    it('should move forwards by the advance-count', async() => {
-      const slides = await getSlides(controller);
-      const btn = await controller.findElement('[on="tap:carousel-1.next()"]');
+  // TODO(sparhami) It seems like scrolling by even 1 pixel using scrollBy
+  // causes snap now. Need touch event support to actually simulate the  user
+  // scrolling.
+  it.skip('should snap on current group when before the midpoint', async() => {
+    const el = await getScrollingElement(controller);
+    const slides = await getSlides(controller);
 
-      await controller.click(btn);
-      await expect(rect(slides[2])).to.include({x: 0});
-      await controller.click(btn);
-      await expect(rect(slides[4])).to.include({x: 0});
-      await controller.click(btn);
-      await expect(rect(slides[0])).to.include({x: 0});
-    });
+    await controller.scrollBy(el, {left: slideWidth - 1});
+    await expect(rect(slides[0])).to.include({x: 0});
+  });
 
-    it('should move backwards by the advance-count', async() => {
-      const slides = await getSlides(controller);
-      const btn = await controller.findElement('[on="tap:carousel-1.prev()"]');
+  it.skip('should move forwards by the advance-count', async() => {
+    const slides = await getSlides(controller);
+    const btn = await controller.findElement('[on="tap:carousel-1.next()"]');
 
-      await controller.click(btn);
-      await expect(rect(slides[4])).to.include({x: 0});
-      await controller.click(btn);
-      await expect(rect(slides[2])).to.include({x: 0});
-      await controller.click(btn);
-      await expect(rect(slides[0])).to.include({x: 0});
-    });
+    await controller.click(btn);
+    await expect(rect(slides[2])).to.include({x: 0});
+    await controller.click(btn);
+    await expect(rect(slides[4])).to.include({x: 0});
+    await controller.click(btn);
+    await expect(rect(slides[0])).to.include({x: 0});
+  });
+
+  it.skip('should move backwards by the advance-count', async() => {
+    const slides = await getSlides(controller);
+    const btn = await controller.findElement('[on="tap:carousel-1.prev()"]');
+
+    await controller.click(btn);
+    await expect(rect(slides[4])).to.include({x: 0});
+    await controller.click(btn);
+    await expect(rect(slides[2])).to.include({x: 0});
+    await controller.click(btn);
+    await expect(rect(slides[0])).to.include({x: 0});
   });
 });
+

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
@@ -33,7 +33,8 @@ describes.endtoend('AMP carousel', {
     controller = env.controller;
   });
 
-  it('should render with the correct initial slide', async() => {
+  //TODO(spaharmi): fails on all environments
+  it.skip('should render with the correct initial slide', async() => {
     const thirdSlide = await getSlide(controller, 2);
 
     // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
@@ -28,6 +28,8 @@ describes.endtoend('AMP carousel mixed length slides', {
       'mixed-lengths-no-snap.amp.html',
   experiments: ['amp-base-carousel', 'layers'],
   initialRect: {width: pageWidth, height: pageHeight},
+  //TODO(spaharmi): fails on viewer and shadow demo
+  environments: ['single'],
 }, async env => {
   let controller;
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -67,7 +67,11 @@ describes.endtoend('AMP carousel mixed length slides', {
       await assertSpacerWidth(1, slideTwoWidth);
     });
 
-    it('should snap on the center point', async() => {
+    it('should snap on the center point', async function() {
+      if (env.environment == 'shadow-demo') {
+        this.skip();
+      }
+
       const el = await getScrollingElement(controller);
       const slides = await getSlides(controller);
       const scrollAmount = 1 + (slideOneWidth + slideTwoWidth) / 2;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -67,19 +67,17 @@ describes.endtoend('AMP carousel mixed length slides', {
       await assertSpacerWidth(1, slideTwoWidth);
     });
 
-    it('should snap on the center point', async function() {
-      if (env.environment == 'shadow-demo') {
-        this.skip();
-      }
+    //TODO(sparhami): fails on shadow demo
+    it.configure().skipShadowDemo().run(
+        'should snap on the center point', async() => {
+          const el = await getScrollingElement(controller);
+          const slides = await getSlides(controller);
+          const scrollAmount = 1 + (slideOneWidth + slideTwoWidth) / 2;
 
-      const el = await getScrollingElement(controller);
-      const slides = await getSlides(controller);
-      const scrollAmount = 1 + (slideOneWidth + slideTwoWidth) / 2;
-
-      await controller.scrollBy(el, {left: scrollAmount});
-      await expect(controller.getElementRect(slides[1])).to.include({
-        x: (pageWidth - slideTwoWidth) / 2,
-      });
-    });
+          await controller.scrollBy(el, {left: scrollAmount});
+          await expect(controller.getElementRect(slides[1])).to.include({
+            x: (pageWidth - slideTwoWidth) / 2,
+          });
+        });
   });
 });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -74,38 +74,36 @@ describes.endtoend('Non-looping AMP carousel', {
     await controller.takeScreenshot('screenshots/snapped.png');
   });
 
-  it('should have the correct scroll position when resizing', async function() {
-    if (env.environment == 'shadow-demo') {
-      this.skip();
-    }
+  //TODO(sparhami): fails on shadow demo
+  it.configure().skipShadowDemo().run(
+      'should have the correct scroll position when resizing', async() => {
+        // Note: 513 seems to be the smallest settable width.
+        await controller.setWindowRect({
+          width: 800,
+          height: 600,
+        });
 
-    // Note: 513 seems to be the smallest settable width.
-    await controller.setWindowRect({
-      width: 800,
-      height: 600,
-    });
+        const firstSlide = await getSlide(controller, 0);
 
-    const firstSlide = await getSlide(controller, 0);
+        // Wait for the first two slides's imgs to load.
+        await waitForCarouselImg(controller, 0);
+        await waitForCarouselImg(controller, 1);
+        await expect(controller.getElementRect(firstSlide)).to.include({
+          'x': 0,
+          'width': 800,
+        });
 
-    // Wait for the first two slides's imgs to load.
-    await waitForCarouselImg(controller, 0);
-    await waitForCarouselImg(controller, 1);
-    await expect(controller.getElementRect(firstSlide)).to.include({
-      'x': 0,
-      'width': 800,
-    });
+        await controller.setWindowRect({
+          width: 900,
+          height: 600,
+        });
 
-    await controller.setWindowRect({
-      width: 900,
-      height: 600,
-    });
-
-    // Normally, resizing would cause the position to change. We're testing
-    // that the carousel moves this to the correct position again.
-    await expect(controller.getElementRect(firstSlide)).to.include({
-      'x': 0,
-      'width': 900,
-    });
-    await controller.takeScreenshot('screenshots/after-resize.png');
-  });
+        // Normally, resizing would cause the position to change. We're testing
+        // that the carousel moves this to the correct position again.
+        await expect(controller.getElementRect(firstSlide)).to.include({
+          'x': 0,
+          'width': 900,
+        });
+        await controller.takeScreenshot('screenshots/after-resize.png');
+      });
 });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -74,7 +74,11 @@ describes.endtoend('Non-looping AMP carousel', {
     await controller.takeScreenshot('screenshots/snapped.png');
   });
 
-  it('should have the correct scroll position when resizing', async() => {
+  it('should have the correct scroll position when resizing', async function() {
+    if (env.environment == 'shadow-demo') {
+      this.skip();
+    }
+
     // Note: 513 seems to be the smallest settable width.
     await controller.setWindowRect({
       width: 800,

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -28,6 +28,8 @@ describes.endtoend('AMP Carousel responsive attributes', {
       'responsive.amp.html',
   experiments: ['amp-base-carousel', 'layers'],
   initialRect: {width: pageWidth, height: pageHeight},
+  //TODO(spaharmi): fails on shadow demo
+  environments: ['single', 'viewer-demo'],
 }, async env => {
   let controller;
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
@@ -56,7 +56,8 @@ describes.endtoend('Vertical AMP carousel', {
     await controller.takeScreenshot('screenshots/vertical/render.png');
   });
 
-  it('should layout the two adjacent slides', async() => {
+  // TODO(sparhami): unskip
+  it.skip('should layout the two adjacent slides', async() => {
     // TODO(sparhami) Verify this is on the right of the 0th slide
     await waitForCarouselImg(controller, 1);
     // TODO(sparhami) Verify this is on the left of the 0th slide


### PR DESCRIPTION
Skips flaky amp-base-carousel e2e tests and un-nests `test-grouping.js` to prevent cascading test failures.

Also creates an `ItConfig` to allow you to skip a single test like 
``` 
it().configure().skipShadowDemo().run('should...', ...)
```
cc\ @sparhami @cvializ 