### PR TITLE
Revert "✅ Make visual tests non-blocking"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       script:
         - node build-system/pr-check/dist-tests.js
     - stage: test
-      name: "[NON-BLOCKING] Visual Diff Tests"
+      name: "Visual Diff Tests"
       script:
         - node build-system/pr-check/visual-diff-tests.js
     - stage: test
@@ -87,8 +87,6 @@ jobs:
   allow_failures:
     - script:
       - node build-system/pr-check/e2e-tests.js
-    - script:
-      - node build-system/pr-check/visual-diff-tests.js
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Reverts ampproject/amphtml#21992

Reason for revert: `🏗 Stability and developer-experience changes for visual diffs testing platform` #21980

Addresses #21056