### PR TITLE
update extension generator to amp.dev

### DIFF
--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -124,7 +124,7 @@ limitations under the License.
     <td><code>&lt;script async custom-element="${name}" src="https://cdn.ampproject.org/v0/${name}-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
     <td>FILL THIS IN</td>
   </tr>
   <tr>

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -61,7 +61,7 @@ tags: {  # <${name}>
   tag_name: "${name.toUpperCase()}"
   requires_extension: "${name}"
   attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/components/${name}"
+  spec_url: "https://amp.dev/documentation/components/${name}"
   amp_layout: {
     supported_layouts: RESPONSIVE
   }


### PR DESCRIPTION
Changes the generated spec_url to be amp.dev instead of ampproject.org