### PR TITLE
Remove references to amp-list-load-more experiment now that the feature has launched

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -197,24 +197,27 @@ export class AmpList extends AMP.BaseElement {
       this.maybeResizeListToFitItems_();
     });
 
-    const promises = [];
-
     if (this.loadMoreEnabled_) {
-      const loadMorePromise = this.mutateElement(() => {
-        this.getLoadMoreService_().initializeLoadMore();
-        const overflowElement = this.getOverflowElement();
-        if (overflowElement) {
-          toggle(overflowElement, false);
-        }
-        this.element.warnOnMissingOverflow = false;
-      }).then(() => {
-        this.adjustContainerForLoadMoreButton_();
-      });
-      promises.push(loadMorePromise);
+      this.initializeLoadMoreElements_();
     }
+    return this.fetchList_();
+  }
 
-    promises.push(this.fetchList_());
-    return Promise.all(promises);
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  initializeLoadMoreElements_() {
+    return this.mutateElement(() => {
+      this.getLoadMoreService_().initializeLoadMore();
+      const overflowElement = this.getOverflowElement();
+      if (overflowElement) {
+        toggle(overflowElement, false);
+      }
+      this.element.warnOnMissingOverflow = false;
+    }).then(() => {
+      this.adjustContainerForLoadMoreButton_();
+    });
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -41,10 +41,6 @@ import {
   setupInput,
   setupJsonFetchInit,
 } from '../../../src/utils/xhr-utils';
-import {
-  installOriginExperimentsForDoc,
-  originExperimentsForDoc,
-} from '../../../src/service/origin-experiments-impl';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {px, setStyles, toggle} from '../../../src/style';
@@ -117,9 +113,8 @@ export class AmpList extends AMP.BaseElement {
 
     /** @private {?../../../extensions/amp-bind/0.1/bind-impl.Bind} */
     this.bind_ = null;
-
-    /** @private {?Promise<boolean>} */
-    this.loadMoreEnabledPromise_ = null;
+    /** @private {boolean} */
+    this.loadMoreEnabled_ = false;
     /** @private {?./service/load-more-service.LoadMoreService} */
     this.loadMoreService_ = null;
     /** @private {?string} */
@@ -156,7 +151,7 @@ export class AmpList extends AMP.BaseElement {
     this.ssrTemplateHelper_ = new SsrTemplateHelper(
         TAG, viewer, this.templates_);
 
-    this.loadMoreEnabledPromise_ = this.getLoadMoreEnabledPromise_();
+    this.loadMoreEnabled_ = this.element.hasAttribute('load-more');
 
     // Store this in buildCallback() because `this.element` sometimes
     // is missing attributes in the constructor.
@@ -184,27 +179,6 @@ export class AmpList extends AMP.BaseElement {
     });
   }
 
-  /**
-   * @return {!Promise}
-   * @private
-   */
-  getLoadMoreEnabledPromise_() {
-    if (!this.element.hasAttribute('load-more')) {
-      return Promise.resolve(false);
-    }
-    if (isExperimentOn(this.win, 'amp-list-load-more')) {
-      return Promise.resolve(true);
-    }
-    installOriginExperimentsForDoc(this.getAmpDoc());
-
-    return originExperimentsForDoc(this.element)
-        .getExperiments()
-        .then(trials => {
-          return trials && trials.includes('amp-list-load-more');
-        });
-  }
-
-
   /** @override */
   reconstructWhenReparented() {
     return false;
@@ -223,35 +197,35 @@ export class AmpList extends AMP.BaseElement {
       this.maybeResizeListToFitItems_();
     });
 
-    const loadMorePromise = this.loadMoreEnabledPromise_.then(enabled => {
-      if (enabled) {
-        this.mutateElement(() => {
-          this.getLoadMoreService_().initializeLoadMore();
-          const overflowElement = this.getOverflowElement();
-          if (overflowElement) {
-            toggle(overflowElement, false);
-          }
-          this.element.warnOnMissingOverflow = false;
-        }).then(() => {
-          this.adjustContainerForLoadMoreButton_();
-        });
-      }
-    });
+    const promises = [];
 
-    return Promise.all([loadMorePromise, this.fetchList_()]);
+    if (this.loadMoreEnabled_) {
+      const loadMorePromise = this.mutateElement(() => {
+        this.getLoadMoreService_().initializeLoadMore();
+        const overflowElement = this.getOverflowElement();
+        if (overflowElement) {
+          toggle(overflowElement, false);
+        }
+        this.element.warnOnMissingOverflow = false;
+      }).then(() => {
+        this.adjustContainerForLoadMoreButton_();
+      });
+      promises.push(loadMorePromise);
+    }
+
+    promises.push(this.fetchList_());
+    return Promise.all(promises);
   }
 
   /**
    * @private
    */
   maybeResizeListToFitItems_() {
-    this.loadMoreEnabledPromise_.then(enabled => {
-      if (enabled) {
-        this.attemptToFitLoadMore_(dev().assertElement(this.container_));
-      } else {
-        this.attemptToFit_(dev().assertElement(this.container_));
-      }
-    });
+    if (this.loadMoreEnabled_) {
+      this.attemptToFitLoadMore_(dev().assertElement(this.container_));
+    } else {
+      this.attemptToFit_(dev().assertElement(this.container_));
+    }
   }
 
   /**
@@ -346,11 +320,9 @@ export class AmpList extends AMP.BaseElement {
     // In the load-more case, we allow the container to be height auto
     // in order to reasonably make space for the load-more button and
     // load-more related UI elements underneath.
-    this.loadMoreEnabledPromise_.then(enabled => {
-      if (!enabled) {
-        this.applyFillContent(container, true);
-      }
-    });
+    if (!this.loadMoreEnabled_) {
+      this.applyFillContent(container, true);
+    }
     return container;
   }
 
@@ -448,11 +420,9 @@ export class AmpList extends AMP.BaseElement {
         if (this.element.hasAttribute('max-items')) {
           items = this.truncateToMaxLen_(items);
         }
-        this.loadMoreEnabledPromise_.then(enabled => {
-          if (enabled) {
-            this.updateLoadMoreSrc_(/**@type {!JsonObject} */(data));
-          }
-        });
+        if (this.loadMoreEnabled_) {
+          this.updateLoadMoreSrc_(/**@type {!JsonObject} */(data));
+        }
         return this.scheduleRender_(items, !!opt_append, data);
       });
     }
