### PR TITLE
✨Add support for mask-trim-zeros attribute on amp-inputmask.

### DIFF
--- a/examples/masking-trim.amp.html
+++ b/examples/masking-trim.amp.html
@@ -20,6 +20,5 @@
     <label>CPF: <input name="cpf" mask="000.000.000-00" placeholder="000.051.271-20" mask-trim-zeros="0"></label>
     <input type="submit">
   </form>
-  <p>It should displays <strong>000.051.271-20</strong>, but is showing <u>005.127.120</u></p>
 </body>
 </html>

--- a/examples/masking-trim.amp.html
+++ b/examples/masking-trim.amp.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Input masking examples in AMP</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-element="amp-inputmask" src="https://cdn.ampproject.org/v0/amp-inputmask-0.1.js"></script>
+    <style amp-custom></style>
+</head>
+<body>
+  <h1>Input Masking</h1>
+  <h2>trim-zeros</h2>
+
+  <p>Copy this text: <strong>00005127120</strong> into input below.</p>
+  <form class="sample-form" method="post" action-xhr="/components/amp-inputmask/default" target="_top">
+    <label>CPF: <input name="cpf" mask="000.000.000-00" placeholder="000.051.271-20" mask-trim-zeros="0"></label>
+    <input type="submit">
+  </form>
+  <p>It should displays <strong>000.051.271-20</strong>, but is showing <u>005.127.120</u></p>
+</body>
+</html>

