### PR TITLE
🏗🚮 Remove blank lines from copyright licenses in `v0.js` without breaking sourcemaps

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -19,6 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const gulp = require('gulp');
+const gulpIf = require('gulp-if');
 const nop = require('gulp-nop');
 const rename = require('gulp-rename');
 const rimraf = require('rimraf');
@@ -399,6 +400,9 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           .on('end', resolve);
     } else {
       return gulp.src(srcs, {base: '.'})
+          .pipe(gulpIf(
+              /(ShadowCSS\.js|document-register-element\.patched\.js)/,
+              shortenLicense()))
           .pipe(sourcemaps.init({loadMaps: true}))
           .pipe(gulpClosureCompile(compilerOptionsArray))
           .on('error', () => handleCompilerError(outputFilename))

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -23,10 +23,10 @@ const gulpIf = require('gulp-if');
 const nop = require('gulp-nop');
 const rename = require('gulp-rename');
 const rimraf = require('rimraf');
-const shortenLicense = require('./shorten-license');
 const sourcemaps = require('gulp-sourcemaps');
 const {gulpClosureCompile, handleCompilerError, handleTypeCheckError} = require('./closure-compile');
 const {isTravisBuild} = require('../travis');
+const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {singlePassCompile} = require('./single-pass');
 const {VERSION: internalRuntimeVersion} = require('../internal-version') ;
 
@@ -400,15 +400,12 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           .on('end', resolve);
     } else {
       return gulp.src(srcs, {base: '.'})
-          .pipe(gulpIf(
-              /(ShadowCSS\.js|document-register-element\.patched\.js)/,
-              shortenLicense()))
+          .pipe(gulpIf(shouldShortenLicense, shortenLicense()))
           .pipe(sourcemaps.init({loadMaps: true}))
           .pipe(gulpClosureCompile(compilerOptionsArray))
           .on('error', () => handleCompilerError(outputFilename))
           .pipe(rename(outputFilename))
           .pipe(sourcemaps.write('.'))
-          .pipe(shortenLicense())
           .pipe(gulp.dest(outputDir))
           .on('end', resolve);
     }

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -19,17 +19,6 @@ const escape = require('regexp.escape');
 const pumpify = require('pumpify');
 const replace = require('gulp-regexp-sourcemaps');
 
-// Keep the number of lines in the original and replacement the same. Because
-// sourcemaps suck.
-function emptyLines(original, replacement) {
-  const lines = original.split('\n').length;
-  const current = replacement.split('\n').length;
-  for (let l = current; l < lines; l++) {
-    replacement += '\n';
-  }
-  return replacement;
-}
-
 /* eslint-disable */
 const MIT_FULL = [
 'Permission is hereby granted, free of charge, to any person obtaining a copy',
@@ -74,8 +63,8 @@ const BSD_SHORT = [
 /* eslint-enable */
 
 const LICENSES = [
-  [MIT_FULL, emptyLines(MIT_FULL, MIT_SHORT)],
-  [POLYMER_BSD_FULL, emptyLines(POLYMER_BSD_FULL, BSD_SHORT)],
+  [MIT_FULL, MIT_SHORT],
+  [POLYMER_BSD_FULL, BSD_SHORT],
 ];
 
 /*

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -67,11 +67,17 @@ const LICENSES = [
   [POLYMER_BSD_FULL, BSD_SHORT],
 ];
 
-/*
+const PATHS = [
+  'third_party/webcomponentsjs/ShadowCSS.js',
+  'node_modules/document-register-element/build/' +
+      'document-register-element.patched.js',
+];
+
+/**
  * We can replace full-text of standard licenses with a pre-approved shorten
  * version.
  */
-module.exports = function() {
+exports.shortenLicense = function() {
   const streams = LICENSES.map(tuple => {
     const regex = new RegExp(escape(tuple[0]), 'g');
     return replace(regex, tuple[1], 'shorten-license');
@@ -80,3 +86,10 @@ module.exports = function() {
   return pumpify.obj(streams);
 };
 
+/**
+ * Returns true if a source file has a license that needs to be shortened.
+ * @param {Vinyl} file
+ */
+exports.shouldShortenLicense = function(file) {
+  return PATHS.some(path => file.path.endsWith(path));
+};

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -29,13 +29,13 @@ const path = require('path');
 const Promise = require('bluebird');
 const relativePath = require('path').relative;
 const rename = require('gulp-rename');
-const shortenLicense = require('./shorten-license');
 const sourcemaps = require('gulp-sourcemaps');
 const tempy = require('tempy');
 const through = require('through2');
 const {extensionBundles, altMainBundles, TYPES} = require('../../bundles.config');
 const {gulpClosureCompile, handleSinglePassCompilerError} = require('./closure-compile');
 const {isTravisBuild} = require('../travis');
+const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {TopologicalSort} = require('topological-sort');
 const TYPES_VALUES = Object.keys(TYPES).map(x => TYPES[x]);
 const wrappers = require('../compile-wrappers');
@@ -589,11 +589,11 @@ function compile(flagsArray) {
   // TODO(@cramforce): Run the post processing step
   return new Promise(function(resolve) {
     return gulp.src(srcs, {base: transformDir})
+        .pipe(gulpIf(shouldShortenLicense, shortenLicense()))
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(flagsArray))
         .on('error', handleSinglePassCompilerError)
         .pipe(sourcemaps.write('.'))
-        .pipe(shortenLicense())
         .pipe(gulpIf(/(\/amp-|\/_base)/, rename(path => path.dirname += '/v0')))
         .pipe(gulp.dest('.'))
         .on('end', resolve);


### PR DESCRIPTION
This PR addresses https://github.com/ampproject/amphtml/issues/22076#issuecomment-488104236 and https://github.com/ampproject/amphtml/pull/21818#pullrequestreview-225709634 without breaking #11589 or #21818. It eliminates the hack mentioned in https://github.com/ampproject/amphtml/pull/21818#issue-269468229. I verified this with @jridgewell's [sourcemaps tool](https://justin.ridgewell.name/source-map-visualization/#custom-choose).

With this, we see licences like this in `v0.js`...
```js
/*
 Copyright (C) 2014-2016 by Andrea Giammarchi - @WebReflection

Use of this source code is governed by a MIT-style
license that can be found in the LICENSE file or at
https://opensource.org/licenses/MIT.

*/
/*

 Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file or at
 https://developers.google.com/open-source/licenses/bsd
*/
```

... instead of like this...
```js
/*
 Copyright (C) 2014-2016 by Andrea Giammarchi - @WebReflection

Use of this source code is governed by a MIT-style
license that can be found in the LICENSE file or at
https://opensource.org/licenses/MIT.















*/
/*

 Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file or at
 https://developers.google.com/open-source/licenses/bsd


*/
```
Fixes #22076