### PR TITLE
🐛 Expand token-prefix meaning on amp-autocomplete

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -416,7 +416,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
           throw new Error(`Unexpected filter: ${this.filter_}`);
       }
     });
-    
+
     return this.truncateToMaxEntries_(filteredData);
   }
 
@@ -434,19 +434,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
       return true;
     }
 
-    // Remove '.'
-    item = item.replace(/[\.]+/g, '');
-    input = input.replace(/[\.]+/g, '');
-
-    // Split by special characters or space ' '
-    const itemTokens = item.split(/[`~(){}_|+\-;:\'",\{\}\[\]\\\/ ]+/g);
-    const inputTokens = input.split(/[`~(){}_|+\-;:\'",\{\}\[\]\\\/ ]+/g);
+    const itemTokens = this.tokenizeString_(item);
+    const inputTokens = this.tokenizeString_(input);
 
     // Match each input token (except the last one) to an item token
-    const itemTokensMap = this.tokensArrayToMap_(itemTokens);
+    const itemTokensMap = this.mapFromTokensArray_(itemTokens);
     const lastInputToken = inputTokens[inputTokens.length - 1];
     inputTokens.splice(inputTokens.length - 1, 1);
-
     let match = true;
     inputTokens.forEach(token => {
       if (token === '') {
@@ -472,13 +466,25 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /**
+   * Takes a string, removes '.', and splits by special characters.
+   * Returns the resulting array of tokens.
+   * @param {string} inputStr
+   * @return {!Array<string>}
+   * @private
+   */
+  tokenizeString_(inputStr) {
+    inputStr = inputStr.replace(/[\.]+/g, '');
+    return inputStr.split(/[`~(){}_|+\-;:\'",\{\}\[\]\\\/ ]+/g);
+  }
+
+  /**
    * Returns the given tokens array as a dictionary of key: token (str) and
    * value: number of occurrences.
    * @param {!Array<string>} tokens
    * @return {!Map<string, number>}
    * @private
    */
-  tokensArrayToMap_(tokens) {
+  mapFromTokensArray_(tokens) {
     const tokensMap = new Map();
     tokens.forEach(token => {
       const count = tokensMap.has(token) ? tokensMap.get(token) + 1 : 1;

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -425,7 +425,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * given item. Assumes toLocaleLowerCase() has been performed on both
    * parameters.
    * @param {string} item
-   * @param {!Array<string>} input
+   * @param {string} input
    * @return {boolean}
    * @private
    */

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -462,7 +462,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       }
       if (!hasOwn(itemTokensMap, token)) {
         match = false;
-        continue;
+        break;
       }
       const count = Number(ownProperty(itemTokensMap, token));
       if (count > 1) {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -421,8 +421,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /**
-   * Returns true if the given tokenized input is a token-prefix match on the
-   * given item. Assumes toLocaleLowerCase() has been performed on both
+   * Returns true if the given input string is a token-prefix match on the
+   * given item string. Assumes toLocaleLowerCase() has been performed on both
    * parameters.
    * @param {string} item
    * @param {string} input

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -464,7 +464,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         match = false;
         continue;
       }
-      const count = ownProperty(itemTokensMap, token);
+      const count = Number(ownProperty(itemTokensMap, token));
       if (count > 1) {
         itemTokensMap[token] = count - 1;
       } else {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -247,6 +247,24 @@ describes.realWin('amp-autocomplete unit tests', {
         'Unexpected filter: invalid');
   });
 
+  it('tokenizeString_ should return an array of tokens', () => {
+    expect(impl.tokenizeString_('')).to.have.ordered.members(['']);
+    expect(impl.tokenizeString_('a b c')).to.have.ordered.members(
+        ['a', 'b', 'c']);
+    expect(impl.tokenizeString_('a-b-c')).to.have.ordered.members(
+        ['a', 'b', 'c']);
+    expect(impl.tokenizeString_('a. ...b).c')).to.have.ordered.members(
+        ['a', 'b', 'c']);
+  });
+
+  it('mapFromTokensArray_ should return a map of token counts', () => {
+    expect(impl.mapFromTokensArray_([])).to.be.empty;
+    expect(impl.mapFromTokensArray_(['a', 'b', 'c'])).to.have.all.keys(
+        'a', 'b', 'c');
+    expect(impl.mapFromTokensArray_(['a', 'b', 'c', 'a', 'a']))
+        .to.have.all.keys('a', 'b', 'c');
+  });
+
   it('tokenPrefixMatch_ should exhaustively match on complex cases', () => {
     const item = 'washington, district of columbia (d.c.)';
     expect(impl.tokenPrefixMatch_(item, 'washington')).to.be.true;
@@ -294,7 +312,7 @@ describes.realWin('amp-autocomplete unit tests', {
 
   it('should call inputHandler_() on input', () => {
     let renderSpy, toggleResultsSpy;
-    return element.layoutCallback().then(() => {
+    return element.layoutCallback().then(() => {'';
       impl.inputElement_.value = 'a';
       renderSpy = sandbox.spy(impl, 'renderResults_');
       toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -229,6 +229,8 @@ describes.realWin('amp-autocomplete unit tests', {
     impl.filter_ = 'token-prefix';
     expect(impl.filterData_(['a', 'b a', 'ab', 'ba', 'c a'], 'a')).to.have
         .ordered.members(['a', 'b a', 'ab', 'c a']);
+    expect(impl.filterData_(['a', 'b a', 'ab', 'ba', 'c a'], 'a c')).to.have
+        .ordered.members(['c a']);
     // None filter
     impl.filter_ = 'none';
     expect(impl.filterData_(['a', 'b a', 'ab', 'ba', 'c a'], 'a')).to.have
@@ -243,6 +245,28 @@ describes.realWin('amp-autocomplete unit tests', {
     impl.filter_ = 'invalid';
     expect(() => impl.filterData_(['a', 'b', 'c'], 'a')).to.throw(
         'Unexpected filter: invalid');
+  });
+
+  it('tokenPrefixMatch_ should exhaustively match on complex cases', () => {
+    const item = 'washington, district of columbia (d.c.)';
+    expect(impl.tokenPrefixMatch_(item, 'washington')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'district of columbia')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'of colum')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item,
+        'district washington columbia of')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'dc')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'washington dc')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'washington, d.c.')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'washington, (dc)')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'w.a.s.h.i.n.g.t.o.n.')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'district-of-columbia')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, "washington 'dc'")).to.be.true;
+    expect(impl.tokenPrefixMatch_(item,
+        'washin.gton,   (..dc)+++++')).to.be.true;
+    expect(impl.tokenPrefixMatch_(item, 'ashington dc')).to.be.false;
+    expect(impl.tokenPrefixMatch_(item, 'washi distri')).to.be.false;
+    expect(impl.tokenPrefixMatch_(item, 'columbia columbia')).to.be.false;
+    expect(impl.tokenPrefixMatch_(item, 'd c')).to.be.false;
   });
 
   it('truncateToMaxEntries_() should truncate given data', () => {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -312,7 +312,7 @@ describes.realWin('amp-autocomplete unit tests', {
 
   it('should call inputHandler_() on input', () => {
     let renderSpy, toggleResultsSpy;
-    return element.layoutCallback().then(() => {'';
+    return element.layoutCallback().then(() => {
       impl.inputElement_.value = 'a';
       renderSpy = sandbox.spy(impl, 'renderResults_');
       toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');


### PR DESCRIPTION
Expand the `token-prefix` filter to match on a wider range of user input types on amp-autocomplete.
- Tokenizes inputs on special character separators in addition to `' '` (space) and ignores `'.'` (dot)
- Adds unit tests for helper functions `tokenPrefixMatch_`, `tokenizeString_`, and `mapFromTokensArray_`
- Makes the following trade off: Calls `tokenizeString_` on the same input one time for every item it is matched against (rather than once total) to prioritize readability in the implementation of `filterData_`. A refactor would be good to minimize this computational cost in the future, but I'd recommend waiting until other filters (fuzzy and custom) are implemented to get a feel for the most useful and readable way to refactor.