### PR TITLE
🏗 Make remote (sauce labs) tests blocking on Travis now that they're green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
       script:
         - node build-system/pr-check/local-tests.js
     - stage: test
-      name: "[NON-BLOCKING] Remote (Sauce Labs) Tests"
+      name: "Remote (Sauce Labs) Tests"
       script:
         - node build-system/pr-check/remote-tests.js
       after_script:
@@ -83,10 +83,8 @@ jobs:
         - node build-system/pr-check/e2e-tests.js
   fast_finish: true
 
-  # TODO(ampproject/wg-infra): remove when remote tests stabilize
+  # TODO(ampproject/wg-infra): remove when these tests stabilize
   allow_failures:
-    - script:
-      - node build-system/pr-check/remote-tests.js
     - script:
       - node build-system/pr-check/e2e-tests.js
 cache:


### PR DESCRIPTION
The `Remote (Sauce Labs) tests` job on Travis has been non-blocking due to rampant disconnection errors and test failures.

- In #21822, we increased the disconnection timeout to give all browsers enough time to complete testing. With this, we're no longer seeing disconnect errors. 
    - Context: `karma-sauce-launcher` lacks a heartbeat to keep test sessions alive (https://github.com/karma-runner/karma-sauce-launcher/pull/161)
- In #21983, we skipped the remaining integration tests that never did work on Safari.

With this, it's time to surface genuine test failures by making the job blocking. Here are the last few runs (all green):
- https://travis-ci.org/ampproject/amphtml/jobs/524602477#L1581-L1584
- https://travis-ci.org/ampproject/amphtml/jobs/524616811#L1931-L1934
- https://travis-ci.org/ampproject/amphtml/jobs/524635006#L1931-L1935

:crossed_fingers: 