### PR TITLE
🏗 Report queued/skipped tests to the test status app

### DIFF
--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -29,6 +29,7 @@ const {
   timedExecOrDie: timedExecOrDieBase} = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../travis');
+const {reportAllExpectedTests} = require('../tasks/runtime-test/status-report');
 
 const FILENAME = 'checks.js';
 const timedExecOrDie =
@@ -71,6 +72,8 @@ function main() {
       timedExecOrDie('gulp dep-check');
       timedExecOrDie('gulp check-types');
     }
+
+    reportAllExpectedTests();
   }
 
   stopTimer(FILENAME, FILENAME, startTime);

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -57,6 +57,7 @@ function main() {
   } else {
     printChangeSummary(FILENAME);
     timedExecOrDie('gulp update-packages');
+    reportAllExpectedTests(buildTargets);
     runCommonChecks();
 
     // Check document links only for PR builds.
@@ -72,8 +73,6 @@ function main() {
       timedExecOrDie('gulp dep-check');
       timedExecOrDie('gulp check-types');
     }
-
-    reportAllExpectedTests(buildTargets);
   }
 
   stopTimer(FILENAME, FILENAME, startTime);

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -73,7 +73,7 @@ function main() {
       timedExecOrDie('gulp check-types');
     }
 
-    reportAllExpectedTests();
+    reportAllExpectedTests(buildTargets);
   }
 
   stopTimer(FILENAME, FILENAME, startTime);

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -29,6 +29,7 @@ const webserver = require('gulp-webserver');
 const {
   reportTestErrored,
   reportTestFinished,
+  reportTestSkipped,
   reportTestStarted,
 } = require('./status-report');
 const {app} = require('../../test-server');
