### PR TITLE
DOMPurify: Remove special-case for "on" attribute

### DIFF
--- a/src/purifier.js
+++ b/src/purifier.js
@@ -101,8 +101,8 @@ export function purifyConfig() {
     FORCE_BODY: true,
     // Avoid need for serializing to/from string by returning Node directly.
     RETURN_DOM: true,
-    // BLACKLISTED_ATTR_VALUES are enough. Other unknown protocols are safe.
-    // This allows native app deeplinks.
+    // Allows native app deeplinks. DOMPurify's remaining checks are sufficient
+    // to prevent code execution.
     ALLOW_UNKNOWN_PROTOCOLS: true,
   }));
   return /** @type {!DomPurifyConfig} */ (config);
@@ -249,7 +249,7 @@ export function addPurifyHooks(purifier, diffing) {
       disableDiffingFor(node);
     }
 
-    if (isValidAttr(tagName, attrName, attrValue, /* opt_purify */ true)) {
+    if (isValidAttr(tagName, attrName, attrValue)) {
       if (attrValue && !startsWith(attrName, 'data-amp-bind-')) {
         attrValue = rewriteAttributeValue(tagName, attrName, attrValue);
       }
@@ -264,10 +264,10 @@ export function addPurifyHooks(purifier, diffing) {
   };
 
   /**
-   * @param {!Node} node
+   * @param {!Node} unusedNode
    * @this {{removed: !Array}} Contains list of removed elements/attrs so far.
    */
-  const afterSanitizeAttributes = function(node) {
+  const afterSanitizeAttributes = function(unusedNode) {
     // DOMPurify doesn't have a tag-specific attribute whitelist API and
     // `allowedAttributes` has a per-invocation scope, so we need to undo
     // changes after sanitizing attributes.
@@ -275,19 +275,6 @@ export function addPurifyHooks(purifier, diffing) {
       delete allowedAttributes[attr];
     });
     allowedAttributesChanges.length = 0;
-
-    // Restore the `on` attribute which DOMPurify incorrectly flags as an
-    // unknown protocol due to presence of the `:` character.
-    remove(this.removed, r => {
-      if (r.from === node && r.attribute) {
-        const {name, value} = r.attribute;
-        if (name.toLowerCase() === 'on') {
-          node.setAttribute('on', value);
-          return true; // Delete from `removed` array once processed.
-        }
-      }
-      return false;
-    });
   };
 
   purifier.addHook('uponSanitizeElement', uponSanitizeElement);

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -23,7 +23,6 @@ import {
   WHITELISTED_TARGETS,
   isValidAttr,
 } from './sanitation';
-import {remove} from './utils/array';
 import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -248,7 +248,7 @@ export function addPurifyHooks(purifier, diffing) {
       disableDiffingFor(node);
     }
 
-    if (isValidAttr(tagName, attrName, attrValue)) {
+    if (isValidAttr(tagName, attrName, attrValue, /* opt_purify */ true)) {
       if (attrValue && !startsWith(attrName, 'data-amp-bind-')) {
         attrValue = rewriteAttributeValue(tagName, attrName, attrValue);
       }

--- a/src/sanitation.js
+++ b/src/sanitation.js
@@ -203,20 +203,24 @@ const INVALID_INLINE_STYLE_REGEX =
  * @param {string} tagName Lowercase tag name.
  * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
+ * @param {boolean} opt_purify Is true, skips some attribute sanitizations
+ *     that are already covered by DOMPurify.
  * @return {boolean}
  */
-export function isValidAttr(tagName, attrName, attrValue) {
-  // "on*" attributes are not allowed.
-  if (startsWith(attrName, 'on') && attrName != 'on') {
-    return false;
-  }
+export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
+  if (!opt_purify) {
+    // "on*" attributes are not allowed.
+    if (startsWith(attrName, 'on') && attrName != 'on') {
+      return false;
+    }
 
-  // No attributes with "javascript" or other blacklisted substrings in them.
-  if (attrValue) {
-    const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
-    for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
-      if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
-        return false;
+    // No attributes with "javascript" or other blacklisted substrings in them.
+    if (attrValue) {
+      const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
+      for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
+        if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
+          return false;
+        }
       }
     }
   }

--- a/src/sanitation.js
+++ b/src/sanitation.js
@@ -203,24 +203,20 @@ const INVALID_INLINE_STYLE_REGEX =
  * @param {string} tagName Lowercase tag name.
  * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
- * @param {boolean} opt_purify Is true, skips some attribute sanitizations
- *     that are already covered by DOMPurify.
  * @return {boolean}
  */
-export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
-  if (!opt_purify) {
-    // "on*" attributes are not allowed.
-    if (startsWith(attrName, 'on') && attrName != 'on') {
-      return false;
-    }
+export function isValidAttr(tagName, attrName, attrValue) {
+  // "on*" attributes are not allowed.
+  if (startsWith(attrName, 'on') && attrName != 'on') {
+    return false;
+  }
 
-    // No attributes with "javascript" or other blacklisted substrings in them.
-    if (attrValue) {
-      const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
-      for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
-        if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
-          return false;
-        }
+  // No attributes with "javascript" or other blacklisted substrings in them.
+  if (attrValue) {
+    const normalized = attrValue.toLowerCase().replace(/[\s,\u0000]+/g, '');
+    for (let i = 0; i < BLACKLISTED_ATTR_VALUES.length; i++) {
+      if (normalized.indexOf(BLACKLISTED_ATTR_VALUES[i]) >= 0) {
+        return false;
       }
     }
   }


### PR DESCRIPTION
No longer needed now that we set `ALLOW_UNKNOWN_PROTOCOLS`.

/to @delima02 