### PR TITLE
Skip the inabox BTF tests.

### DIFF
--- a/test/integration/test-amp-inabox.js
+++ b/test/integration/test-amp-inabox.js
@@ -66,9 +66,12 @@ function unregisterIframe(frame) {
   }
 }
 
-// TODO: Unskip the cross domain tests on Firefox, which broke because localhost
+// TODO(zombifier):
+// - Unskip the cross domain tests on Firefox, which broke because localhost
 // subdomains no longer work on version 65.
-// TODO(zombifier): Unskip on Windows once these tests work.
+// - Unskip on Windows once these tests work there.
+// - The BTF test fails on Safari and flakes on other platforms (#21311).
+// Should be ported to being E2E tests.
 describe.configure().skipWindows().run('inabox', function() {
 
   function testAmpComponents() {
@@ -161,8 +164,6 @@ describe.configure().skipWindows().run('inabox', function() {
         env.iframe.style.height = '100vh';
       });
 
-      // TODO(zombifier, #21545): fix this flaky test. Was using configuration:
-      // it.configure().skipSafari().run(...
       it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
         // See amp4test.js for creative content
         return testAmpComponentsBTF(env.win);
@@ -212,7 +213,6 @@ describe.configure().skipWindows().run('inabox', function() {
     });
   });
 
-  // TODO(zombifier, #21311): Investigate why Safari on SauceLabs timeout.
   describes.integration('AMPHTML ads rendered on non-AMP page BTF within ' +
       'friendly frame and safe frame', {
     amp: false,
@@ -238,13 +238,13 @@ describe.configure().skipWindows().run('inabox', function() {
       env.win.document.body.removeChild(iframe);
     });
 
-    it.configure().skipSafari().run('should layout amp-img, amp-pixel, ' +
+    it.skip('should layout amp-img, amp-pixel, ' +
         'amp-analytics within friendly frame', () => {
       writeFriendlyFrame(env.win.document, iframe, adContent);
       return testAmpComponentsBTF(env.win);
     });
 
-    it.configure().ifChrome().run('should layout amp-img, amp-pixel, ' +
+    it.skip('should layout amp-img, amp-pixel, ' +
         'amp-analytics within safe frame', () => {
       writeSafeFrame(env.win.document, iframe, adContent);
       return testAmpComponentsBTF(env.win);
@@ -252,7 +252,6 @@ describe.configure().skipWindows().run('inabox', function() {
   });
 });
 
-// TODO(zombifier): Unskip on Windows once these tests work.
 describe.configure().skipWindows().run('inabox with a complex ' +
     'image ad', function() {
   const {testServerPort} = window.ampTestRuntimeConfig;
@@ -350,7 +349,6 @@ describe.configure().skipWindows().run('inabox with a complex ' +
     });
   });
 
-  // TODO(zombifier, #21311): Investigate why Safari on SauceLabs timeout.
   describes.integration('AMP Inabox Rendering BTF', {
     amp: false,
     body: `
@@ -371,14 +369,14 @@ describe.configure().skipWindows().run('inabox with a complex ' +
       }, 2000);
     });
 
-    it.configure().skipSafari().run(
+    it.skip(
         'should properly render ad in a friendly iframe with viewability pings',
         () => {
           writeFriendlyFrame(doc, iframe, adBody);
           return testVisibilityPings(2000, 3000);
         });
 
-    it.configure().ifChrome().run(
+    it.skip(
         'should properly render ad in a safe frame with viewability pings',
         () => {
           writeSafeFrame(doc, iframe, adBody);


### PR DESCRIPTION
As noted in #21311 these tests are unreliable. This is most likely due to the various workarounds so the inabox creatives can work properly in an iframed host page smaller than the viewport size. The best solution going forward is probably to port them to being e2e tests.

Also coalesced the various comments across the file into one at the top.