@@ -260,7 +261,7 @@ async function runTests() {
     if (testsToRun.length == 0) {
       log(green('INFO:'),
           'No unit tests were directly affected by local changes.');
-      return Promise.resolve();
+      return reportTestSkipped();
     } else {
       log(green('INFO:'), 'Running the following unit tests:');
       testsToRun.forEach(test => {

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -19,7 +19,6 @@ const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const requestPromise = require('request-promise');
 const {cyan, green, yellow} = require('ansi-colors');
-const {determineBuildTargets} = require('./build-targets');
 const {gitCommitHash} = require('../../git');
 const {isTravisPullRequestBuild} = require('../../travis');
 
@@ -97,9 +96,7 @@ exports.reportTestStarted = () => {
   return postReport(inferTestType(), 'started');
 };
 
-exports.reportAllExpectedTests = async () => {
-  const buildTargets = determineBuildTargets();
-
+exports.reportAllExpectedTests = async buildTargets => {
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const action = TEST_TYPE_ACTIVATORS[type].some(buildTargets.has)
         ? 'queued' : 'skipped';

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -94,6 +94,10 @@ exports.reportTestFinished = (success, failed) => {
   return postReport(inferTestType(), `report/${success}/${failed}`);
 };
 
+exports.reportTestSkipped = () => {
+  return postReport(inferTestType(), 'skipped');
+};
+
 exports.reportTestStarted = () => {
   return postReport(inferTestType(), 'started');
 };

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -34,7 +34,7 @@ const TEST_TYPE_SUBTYPES = new Map([
   ['integration', ['default', 'saucelabs', 'single-pass']],
   ['unit', ['default', 'local-changes', 'saucelabs']],
 ]);
-const TEST_TYPE_ACTIVATORS = new Map([
+const TEST_TYPE_BUILD_TARGETS = new Map([
   ['integration', ['RUNTIME', 'BUILD_SYSTEM', 'INTEGRATION_TEST']],
   ['unit', ['RUNTIME', 'BUILD_SYSTEM', 'UNIT_TEST']],
 ]);
@@ -98,9 +98,8 @@ exports.reportTestStarted = () => {
 
 exports.reportAllExpectedTests = async buildTargets => {
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
-    const testTypeActivators = TEST_TYPE_ACTIVATORS.get(type);
-    log(green('DEBUG:'), type, testTypeActivators, buildTargets);
-    const action = testTypeActivators.some(buildTargets.has)
+    const testTypeBuildTargets = TEST_TYPE_BUILD_TARGETS.get(type);
+    const action = testTypeBuildTargets.some(target => buildTargets.has(target))
       ? 'queued' : 'skipped';
     for (const subType of subTypes) {
       await postReport(`${type}/${subType}`, action);

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -32,8 +32,8 @@ const IS_UNIT = !!argv.unit;
 
 const TEST_TYPE_SUBTYPES = new Map([
   // TODO(danielrozenberg): add 'saucelabs' to integration tests when supported.
-  ['integration', ['default', 'single-pass']],
-  ['unit', ['default', 'local-changes', 'saucelabs']],
+  ['integration', ['local', 'single-pass']],
+  ['unit', ['local', 'local-changes', 'saucelabs']],
   // TODO(danielrozenberg): add 'e2e' tests.
 ]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
@@ -63,7 +63,7 @@ function inferTestType() {
   } else if (IS_SINGLE_PASS) {
     return `${type}/single-pass`;
   } else {
-    return `${type}/default`;
+    return `${type}/local`;
   }
 }
 

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -31,8 +31,10 @@ const IS_SINGLE_PASS = !!argv.single_pass;
 const IS_UNIT = !!argv.unit;
 
 const TEST_TYPE_SUBTYPES = new Map([
-  ['integration', ['default', 'saucelabs', 'single-pass']],
+  // TODO(danielrozenberg): add 'saucelabs' to integration tests when supported.
+  ['integration', ['default', 'single-pass']],
   ['unit', ['default', 'local-changes', 'saucelabs']],
+  // TODO(danielrozenberg): add 'e2e' tests.
 ]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
   ['integration', ['RUNTIME', 'BUILD_SYSTEM', 'INTEGRATION_TEST']],

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -97,8 +97,8 @@ exports.reportTestStarted = () => {
 };
 
 exports.reportAllExpectedTests = async buildTargets => {
-  for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
-    const action = TEST_TYPE_ACTIVATORS[type].some(buildTargets.has)
+  `for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {`
+    const action = TEST_TYPE_ACTIVATORS.get(type).some(buildTargets.has)
       ? 'queued' : 'skipped';
     for (const subType of subTypes) {
       await postReport(`${type}/${subType}`, action);

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -99,7 +99,7 @@ exports.reportTestStarted = () => {
 exports.reportAllExpectedTests = async buildTargets => {
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const action = TEST_TYPE_ACTIVATORS[type].some(buildTargets.has)
-        ? 'queued' : 'skipped';
+      ? 'queued' : 'skipped';
     for (const subType of subTypes) {
       await postReport(`${type}/${subType}`, action);
     }

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -97,7 +97,7 @@ exports.reportTestStarted = () => {
 };
 
 exports.reportAllExpectedTests = async buildTargets => {
-  `for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {`
+  for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const action = TEST_TYPE_ACTIVATORS.get(type).some(buildTargets.has)
       ? 'queued' : 'skipped';
     for (const subType of subTypes) {

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -31,14 +31,14 @@ const IS_SAUCELABS = !!(argv.saucelabs || argv.saucelabs_lite);
 const IS_SINGLE_PASS = !!argv.single_pass;
 const IS_UNIT = !!argv.unit;
 
-const TEST_TYPE_SUBTYPES = new Map({
-  integration: ['default', 'saucelabs', 'single-pass'],
-  unit: ['default', 'local-changes', 'saucelabs'],
-});
-const TEST_TYPE_ACTIVATORS = new Map({
-  integration: ['RUNTIME', 'BUILD_SYSTEM', 'INTEGRATION_TEST'],
-  unit: ['RUNTIME', 'BUILD_SYSTEM', 'UNIT_TEST'],
-});
+const TEST_TYPE_SUBTYPES = new Map([
+  ['integration', ['default', 'saucelabs', 'single-pass']],
+  ['unit', ['default', 'local-changes', 'saucelabs']],
+]);
+const TEST_TYPE_ACTIVATORS = new Map([
+  ['integration', ['RUNTIME', 'BUILD_SYSTEM', 'INTEGRATION_TEST']],
+  ['unit', ['RUNTIME', 'BUILD_SYSTEM', 'UNIT_TEST']],
+]);
 
 function inferTestType() {
   let type;

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -75,8 +75,10 @@ function postReport(type, action) {
         .then(body => {
           log(green('INFO:'), 'reported', cyan(`${type}/${action}`),
               'to the test-status GitHub App');
-          log(green('INFO:'), 'response from test-status was',
-              body.length ? 'empty' : cyan(body.substr(0, 100)));
+          if (body.length > 0) {
+            log(green('INFO:'), 'response from test-status was',
+                cyan(body.substr(0, 100)));
+          }
         }).catch(error => {
           log(yellow('WARNING:'), 'failed to report', cyan(`${type}/${action}`),
               'to the test-status GitHub App:\n', error.message.substr(0, 100));

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -98,7 +98,9 @@ exports.reportTestStarted = () => {
 
 exports.reportAllExpectedTests = async buildTargets => {
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
-    const action = TEST_TYPE_ACTIVATORS.get(type).some(buildTargets.has)
+    const testTypeActivators = TEST_TYPE_ACTIVATORS.get(type);
+    log(green('DEBUG:'), type, testTypeActivators, buildTargets);
+    const action = testTypeActivators.some(buildTargets.has)
       ? 'queued' : 'skipped';
     for (const subType of subTypes) {
       await postReport(`${type}/${subType}`, action);


### PR DESCRIPTION
Add an early indicator for which test types are expected to run vs. which ones are skipped in the PR.

This PR also fixes the missing `skipped` status for `--local-changes`, which can be determined _after_ the `gulp test --unit --local-changes` command is executed (whether other test types get skipped is determined before executing their equivalent `gulp test` command)