### PR TITLE
✨ Support ability to 'disable' an item on amp-autocomplete.

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -22,6 +22,12 @@
     input[name=favoriteState] {
       width: 2em;
     }
+    .out-of-stock {
+      text-align: right;
+      text-transform: uppercase;
+      font: 8pt 'Arial', sans-serif;
+      right: 0;
+    }
   </style>
   <script>
       (self.AMP=self.AMP||[]).push((AMP) => {
@@ -573,43 +579,32 @@
         </div>
     </form>
 
-    <h2>'Disable' attribute</h2>
+    <h2>'Disabled' attribute</h2>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank">
       <amp-autocomplete filter="substring" min-characters="0" [src]="manualFilterData" >
-        <input type="text" on="input-debounced:AMP.setState({ manualFilterData: event.value.length == 0 ? 
-          initialInventory : { 'items' : [ 'apple', 'orange', 'banana', 'avocado' ]} })">
+        <input type="text">
           <amp-state id="initialInventory">
               <script type="application/json">
-                { "items" : [ { "value" : "Doctor Approved", 
+                { "items" : [ { "value" : "apple",
                                 "disabled" : "true" },
-                              { "value" : "apple",
-                                "trending" : "true" },
-                              { "value" : "orange",
-                                "trending" : "true" },
-                              { "value" : "Trending Fruit", 
-                                "disabled" : "true" },
+                              { "value" : "orange" },
                               { "value" : "avocado",
-                                "trending" : "true" },
-                              { "value" : "banana",
-                                "trending" : "true" } ] }
+                                "disabled" : "true" },
+                              { "value" : "banana" } ] }
               </script>
           </amp-state>
         <template type="amp-mustache">
             {{#disabled}}
               <div disabled>
-                <b>{{value}}</b>
+                {{value}}
+                <span class="out-of-stock">out of stock</span>
               </div>
             {{/disabled}}
-            {{#trending}}
+            {{^disabled}}
               <div data-value="{{value}}">
-                ✨ {{value}} 
+                {{value}}
               </div>
-            {{/trending}}
-            {{^value}}
-              <div data-value="{{.}}">
-                {{.}}
-              </div>
-            {{/value}}
+            {{/disabled}}
         </template> 
       </amp-autocomplete>
       <input name="submit-button" type="submit" value="Submit">

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -577,25 +577,29 @@
     <form method="post" action-xhr="/form/echo-json/post" target="_blank">
       <amp-autocomplete filter="substring" min-characters="0" [src]="manualFilterData" >
         <input type="text" on="input-debounced:AMP.setState({ manualFilterData: event.value.length == 0 ? 
-          initialInventory : { 'items' : [ 'apple', 'orange', 'banana' ]} })">
+          initialInventory : { 'items' : [ 'apple', 'orange', 'banana', 'avocado' ]} })">
           <amp-state id="initialInventory">
               <script type="application/json">
