### PR TITLE
Custom CTA label for story page attachments.

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-page-attachment-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment-desktop.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   'open attachment': async (page, name) => {
-    await page.tap('.i-amphtml-story-page-open-attachment-text');
+    await page.tap('.i-amphtml-story-page-open-attachment-label');
     await page.waitFor(410);
   },
  };

--- a/examples/visual-tests/amp-story/amp-story-page-attachment.js
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   'open attachment': async (page, name) => {
-    await page.tap('.i-amphtml-story-page-open-attachment-text');
+    await page.tap('.i-amphtml-story-page-open-attachment-label');
     await page.waitFor(410);
   },
  };

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1144,7 +1144,7 @@ export class AmpStoryPage extends AMP.BaseElement {
           .querySelector('.i-amphtml-story-page-open-attachment-label');
 
 
-      const openAttachmentLabel = attachmentEl.getAttribute('data-cta-label') ||
+      const openAttachmentLabel = attachmentEl.getAttribute('data-cta-text') ||
           Services.localizationService(this.win).getLocalizedString(
               LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -144,7 +144,7 @@ const buildOpenAttachmentElement = element =>
           <span class="i-amphtml-story-page-open-attachment-bar-left"></span>
           <span class="i-amphtml-story-page-open-attachment-bar-right"></span>
         </span>
-        <span class="i-amphtml-story-page-open-attachment-text"></span>
+        <span class="i-amphtml-story-page-open-attachment-label"></span>
       </div>`;
 
 /**
@@ -1141,10 +1141,11 @@ export class AmpStoryPage extends AMP.BaseElement {
           .addEventListener('click', () => this.openAttachment());
 
       const textEl = this.openAttachmentEl_
-          .querySelector('.i-amphtml-story-page-open-attachment-text');
+          .querySelector('.i-amphtml-story-page-open-attachment-label');
 
-      const openAttachmentLabel = Services.localizationService(this.win)
-          .getLocalizedString(
+
+      const openAttachmentLabel = attachmentEl.getAttribute('data-cta-label') ||
+          Services.localizationService(this.win).getLocalizedString(
               LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
 
       this.mutateElement(() => {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -940,14 +940,19 @@ amp-story-page .i-amphtml-story-page-open-attachment-icon::after {
              open-attachment-bar-right 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) both !important;
 }
 
-amp-story-page .i-amphtml-story-page-open-attachment-text {
+amp-story-page .i-amphtml-story-page-open-attachment-label {
   position: relative !important;
   padding: 0 24px !important;
+  height: 40px !important;
+  max-width: calc(100% - 48px) !important;
   color: #FFF !important;
   font-family: 'Roboto', sans-serif !important;
   font-size: 15px !important;
   font-weight: bold !important;
   letter-spacing: 0.3px;
   line-height: 40px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
+  white-space: nowrap !important;
 }

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -392,7 +392,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   it('should build the open attachment UI with custom CTA label', () => {
     const attachmentEl =
         win.document.createElement('amp-story-page-attachment');
-    attachmentEl.setAttribute('data-cta-label', 'Custom label');
+    attachmentEl.setAttribute('data-cta-text', 'Custom label');
     element.appendChild(attachmentEl);
 
     page.buildCallback();

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -17,6 +17,7 @@
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryPage, PageState} from '../amp-story-page';
 import {AmpStoryStoreService} from '../amp-story-store-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {MediaType} from '../media-pool';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {installFriendlyIframeEmbed}
@@ -44,6 +45,9 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
 
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
+
     const story = win.document.createElement('amp-story');
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
 
@@ -55,7 +59,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     win.document.body.appendChild(story);
 
     page = new AmpStoryPage(element);
-    page.element.getResources = () => win.services.resources.obj;
+    sandbox.stub(page, 'mutateElement').callsFake(fn => fn());
   });
 
   afterEach(() => {
@@ -323,7 +327,6 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should find pageIds in a goToPage action with multiple actions', () => {
-
     const multipleActionButton = createElementWithAttributes(
         win.document,
         'button',
@@ -342,7 +345,6 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should find pageIds in a goToPage action with multiple events', () => {
-
     const multipleEventsButton = createElementWithAttributes(
         win.document,
         'button',
@@ -359,5 +361,47 @@ describes.realWin('amp-story-page', {amp: true}, env => {
           expect(actions.length).to.be.equal(1);
           expect(actions[0]).to.be.equal('pageId');
         });
+  });
+
+  it('should not build the open attachment UI if no attachment', () => {
+    page.buildCallback();
+    return page.layoutCallback().then(() => {
+      page.setState(PageState.PLAYING);
+
+      const openAttachmentEl =
+          element.querySelector('.i-amphtml-story-page-open-attachment');
+      expect(openAttachmentEl).to.not.exist;
+    });
+  });
+
+  it('should build the open attachment UI if attachment', () => {
+    const attachmentEl =
+        win.document.createElement('amp-story-page-attachment');
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    return page.layoutCallback().then(() => {
+      page.setState(PageState.PLAYING);
+
+      const openAttachmentEl =
+          element.querySelector('.i-amphtml-story-page-open-attachment');
+      expect(openAttachmentEl).to.exist;
+    });
+  });
+
+  it('should build the open attachment UI with custom CTA label', () => {
+    const attachmentEl =
+        win.document.createElement('amp-story-page-attachment');
+    attachmentEl.setAttribute('data-cta-label', 'Custom label');
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    return page.layoutCallback().then(() => {
+      page.setState(PageState.PLAYING);
+
+      const openAttachmentLabelEl =
+          element.querySelector('.i-amphtml-story-page-open-attachment-label');
+      expect(openAttachmentLabelEl.textContent).to.equal('Custom label');
+    });
   });
 });


### PR DESCRIPTION
Ability for publishers to control the default "Swipe up" text that appears on story pages when an `amp-story-page-attachment` is provided.
Publishers can specify a new `data-cta-label` attribute on the `amp-story-page-attachment` element.

```
<amp-story-page-attachment layout="nodisplay" data-cta-label="More cute cats">
  /* AMPHTML content */
</amp-story-page-attachment>
```

![image](https://user-images.githubusercontent.com/1492044/56758508-d20d7a80-6764-11e9-873a-fca62fbf6398.png)
![image](https://user-images.githubusercontent.com/1492044/56758589-03864600-6765-11e9-998c-93784f9df304.png)


https://github.com/ampproject/amphtml/issues/21920