### PR TITLE
🐛  don't auto lightbox elements with subscriptions-action attribute

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -91,6 +91,9 @@ const DISABLED_BY_ATTR = [
   // onclick action(e.g. `button`) or where it cannot be determined whether
   // they're actionable or not (e.g. `amp-script`).
   'amp-selector [option]',
+
+  // amp-subscriptions actions
+  '[subscriptions-action]',
 ].join(',');
 
 /**

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -203,6 +203,10 @@ describes.realWin(TAG, {
         mutate: el => el.setAttribute('data-amp-auto-lightbox-disable', ''),
       },
       {
+        rejects: 'amp-subscriptions asubnodes',
+        mutate: el => el.setAttribute('subscriptions-action', ''),
+      },
+      {
         rejects: 'placeholder subnodes',
         mutate: el => el.setAttribute('placeholder', ''),
       },

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -203,7 +203,7 @@ describes.realWin(TAG, {
         mutate: el => el.setAttribute('data-amp-auto-lightbox-disable', ''),
       },
       {
-        rejects: 'amp-subscriptions asubnodes',
+        rejects: 'amp-subscriptions subnodes',
         mutate: el => el.setAttribute('subscriptions-action', ''),
       },
       {


### PR DESCRIPTION
Don't auto lightbox elements with subscriptions-action attribute and their descendants



