### PR TITLE
Fix the copy to clipboard sharing option on Stories.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -310,7 +310,11 @@ export class ShareWidget {
 
     listen(linkShareButton, 'click', e => {
       e.preventDefault();
-      this.copyUrlToClipboard_(this.root.querySelector('#page-share').checked);
+      let shareFromCurrentPage = false;
+      if (isExperimentOn(this.win, 'amp-story-branching')) {
+        shareFromCurrentPage = this.root.querySelector('#page-share').checked;
+      }
+      this.copyUrlToClipboard_(shareFromCurrentPage);
     });
   }
 
@@ -329,13 +333,13 @@ export class ShareWidget {
   }
 
   /**
-   * @param {boolean=} sharePage
+   * @param {boolean} shareFromCurrentPage
    * @private
    */
-  copyUrlToClipboard_(sharePage = false) {
+  copyUrlToClipboard_(shareFromCurrentPage) {
     const currentPageId = this.storeService_.get(StateProperty.CURRENT_PAGE_ID);
     const shouldAddFragment =
-      (isExperimentOn(this.win, 'amp-story-branching') && sharePage);
+      (isExperimentOn(this.win, 'amp-story-branching') && shareFromCurrentPage);
 
     const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl +
     (shouldAddFragment ? '#page=' + currentPageId : '');


### PR DESCRIPTION
The "Get link" sharing button in the bookend is currently broken in all stories ([example](https://www.washingtonpost.com/graphics/2019/world/amp-stories/sri-lanka-mourning/)).

`this.root.querySelector('#page-share')` is only available if the `amp-story-branching` experiment is enabled.