### PR TITLE
✅ amp-iframe: fix test flake

### DIFF
--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -510,7 +510,6 @@ describes.realWin('amp-iframe', {
       });
     });
 
-    // TODO(@aghassemi): unskip flaky test
     it('should allow resize events w/ srcdoc', function* () {
       const srcdoc = `
         <!doctype html>

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -511,18 +511,20 @@ describes.realWin('amp-iframe', {
     });
 
     // TODO(@aghassemi): unskip flaky test
-    it.skip('should allow resize events w/ srcdoc', function* () {
+    it('should allow resize events w/ srcdoc', function* () {
       const srcdoc = `
-        <!doctype html>>
+        <!doctype html>
         <html>
          <body>
           <script>
+            setTimeout(() => {
               window.parent.postMessage({
                 sentinel: 'amp',
                 type: 'embed-size',
                 height: 200,
                 width: 300,
               }, '*');
+            }, 100);
           </script>
          </body>
         </html>


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/21960 

We were sending resize message too early causing a race (e.g. if parent was not yet listening for it). Moving it to an async callback will eliminate the sync race.
