### PR TITLE
Match RC and Canary experiment percentages

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -19,7 +19,7 @@
 
   "a4aFastFetchAdSenseLaunched": 0,
   "a4aFastFetchDoubleclickLaunched": 0,
-  "a4aProfilingRate": 0.1,
+  "a4aProfilingRate": 0.01,
   "ad-type-custom": 1,
   "amp-access-iframe": 1,
   "amp-ad-ff-adx-ady": 0.01,
@@ -40,6 +40,7 @@
   "amp-sidebar toolbar": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
+  "ampdoc-closest": 0.01,
   "as-use-attr-for-format": 0.01,
   "blurry-placeholder": 1,
   "chunked-amp": 1,


### PR DESCRIPTION
This moves `a4aProfilingRate` to 1% in canary (to match its 1% in RC), and moves `ampdoc-closest` to 1% in canary (to match its 1% in RC).