### PR TITLE
✅ Allowing service-worker-scope attribute in amp-web-push for AMP validator

### DIFF
--- a/extensions/amp-web-push/0.1/test/validator-amp-web-push.html
+++ b/extensions/amp-web-push/0.1/test/validator-amp-web-push.html
@@ -28,7 +28,7 @@
   <script async custom-element="amp-web-push" src="https://cdn.ampproject.org/v0/amp-web-push-0.1.js"></script>
 </head>
 <body>
-  <!-- Valid: Example of amp-web-push usage -->
+  <!-- Valid: Default amp-web-push usage. -->
   <amp-web-push
     id="amp-web-push"
     layout="nodisplay"
@@ -36,6 +36,27 @@
     permission-dialog-url="https://example.com/permission-dialog.html"
     service-worker-url="https://example.com/service-worker.js">
   </amp-web-push>
+
+  <!-- Valid: Has optional service-worker-scope attribute, referencing the root. -->
+  <amp-web-push
+    id="amp-web-push"
+    layout="nodisplay"
+    helper-iframe-url="https://example.com/helper-iframe.html"
+    permission-dialog-url="https://example.com/permission-dialog.html"
+    service-worker-url="https://example.com/service-worker.js"
+    service-worker-scope="/">
+  </amp-web-push>
+
+  <!-- Valid: Has optional service-worker-scope attribute, referencing a subpath. -->
+  <amp-web-push
+    id="amp-web-push"
+    layout="nodisplay"
+    helper-iframe-url="https://example.com/subpath/helper-iframe.html"
+    permission-dialog-url="https://example.com/subpath/permission-dialog.html"
+    service-worker-url="https://example.com/subpath/service-worker.js"
+    service-worker-scope="/subpath">
+  </amp-web-push>
+
   <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="250" height="80">
     <button on="tap:amp-web-push.subscribe">Subscribe to Notifications</button>
   </amp-web-push-widget>

--- a/extensions/amp-web-push/0.1/test/validator-amp-web-push.html
+++ b/extensions/amp-web-push/0.1/test/validator-amp-web-push.html
@@ -54,7 +54,7 @@
     helper-iframe-url="https://example.com/subpath/helper-iframe.html"
     permission-dialog-url="https://example.com/subpath/permission-dialog.html"
     service-worker-url="https://example.com/subpath/service-worker.js"
-    service-worker-scope="/subpath">
+    service-worker-scope="/subpath/">
   </amp-web-push>
 
   <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="250" height="80">

--- a/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
+++ b/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
@@ -29,7 +29,7 @@ PASS
 |    <script async custom-element="amp-web-push" src="https://cdn.ampproject.org/v0/amp-web-push-0.1.js"></script>
 |  </head>
 |  <body>
-|    <!-- Valid: Example of amp-web-push usage -->
+|    <!-- Valid: Default amp-web-push usage. -->
 |    <amp-web-push
 |      id="amp-web-push"
 |      layout="nodisplay"
@@ -37,6 +37,27 @@ PASS
 |      permission-dialog-url="https://example.com/permission-dialog.html"
 |      service-worker-url="https://example.com/service-worker.js">
 |    </amp-web-push>
+|
+|    <!-- Valid: Has optional service-worker-scope attribute, referencing the root. -->
+|    <amp-web-push
+|      id="amp-web-push"
+|      layout="nodisplay"
+|      helper-iframe-url="https://example.com/helper-iframe.html"
+|      permission-dialog-url="https://example.com/permission-dialog.html"
+|      service-worker-url="https://example.com/service-worker.js"
+|      service-worker-scope="/">
+|    </amp-web-push>
+|
+|    <!-- Valid: Has optional service-worker-scope attribute, referencing a subpath. -->
+|    <amp-web-push
+|      id="amp-web-push"
+|      layout="nodisplay"
+|      helper-iframe-url="https://example.com/subpath/helper-iframe.html"
+|      permission-dialog-url="https://example.com/subpath/permission-dialog.html"
+|      service-worker-url="https://example.com/subpath/service-worker.js"
+|      service-worker-scope="/subpath">
+|    </amp-web-push>
+|
 |    <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="250" height="80">
 |      <button on="tap:amp-web-push.subscribe">Subscribe to Notifications</button>
 |    </amp-web-push-widget>

--- a/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
+++ b/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
@@ -55,7 +55,7 @@ PASS
 |      helper-iframe-url="https://example.com/subpath/helper-iframe.html"
 |      permission-dialog-url="https://example.com/subpath/permission-dialog.html"
 |      service-worker-url="https://example.com/subpath/service-worker.js"
-|      service-worker-scope="/subpath">
+|      service-worker-scope="/subpath/">
 |    </amp-web-push>
 |
 |    <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="250" height="80">

--- a/extensions/amp-web-push/validator-amp-web-push.protoascii
+++ b/extensions/amp-web-push/validator-amp-web-push.protoascii
@@ -57,6 +57,13 @@ tags: {  # <amp-web-push>
       allow_relative: false
     }
   }
+  attrs: {
+    name: "service-worker-scope"
+    value_url: {
+      protocol: "https"
+      allow_relative: true
+    }
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-web-push"
   amp_layout: {


### PR DESCRIPTION
Adding validation for `service-worker-scope` attribute in `amp-web-push` component (complementing change made in #21702).

The rule created in validator-amp-web-push.protoascii defines the attribute as:

- Optional: By not adding a "mandatory" attribute in the declaration.
- Of type URL, HTTPS and relative: This comes from [SW Spec](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register#Parameters): 

"**scope**: A USVString representing a URL that defines a service worker's registration scope; that is, what range of URLs a service worker can control. This is usually a relative URL. It is relative to the base URL of the application."

Tests have been added to show the different use cases: 
- Using the component without service-worker-scope.
- Using the component with service-worker-scope, in the root, and a subpath.

@jridgewell: if you can double-check all this is correct, would be great.

Thanks for the help.