### PR TITLE
🐛 fixed-layer: Fix hidden observer init in PWA

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -255,8 +255,9 @@ export class FixedLayer {
       return;
     }
 
-    const {documentElement} = this.ampdoc.getRootNode();
-    const hiddenObserver = Services.hiddenObserverForDoc(documentElement);
+    const root = this.ampdoc.getRootNode();
+    const element = root.documentElement || root;
+    const hiddenObserver = Services.hiddenObserverForDoc(element);
     this.hiddenObserverUnlistener_ = hiddenObserver.add(() => {
       if (!this.updatePass_.isPending()) {
         // Wait one animation frame so that other mutations may arrive.

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -46,9 +46,7 @@ export class HiddenObserver {
   constructor(ampdoc, opt_root) {
     /** @const {!Document|!ShadowRoot} */
     this.root_ = opt_root || ampdoc.getRootNode();
-
-    const doc = opt_root ? opt_root.ownerDocument :
-      (this.root_.ownerDocument || this.root_);
+    const doc = this.root_.ownerDocument || this.root_;
 
     /** @const {!Window} */
     this.win_ = /** @type {!Window} */(devAssert(doc.defaultView));

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -47,7 +47,8 @@ export class HiddenObserver {
     /** @const {!Document|!ShadowRoot} */
     this.root_ = opt_root || ampdoc.getRootNode();
 
-    const doc = opt_root ? opt_root.ownerDocument : this.root_;
+    const doc = opt_root ? opt_root.ownerDocument :
+      (this.root_.ownerDocument || this.root_);
 
     /** @const {!Window} */
     this.win_ = /** @type {!Window} */(devAssert(doc.defaultView));


### PR DESCRIPTION
Hidden observer fails to init in PWAs because `document` is assumed
instead of allowing for the possibility of `document` or `shadowRoot`. Add
fallbacks for `shadowRoot`.

Fixes #21975
Fixes #21113.