### PR TITLE
small fix for amp auto anchor ads

### DIFF
--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -53,7 +53,7 @@ export class AnchorAdStrategy {
       return Promise.resolve(false);
     }
     Services.extensionsFor(this.ampdoc.win)./*OK*/installExtensionForDoc(
-        this.ampdoc, STICKY_AD_TAG);
+        this.ampdoc, STICKY_AD_TAG, '1.0');
     this.placeStickyAd_();
     return Promise.resolve(true);
   }


### PR DESCRIPTION
Under amp-auto-ads extension, the service to fetch amp-sticky ad ext does not have the correct version passed (its default is 0.1), resulting in a 404. Passing 1.0 resolves it.