### PR TITLE
♿amp-base-carousel a11y fixes

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.css
@@ -26,6 +26,7 @@ amp-base-carousel {
   position: absolute;
   top: 0;
   bottom: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
 }
@@ -38,11 +39,15 @@ amp-base-carousel {
   right: 0;
 }
 
-[i-amphtml-carousel-at-start="true"] .i-amphtml-carousel-scroll[loop="false"] ~ .i-amphtml-carousel-arrow-prev-slot,
-[i-amphtml-carousel-at-end="true"] .i-amphtml-carousel-scroll[loop="false"] ~ .i-amphtml-carousel-arrow-next-slot,
-[i-amphtml-carousel-hide-buttons="true"] .i-amphtml-carousel-arrow-prev-slot,
-[i-amphtml-carousel-hide-buttons="true"] .i-amphtml-carousel-arrow-next-slot {
+amp-base-carousel[loop="false"] .i-amphtml-carousel-arrow-prev-slot > [disabled],
+amp-base-carousel[loop="false"] .i-amphtml-carousel-arrow-next-slot > [disabled],
+amp-base-carousel[i-amphtml-carousel-hide-buttons] .i-amphtml-carousel-arrow-prev-slot,
+amp-base-carousel[i-amphtml-carousel-hide-buttons] .i-amphtml-carousel-arrow-next-slot {
   opacity: 0;
+  /** 
+   * Note, screen readers can still activate the buttons when hide buttons is
+   * specified, even though we have `pointer-events: none`.
+   */
   pointer-events: none;
 }
 

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -261,9 +261,9 @@ class AmpCarousel extends AMP.BaseElement {
     const html = htmlFor(this.element);
     return html`
       <div class="i-amphtml-carousel-content">
+        <div class="i-amphtml-carousel-scroll"></div>
         <div class="i-amphtml-carousel-arrow-prev-slot"></div>
         <div class="i-amphtml-carousel-arrow-next-slot"></div>
-        <div class="i-amphtml-carousel-scroll"></div>
       </div>
     `;
   }

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -59,11 +59,11 @@ class AmpCarousel extends AMP.BaseElement {
     /** @private {!Array<!Element>} */
     this.slides_ = [];
 
-    /** @private {!Element} */
+    /** @private {?Element} */
     this.nextArrowSlot_ = null;
 
-    /** @private {!Element} */
-    this.prevArrowSlow_ = null;
+    /** @private {?Element} */
+    this.prevArrowSlot_ = null;
 
     /**
      * Whether or not the user has interacted with the carousel using touch in

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -329,13 +329,16 @@ class AmpCarousel extends AMP.BaseElement {
    */
   updateUi_() {
     const index = this.carousel_.getCurrentIndex();
+    const loop = this.carousel_.getLoop();
     // TODO(sparhami) for Shadow DOM, we will need to get the assigned nodes
     // instead.
     iterateCursor(this.prevArrowSlot_.children, child => {
-      toggleAttribute(child, 'disabled', index == 0);
+      const disabled = !loop && index == 0;
+      toggleAttribute(child, 'disabled', disabled);
     });
     iterateCursor(this.nextArrowSlot_.children, child => {
-      toggleAttribute(child, 'disabled', index == this.slides_.length - 1);
+      const disabled = !loop && index == this.slides_.length - 1;
+      toggleAttribute(child, 'disabled', disabled);
     });
     toggleAttribute(
         this.element, 'i-amphtml-carousel-hide-buttons', this.hadTouch_);

--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -89,21 +89,31 @@ export class AutoAdvance {
 
   /**
    * Stops the auto advance. Once stopped, auto advance cannot be started
-   * again.
+   * again. This  sets the `stopped_` flag, which is checked in
+   * `shouldAutoAdvance_`.
    */
   stop() {
     this.stopped_ = true;
   }
 
   /**
-   * Pauses the auto advance. It can be resumed again by calling `resume`.
+   * Pauses the auto advance. It can be resumed again by calling `resume`. This
+   * sets the `paused_` flag, which is checked in `shouldAutoAdvance_`.
+   *
+   * This should only be used internally, rather than by an external developer.
+   * If the functionallity is desired, `stop` shoould be used instead.
    */
   pause() {
     this.paused_ = true;
   }
 
   /**
-   * Resumes the auto advance as long as it is not stopped.
+   * Resumes the auto advance as long as it is not stopped. This clears the
+   * `paused_` flag, which is checked in `shouldAutoAdvance_`.
+   *
+   * This should only be used internally, rather than by an external developer
+   * If the functionallity is desired, a `start` function, undoing
+   * `stop` should be implemented instead.
    */
   resume() {
     this.paused_ = false;

--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -71,6 +71,9 @@ export class AutoAdvance {
     /** @private {boolean} */
     this.paused_ = false;
 
+    /** @private {boolean} */
+    this.stopped_ = false;
+
     /** @private {?function()} */
     this.debouncedAdvance_ = null;
 
@@ -82,6 +85,29 @@ export class AutoAdvance {
         'scroll', () => this.handleScroll_(), true);
     this.scrollContainer_.addEventListener(
         'touchstart', () => this.handleTouchStart_(), true);
+  }
+
+  /**
+   * Stops the auto advance. Once stopped, auto advance cannot be started
+   * again.
+   */
+  stop() {
+    this.stopped_ = true;
+  }
+
+  /**
+   * Pauses the auto advance. It can be resumed again by calling `resume`.
+   */
+  pause() {
+    this.paused_ = true;
+  }
+
+  /**
+   * Resumes the auto advance as long as it is not stopped.
+   */
+  resume() {
+    this.paused_ = false;
+    this.resetAutoAdvance_();
   }
 
   /**
@@ -135,11 +161,10 @@ export class AutoAdvance {
    * Handles touchstart, pausing the autoadvance until the user lets go.
    */
   handleTouchStart_() {
-    this.paused_ = true;
+    this.pause();
 
     listenOnce(window, 'touchend', () => {
-      this.paused_ = false;
-      this.resetAutoAdvance_();
+      this.resume();
     }, {
       capture: true,
     });
@@ -152,6 +177,7 @@ export class AutoAdvance {
   shouldAutoAdvance_() {
     return this.autoAdvance_ &&
         !this.paused_ &&
+        !this.stopped_ &&
         this.advances_ < this.maxAdvances_;
   }
 

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getDetail} from '../../../src/event-helper';
+
+/**
+ * Accessibility for the carousel. This behaves either as a list or by
+ * exposing a single item at a time using `aria-hidden`.
+ */
+export class CarouselAccessibility {
+  /**
+   * @param {{
+   *   win: !Window,
+   *   element: !Element,
+   *   scrollContainer: !Element,
+   *   runMutate: function(function()),
+   *   autoAdvance: !AutoAdvance,
+   * }} config
+   */
+  constructor({
+    win,
+    element,
+    scrollContainer,
+    runMutate,
+    autoAdvance,
+  }) {
+    /** @private @const */
+    this.win_ = win;
+
+    /** @private @const */
+    this.scrollContainer_ = scrollContainer;
+
+    /** @private @const */
+    this.runMutate_ = runMutate;
+
+    /** @private {!Array<!Element>} */
+    this.slides_ = [];
+
+    /** @private {number} */
+    this.visibleCount_ = 1;
+
+    /** @private {boolean} */
+    this.mixedLength_ = false;
+
+    element.addEventListener('focus', () => {
+      autoAdvance.stop();
+    }, true);
+    element.addEventListener('indexchange', event => {
+      this.onIndexChanged_(event);
+    });
+  }
+
+  /**
+   * Updates whether or not the carousel is using mixed lengths. When using
+   * mixed lengths, the carousel is treated as a list.
+   * @param {boolean} mixedLength
+   */
+  updateMixedLength_(mixedLength) {
+    this.mixedLength_ = mixedLength;
+  }
+
+  /**
+   * Updates the UI in response to configuration changes.
+   */
+  updateUi() {
+    if (this.updating_) {
+      return;
+    }
+
+    this.updating_ = true;
+    this.runMutate_(() => {
+      this.updating_ = false;
+
+      this.updateConfiguration_();
+      this.updateAriaHidden_();
+    });
+  }
+
+  /**
+   * Updates the slides, setting aria properties.
+   * @param {!Array<!Element>} slides
+   */
+  updateSlides(slides) {
+    this.slides_ = slides;
+    this.updateUi();
+  }
+
+  /**
+   * Updates the visible count. When not in mixed length mode, this causes the
+   * carousel to be treated as a list when it is set to a value of two or
+   * greater.
+   * @param {number} visibleCount
+   */
+  updateVisibleCount(visibleCount) {
+    this.visibleCount_ = visibleCount;
+    this.updateUi();
+  }
+
+  /**
+   * @return {boolean} True if we should treat the carousel as a list, false if
+   *    we should expose a single slide at a time.
+   */
+  treatAsList_() {
+    return this.mixedLength_ || this.visibleCount_ >= 2;
+  }
+
+  /**
+   * Updates the configuration, setting attributes correctly depending on
+   * whether the carousel is a list or we are exposing a single item at a time.
+   */
+  updateConfiguration_() {
+    if (this.treatAsList_()) {
+      this.scrollContainer_.removeAttribute('aria-live');
+      this.scrollContainer_.setAttribute('role', 'list');
+      this.slides_.forEach(slide => {
+        slide.setAttribute('role', 'listitem');
+      });
+    } else {
+      this.scrollContainer_.setAttribute('aria-live', 'polite');
+      this.scrollContainer_.removeAttribute('role');
+      this.slides_.forEach(slide => {
+        slide.removeAttribute('role');
+      });
+    }
+  }
+
+  /**
+   * Updates `aria-hidden` for the slides. When in list mode, this will be
+   * `false` for all the slides. When not in list mode, the current slide will
+   * have `aria-hidden="false"`, with the rest having `aria-hidden="true"`.
+   */
+  updateAriaHidden_() {
+    this.slides_.forEach((slide, i) => {
+      const hide = !this.treatAsList_() && i !== this.index_;
+      slide.setAttribute('aria-hidden', hide);
+    });
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   */
+  onIndexChanged_(event) {
+    const detail = getDetail(event);
+    const index = detail['index'];
+
+    this.index_ = index;
+    this.runMutate_(() => {
+      this.updateAriaHidden_();
+    });
+  }
+}

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -15,6 +15,7 @@
  */
 
 import {getDetail} from '../../../src/event-helper';
+import {AutoAdvance} from './auto-advance';
 
 /**
  * Accessibility for the carousel. This behaves either as a list or by
@@ -55,6 +56,12 @@ export class CarouselAccessibility {
     /** @private {boolean} */
     this.mixedLength_ = false;
 
+    /** @private {boolean} */
+    this.updating_ = false;
+
+    /** @private {number} */
+    this.index_ = 0;
+
     element.addEventListener('focus', () => {
       autoAdvance.stop();
     }, true);
@@ -68,7 +75,7 @@ export class CarouselAccessibility {
    * mixed lengths, the carousel is treated as a list.
    * @param {boolean} mixedLength
    */
-  updateMixedLength_(mixedLength) {
+  updateMixedLength(mixedLength) {
     this.mixedLength_ = mixedLength;
   }
 

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -15,7 +15,13 @@
  */
 
 import {getDetail} from '../../../src/event-helper';
-import {AutoAdvance} from './auto-advance';
+
+/**
+ * @typedef {{
+ *   stop: function(),
+ * }}
+ */
+let StoppableDef;
 
 /**
  * Accessibility for the carousel. This behaves either as a list or by
@@ -28,7 +34,7 @@ export class CarouselAccessibility {
    *   element: !Element,
    *   scrollContainer: !Element,
    *   runMutate: function(function()),
-   *   autoAdvance: !AutoAdvance,
+   *   stoppable: !StoppableDef,
    * }} config
    */
   constructor({
@@ -36,7 +42,7 @@ export class CarouselAccessibility {
     element,
     scrollContainer,
     runMutate,
-    autoAdvance,
+    stoppable,
   }) {
     /** @private @const */
     this.win_ = win;
@@ -63,7 +69,7 @@ export class CarouselAccessibility {
     this.index_ = 0;
 
     element.addEventListener('focus', () => {
-      autoAdvance.stop();
+      stoppable.stop();
     }, true);
     element.addEventListener('indexchange', event => {
       this.onIndexChanged_(event);

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -386,14 +386,17 @@ export class Carousel {
 
   /**
    * Pauses the auto advance temporarily. This can be resumed by calling
-   * resumeAutoAdvance.
+   * resumeAutoAdvance. This should only be used internally for the carousel
+   * implementation and not exposed.
    */
   pauseAutoAdvance() {
     this.autoAdvance_.pause();
   }
 
   /**
-   * Resumes auto advance when paused by pauseAutoAdvance.
+   * Resumes auto advance when paused by pauseAutoAdvance. Note that if the
+   * autoadvance has been stopped, this has no effect. This should only be used
+   * internally for the carousel implementation and not exposed.
    */
   resumeAutoAdvance() {
     this.autoAdvance_.resume();

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -184,7 +184,7 @@ export class Carousel {
       element,
       scrollContainer,
       runMutate,
-      autoAdvance: this.autoAdvance_,
+      stoppable: this.autoAdvance_,
     });
 
     /** @private @const */

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -407,6 +407,13 @@ export class Carousel {
   }
 
   /**
+   * @return {boolean} Whether or not looping is enabled.
+   */
+  getLoop() {
+    return this.loop_;
+  }
+
+  /**
    * Moves the carousel to a given index. If the index is out of range, the
    * carousel is not moved.
    * @param {number} index

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -27,6 +27,7 @@ import {
   updateLengthStyle,
 } from './dimensions.js';
 import {AutoAdvance} from './auto-advance';
+import {CarouselAccessibility} from './carousel-accessibility';
 import {
   backwardWrappingDistance,
   forwardWrappingDistance,
@@ -175,6 +176,15 @@ export class Carousel {
       win,
       scrollContainer,
       advanceable: this,
+    });
+
+    /** @private @const */
+    this.carouselAccessibility_ = new CarouselAccessibility({
+      win,
+      element,
+      scrollContainer,
+      runMutate,
+      autoAdvance: this.autoAdvance_,
     });
 
     /** @private @const */
@@ -375,6 +385,21 @@ export class Carousel {
   }
 
   /**
+   * Pauses the auto advance temporarily. This can be resumed by calling
+   * resumeAutoAdvance.
+   */
+  pauseAutoAdvance() {
+    this.autoAdvance_.pause();
+  }
+
+  /**
+   * Resumes auto advance when paused by pauseAutoAdvance.
+   */
+  resumeAutoAdvance() {
+    this.autoAdvance_.resume();
+  }
+
+  /**
    * @return {number} The current index of the carousel.
    */
   getCurrentIndex() {
@@ -487,6 +512,7 @@ export class Carousel {
    */
   updateMixedLength(mixedLength) {
     this.mixedLength_ = mixedLength;
+    this.carouselAccessibility_.updateMixedLength(mixedLength);
     this.updateUi();
   }
 
@@ -497,6 +523,7 @@ export class Carousel {
    */
   updateSlides(slides) {
     this.slides_ = slides;
+    this.carouselAccessibility_.updateSlides(slides);
     this.updateUi();
   }
 
@@ -571,6 +598,7 @@ export class Carousel {
    */
   updateVisibleCount(visibleCount) {
     this.visibleCount_ = Math.max(1, visibleCount);
+    this.carouselAccessibility_.updateVisibleCount(visibleCount);
     this.updateUi();
   }
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -878,3 +878,30 @@ export function domOrderComparator(element1, element2) {
   // if fe2 is following or contained by fe1, then fe1 is before fe2
   return -1;
 }
+
+
+/**
+ * Like `Element.prototype.toggleAttribute`. This either toggles an attribute
+ * on by adding an attribute with an empty value, or toggles it off by removing
+ * the attribute. This does not mutate the element if the new state matches
+ * the existing state.
+ * @param {!Element} element An element to toggle the attribute for.
+ * @param {string} name The name of the attribute.
+ * @param {boolean=} forced Whether the attribute should be forced on/off. If
+ *    not specified, it will be toggled from the current state.
+ * @return {boolean} Whether or not the element now has the attribute.
+ */
+export function toggleAttribute(element, name, forced) {
+  const hasAttribute = element.hasAttribute(name);
+  const enabled = forced !== undefined ? forced : !hasAttribute;
+
+  if (enabled !== hasAttribute) {
+    if (enabled) {
+      element.setAttribute(name, '');
+    } else {
+      element.removeAttribute(name);
+    }
+  }
+
+  return enabled;
+}

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1126,4 +1126,51 @@ describes.realWin('DOM', {
       });
     });
   });
+
+  describe('toggleAttribute', () => {
+    let el;
+
+    beforeEach(() => {
+      el = document.createElement('div');
+    });
+
+    it('should toggle to remove the attribute with an empty value', () => {
+      el.setAttribute('foo', '');
+      dom.toggleAttribute(el, 'foo');
+      expect(el.getAttribute('foo')).to.be.null;
+    });
+
+    it('should toggle to remove the attribute with a non-empty value', () => {
+      el.setAttribute('foo', 'asdf');
+      dom.toggleAttribute(el, 'foo');
+      expect(el.getAttribute('foo')).to.be.null;
+    });
+
+    it('should toggle to add the attribute', () => {
+      dom.toggleAttribute(el, 'foo');
+      expect(el.getAttribute('foo')).to.equal('');
+    });
+
+    it('should remove the attribute when forced', () => {
+      el.setAttribute('foo', '');
+      dom.toggleAttribute(el, 'foo', false);
+      expect(el.getAttribute('foo')).to.be.null;
+    });
+
+    it('should not add the attribute when forced off', () => {
+      dom.toggleAttribute(el, 'foo', false);
+      expect(el.getAttribute('foo')).to.be.null;
+    });
+
+    it('should add the attribute when forced and it does not exist', () => {
+      dom.toggleAttribute(el, 'foo', true);
+      expect(el.getAttribute('foo')).to.equal('');
+    });
+
+    it('should leave the attribute when forced and it exists', () => {
+      el.setAttribute('foo', 'asdf');
+      dom.toggleAttribute(el, 'foo', true);
+      expect(el.getAttribute('foo')).to.equal('asdf');
+    });
+  });
 });


### PR DESCRIPTION
- Add z-index so buttons are clickable by VoiceOver when 'hidden'
- Use `disabled` attribute for next/prev button when at the start/end for accessibility
- Pause auto advance when `pauseCallback` is called
- Pause auto advance when the carousel gains focus
- Add/remove aria-hidden on slides as the index changes
- Treat carousels with multiple items visible at once as a list

