### PR TITLE
🐛 Fix amp-autocomplete bugs related to results display and interaction

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -33,11 +33,11 @@
     <p>form has no autocomplete attr</p>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank">
       <label for="frmEmailA">Personal Email</label>
-      <input type="email" name="email" id="frmEmailA" placeholder="name@example.com" required autocomplete="email"><br>
+      <input type="text" name="email" id="frmEmailA" placeholder="name@example.com" required autocomplete="email"><br>
 
       <label for="frmEmailB">Autocomplete Email</label>
       <amp-autocomplete filter="substring" min-characters="0">
-        <input type="email" name="email" id="frmEmailB" placeholder="name@example.com" required autocomplete="email">
+        <input type="text" name="email" id="frmEmailB" placeholder="name@example.com" required autocomplete="email">  
         <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
@@ -48,11 +48,11 @@
     <p>form has autocomplete="on"</p>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="on">
       <label for="frmEmailC">Personal Email</label>
-      <input type="email" name="email" id="frmEmailC" placeholder="name@example.com" required autocomplete="email"><br>
+      <input type="text" name="email" id="frmEmailC" placeholder="name@example.com" required autocomplete="email"><br>
 
       <label for="frmEmailD">Autocomplete Email</label>
       <amp-autocomplete filter="substring" min-characters="0">
-        <input type="email" name="email" id="frmEmailD" placeholder="name@example.com" required autocomplete="email">
+        <input type="text" name="email" id="frmEmailD" placeholder="name@example.com" required autocomplete="email">  
         <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
@@ -63,11 +63,11 @@
     <p>form and input have autocomplete="off"</p>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="off">
       <label for="frmEmailE">Personal Email</label>
-      <input type="email" name="email" id="frmEmailE" placeholder="name@example.com" required autocomplete="off"><br>
+      <input type="text" name="email" id="frmEmailE" placeholder="name@example.com" required autocomplete="off"><br>
 
       <label for="frmEmailF">Autocomplete Email</label>
       <amp-autocomplete filter="substring" min-characters="0">
