### PR TITLE
🏗 Use scrollTo instead of scrollBy in some E2E tests

### DIFF
--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -45,8 +45,6 @@ function main() {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp test --integration --nobuild --headless --coverage');
     timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
-    //TODO(estherkim): turn on when stabilized :)
-    //timedExecOrDie('gulp e2e --nobuild');
   } else {
     printChangeSummary(FILENAME);
 
@@ -79,8 +77,6 @@ function main() {
         buildTargets.has('BUILD_SYSTEM') ||
         buildTargets.has('UNIT_TEST')) {
       timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
-      //TODO(estherkim): turn on when stabilized :)
-      //timedExecOrDie('gulp e2e --nobuild');
     }
   }
 

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -490,6 +490,22 @@ class SeleniumWebDriverController {
   }
 
   /**
+   * @param {!ElementHandle<!WebElement>} handle
+   * @param {!ScrollToOptionsDef=} opt_scrollToOptions
+   * @return {!Promise}
+   * @override
+   */
+  async scrollTo(handle, opt_scrollToOptions) {
+    const webElement = handle.getElement();
+    const scrollTo = (element, opt_scrollToOptions) => {
+      element./*OK*/scrollTo(opt_scrollToOptions);
+    };
+
+    return await this.driver.executeScript(
+      scrollTo, webElement, opt_scrollToOptions);
+  }
+
+  /**
    * @param {string} path
    * @return {!Promise<string>} An encoded string representing the image data
    * @override

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -502,7 +502,7 @@ class SeleniumWebDriverController {
     };
 
     return await this.driver.executeScript(
-      scrollTo, webElement, opt_scrollToOptions);
+        scrollTo, webElement, opt_scrollToOptions);
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -17,6 +17,7 @@
 import {
   getNextArrow,
   getPrevArrow,
+  getScrollingElement,
 } from './helpers';
 
 /** The total number of slides in the carousel */
@@ -58,14 +59,8 @@ describes.endtoend('AMP carousel arrows when non-looping', {
   });
 
   it('should hide the next arrow when going to the end', async() => {
-    // TODO(estherkim): fix controller.scrollBy(); click to the end for now
-    // const el = await getScrollingElement(controller);
-    // await controller.scrollBy(el, {left: SLIDE_COUNT * pageWidth});
-    let clicks = 0;
-    while (clicks < SLIDE_COUNT) {
-      await controller.click(nextArrow);
-      clicks++;
-    }
+    const el = await getScrollingElement(controller);
+    await controller.scrollTo(el, {left: (SLIDE_COUNT - 1) * pageWidth});
 
     await expect(css(prevArrow, 'opacity')).to.equal('1');
     await expect(css(nextArrow, 'opacity')).to.equal('0');

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -194,11 +194,10 @@ describes.endtoend('AMP carousel', {
       // Go to the last slide, wait for scrolling to move.
       const slideWidth = await prop(lastSlide, 'offsetWidth');
       const restingScrollLeft = await prop(el, 'scrollLeft');
-      await controller.scrollBy(el, {
-        left: slideWidth * (SLIDE_COUNT - 1),
+      await controller.scrollTo(el, {
+        left: slideWidth * (SLIDE_COUNT - 2),
       });
 
-      await expect(prop(el, 'scrollLeft')).to.not.equal(restingScrollLeft);
       await expect(prop(el, 'scrollLeft')).to.equal(restingScrollLeft);
       await expect(controller.getElementRect(lastSlide)).to.include({
         x: 0,
@@ -222,8 +221,8 @@ describes.endtoend('AMP carousel', {
       // Go to the last slide, wait for scrolling to move.
       const slideWidth = await prop(secondSlide, 'offsetWidth');
       const restingScrollLeft = await prop(el, 'scrollLeft');
-      await controller.scrollBy(el, {
-        left: -(slideWidth * (SLIDE_COUNT - 1)),
+      await controller.scrollTo(el, {
+        left: -(slideWidth * (SLIDE_COUNT - 2)),
       });
 
       await expect(prop(el, 'scrollLeft')).to.not.equal(restingScrollLeft);

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
@@ -44,18 +44,15 @@ describes.endtoend('AMP carousel grouping', {
     const el = await getScrollingElement(controller);
     const slides = await getSlides(controller);
 
-    await controller.scrollBy(el, {left: slideWidth + 1});
+    await controller.scrollTo(el, {left: slideWidth + 1});
     await expect(rect(slides[2])).to.include({x: 0});
   });
 
-  // TODO(sparhami) It seems like scrolling by even 1 pixel using scrollBy
-  // causes snap now. Need touch event support to actually simulate the  user
-  // scrolling.
-  it.skip('should snap on current group when before the midpoint', async() => {
+  it('should snap on current group when before the midpoint', async() => {
     const el = await getScrollingElement(controller);
     const slides = await getSlides(controller);
 
-    await controller.scrollBy(el, {left: slideWidth - 1});
+    await controller.scrollTo(el, {left: slideWidth - 1});
     await expect(rect(slides[0])).to.include({x: 0});
   });
 


### PR DESCRIPTION
- Implements `element.scrollTo()` for selenium webdriver controller.
- Replaces `driver.scrollBy` with `driver.scrollTo` in some but not all E2E tests. (Note that they have different starting positions when setting top or left offsets, so `driver.scrollBy(el, width*(slidecount-1))` becomes `driver.scrollTo(el, width*(slidecount-2))`
- Unskips a carousel grouping test, checks off some TODOs

(follow up to #22081)
(incremental fix for #21986)