### PR TITLE
🐛 Replace internal version with compile time constant

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -47,6 +47,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
 
   private boolean single_file_compilation = false;
 
+  private String amp_version = "";
+
   /**
    * List of string suffixes to eliminate from the AST.
    */
@@ -82,7 +84,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     CompilerOptions options = super.createOptions();
     options.setCollapsePropertiesLevel(CompilerOptions.PropertyCollapseLevel.ALL);
     AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes,
-        assignmentReplacements, prodAssignmentReplacements);
+        assignmentReplacements, prodAssignmentReplacements, amp_version);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
     options.setDevirtualizePrototypeMethods(true);
     options.setExtractPrototypeMemberDeclarations(true);
@@ -138,6 +140,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.pseudo_names = true;
       } else if (arg.contains("SINGLE_FILE_COMPILATION=true")) {
         runner.single_file_compilation = true;
+      } else if (arg.contains("VERSION=")) {
+        runner.amp_version = arg.substring(arg.lastIndexOf("=") + 1);
       }
     }
 

--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -49,15 +49,19 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
   private final ImmutableMap<String, Node> assignmentReplacements;
   private final ImmutableMap<String, Node> prodAssignmentReplacements;
   final boolean isProd;
+  private final String amp_version;
 
   public AmpPass(AbstractCompiler compiler, boolean isProd,
         ImmutableSet<String> stripTypeSuffixes,
-        ImmutableMap<String, Node> assignmentReplacements, ImmutableMap<String, Node> prodAssignmentReplacements) {
+        ImmutableMap<String, Node> assignmentReplacements,
+        ImmutableMap<String, Node> prodAssignmentReplacements,
+        String amp_version) {
     this.compiler = compiler;
     this.stripTypeSuffixes = stripTypeSuffixes;
     this.isProd = isProd;
     this.assignmentReplacements = assignmentReplacements;
     this.prodAssignmentReplacements = prodAssignmentReplacements;
+    this.amp_version = amp_version;
   }
 
   @Override public void process(Node externs, Node root) {
@@ -86,6 +90,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
         maybeReplaceRValueInVar(n, prodAssignmentReplacements);
       }
       maybeReplaceRValueInVar(n, assignmentReplacements);
+      maybeReplaceCallWithVersion(n, parent);
     }
   }
 
@@ -181,6 +186,22 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
       }
     }
     return false;
+  }
+
+  private void maybeReplaceCallWithVersion(Node n, Node parent) {
+    if (n == null || !n.isCall() || amp_version.isEmpty()) {
+      return;
+    }
+
+    String name = buildQualifiedName(n);
+    if (!name.equals("version$$module$src$internal_version()")) {
+      return;
+    }
+
+    Node version =  IR.string(amp_version);
+    version.useSourceInfoIfMissingFrom(n);
+    parent.replaceChild(n, version);
+    compiler.reportChangeToEnclosingScope(parent);
   }
 
   private void maybeReplaceRValueInVar(Node n, Map<String, Node> map) {

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -35,7 +35,7 @@ public class AmpPassTest extends CompilerTestCase {
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
     return new AmpPass(compiler, /* isProd */ true, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements);
+        prodAssignmentReplacements, "123");
   }
 
   @Override protected int getNumRepetitions() {
@@ -366,5 +366,17 @@ public class AmpPassTest extends CompilerTestCase {
             "  console.log(a);",
             "})(self.AMP);",
             "console.log(a);"));
+  }
+
+  @Test public void testAmpVersionReplacement() throws Exception {
+    test(
+        LINE_JOINER.join(
+            "var a = `test${version$$module$src$internal_version()}ing`;",
+            "var b = 'test' + version$$module$src$internal_version() + 'ing';",
+            "var c = version$$module$src$internal_version();"),
+        LINE_JOINER.join(
+            "var a = `test${'123'}ing`;",
+            "var b = 'test' + '123' + 'ing';",
+            "var c = '123';"));
   }
 }

