### PR TITLE
Remove resizable children experiment

### DIFF
--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -383,11 +383,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/18845',
   },
   {
-    id: 'amp-list-resizable-children',
-    name: 'Experiment for allowing amp-list to resize when its children resize',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/18875',
-  },
-  {
     id: 'hidden-mutation-observer',
     name: "Enables FixedLayer's hidden-attribute mutation observer",
     spec: 'https://github.com/ampproject/amphtml/issues/17475',


### PR DESCRIPTION
Remove resizable children experiment from `experiment.js`. Do not merge before https://github.com/ampproject/amphtml/pull/21843. 