### PR TITLE
🏗🚮 Use `compiler.jar` instead of `runner.jar` for single pass, remove unnecessary code

### DIFF
--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -74,22 +74,30 @@ exports.gulpClosureCompile = function(compilerOptions) {
     logger: errors => compilerErrors = errors, // Capture compiler errors
   };
 
-  // SIGNIFICANTLY speed up compilation on Mac OS and Linux using nailgun
-  // See https://github.com/facebook/nailgun.
-  if (process.platform == 'darwin' || process.platform == 'linux') {
-    compilerOptions = [
-      '--nailgun-port',
-      closureNailgunPort,
-      'org.ampproject.AmpCommandLineRunner',
-      '--',
-    ].concat(compilerOptions);
-    pluginOptions.platform = ['native']; // nailgun-runner isn't a java binary
-    initOptions.extraArguments = null; // Already part of nailgun-server
+  if (compilerOptions.includes('SINGLE_FILE_COMPILATION=true')) {
+    // For single-pass compilation, use the default compiler.jar
+    // TODO(rsimha): Use the native compiler instead of compiler.jar once a fix
+    // is checked in for https://github.com/google/closure-compiler/issues/3041
+    closureCompiler.compiler.JAR_PATH =
+          require.resolve('../../third_party/closure-compiler/compiler.jar');
+  } else {
+    // On Mac OS and Linux, speed up compilation using nailgun.
+    // See https://github.com/facebook/nailgun.
+    if (process.platform == 'darwin' || process.platform == 'linux') {
+      compilerOptions = [
+        '--nailgun-port',
+        closureNailgunPort,
+        'org.ampproject.AmpCommandLineRunner',
+        '--',
+      ].concat(compilerOptions);
+      pluginOptions.platform = ['native']; // nailgun-runner isn't a java binary
+      initOptions.extraArguments = null; // Already part of nailgun-server
+    } else {
+      // For other platforms, use AMP's custom runner.jar
+      closureCompiler.compiler.JAR_PATH =
+            require.resolve('../runner/dist/runner.jar');
+    }
   }
-
-  // Override to local closure compiler JAR
-  closureCompiler.compiler.JAR_PATH =
-        require.resolve('../runner/dist/runner.jar');
 
   return closureCompiler.gulp(initOptions)(compilerOptions, pluginOptions);
 };

--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -35,16 +35,9 @@ import java.util.Collection;
  */
 public final class AmpCodingConvention extends CodingConventions.Proxy {
 
-  private boolean singleFileCompilation = false;
-
   /** By default, decorate the ClosureCodingConvention. */
   public AmpCodingConvention() {
     this(new ClosureCodingConvention());
-  }
-
-  public AmpCodingConvention(boolean singleFileCompilation) {
-    this(new ClosureCodingConvention());
-    this.singleFileCompilation = singleFileCompilation;
   }
 
   /** Decorates a wrapped CodingConvention. */
@@ -80,9 +73,6 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
    * delivery), this could go away there.
    */
   @Override public boolean isExported(String name, boolean local) {
-    if (singleFileCompilation) {
-      return false;
-    }
     // This stops compiler from inlining functions (local or not) that end with
     // NoInline in their name. Mostly used for externing try-catch to avoid v8
     // de-optimization (https://goo.gl/gvzlDp)

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -41,11 +41,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    */
   private boolean typecheck_only = false;
 
-  private boolean pseudo_names = false;
-
   private boolean is_production_env = true;
-
-  private boolean single_file_compilation = false;
 
   private String amp_version = "";
 
@@ -84,35 +80,32 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     CompilerOptions options = super.createOptions();
     options.setCollapsePropertiesLevel(CompilerOptions.PropertyCollapseLevel.ALL);
     AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes,
-        assignmentReplacements, prodAssignmentReplacements, amp_version, single_file_compilation);
+        assignmentReplacements, prodAssignmentReplacements, amp_version);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
     options.setDevirtualizePrototypeMethods(true);
     options.setExtractPrototypeMemberDeclarations(true);
     options.setSmartNameRemoval(true);
     options.optimizeCalls = true;