-                { "items" : [ { "value" : "Recommended Fruit", 
-                                "sectionHeader": "true" },
+                { "items" : [ { "value" : "Doctor Approved", 
+                                "disabled" : "true" },
                               { "value" : "apple",
                                 "trending" : "true" },
                               { "value" : "orange",
+                                "trending" : "true" },
+                              { "value" : "Trending Fruit", 
+                                "disabled" : "true" },
+                              { "value" : "avocado",
                                 "trending" : "true" },
                               { "value" : "banana",
                                 "trending" : "true" } ] }
               </script>
           </amp-state>
         <template type="amp-mustache">
-            {{#sectionHeader}}
+            {{#disabled}}
               <div disabled>
                 <b>{{value}}</b>
               </div>
-            {{/sectionHeader}}
+            {{/disabled}}
             {{#trending}}
               <div data-value="{{value}}">
                 ✨ {{value}} 

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -12,11 +12,13 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <style amp-custom>
+    body {
+        padding: 15px;
+    }
     .custom-population {
         padding-top: 4px;
         font: 8pt 'Courier New', Courier, monospace;
     }
-
     input[name=favoriteState] {
       width: 2em;
     }
@@ -569,6 +571,44 @@
                 <div>Here are the results for the search: {{term}}</div>
             </template>
         </div>
+    </form>
+
+    <h2>'Disable' attribute</h2>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0" [src]="manualFilterData" >
+        <input type="text" on="input-debounced:AMP.setState({ manualFilterData: event.value.length == 0 ? 
+          initialInventory : { 'items' : [ 'apple', 'orange', 'banana' ]} })">
+          <amp-state id="initialInventory">
+              <script type="application/json">
+                { "items" : [ { "value" : "Recommended Fruit", 
+                                "sectionHeader": "true" },
+                              { "value" : "apple",
+                                "trending" : "true" },
+                              { "value" : "orange",
+                                "trending" : "true" },
+                              { "value" : "banana",
+                                "trending" : "true" } ] }
+              </script>
+          </amp-state>
+        <template type="amp-mustache">
+            {{#sectionHeader}}
+              <div disabled>
+                <b>{{value}}</b>
+              </div>
+            {{/sectionHeader}}
+            {{#trending}}
+              <div data-value="{{value}}">
+                ✨ {{value}} 
+              </div>
+            {{/trending}}
+            {{^value}}
+              <div data-value="{{.}}">
+                {{.}}
+              </div>
+            {{/value}}
+        </template> 
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     </form>
 </body>
 </html>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -581,30 +581,28 @@
 
     <h2>'Disabled' attribute</h2>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="0" [src]="manualFilterData" >
+      <amp-autocomplete filter="substring" min-characters="0">
         <input type="text">
-          <amp-state id="initialInventory">
-              <script type="application/json">
-                { "items" : [ { "value" : "apple",
-                                "disabled" : "true" },
-                              { "value" : "orange" },
-                              { "value" : "avocado",
-                                "disabled" : "true" },
-                              { "value" : "banana" } ] }
-              </script>
-          </amp-state>
+          <script type="application/json">
+            { "items" : [ { "value" : "apple",
+                            "disabled" : "true" },
+                          { "value" : "orange" },
+                          { "value" : "avocado",
+                            "disabled" : "true" },
+                          { "value" : "banana" } ] }
+          </script>
         <template type="amp-mustache">
-            {{#disabled}}
-              <div disabled>
-                {{value}}
-                <span class="out-of-stock">out of stock</span>
-              </div>
-            {{/disabled}}
-            {{^disabled}}
-              <div data-value="{{value}}">
-                {{value}}
-              </div>
-            {{/disabled}}
+          {{#disabled}}
+            <div disabled>
+              {{value}}
+              <span class="out-of-stock">out of stock</span>
+            </div>
+          {{/disabled}}
+          {{^disabled}}
+            <div data-value="{{value}}">
+              {{value}}
+            </div>
+          {{/disabled}}
         </template> 
       </amp-autocomplete>
       <input name="submit-button" type="submit" value="Submit">

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -593,7 +593,7 @@
           </script>
         <template type="amp-mustache">
           {{#disabled}}
-            <div disabled>
+            <div data-disabled>
               {{value}}
               <span class="out-of-stock">out of stock</span>
             </div>

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -72,5 +72,5 @@ amp-autocomplete > input {
 }
 
 .i-amphtml-autocomplete-item[disabled] {
-  color: silver;
+  color: rgba(0,0,0,.33);
 }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -70,3 +70,7 @@ amp-autocomplete > input {
 .i-amphtml-autocomplete-item-active:not([disabled]) {
   background-color: rgba(0,0,0,.15); /* default-ui-light-gray */
 }
+
+.i-amphtml-autocomplete-item[disabled] {
+  color: silver;
+}

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -63,10 +63,10 @@ amp-autocomplete > input {
   border-radius: 0px 0px 4px 4px; /* default-ui-border-radius */
 }
 
-.i-amphtml-autocomplete-item:hover {
+.i-amphtml-autocomplete-item:hover:not([disabled]) {
   background-color: rgba(0,0,0,.15); /* default-ui-light-gray */
 }
 
-.i-amphtml-autocomplete-item-active {
+.i-amphtml-autocomplete-item-active:not([disabled]) {
   background-color: rgba(0,0,0,.15); /* default-ui-light-gray */
 }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.css
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.css
@@ -63,14 +63,14 @@ amp-autocomplete > input {
   border-radius: 0px 0px 4px 4px; /* default-ui-border-radius */
 }
 
-.i-amphtml-autocomplete-item:hover:not([disabled]) {
+.i-amphtml-autocomplete-item:hover:not([data-disabled]) {
   background-color: rgba(0,0,0,.15); /* default-ui-light-gray */
 }
 
-.i-amphtml-autocomplete-item-active:not([disabled]) {
+.i-amphtml-autocomplete-item-active:not([data-disabled]) {
   background-color: rgba(0,0,0,.15); /* default-ui-light-gray */
 }
 
-.i-amphtml-autocomplete-item[disabled] {
+.i-amphtml-autocomplete-item[data-disabled] {
   color: rgba(0,0,0,.33);
 }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -182,8 +182,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
           /** @type {!JsonObject} */({})).then(
           renderedEl => {
             userAssert(renderedEl.hasAttribute('data-value') ||
-              renderedEl.hasAttribute('disabled'),
-            `${TAG} requires a "data-value" or "disabled" attribute.`);
+              renderedEl.hasAttribute('data-disabled'),
+            `${TAG} requires a "data-value" or "data-disabled" attribute.`);
           });
     }
 
@@ -393,7 +393,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       renderPromise = this.templates_.renderTemplateArray(this.templateElement_,
           filteredData).then(renderedChildren => {
         renderedChildren.map(child => {
-          if (child.hasAttribute('disabled')) {
+          if (child.hasAttribute('data-disabled')) {
             child.setAttribute('aria-disabled', 'true');
           }
           child.classList.add('i-amphtml-autocomplete-item');
@@ -652,7 +652,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   selectItem_(element) {
-    if (element === null || element.hasAttribute('disabled')) {
+    if (element === null || element.hasAttribute('data-disabled')) {
       return;
     }
     this.inputElement_.value = this.userInput_ =
@@ -688,6 +688,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const keyUpWhenNoneActive = this.activeIndex_ === -1 && delta < 0;
     const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
     const enabledElements = this.getEnabledItems_();
+    if (enabledElements.length === 0) {
+      return Promise.resolve();
+    }
     const activeIndex = mod(index, enabledElements.length);
     const newActiveElement = enabledElements[activeIndex];
     this.inputElement_.value = newActiveElement.getAttribute('data-value');
@@ -714,13 +717,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /** Returns all item elements in the results container that do not have the
-   * 'disabled' attribute.
+   * 'data-disabled' attribute.
    * @return {!NodeList}
    * @private
    */
   getEnabledItems_() {
     return this.container_.querySelectorAll(
-        '.i-amphtml-autocomplete-item:not([disabled])');
+        '.i-amphtml-autocomplete-item:not([data-disabled])');
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -181,8 +181,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.templates_.renderTemplate(this.templateElement_,
           /** @type {!JsonObject} */({})).then(
           renderedEl => {
-            userAssert(renderedEl.hasAttribute('data-value'),
-                `${TAG} requires the "data-value" attribute on <template>.`);
+            userAssert(renderedEl.hasAttribute('data-value') ||
+              renderedEl.hasAttribute('disabled'),
+            `${TAG} requires a "data-value" or "disabled" attribute.`);
           });
     }
 
@@ -648,7 +649,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   selectItem_(element) {
-    if (element === null) {
+    if (element === null || element.hasAttribute('disabled')) {
       return;
     }
     this.inputElement_.value = this.userInput_ =
@@ -685,6 +686,16 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const index = keyUpWhenNoneActive ? delta : this.activeIndex_ + delta;
     const activeIndex = mod(index, this.container_.children.length);
     const newActiveElement = this.container_.children[activeIndex];
+
+    // Mark the next element as active if the current is 'disabled'
+    if (newActiveElement.hasAttribute('disabled')) {
+      if (this.container_.children.length === 1) {
+        return;
+      }
+      const newDelta = delta < 0 ? delta - 1 : delta + 1;
+      return this.updateActiveItem_(newDelta);
+    }
+
     this.inputElement_.value = newActiveElement.getAttribute('data-value');
 
     // Element visibility logic

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -665,7 +665,7 @@ describes.realWin('amp-autocomplete unit tests', {
       expect(impl.container_.children.length).to.equal(3);
       expect(impl.getEnabledItems_().length).to.equal(2);
       expect(impl.container_.children[2].hasAttribute(
-        'aria-disabled')).to.be.true;
+          'aria-disabled')).to.be.true;
     });
   });
 });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -642,4 +642,30 @@ describes.realWin('amp-autocomplete unit tests', {
           'i-amphtml-autocomplete-item-active');
     });
   });
+
+  it('should not select disabled items', () => {
+    const disabledItem = doc.createElement('div');
+    disabledItem.setAttribute('disabled', '');
+    expect(impl.selectItem_(disabledItem)).to.be.undefined;
+  });
+
+  it('should not return disabled items from getEnabledItems_()', () => {
+    impl.templateElement_ = doc.createElement('template');
+    const sourceData = ['apple', 'mango', 'pear'];
+    const renderedChildren = sourceData.map(item => {
+      const renderedChild = doc.createElement('div');
+      renderedChild.setAttribute('data-value', item);
+      return renderedChild;
+    });
+    renderedChildren[2].setAttribute('disabled', '');
+    sandbox.stub(impl.templates_, 'renderTemplateArray').returns(
+        Promise.resolve(renderedChildren));
+
+    return impl.renderResults_(sourceData, impl.container_).then(() => {
+      expect(impl.container_.children.length).to.equal(3);
+      expect(impl.getEnabledItems_().length).to.equal(2);
+      expect(impl.container_.children[2].hasAttribute(
+        'aria-disabled')).to.be.true;
+    });
+  });
 });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -645,7 +645,7 @@ describes.realWin('amp-autocomplete unit tests', {
 
   it('should not select disabled items', () => {
     const disabledItem = doc.createElement('div');
-    disabledItem.setAttribute('disabled', '');
+    disabledItem.setAttribute('data-disabled', '');
     expect(impl.selectItem_(disabledItem)).to.be.undefined;
   });
 
@@ -657,7 +657,7 @@ describes.realWin('amp-autocomplete unit tests', {
       renderedChild.setAttribute('data-value', item);
       return renderedChild;
     });
-    renderedChildren[2].setAttribute('disabled', '');
+    renderedChildren[2].setAttribute('data-disabled', '');
     sandbox.stub(impl.templates_, 'renderTemplateArray').returns(
         Promise.resolve(renderedChildren));
 

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -217,6 +217,24 @@
       </template>
     </amp-autocomplete> 
 
+    <!-- Valid: amp-component with remote data and rich content template -->
+    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
+      <input type="text">
+      <template type="amp-mustache" id="amp-template-default">
+        {{#disabled}}
+          <div disabled>
+            <b>{{value}}</b>
+          </div>
+        {{/disabled}}
+        {{^disabled}}
+        <div class="city-item" data-value="{{value}}">
+            <div>{{value}}</div>
+            <div class="custom-population">Population: {{population}}</div>        
+        </div>
+        {{/disabled}}
+      </template>
+    </amp-autocomplete> 
+
     <!-- Valid: amp-component with static data and template attr -->
     <amp-autocomplete template="my-template-id">
       <input type="text">

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -222,7 +222,7 @@
       <input type="text">
       <template type="amp-mustache" id="amp-template-default">
         {{#disabled}}
-          <div disabled>
+          <div data-disabled>
             <b>{{value}}</b>
           </div>
         {{/disabled}}

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -218,6 +218,24 @@ FAIL
 |        </template>
 |      </amp-autocomplete> 
 |
+|      <!-- Valid: amp-component with remote data and rich content template -->
+|      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
+|        <input type="text">
+|        <template type="amp-mustache" id="amp-template-default">
+|          {{#disabled}}
+|            <div disabled>
+|              <b>{{value}}</b>
+|            </div>
+|          {{/disabled}}
+|          {{^disabled}}
+|          <div class="city-item" data-value="{{value}}">
+|              <div>{{value}}</div>
+|              <div class="custom-population">Population: {{population}}</div>        
+|          </div>
+|          {{/disabled}}
+|        </template>
+|      </amp-autocomplete> 
+|
 |      <!-- Valid: amp-component with static data and template attr -->
 |      <amp-autocomplete template="my-template-id">
 |        <input type="text">
@@ -256,7 +274,7 @@ FAIL
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:256:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:274:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
 |          <input type="text">
 |          <script type="application/json"> {} </script>
 |      </amp-autocomplete>  
@@ -264,7 +282,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:256:4 The attribute 'w
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:262:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete with src attribute'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:280:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete with src attribute'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
 |          <input type="text">
 |          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -272,7 +290,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:262:4 The specified la
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:268:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:286:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="text">
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -280,14 +298,14 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:268:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:274:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:292:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="text">
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:279:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="text">
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -295,7 +313,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:279:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:285:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:303:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="text">
 |      </amp-autocomplete>
 |    </form>
@@ -303,7 +321,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:285:4 The attribute 'f
 |    <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
 |    <amp-autocomplete>
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:291:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:309:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input type="text">
 |      <script type="application/json"> {} </script>
 |    </amp-autocomplete>
@@ -311,7 +329,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:291:2 The tag 'amp-aut
 |    <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
 |    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:315:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input type="text">
 |    </amp-autocomplete>
 |

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -223,7 +223,7 @@ FAIL
 |        <input type="text">
 |        <template type="amp-mustache" id="amp-template-default">
 |          {{#disabled}}
-|            <div disabled>
+|            <div data-disabled>
 |              <b>{{value}}</b>
 |            </div>
 |          {{/disabled}}

--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -106,14 +106,3 @@ tags: {  # amp-autocomplete JSON
     }
   }
 }
-tags: {  # amp-autocomplete disabled
-  html_format: AMP
-  tag_name: "DIV"
-  spec_name: "amp-autocomplete disabled"
-  requires_extension: "amp-autocomplete"
-  mandatory_ancestor: "AMP-AUTOCOMPLETE"
-  attrs: {
-    name: "disabled"
-    value: ""
-  }
-}

--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -106,3 +106,14 @@ tags: {  # amp-autocomplete JSON
     }
   }
 }
+tags: {  # amp-autocomplete disabled
+  html_format: AMP
+  tag_name: "DIV"
+  spec_name: "amp-autocomplete disabled"
+  requires_extension: "amp-autocomplete"
+  mandatory_ancestor: "AMP-AUTOCOMPLETE"
+  attrs: {
+    name: "disabled"
+    value: ""
+  }
+}


### PR DESCRIPTION
The ability to `disable` an item on `amp-autocomplete` means to be able to suggest it among the list of results but not allow a user to keyboard navigate to it or select it from the list. This is to suggest that the item is not currently available for whatever reason. 

This change recognizes the `data-disabled` attribute on amp-autocomplete. This is only supported through Json datatypes and templating.

- Implement this in a way that accounts for item selection and `activeItem` highlighting through keyboard navigation.
- Add an example of using this feature
- Add validator and unit tests for this feature
- Modify relevant CSS selectors