--- a/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
@@ -92,8 +92,9 @@ export function getPrefixSubsets(mask) {
     // The array of subprefixes grows with the factorial of prefix.length
     // so we cap it at 5! = 120
     if (prefix.length > 5) {
-      user().warn('amp-inputmask does not support prefix trimming ' +
-          'for masks that start with more than 5 non-mask characters.');
+      user().warn('AMP-INPUTMASK',
+          'amp-inputmask does not support prefix trimming for masks ' +
+          'that start with more than 5 non-mask characters.');
       continue;
     }
 

--- a/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
@@ -24,7 +24,16 @@ import {dict} from '../../../src/utils/object';
  * @param {!Object} Inputmask
  */
 export function factory(Inputmask) {
-  Inputmask.extendAliases(dict({
+  Inputmask.extendAliases(getAliasDefinition());
+}
+
+/**
+ * Gets the alias definition for the custom mask.
+ * @return {!Object}
+ * @private visible for testing
+ */
+export function getAliasDefinition() {
+  return dict({
     'custom': {
       'prefixes': [],
       /**
@@ -43,81 +52,93 @@ export function factory(Inputmask) {
        * @return {string}
        */
       'onBeforeMask': function(value, opts) {
-        const processedValue = value.replace(/^0{1,2}/, '').replace(/[\s]/g, '');
         const prefixes = opts['prefixes'];
+        const trimZeros = opts['trimZeros'];
+
+        let processedValue = value;
+        if (trimZeros) {
+          const re = new RegExp(`^0{1,${trimZeros}}`);
+          processedValue = processedValue.replace(re, '');
+        }
+        processedValue = processedValue.replace(/[\s]/g, '');
 
         return removePrefix(processedValue, prefixes);
       },
     },
-  }));
+  });
+}
 
-  /**
-   * A prefix is defined as non-mask characters at the beginning of a mask
-   * definition.
-   */
-  const prefixRe = /^([^\*\[\]a\?9\\]+)[\*\[\]a\?9\\]/i;
+/**
+ * A prefix is defined as non-mask characters at the beginning of a mask
+ * definition.
+ */
+export const prefixRe = /^([^\*\[\]a\?9\\]+)[\*\[\]a\?9\\]/i;
 
-  /**
-   * Gets a map of substrings of the mask prefixes.
-   * e.g. +1(000)000-0000" -> ["+1(", "+1", "+", "1(", ...]
-   * @param {!Array<string>|string} mask
-   * @return {!Array<string>}
-   */
-  function getPrefixSubsets(mask) {
-    const masks = (typeof mask == 'string' ? [mask] : mask);
+/**
+ * Gets a map of substrings of the mask prefixes.
+ * e.g. +1(000)000-0000" -> ["+1(", "+1", "+", "1(", ...]
+ * @param {!Array<string>|string} mask
+ * @return {!Array<string>}
+ * @private visible for testing
+ */
+export function getPrefixSubsets(mask) {
+  const masks = (typeof mask == 'string' ? [mask] : mask);
 
-    const prefixes = {};
-    for (let i = 0; i < masks.length; i++) {
-      const prefix = getMaskPrefix(masks[i]);
-      if (prefix.length == 0) {
-        continue;
-      }
-
-      const stack = [prefix];
-      while (stack.length) {
-        const prefix = stack.pop();
-        prefixes[prefix] = true;
-
-        if (prefix.length > 1) {
-          stack.push(prefix.slice(1));
-          stack.push(prefix.slice(0, -1));
-        }
-      }
+  const prefixes = {};
+  for (let i = 0; i < masks.length; i++) {
+    const prefix = getMaskPrefix(masks[i]);
+    // The array of subprefixes grows with the factorial of prefix.length
+    // so we cap it at 5! = 120
+    if (prefix.length == 0 || prefix.length > 5) {
+      continue;
     }
 
-    return Object.keys(prefixes);
-  }
+    const stack = [prefix];
+    while (stack.length) {
+      const prefix = stack.pop();
+      prefixes[prefix] = true;
 
-  /**
-   * Gets any literal non-variable mask characters from the
-   * beginning of the mask string
-   * e.g. "+1(000)000-0000" -> "+1("
-   * @param {string} mask
-   * @return {string}
-   */
-  function getMaskPrefix(mask) {
-    const processedMask = mask.replace(/[\s]/g, '');
-    const match = prefixRe.exec(processedMask);
-    const prefix = (match && match[1]) || '';
-
-    return prefix;
-  }
-
-  /**
-   * Remove a mask prefix from the input value
-   * @param {string} value
-   * @param {!Array<string>} prefixes
-   * @return {string}
-   */
-  function removePrefix(value, prefixes) {
-    const longestPrefix = prefixes
-        .filter(prefix => value.indexOf(prefix) == 0)
-        .sort((a, b) => b.length - a.length)[0];
-
-    if (longestPrefix) {
-      return value.slice(longestPrefix.length);
-    } else {
-      return value;
+      if (prefix.length > 1) {
+        stack.push(prefix.slice(1));
+        stack.push(prefix.slice(0, -1));
+      }
     }
+  }
+
+  return Object.keys(prefixes);
+}
+
+/**
+ * Gets any literal non-variable mask characters from the
+ * beginning of the mask string
+ * e.g. "+1(000)000-0000" -> "+1("
+ * @param {string} mask
+ * @return {string}
+ * @private visible for testing
+ */
+export function getMaskPrefix(mask) {
+  const processedMask = mask.replace(/[\s]/g, '');
+  const match = prefixRe.exec(processedMask);
+  const prefix = (match && match[1]) || '';
+
+  return prefix;
+}
+
+/**
+ * Remove a mask prefix from the input value
+ * @param {string} value
+ * @param {!Array<string>} prefixes
+ * @return {string}
+ * @private visible for testing
+ */
+export function removePrefix(value, prefixes) {
+  const longestPrefix = prefixes
+      .filter(prefix => value.indexOf(prefix) == 0)
+      .sort((a, b) => b.length - a.length)[0];
+
+  if (longestPrefix) {
+    return value.slice(longestPrefix.length);
+  } else {
+    return value;
   }
 }

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -59,36 +59,6 @@ const MaskCharsToInputmask = dict({
   [MaskChars.ESCAPE]: '\\',
 });
 
-let Inputmask_;
-/**
- * Require and configure the Inputmask dependency.
- * @param {!Element} element
- * @return {function(!Object):!Inputmask}
- */
-function getInputmask(element) {
-  if (Inputmask_) {
-    return Inputmask_;
-  }
-
-  const inputmaskFactory = requireExternal('inputmaskFactory');
-  Inputmask_ = inputmaskFactory(element);
-  inputmaskCustomAliasFactory(Inputmask_);
-  inputmaskPaymentCardAliasFactory(Inputmask_);
-
-  Inputmask_.extendDefaults(dict({
-    // A list of supported input type attribute values
-    'supportsInputType': [
-      'text',
-      'tel',
-      'search',
-      // 'password', // use-case?
-      // 'email', // doesn't support setSelectionRange. workaround?
-    ],
-  }));
-
-  return Inputmask_;
-}
-
 /**
  * TODO(cvializ): allow masks to be passed as data
  * @implements {MaskInterface}
@@ -100,7 +70,7 @@ export class Mask {
    * @param {string} mask
    */
   constructor(element, mask) {
-    const Inputmask = getInputmask(element);
+    this.Inputmask_ = Mask.getInputmask_(element);
 
     this.element_ = element;
 
@@ -120,13 +90,50 @@ export class Mask {
       } else {
         config['alias'] = namedFormat;
       }
-    } else {
-      const inputmaskMask = convertAmpMaskToInputmask(trimmedMask);
-      config['alias'] = 'custom';
-      config['customMask'] = inputmaskMask;
+      this.controller_ = this.Inputmask_(config);
+      return;
     }
 
-    this.controller_ = Inputmask(config);
+    // If not a named mask, it is a custom mask
+    config['alias'] = 'custom';
+
+    const inputmaskMask = convertAmpMaskToInputmask(trimmedMask);
+    config['customMask'] = inputmaskMask;
+    const trimZeros = element.getAttribute('mask-trim-zeros');
+    config['trimZeros'] = trimZeros ? Number(trimZeros) : 2;
+
+    this.controller_ = this.Inputmask_(config);
+  }
+
+  /**
+   * Require and configure the Inputmask dependency.
+   * @param {!Element} element
+   * @return {function(!Object):!Inputmask}
+   * @private visible for testing
+   */
+  static getInputmask_(element) {
+    if (this.Inputmask_) {
+      return this.Inputmask_;
+    }
+
+
+    const inputmaskFactory = requireExternal('inputmaskFactory');
+    const Inputmask = inputmaskFactory(element);
+    inputmaskCustomAliasFactory(Inputmask);
+    inputmaskPaymentCardAliasFactory(Inputmask);
+
+    Inputmask.extendDefaults(dict({
+      // A list of supported input type attribute values
+      'supportsInputType': [
+        'text',
+        'tel',
+        'search',
+        // 'password', // use-case?
+        // 'email', // doesn't support setSelectionRange. workaround?
+      ],
+    }));
+
+    return Inputmask;
   }
 
   /** @override */

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -90,17 +90,15 @@ export class Mask {
       } else {
         config['alias'] = namedFormat;
       }
-      this.controller_ = this.Inputmask_(config);
-      return;
+    } else {
+      // If not a named mask, it is a custom mask
+      config['alias'] = 'custom';
+
+      const inputmaskMask = convertAmpMaskToInputmask(trimmedMask);
+      config['customMask'] = inputmaskMask;
+      const trimZeros = element.getAttribute('mask-trim-zeros');
+      config['trimZeros'] = trimZeros ? Number(trimZeros) : 2;
     }
-
-    // If not a named mask, it is a custom mask
-    config['alias'] = 'custom';
-
-    const inputmaskMask = convertAmpMaskToInputmask(trimmedMask);
-    config['customMask'] = inputmaskMask;
-    const trimZeros = element.getAttribute('mask-trim-zeros');
-    config['trimZeros'] = trimZeros ? Number(trimZeros) : 2;
 
     this.controller_ = this.Inputmask_(config);
   }

--- a/extensions/amp-inputmask/0.1/test/test-inputmask-custom-alias.js
+++ b/extensions/amp-inputmask/0.1/test/test-inputmask-custom-alias.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getAliasDefinition,
+  getMaskPrefix,
+  getPrefixSubsets,
+  removePrefix,
+} from '../inputmask-custom-alias';
+
+describes.sandboxed('inputmask "custom" alias', {}, () => {
+
+  describe('removePrefix', () => {
+
+    it('should remove a prefix from the given input string', () => {
+      const value = '+1(555)555-5555';
+      expect(removePrefix(value, ['+1('])).to.equal('555)555-5555');
+      expect(removePrefix(value, ['+1'])).to.equal('(555)555-5555');
+      expect(removePrefix(value, ['+'])).to.equal('1(555)555-5555');
+    });
+
+    it('should remove the longest prefix match from the input string', () => {
+      const prefices = ['+1(', '+1', '+', '1(', '1', '('];
+
+      expect(removePrefix('+1555-555-5555', prefices))
+          .to.equal('555-555-5555');
+      expect(removePrefix('1555-555-5555', prefices))
+          .to.equal('555-555-5555');
+      expect(removePrefix('+1555-555-5555', prefices))
+          .to.equal('555-555-5555');
+      expect(removePrefix('15555555555', prefices))
+          .to.equal('5555555555');
+      expect(removePrefix('+1(555)-555-5555', prefices))
+          .to.equal('555)-555-5555');
+    });
+
+    it('should return the input string if no prefix matches', () => {
+      const value = '555-555-5555';
+      const prefix = '+1(';
+      expect(removePrefix(value, [prefix])).to.equal('555-555-5555');
+    });
+  });
+
+  describe('getMaskPrefix', () => {
+    it('should return non-mask characters at the start of the string', () => {
+      const maskString = '+1(999)999-9999';
+      expect(getMaskPrefix(maskString)).to.equal('+1(');
+    });
+
+    it('should return "" when no non-mask characters are found', () => {
+      const maskString = '999)999-9999';
+      expect(getMaskPrefix(maskString)).to.equal('');
+    });
+  });
+
+  describe('getPrefixSubsets', () => {
+    it('should return all substrings of a mask\'s non-mask prefix', () => {
+      expect(getPrefixSubsets('(999)999-9999')).to.have.members(['(']);
+      expect(getPrefixSubsets('1(999)999-9999')).to.have.members(
+          ['1(', '1', '(']);
+      expect(getPrefixSubsets('+1(999)999-9999')).to.have.members(
+          ['+1(', '+1', '+', '1(', '1', '(']);
+    });
+
+    it('should return no substrings of a mask with no non-mask prefix', () => {
+      expect(getPrefixSubsets('999)999-9999')).to.have.members([]);
+    });
+
+    it('should return no substrings of a mask if a non-mask prefix ' +
+        'has more than 5 characters', () => {
+      expect(getPrefixSubsets('++++1(999)999-9999')).to.have.members([]);
+    });
+  });
+
+  describe('alias config', () => {
+    it('should cache prefixes when installed', () => {
+      const alias = getAliasDefinition();
+      const opts = {'customMask': '+1(999)999-9999'};
+
+      alias.custom.mask(opts);
+      expect(opts.prefixes).to.have.members(
+          ['+1(', '+1', '+', '1(', '1', '(']);
+    });
+
+    it('should trim leading zeros when configured', () => {
+      const alias = getAliasDefinition();
+      const opts = {'customMask': '+1(999)999-9999', trimZeros: 2};
+
+      alias.custom.mask(opts);
+      expect(alias.custom.onBeforeMask('555-555-5555', opts))
+          .to.equal('555-555-5555');
+      expect(alias.custom.onBeforeMask('0555-555-5555', opts))
+          .to.equal('555-555-5555');
+      expect(alias.custom.onBeforeMask('00555-555-5555', opts))
+          .to.equal('555-555-5555');
+      expect(alias.custom.onBeforeMask('000555-555-5555', opts))
+          .to.equal('0555-555-5555');
+    });
+
+    it('should not trim leading zeros when not configured', () => {
+      const alias = getAliasDefinition();
+      const opts = {'customMask': '+1(999)999-9999', trimZeros: 0};
+
+      alias.custom.mask(opts);
+      expect(alias.custom.onBeforeMask('00555-555-5555', opts))
+          .to.equal('00555-555-5555');
+    });
+
+    it('should trim non-mask prefixes when configured', () => {
+      const alias = getAliasDefinition();
+      const opts = {'customMask': '+1(999)999-9999', trimZeros: 0};
+
+      alias.custom.mask(opts);
+      expect(alias.custom.onBeforeMask('+1555-555-5555', opts))
+          .to.equal('555-555-5555');
+    });
+  });
+});

