### PR TITLE
🏗✨ Add `--full_sourcemaps`, a `gulp dist` flag to include source code in sourcemaps

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -369,6 +369,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       // required.
       only_closure_dependencies: true,
       output_wrapper: wrapper,
+      source_map_include_content: !!argv.full_sourcemaps,
       source_map_location_mapping: '|' + sourceMapBase,
       warning_level: options.verboseLogging ? 'VERBOSE' : 'DEFAULT',
       jscomp_error: [],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1755,6 +1755,7 @@ gulp.task('dist', 'Build production binaries', maybeUpdatePackages, dist, {
     noextensions: '  Builds with no extensions.',
     single_pass_dest: '  The directory closure compiler will write out to ' +
             'with --single_pass mode. The default directory is `dist`',
+    full_sourcemaps: '  Includes source code content in sourcemaps',
   },
 });
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',


### PR DESCRIPTION
The default `gulp dist` doesn't include source code content in sourcemaps. This is useful while debugging, and can be enabled by passing [`--source_map_include_content=true`](https://github.com/google/closure-compiler/wiki/Flags-and-Options#reports) to closure compiler.

This PR adds a flag for `gulp dist` called `--full_sourcemaps`, which internally sets the closure compiler flag.

Addresses https://github.com/ampproject/amphtml/pull/21832#pullrequestreview-228148815