@@ -612,16 +582,16 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   maybeRenderLoadMoreTemplates_(data) {
-    return this.loadMoreEnabledPromise_.then(enabled => {
-      if (enabled) {
-        const promises = [];
-        promises.push(this.maybeRenderLoadMoreElement_(
-            this.getLoadMoreService_().getLoadMoreButton(), data));
-        promises.push(this.maybeRenderLoadMoreElement_(
-            this.getLoadMoreService_().getLoadMoreEndElement(), data));
-        return Promise.all(promises);
-      }
-    });
+    if (this.loadMoreEnabled_) {
+      const promises = [];
+      promises.push(this.maybeRenderLoadMoreElement_(
+          this.getLoadMoreService_().getLoadMoreButton(), data));
+      promises.push(this.maybeRenderLoadMoreElement_(
+          this.getLoadMoreService_().getLoadMoreEndElement(), data));
+      return Promise.all(promises);
+    } else {
+      return Promise.resolve();
+    }
   }
 
   /**
@@ -877,31 +847,29 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   maybeSetLoadMore_() {
-    return this.loadMoreEnabledPromise_.then(enabled => {
-      if (!enabled) {
-        return;
+    if (!this.loadMoreEnabled_) {
+      return Promise.resolve();
+    }
+    if (this.loadMoreSrc_) {
+      const autoLoad = this.element.getAttribute('load-more') === 'auto';
+      if (autoLoad) {
+        this.setupLoadMoreAuto_();
       }
-      if (this.loadMoreSrc_) {
-        const autoLoad = this.element.getAttribute('load-more') === 'auto';
-        if (autoLoad) {
-          this.setupLoadMoreAuto_();
-        }
-        return this.mutateElement(() => {
-          this.getLoadMoreService_().toggleLoadMoreLoading(false);
-          // Set back to visible because there are actually more elements
-          // to load. See comment in initializeLoadMoreButton_ for context.
-          setStyles(this.getLoadMoreService_().getLoadMoreButton(), {
-            visibility: '',
-          });
-          this.unlistenLoadMore_ = listen(
-              this.getLoadMoreService_().getLoadMoreButtonClickable(),
-              'click', () => this.loadMoreCallback_());
+      return this.mutateElement(() => {
+        this.getLoadMoreService_().toggleLoadMoreLoading(false);
+        // Set back to visible because there are actually more elements
+        // to load. See comment in initializeLoadMoreButton_ for context.
+        setStyles(this.getLoadMoreService_().getLoadMoreButton(), {
+          visibility: '',
         });
-      } else {
-        return this.mutateElement(
-            () => this.getLoadMoreService_().setLoadMoreEnded());
-      }
-    });
+        this.unlistenLoadMore_ = listen(
+            this.getLoadMoreService_().getLoadMoreButtonClickable(),
+            'click', () => this.loadMoreCallback_());
+      });
+    } else {
+      return this.mutateElement(
+          () => this.getLoadMoreService_().setLoadMoreEnded());
+    }
   }
 
   /**
@@ -993,7 +961,6 @@ export class AmpList extends AMP.BaseElement {
             return this.loadMoreCallback_();
           }
         });
-
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -847,9 +847,17 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   maybeSetLoadMore_() {
-    if (!this.loadMoreEnabled_) {
-      return Promise.resolve();
+    if (this.loadMoreEnabled_) {
+      return this.setLoadMore_();
     }
+    return Promise.resolve();
+  }
+
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  setLoadMore_() {
     if (this.loadMoreSrc_) {
       const autoLoad = this.element.getAttribute('load-more') === 'auto';
       if (autoLoad) {

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -90,9 +90,9 @@ describes.realWin('amp-list component', {
       list.buildCallback();
     });
 
-    it('should create load-more elements after layout callback', async() => {
+    it('should create load-more elements after initialization', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
-      await list.layoutCallback();
+      await list.initializeLoadMoreElements_();
 
       expect(list.element.querySelectorAll('[load-more-button]'))
           .to.have.lengthOf(1);
@@ -103,7 +103,7 @@ describes.realWin('amp-list component', {
 
     it('should hide load-more-button at layout', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
-      await list.layoutCallback();
+      await list.initializeLoadMoreElements_();
 
       const button = list.element.querySelector('[load-more-button]');
       const buttonStyles = win.getComputedStyle(button);
@@ -115,7 +115,7 @@ describes.realWin('amp-list component', {
 
     it('should hide load-more-failed element at layout', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
-      await list.layoutCallback();
+      await list.initializeLoadMoreElements_();
 
       const failedElement = list.element.querySelector('[load-more-failed]');
       const failedStyles = win.getComputedStyle(failedElement);
@@ -124,7 +124,7 @@ describes.realWin('amp-list component', {
 
     it('should hide load-more-loading element at layout', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
-      await list.layoutCallback();
+      await list.initializeLoadMoreElements_();
 
       const loader = list.element.querySelector('[load-more-loading]');
       const loaderStyles = win.getComputedStyle(loader);

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -90,7 +90,7 @@ describes.realWin('amp-list component', {
       list.buildCallback();
     });
 
-    it('should create load-more elements after initialization', async() => {
+    it('should create load-more elements after init', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.initializeLoadMoreElements_();
 
@@ -101,7 +101,7 @@ describes.realWin('amp-list component', {
       expect(list.element.querySelector('[load-more-end]')).to.be.null;
     });
 
-    it('should hide load-more-button at layout', async() => {
+    it('should hide load-more-button after init', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.initializeLoadMoreElements_();
 
@@ -113,7 +113,7 @@ describes.realWin('amp-list component', {
       });
     });
 
-    it('should hide load-more-failed element at layout', async() => {
+    it('should hide load-more-failed element after init', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.initializeLoadMoreElements_();
 
@@ -122,7 +122,7 @@ describes.realWin('amp-list component', {
       expect(failedStyles.display).to.equal('none');
     });
 
-    it('should hide load-more-loading element at layout', async() => {
+    it('should hide load-more-loading element after init', async() => {
       sandbox.stub(list, 'getPlaceholder').returns(null);
       await list.initializeLoadMoreElements_();
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -346,6 +346,7 @@ describes.repeated('amp-list', {
       });
 
       it('should fail to load b/c data array is absent', () => {
+        expectAsyncConsoleError(/Response must contain an array/, 1);
         listMock.expects('fetch_').returns(Promise.resolve({})).once();
         listMock.expects('toggleLoading').withExactArgs(false).once();
         return expect(list.layoutCallback()).to.eventually.be
@@ -353,6 +354,7 @@ describes.repeated('amp-list', {
       });
 
       it('should fail to load b/c data single-item object is absent', () => {
+        expectAsyncConsoleError(/Response must contain an array or object/, 1);
         element.setAttribute('single-item', 'true');
         listMock.expects('fetch_').returns(Promise.resolve()).once();
         listMock.expects('toggleLoading').withExactArgs(false).once();
@@ -474,11 +476,10 @@ describes.repeated('amp-list', {
         });
 
         it('should error if proxied fetch returns invalid data', () => {
+          expectAsyncConsoleError(/Expected response with format/, 1);
           sandbox.stub(ssrTemplateHelper, 'fetchAndRenderTemplate')
               .returns(Promise.resolve(undefined));
-
           listMock.expects('toggleLoading').withExactArgs(false).once();
-
           return expect(list.layoutCallback()).to.eventually.be
               .rejectedWith(/Expected response with format/);
         });


### PR DESCRIPTION
Follow up to https://github.com/ampproject/amphtml/issues/14060. Basically adding origin trials resulted in a bunch of ugly promises to wait for the extension script to install. Now that `load-more` is launched, this PR removes said promises and makes the code path here easier to read.