--- a/extensions/amp-inputmask/0.1/test/test-mask-impl.js
+++ b/extensions/amp-inputmask/0.1/test/test-mask-impl.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Mask} from '../mask-impl';
+
+describes.sandboxed('amp-inputmask mask-impl', {}, () => {
+
+  class FakeElement {}
+
+  describe('config', () => {
+
+    let constructorStub;
+
+    beforeEach(() => {
+      constructorStub = sandbox.stub();
+      constructorStub.extendDefaults = function() {};
+
+      sandbox.stub(Mask, 'getInputmask_').returns(constructorStub);
+
+      FakeElement.prototype.getAttribute = sandbox.stub();
+    });
+
+    it('should create a custom mask with the custom mask string' +
+        ' and default options', () => {
+      const fakeElement = new FakeElement();
+      const maskString = '0';
+
+      new Mask(fakeElement, maskString);
+      const results = constructorStub.getCall(0).args[0];
+      expect(results).to.include.deep({
+        'alias': 'custom',
+        'customMask': ['9'],
+        'jitMasking': true,
+        'noValuePatching': true,
+        'placeholder': '\u2000',
+        'showMaskOnFocus': false,
+        'showMaskOnHover': false,
+        'trimZeros': 2,
+      });
+    });
+
+    it('should create a custom mask with the custom mask string' +
+        ' and configurable zeros', () => {
+      const fakeElement = new FakeElement();
+      fakeElement.getAttribute.withArgs('mask-trim-zeros').returns('0');
+      const maskString = '0';
+
+      new Mask(fakeElement, maskString);
+
+      const results = constructorStub.getCall(0).args[0];
+      expect(results).to.include.deep({
+        'trimZeros': 0,
+      });
+    });
+  });
+});

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.html
@@ -58,6 +58,8 @@
     <input mask="00000 00000-0000" type="tel">
     <!-- Valid: mask attr with named mask literal with escape char -->
     <input mask="00000 p\ayment-card" type="tel">
