### PR TITLE
📖Add missing documentation for date picker change event

### DIFF
--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -610,6 +610,12 @@ For a single date picker:
 </tr>
 </table>
 
+```html
+<amp-date-picker type="single" on="select: AMP.setState({date: event.date, templateSelected: event.id})" ...>
+  <!-- ... -->
+</amp-date-picker>
+```
+
 For a date range picker:
 
 <table>
@@ -630,6 +636,12 @@ For a date range picker:
 <td>A shortcut for the last date in the date range (<code>event.dates[event.dates.length - 1]</code>).
 </tr>
 </table>
+
+```html
+<amp-date-picker type="range" on="select: AMP.setState({dates: event.dates, firstTemplate: event.start.id})" ...>
+  <!-- ... -->
+</amp-date-picker>
+```
 
 ## Actions
 

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -586,6 +586,50 @@ an interaction with the calendar view, i.e. when the overlay would open.
 The date picker triggers the  `deactivate` event when the user ends
 their interaction with the calendar view, i.e. when the overlay would close.
 
+##### select
+
+The date picker triggers the `select` event when the user selects a date or
+date range. When selecting a date range, the event is emitted when the end
+date and start date are both selected.
+The `select` event contains the following properties.
+
+For a single date picker:
+
+<table>
+<tr>
+<th width="30%">Property</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><code>date</code></td>
+<td>The date that was selected.</td>
+</tr>
+<tr>
+<td><code>id</code></td>
+<td>The <code>id</code> attribute of the first <a href="#templates">date template</a> that applies to this date.</td>
+</tr>
+</table>
+
+For a date range picker:
+
+<table>
+<tr>
+<th width="30%">Property</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><code>dates</code></td>
+<td>An array of the dates that were selected. Each object in the array contains the <code>date</code> and <code>id</code> properties from the single date picker <code>change</code> event object.</td>
+</tr>
+<tr>
+<td><code>start</code></td>
+<td>A shortcut for the first date in the date range (<code>event.dates[0]</code>).
+</tr>
+<tr>
+<td><code>end</code></td>
+<td>A shortcut for the last date in the date range (<code>event.dates[event.dates.length - 1]</code>).
+</tr>
+</table>
 
 ## Actions
 

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -99,7 +99,7 @@ By specifying `mode="static"`, the `amp-date-picker` renders a static calendar v
 
 For a static date picker, you must specify a size-defined layout, which can be one of: `fixed`, `fixed-height`, `responsive`, `fill` or `flex-item`.
 
-When the `static` amp-date-picker is rendered in a `<form>`, if there are no [inputs specified with `*input-selector`](#input-selector), the amp-date-picker creates hidden input elements (e.g., `<input type="hidden" ...`). The amp-date-picker names the elements as `date` or `start-date` and `end-date`; if those names are already used in the form, the amp-date-picker attempts to name the input fields with the `id` of the `<amp-date-picker>`.
+When the `static` amp-date-picker is rendered in a `<form>`, if there are no [inputs specified with `*input-selector`](#input-selector), the amp-date-picker creates hidden input elements (e.g., `<input type="hidden" …`). The amp-date-picker names the elements as `date` or `start-date` and `end-date`; if those names are already used in the form, the amp-date-picker attempts to name the input fields with the `id` of the `<amp-date-picker>`.
 
 *Example: static date picker in a form field*
 
@@ -611,8 +611,8 @@ For a single date picker:
 </table>
 
 ```html
-<amp-date-picker type="single" on="select: AMP.setState({date: event.date, templateSelected: event.id})" ...>
-  <!-- ... -->
+<amp-date-picker type="single" on="select: AMP.setState({date: event.date, templateSelected: event.id})" …>
+  <!-- … -->
 </amp-date-picker>
 ```
 
@@ -638,8 +638,8 @@ For a date range picker:
 </table>
 
 ```html
-<amp-date-picker type="range" on="select: AMP.setState({dates: event.dates, firstTemplate: event.start.id})" ...>
-  <!-- ... -->
+<amp-date-picker type="range" on="select: AMP.setState({dates: event.dates, firstTemplate: event.start.id})" …>
+  <!-- … -->
 </amp-date-picker>
 ```
 


### PR DESCRIPTION
I was checking the date picker documentation recently for how it describes the `select` event, and I noticed it did not describe the `select` event. This PR implements the missing documentation.