### PR TITLE
📖 Update Sample document of AMP HTML Format needs amp-ad script

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -74,6 +74,7 @@ In concrete terms this means that:
     }
     </script>
     <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
   </head>


### PR DESCRIPTION
## About
Sample Document of AMP HTML Format has a warning of a script using amphtml-validator.
It uses amp-ad in AMP-HTML, but it does not load amp-ad script.

## Test
- [x] checked it using amphtml-validator

before
```
➜  amp-test amphtml-validator index.html
index.html: PASS
index.html:108:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad)
```

after
```
➜  amp-test amphtml-validator index.html
index.html: PASS
```


