### PR TITLE
🐛Propagate data-ad-host attribute to ad url param for amp-auto-ads.

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -195,6 +195,7 @@ class AdSenseNetworkConfig {
     return dict({
       'type': 'adsense',
       'data-ad-client': this.autoAmpAdsElement_.getAttribute('data-ad-client'),
+      'data-ad-host': this.autoAmpAdsElement_.getAttribute('data-ad-host'),
     });
   }
 


### PR DESCRIPTION
Simple fix to support revenue share in amp auto ads. data-ad-host is added to attributes obj before AdStrategy constructor is called [here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-auto-ads/0.1/amp-auto-ads.js#L82). 

Result: If data-ad-host="ca-foo-bar" is in <amp-auto-ads> then adsense ad request should have "host=ca-foo-bar" in url param