### PR TITLE
🏗♻️ Consolidate single pass compilation steps, eliminate ~1200 file reads / writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ chromedriver.log
 sc-*-linux*
 EXTENSIONS_CSS_MAP
 deps.txt
-flags-array.txt
-out/
 firebase
 .firebaserc
 firebase.json

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -133,20 +133,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     }
 
     console/*OK*/.assert(typeof entryModuleFilenames == 'string');
-    const entryModule = entryModuleFilenames;
-    // TODO(@cramforce): Run the post processing step
-    return singlePassCompile(
-        entryModule,
-        compilationOptions
-    ).then(() => {
-      return new Promise((resolve, reject) => {
-        gulp.src(outputDir + '/**/*.js')
-            .pipe(shortenLicense())
-            .pipe(gulp.dest(outputDir))
-            .on('end', resolve)
-            .on('error', reject);
-      });
-    });
+    return singlePassCompile(entryModuleFilenames, compilationOptions);
   }
 
   return new Promise(function(resolve) {

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -28,6 +28,7 @@ const move = require('glob-move');
 const path = require('path');
 const Promise = require('bluebird');
 const relativePath = require('path').relative;
+const shortenLicense = require('./shorten-license');
 const sourcemaps = require('gulp-sourcemaps');
 const tempy = require('tempy');
 const through = require('through2');
@@ -595,12 +596,14 @@ function postProcessConcat() {
 }
 
 function compile(flagsArray) {
+  // TODO(@cramforce): Run the post processing step
   return new Promise(function(resolve) {
     return gulp.src(srcs, {base: transformDir})
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(flagsArray))
         .on('error', handleSinglePassCompilerError)
         .pipe(sourcemaps.write('.'))
+        .pipe(shortenLicense())
         .pipe(gulp.dest('.'))
         .on('end', resolve);
   });

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -25,7 +25,6 @@ const gulp = require('gulp');
 const gulpIf = require('gulp-if');
 const log = require('fancy-log');
 const minimist = require('minimist');
-const move = require('glob-move');
 const path = require('path');
 const Promise = require('bluebird');
 const relativePath = require('path').relative;

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -22,12 +22,14 @@ const conf = require('../build.conf');
 const devnull = require('dev-null');
 const fs = require('fs-extra');
 const gulp = require('gulp');
+const gulpIf = require('gulp-if');
 const log = require('fancy-log');
 const minimist = require('minimist');
 const move = require('glob-move');
 const path = require('path');
 const Promise = require('bluebird');
 const relativePath = require('path').relative;
+const rename = require('gulp-rename');
 const shortenLicense = require('./shorten-license');
 const sourcemaps = require('gulp-sourcemaps');
 const tempy = require('tempy');
@@ -515,18 +517,7 @@ exports.singlePassCompile = function(entryModule, options) {
     define: options.define,
     externs: options.externs,
     hideWarningsFor: options.hideWarningsFor,
-  }).then(compile).then(function() {
-    // Move things into place as AMP expects them.
-    fs.ensureDirSync(`${singlePassDest}/v0`);
-    return Promise.all([
-      // Move all files that need to live in /v0/. ex. _base files
-      // all extensions.
-      move(`${singlePassDest}/amp*`, `${singlePassDest}/v0`).then(() => {
-        return move('dist/v0/amp4ads*', 'dist');
-      }),
-      move(`${singlePassDest}/_base*`, `${singlePassDest}/v0`),
-    ]);
-  }).then(wrapMainBinaries).then(postProcessConcat).catch(e => {
+  }).then(compile).then(wrapMainBinaries).then(postProcessConcat).catch(e => {
     // NOTE: passing the message here to colors.red breaks the output.
     console./*OK*/error(e.message);
     process.exit(1);
@@ -604,6 +595,7 @@ function compile(flagsArray) {
         .on('error', handleSinglePassCompilerError)
         .pipe(sourcemaps.write('.'))
         .pipe(shortenLicense())
+        .pipe(gulpIf(/(\/amp-|\/_base)/, rename(path => path.dirname += '/v0')))
         .pipe(gulp.dest('.'))
         .on('end', resolve);
   });

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "formidable": "1.2.1",
     "fs-extra": "7.0.1",
     "fuse.js": "3.4.4",
-    "glob-move": "1.0.1",
     "globs-to-files": "1.0.0",
     "google-closure-compiler": "20190215.0.2",
     "gulp": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "gulp-file": "0.4.0",
     "gulp-git": "2.9.0",
     "gulp-help": "1.6.1",
+    "gulp-if": "2.0.2",
     "gulp-load-plugins": "1.5.0",
     "gulp-nop": "0.0.3",
     "gulp-regexp-sourcemaps": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,7 +1301,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -1321,9 +1321,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "11.9.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.5.tgz#011eece9d3f839a806b63973e228f85967b79ed3"
-  integrity sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==
+  version "11.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
+  integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
 "@types/node@^10.11.7":
   version "10.12.27"
@@ -6227,16 +6227,6 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
-glob-move@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/glob-move/-/glob-move-1.0.1.tgz#a6287586e26b0152bd366e84de9a8ee87b8025cc"
-  integrity sha1-pih1huJrAVK9Nm6E3pqO6HuAJcw=
-  dependencies:
-    es6-promisify "^5.0.0"
-    glob "*"
-    glob-promise "*"
-    mv "^2.1.1"
-
 glob-parent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
@@ -6251,13 +6241,6 @@ glob-parent@^3.0.1, glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
-
-glob-promise@*:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
-  integrity sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==
-  dependencies:
-    "@types/glob" "*"
 
 glob-stream@^3.1.5:
   version "3.1.18"
@@ -6290,7 +6273,15 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@*, glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@3.2.x, "glob@~ 3.2.1", glob@~3.2.8:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
+  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
+  dependencies:
+    inherits "2"
+    minimatch "0.3"
+
+glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -6301,14 +6292,6 @@ glob@*, glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@3.2.x, "glob@~ 3.2.1", glob@~3.2.8:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
-  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
-  dependencies:
-    inherits "2"
-    minimatch "0.3"
 
 glob@^4.3.1:
   version "4.5.3"
@@ -6324,17 +6307,6 @@ glob@^5.0.10, glob@^5.0.6:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -10386,15 +10358,6 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mv@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
-  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
-  dependencies:
-    mkdirp "~0.5.1"
-    ncp "~2.0.0"
-    rimraf "~2.4.0"
-
 mz@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -10445,11 +10408,6 @@ ncp@0.4.x:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
   integrity sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=
-
-ncp@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
   version "2.2.4"
@@ -12807,13 +12765,6 @@ rimraf@2.6.3, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.4, rimraf@
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
-
-rimraf@~2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
-  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
-  dependencies:
-    glob "^6.0.1"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6615,7 +6615,7 @@ gulp-help@1.6.1:
     chalk "^1.0.0"
     object-assign "^3.0.0"
 
-gulp-if@^2.0.0:
+gulp-if@2.0.2, gulp-if@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/gulp-if/-/gulp-if-2.0.2.tgz#a497b7e7573005041caa2bc8b7dda3c80444d629"
   integrity sha1-pJe351cwBQQcqivIt92jyARE1ik=


### PR DESCRIPTION
Running `gulp dist --single_pass` generates a `.js` and a `.map` file each for ~150 extensions. The build steps in `singlePassCompile` as written today do 2 extra file reads and file writes for each of the 300 `.js` / `.map` files.

This PR consolidates all the compilation steps into a series of `gulp` stream operations with one final file write at the end, and eliminates ~1200 unnecessary file reads / writes. 

Follow up to #21953