-        <input type="email" name="email" id="frmEmailF" placeholder="name@example.com" required autocomplete="email">
+        <input type="text" name="email" id="frmEmailF" placeholder="name@example.com" required autocomplete="email">  
         <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -46,6 +46,7 @@ amp-autocomplete > input {
 .i-amphtml-autocomplete-results-up {
   top: auto;
   bottom: 100%;
+  margin-bottom: .5rem; /* default-ui-space-small */
 }
 
 .i-amphtml-autocomplete-item {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -43,6 +43,11 @@ amp-autocomplete > input {
   z-index: 10;
 }
 
+.i-amphtml-autocomplete-results-up {
+  top: auto;
+  bottom: 100%;
+}
+
 .i-amphtml-autocomplete-item {
   position: relative;
   padding: .5rem 1rem; /* default-ui-space-small default-ui-space-medium */

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -581,6 +581,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
     // Toggle results.
     return this.mutateElement(() => {
       if (!display) {
+        this.userInput_ = this.inputElement_.value;
+        this.filterDataAndRenderResults_(this.sourceData_, this.userInput_);
         this.resetActiveElement_();
       } else {
         this.setResultDisplayDirection_();
@@ -675,13 +677,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.inputElement_.value = newActiveElement.getAttribute('data-value');
 
     // Element visibility logic
-    const itemTop = newActiveElement.offsetTop;
-    const itemHeight = newActiveElement.offsetHeight;
+    const {offsetTop: itemTop, offsetHeight: itemHeight} = newActiveElement;
+
     const resultTop = this.container_.scrollTop;
-    if (resultTop > itemTop || 
+    if (resultTop > itemTop ||
       resultTop + this.container_.offsetHeight < itemTop + itemHeight) {
-        this.container_.scrollTop = delta > 0 ? 
-          itemTop + itemHeight - this.container_.offsetHeight : itemTop;
+      this.container_.scrollTop = delta > 0 ?
+        itemTop + itemHeight - this.container_.offsetHeight : itemTop;
     }
 
     return this.mutateElement(() => {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -667,11 +667,23 @@ export class AmpAutocomplete extends AMP.BaseElement {
     if (delta === 0 || !this.resultsShowing_()) {
       return Promise.resolve();
     }
+    // Active element logic
     const keyUpWhenNoneActive = this.activeIndex_ === -1 && delta < 0;
     const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
     const activeIndex = mod(index, this.container_.children.length);
     const newActiveElement = this.container_.children[activeIndex];
     this.inputElement_.value = newActiveElement.getAttribute('data-value');
+
+    // Element visibility logic
+    const itemTop = newActiveElement.offsetTop;
+    const itemHeight = newActiveElement.offsetHeight;
+    const resultTop = this.container_.scrollTop;
+    if (resultTop > itemTop || 
+      resultTop + this.container_.offsetHeight < itemTop + itemHeight) {
+        this.container_.scrollTop = delta > 0 ? 
+          itemTop + itemHeight - this.container_.offsetHeight : itemTop;
+    }
+
     return this.mutateElement(() => {
       this.resetActiveElement_();
       newActiveElement.classList.add('i-amphtml-autocomplete-item-active');

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -134,6 +134,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
+
+    /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = null;
   }
 
   /** @override */
@@ -142,6 +145,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
         `Experiment ${EXPERIMENT} is not turned on.`);
 
     this.action_ = Services.actionServiceForDoc(this.element);
+    this.viewport_ = Services.viewportForDoc(this.element);
+
     const jsonScript =
       this.element.querySelector('script[type="application/json"]');
     if (jsonScript) {
@@ -245,7 +250,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
    */
   createContainer_() {
     const container = this.element.ownerDocument.createElement('div');
+    const viewHeight = this.viewport_.getHeight() || 0;
     container.classList.add('i-amphtml-autocomplete-results');
+    if (this.inputElement_.getBoundingClientRect().top > (viewHeight / 2)) {
+      container.classList.add('i-amphtml-autocomplete-results-up');
+    }
     container.setAttribute('role', 'list');
     toggle(container, false);
     return container;
@@ -573,9 +582,25 @@ export class AmpAutocomplete extends AMP.BaseElement {
     return this.mutateElement(() => {
       if (!display) {
         this.resetActiveElement_();
+      } else {
+        this.setResultDisplayDirection_();
       }
       this.toggleResults_(display);
     });
+  }
+
+  /**
+   * Display results upwards or downwards based on location in the viewport.
+   * @private
+   */
+  setResultDisplayDirection_() {
+    const viewHeight = this.viewport_.getHeight() || 0;
+    if (this.inputElement_.getBoundingClientRect().top > (viewHeight / 2)) {
+      this.container_.classList.add('i-amphtml-autocomplete-results-up');
+    } else {
+      this.container_.classList.toggle(
+          'i-amphtml-autocomplete-results-up', false);
+    }
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -696,12 +696,20 @@ export class AmpAutocomplete extends AMP.BaseElement {
     switch (event.key) {
       case Keys.DOWN_ARROW:
         event.preventDefault();
-        // Disrupt loop around to display user input.
-        if (this.activeIndex_ === this.container_.children.length - 1) {
-          this.displayUserInput_();
-          return Promise.resolve();
+        if (this.resultsShowing_()) {
+          // Disrupt loop around to display user input.
+          if (this.activeIndex_ === this.container_.children.length - 1) {
+            this.displayUserInput_();
+            return Promise.resolve();
+          }
+          return this.updateActiveItem_(1);
         }
-        return this.updateActiveItem_(1);
+        else {
+          return this.mutateElement(() => {
+            this.filterDataAndRenderResults_(this.sourceData_, this.userInput_);
+            this.toggleResults_(true);
+          });
+        }
       case Keys.UP_ARROW:
         event.preventDefault();
         // Disrupt loop around to display user input.

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -688,44 +688,24 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.inputElement_.value = newActiveElement.getAttribute('data-value');
 
     // Element visibility logic
-    let overflowEl;
+    let shouldScroll, newTop;
 
     return this.measureMutateElement(() => {
-      overflowEl = this.measureContainerScroll_(newActiveElement, delta > 0);
+      const {offsetTop: itemTop, offsetHeight: itemHeight} = newActiveElement;
+      const {scrollTop: resultTop, offsetHeight: resultHeight} =
+        this.container_;
+      shouldScroll = (resultTop > itemTop ||
+        resultTop + resultHeight < itemTop + itemHeight);
+      newTop = delta > 0 ? itemTop + itemHeight - resultHeight : itemTop;
     }, () => {
-      if (overflowEl.shouldScroll) {
-        this.container_./*OK*/scrollTop = overflowEl.newTop;
+      if (shouldScroll) {
+        this.container_./*OK*/scrollTop = newTop;
       }
       this.resetActiveElement_();
       newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
       this.activeIndex_ = activeIndex;
       this.activeElement_ = newActiveElement;
     });
-  }
-
-  /**
-   * Given an element and boolean direction, returns an object of the format:
-   * { shouldScroll: boolean, newTop: number }
-   *
-   * This method assumes that the element it is passed is a child
-   * of the results container, otherwise known as a suggested item.
-   * It then calculates whether the item element is visible within
-   * the scope of the container element, and if not, what the container
-   * should be scrolled to (either upwards or downwards),in order for the
-   * element to be seen. Should be called in a measureMutate context.
-   *
-   * @param {!Element} element
-   * @param {boolean} goingDown
-   * @return {!Object}
-   * @private
-   */
-  measureContainerScroll_(element, goingDown) {
-    const {offsetTop: itemTop, offsetHeight: itemHeight} = element;
-    const {scrollTop: resultTop, offsetHeight: resultHeight} = this.container_;
-    const shouldScroll = (resultTop > itemTop ||
-      resultTop + resultHeight < itemTop + itemHeight);
-    const newTop = goingDown ? itemTop + itemHeight - resultHeight : itemTop;
-    return {shouldScroll, newTop};
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -336,7 +336,8 @@ describes.realWin('amp-autocomplete unit tests', {
       eventPreventSpy = sandbox.spy(event, 'preventDefault');
     });
 
-    it('should updateActiveItem_ on Down arrow', () => {
+    it('should updateActiveItem_ when results showing on Down arrow', () => {
+      sandbox.stub(impl, 'resultsShowing_').onFirstCall().returns(true);
       return element.layoutCallback().then(() => {
         impl.activeIndex_ = 0;
         return impl.keyDownHandler_(event);
@@ -348,11 +349,27 @@ describes.realWin('amp-autocomplete unit tests', {
     });
 
     it('should displayUserInput_ when looping on Down arrow', () => {
+      sandbox.stub(impl, 'resultsShowing_').returns(true);
       return element.layoutCallback().then(() => {
         return impl.keyDownHandler_(event);
       }).then(() => {
         expect(eventPreventSpy).to.have.been.calledOnce;
         expect(displayInputSpy).to.have.been.calledOnce;
+        expect(updateActiveSpy).not.to.have.been.called;
+      });
+    });
+
+    it('should display results if not already on Down arrow', () => {
+      let filterAndRenderSpy, toggleResultsSpy;
+      return element.layoutCallback().then(() => {
+        filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
+        toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
+        return impl.keyDownHandler_(event);
+      }).then(() => {
+        expect(eventPreventSpy).to.have.been.calledOnce;
+        expect(filterAndRenderSpy).to.have.been.calledOnce;
+        expect(toggleResultsSpy).to.have.been.calledWith(true);
+        expect(displayInputSpy).not.to.have.been.called;
         expect(updateActiveSpy).not.to.have.been.called;
       });
     });


### PR DESCRIPTION
- Re-renders results on down arrow key if none are showing.
- Re-renders results to an active item on blur so that if the element gain focus again, it will display updated suggestions.
- Points the results upwards or downwards based on input position in the viewport.
- Makes sure the active item is always visible in the results and is scrolled to within its container element if necessary.