-    if (!single_file_compilation) {
-      // Have to turn this off because we cannot know whether sub classes
-      // might override a method. In the future this might be doable
-      // with using a more complete extern file instead.
-      options.setRemoveUnusedPrototypeProperties(false);
-      options.setInlineProperties(false);
-      options.setComputeFunctionSideEffects(false);
-      // Since we are not computing function side effects, at least let the
-      // compiler remove calls to functions with `@nosideeffects`.
-      options.setMarkNoSideEffectCalls(true);
-      // Property renaming. Relies on AmpCodingConvention to be safe.
-      options.setRenamingPolicy(VariableRenamingPolicy.ALL,
-          PropertyRenamingPolicy.ALL_UNQUOTED);
-    }
+    // Have to turn this off because we cannot know whether sub classes
+    // might override a method. In the future this might be doable
+    // with using a more complete extern file instead.
+    options.setRemoveUnusedPrototypeProperties(false);
+    options.setInlineProperties(false);
+    options.setComputeFunctionSideEffects(false);
+    // Since we are not computing function side effects, at least let the
+    // compiler remove calls to functions with `@nosideeffects`.
+    options.setMarkNoSideEffectCalls(true);
+    // Property renaming. Relies on AmpCodingConvention to be safe.
+    options.setRenamingPolicy(VariableRenamingPolicy.ALL,
+        PropertyRenamingPolicy.ALL_UNQUOTED);
     options.setDisambiguatePrivateProperties(true);
-    options.setGeneratePseudoNames(pseudo_names);
     return options;
   }
 
   @Override protected void setRunOptions(CompilerOptions options)
       throws IOException, FlagUsageException {
     super.setRunOptions(options);
-    options.setCodingConvention(new AmpCodingConvention(single_file_compilation));
+    options.setCodingConvention(new AmpCodingConvention());
   }
 
   /**
@@ -134,10 +127,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.typecheck_only = true;
       } else if (arg.contains("FORTESTING=true")) {
         runner.is_production_env = false;
-      } else if (arg.contains("PSEUDO_NAMES=true")) {
-        runner.pseudo_names = true;
-      } else if (arg.contains("SINGLE_FILE_COMPILATION=true")) {
-        runner.single_file_compilation = true;
       } else if (arg.contains("VERSION=")) {
         runner.amp_version = arg.substring(arg.lastIndexOf("=") + 1);
       }

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -41,6 +41,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    */
   private boolean typecheck_only = false;
 
+  private boolean pseudo_names = false;
+
   private boolean is_production_env = true;
 
   private String amp_version = "";
@@ -99,6 +101,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setRenamingPolicy(VariableRenamingPolicy.ALL,
         PropertyRenamingPolicy.ALL_UNQUOTED);
     options.setDisambiguatePrivateProperties(true);
+    options.setGeneratePseudoNames(pseudo_names);
     return options;
   }
 
@@ -127,6 +130,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.typecheck_only = true;
       } else if (arg.contains("FORTESTING=true")) {
         runner.is_production_env = false;
+      } else if (arg.contains("PSEUDO_NAMES=true")) {
+        runner.pseudo_names = true;
       } else if (arg.contains("VERSION=")) {
         runner.amp_version = arg.substring(arg.lastIndexOf("=") + 1);
       }

--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -50,21 +50,18 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
   private final ImmutableMap<String, Node> prodAssignmentReplacements;
   final boolean isProd;
   private final String amp_version;
-  final boolean isSinglePass;
 
   public AmpPass(AbstractCompiler compiler, boolean isProd,
         ImmutableSet<String> stripTypeSuffixes,
         ImmutableMap<String, Node> assignmentReplacements,
         ImmutableMap<String, Node> prodAssignmentReplacements,
-        String amp_version,
-        boolean isSinglePass) {
+        String amp_version) {
     this.compiler = compiler;
     this.stripTypeSuffixes = stripTypeSuffixes;
     this.isProd = isProd;
     this.assignmentReplacements = assignmentReplacements;
     this.prodAssignmentReplacements = prodAssignmentReplacements;
     this.amp_version = amp_version;
-    this.isSinglePass = isSinglePass;
   }
 
   @Override public void process(Node externs, Node root) {
@@ -78,7 +75,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
   @Override public void visit(NodeTraversal t, Node n, Node parent) {
     if (isCallRemovable(n)) {
       maybeEliminateCallExceptFirstParam(n, parent);
-    } else if (!this.isSinglePass && isAmpExtensionCall(n)) {
+    } else if (isAmpExtensionCall(n)) {
       inlineAmpExtensionCall(n, parent);
     // Remove any `getMode().localDev` and `getMode().test` calls and replace it with `false`.
     } else if (isProd && isFunctionInvokeAndPropAccess(n, "$mode.getMode",


### PR DESCRIPTION
Today, `gulp dist --single_pass` makes one large closure invocation (among others) to compile `v0.js` + `extensions/`. This internally uses `runner.jar`, which happens to disable all custom passes for the singe pass invocation.

This PR switches the single pass invocation to use `compiler.jar`, and removes all single pass specific code from `runner.jar`.

Addresses https://github.com/ampproject/amphtml/pull/21953#issuecomment-487422465
Requires #22064
Requires #22216 
Potentially unblocks #22040