### PR TITLE
🐛 Workaround M72-M75 user-activation breakage for iframe players

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -945,6 +945,18 @@ const forbiddenTermsSrcInclusive = {
     ],
   },
   '\\.matches\\(': 'Please use matches() helper in src/dom.js',
+  'addUnsafeAllowAutoplay\\(': {
+    // TODO(alanorozco, #21247): Remove as this refers to a temporary
+    // workaround.
+    message: 'addUnsafeAllowAutoplay() should only be used by sanctioned' +
+      'extensions or by the VideoManager service. See #21242 for details',
+    whitelist: [
+      'extensions/amp-ima-video/0.1/amp-ima-video.js',
+      'extensions/amp-youtube/0.1/amp-youtube.js',
+      'src/iframe-video.js',
+      'src/service/video-manager-impl.js',
+    ],
+  },
 };
 
 // Terms that must appear in a source file.

--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -139,15 +139,24 @@ export function mutedOrUnmutedEvent(isMuted) {
 
 
 /**
- * TEMPORARY workaround for M72-M74 user-activation breakage.
- * If this method is still here in May 2019, please ping @aghassemi
- * Only used by trusted video players: IMA and YouTube.
+ * TEMPORARY workaround for M72-M75 user-activation breakage.
+ * If this function is still here in June 2019, please ping `@aghassemi` and
+ * `@alanorozco`.
+ *
+ * - Used directly ONLY by trusted video players: amp-ima-video and amp-youtube.
+ * - Used indirectly ONLY through the `VideoManager` on execution of a
+ *   high-trust common action on an iframe player component.
+ *
  * See https://github.com/ampproject/amphtml/issues/21242 for details.
  * TODO(aghassemi, #21247)
+ *
  * @param {Element} iframe
  */
 export function addUnsafeAllowAutoplay(iframe) {
-  let val = iframe.getAttribute('allow') || '';
-  val += 'autoplay;';
-  iframe.setAttribute('allow', val);
+  const allow = iframe.getAttribute('allow') || '';
+  if (allow.indexOf('autoplay') >= 0) {
+    return;
+  }
+  const delimited = allow.replace(/([^;])$/, '$1;');
+  iframe.setAttribute('allow', `${delimited}autoplay;`);
 }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -257,7 +257,7 @@ export class VideoManager {
     Object.keys(handlers).forEach(action => {
       video.registerAction(
           action,
-          decorateCommonActionHandler(handlers[action]),
+          decorateCommonActionHandler(video, handlers[action]),
           // Only require ActionTrust.LOW for video actions to defer to platform
           // specific handling (e.g. user gesture requirement for unmuted
           // playback).

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -67,21 +67,6 @@ const TAG = 'video-manager';
 const SECONDS_PLAYED_MIN_DELAY = 1000;
 
 /**
- * Decorates/wraps a video common action handler to inform user interaction.
- *
- * @param {!../video-interface.VideoOrBaseElementDef} video
- * @param {function()} handler
- * @return {function(!./action-impl.ActionInvocation)}
- */
-function decorateCommonActionHandler(video, handler) {
-  return invocation => {
-    userInteractedWith(video);
-    maybeAddUnsafeAllowAutoplay(video, invocation);
-    handler();
-  };
-}
-
-/**
  * TEMPORARY workaround for for M72-M75 user-activation breakage.
  * If this function is still here in June 2019, please ping `@aghassemi` and
  * `@alanorozco`.
@@ -255,9 +240,15 @@ export class VideoManager {
     };
 
     Object.keys(handlers).forEach(action => {
+      const handler = handlers[action];
+      const decoratedHandler = invocation => {
+        userInteractedWith(video);
+        maybeAddUnsafeAllowAutoplay(video, invocation);
+        handler();
+      };
       video.registerAction(
           action,
-          decorateCommonActionHandler(video, handlers[action]),
+          decoratedHandler,
           // Only require ActionTrust.LOW for video actions to defer to platform
           // specific handling (e.g. user gesture requirement for unmuted
           // playback).


### PR DESCRIPTION
- Fixes #22122.
- Small restructuring around `VideoManager`.
- Fixes a case where `allow` attribute would not be concatenated correctly (not present in codebase but good to keep in mind).
- Forbids `addUnsafeAllowAutoplay`.