### PR TITLE
✅ Make Sauce labs integration tests green

### DIFF
--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -24,8 +24,8 @@ function poll(description, condition, opt_onError) {
 }
 
 // TODO(choumx): If possible / desired, make these tests work on Single-pass,
-// and on Windows (Edge, Firefox, and Chrome).
-describe.configure().skipSinglePass().skipWindows().run('amp-' +
+// on Windows (Edge, Firefox, and Chrome), and on Safari.
+describe.configure().skipSafari().skipSinglePass().skipWindows().run('amp-' +
     'script', function() {
   this.timeout(TIMEOUT);
 


### PR DESCRIPTION
These tests have been failing consistently on Sauce labs. It looks like they never did work on Safari.

The last four runs from today all show the exact same failures, all on Safari:
https://travis-ci.org/ampproject/amphtml/jobs/524563240#L2047
https://travis-ci.org/ampproject/amphtml/jobs/524545924#L2047
https://travis-ci.org/ampproject/amphtml/jobs/524545470#L2047
https://travis-ci.org/ampproject/amphtml/jobs/524525824#L2047

This is part of an effort to make Sauce labs runs green, and eventually block PRs when they fail.

