### PR TITLE
🏗🐛 Fix flaky Karma startup by refreshing the `wd` cache (again)

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -22,6 +22,7 @@ const fs = require('fs');
 const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
+const {exec} = require('../../exec');
 const {gitDiffNameOnlyMaster} = require('../../git');
 const {green, cyan, red} = colors;
 const {isTravisBuild} = require('../../travis');
@@ -217,4 +218,16 @@ function unitTestsToRun(unitTestPaths) {
   return testsToRun;
 }
 
-module.exports = {getAdTypes, unitTestsToRun};
+/**
+ * Mitigates https://github.com/karma-runner/karma-sauce-launcher/issues/117
+ * by refreshing the wd cache so that Karma can launch without an error.
+ */
+function refreshKarmaWdCache() {
+  exec('node ./node_modules/wd/scripts/build-browser-scripts.js');
+}
+
+module.exports = {
+  getAdTypes,
+  refreshKarmaWdCache,
+  unitTestsToRun,
+};

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -36,7 +36,7 @@ const {app} = require('../../test-server');
 const {build} = require('../build');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
 const {css} = require('../css');
-const {getAdTypes, unitTestsToRun} = require('./helpers');
+const {getAdTypes, refreshKarmaWdCache, unitTestsToRun} = require('./helpers');
 const {getStdout} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
 
@@ -348,6 +348,9 @@ async function runTests() {
 
   // Listen for Ctrl + C to cancel testing
   const handlerProcess = createCtrlcHandler('test');
+
+  // Avoid Karma startup errors
+  refreshKarmaWdCache();
 
   // Run Sauce Labs tests in batches to avoid timeouts when connecting to the
   // Sauce Labs environment.


### PR DESCRIPTION
**Background:**
- https://github.com/karma-runner/karma-sauce-launcher/issues/117 sometimes causes the `Cannot find module '../build/safe-execute'` error during Karma test runs
- The bug was fixed via the workaround in #13328
- `karma-sauce-launcher` was upgraded to a version that didn't depend on `wd`
- The workaround was reverted in #19889
- `karma-sauce-launcher` was rolled back to the old version in #21578 because it caused disconnection errors on Sauce labs 

This PR reinstates the workaround from #13328 until such time that we need it.