+    <!-- Valid: mask attr with numeric mask-trim-zeros -->
+    <input mask="00000" mask-trim-zeros="0" type="tel">
   </form>
 
 
@@ -89,6 +91,8 @@
     <!-- Invalid: mask attr with spaces named masks -->
     <input mask="payment-card "></div>
     <input mask=" payment-card "></div>
+    <!-- Invalid: mask attr with non-numeric mask-trim-zeros -->
+    <input mask="00000" mask-trim-zeros="wow" type="tel">
   </form>
   </form>
 

--- a/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
+++ b/extensions/amp-inputmask/0.1/test/validator-amp-inputmask.out
@@ -59,6 +59,8 @@ FAIL
 |      <input mask="00000 00000-0000" type="tel">
 |      <!-- Valid: mask attr with named mask literal with escape char -->
 |      <input mask="00000 p\ayment-card" type="tel">
+|      <!-- Valid: mask attr with numeric mask-trim-zeros -->
+|      <input mask="00000" mask-trim-zeros="0" type="tel">
 |    </form>
 |
 |
@@ -66,62 +68,66 @@ FAIL
 |      <!-- Invalid: mask-output attr without mask attr -->
 |      <input mask-output="raw" type="text">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:66:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:68:4 The attribute 'mask-output' may not appear in tag 'input'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=date -->
 |      <input mask="L0L_0L0" type="date">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:68:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'date'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:70:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'date'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=email -->
 |      <input mask="L0L_0L0" type="email">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:70:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'email'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:72:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'email'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=number -->
 |      <input mask="L0L_0L0" type="number">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:72:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'number'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:74:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'number'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=button -->
 |      <input mask="L0L_0L0" type="button">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:74:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:76:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=range -->
 |      <input mask="L0L_0L0" type="range">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:76:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:78:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=hidden -->
 |      <input mask="L0L_0L0" type="hidden">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:78:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'hidden'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:80:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'hidden'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with type=password -->
 |      <input mask="L0L_0L0" type="password">
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:80:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'password'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'type' in tag 'input [mask] (custom mask)' is set to the invalid value 'password'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with div[contenteditable] -->
 |      <div contenteditable mask="L0L_0L0"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'contenteditable' may not appear in tag 'div'. [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:82:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'mask' may not appear in tag 'div'. [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple masks that includes named mask -->
 |      <input mask="LOL_0L0 payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:84:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'LOL_0L0 payment-card'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:86:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'LOL_0L0 payment-card'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with multiple named masks -->
 |      <input mask="payment-card payment-card"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:86:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card payment-card'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:88:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card payment-card'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <input mask="payment-card date-mm-yy"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:87:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:89:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <input mask="payment-card  date-mm-yy"></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:88:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:90:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card date-mm-yy'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <!-- Invalid: mask attr with spaces named masks -->
 |      <input mask="payment-card "></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:90:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card '. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:92:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value 'payment-card '. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |      <input mask=" payment-card "></div>
 >>     ^~~~~~~~~
-amp-inputmask/0.1/test/validator-amp-inputmask.html:91:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value ' payment-card '. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+amp-inputmask/0.1/test/validator-amp-inputmask.html:93:4 The attribute 'mask' in tag 'input [mask] (custom mask)' is set to the invalid value ' payment-card '. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
+|      <!-- Invalid: mask attr with non-numeric mask-trim-zeros -->
+|      <input mask="00000" mask-trim-zeros="wow" type="tel">
+>>     ^~~~~~~~~
+amp-inputmask/0.1/test/validator-amp-inputmask.html:95:4 The attribute 'mask-trim-zeros' in tag 'input [mask] (custom mask)' is set to the invalid value 'wow'. (see https://amp.dev/documentation/components/amp-inputmask) [DISALLOWED_HTML]
 |    </form>
 |    </form>
 |

--- a/extensions/amp-inputmask/amp-inputmask.md
+++ b/extensions/amp-inputmask/amp-inputmask.md
@@ -150,6 +150,18 @@ Space characters " " will be automatically added as the user types.
 <input type="tel" mask="payment-card" placeholder="0000 0000 0000 0000">
 ```
 
+#### mask-trim-zeros
+
+Specifies how many zeros the mask will remove from pasted values into
+custom masks. For backwards compatibility, the default is `2`.
+Specify `0` to disable this behavior.
+
+When users paste values from spreadsheets, often there is a zero padding
+on the left side. For example, North American phone numbers are sometimes
+stored as 015551112222 where 1 is the country code, but it has been zero-padded.
+The `mask-trim-zeros` attribute will remove up to the given number of zeros.
+The `mask-trim-zeros` attribute does not affect named masks.
+
 #### mask-output
 
 Specifies how the form will submit the input value.

--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -45,6 +45,10 @@ tags: {
         "|date-yyyy-mm-dd"
         ")"
   }
+  attrs: {
+    name: "mask-trim-zeros"
+    value_regex: "\\d+"
+  }
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"


### PR DESCRIPTION
Fixes #21706 (the original document will need to add `mask-trim-zeros="0"`)

✅Adds unit tests, since the integration tests ended up being flaky 
📖Renamed `README.md` to fit the convention for the other components

A small refactor to improve unit-testability.

