### PR TITLE
✨amp-experiment 1.0: Enforced a 3KB JSON limitation

### DIFF
--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -31,6 +31,9 @@ import {parseMutation} from './mutation-parser';
 
 const TAG = 'amp-experiment';
 
+/** @const {number} */
+const MAX_JSON_SIZE = 3000;
+
 export class AmpExperiment extends AMP.BaseElement {
 
   /** @override */
@@ -110,10 +113,20 @@ export class AmpExperiment extends AMP.BaseElement {
             && children[0].getAttribute('type').toUpperCase()
                 == 'APPLICATION/JSON',
         '<amp-experiment> should contain exactly one ' +
-        '<script type="application/json"> child.');
+      '<script type="application/json"> child.');
+
+    const experimentJson = children[0].textContent;
+
+    // Enforce the size limitation on the JSON
+    if (experimentJson.length > MAX_JSON_SIZE) {
+      const jsonError = `Max JSON size exceeded: ${experimentJson.length} > `
+        + MAX_JSON_SIZE;
+      user().error(TAG, jsonError);
+      throw new Error(jsonError);
+    }
 
     return /** @type {!JsonObject} */ (
-      devAssert(parseJson(children[0].textContent)));
+      devAssert(parseJson(experimentJson)));
   }
 
   /**

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -147,6 +147,22 @@ describes.realWin('amp-experiment', {
     });
   });
 
+  it('should throw if JSON size exceeds the max size', () => {
+    let longString = '';
+    for (let i = 0; i < 3000; i++) {
+      longString += i;
+    }
+    addConfigElement(
+        'script',
+        'application/json',
+        `{"longString": "${longString}"}`
+    );
+    expectAsyncConsoleError(/Max JSON size/);
+    return expect(experiment.buildCallback()).to.eventually
+        .be.rejectedWith(/Max JSON size/);
+  });
+
+
   it('should apply the mutations from the variant', () => {
     addConfigElement('script');
     const stub = sandbox.stub(variant, 'allocateVariant');


### PR DESCRIPTION
relates to #20225

This adds a 3KB max size for the amp-experiment total JSON. This was per the design doc, and can be changed later, if needed / reasonable 😄 

cc @jeffjose and cc @kristoferbaxter if 3KB seems reasonable

# Example

<img width="1440" alt="Screen Shot 2019-05-06 at 6 48 23 PM" src="https://user-images.githubusercontent.com/1448289/57267436-00c50400-7035-11e9-9421-29cb2b4fed8e.png">
