### PR TITLE
🐛 amp inabox: Added the inabox `height: auto !important` experiment to the prod config

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -6,7 +6,8 @@
     "ampdoc-shell",
     "disable-amp-story-desktop",
     "inabox-viewport-friendly",
-    "linker-meta-opt-in"
+    "linker-meta-opt-in",
+    "inabox-remove-height-auto"
   ],
   "allow-url-opt-in": [
     "pump-early-frame",


### PR DESCRIPTION
relates to #22059

Follow up to #22084 . This allows doc level opt in to the new experiment for removing `height: auto !important` for amp4ads.

cc @jeffkaufman @keithwrightbos We'd want to roll out this experiment at 0% and slowly roll out to 100%. 😄 Ensuring their is no drop in revenue, or anything like that.