### PR TITLE
🏗 Replace `gulp-closure-compiler` with `google-closure-compiler`

### DIFF
--- a/build-system/single-pass.js
+++ b/build-system/single-pass.js
@@ -57,9 +57,6 @@ const commonJsModules = [
   'node_modules/set-dom/',
 ];
 
-// Override to local closure compiler JAR
-ClosureCompiler.JAR_PATH = require.resolve('./runner/dist/runner.jar');
-
 const mainBundle = 'src/amp.js';
 const extensionsInfo = {};
 let extensions = extensionBundles.concat(altMainBundles)
@@ -608,6 +605,9 @@ function formatSinglePassClosureCompilerError(message) {
 }
 
 function compile(flagsArray) {
+  // Override to local closure compiler JAR
+  ClosureCompiler.JAR_PATH = require.resolve('./runner/dist/runner.jar');
+
   fs.writeFileSync('flags-array.txt', JSON.stringify(flagsArray, null, 2));
   return new Promise(function(resolve, reject) {
     new ClosureCompiler(flagsArray).run(function(exitCode, stdOut, stdErr) {

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -344,10 +344,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     }
     externs.push('build-system/amp.multipass.extern.js');
 
-    const platformOptions = {
-      platform: ['java'],
-    };
-
     /* eslint "google-camelcase/google-camelcase": 0*/
     const compilerOptions = {
       compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
@@ -406,6 +402,11 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     if (compilerOptions.define.length == 0) {
       delete compilerOptions.define;
     }
+
+    // Required in order to override the JAR used by closure compiler
+    const platformOptions = {
+      platform: ['java'],
+    };
 
     // Override to local closure compiler JAR
     closureCompiler.compiler.JAR_PATH =

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -20,6 +20,7 @@ const closureCompiler = require('google-closure-compiler');
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const gulp = require('gulp');
+const nop = require('gulp-nop');
 const {isTravisBuild} = require('../travis');
 const {VERSION: internalRuntimeVersion} = require('../internal-version') ;
 
@@ -425,7 +426,9 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
 
     let stream = gulp.src(srcs, {base: '.'})
         .pipe(sourcemaps.init({loadMaps: true}))
-        .pipe(replace(/\$internalRuntimeVersion\$/g, internalRuntimeVersion, 'runtime-version'))
+        .pipe(replace(
+            /\$internalRuntimeVersion\$/g, internalRuntimeVersion,
+            'runtime-version'))
         .pipe(shortenLicense())
         .pipe(gulpClosureCompiler(compilerOptions, platformOptions))
         .on('error', function(err) {
@@ -443,7 +446,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           .on('end', resolve);
     } else {
       stream = stream
-          .pipe(gulp.dest(outputDir))
+          .pipe(nop())
           .on('end', resolve);
     }
     return stream;

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -75,7 +75,6 @@ exports.closureCompile = function(entryModuleFilename, outputDir,
 };
 
 function cleanupBuildDir() {
-  fs.mkdirsSync('build/cc');
   rimraf.sync('build/fake-module');
   rimraf.sync('build/patched-module');
   fs.mkdirsSync('build/patched-module/document-register-element/build');
@@ -176,8 +175,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     }
     const checkTypes =
         options.checkTypes || options.typeCheckOnly || argv.typecheck_only;
-    const intermediateFilename = 'build/cc/' +
-        entryModuleFilename.replace(/\//g, '_').replace(/^\./, '');
     // If undefined/null or false then we're ok executing the deletions
     // and mkdir.
     if (!options.preventRemoveAndMakeDir) {
@@ -189,9 +186,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     let wrapper = '(function(){%output%})();';
     if (options.wrapper) {
       wrapper = options.wrapper.replace('<%= contents %>', '%output%');
-    }
-    if (fs.existsSync(intermediateFilename)) {
-      fs.unlinkSync(intermediateFilename);
     }
     let sourceMapBase = 'http://localhost:8000/';
     if (isProdBuild) {
@@ -358,7 +352,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
 
     /* eslint "google-camelcase/google-camelcase": 0*/
     const compilerOptions = {
-      js_output_file: intermediateFilename,
       compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
       // Turns on more optimizations.
       assume_function_wrapper: true,

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "gulp-git": "2.9.0",
     "gulp-help": "1.6.1",
     "gulp-load-plugins": "1.5.0",
+    "gulp-nop": "0.0.3",
     "gulp-regexp-sourcemaps": "1.0.1",
     "gulp-rename": "1.4.0",
     "gulp-sourcemaps": "2.6.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "google-closure-compiler": "20190215.0.2",
     "gulp": "3.9.1",
     "gulp-ava": "1.0.0",
-    "gulp-closure-compiler": "0.4.0",
     "gulp-eslint": "5.0.0",
     "gulp-eslint-if-fixed": "1.0.0",
     "gulp-file": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13947,16 +13947,6 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
-temp-write@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-1.1.2.tgz#75b57a3cd9f802beaae3762b11e66ab1f4afd947"
-  integrity sha1-dbV6PNn4Ar6q43YrEeZqsfSv2Uc=
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    os-tmpdir "^1.0.0"
-    uuid "^2.0.1"
-
 tempy@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6645,6 +6645,14 @@ gulp-match@^1.0.3:
   dependencies:
     minimatch "^3.0.3"
 
+gulp-nop@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/gulp-nop/-/gulp-nop-0.0.3.tgz#e9ecd8b994d55817ab5ce16ba18f614d7810ecbe"
+  integrity sha1-6ezYuZTVWBerXOFroY9hTXgQ7L4=
+  dependencies:
+    gulp-util "~2.2.14"
+    through "~2.3.4"
+
 gulp-regexp-sourcemaps@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gulp-regexp-sourcemaps/-/gulp-regexp-sourcemaps-1.0.1.tgz#a8812244852c10950683a948e1c0dad0b1249979"
@@ -6676,7 +6684,7 @@ gulp-sourcemaps@2.6.5:
     strip-bom-string "1.X"
     through2 "2.X"
 
-gulp-util@^2.2.19:
+gulp-util@^2.2.19, gulp-util@~2.2.14:
   version "2.2.20"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-2.2.20.tgz#d7146e5728910bd8f047a6b0b1e549bc22dbd64c"
   integrity sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -4980,7 +4980,7 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.48"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.48.tgz#9a0b31eeded39e64453bcedf6f9d50bbbfb43850"
   integrity sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==
@@ -4988,6 +4988,15 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.9, es5-ext@~
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
     next-tick "1"
+
+es5-ext@^0.10.45, es5-ext@~0.10.2, es5-ext@~0.10.46:
+  version "0.10.49"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.49.tgz#059a239de862c94494fec28f8150c977028c6c5e"
+  integrity sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "^1.0.0"
 
 es6-error@^4.0.1:
   version "4.1.1"
@@ -6312,7 +6321,7 @@ glob@^4.3.1:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^5.0.10, glob@^5.0.14, glob@^5.0.6:
+glob@^5.0.10, glob@^5.0.6:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
@@ -6500,16 +6509,6 @@ google-closure-compiler@20190215.0.2:
     google-closure-compiler-linux "^20190215.0.1"
     google-closure-compiler-osx "^20190215.0.1"
 
-google-closure-compiler@^20151015.0.0:
-  version "20151015.7.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20151015.7.0.tgz#a494909eb33ec5b6aed1ffb712f0557ff596ba6f"
-  integrity sha1-pJSQnrM+xbau0f+3EvBVf/WWum8=
-  dependencies:
-    chalk "^1.0.0"
-    gulp-util "^3.0.7"
-    through2 "^2.0.0"
-    vinyl-sourcemaps-apply "^0.2.0"
-
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -6570,20 +6569,6 @@ gulp-ava@1.0.0:
     gulp-util "^3.0.8"
     resolve-cwd "^2.0.0"
     through2 "^3.0.0"
-
-gulp-closure-compiler@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/gulp-closure-compiler/-/gulp-closure-compiler-0.4.0.tgz#c4726edb1b44cb758e00d5b1522e1bdcd4e1a49a"
-  integrity sha1-xHJu2xtEy3WOANWxUi4b3NThpJo=
-  dependencies:
-    glob "^5.0.14"
-    google-closure-compiler "^20151015.0.0"
-    graceful-fs "^4.1.2"
-    gulp-util "^3.0.0"
-    mkdirp "^0.5.0"
-    temp-write "^1.0.0"
-    through "^2.3.4"
-    uuid "^2.0.1"
 
 gulp-eslint-if-fixed@1.0.0:
   version "1.0.0"
@@ -6705,7 +6690,7 @@ gulp-util@^2.2.19:
     through2 "^0.5.0"
     vinyl "^0.2.1"
 
-gulp-util@^3.0.0, gulp-util@^3.0.7, gulp-util@^3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -10473,7 +10458,7 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
-next-tick@1:
+next-tick@1, next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
@@ -14101,7 +14086,7 @@ through2@^3.0.0:
     readable-stream "2 || 3"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -14757,11 +14742,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
This PR replaces `gulp-closure-compiler` (which has not received an update in 3 years) with the native `gulp` plugin that is part of `google-closure-compiler`. With this, we can do custom text replacements on `gulp.src` and pass them directly to closure compiler without having to copy the intermediate output to a temp directory.

Addresses https://github.com/ampproject/amphtml/issues/21828#issuecomment-483487677.
Partial fix for #21828
Follow up to #21830
Follow up to #16799
Fixes #21839