### PR TITLE
🏗 Add the text `[non-blocking]` to the Remote and e2e Travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ jobs:
       script:
         - node build-system/pr-check/local-tests.js
     - stage: test
-      name: "Remote (Sauce Labs) Tests"
+      name: "[NON-BLOCKING] Remote (Sauce Labs) Tests"
       script:
         - node build-system/pr-check/remote-tests.js
       after_script:
         - build-system/sauce_connect/stop_sauce_connect.sh
     - stage: test
-      name: "End to End Tests"
+      name: "[NON-BLOCKING] End to End Tests"
       script:
         - node build-system/pr-check/e2e-tests.js
   fast_finish: true


### PR DESCRIPTION
@cathyxz's comment in the chat made me realize that it isn't entirely clear to everyone that these two stages are non-blocking, so adding this to their name.

Before this PR:
![image](https://user-images.githubusercontent.com/1839738/56682640-fb150900-6699-11e9-8fb8-021be073ef8e.png)

After this PR:
![image](https://user-images.githubusercontent.com/1839738/56682761-3ca5b400-669a-11e9-9f4e-962b7ff4ff4f.png)
