### PR TITLE
amp-script: Allow attribute mutations on built-ins

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -208,12 +208,21 @@ export class SanitizerImpl {
 
     /** @private {!Object<string, boolean>} */
     this.allowedTags_ = getAllowedTags();
+    // For now, only allow built-in AMP components.
+    this.allowedTags_['amp-img'] = true;
+    this.allowedTags_['amp-layout'] = true;
+    this.allowedTags_['amp-pixel'] = true;
 
     /** @const @private {!Element} */
     this.wrapper_ = win.document.createElement('div');
   }
 
   /**
+   * TODO(choumx): This is currently called by worker-dom on node creation,
+   * so all invocations are on super-simple nodes like <p></p>.
+   * Either it should be moved to node insertion to justify the more expensive
+   * sanitize() call, or this method should be a simple string lookup.
+   *
    * @param {!Node} node
    * @return {boolean}
    */
@@ -254,7 +263,8 @@ export class SanitizerImpl {
     const tag = node.nodeName.toLowerCase();
     // DOMPurify's attribute validation is tag-agnostic, so we need to check
     // that the tag itself is valid. E.g. a[href] is ok, but base[href] is not.
-    if (this.allowedTags_[tag] || startsWith(tag, 'amp-')) {
+    // TODO(choumx): This is actually more strict than sanitize().
+    if (this.allowedTags_[tag]) {
       const attr = attribute.toLowerCase();
       if (validateAttributeChange(this.purifier_, node, attr, value)) {
         if (value == null) {

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -55,7 +55,27 @@ describe('SanitizerImpl', () => {
       const base = win.document.createElement('base');
       // 'href' attribute is allowed but 'base' tag isn't.
       s.mutateAttribute(base, 'href', '/foo.html');
-      expect(base.getAttribute('href')).to.equal(null);
+      expect(base.getAttribute('href')).to.be.null;
+    });
+
+    it('should allow changes to built-in AMP tags', () => {
+      const img = win.document.createElement('amp-img');
+      s.mutateAttribute(img, 'src', 'foo.jpg');
+      expect(img.getAttribute('src')).to.include('foo.jpg');
+
+      const layout = win.document.createElement('amp-layout');
+      s.mutateAttribute(layout, 'width', '10');
+      expect(layout.getAttribute('width')).to.equal('10');
+
+      const pixel = win.document.createElement('amp-pixel');
+      s.mutateAttribute(pixel, 'src', '/foo/track');
+      expect(pixel.getAttribute('src')).to.include('/foo/track');
+    });
+
+    it('should not allow changes to other AMP tags', () => {
+      const analytics = win.document.createElement('amp-analytics');
+      s.mutateAttribute(analytics, 'data-credentials', 'include');
+      expect(analytics.getAttribute('data-credentials')).to.be.null;
     });
   });
 });

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -403,7 +403,7 @@ export function validateAttributeChange(purifier, node, attr, value) {
     // implications beyond URLs etc. that are covered by isValidAttr().
     // This is OK for now, but we should instead somehow modify ALLOWED_ATTR
     // to preserve value sanitization.
-    const whitelisted = WHITELISTED_ATTRS[attr];
+    const whitelisted = WHITELISTED_ATTRS.includes(attr);
     const attrsByTags = WHITELISTED_ATTRS_BY_TAGS[tag];
     const whitelistedForTag = attrsByTags && attrsByTags.includes(attr);
     if (!whitelisted && !whitelistedForTag && !startsWith(tag, 'amp-')) {

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -403,9 +403,10 @@ export function validateAttributeChange(purifier, node, attr, value) {
     // implications beyond URLs etc. that are covered by isValidAttr().
     // This is OK for now, but we should instead somehow modify ALLOWED_ATTR
     // to preserve value sanitization.
+    const whitelisted = WHITELISTED_ATTRS[attr];
     const attrsByTags = WHITELISTED_ATTRS_BY_TAGS[tag];
     const whitelistedForTag = attrsByTags && attrsByTags.includes(attr);
-    if (!whitelistedForTag && !startsWith(tag, 'amp-')) {
+    if (!whitelisted && !whitelistedForTag && !startsWith(tag, 'amp-')) {
       return false;
     }
   }

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -638,6 +638,13 @@ describe('validateAttributeChange', () => {
     expect(vac('p', 'data-amp-bind-text', 'foo')).to.be.false;
   });
 
+  it('should allow whitelisted attributes', () => {
+    purifier.isValidAttribute = () => false;
+
+    expect(vac('p', 'heights', '(min-width:500px) 200px, 80%')).to.be.true;
+    expect(vac('button', 'on', 'tap:AMP.print')).to.be.true;
+  });
+
   it('should allow whitelisted-by-tag attributes', () => {
     purifier.isValidAttribute = () => false;
 


### PR DESCRIPTION
Fixes two small bugs in #21782:
1. `getAllowedTags()` doesn't contain AMP tags, so we need to manually add support
2. Allow tag-agnostic whitelisted attributes (`WHITELISTED_ATTRS`)

Also added a couple TODOs since there's more I'd like to do to make these code paths cleaner and more readable.

/to @jridgewell /cc @kristoferbaxter  