### PR TITLE
Add explicity `--unit` to automated tests that run on `--local-changes`

### DIFF
--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,8 +25,8 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_LINT_LOCAL="gulp lint --local-changes"
-GULP_TEST_LOCAL="gulp test --local-changes --headless"
+GULP_LINT_LOCAL="gulp lint --unit --local-changes"
+GULP_TEST_LOCAL="gulp test --unit --local-changes --headless"
 
 echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "to skip them.)")
 echo -e "\n"

--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,7 +25,7 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_LINT_LOCAL="gulp lint --unit --local-changes"
+GULP_LINT_LOCAL="gulp lint --local-changes"
 GULP_TEST_LOCAL="gulp test --unit --local-changes --headless"
 
 echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "to skip them.)")

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -81,7 +81,7 @@ const command = {
     timedExecOrDie(cmd + ' --headless --coverage');
   },
   runUnitTestsOnLocalChanges: function() {
-    timedExecOrDie('gulp test --nobuild --headless --local-changes');
+    timedExecOrDie('gulp test --unit --nobuild --headless --local-changes');
   },
   runDevDashboardTests: function() {
     timedExecOrDie('gulp test --dev_dashboard --nobuild');

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -66,7 +66,7 @@ function main() {
     if (buildTargets.has('RUNTIME') ||
         buildTargets.has('BUILD_SYSTEM') ||
         buildTargets.has('UNIT_TEST')) {
-      timedExecOrDie('gulp test --nobuild --headless --local-changes');
+      timedExecOrDie('gulp test --unit --nobuild --headless --local-changes');
     }
 
     if (buildTargets.has('RUNTIME') ||


### PR DESCRIPTION
Fixed that issue noticed by Raghu in https://github.com/ampproject/amphtml/pull/21407#pullrequestreview-223524623