### PR TITLE
🏗 Remove parallelization from visual diff to avoid flakiness

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -56,7 +56,7 @@ const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 7000;
 const NAVIGATE_RETRIES = 3;
 const NAVIGATE_RETRY_TIMEOUT_MS = 2000;
-const MAX_PARALLEL_TABS = 10;
+const MAX_PARALLEL_TABS = 1;
 const WAIT_FOR_TABS_MS = 1000;
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
 


### PR DESCRIPTION
Will restore it once I figure out a more permanent fix. Technically this just reduces the number of parallel running pages from 10 to 1 😅

I re-ran the visual diff test stage 7 times and it passed every time. This increases the running time from ~1.5 to ~5 minutes, so still within reason