### PR TITLE
Better support for HTMLMediaElement in the loadPromise helper.

### DIFF
--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -129,6 +129,11 @@ export class AmpAudio extends AMP.BaseElement {
       artwork: [{src: artwork}],
     };
 
+    // Resolve layoutCallback right away if the audio won't preload.
+    if (this.element.getAttribute('preload') === 'none') {
+      return this.audio_;
+    }
+
     return this.loadPromise(this.audio_);
   }
 

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -59,9 +59,17 @@ describes.realWin('amp-audio', {
   function attachAndRun(attributes, opt_childNodesAttrs) {
     naturalDimensions_['AMP-AUDIO'] = {width: '300px', height: '30px'};
     const ampAudio = getAmpAudio(attributes, opt_childNodesAttrs);
-    return ampAudio.build().then(() => {
-      return ampAudio.layoutCallback();
-    }).then(() => ampAudio);
+    return ampAudio.build()
+        .then(() => ampAudio.layoutCallback())
+        .then(() => ampAudio)
+        .catch(error => {
+          // Ignore failed to load errors since sources are fake.
+          if (error.toString().indexOf('Failed to load') > -1) {
+            return ampAudio;
+          } else {
+            throw error;
+          }
+        });
   }
 
   function attachToAmpStoryAndRun(attributes) {
@@ -74,19 +82,27 @@ describes.realWin('amp-audio', {
     ampStory.appendChild(ampAudio);
     doc.body.appendChild(ampStory);
 
-    return ampAudio.build().then(() => {
-      return ampAudio.layoutCallback();
-    }).then(() => ampAudio);
+    return ampAudio.build()
+        .then(() => ampAudio.layoutCallback())
+        .then(() => ampAudio)
+        .catch(error => {
+          // Ignore failed to load errors since sources are fake.
+          if (error.toString().indexOf('Failed to load') > -1) {
+            return ampAudio;
+          } else {
+            throw error;
+          }
+        });
   }
 
   it('should load audio through attribute', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
     }).then(a => {
       const audio = a.querySelector('audio');
       expect(audio.tagName).to.equal('AUDIO');
       expect(audio.getAttribute('src'))
-          .to.equal('https://origin.com/audio.mp3');
+          .to.equal('audio.mp3');
       expect(audio.hasAttribute('controls')).to.be.true;
       expect(a.style.width).to.be.equal('300px');
       expect(a.style.height).to.be.equal('30px');
@@ -95,7 +111,7 @@ describes.realWin('amp-audio', {
 
   it('should not preload audio', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
       preload: 'none',
     }).then(a => {
       const audio = a.querySelector('audio');
@@ -105,7 +121,7 @@ describes.realWin('amp-audio', {
 
   it('should only preload audio metadata', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
       preload: 'metadata',
     }).then(a => {
       const audio = a.querySelector('audio');
@@ -116,7 +132,7 @@ describes.realWin('amp-audio', {
   it('should attach `<audio>` element and execute relevant actions for ' +
   'layout="nodisplay"', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
       preload: 'none',
       layout: 'nodisplay',
     }).then(ampAudio => {
@@ -141,9 +157,9 @@ describes.realWin('amp-audio', {
       muted: '',
       loop: '',
     }, [
-      {tag: 'source', src: 'https://origin.com/audio.mp3',
+      {tag: 'source', src: 'audio.mp3',
         type: 'audio/mpeg'},
-      {tag: 'source', src: 'https://origin.com/audio.ogg', type: 'audio/ogg'},
+      {tag: 'source', src: 'audio.ogg', type: 'audio/ogg'},
       {tag: 'text', text: 'Unsupported.'},
     ]).then(a => {
       const audio = a.querySelector('audio');
@@ -160,10 +176,10 @@ describes.realWin('amp-audio', {
       expect(audio.hasAttribute('src')).to.be.false;
       expect(audio.childNodes[0].tagName).to.equal('SOURCE');
       expect(audio.childNodes[0].getAttribute('src'))
-          .to.equal('https://origin.com/audio.mp3');
+          .to.equal('audio.mp3');
       expect(audio.childNodes[1].tagName).to.equal('SOURCE');
       expect(audio.childNodes[1].getAttribute('src'))
-          .to.equal('https://origin.com/audio.ogg');
+          .to.equal('audio.ogg');
       expect(audio.childNodes[2].nodeType).to.equal(Node.TEXT_NODE);
       expect(audio.childNodes[2].textContent).to.equal('Unsupported.');
     });
@@ -171,7 +187,7 @@ describes.realWin('amp-audio', {
 
   it('should set its dimensions to the browser natural', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
     }).then(a => {
       const audio = a.querySelector('audio');
       expect(a.style.width).to.be.equal('300px');
@@ -189,7 +205,7 @@ describes.realWin('amp-audio', {
   it('should set its natural dimension only if not specified', () => {
     return attachAndRun({
       'width': '500',
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
     }).then(a => {
       expect(a.style.width).to.be.equal('500px');
       expect(a.style.height).to.be.equal('30px');
@@ -216,7 +232,7 @@ describes.realWin('amp-audio', {
 
   it('should propagate ARIA attributes', () => {
     return attachAndRun({
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
       'aria-label': 'Hello',
       'aria-labelledby': 'id2',
       'aria-describedby': 'id3',
@@ -231,7 +247,7 @@ describes.realWin('amp-audio', {
   it('should play/pause when `play`/`pause` actions are called', () => {
     return attachAndRun({
       'width': '500',
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
     }).then(ampAudio => {
       const impl = ampAudio.implementation_;
       impl.executeAction({method: 'play', satisfiesTrust: () => true});
@@ -246,7 +262,7 @@ describes.realWin('amp-audio', {
     'of `amp-story`', () => {
     return attachToAmpStoryAndRun({
       'width': '500',
-      src: 'https://origin.com/audio.mp3',
+      src: 'audio.mp3',
     }).then(ampAudio => {
       const impl = ampAudio.implementation_;
       impl.executeAction({method: 'play', satisfiesTrust: () => true});

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -326,7 +326,7 @@ class AmpVideo extends AMP.BaseElement {
       this.propagateLayoutChildren_();
     }
 
-    // loadPromise for media elements listens to `loadstart`
+    // loadPromise for media elements listens to `loadedmetadata`.
     return this.loadPromise(this.video_).then(() => {
       this.element.dispatchCustomEvent(VideoEvents.LOAD);
     });

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -327,9 +327,16 @@ class AmpVideo extends AMP.BaseElement {
     }
 
     // loadPromise for media elements listens to `loadedmetadata`.
-    return this.loadPromise(this.video_).then(() => {
+    const promise = this.loadPromise(this.video_).then(() => {
       this.element.dispatchCustomEvent(VideoEvents.LOAD);
     });
+
+    // Resolve layoutCallback right away if the video won't preload.
+    if (this.element.getAttribute('preload') === 'none') {
+      return;
+    }
+
+    return promise;
   }
 
   /**

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -15,6 +15,7 @@
  */
 
 import {internalListenImplementation} from './event-helper-listen';
+import {lastChildElement} from './dom';
 import {user} from './log';
 
 /** @const {string}  */
@@ -173,7 +174,8 @@ export function loadPromise(eleOrWindow) {
     // document order. If the last source errors, then the media element
     // loading errored.
     if (isMediaElement && !eleOrWindow.hasAttribute('src')) {
-      errorTarget = eleOrWindow.querySelector('source:last-of-type');
+      errorTarget =
+          lastChildElement(eleOrWindow, child => child.tagName === 'SOURCE');
       if (!errorTarget) {
         return reject(new Error('Media has no source.'));
       }

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -131,6 +131,7 @@ export function listenOncePromise(element, eventType, opt_evtListenerOpts,
  */
 export function isLoaded(eleOrWindow) {
   return !!(eleOrWindow.complete || eleOrWindow.readyState == 'complete'
+      || (eleOrWindow instanceof HTMLMediaElement && eleOrWindow.readyState > 0)
       // If the passed in thing is a Window, infer loaded state from
       //
       || (eleOrWindow.document
@@ -154,14 +155,13 @@ export function loadPromise(eleOrWindow) {
   const loadingPromise = new Promise((resolve, reject) => {
     // Listen once since IE 5/6/7 fire the onload event continuously for
     // animated GIFs.
-    const {tagName} = eleOrWindow;
-    if (tagName === 'AUDIO' || tagName === 'VIDEO') {
-      unlistenLoad = listenOnce(eleOrWindow, 'loadstart', resolve);
+    if (eleOrWindow instanceof HTMLMediaElement) {
+      unlistenLoad = listenOnce(eleOrWindow, 'loadedmetadata', resolve);
     } else {
       unlistenLoad = listenOnce(eleOrWindow, 'load', resolve);
     }
     // For elements, unlisten on error (don't for Windows).
-    if (tagName) {
+    if (eleOrWindow.tagName) {
       unlistenError = listenOnce(eleOrWindow, 'error', reject);
     }
   });

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -175,7 +175,7 @@ export function loadPromise(eleOrWindow) {
     if (isMediaElement && !eleOrWindow.hasAttribute('src')) {
       errorTarget = eleOrWindow.querySelector('source:last-of-type');
       if (!errorTarget) {
-        return reject('Media has no source.');
+        return reject(new Error('Media has no source.'));
       }
     }
     unlistenError = listenOnce(errorTarget, 'error', reject);

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -131,7 +131,7 @@ export function listenOncePromise(element, eventType, opt_evtListenerOpts,
  */
 export function isLoaded(eleOrWindow) {
   return !!(eleOrWindow.complete || eleOrWindow.readyState == 'complete'
-      || (eleOrWindow instanceof HTMLMediaElement && eleOrWindow.readyState > 0)
+      || (isHTMLMediaElement(eleOrWindow) && eleOrWindow.readyState > 0)
       // If the passed in thing is a Window, infer loaded state from
       //
       || (eleOrWindow.document
@@ -155,7 +155,7 @@ export function loadPromise(eleOrWindow) {
   const loadingPromise = new Promise((resolve, reject) => {
     // Listen once since IE 5/6/7 fire the onload event continuously for
     // animated GIFs.
-    if (eleOrWindow instanceof HTMLMediaElement) {
+    if (isHTMLMediaElement(eleOrWindow)) {
       unlistenLoad = listenOnce(eleOrWindow, 'loadedmetadata', resolve);
     } else {
       unlistenLoad = listenOnce(eleOrWindow, 'load', resolve);
@@ -192,6 +192,15 @@ function failedToLoad(eleOrWindow) {
     target = target.src;
   }
   throw user().createError(LOAD_FAILURE_PREFIX, target);
+}
+
+/**
+ * Returns true if the parameter is a HTMLMediaElement.
+ * @param {!Element|!Window} eleOrWindow
+ * @return {boolean}
+ */
+function isHTMLMediaElement(eleOrWindow) {
+  return eleOrWindow.tagName === 'AUDIO' || eleOrWindow.tagName === 'VIDEO';
 }
 
 /**


### PR DESCRIPTION
This PR ensures that `amp-video` and `amp-audio` `layoutCallback`s complete and don't remain pending.

- Changing `loadstart` to `loadedmetadata` to resolve the `loadPromise`

`amp-video` and `amp-audio` rely on `loadPromise` to complete their `layoutCallback`. This PR improves the `isLoaded` helper so it correctly detects that the HTMLMediaElement already triggered the event `loadPromise` would be waiting for.
Without this, `amp-video` and `amp-audio` `layoutCallback` could potentially never resolve in specific contexts, like when handled by the amp-story media pool.

The code used to listen to the `loadstart` event, but there is no way to synchronously check if this event already fired. We switch to listening to the `loadedmetadata` event that can be checked synchronously with `readyState > 0`.

- Handling `source` children

From [the spec](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element): _"If a source element is inserted as a child of a media element that has no src attribute [...] the user agent must invoke the media element's resource selection algorithm."_.
If the `HTMLMediaElement` has no `src`, we listen to `loadedmetadata` and `error` events on the `source` elements.
If a `source` provides an unsupported format, or fails to load, it will trigger an error. But the following `source` element could load. So we listen for the `error` event on the last `source` element, but for `loadedmetadata` on any.

- Handling `preload="none"`

If the `HTMLMediaElement` specified `preload="none"`, we resolve the `layoutCallback` right away, without waiting for the `loadPromise` that wouldn't resolve before the user interacts with the media.

I believe this should live in `layoutCallback` as it could be misleading for `loadPromise` to resolve before the media actually loaded.

- Using a local URL for the `amp-story` tests, copying the error handling used in `test-amp-video.js`

Fixes https://github.com/ampproject/amphtml/issues/21794