### PR TITLE
Update the select event on amp-autocomplete

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -29,6 +29,22 @@
 </head>
 <body>
     <h1>Autocomplete</h1>
+    <h2>Select Event</h2>
+    <p>min-characters = 0</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json"
+        on="select:AMP.setState({inputSelect: event.value})">
+          <input type="text" name="input2" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
+    <div submit-success>
+        <template type="amp-mustache">
+            Success! {{input2}}
+        </template>
+    </div>
+    </form>
+    <p [text]="'Hello ' + inputSelect">Hello World</p>
+
     <h2>Disable browser autofill</h2>
     <p>form has no autocomplete attr</p>
     <form method="post" action-xhr="/form/echo-json/post" target="_blank">

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -789,8 +789,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
         });
       case Keys.TAB:
         if (this.activeElement_) {
-          this.fireSelectEvent_(this.userInput_ =
-            this.inputElement_.value);
+          this.userInput_ = this.inputElement_.value;
+          this.fireSelectEvent_(this.userInput_);
         }
         return Promise.resolve();
       default:

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -665,7 +665,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   fireSelectEvent_(value) {
     const name = 'select';
     const selectEvent = createCustomEvent(this.win,
-        `amp-autocomplete.${name}`, /** @type {!JsonObject} */{value});
+        `amp-autocomplete.${name}`, /** @type {!JsonObject} */({value}));
     this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
   }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -665,7 +665,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   fireSelectEvent_(value) {
     const name = 'select';
     const selectEvent = createCustomEvent(this.win,
-        `amp-autocomplete.${name}`, {value});
+        `amp-autocomplete.${name}`, /** @type {!JsonObject} */{value});
     this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
   }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -665,7 +665,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   fireSelectEvent_(value) {
     const name = 'select';
     const selectEvent = createCustomEvent(this.win,
-        `amp-autocomplete.${name}`, value);
+        `amp-autocomplete.${name}`, {value});
     this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
   }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -788,8 +788,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
           this.toggleResults_(false);
         });
       case Keys.TAB:
-        this.fireSelectEvent_(this.userInput_ =
-          this.inputElement_.value);
+        if (this.activeElement_) {
+          this.fireSelectEvent_(this.userInput_ =
+            this.inputElement_.value);
+        }
         return Promise.resolve();
       default:
         return Promise.resolve();

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -787,6 +787,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
           this.displayUserInput_();
           this.toggleResults_(false);
         });
+      case Keys.TAB:
+        this.fireSelectEvent_(this.userInput_ =
+          this.inputElement_.value);
+        return Promise.resolve();
       default:
         return Promise.resolve();
     }

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -521,6 +521,19 @@ describes.realWin('amp-autocomplete unit tests', {
     });
   });
 
+  it('should call keyDownHandler_() on Tab', () => {
+    const event = {key: Keys.TAB};
+    impl.inputElement_.value = 'expected';
+    expect(impl.userInput_).not.to.equal(impl.inputElement_.value);
+    const fireEventSpy = sandbox.spy(impl, 'fireSelectEvent_');
+    return element.layoutCallback().then(() => {
+      return impl.keyDownHandler_(event);
+    }).then(() => {
+      expect(impl.userInput_).to.equal(impl.inputElement_.value);
+      expect(fireEventSpy).to.have.been.calledWith(impl.userInput_);
+    });
+  });
+
   it('should call keyDownHandler_() and fallthrough on any other key', () => {
     const event = {key: Keys.LEFT_ARROW};
     return element.layoutCallback().then(() => {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -524,6 +524,7 @@ describes.realWin('amp-autocomplete unit tests', {
   it('should call keyDownHandler_() on Tab', () => {
     const event = {key: Keys.TAB};
     impl.inputElement_.value = 'expected';
+    impl.activeElement_ = doc.createElement('div');
     expect(impl.userInput_).not.to.equal(impl.inputElement_.value);
     const fireEventSpy = sandbox.spy(impl, 'fireSelectEvent_');
     return element.layoutCallback().then(() => {

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -127,7 +127,7 @@ Read more about [AMP Actions and Events](../../spec/amp-actions-and-events.md).
 <table>
   <tr>
     <td width="40%"><strong>select</strong></td>
-    <td><code>amp-autocomplete</code> triggers the <code>select</code> event when the user selects an option via click, tap, keyboard navigation or accepting typeahead.
+    <td><code>amp-autocomplete</code> triggers the <code>select</code> event when the user selects an option via click, tap, keyboard navigation or accepting typeahead. It also fires the <code>select</code> event if a user keyboard navigates to an item and Tabs away from the input field.
     <code>event</code> contains the <code>value</code> attribute value of the selected element.</td>
   </tr>
 

--- a/src/utils/key-codes.js
+++ b/src/utils/key-codes.js
@@ -38,4 +38,5 @@ export const Keys = {
   UP_ARROW: 'ArrowUp',
   RIGHT_ARROW: 'ArrowRight',
   DOWN_ARROW: 'ArrowDown',
+  TAB: 'Tab',
 };


### PR DESCRIPTION
- Update the `select` event on `amp-autocomplete` to contain the selected value in the `event.value` property.
- Fire the `select` event on `Tab` with the active highlighted item if there is one
- Add an example that listens to the `select` event
- Add the `Tab` key in common `key-codes.js`