### PR TITLE
Add error logging for page navigation errors in visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -243,7 +243,7 @@ function addTestError(testErrors, name, message, error, fatal) {
  */
 function logTestError(testError) {
   log('error', 'Error in test', colors.yellow(testError.name), '\n  ',
-      testError.message, `\n  ${testError.fatal ? "FATAL" : "Non-fatal"}:`,
+      testError.message, `\n  ${testError.fatal ? 'FATAL' : 'Non-fatal'}:`,
       testError.error);
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -500,6 +500,7 @@ async function snapshotWebpages(percy, browser, webpages) {
   log('travis', '\n');
   if (isTravisBuild()) {
     testErrors.sort((a, b) => a.name.localeCompare(b.name));
+    // TODO(danielrozenberg): add Travis log folding.
     testErrors.forEach(logTestError);
   }
   return testErrors.every(testError => !testError.fatal);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -502,8 +502,7 @@ async function snapshotWebpages(percy, browser, webpages) {
     testErrors.sort((a, b) => a.name.localeCompare(b.name));
     testErrors.forEach(logTestError);
   }
-  log('info', 'DEBUG', testErrors.map(testError => testError.fatal));
-  return testErrors.some(testError => testError.fatal);
+  return testErrors.every(testError => !testError.fatal);
 }
 
 /**

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -392,7 +392,7 @@ async function snapshotWebpages(percy, browser, webpages) {
                   'has errored with:', navigationError);
               log('error', 'Continuing to verify page regardless...');
             }
-            testErrors.push({name, navigationError});
+            testErrors.push({name, error: navigationError});
           })
           .then(async() => {
             // Visibility evaluations can only be performed on the active tab,
@@ -459,7 +459,7 @@ async function snapshotWebpages(percy, browser, webpages) {
               log('error', 'Error in test', colors.cyan(name));
               log('error', 'Exception thrown:', testError);
             }
-            testErrors.push({name, testError});
+            testErrors.push({name, error: testError});
           })
           .then(async() => {
             await page.close();
@@ -475,9 +475,9 @@ async function snapshotWebpages(percy, browser, webpages) {
   log('travis', '\n');
   if (isTravisBuild()) {
     testErrors.forEach(testErrorObject => {
-      const {name, testError} = testErrorObject;
+      const {name, error} = testErrorObject;
       log('error', 'Error in test', colors.cyan(name));
-      log('error', 'Exception thrown:', testError);
+      log('error', 'Exception thrown:', error);
     });
   }
   return testErrors.length == 0;

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -242,7 +242,7 @@ function addTestError(testErrors, name, message, error, fatal) {
  * @param {!JsonObject} testError object as created by addTestError.
  */
 function logTestError(testError) {
-  log('error', 'Error in test', colors.yellow(testError.name), '\n  :',
+  log('error', 'Error in test', colors.yellow(testError.name), '\n  ',
       testError.message, '\n  ', testError.error);
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -242,8 +242,8 @@ function addTestError(testErrors, name, message, error, fatal) {
  * @param {!JsonObject} testError object as created by addTestError.
  */
 function logTestError(testError) {
-  log('error', 'Error in test', colors.yellow(name), '\n  :', message, '\n  ',
-        navigationError);
+  log('error', 'Error in test', colors.yellow(testError.name), '\n  :',
+      testError.message, '\n  ', testError.error);
 }
 
 /**
@@ -383,7 +383,6 @@ async function snapshotWebpages(percy, browser, webpages) {
   const pagePromises = {};
   const testErrors = [];
   let testNumber = 0;
-  let fatalFailure = false;
   for (const webpage of webpages) {
     const {viewport, name: pageName} = webpage;
     for (const [testName, testFunction] of Object.entries(webpage.tests_)) {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -502,6 +502,7 @@ async function snapshotWebpages(percy, browser, webpages) {
     testErrors.sort((a, b) => a.name.localeCompare(b.name));
     testErrors.forEach(logTestError);
   }
+  log('info', 'DEBUG', testErrors.map(testError => testError.fatal));
   return testErrors.some(testError => testError.fatal);
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -243,7 +243,7 @@ function addTestError(testErrors, name, message, error, fatal) {
  */
 function logTestError(testError) {
   log(testError.fatal ? 'error' : 'warning', 'Error in test',
-      colors.yellow(testError.name), '\n  ', testError.message, `\n  `,
+      colors.yellow(testError.name), '\n  ', testError.message, '\n  ',
       testError.error);
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -388,7 +388,7 @@ async function snapshotWebpages(percy, browser, webpages) {
           })
           .catch(navigationError => {
             log('error', 'Page navigator of test', colors.yellow(name),
-            'has errored with:', navigationError);
+                'has errored with:', navigationError);
             log('error', 'Continuing to verify page regardless...');
           })
           .then(async() => {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -387,9 +387,12 @@ async function snapshotWebpages(percy, browser, webpages) {
                 'is done, verifying page');
           })
           .catch(navigationError => {
-            log('error', 'Page navigator of test', colors.yellow(name),
-                'has errored with:', navigationError);
-            log('error', 'Continuing to verify page regardless...');
+            if (!isTravisBuild()) {
+              log('error', 'Page navigator of test', colors.yellow(name),
+                  'has errored with:', navigationError);
+              log('error', 'Continuing to verify page regardless...');
+            }
+            testErrors.push({name, navigationError});
           })
           .then(async() => {
             // Visibility evaluations can only be performed on the active tab,

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -388,7 +388,7 @@ async function snapshotWebpages(percy, browser, webpages) {
           })
           .catch(navigationError => {
             if (!isTravisBuild()) {
-              log('error', 'Page navigator of test', colors.yellow(name),
+              log('error', 'Page navigation of test', colors.yellow(name),
                   'has errored with:', navigationError);
               log('error', 'Continuing to verify page regardless...');
             }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -243,7 +243,8 @@ function addTestError(testErrors, name, message, error, fatal) {
  */
 function logTestError(testError) {
   log('error', 'Error in test', colors.yellow(testError.name), '\n  ',
-      testError.message, '\n  ', testError.error);
+      testError.message, `\n  ${testError.fatal ? "FATAL" : "Non-fatal"}:`,
+      testError.error);
 }
 
 /**

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -242,8 +242,8 @@ function addTestError(testErrors, name, message, error, fatal) {
  * @param {!JsonObject} testError object as created by addTestError.
  */
 function logTestError(testError) {
-  log('error', 'Error in test', colors.yellow(testError.name), '\n  ',
-      testError.message, `\n  ${testError.fatal ? 'FATAL' : 'Non-fatal'}:`,
+  log(testError.fatal ? 'error' : 'warning', 'Error in test',
+      colors.yellow(testError.name), '\n  ', testError.message, `\n  `,
       testError.error);
 }
 
@@ -419,7 +419,7 @@ async function snapshotWebpages(percy, browser, webpages) {
                 'The browser test runner failed to complete the navigation ' +
                 'to the test page', navigationError, /* fatal */ false);
             if (!isTravisBuild()) {
-              log('error', 'Continuing to verify page regardless...');
+              log('warning', 'Continuing to verify page regardless...');
             }
           })
           .then(async() => {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -474,6 +474,7 @@ async function snapshotWebpages(percy, browser, webpages) {
   }
   log('travis', '\n');
   if (isTravisBuild()) {
+    testErrors.sort((a, b) => a.name.localeCompare(b.name));
     testErrors.forEach(testErrorObject => {
       const {name, error} = testErrorObject;
       log('error', 'Error in test', colors.cyan(name));


### PR DESCRIPTION
In debugging of #21056.

Note that this PR also removes a superfluous navigation to `about:blank` before the actual page navigation, since each page uses a separate, newly created tab. The explicit navigation to `about:blank` is holdout from older code, when we were reusing tabs. This change _might_ have the accidental side effect of fixing the above issue (although I doubt it)