### PR TITLE
🏗🐛 Make `validator` functions `async` so that their `gulp` tasks complete

### DIFF
--- a/build-system/tasks/validator.js
+++ b/build-system/tasks/validator.js
@@ -26,14 +26,14 @@ if (argv.update_tests) {
 /**
  * Simple wrapper around the python based validator build.
  */
-function validator() {
+async function validator() {
   execOrDie('cd validator && python build.py' + validatorArgs);
 }
 
 /**
  * Simple wrapper around the python based validator webui build.
  */
-function validatorWebui() {
+async function validatorWebui() {
   execOrDie('cd validator/webui && python build.py' + validatorArgs);
 }
 


### PR DESCRIPTION
#22125 upgraded `gulp` to v4 and updated all tasks to the new API. It resulted an error in the validator checks because the functions are not `async`, so the `gulp` task wouldn't exit cleanly.

See https://travis-ci.org/ampproject/amphtml/jobs/527924651#L315

This PR makes both functions in `build-system/tasks/validator.js` async.