### PR TITLE
use the `rename_prefix_namespace` flag instead of setting it in java

### DIFF
--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -103,9 +103,11 @@ exports.getFlags = function(config) {
     source_map_location_mapping: ['|/'],
     //new_type_inf: true,
     language_in: 'ES6',
-    // This is important for exports across js modules. Because of the async
-    // loading nature of amp scripts we export everything through the `_`
-    // namespace to be referenced across `chunks`.
+    // By default closure puts all of the public exports on the global, but
+    // because of the wrapper modules (to mitigate async loading of scripts)
+    // that we add to the js binaries this prevents other js binaries from
+    // accessing the symbol, we remedy this by attaching all public exports
+    // to `_` and everything imported across modules is is accessed through `_`.
     rename_prefix_namespace: '_',
     language_out: config.language_out || 'ES5',
     module_output_path_prefix: config.writeTo || 'out/',

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -103,6 +103,10 @@ exports.getFlags = function(config) {
     source_map_location_mapping: ['|/'],
     //new_type_inf: true,
     language_in: 'ES6',
+    // This is important for exports across js modules. Because of the async
+    // loading nature of amp scripts we export everything through the `_`
+    // namespace to be referenced across `chunks`.
+    rename_prefix_namespace: '_',
     language_out: config.language_out || 'ES5',
     module_output_path_prefix: config.writeTo || 'out/',
     module_resolution: 'NODE',

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -90,9 +90,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setExtractPrototypeMemberDeclarations(true);
     options.setSmartNameRemoval(true);
     options.optimizeCalls = true;
-    if (single_file_compilation) {
-      options.renamePrefixNamespace = "_";
-    } else {
+    if (!single_file_compilation) {
       // Have to turn this off because we cannot know whether sub classes
       // might override a method. In the future this might be doable
       // with using a more complete extern file instead.


### PR DESCRIPTION
to try and remove as much custom settings in the java code, set `rename_prefix_namespace` through the config flag instead.