### PR TITLE
🏗 Run E2E test job in PRs only when you have a build artifact

### DIFF
--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -29,7 +29,7 @@ const {
   startTimer,
   stopTimer,
   timedExecOrDie: timedExecOrDieBase} = require('./utils');
-const {determineBuildTargets} = require('./build-targets');  
+const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../travis');
 
 const FILENAME = 'e2e-tests.js';


### PR DESCRIPTION
Uses the same logic that creates a build artifact in the build job when running the e2e test job.

Fixes #21880 