### PR TITLE
Handling video visibility updates.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -23,10 +23,6 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
  width: 100vw!important;
 }
 
-.i-amphtml-story-desktop-panels .i-amphtml-story-logo {
- display: block!important;
-}
-
 .i-amphtml-story-background-container {
  opacity: .8!important;
  position: absolute!important;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -613,7 +613,8 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     // Considers amp-audio elements with a layout=nodisplay attribute as
     // displayed, since we want them to play when the page is active.
-    if (ampEl.getAttribute('layout') === Layout.NODISPLAY) {
+    if (ampEl.tagName === 'AMP-AUDIO' &&
+        ampEl.getLayout() === Layout.NODISPLAY) {
       return true;
     }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -70,6 +70,7 @@ import {getLogEntries} from './logging';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
+import {isMediaDisplayed} from './utils';
 import {toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
 
@@ -609,16 +610,10 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   isMediaDisplayed_(mediaEl) {
-    const ampEl = isAmpElement(mediaEl) ? mediaEl : mediaEl.parentElement;
-
-    // Considers amp-audio elements with a layout=nodisplay attribute as
-    // displayed, since we want them to play when the page is active.
-    if (ampEl.tagName === 'AMP-AUDIO' &&
-        ampEl.getLayout() === Layout.NODISPLAY) {
-      return true;
-    }
-
-    return this.resources_.getResourceForElement(ampEl).isDisplayed();
+    const ampEl = dev().assertElement(
+        isAmpElement(mediaEl) ? mediaEl : mediaEl.parentElement);
+    const resource = this.resources_.getResourceForElement(ampEl);
+    return isMediaDisplayed(ampEl, resource);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -380,18 +380,13 @@ amp-story-grid-layer .i-amphtml-embedded-component::after {
   padding: 0 !important;
 }
 
-.i-amphtml-story-grid-template-fill > :not(:first-child) {
-  display: none !important;
-}
-
-.i-amphtml-story-logo {
-  display: none !important;
-  margin: 15px !important;
-}
-
-.i-amphtml-story-grid-template-fill > :first-child {
+.i-amphtml-story-grid-template-fill > * {
+  /**
+   * Publishers need to be able to override the display of an amp-img or
+   * amp-video from their custom CSS, to toggle assets based on media queries.
+   */
+  display: block;
   bottom: 0 !important;
-  display: block !important;
   height: auto !important;
   left: 0 !important;
   position: absolute !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -381,11 +381,6 @@ amp-story-grid-layer .i-amphtml-embedded-component::after {
 }
 
 .i-amphtml-story-grid-template-fill > * {
-  /**
-   * Publishers need to be able to override the display of an amp-img or
-   * amp-video from their custom CSS, to toggle assets based on media queries.
-   */
-  display: block;
   bottom: 0 !important;
   height: auto !important;
   left: 0 !important;

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -21,7 +21,6 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AdvancementMode} from './story-analytics';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
@@ -29,7 +28,7 @@ import {closest, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getAmpdoc} from '../../../src/service';
-import {hasTapAction, timeStrToMillis} from './utils';
+import {hasTapAction, isMediaDisplayed, timeStrToMillis} from './utils';
 import {
   interactiveElementsSelectors,
 } from './amp-story-embedded-component';
@@ -755,9 +754,7 @@ class MediaBasedAdvancement extends AdvancementConfig {
     for (let i = 0; i < this.elements_.length; i++) {
       const element = this.elements_[i];
       const resource = this.resources_.getResourceForElement(element);
-      if (resource.isDisplayed() ||
-          (element.tagName === 'AMP-AUDIO' &&
-              element.getLayout() === Layout.NODISPLAY)) {
+      if (isMediaDisplayed(element, resource)) {
         return element;
       }
     }

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -126,6 +126,9 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should perform media operations when state becomes active', done => {
+    sandbox.stub(page.resources_, 'getResourceForElement')
+        .returns({isDisplayed: () => true});
+
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
     gridLayerEl.appendChild(videoEl);
@@ -177,6 +180,9 @@ describes.realWin('amp-story-page', {amp: true}, env => {
       const videoEl = fieDoc.querySelector('video');
 
       let mediaPoolMock;
+
+      sandbox.stub(page.resources_, 'getResourceForElement')
+          .returns({isDisplayed: () => true});
 
       page.buildCallback();
       page.layoutCallback()
@@ -240,6 +246,9 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should pause/rewind media when state becomes not active', done => {
+    sandbox.stub(page.resources_, 'getResourceForElement')
+        .returns({isDisplayed: () => true});
+
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
     gridLayerEl.appendChild(videoEl);
@@ -280,6 +289,8 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should pause media when state becomes paused', done => {
+    sandbox.stub(page.resources_, 'getResourceForElement')
+        .returns({isDisplayed: () => true});
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
     gridLayerEl.appendChild(videoEl);

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {closestAncestorElementBySelector} from '../../../src/dom';
 import {createShadowRoot} from '../../../src/shadow-embed';
@@ -260,4 +261,19 @@ export function getHistoryState(win, stateName) {
     return getState(history)[stateName];
   }
   return null;
+}
+
+/**
+ * Returns a boolean indicating whether the media element is visible or has to
+ * play, or hidden by any publisher CSS rule.
+ * @param {!Element} ampMediaEl amp-video or amp-audio
+ * @param {!../../../src/service/resource.Resource} resource
+ * @return {boolean}
+ */
+export function isMediaDisplayed(ampMediaEl, resource) {
+  // Considers amp-audio elements with a layout=nodisplay attribute as
+  // displayed, since they are expected to play when the page is active.
+  return resource.isDisplayed() ||
+      (ampMediaEl.tagName === 'AMP-AUDIO' &&
+          ampMediaEl.getLayout() === Layout.NODISPLAY);
 }


### PR DESCRIPTION
As we introduce new `orientation` attributes, and element based CSS Media Queries, we want publishers to be able to specify different assets (images, videos) depending on the viewport size or orientation.

This PR ensures that videos are played/paused accordingly as they get hidden/displayed.
The feature is actually pretty complex but fits in not so many lines of code. I tried to keep the code behavior as similar as possible, and only add some code that reacts to visibility changes.
Feel free to ask all the questions you have, and suggest more code comments to explain how things work!

Changelog:
- `.i-amphtml-story-grid-template-fill` can now potentially have multiple children, as publishers should be able to provide different version of the same asset
- `.i-amphtml-story-grid-template-fill` children `display` can now be overriden, so publishers can easily set `display: block/none;` from their CSS or media queries to decide which asset should be visible
- Extracting `mute`, `unmute`, `play`, and `pause` methods from their respective `*All` method so it can be used for only one video. That makes the code diff pretty big, but there's no change
- `getMediaBySelector_` returns a filtered list of media elements, only containing the ones that are visible (ie: the ones we want to play). It relies on some layout properties cached by the AMP runtime, so there's no performance implication
- New `onVideoVisibilityUpdate_` that's triggered when the video becomes hidden/visible, from AMP runtime events. Depending on if the video was hidden or displayed, it will either pause or play it
- `MediaBasedAdvancement` accepts a list of elements, that can be configured using a `data-id` attribute, or `id` attribute for backward compatibility. If two or more elements are provided, it will base the advancement on the first visible one, and update itself as the video are displayed/hidden
- When a video becomes visible as you resize your viewport (eg: orientation change), it plays from the beginning

[Demo available here on page 3](https://stamp-hide-video.firebaseapp.com/examples/s20/body-painting/index.html). There is one landscape and one portrait video that look very different, and have very different length so you can check if the progress bar works correctly. Try rotating your phone :)

Part of #21661
Fixes #15515