### PR TITLE
🏗 Stability and developer-experience changes for visual diffs testing platform

### DIFF
--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -25,6 +25,25 @@ const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
 const CSS_SELECTOR_TIMEOUT_MS =
     CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS;
 
+const HTML_ESCAPE_CHARS = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '`': '&#x60;',
+};
+const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
+
+/**
+ * Escapes a string of HTML elements to HTML entities.
+ *
+ * @param {string} html HTML as string to escape.
+ */
+function escapeHtml(html) {
+  return html.replace(HTML_ESCAPE_REGEX, c => HTML_ESCAPE_CHARS[c]);
+}
+
 /**
  * Logs a message to the console.
  *
@@ -207,6 +226,7 @@ async function waitForSelectorExistence(page, selector) {
 }
 
 module.exports = {
+  escapeHtml,
   log,
   waitForLoaderDots,
   verifySelectorsInvisible,

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -507,10 +507,6 @@ async function snapshotWebpages(percy, browser, webpages) {
             }
           })
           .then(async() => {
-            // Visibility evaluations can only be performed on the active tab,
-            // even in the headless browser mode.
-            await page.bringToFront();
-
             // Perform visibility checks: wait for all AMP built-in loader dots
             // to disappear (i.e., all visible components are finished being
             // layed out and external resources such as images are loaded and

--- a/build-system/tasks/visual-diff/snippets/snapshot-error.html
+++ b/build-system/tasks/visual-diff/snippets/snapshot-error.html
@@ -9,6 +9,10 @@
       background-color: lemonchiffon;
       padding: 10px;
     }
+
+    div.snapshot {
+      font-size: 8px;
+    }
   </style>
 </head>
 
@@ -16,5 +20,7 @@
   <h1>Snapshot error in test <code>__TEST_NAME__</code></h1>
   <p>Inspect the Travis logs for the full error message</p>
   <div>__TEST_ERROR__</div>
+  <h2>HTML Snapshot</h2>
+  <div class="snapshot">__HTML_SNAPSHOT__</div>
 </body>
 </html>


### PR DESCRIPTION
Progress on #21056

Stability changes:
* Parallelize visibility helper methods using Promises
* Replace page navigation retry mechanism with a more robust check for event-based responses
  * Increase page navigation timeout from 7 to 30 seconds (last increase was in #seconds
* Preallocate tabs instead of opening and closing one tab per test
  * Increase number of parallel tabs from 1 to 5 (was 10 before #21991)

Developer experience changes:
* Print HTML of document to the snapshot error page
  * e.g., https://percy.io/ampproject/amphtml/builds/1801799/view/117271471/375?mode=diff&browser=firefox&snapshot=117271471
* Record and print `console.METHOD(...)` calls inside the page when test fails
  * e.g., https://travis-ci.org/ampproject/amphtml/jobs/526199016#L1563-L1584

Minor changes:
* Do not bring page to front; this is now a no-op

> **DO NOT MERGE**: remove commit ede924c before merging, this commit is there to get faster results from Travis runs but will BREAK TRAVIS BUILDS FOR EVERYONE if merged