### PR TITLE
🌐 Support RTL inputs and datasets on amp-autocomplete

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -868,7 +868,6 @@ amp-autocomplete {
 }
 
 amp-autocomplete > input {
-  text-align: start !important;
   padding: .5rem; /* default-ui-space-large */
   border: 1px solid rgba(0,0,0,.33) /* default-ui-med-gray */
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -868,6 +868,7 @@ amp-autocomplete {
 }
 
 amp-autocomplete > input {
+  text-align: start !important;
   padding: .5rem; /* default-ui-space-large */
   border: 1px solid rgba(0,0,0,.33) /* default-ui-med-gray */
 }

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -240,20 +240,34 @@
         target="_blank">
         <fieldset>
             <label>
-                <span>Your name</span>
-                <amp-autocomplete filter="substring" min-characters="0" max-entries="2">
-                    <input type="text" name="name" required>
+                <span>Your favorite color (in Arabic)</span>
+                <amp-autocomplete filter="substring" min-characters="0">
+                    <input type="text" required>
                     <script type="application/json">
-                        { "items" : ["hello a", "hello b", "hello c"] }
+                        { "items" : [ 
+                          "أبيض", "أسود", "أحمر", "أصفر",
+                          "أخضر", "أزرق", "بني", "برتقالى"]
+                        }
+                    </script>
+                </amp-autocomplete>
+            </label><br>
+            <label>
+                <span>Your favorite color (in English)</span>
+                <amp-autocomplete filter="prefix" min-characters="0">
+                    <input type="text" required>
+                    <script type="application/json">
+                        { "items" : ["white", "black", "red", "yellow",
+                        "green", "blue", "brown", "orange"] }
                     </script>
                 </amp-autocomplete>
             </label>
             <label>
-                <span>Your email</span>
-                <amp-autocomplete filter="prefix" min-characters="3">
-                    <input type="text" name="email" required>
+                <span>Your favorite color (in Arabic and English)</span>
+                <amp-autocomplete filter="prefix" min-characters="0">
+                    <input type="text" required>
                     <script type="application/json">
-                        { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
+                        { "items" : ["أبيض", "white", "أسود", "black", "أحمر", "red", "أصفر", "yellow", "أخضر", 
+                        "green", "أزرق", "blue", "بني", "brown", "برتقالى", "orange"] }
                     </script>
                 </amp-autocomplete>
             </label>

--- a/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
+++ b/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
@@ -34,6 +34,13 @@
         { "items" : ["apple", "banana", "orange"] }
       </script>
     </amp-autocomplete>
+
+    <amp-autocomplete id="autocomplete-rtl" filter="substring" min-characters="0">
+        <input type="text" id="input-rtl">
+        <script type="application/json">
+          { "items" : ["تفاحة", "موز", "برتقال"] }
+        </script>
+      </amp-autocomplete>
     <input type="submit" value="Submit">
   </form>
 </body>

--- a/examples/visual-tests/amp-autocomplete/amp-autocomplete.js
+++ b/examples/visual-tests/amp-autocomplete/amp-autocomplete.js
@@ -23,4 +23,9 @@ module.exports = {
     await page.tap('input#input1');
     await verifySelectorsVisible(page, name, ['amp-autocomplete#autocomplete1 > .i-amphtml-autocomplete-results']);
   },
+
+  'tap input-rtl to focus and display results': async (page, name) => {
+    await page.tap('input#input-rtl');
+    await verifySelectorsVisible(page, name, ['amp-autocomplete#autocomplete-rtl > .i-amphtml-autocomplete-results']);
+  },
 };

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -165,6 +165,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const inputType = this.inputElement_.getAttribute('type');
     userAssert(inputType === 'text' || inputType === 'search',
         `${TAG} requires the "type=text|search" attribute on <input>`);
+    this.inputElement_.setAttribute('dir', 'auto');
 
     userAssert(this.inputElement_.form, `${TAG} should be inside a <form> tag`);
     if (this.inputElement_.form.hasAttribute('autocomplete')) {
@@ -329,6 +330,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     element.classList.add('i-amphtml-autocomplete-item');
     element.setAttribute('role', 'listitem');
     element.setAttribute('data-value', item);
+    element.setAttribute('dir', 'auto');
     element.textContent = item;
     return element;
   }
@@ -394,6 +396,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         renderedChildren.map(child => {
           child.classList.add('i-amphtml-autocomplete-item');
           child.setAttribute('role', 'listitem');
+          child.setAttribute('dir', 'auto');
           container.appendChild(child);
         });
       });

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -396,7 +396,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
         renderedChildren.map(child => {
           child.classList.add('i-amphtml-autocomplete-item');
           child.setAttribute('role', 'listitem');
-          child.setAttribute('dir', 'auto');
           container.appendChild(child);
         });
       });


### PR DESCRIPTION
- Set `dir="auto"` attributes on amp-autocomplete input and generated item elements.
- Add example usage
- Add visual test for rtl dataset