### PR TITLE
✅ Fix carousel arrows non looping e2e test

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -20,7 +20,7 @@ import {
 } from './helpers';
 
 /** The total number of slides in the carousel */
-const SLIDE_COUNT = 7;
+const SLIDE_COUNT = 4;
 const pageWidth = 600;
 const pageHeight = 600;
 
@@ -58,7 +58,9 @@ describes.endtoend('AMP carousel arrows when non-looping', {
   });
 
   it('should hide the next arrow when going to the end', async() => {
-    // click to the end instead of using controller.scrollBy()
+    // TODO(estherkim): fix controller.scrollBy(); click to the end for now
+    // const el = await getScrollingElement(controller);
+    // await controller.scrollBy(el, {left: SLIDE_COUNT * pageWidth});
     let clicks = 0;
     while (clicks < SLIDE_COUNT) {
       await controller.click(nextArrow);

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -16,9 +16,7 @@
 
 import {
   getNextArrow,
-  getNextArrowSlot,
-  getPrevArrowSlot,
-  getScrollingElement,
+  getPrevArrow,
 } from './helpers';
 
 /** The total number of slides in the carousel */
@@ -34,9 +32,8 @@ describes.endtoend('AMP carousel arrows when non-looping', {
   environments: ['single', 'viewer-demo'],
 }, async env => {
   let controller;
+  let prevArrow;
   let nextArrow;
-  let prevArrowSlot;
-  let nextArrowSlot;
 
   function css(handle, name) {
     return controller.getElementCssValue(handle, name);
@@ -45,27 +42,30 @@ describes.endtoend('AMP carousel arrows when non-looping', {
   beforeEach(async() => {
     controller = env.controller;
 
-    prevArrowSlot = await getPrevArrowSlot(controller);
-    nextArrowSlot = await getNextArrowSlot(controller);
+    prevArrow = await getPrevArrow(controller);
     nextArrow = await getNextArrow(controller);
   });
 
   it('should have the arrows in the correct initial state', async() => {
-    await expect(css(prevArrowSlot, 'opacity')).to.equal('0');
-    await expect(css(nextArrowSlot, 'opacity')).to.equal('1');
+    await expect(css(prevArrow, 'opacity')).to.equal('0');
+    await expect(css(nextArrow, 'opacity')).to.equal('1');
   });
 
   it('should show the prev arrow when going to the first slide', async() => {
     await controller.click(nextArrow);
-    await expect(css(prevArrowSlot, 'opacity')).to.equal('1');
-    await expect(css(nextArrowSlot, 'opacity')).to.equal('1');
+    await expect(css(prevArrow, 'opacity')).to.equal('1');
+    await expect(css(nextArrow, 'opacity')).to.equal('1');
   });
 
   it('should hide the next arrow when going to the end', async() => {
-    const el = await getScrollingElement(controller);
-    await controller.scrollBy(el, {left: SLIDE_COUNT * pageWidth});
+    // click to the end instead of using controller.scrollBy()
+    let clicks = 0;
+    while (clicks < SLIDE_COUNT) {
+      await controller.click(nextArrow);
+      clicks++;
+    }
 
-    await expect(css(prevArrowSlot, 'opacity')).to.equal('1');
-    await expect(css(nextArrowSlot, 'opacity')).to.equal('0');
+    await expect(css(prevArrow, 'opacity')).to.equal('1');
+    await expect(css(nextArrow, 'opacity')).to.equal('0');
   });
 });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -30,7 +30,7 @@ describes.endtoend('Non-looping AMP carousel', {
   initialRect: {width: pageWidth, height: pageHeight},
 }, async env => {
   /** The total number of slides in the carousel */
-  const SLIDE_COUNT = 7;
+  const SLIDE_COUNT = 4;
   let controller;
 
   function prop(el, name) {

--- a/test/manual/amp-base-carousel/non-looping.amp.html
+++ b/test/manual/amp-base-carousel/non-looping.amp.html
@@ -22,9 +22,6 @@
     <amp-img src="./img/greengradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/bluegradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/orangegradient.png" layout="flex-item"></amp-img>
-    <amp-img src="./img/tealgradient.png" layout="flex-item"></amp-img>
-    <amp-img src="./img/lemonyellowgradient.png" layout="flex-item"></amp-img>
-    <amp-img src="./img/lilacgradient.png" layout="flex-item"></amp-img>
   </amp-base-carousel>
   <button on="tap:carousel-1.prev()">Prev</button>
   <button on="tap:carousel-1.next()">Next</button>


### PR DESCRIPTION
This test checks the opacity values of the next and previous carousel arrows when you are at the beginning of the carousel, in the middle, and at the end. Currently the test fails because it looks for `prevArrowSlot` and `nextArrowSlot` opacity values which doesn't always exist. 

This PR changes the test to look at the button elements instead. It also clicks instead of scrolls to get to the end of the carousel because `controller.scrollBy()` doesn't seem to work locally.

(incremental fix for #21986)

