### PR TITLE
🐛 Add safe zone in screen edges to prevent blocking navigation

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -46,7 +46,7 @@ import {LoadingSpinner} from './loading-spinner';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
-import {VideoEvents, delegateAutoplay, delegateAutoplay} from '../../../src/video-interface';
+import {VideoEvents, delegateAutoplay} from '../../../src/video-interface';
 import {
   childElement,
   closestAncestorElementBySelector,
@@ -57,7 +57,6 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {debounce} from '../../../src/utils/rate-limit';
-
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -533,6 +533,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     this.mutateElement(() => {
       componentEls.forEach(el => {
+        userAssert(
+          el.getAttribute('layout') === 'fixed',
+          'Embedded ' + 'components inside amp-story must use layout="fixed".'
+        );
         el.classList.add('i-amphtml-embedded-component');
       });
     });

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -46,7 +46,7 @@ import {LoadingSpinner} from './loading-spinner';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
-import {VideoEvents, delegateAutoplay} from '../../../src/video-interface';
+import {VideoEvents, delegateAutoplay, delegateAutoplay} from '../../../src/video-interface';
 import {
   childElement,
   closestAncestorElementBySelector,
@@ -57,6 +57,7 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {debounce} from '../../../src/utils/rate-limit';
+
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
@@ -533,10 +534,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     this.mutateElement(() => {
       componentEls.forEach(el => {
-        userAssert(
-          el.getAttribute('layout') === 'fixed',
-          'Embedded ' + 'components inside amp-story must use layout="fixed".'
-        );
         el.classList.add('i-amphtml-embedded-component');
       });
     });

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -43,11 +43,11 @@ const NEXT_SCREEN_AREA_RATIO = 0.75;
 const PREVIOUS_SCREEN_AREA_RATIO = 0.25;
 
 /**
- * Percentage of the screen considered edge.
+ * Protected edges of the screen in pixels.
  * @const {number}
  * @private
  */
-const SCREEN_EDGE_PERCENT = 0.15;
+const PROTECTED_SCREEN_EDGE_PX = 48;
 
 const INTERACTIVE_EMBEDDED_COMPONENTS_SELECTORS = Object.values(
   interactiveElementsSelectors()
@@ -493,12 +493,7 @@ class ManualAdvancement extends AdvancementConfig {
     let valid = true;
     let tagName;
 
-    if (
-      this.isInScreenEdge_(event, pageRect) &&
-      this.storeService_.get(StateProperty.INTERACTIVE_COMPONENT_STATE)
-        .state !== EmbeddedComponentState.EXPANDED
-    ) {
-      event.preventDefault();
+    if (this.isInScreenSideEdge_(event, pageRect)) {
       return false;
     }
 
@@ -529,11 +524,9 @@ class ManualAdvancement extends AdvancementConfig {
    * @private
    */
   isInScreenSideEdge_(event, pageRect) {
-    const edgeOfScreen = pageRect.width * SCREEN_EDGE_PERCENT;
-
     return (
-      event.clientX <= edgeOfScreen ||
-      event.clientX >= pageRect.width - edgeOfScreen
+      event.clientX <= PROTECTED_SCREEN_EDGE_PX ||
+      event.clientX >= pageRect.width - PROTECTED_SCREEN_EDGE_PX
     );
   }
 
@@ -566,7 +559,7 @@ class ManualAdvancement extends AdvancementConfig {
    */
   maybePerformNavigation_(event) {
     const target = dev().assertElement(event.target);
-    const pageRect = this.element_./*OK*/ getBoundingClientRect();
+    const pageRect = this.element_.getLayoutBox();
 
     if (this.isHandledByEmbeddedComponent_(event, pageRect)) {
       event.preventDefault();

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -43,7 +43,8 @@ const NEXT_SCREEN_AREA_RATIO = 0.75;
 const PREVIOUS_SCREEN_AREA_RATIO = 0.25;
 
 /**
- * Protected edges of the screen in pixels.
+ * Protected edges of the screen in pixels. When tapped on these areas, we will
+ * always perform navigation. Even if a clickable element is there.
  * @const {number}
  * @private
  */
@@ -517,7 +518,7 @@ class ManualAdvancement extends AdvancementConfig {
   }
 
   /**
-   * Checks if click was inside of one of the horizontal edges of the screen.
+   * Checks if click was inside of one of the side edges of the screen.
    * @param {!Event} event
    * @param {!ClientRect} pageRect
    * @return {boolean}


### PR DESCRIPTION
Adds some safeguards for the use of embedded components:
* If user clicks towards the vertical edges of the screen, no tooltip will be shown.