--- a/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
@@ -29,7 +29,7 @@ public class AmpPassTestEnvTest extends CompilerTestCase {
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
     return new AmpPass(compiler, /* isProd */ false, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements);
+        prodAssignmentReplacements, "123");
   }
 
   @Override protected int getNumRepetitions() {

--- a/build-system/single-pass.js
+++ b/build-system/single-pass.js
@@ -36,6 +36,7 @@ const {isTravisBuild} = require('./travis');
 const {TopologicalSort} = require('topological-sort');
 const TYPES_VALUES = Object.keys(TYPES).map(x => TYPES[x]);
 const wrappers = require('./compile-wrappers');
+const {VERSION: internalRuntimeVersion} = require('./internal-version') ;
 
 const argv = minimist(process.argv.slice(2));
 let singlePassDest = typeof argv.single_pass_dest === 'string' ?
@@ -84,6 +85,7 @@ const jsFilesToWrap = [];
 
 exports.getFlags = function(config) {
   config.define.push('SINGLE_FILE_COMPILATION=true');
+  config.define.push(`VERSION=${internalRuntimeVersion}`);
   /* eslint "google-camelcase/google-camelcase": 0 */
   // Reasonable defaults.
   const flags = {

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -25,7 +25,6 @@ const {isTravisBuild} = require('../travis');
 const {VERSION: internalRuntimeVersion} = require('../internal-version') ;
 
 const rename = require('gulp-rename');
-const replace = require('gulp-regexp-sourcemaps');
 const rimraf = require('rimraf');
 const shortenLicense = require('../shorten-license');
 const sourcemaps = require('gulp-sourcemaps');
@@ -126,7 +125,9 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     'third_party/moment/moment.extern.js',
     'third_party/react-externs/externs.js',
   ];
-  const define = [];
+  const define = [
+    `VERSION=${internalRuntimeVersion}`,
+  ];
   if (argv.pseudo_names) {
     define.push('PSEUDO_NAMES=true');
   }
@@ -155,12 +156,11 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     ).then(() => {
       return new Promise((resolve, reject) => {
         const stream = gulp.src(outputDir + '/**/*.js');
-        stream.on('end', resolve);
-        stream.on('error', reject);
-        stream.pipe(
-            replace(/\$internalRuntimeVersion\$/g, internalRuntimeVersion, 'runtime-version'))
+        stream
             .pipe(shortenLicense())
-            .pipe(gulp.dest(outputDir));
+            .pipe(gulp.dest(outputDir))
+            .on('end', resolve)
+            .on('error', reject);
       });
     });
   }
@@ -433,9 +433,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           .on('error', handleCompilerError)
           .pipe(rename(outputFilename))
           .pipe(sourcemaps.write('.'))
-          .pipe(replace(
-              /\$internalRuntimeVersion\$/g, internalRuntimeVersion,
-              'runtime-version'))
           .pipe(shortenLicense())
           .pipe(gulp.dest(outputDir))
           .on('end', resolve);

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -155,8 +155,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
         compilationOptions
     ).then(() => {
       return new Promise((resolve, reject) => {
-        const stream = gulp.src(outputDir + '/**/*.js');
-        stream
+        gulp.src(outputDir + '/**/*.js')
             .pipe(shortenLicense())
             .pipe(gulp.dest(outputDir))
             .on('end', resolve)

--- a/src/internal-version.js
+++ b/src/internal-version.js
@@ -18,8 +18,8 @@
  * Returns the internal AMP runtime version. Note that this is not the RTV,
  * which is a prefix and the runtime version.
  *
- * TODO: Calling this function should be replaced by a compile-time constant
- * string. For now, function's return value is compiled, not the call site.
+ * The call sites for this function are replaced with a compile time constant
+ * string.
  *
  * @return {string}
  */


### PR DESCRIPTION
This implements a compile time constant replacement for the AMP Version magic string. This also fixes the last remaining issue with sourcemaps, caused by the old string replace not keeping the same number of chars in the replacement.

```js
// input
import {version} from './internal-version';
console.log(version());

// output
console.log("1904010000000");
```