### PR TITLE
Layers: guard against repeated cross-origin accesses

### DIFF
--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -17,15 +17,14 @@
 import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev, devAssert} from '../log';
-import {getFriendlyIframeEmbedOptional, isInFie} from '../friendly-iframe-embed';
 import {getMode} from '../mode';
+import {isInFie} from '../friendly-iframe-embed';
 import {listen} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
 import {rootNodeFor} from '../dom';
 
 const LAYOUT_PROP = '__AMP_LAYOUT';
-const FRAME_PARENT = '__AMP_FRAME_PARENT';
 
 /**
  * The Size of an element.
@@ -1286,32 +1285,15 @@ function sameDocument(element, other) {
 /**
  * Attempts to cross the FIE boundary to the parent node.
  *
- * @param {!Node} node
+ * @param {!Node} doc
  * @return {?Element}
  */
-function frameParent(node) {
-  devAssert(node.nodeType === Node.DOCUMENT_NODE);
-  const {defaultView} = node;
-  if (!defaultView) {
-    // Somehow, we're disconnected from the window.
-    return null;
-  }
-  return defaultView[FRAME_PARENT] === undefined
-    ? (defaultView[FRAME_PARENT] = frameParentInternal(defaultView))
-    : defaultView[FRAME_PARENT];
-}
-
-/**
- * Grabs the frameElement of the window, which may throw if the parent window
- * is cross origin.
- *
- * @param {!Window} win
- * @return {?Element}
- */
-function frameParentInternal(win) {
+function frameParent(doc) {
+  devAssert(doc.nodeType === Node.DOCUMENT_NODE);
   try {
-    return win && isInFie(win.document.documentElement)
-      ? win.frameElement
+    const {defaultView} = doc;
+    return defaultView && isInFie(doc.documentElement)
+      ? defaultView.frameElement
       : null;
   } catch (e) { }
   return null;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -1310,7 +1310,8 @@ function frameParent(node) {
  */
 function frameParentInternal(win) {
   try {
-    const frameElement = win && win.frameElement;
+    const frameElement = win && /** @type {?HTMLIFrameElement} */(
+      win.frameElement);
     return frameElement && getFriendlyIframeEmbedOptional(frameElement)
       ? frameElement
       : null;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -17,7 +17,7 @@
 import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev, devAssert} from '../log';
-import {getFriendlyIframeEmbedOptional} from '../friendly-iframe-embed';
+import {getFriendlyIframeEmbedOptional, isInFie} from '../friendly-iframe-embed';
 import {getMode} from '../mode';
 import {listen} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
@@ -1310,10 +1310,8 @@ function frameParent(node) {
  */
 function frameParentInternal(win) {
   try {
-    const frameElement = win && /** @type {?HTMLIFrameElement} */(
-      win.frameElement);
-    return frameElement && getFriendlyIframeEmbedOptional(frameElement)
-      ? frameElement
+    return win && isInFie(win.document.documentElement)
+      ? win.frameElement
       : null;
   } catch (e) { }
   return null;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -25,6 +25,7 @@ import {remove} from '../utils/array';
 import {rootNodeFor} from '../dom';
 
 const LAYOUT_PROP = '__AMP_LAYOUT';
+const FRAME_PARENT = '__AMP_FRAME_PARENT';
 
 /**
  * The Size of an element.
@@ -1290,9 +1291,26 @@ function sameDocument(element, other) {
  */
 function frameParent(node) {
   devAssert(node.nodeType === Node.DOCUMENT_NODE);
+  const {defaultView} = node;
+  if (!defaultView) {
+    // Somehow, we're disconnected from the window.
+    return null;
+  }
+  return defaultView[FRAME_PARENT] === undefined
+    ? (defaultView[FRAME_PARENT] = frameParentInternal(defaultView))
+    : defaultView[FRAME_PARENT];
+}
+
+/**
+ * Grabs the frameElement of the window, which may throw if the parent window
+ * is cross origin.
+ *
+ * @param {!Window} win
+ * @return {?Element}
+ */
+function frameParentInternal(win) {
   try {
-    const {defaultView} = node;
-    const frameElement = defaultView && defaultView.frameElement;
+    const frameElement = win && win.frameElement;
     return frameElement && getFriendlyIframeEmbedOptional(frameElement)
       ? frameElement
       : null;


### PR DESCRIPTION
Part of the layers algorithm is to traverse out of FIE frames to the
parent AMP doc. To do this, when we hit the document node, we test to
see if we can access the document's window's `frameElement`. However,
if the parent window is cross-origin, this will cause an error.

We actually guard against this error, so there is no real issue. But these
accesses are still logged in dev tools, which gets really annoying. This
is a nice-to-have change so that we only attempt getting the
`frameElement` once, and cache the result.