### PR TITLE
Optional story page attachment title.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment-header.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment-header.css
@@ -15,6 +15,7 @@
  */
 
 .i-amphtml-story-page-attachment-header {
+  display: flex !important;
   position: relative !important;
   height: 40px !important;
   background: #fff !important;
@@ -24,11 +25,23 @@
 }
 
 .i-amphtml-story-page-attachment-close-button {
-  display: inline-block !important;
+  display: block !important;
   margin: 8px !important;
   height: 24px !important;
   width: 24px !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(0, 0, 0, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
   color: rgba(0, 0, 0, 0.87) !important;
   cursor: pointer !important;
+}
+
+.i-amphtml-story-page-attachment-title {
+  font-family: 'Roboto', sans-serif !important;
+  width: calc(100% - 80px) !important;
+  padding-right: 40px !important;
+  font-size: 16px !important;
+  line-height: 40px !important;
+  overflow: hidden !important;
+  text-align: center !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -73,6 +73,7 @@ const getHeaderEl = element => {
       <span
           class="i-amphtml-story-page-attachment-close-button" role="button">
       </span>
+      <span class="i-amphtml-story-page-attachment-title"></span>
     </div>`;
 };
 
@@ -131,9 +132,15 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     const templateEl = getTemplateEl(this.element);
-
     const headerShadowRootEl = this.win.document.createElement('div');
     this.headerEl_ = getHeaderEl(this.element);
+
+    if (this.element.hasAttribute('data-title')) {
+      this.headerEl_
+          .querySelector('.i-amphtml-story-page-attachment-title')
+          .textContent = this.element.getAttribute('data-title');
+    }
+
     createShadowRootWithStyle(headerShadowRootEl, this.headerEl_, CSS);
     templateEl.insertBefore(headerShadowRootEl, templateEl.firstChild);
 


### PR DESCRIPTION
Ability for publishers to provide an optional title to the page attachment.
Publishers can specify a new `data-title` attribute on the `amp-story-page-attachment` element.

```
<amp-story-page-attachment layout="nodisplay" data-title="More cute cats">
  /* AMPHTML content */
</amp-story-page-attachment>
```

![image](https://user-images.githubusercontent.com/1492044/56765334-ca55d200-6774-11e9-980b-2d752e460ab1.png)

![image](https://user-images.githubusercontent.com/1492044/56765329-c6c24b00-6774-11e9-9bde-747b6adb3778.png)

https://github.com/ampproject/amphtml/issues/21921