### PR TITLE
Implementation for amp-user-location component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 build
 .amp-build
 c
-# DO NOT SUBMIT
-credentials
 /dist
 dist.3p
 dist.tools

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 build
 .amp-build
 c
+# DO NOT SUBMIT
+credentials
 /dist
 dist.3p
 dist.tools

--- a/ads/beaverads.js
+++ b/ads/beaverads.js
@@ -23,13 +23,19 @@ import {loadScript, validateData} from '../3p/3p';
 export function beaverads(global, data) {
   validateData(data, ['blockId']);
 
-  const url = 'https://code.beaverads.com/data/' +
-      encodeURIComponent(data['blockId']) + '.js?async=1&div=c';
+  const url =
+    'https://code.beaverads.com/data/' +
+    encodeURIComponent(data['blockId']) +
+    '.js?async=1&div=c';
 
-  loadScript(global, url, () => {
-    global.context.renderStart();
-  }, () => {
-    global.context.noContentAvailable();
-  });
-
+  loadScript(
+    global,
+    url,
+    () => {
+      global.context.renderStart();
+    },
+    () => {
+      global.context.noContentAvailable();
+    }
+  );
 }

--- a/build-system/amp-cors.js
+++ b/build-system/amp-cors.js
@@ -21,9 +21,9 @@
  * @type {RegExp}
  */
 const ORIGIN_REGEX = new RegExp(
-  '^http://localhost:8000|' +
-    '^http://.+.localhost:8000|' +
-    '^https?://.+.herokuapp.com'
+  '^https?://localhost:8000|' +
+    '^https?://.+\.localhost:8000|' +
+    '^https?://.+\.herokuapp.com'
 );
 
 /**
@@ -33,9 +33,9 @@ const ORIGIN_REGEX = new RegExp(
  * @type {RegExp}
  */
 const SOURCE_ORIGIN_REGEX = new RegExp(
-  '^http://localhost:8000|' +
-    '^http://.+.localhost:8000|' +
-    '^https?://.+.herokuapp.com'
+  '^https?://localhost:8000|' +
+    '^https?://.+\.localhost:8000|' +
+    '^https?://.+\.herokuapp.com'
 );
 
 function assertCors(

--- a/build-system/amp-cors.js
+++ b/build-system/amp-cors.js
@@ -22,8 +22,8 @@
  */
 const ORIGIN_REGEX = new RegExp(
   '^https?://localhost:8000|' +
-    '^https?://.+\.localhost:8000|' +
-    '^https?://.+\.herokuapp.com'
+    '^https?://.+.localhost:8000|' +
+    '^https?://.+.herokuapp.com'
 );
 
 /**
@@ -34,8 +34,8 @@ const ORIGIN_REGEX = new RegExp(
  */
 const SOURCE_ORIGIN_REGEX = new RegExp(
   '^https?://localhost:8000|' +
-    '^https?://.+\.localhost:8000|' +
-    '^https?://.+\.herokuapp.com'
+    '^https?://.+.localhost:8000|' +
+    '^https?://.+.herokuapp.com'
 );
 
 function assertCors(

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -49,6 +49,7 @@ app.use(bodyParser.text());
 app.use('/amp4test', require('./amp4test').app);
 app.use('/analytics', require('./routes/analytics'));
 app.use('/list/', require('./routes/list'));
+app.use('/user-location/', require('./routes/user-location'));
 
 // Append ?csp=1 to the URL to turn on the CSP header.
 // TODO: shall we turn on CSP all the time?
@@ -286,19 +287,20 @@ app.use('/form/echo-json/post', (req, res) => {
   const form = new formidable.IncomingForm();
   const fields = Object.create(null);
   form.on('field', function(name, value) {
-    if (name in fields) {
-      const realName = name; // .slice(0, name.length - 2);
-      if (realName in fields) {
-        if (!Array.isArray(fields[realName])) {
-          fields[realName] = [fields[realName]];
-        }
-      } else {
-        fields[realName] = [];
-      }
-      fields[realName].push(value);
-    } else {
+    if (!(name in fields)) {
       fields[name] = value;
+      return;
     }
+
+    const realName = name;
+    if (realName in fields) {
+      if (!Array.isArray(fields[realName])) {
+        fields[realName] = [fields[realName]];
+      }
+    } else {
+      fields[realName] = [];
+    }
+    fields[realName].push(value);
   });
   form.parse(req, unusedErr => {
     res.setHeader('Content-Type', 'application/json; charset=utf-8');

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -284,7 +284,25 @@ app.use('/form/redirect-to/post', (req, res) => {
 app.use('/form/echo-json/post', (req, res) => {
   cors.assertCors(req, res, ['POST']);
   const form = new formidable.IncomingForm();
-  form.parse(req, (err, fields) => {
+  const fields = Object.create(null);
+  form.on('field', function(name, value) {
+    console.log(name, value);
+    // fields[name] = value;
+    if (name in fields) {
+      const realName = name; // .slice(0, name.length - 2);
+      if (realName in fields) {
+        if (!Array.isArray(fields[realName])) {
+          fields[realName] = [fields[realName]];
+        }
+      } else {
+        fields[realName] = [];
+      }
+      fields[realName].push(value);
+    } else {
+      fields[name] = value;
+    }
+  });
+  form.parse(req, unusedErr => {
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     if (fields['email'] == 'already@subscribed.com') {
       res.statusCode = 500;

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -286,8 +286,6 @@ app.use('/form/echo-json/post', (req, res) => {
   const form = new formidable.IncomingForm();
   const fields = Object.create(null);
   form.on('field', function(name, value) {
-    console.log(name, value);
-    // fields[name] = value;
     if (name in fields) {
       const realName = name; // .slice(0, name.length - 2);
       if (realName in fields) {
@@ -989,6 +987,8 @@ app.get(
           file = addViewerIntegrationScript(req.query['amp_js_v'], file);
         }
         file = file.replace(/__TEST_SERVER_PORT__/g, TEST_SERVER_PORT);
+        file = file.replace(/__VIALIZ_MAP_KEY__/g,
+            fs.readFileSync(`${pc.cwd()}/credentials/vializ_map_key`));
 
         if (inabox && req.headers.origin && req.query.__amp_source_origin) {
           // Allow CORS requests for A4A.

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -987,8 +987,6 @@ app.get(
           file = addViewerIntegrationScript(req.query['amp_js_v'], file);
         }
         file = file.replace(/__TEST_SERVER_PORT__/g, TEST_SERVER_PORT);
-        file = file.replace(/__VIALIZ_MAP_KEY__/g,
-            fs.readFileSync(`${pc.cwd()}/credentials/vializ_map_key`));
 
         if (inabox && req.headers.origin && req.query.__amp_source_origin) {
           // Allow CORS requests for A4A.

--- a/build-system/routes/user-location.js
+++ b/build-system/routes/user-location.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const cors = require('../amp-cors');
+const router = require('express').Router();
+
+router.use('/general-deals', (req, res) => {
+  cors.assertCors(req, res, ['GET']);
+  res.json({
+    businesses: [
+      'general business 1',
+      'general business 2',
+      'general business 3',
+    ],
+  });
+});
+
+router.use('/localized-deals', (req, res) => {
+  cors.assertCors(req, res, ['GET']);
+
+  const {lat, lon} = req.query;
+
+  res.json({
+    lat,
+    lon,
+    businesses: ['local business 1', 'local business 2', 'local business 3'],
+  });
+});
+
+module.exports = router;

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -399,6 +399,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-user-location',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-gfycat',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/amp-user-location.amp.html
+++ b/examples/amp-user-location.amp.html
@@ -184,8 +184,11 @@
 <span hidden id="errored6">Errored!</span>
 <span hidden id="requesting6">Please wait</span>
 <amp-list
-    src="https://localhost:8000/user-location/general-deals"
-    [src]="'https://localhost:8000/user-location/localized-deals/TODO?lat=' + listLat + '&lon=' + listLon"
+    src="//localhost:8000/user-location/general-deals"
+    [src]="listLat ?
+        ('//localhost:8000/user-location/localized-deals?lat=' + listLat + '&lon=' + listLon) :
+        '//localhost:8000/user-location/general-deals'"
+    items="."
     layout="responsive" width="16" height="9" single-item
 >
   <template type="amp-mustache">

--- a/examples/amp-user-location.amp.html
+++ b/examples/amp-user-location.amp.html
@@ -6,15 +6,11 @@
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    amp-user-location {
-      color: red;
-    }
-  </style>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -30,41 +26,10 @@
 <amp-user-location id="location" layout="nodisplay"
     on="approve: approved.show; deny: denied.show; error: errored.show"
 ></amp-user-location>
-<p hidden id="approved">Approved!</p>
-<p hidden id="denied">Denied!</p>
-<p hidden id="errored">Errored!</p>
 <button on="tap: location.request()">Get my location</button>
-
-
-<h2>Form and variable substitution usage</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
-<amp-user-location on="
-  approve: location-form.submit;
-  deny: denied2.show;
-  error: errored2.show" id="location2" layout="nodisplay">
-</amp-user-location>
-<p hidden id="denied2">Denied!</p>
-<p hidden id="errored2">Errored!</p>
-<fieldset>
-  <legend>Location form</legend>
-  <button on="tap: location2.request()">Use my location</button>
-  <form id="location-form" method="POST" action-xhr="https://localhost:8000/form/echo-json/post">
-    <input type="hidden" name="latlon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION">
-    <input type="hidden" name="lat" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LAT)">
-    <input type="hidden" name="lon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LON)">
-    <div submit-success>
-      <template type="amp-mustache">
-        <p>latlon: <b>{{latlon}}</b></p>
-        <p>lat: <b>{{lat}}</b></p>
-        <p>lon: <b>{{lon}}</b></p>
-      </template>
-    </div>
-  </form>
-</fieldset>
-
+<span hidden id="approved">Approved!</span>
+<span hidden id="denied">Denied!</span>
+<span hidden id="errored">Errored!</span>
 
 <h2>Bind usage</h2>
 <p>
@@ -78,12 +43,12 @@
     deny: denied3.show;
     error: errored3.show"
 ></amp-user-location>
-<p hidden [hidden]="!example3.lat && !example3.lon">
-  Approved! <span [text]="example3.lat && example3.lon ? example3.lat + ' ' + example3.lon:''"></span>
-</p>
-<p hidden id="denied3">Denied!</p>
-<p hidden id="errored3">Errored!</p>
 <button on="tap: location3.request()">Get my location</button>
+<span hidden [hidden]="!example3.lat && !example3.lon">
+  Approved! <span [text]="example3.lat && example3.lon ? example3.lat + ' ' + example3.lon:''"></span>
+</span>
+<span hidden id="denied3">Denied!</span>
+<span hidden id="errored3">Errored!</span>
 
 
 <h2>Analytics usage</h2>
@@ -96,9 +61,9 @@
     error: error4.show"
 ></amp-user-location>
 <button on="tap: location4.request()">Get my location</button>
-<p hidden id="approved4">Approved!</p>
-<p hidden id="denied4">Denied!</p>
-<p hidden id="errored4">Errored!</p>
+<span hidden id="approved4">Approved!</span>
+<span hidden id="denied4">Denied!</span>
+<span hidden id="errored4">Errored!</span>
 
 <amp-analytics id="analytics1">
   <script type="application/json">
@@ -107,7 +72,8 @@
     "requests": {
       "endpoint": "/analytics",
       "base": "${endpoint}/${type}?path=${canonicalPath}",
-      "event": "${base}&lat=${ampUserLocation(LAT)}&lon=${ampUserLocation(LON)}&latlon=${ampUserLocation()}"
+      "event": "${base}&lat=${ampUserLocation(LAT)}&lon=${ampUserLocation(LON)}&latlon=${ampUserLocation()}",
+      "poll": "${base}&polling&lat=${ampUserLocationPoll(LAT)}&lon=${ampUserLocationPoll(LON)}&latlon=${ampUserLocationPoll()}"
     },
     "triggers": {
       "pageview": {
@@ -141,6 +107,15 @@
           "selector": "body"
         }
       },
+      "clickPingsPoll": {
+        "on": "click",
+        "selector": "${selector}",
+        "request": "poll",
+        "vars": {
+          "type": "click",
+          "selector": "body"
+        }
+      },
       "timer": {
         "on": "timer",
         "timerSpec": {
@@ -167,14 +142,14 @@
   deny: denied5.show, requesting5.hide;
   error: errored5.show, requesting5.hide;" id="location5" layout="nodisplay">
 </amp-user-location>
-<p hidden id="denied5">Denied!</p>
-<p hidden id="errored5">Errored!</p>
-<p hidden id="requesting5">Please wait</p>
 <fieldset>
   <legend>List form</legend>
   <button on="tap: requesting5.show, location5.request();">Use my location</button>
+  <span hidden id="denied5">Denied!</span>
+  <span hidden id="errored5">Errored!</span>
+  <span hidden id="requesting5">Please wait</span>
   <form
-      id="list-form" method="POST" action-xhr="https://localhost:8000/form/echo-json/post"
+      id="list-form" method="POST" action-xhr="/form/echo-json/post"
       on="submit-success: requesting5.hide, AMP.setState({listData: event.response})">
     <input type="hidden" name="latlon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION">
     <input type="hidden" name="lat" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LAT)">
@@ -183,18 +158,18 @@
     <input hidden type="checkbox" checked name="businesses" value="JCarlos">
     <input hidden type="checkbox" checked name="businesses" value="Carlos O'Vializ's">
   </form>
+  <amp-list [src]="listData" layout="responsive" width="16" height="9" single-item>
+    <template type="amp-mustache">
+    <p>Businesses near <b>{{lat}} {{lon}}</b></p>
+    <ul>
+      {{#businesses}}<li>{{.}}</li>{{/businesses}}
+    </ul>
+    </template>
+  </amp-list>
 </fieldset>
-<amp-list [src]="listData" layout="responsive" width="16" height="9" single-item>
-  <template type="amp-mustache">
-  <p>Businesses near <b>{{lat}} {{lon}}</b></p>
-  <ul>
-    {{#businesses}}<li>{{.}}</li>{{/businesses}}
-  </ul>
-  </template>
-</amp-list>
 
 
-<h2>amp-list usage with amp-bind</h2>
+<!-- <h2>amp-list usage with amp-bind</h2>
 <p>
   This example populates variable substitution for analytics
   and triggers the AMP actions and events.
@@ -204,10 +179,10 @@
   deny: denied6.show, requesting6.hide;
   error: errored6.show, requesting6.hide;" id="location6" layout="nodisplay">
 </amp-user-location>
-<p hidden id="denied6">Denied!</p>
-<p hidden id="errored6">Errored!</p>
 <button on="tap: requesting6.show, location6.request();">Get my local deals</button>
-<p hidden id="requesting6">Please wait</p>
+<span hidden id="denied6">Denied!</span>
+<span hidden id="errored6">Errored!</span>
+<span hidden id="requesting6">Please wait</span>
 <amp-list
     src="https://localhost:8000/user-location/general-deals"
     [src]="'https://localhost:8000/user-location/localized-deals/TODO?lat=' + listLat + '&lon=' + listLon"
@@ -219,10 +194,70 @@
     {{#businesses}}<li>{{.}}</li>{{/businesses}}
   </ul>
   </template>
-</amp-list>
+</amp-list> -->
 
 <h2>amp-pixel</h2>
 <amp-pixel width="1" height="1" src="//localhost:8000/pixel?location=$AMP_USER_LOCATION"></amp-pixel>
 
+
+<h2>Form and variable substitution usage</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-user-location on="
+  approve: locationForm.submit;
+  deny: formDenied.show;
+  error: formErrored.show" id="formLocation" layout="nodisplay">
+</amp-user-location>
+<span hidden id="formDenied">Denied!</span>
+<span hidden id="formErrored">Errored!</span>
+<fieldset>
+  <legend>Location form</legend>
+  <button on="tap: formLocation.request()">Use my location</button>
+  <form id="locationForm" method="POST" action-xhr="/form/echo-json/post">
+    <input type="hidden" name="latlon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION">
+    <input type="hidden" name="lat" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LAT)">
+    <input type="hidden" name="lon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LON)">
+    <div submit-success>
+      <template type="amp-mustache">
+        <p>latlon: <b>{{latlon}}</b></p>
+        <p>lat: <b>{{lat}}</b></p>
+        <p>lon: <b>{{lon}}</b></p>
+        <!-- DO NOT SUBMIT: Remove these API keys before merging PR -->
+        <amp-iframe
+          layout="responsive"
+          width="800"
+          height="600"
+          sandbox="allow-scripts"
+          src="https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&center={{lat}},{{lon}}&zoom=17">
+        </iframe>
+      </template>
+    </div>
+  </form>
+</fieldset>
+
+<h2>amp-user-location with amp-iframe and amp-bind</h2>
+<amp-user-location on="
+  approve: AMP.setState({mapLat: event.lat, mapLon: event.lon}), mapWait.hide;
+  deny: mapDenied.show, mapWait.hide;
+  error: mapErrored.show, mapWait.hide;"
+  id="mapLocation" layout="nodisplay">
+</amp-user-location>
+<amp-state id="mapLat"><script type="application/json">0</script></amp-state>
+<amp-state id="mapLon"><script type="application/json">0</script></amp-state>
+<button on="tap: mapWait.show, mapLocation.request()">Use my location</button>
+<span hidden id="mapWait">Getting your location</span>
+<span hidden id="mapDenied">Denied!</span>
+<span hidden id="mapErrored">Errored!</span>
+<!-- DO NOT SUBMIT: Remove these API keys before merging PR -->
+<amp-iframe
+    layout="responsive"
+    width="800"
+    height="600"
+    sandbox="allow-scripts"
+    src="https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&center=0,0&zoom=0"
+    [src]="'https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&zoom=' + (mapLat ? 17 : 0) + '&center=' +
+    mapLat + ',' + mapLon">
 </body>
 </html>

--- a/examples/amp-user-location.amp.html
+++ b/examples/amp-user-location.amp.html
@@ -169,7 +169,7 @@
 </fieldset>
 
 
-<!-- <h2>amp-list usage with amp-bind</h2>
+<h2>amp-list usage with amp-bind</h2>
 <p>
   This example populates variable substitution for analytics
   and triggers the AMP actions and events.
@@ -194,7 +194,7 @@
     {{#businesses}}<li>{{.}}</li>{{/businesses}}
   </ul>
   </template>
-</amp-list> -->
+</amp-list>
 
 <h2>amp-pixel</h2>
 <amp-pixel width="1" height="1" src="//localhost:8000/pixel?location=$AMP_USER_LOCATION"></amp-pixel>
@@ -224,40 +224,9 @@
         <p>latlon: <b>{{latlon}}</b></p>
         <p>lat: <b>{{lat}}</b></p>
         <p>lon: <b>{{lon}}</b></p>
-        <!-- DO NOT SUBMIT: Remove these API keys before merging PR -->
-        <amp-iframe
-          layout="responsive"
-          width="800"
-          height="600"
-          sandbox="allow-scripts"
-          src="https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&center={{lat}},{{lon}}&zoom=17">
-        </iframe>
       </template>
     </div>
   </form>
 </fieldset>
-
-<h2>amp-user-location with amp-iframe and amp-bind</h2>
-<amp-user-location on="
-  approve: AMP.setState({mapLat: event.lat, mapLon: event.lon}), mapWait.hide;
-  deny: mapDenied.show, mapWait.hide;
-  error: mapErrored.show, mapWait.hide;"
-  id="mapLocation" layout="nodisplay">
-</amp-user-location>
-<amp-state id="mapLat"><script type="application/json">0</script></amp-state>
-<amp-state id="mapLon"><script type="application/json">0</script></amp-state>
-<button on="tap: mapWait.show, mapLocation.request()">Use my location</button>
-<span hidden id="mapWait">Getting your location</span>
-<span hidden id="mapDenied">Denied!</span>
-<span hidden id="mapErrored">Errored!</span>
-<!-- DO NOT SUBMIT: Remove these API keys before merging PR -->
-<amp-iframe
-    layout="responsive"
-    width="800"
-    height="600"
-    sandbox="allow-scripts"
-    src="https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&center=0,0&zoom=0"
-    [src]="'https://www.google.com/maps/embed/v1/view?key=__VIALIZ_MAP_KEY__&zoom=' + (mapLat ? 17 : 0) + '&center=' +
-    mapLat + ',' + mapLon">
 </body>
 </html>

--- a/examples/amp-user-location.amp.html
+++ b/examples/amp-user-location.amp.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-user-location example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-user-location {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<h1>amp-user-location</h1>
+
+<h2>Basic usage</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-user-location id="location" layout="nodisplay"
+    on="approve: approved.show; deny: denied.show; error: errored.show"
+></amp-user-location>
+<p hidden id="approved">Approved!</p>
+<p hidden id="denied">Denied!</p>
+<p hidden id="errored">Errored!</p>
+<button on="tap: location.request()">Get my location</button>
+
+
+<h2>Form and variable substitution usage</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-user-location on="
+  approve: location-form.submit;
+  deny: denied2.show;
+  error: errored2.show" id="location2" layout="nodisplay">
+</amp-user-location>
+<p hidden id="denied2">Denied!</p>
+<p hidden id="errored2">Errored!</p>
+<fieldset>
+  <legend>Location form</legend>
+  <button on="tap: location2.request()">Use my location</button>
+  <form id="location-form" method="POST" action-xhr="https://localhost:8000/form/echo-json/post">
+    <input type="hidden" name="latlon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION">
+    <input type="hidden" name="lat" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LAT)">
+    <input type="hidden" name="lon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LON)">
+    <div submit-success>
+      <template type="amp-mustache">
+        <p>latlon: <b>{{latlon}}</b></p>
+        <p>lat: <b>{{lat}}</b></p>
+        <p>lon: <b>{{lon}}</b></p>
+      </template>
+    </div>
+  </form>
+</fieldset>
+
+
+<h2>Bind usage</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-state id="example3"><script type="application/json">{}</script></amp-state>
+<amp-user-location id="location3" layout="nodisplay"
+    on="
+    approve: AMP.setState({example3: {lat: event.lat, lon: event.lon}});
+    deny: denied3.show;
+    error: errored3.show"
+></amp-user-location>
+<p hidden [hidden]="!example3.lat && !example3.lon">
+  Approved! <span [text]="example3.lat && example3.lon ? example3.lat + ' ' + example3.lon:''"></span>
+</p>
+<p hidden id="denied3">Denied!</p>
+<p hidden id="errored3">Errored!</p>
+<button on="tap: location3.request()">Get my location</button>
+
+
+<h2>Analytics usage</h2>
+<p>
+  This example consumes analytics variables exposed by the component
+</p>
+<amp-user-location id="location4" layout="nodisplay"
+    on="approve: approved4.show;
+    deny: denied4.show;
+    error: error4.show"
+></amp-user-location>
+<button on="tap: location4.request()">Get my location</button>
+<p hidden id="approved4">Approved!</p>
+<p hidden id="denied4">Denied!</p>
+<p hidden id="errored4">Errored!</p>
+
+<amp-analytics id="analytics1">
+  <script type="application/json">
+  {
+    "transport": {"beacon": true, "xhrpost": false},
+    "requests": {
+      "endpoint": "/analytics",
+      "base": "${endpoint}/${type}?path=${canonicalPath}",
+      "event": "${base}&lat=${ampUserLocation(LAT)}&lon=${ampUserLocation(LON)}&latlon=${ampUserLocation()}"
+    },
+    "triggers": {
+      "pageview": {
+        "on": "visible",
+        "request": "event",
+        "vars": {
+          "type": "pageLoad"
+        }
+      },
+      "visibility": {
+        "on": "visible",
+        "request": "event",
+        "selector": "#location4",
+        "visibilitySpec": {
+          "visiblePercentageMin": 20,
+          "visiblePercentageMax": 80,
+          "totalTimeMin": 5000,
+          "continuousTimeMin": 2000,
+          "waitFor": "ini-load"
+        },
+        "vars": {
+          "type": "visible"
+        }
+      },
+      "clickPings": {
+        "on": "click",
+        "selector": "${selector}",
+        "request": "event",
+        "vars": {
+          "type": "click",
+          "selector": "body"
+        }
+      },
+      "timer": {
+        "on": "timer",
+        "timerSpec": {
+          "interval": 5,
+          "maxTimerLength": 20
+        },
+        "request": "event",
+        "vars": {
+          "type": "timer"
+        }
+      }
+    }
+  }
+  </script>
+</amp-analytics>
+
+<h2>amp-list usage without amp-bind</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-user-location on="
+  approve: list-form.submit;
+  deny: denied5.show, requesting5.hide;
+  error: errored5.show, requesting5.hide;" id="location5" layout="nodisplay">
+</amp-user-location>
+<p hidden id="denied5">Denied!</p>
+<p hidden id="errored5">Errored!</p>
+<p hidden id="requesting5">Please wait</p>
+<fieldset>
+  <legend>List form</legend>
+  <button on="tap: requesting5.show, location5.request();">Use my location</button>
+  <form
+      id="list-form" method="POST" action-xhr="https://localhost:8000/form/echo-json/post"
+      on="submit-success: requesting5.hide, AMP.setState({listData: event.response})">
+    <input type="hidden" name="latlon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION">
+    <input type="hidden" name="lat" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LAT)">
+    <input type="hidden" name="lon" data-amp-replace="AMP_USER_LOCATION" value="AMP_USER_LOCATION(LON)">
+    <input hidden type="checkbox" checked name="businesses" value="McCarlos">
+    <input hidden type="checkbox" checked name="businesses" value="JCarlos">
+    <input hidden type="checkbox" checked name="businesses" value="Carlos O'Vializ's">
+  </form>
+</fieldset>
+<amp-list [src]="listData" layout="responsive" width="16" height="9" single-item>
+  <template type="amp-mustache">
+  <p>Businesses near <b>{{lat}} {{lon}}</b></p>
+  <ul>
+    {{#businesses}}<li>{{.}}</li>{{/businesses}}
+  </ul>
+  </template>
+</amp-list>
+
+
+<h2>amp-list usage with amp-bind</h2>
+<p>
+  This example populates variable substitution for analytics
+  and triggers the AMP actions and events.
+</p>
+<amp-user-location on="
+  approve: AMP.setState({listLat: event.lat, listLon: event.lon}), requesting6.hide;
+  deny: denied6.show, requesting6.hide;
+  error: errored6.show, requesting6.hide;" id="location6" layout="nodisplay">
+</amp-user-location>
+<p hidden id="denied6">Denied!</p>
+<p hidden id="errored6">Errored!</p>
+<button on="tap: requesting6.show, location6.request();">Get my local deals</button>
+<p hidden id="requesting6">Please wait</p>
+<amp-list
+    src="https://localhost:8000/user-location/general-deals"
+    [src]="'https://localhost:8000/user-location/localized-deals/TODO?lat=' + listLat + '&lon=' + listLon"
+    layout="responsive" width="16" height="9" single-item
+>
+  <template type="amp-mustache">
+  <p>Businesses near <b>{{lat}} {{lon}}</b></p>
+  <ul>
+    {{#businesses}}<li>{{.}}</li>{{/businesses}}
+  </ul>
+  </template>
+</amp-list>
+
+<h2>amp-pixel</h2>
+<amp-pixel width="1" height="1" src="//localhost:8000/pixel?location=$AMP_USER_LOCATION"></amp-pixel>
+
+</body>
+</html>

--- a/examples/amp-user-location.amp.html
+++ b/examples/amp-user-location.amp.html
@@ -19,10 +19,6 @@
 <h1>amp-user-location</h1>
 
 <h2>Basic usage</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
 <amp-user-location id="location" layout="nodisplay"
     on="approve: approved.show; deny: denied.show; error: errored.show"
 ></amp-user-location>
@@ -32,10 +28,6 @@
 <span hidden id="errored">Errored!</span>
 
 <h2>Bind usage</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
 <amp-state id="example3"><script type="application/json">{}</script></amp-state>
 <amp-user-location id="location3" layout="nodisplay"
     on="
@@ -52,9 +44,6 @@
 
 
 <h2>Analytics usage</h2>
-<p>
-  This example consumes analytics variables exposed by the component
-</p>
 <amp-user-location id="location4" layout="nodisplay"
     on="approve: approved4.show;
     deny: denied4.show;
@@ -133,10 +122,6 @@
 </amp-analytics>
 
 <h2>amp-list usage without amp-bind</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
 <amp-user-location on="
   approve: list-form.submit;
   deny: denied5.show, requesting5.hide;
@@ -170,10 +155,6 @@
 
 
 <h2>amp-list usage with amp-bind</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
 <amp-user-location on="
   approve: AMP.setState({listLat: event.lat, listLon: event.lon}), requesting6.hide;
   deny: denied6.show, requesting6.hide;
@@ -204,10 +185,6 @@
 
 
 <h2>Form and variable substitution usage</h2>
-<p>
-  This example populates variable substitution for analytics
-  and triggers the AMP actions and events.
-</p>
 <amp-user-location on="
   approve: locationForm.submit;
   deny: formDenied.show;

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -113,6 +113,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'ampdocUrl': 'AMPDOC_URL',
       'ampGeo': 'AMP_GEO',
       'ampUserLocation': 'AMP_USER_LOCATION',
+      'ampUserLocationPoll': 'AMP_USER_LOCATION_POLL',
       'ampState': 'AMP_STATE',
       'ampVersion': 'AMP_VERSION',
       'ancestorOrigin': 'ANCESTOR_ORIGIN',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -112,6 +112,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'ampdocHostname': 'AMPDOC_HOSTNAME',
       'ampdocUrl': 'AMPDOC_URL',
       'ampGeo': 'AMP_GEO',
+      'ampUserLocation': 'AMP_USER_LOCATION',
       'ampState': 'AMP_STATE',
       'ampVersion': 'AMP_VERSION',
       'ancestorOrigin': 'ANCESTOR_ORIGIN',

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActionTrust} from '../../../src/action-constants';
+import {Layout} from '../../../src/layout';
+import {PositionError} from './position-error';
+import {Services} from '../../../src/services';
+import {
+  UserLocationConfigDef,
+  UserLocationDef,
+  UserLocationService,
+} from './user-location-service';
+import {createCustomEvent} from '../../../src/event-helper';
+import {getMode} from '../../../src/mode';
+import {isCanary, isExperimentOn} from '../../../src/experiments';
+import {isJsonScriptTag} from '../../../src/dom';
+import {tryParseJson} from '../../../src/json';
+import {userAssert} from '../../../src/log';
+
+const TAG = 'amp-user-location';
+const SERVICE_TAG = 'user-location';
+
+
+const LOCATION_SEPARATOR = ',';
+
+
+/** @enum {string} */
+export const AmpUserLocationEvent = {
+  APPROVE: 'approve',
+  DENY: 'deny',
+  ERROR: 'error',
+};
+
+/** @enum {string} */
+const AmpUserLocationAction = {
+  REQUEST: 'request',
+};
+
+export class AmpUserLocation extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?UserLocationConfigDef} */
+    this.config_ = null;
+
+    /** @private {?../../../src/service/action-impl.ActionService} */
+    this.action_ = null;
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.NODISPLAY;
+  }
+
+  /** @override */
+  buildCallback() {
+    userAssert(
+        isExperimentOn(this.win, 'amp-user-location'),
+        'The "amp-user-location" experiment must be enabled ' +
+        'to use amp-user-location');
+    this.config_ = this.parse_();
+
+    this.action_ = Services.actionServiceForDoc(this.element);
+
+    this.registerAction(
+        AmpUserLocationAction.REQUEST,
+        () => this.userLocationInteraction_(),
+        ActionTrust.HIGH);
+  }
+
+  /**
+   * Parse a JSON script tag for configuration, if present.
+   * @return {?UserLocationConfigDef}
+   */
+  parse_() {
+    const {children} = this.element;
+    if (children.length != 1) {
+      return null;
+    }
+
+    const firstChild = children[0];
+    if (!isJsonScriptTag(firstChild)) {
+      this.user().error(TAG,
+          'amp-user-location config should be in a <script> tag ' +
+          'with type="application/json".');
+      return;
+    }
+
+    const json = tryParseJson(firstChild.textContent, e => {
+      this.user().error(TAG,
+          'Failed to parse amp-user-location config. ' +
+          'Is it valid JSON?', e);
+    });
+    if (json === null) {
+      return null;
+    }
+
+    return {
+      fallback: json['fallback'],
+      maxAge: json['maxAge'],
+      precision: json['precision'],
+      timeout: json['timeout'],
+    };
+  }
+
+  /**
+   * On user interaction, request the location
+   * and fire the resulting AMP Events
+   * @private
+   */
+  userLocationInteraction_() {
+    let override = null;
+    const {localDev, userLocationOverride} = getMode(this.win);
+    if (userLocationOverride && (isCanary(this.win) || localDev) &&
+      /^[\w-,]+$/.test(userLocationOverride)) {
+      // Debug override case, only works in canary or localdev and matches
+      // numeric and limited symbolic characters only to prevent xss vector.
+      // The regex is not trying to ensure correctness.
+      const split = userLocationOverride.split(LOCATION_SEPARATOR);
+      const lat = Number(split[0]);
+      const lon = Number(split[1]);
+      override = {lat, lon};
+    }
+
+    const servicePromise = Services.userLocationForDocOrNull(this.element);
+
+    return servicePromise.then(userLocationService => {
+      const config = this.config_ || {};
+      return userLocationService.requestLocation(config, override);
+    }).then(location => {
+      this.triggerEvent_(AmpUserLocationEvent.APPROVE, location);
+    }).catch(error => {
+      const {code} = error;
+      if (code == PositionError.PERMISSION_DENIED) {
+        this.triggerEvent_(AmpUserLocationEvent.DENY);
+        return;
+      }
+
+      if (code == PositionError.PLATFORM_UNSUPPORTED ||
+          code == PositionError.POSITION_UNAVAILABLE ||
+          code == PositionError.TIMEOUT) {
+        this.triggerEvent_(AmpUserLocationEvent.ERROR);
+      }
+    });
+  }
+
+  /**
+   * Trigger the given AMP action. Triggered when the overlay opens or when
+   * the static date picker should receive focus from the attached input.
+   * @param {string} name
+   * @param {UserLocationDef=} opt_data
+   * @private
+   */
+  triggerEvent_(name, opt_data = null) {
+    const event = createCustomEvent(this.win, `${TAG}.${name}`, opt_data);
+    this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
+  }
+}
+
+AMP.extension('amp-user-location', '0.1', AMP => {
+  AMP.registerElement(TAG, AmpUserLocation);
+  AMP.registerServiceForDoc(SERVICE_TAG, UserLocationService);
+});

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -108,7 +108,7 @@ export class AmpUserLocation extends AMP.BaseElement {
 
     return {
       fallback: json['fallback'],
-      maxAge: json['maxAge'],
+      maximumAge: json['maximumAge'],
       precision: json['precision'],
       timeout: json['timeout'],
     };

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -18,7 +18,6 @@ import {ActionTrust} from '../../../src/action-constants';
 import {Layout} from '../../../src/layout';
 import {PositionError} from './position-error';
 import {Services} from '../../../src/services';
-import {UserLocation, UserLocationSource} from './user-location';
 import {UserLocationService} from './user-location-service';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
@@ -114,14 +113,10 @@ export class AmpUserLocation extends AMP.BaseElement {
     }
 
     let jsonFallback = json['fallback'];
-    let fallback = null;
+    let fallback;
     if (jsonFallback) {
       jsonFallback = jsonFallback.split(',');
-      fallback = new UserLocation(
-        UserLocationSource.FALLBACK,
-        Number(jsonFallback[0]),
-        Number(jsonFallback[1])
-      );
+      fallback = {lat: Number(jsonFallback[0]), lon: Number(jsonFallback[1])};
     }
 
     return {

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -129,8 +129,8 @@ export class AmpUserLocation extends AMP.BaseElement {
           /** @type {./user-location-service.UserLocationConfigDef} */ ({});
         return userLocationService.requestLocation(config);
       })
-      .then(location => {
-        this.triggerEvent_(AmpUserLocationEvent.APPROVE, location);
+      .then(position => {
+        this.triggerEvent_(AmpUserLocationEvent.APPROVE, position);
       })
       .catch(error => {
         if (error == PositionError.PERMISSION_DENIED) {

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -83,9 +83,14 @@ export class AmpUserLocation extends AMP.BaseElement {
    */
   parse_() {
     const {children} = this.element;
-    if (children.length != 1) {
+    if (children.length == 0) {
       return null;
     }
+
+    userAssert(
+      children.length == 1,
+      'amp-user-location may only have one configuration json <script> tag'
+    );
 
     const firstChild = children[0];
     if (!isJsonScriptTag(firstChild)) {
@@ -147,23 +152,21 @@ export class AmpUserLocation extends AMP.BaseElement {
           this.triggerEvent_(AmpUserLocationEvent.APPROVE, position);
         },
         error => {
-          if (error.code == PositionError.PERMISSION_DENIED) {
-            this.triggerEvent_(
-              AmpUserLocationEvent.DENY,
-              dict({'fallback': error.fallback})
-            );
-            return;
-          }
-
-          if (
-            error.code == PositionError.PLATFORM_UNSUPPORTED ||
-            error.code == PositionError.POSITION_UNAVAILABLE ||
-            error.code == PositionError.TIMEOUT
-          ) {
-            this.triggerEvent_(
-              AmpUserLocationEvent.ERROR,
-              dict({'fallback': error.fallback})
-            );
+          switch (error.code) {
+            case PositionError.PERMISSION_DENIED:
+              this.triggerEvent_(
+                AmpUserLocationEvent.DENY,
+                dict({'fallback': error.fallback})
+              );
+              return;
+            case PositionError.PLATFORM_UNSUPPORTED:
+            case PositionError.POSITION_UNAVAILABLE:
+            case PositionError.TIMEOUT:
+            default:
+              this.triggerEvent_(
+                AmpUserLocationEvent.ERROR,
+                dict({'fallback': error.fallback})
+              );
           }
         }
       );

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -60,17 +60,19 @@ export class AmpUserLocation extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     userAssert(
-        isExperimentOn(this.win, 'amp-user-location'),
-        'The "amp-user-location" experiment must be enabled ' +
-        'to use amp-user-location');
+      isExperimentOn(this.win, 'amp-user-location'),
+      'The "amp-user-location" experiment must be enabled ' +
+        'to use amp-user-location'
+    );
     this.config_ = this.parse_();
 
     this.action_ = Services.actionServiceForDoc(this.element);
 
     this.registerAction(
-        AmpUserLocationAction.REQUEST,
-        () => this.userLocationInteraction_(),
-        ActionTrust.HIGH);
+      AmpUserLocationAction.REQUEST,
+      () => this.userLocationInteraction_(),
+      ActionTrust.HIGH
+    );
   }
 
   /**
@@ -85,16 +87,20 @@ export class AmpUserLocation extends AMP.BaseElement {
 
     const firstChild = children[0];
     if (!isJsonScriptTag(firstChild)) {
-      this.user().error(TAG,
-          'amp-user-location config should be in a <script> tag ' +
-          'with type="application/json".');
+      this.user().error(
+        TAG,
+        'amp-user-location config should be in a <script> tag ' +
+          'with type="application/json".'
+      );
       return null;
     }
 
     const json = tryParseJson(firstChild.textContent, e => {
-      this.user().error(TAG,
-          'Failed to parse amp-user-location config. ' +
-          'Is it valid JSON?', e);
+      this.user().error(
+        TAG,
+        'Failed to parse amp-user-location config. Is it valid JSON?',
+        e
+      );
     });
     if (json === null) {
       return null;
@@ -116,24 +122,30 @@ export class AmpUserLocation extends AMP.BaseElement {
   userLocationInteraction_() {
     const servicePromise = Services.userLocationForDocOrNull(this.element);
 
-    return servicePromise.then(userLocationService => {
-      const config = this.config_ ||
-      /** @type {./user-location-service.UserLocationConfigDef} */ ({});
-      return userLocationService.requestLocation(config);
-    }).then(location => {
-      this.triggerEvent_(AmpUserLocationEvent.APPROVE, location);
-    }).catch(error => {
-      if (error == PositionError.PERMISSION_DENIED) {
-        this.triggerEvent_(AmpUserLocationEvent.DENY);
-        return;
-      }
+    return servicePromise
+      .then(userLocationService => {
+        const config =
+          this.config_ ||
+          /** @type {./user-location-service.UserLocationConfigDef} */ ({});
+        return userLocationService.requestLocation(config);
+      })
+      .then(location => {
+        this.triggerEvent_(AmpUserLocationEvent.APPROVE, location);
+      })
+      .catch(error => {
+        if (error == PositionError.PERMISSION_DENIED) {
+          this.triggerEvent_(AmpUserLocationEvent.DENY);
+          return;
+        }
 
-      if (error == PositionError.PLATFORM_UNSUPPORTED ||
+        if (
+          error == PositionError.PLATFORM_UNSUPPORTED ||
           error == PositionError.POSITION_UNAVAILABLE ||
-          error == PositionError.TIMEOUT) {
-        this.triggerEvent_(AmpUserLocationEvent.ERROR);
-      }
-    });
+          error == PositionError.TIMEOUT
+        ) {
+          this.triggerEvent_(AmpUserLocationEvent.ERROR);
+        }
+      });
   }
 
   /**
@@ -144,8 +156,7 @@ export class AmpUserLocation extends AMP.BaseElement {
    * @private
    */
   triggerEvent_(name, data = undefined) {
-    const event = createCustomEvent(
-        this.win, `${TAG}.${name}`, data);
+    const event = createCustomEvent(this.win, `${TAG}.${name}`, data);
     this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
   }
 }

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -117,7 +117,8 @@ export class AmpUserLocation extends AMP.BaseElement {
     const servicePromise = Services.userLocationForDocOrNull(this.element);
 
     return servicePromise.then(userLocationService => {
-      const config = this.config_ || {};
+      const config = this.config_ ||
+      /** @type {./user-location-service.UserLocationConfigDef} */ ({});
       return userLocationService.requestLocation(config);
     }).then(location => {
       this.triggerEvent_(AmpUserLocationEvent.APPROVE, location);
@@ -139,12 +140,12 @@ export class AmpUserLocation extends AMP.BaseElement {
    * Trigger the given AMP action. Triggered when the overlay opens or when
    * the static date picker should receive focus from the attached input.
    * @param {string} name
-   * @param {?./user-location-service.UserLocationDef=} opt_data
+   * @param {!./user-location-service.UserLocation=} data
    * @private
    */
-  triggerEvent_(name, opt_data = null) {
+  triggerEvent_(name, data = undefined) {
     const event = createCustomEvent(
-        this.win, `${TAG}.${name}`, /** @type {JsonObject}*/ (opt_data));
+        this.win, `${TAG}.${name}`, data);
     this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
   }
 }

--- a/extensions/amp-user-location/0.1/position-error.js
+++ b/extensions/amp-user-location/0.1/position-error.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The spec does not expose this enum, so we define it here.
+ * This is 1-indexed corresponding with the spec.
+ * @enum {number}
+ */
+export const PositionError = {
+  PERMISSION_DENIED: 1,
+  POSITION_UNAVAILABLE: 2,
+  TIMEOUT: 3,
+  PLATFORM_UNSUPPORTED: 4,
+};

--- a/extensions/amp-user-location/0.1/test/test-amp-user-location.js
+++ b/extensions/amp-user-location/0.1/test/test-amp-user-location.js
@@ -19,195 +19,246 @@ import {PositionError} from '../position-error';
 import {Services} from '../../../../src/services';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describes.realWin('amp-user-location', {
-  amp: {
-    extensions: ['amp-user-location'],
+describes.realWin(
+  'amp-user-location',
+  {
+    amp: {
+      extensions: ['amp-user-location'],
+    },
   },
-}, env => {
+  env => {
+    let win;
+    let doc;
 
-  let win;
-  let doc;
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      toggleExperiment(win, 'amp-user-location', true);
+    });
 
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-    toggleExperiment(win, 'amp-user-location', true);
-  });
+    function newUserLocation(opt_config) {
+      const userLocation = doc.createElement('amp-user-location');
+      doc.body.appendChild(userLocation);
 
-  function newUserLocation(opt_config) {
-    const userLocation = doc.createElement('amp-user-location');
-    doc.body.appendChild(userLocation);
-
-    if (opt_config) {
-      const configElement = win.document.createElement('script');
-      configElement.setAttribute('type', 'application/json');
-      if (typeof opt_config == 'string') {
-        configElement.textContent = opt_config;
-      } else {
-        configElement.textContent = JSON.stringify(opt_config);
+      if (opt_config) {
+        const configElement = win.document.createElement('script');
+        configElement.setAttribute('type', 'application/json');
+        if (typeof opt_config == 'string') {
+          configElement.textContent = opt_config;
+        } else {
+          configElement.textContent = JSON.stringify(opt_config);
+        }
+        userLocation.appendChild(configElement);
       }
-      userLocation.appendChild(configElement);
+
+      return userLocation.build().then(() => userLocation);
     }
 
-    return userLocation.build().then(() => userLocation);
-  }
-
-  it('should build if experiment is on', () => {
-    const element = newUserLocation();
-    return element.catch(unused => {
-      throw new Error('component should have built');
-    });
-  });
-
-  it('should not build if experiment is off', () => {
-    return allowConsoleError(() => {
-      toggleExperiment(env.win, 'amp-user-location', false);
-      return newUserLocation().catch(err => {
-        expect(err.message).to.include('experiment must be enabled');
+    it('should build if experiment is on', () => {
+      const element = newUserLocation();
+      return element.catch(unused => {
+        throw new Error('component should have built');
       });
     });
-  });
 
-  it('should parse config when built, if present', () => {
-    return Promise.all([
-      newUserLocation().then(element => element.getImpl()).then(impl => {
-        expect(impl.config_).to.be.null;
-      }),
-      newUserLocation({}).then(element => element.getImpl()).then(impl => {
-        expect(impl.config_).to.not.be.null;
-      }),
-    ]);
-  });
-
-  it('should error with invalid config', () => {
-    return allowConsoleError(() => {
-      return newUserLocation('this is not valid json').catch(err => {
-        expect(err.message).to.include(
-            'Failed to parse amp-user-location config');
+    it('should not build if experiment is off', () => {
+      return allowConsoleError(() => {
+        toggleExperiment(env.win, 'amp-user-location', false);
+        return newUserLocation().catch(err => {
+          expect(err.message).to.include('experiment must be enabled');
+        });
       });
     });
-  });
 
-  it('should parse recognized fields in the config', () => {
-    const testConfig = {
-      fallback: '40,-22',
-      maxAge: 60000,
-      precision: 'low',
-      timeout: 10000,
-      doNotExpose: 'wow',
-    };
+    it('should parse config when built, if present', () => {
+      return Promise.all([
+        newUserLocation()
+          .then(element => element.getImpl())
+          .then(impl => {
+            expect(impl.config_).to.be.null;
+          }),
+        newUserLocation({})
+          .then(element => element.getImpl())
+          .then(impl => {
+            expect(impl.config_).to.not.be.null;
+          }),
+      ]);
+    });
 
-    return newUserLocation(testConfig).then(element => {
-      return element.getImpl();
-    }).then(impl => {
-      expect(impl.config_).to.include({
+    it('should error with invalid config', () => {
+      return allowConsoleError(() => {
+        return newUserLocation('this is not valid json').catch(err => {
+          expect(err.message).to.include(
+            'Failed to parse amp-user-location config'
+          );
+        });
+      });
+    });
+
+    it('should parse recognized fields in the config', () => {
+      const testConfig = {
         fallback: '40,-22',
         maxAge: 60000,
+        precision: 'low',
         timeout: 10000,
+        doNotExpose: 'wow',
+      };
+
+      return newUserLocation(testConfig)
+        .then(element => {
+          return element.getImpl();
+        })
+        .then(impl => {
+          expect(impl.config_).to.include({
+            fallback: '40,-22',
+            maxAge: 60000,
+            timeout: 10000,
+          });
+          expect(impl.config_).to.not.have.property('doNotExpose');
+        });
+    });
+
+    it('should trigger the "approve" event if user approves geolocation', () => {
+      class UserLocationFake {}
+      UserLocationFake.prototype.requestLocation = sandbox.stub().resolves({
+        lat: 10,
+        lon: -10,
       });
-      expect(impl.config_).to.not.have.property('doNotExpose');
-    });
-  });
-
-  it('should trigger the "approve" event if user approves geolocation', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation = sandbox.stub().resolves({
-      lat: 10, lon: -10,
-    });
-    sandbox.stub(Services, 'userLocationForDocOrNull')
+      sandbox
+        .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(
-          AmpUserLocationEvent.APPROVE,
-          {lat: 10, lon: -10});
+      let triggerSpy;
+      return newUserLocation()
+        .then(element => element.getImpl())
+        .then(impl => {
+          triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+          return impl.userLocationInteraction_();
+        })
+        .then(() => {
+          expect(triggerSpy).to.have.been.calledWith(
+            AmpUserLocationEvent.APPROVE,
+            {lat: 10, lon: -10}
+          );
+        });
     });
-  });
 
-  it('should trigger the "deny" event if user denies geolocation', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects(PositionError.PERMISSION_DENIED);
-    sandbox.stub(Services, 'userLocationForDocOrNull')
+    it('should trigger the "deny" event if user denies geolocation', () => {
+      class UserLocationFake {}
+      UserLocationFake.prototype.requestLocation = sandbox
+        .stub()
+        .rejects(PositionError.PERMISSION_DENIED);
+      sandbox
+        .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.DENY);
+      let triggerSpy;
+      return newUserLocation()
+        .then(element => element.getImpl())
+        .then(impl => {
+          triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+          return impl.userLocationInteraction_();
+        })
+        .then(() => {
+          expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.DENY);
+        });
     });
-  });
 
-  it('should trigger the "error" event if geolocation timeouts', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects(PositionError.TIMEOUT);
-    sandbox.stub(Services, 'userLocationForDocOrNull')
+    it('should trigger the "error" event if geolocation timeouts', () => {
+      class UserLocationFake {}
+      UserLocationFake.prototype.requestLocation = sandbox
+        .stub()
+        .rejects(PositionError.TIMEOUT);
+      sandbox
+        .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+      let triggerSpy;
+      return newUserLocation()
+        .then(element => element.getImpl())
+        .then(impl => {
+          triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+          return impl.userLocationInteraction_();
+        })
+        .then(() => {
+          expect(triggerSpy).to.have.been.calledWith(
+            AmpUserLocationEvent.ERROR
+          );
+        });
     });
-  });
 
-  it('should trigger the "error" event if geolocation is unavailable', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects(PositionError.POSITION_UNAVAILABLE);
-    sandbox.stub(Services, 'userLocationForDocOrNull')
+    it('should trigger the "error" event if geolocation is unavailable', () => {
+      class UserLocationFake {}
+      UserLocationFake.prototype.requestLocation = sandbox
+        .stub()
+        .rejects(PositionError.POSITION_UNAVAILABLE);
+      sandbox
+        .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+      let triggerSpy;
+      return newUserLocation()
+        .then(element => element.getImpl())
+        .then(impl => {
+          triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+          return impl.userLocationInteraction_();
+        })
+        .then(() => {
+          expect(triggerSpy).to.have.been.calledWith(
+            AmpUserLocationEvent.ERROR
+          );
+        });
     });
-  });
 
-  it('should trigger the "error" event if the platform ' +
-      'does not support geolocation', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects(PositionError.PLATFORM_UNSUPPORTED);
-    sandbox.stub(Services, 'userLocationForDocOrNull')
+    it(
+      'should trigger the "error" event if the platform ' +
+        'does not support geolocation',
+      () => {
+        class UserLocationFake {}
+        UserLocationFake.prototype.requestLocation = sandbox
+          .stub()
+          .rejects(PositionError.PLATFORM_UNSUPPORTED);
+        sandbox
+          .stub(Services, 'userLocationForDocOrNull')
+          .resolves(new UserLocationFake());
+
+        let triggerSpy;
+        return newUserLocation()
+          .then(element => element.getImpl())
+          .then(impl => {
+            triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+            return impl.userLocationInteraction_();
+          })
+          .then(() => {
+            expect(triggerSpy).to.have.been.calledWith(
+              AmpUserLocationEvent.ERROR
+            );
+          });
+      }
+    );
+
+    it('should "approve" with override if override is present', () => {
+      class UserLocationFake {}
+      UserLocationFake.prototype.requestLocation = sandbox
+        .stub()
+        .callsFake(() => ({lat: 10, lon: -10}));
+      sandbox
+        .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+      let triggerSpy;
+      return newUserLocation()
+        .then(element => element.getImpl())
+        .then(impl => {
+          triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+          return impl.userLocationInteraction_();
+        })
+        .then(() => {
+          expect(triggerSpy).to.have.been.calledWith(
+            AmpUserLocationEvent.APPROVE,
+            {lat: 10, lon: -10}
+          );
+        });
     });
-  });
-
-  it('should "approve" with override if override is present', () => {
-    class UserLocationFake {}
-    UserLocationFake.prototype.requestLocation =
-        sandbox.stub().callsFake(() => ({lat: 10, lon: -10}));
-    sandbox.stub(Services, 'userLocationForDocOrNull')
-        .resolves(new UserLocationFake());
-
-    let triggerSpy;
-    return newUserLocation().then(element => element.getImpl()).then(impl => {
-      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
-      return impl.userLocationInteraction_();
-    }).then(() => {
-      expect(triggerSpy).to.have.been.calledWith(
-          AmpUserLocationEvent.APPROVE,
-          {lat: 10, lon: -10});
-    });
-  });
-});
+  }
+);

--- a/extensions/amp-user-location/0.1/test/test-amp-user-location.js
+++ b/extensions/amp-user-location/0.1/test/test-amp-user-location.js
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as mode from '../../../../src/mode';
+import {AmpUserLocationEvent} from '../amp-user-location';
+import {PositionError} from '../position-error';
+import {Services} from '../../../../src/services';
+import {toggleExperiment} from '../../../../src/experiments';
+
+describes.realWin('amp-user-location', {
+  amp: {
+    extensions: ['amp-user-location'],
+  },
+}, env => {
+
+  let win;
+  let doc;
+  let getModeStub;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    toggleExperiment(win, 'amp-user-location', true);
+  });
+
+  function newUserLocation(opt_config) {
+    const userLocation = doc.createElement('amp-user-location');
+    doc.body.appendChild(userLocation);
+
+    if (opt_config) {
+      const configElement = win.document.createElement('script');
+      configElement.setAttribute('type', 'application/json');
+      if (typeof opt_config == 'string') {
+        configElement.textContent = opt_config;
+      } else {
+        configElement.textContent = JSON.stringify(opt_config);
+      }
+      userLocation.appendChild(configElement);
+    }
+
+    return userLocation.build().then(() => userLocation);
+  }
+
+  it('should build if experiment is on', () => {
+    const element = newUserLocation();
+    return element.catch(unused => {
+      throw new Error('component should have built');
+    });
+  });
+
+  it('should not build if experiment is off', () => {
+    return allowConsoleError(() => {
+      toggleExperiment(env.win, 'amp-user-location', false);
+      return newUserLocation().catch(err => {
+        expect(err.message).to.include('experiment must be enabled');
+      });
+    });
+  });
+
+  it('should parse config when built, if present', () => {
+    return Promise.all([
+      newUserLocation().then(element => element.getImpl()).then(impl => {
+        expect(impl.config_).to.be.null;
+      }),
+      newUserLocation({}).then(element => element.getImpl()).then(impl => {
+        expect(impl.config_).to.not.be.null;
+      }),
+    ]);
+  });
+
+  it('should error with invalid config', () => {
+    return allowConsoleError(() => {
+      return newUserLocation('this is not valid json').catch(err => {
+        expect(err.message).to.include(
+            'Failed to parse amp-user-location config');
+      });
+    });
+  });
+
+  it('should parse recognized fields in the config', () => {
+    const testConfig = {
+      fallback: '40,-22',
+      maxAge: 60000,
+      precision: 'low',
+      timeout: 10000,
+      doNotExpose: 'wow',
+    };
+
+    return newUserLocation(testConfig).then(element => {
+      return element.getImpl();
+    }).then(impl => {
+      expect(impl.config_).to.include({
+        fallback: '40,-22',
+        maxAge: 60000,
+        timeout: 10000,
+      });
+      expect(impl.config_).to.not.have.property('doNotExpose');
+    });
+  });
+
+  it('should trigger the "approve" event if user approves geolocation', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation = sandbox.stub().resolves({
+      lat: 10, lon: -10,
+    });
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(
+          AmpUserLocationEvent.APPROVE,
+          {lat: 10, lon: -10});
+    });
+  });
+
+  it('should trigger the "deny" event if user denies geolocation', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation =
+        sandbox.stub().rejects({code: PositionError.PERMISSION_DENIED});
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.DENY);
+    });
+  });
+
+  it('should trigger the "error" event if geolocation timeouts', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation =
+        sandbox.stub().rejects({code: PositionError.TIMEOUT});
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+    });
+  });
+
+  it('should trigger the "error" event if geolocation is unavailable', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation =
+        sandbox.stub().rejects({code: PositionError.POSITION_UNAVAILABLE});
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+    });
+  });
+
+  it('should trigger the "error" event if the platform ' +
+      'does not support geolocation', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation =
+        sandbox.stub().rejects({code: PositionError.PLATFORM_UNSUPPORTED});
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
+    });
+  });
+
+  it('should "approve" with override if override is present', () => {
+    class UserLocationFake {}
+    UserLocationFake.prototype.requestLocation =
+        sandbox.stub().callsFake((unusedConfig, override) => override);
+    sandbox.stub(Services, 'userLocationForDocOrNull')
+        .resolves(new UserLocationFake());
+
+    getModeStub = sandbox.stub(mode, 'getMode');
+    getModeStub.returns({userLocationOverride: '10,-10', localDev: true});
+
+    let triggerSpy;
+    return newUserLocation().then(element => element.getImpl()).then(impl => {
+      triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      return impl.userLocationInteraction_();
+    }).then(() => {
+      expect(triggerSpy).to.have.been.calledWith(
+          AmpUserLocationEvent.APPROVE,
+          {lat: 10, lon: -10});
+    });
+  });
+});

--- a/extensions/amp-user-location/0.1/test/test-amp-user-location.js
+++ b/extensions/amp-user-location/0.1/test/test-amp-user-location.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as mode from '../../../../src/mode';
 import {AmpUserLocationEvent} from '../amp-user-location';
 import {PositionError} from '../position-error';
 import {Services} from '../../../../src/services';
@@ -28,7 +27,6 @@ describes.realWin('amp-user-location', {
 
   let win;
   let doc;
-  let getModeStub;
 
   beforeEach(() => {
     win = env.win;
@@ -133,7 +131,7 @@ describes.realWin('amp-user-location', {
   it('should trigger the "deny" event if user denies geolocation', () => {
     class UserLocationFake {}
     UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects({code: PositionError.PERMISSION_DENIED});
+        sandbox.stub().rejects(PositionError.PERMISSION_DENIED);
     sandbox.stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
@@ -149,7 +147,7 @@ describes.realWin('amp-user-location', {
   it('should trigger the "error" event if geolocation timeouts', () => {
     class UserLocationFake {}
     UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects({code: PositionError.TIMEOUT});
+        sandbox.stub().rejects(PositionError.TIMEOUT);
     sandbox.stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
@@ -165,7 +163,7 @@ describes.realWin('amp-user-location', {
   it('should trigger the "error" event if geolocation is unavailable', () => {
     class UserLocationFake {}
     UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects({code: PositionError.POSITION_UNAVAILABLE});
+        sandbox.stub().rejects(PositionError.POSITION_UNAVAILABLE);
     sandbox.stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
@@ -182,7 +180,7 @@ describes.realWin('amp-user-location', {
       'does not support geolocation', () => {
     class UserLocationFake {}
     UserLocationFake.prototype.requestLocation =
-        sandbox.stub().rejects({code: PositionError.PLATFORM_UNSUPPORTED});
+        sandbox.stub().rejects(PositionError.PLATFORM_UNSUPPORTED);
     sandbox.stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
@@ -198,12 +196,9 @@ describes.realWin('amp-user-location', {
   it('should "approve" with override if override is present', () => {
     class UserLocationFake {}
     UserLocationFake.prototype.requestLocation =
-        sandbox.stub().callsFake((unusedConfig, override) => override);
+        sandbox.stub().callsFake(() => ({lat: 10, lon: -10}));
     sandbox.stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
-
-    getModeStub = sandbox.stub(mode, 'getMode');
-    getModeStub.returns({userLocationOverride: '10,-10', localDev: true});
 
     let triggerSpy;
     return newUserLocation().then(element => element.getImpl()).then(impl => {

--- a/extensions/amp-user-location/0.1/test/test-user-location-service.js
+++ b/extensions/amp-user-location/0.1/test/test-user-location-service.js
@@ -61,8 +61,10 @@ describes.sandboxed('user-location-service', {}, () => {
 
   describe('location requests', () => {
     it('should return location when user approves', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(0, getFakePosition(10, -10));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        0,
+        getFakePosition(10, -10)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
       return service.requestLocation({}).then(location => {
@@ -71,91 +73,124 @@ describes.sandboxed('user-location-service', {}, () => {
     });
 
     it('should return location when user requests a second time', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(0, getFakePosition(10, -10));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        0,
+        getFakePosition(10, -10)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(location => {
-        expect(location).to.include({lat: 10, lon: -10});
-        return service.requestLocation({});
-      }).then(location => {
-        expect(win.navigator.geolocation.getCurrentPosition)
-            .to.have.been.calledTwice;
-        expect(location).to.include({lat: 10, lon: -10});
-      });
+      return service
+        .requestLocation({})
+        .then(location => {
+          expect(location).to.include({lat: 10, lon: -10});
+          return service.requestLocation({});
+        })
+        .then(location => {
+          expect(win.navigator.geolocation.getCurrentPosition).to.have.been
+            .calledTwice;
+          expect(location).to.include({lat: 10, lon: -10});
+        });
     });
 
     it('should not return location when user denies', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(1, getFakeError(PositionError.PERMISSION_DENIED));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        1,
+        getFakeError(PositionError.PERMISSION_DENIED)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      }, err => {
-        expect(err).to.equal(PositionError.PERMISSION_DENIED);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.PERMISSION_DENIED);
+        }
+      );
     });
 
     it('should not return location when geolocation timeouts', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(1, getFakeError(PositionError.TIMEOUT));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        1,
+        getFakeError(PositionError.TIMEOUT)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      }, err => {
-        expect(err).to.equal(PositionError.TIMEOUT);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.TIMEOUT);
+        }
+      );
     });
 
     it('should not return location when geolocation is unavailable', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(1, getFakeError(PositionError.POSITION_UNAVAILABLE));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        1,
+        getFakeError(PositionError.POSITION_UNAVAILABLE)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      }, err => {
-        expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
+        }
+      );
     });
 
     it('should not return location when an unknown error occurs', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(1, getFakeError(-1));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        1,
+        getFakeError(-1)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      }, err => {
-        expect(err).to.equal(null);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(null);
+        }
+      );
     });
 
     it('should not return location when geolocation is not supported', () => {
       platformService.isChrome.returns(true);
       viewerService.isEmbedded.returns(true);
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(0, getFakePosition(10, -10));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        0,
+        getFakePosition(10, -10)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      },err => {
-        expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
+        }
+      );
     });
 
     it('should not return location when geolocation is not available', () => {
       delete win.navigator.geolocation;
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      },err => {
-        expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
+        }
+      );
     });
 
     it('should return location when override is specified', () => {
@@ -164,8 +199,8 @@ describes.sandboxed('user-location-service', {}, () => {
 
       const service = new UserLocationService(new FakeAmpdoc());
       return service.requestLocation({}).then(location => {
-        expect(win.navigator.geolocation.getCurrentPosition)
-            .to.not.have.been.called;
+        expect(win.navigator.geolocation.getCurrentPosition).to.not.have.been
+          .called;
         expect(location).to.include({lat: 10, lon: -10});
       });
     });
@@ -175,11 +210,14 @@ describes.sandboxed('user-location-service', {}, () => {
       getModeStub.returns({userLocationOverride: error, localDev: true});
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        throw new Error('should not succeed');
-      }, err => {
-        expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
-      });
+      return service.requestLocation({}).then(
+        () => {
+          throw new Error('should not succeed');
+        },
+        err => {
+          expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
+        }
+      );
     });
   });
 
@@ -193,30 +231,41 @@ describes.sandboxed('user-location-service', {}, () => {
     });
 
     it('should return results after the user approves geolocation', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(0, getFakePosition(10, -10));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        0,
+        getFakePosition(10, -10)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(() => {
-        return service.getLocation();
-      }).then(position => {
-        expect(position).to.include({lat: 10, lon: -10});
-      });
+      return service
+        .requestLocation({})
+        .then(() => {
+          return service.getLocation();
+        })
+        .then(position => {
+          expect(position).to.include({lat: 10, lon: -10});
+        });
     });
 
     it('should return unavailable after the user denies geolocation', () => {
-      win.navigator.geolocation.getCurrentPosition
-          .callsArgWith(1, getFakeError(PositionError.PERMISSION_DENIED));
+      win.navigator.geolocation.getCurrentPosition.callsArgWith(
+        1,
+        getFakeError(PositionError.PERMISSION_DENIED)
+      );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).catch(error => {
-        // swallow the error
-        expect(error).to.equal(PositionError.PERMISSION_DENIED);
-      }).then(() => {
-        return service.getLocation();
-      }).then(result => {
-        expect(result).to.include({source: UserLocationSource.UNAVAILABLE});
-      });
+      return service
+        .requestLocation({})
+        .catch(error => {
+          // swallow the error
+          expect(error).to.equal(PositionError.PERMISSION_DENIED);
+        })
+        .then(() => {
+          return service.getLocation();
+        })
+        .then(result => {
+          expect(result).to.include({source: UserLocationSource.UNAVAILABLE});
+        });
     });
   });
 });

--- a/extensions/amp-user-location/0.1/test/test-user-location-service.js
+++ b/extensions/amp-user-location/0.1/test/test-user-location-service.js
@@ -160,7 +160,11 @@ describes.sandboxed('user-location-service', {}, () => {
       );
 
       const service = new UserLocationService(new FakeAmpdoc());
-      return service.requestLocation({}).then(
+      let promise;
+      allowConsoleError(() => {
+        promise = service.requestLocation({});
+      });
+      return promise.then(
         () => {
           throw new Error('should not succeed');
         },
@@ -338,7 +342,7 @@ describes.sandboxed('user-location-service', {}, () => {
         });
     });
 
-    it('should return unavailable if the platform does not support', () => {
+    it('should return unsupported if the platform does not support', () => {
       platformService.isChrome.returns(true);
       viewerService.isEmbedded.returns(true);
       win.navigator.geolocation.getCurrentPosition.callsArgWith(

--- a/extensions/amp-user-location/0.1/test/test-user-location-service.js
+++ b/extensions/amp-user-location/0.1/test/test-user-location-service.js
@@ -57,7 +57,7 @@ describes.sandboxed('user-location-service', {}, () => {
       },
     };
 
-    FakeAmpdoc.prototype.getWin = sandbox.stub().returns(win);
+    FakeAmpdoc.prototype.win = win;
     FakeViewerService.prototype.isEmbedded = sandbox.stub().returns(false);
     FakePlatformService.prototype.isChrome = sandbox.stub().returns(false);
     FakePermissionStatus.prototype.addEventListener = sandbox.stub();

--- a/extensions/amp-user-location/0.1/test/test-user-location-service.js
+++ b/extensions/amp-user-location/0.1/test/test-user-location-service.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PositionError} from '../position-error';
+import {Services} from '../../../../src/services';
+import {UserLocationService} from '../user-location-service';
+
+describes.sandboxed('amp-user-location', {}, () => {
+  let win;
+  let platformService;
+  let viewerService;
+
+  class FakeAmpdoc {}
+  class FakeViewerService {}
+  class FakePlatformService {}
+
+  function getFakePosition(lat, lon) {
+    return {coords: {latitude: lat, longitude: lon}};
+  }
+
+  function getFakeError(code) {
+    return {
+      code,
+      PERMISSION_DENIED: PositionError.PERMISSION_DENIED,
+      POSITION_UNAVAILABLE: PositionError.POSITION_UNAVAILABLE,
+      TIMEOUT: PositionError.TIMEOUT,
+    };
+  }
+
+  beforeEach(() => {
+    win = {navigator: {geolocation: {getCurrentPosition: sandbox.stub()}}};
+
+    FakeAmpdoc.prototype.getWin = sandbox.stub().returns(win);
+    FakeViewerService.prototype.isEmbedded = sandbox.stub().returns(false);
+    FakePlatformService.prototype.isChrome = sandbox.stub().returns(false);
+
+    platformService = new FakePlatformService();
+    viewerService = new FakeViewerService();
+    sandbox.stub(Services, 'platformFor').returns(platformService);
+    sandbox.stub(Services, 'viewerForDoc').returns(viewerService);
+  });
+
+  it('should return location when user approves', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(0, getFakePosition(10, -10));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(location => {
+      expect(location).to.include({lat: 10, lon: -10});
+    });
+  });
+
+  it('should return location when user requests a second time', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(0, getFakePosition(10, -10));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(location => {
+      expect(location).to.include({lat: 10, lon: -10});
+      return service.requestLocation({});
+    }).then(location => {
+      expect(win.navigator.geolocation.getCurrentPosition)
+          .to.have.been.calledTwice;
+      expect(location).to.include({lat: 10, lon: -10});
+    });
+  });
+
+  it('should not return location when user denies', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(1, getFakeError(PositionError.PERMISSION_DENIED));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    }, err => {
+      expect(err).to.equal(PositionError.PERMISSION_DENIED);
+    });
+  });
+
+  it('should not return location when geolocation timeouts', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(1, getFakeError(PositionError.TIMEOUT));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    }, err => {
+      expect(err).to.equal(PositionError.TIMEOUT);
+    });
+  });
+
+  it('should not return location when geolocatiom is unavailable', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(1, getFakeError(PositionError.POSITION_UNAVAILABLE));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    }, err => {
+      expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
+    });
+  });
+
+  it('should not return location when an unknown error occurs', () => {
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(1, getFakeError(-1));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    }, err => {
+      expect(err).to.equal(undefined);
+    });
+  });
+
+  it('should not return location when geolocation is not supported', () => {
+    platformService.isChrome.returns(true);
+    viewerService.isEmbedded.returns(true);
+    win.navigator.geolocation.getCurrentPosition
+        .callsArgWith(0, getFakePosition(10, -10));
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    },err => {
+      expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
+    });
+  });
+
+  it('should not return location when geolocation is not available', () => {
+    delete win.navigator.geolocation;
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}).then(() => {
+      throw new Error('should not succeed');
+    },err => {
+      expect(err).to.equal(PositionError.PLATFORM_UNSUPPORTED);
+    });
+  });
+
+  it('should return location when override is specified', () => {
+    const fakeUserLocationDef = {lat: 10, lon: -10};
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}, fakeUserLocationDef).then(location => {
+      expect(win.navigator.geolocation.getCurrentPosition)
+          .to.not.have.been.called;
+      expect(location).to.include({lat: 10, lon: -10});
+    });
+  });
+
+  it('should not return location when override error is specified', () => {
+    const error = 'error';
+
+    const service = new UserLocationService(new FakeAmpdoc());
+    return service.requestLocation({}, error).then(() => {
+      throw new Error('should not succeed');
+    }, err => {
+      expect(win.navigator.geolocation.getCurrentPosition)
+          .to.not.have.been.called;
+      expect(err).to.equal(PositionError.POSITION_UNAVAILABLE);
+    });
+  });
+});

--- a/extensions/amp-user-location/0.1/test/validator-amp-user-location.html
+++ b/extensions/amp-user-location/0.1/test/validator-amp-user-location.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
 <!doctype html>
 <html ⚡>
 <head>
@@ -6,11 +21,6 @@
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    amp-user-location {
-      color: red;
-    }
-  </style>
   <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/extensions/amp-user-location/0.1/test/validator-amp-user-location.html
+++ b/extensions/amp-user-location/0.1/test/validator-amp-user-location.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-user-location example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-user-location {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- Valid: amp-user-location with id -->
+  <amp-user-location id="location" layout="nodisplay"></amp-user-location>
+  <!-- Invalid: amp-user-location without id -->
+  <amp-user-location layout="nodisplay"></amp-user-location>
+  <!-- Invalid: amp-user-location with layout responsive -->
+  <amp-user-location id="location" layout="responsive"></amp-user-location>
+</body>
+</html>

--- a/extensions/amp-user-location/0.1/test/validator-amp-user-location.out
+++ b/extensions/amp-user-location/0.1/test/validator-amp-user-location.out
@@ -1,4 +1,19 @@
 FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>
@@ -7,11 +22,6 @@ FAIL
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      amp-user-location {
-|        color: red;
-|      }
-|    </style>
 |    <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
@@ -21,10 +31,10 @@ FAIL
 |    <!-- Invalid: amp-user-location without id -->
 |    <amp-user-location layout="nodisplay"></amp-user-location>
 >>   ^~~~~~~~~
-amp-user-location/0.1/test/validator-amp-user-location.html:21:2 The mandatory attribute 'id' is missing in tag 'amp-user-location'. (see https://www.ampproject.org/docs/reference/components/amp-user-location) [AMP_TAG_PROBLEM]
+amp-user-location/0.1/test/validator-amp-user-location.html:31:2 The mandatory attribute 'id' is missing in tag 'amp-user-location'. (see https://amp.dev/documentation/components/amp-user-location) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: amp-user-location with layout responsive -->
 |    <amp-user-location id="location" layout="responsive"></amp-user-location>
 >>   ^~~~~~~~~
-amp-user-location/0.1/test/validator-amp-user-location.html:23:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-user-location'. (see https://www.ampproject.org/docs/reference/components/amp-user-location) [AMP_LAYOUT_PROBLEM]
+amp-user-location/0.1/test/validator-amp-user-location.html:33:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-user-location'. (see https://amp.dev/documentation/components/amp-user-location) [AMP_LAYOUT_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-user-location/0.1/test/validator-amp-user-location.out
+++ b/extensions/amp-user-location/0.1/test/validator-amp-user-location.out
@@ -1,0 +1,30 @@
+FAIL
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-user-location example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-user-location {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: amp-user-location with id -->
+|    <amp-user-location id="location" layout="nodisplay"></amp-user-location>
+|    <!-- Invalid: amp-user-location without id -->
+|    <amp-user-location layout="nodisplay"></amp-user-location>
+>>   ^~~~~~~~~
+amp-user-location/0.1/test/validator-amp-user-location.html:21:2 The mandatory attribute 'id' is missing in tag 'amp-user-location'. (see https://www.ampproject.org/docs/reference/components/amp-user-location) [AMP_TAG_PROBLEM]
+|    <!-- Invalid: amp-user-location with layout responsive -->
+|    <amp-user-location id="location" layout="responsive"></amp-user-location>
+>>   ^~~~~~~~~
+amp-user-location/0.1/test/validator-amp-user-location.html:23:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-user-location'. (see https://www.ampproject.org/docs/reference/components/amp-user-location) [AMP_LAYOUT_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -52,8 +52,11 @@ export class UserLocation {
  */
 export let UserLocationConfigDef;
 
-/** @enum {string} */
-const PermissionStatus = {
+/**
+ * @enum {string}
+ * @private visible for testing
+ */
+export const PermissionStatus = {
   GRANTED: 'granted',
   DENIED: 'denied',
   PROMPT: 'prompt',
@@ -204,6 +207,7 @@ export class UserLocationService {
    */
   purge() {
     this.cachedLocation_ = new UserLocation(UserLocationSource.UNAVAILABLE);
+    this.firstRequestedDeferred_ = null; // After purge, do not allow polling
     this.requestedObservable_ = this.createRequestedObservable_();
   }
 
@@ -237,15 +241,15 @@ export class UserLocationService {
   /**
    * Called to retrieve the user location after the user has requested it.
    * This will wait for the location to become available if necessary.
-   * @param {boolean=} opt_poll
+   * @param {boolean=} poll
    * @return {!Promise<!UserLocation>}
    */
-  getLocation(opt_poll) {
+  getLocation(poll = false) {
     if (!this.geolocationSupported_) {
       return Promise.resolve(new UserLocation(UserLocationSource.UNSUPPORTED));
     }
 
-    if (opt_poll && this.firstRequestedDeferred_) {
+    if (poll && this.firstRequestedDeferred_) {
       return this.firstRequestedDeferred_.promise;
     }
 

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -112,12 +112,13 @@ export class UserLocationService {
 
     const viewer = Services.viewerForDoc(ampdoc);
     const platform = Services.platformFor(win);
-    const viewerSupportsGeolocation =
-        !(viewer.isEmbedded() && platform.isChrome());
+    const viewerSupportsGeolocation = !(
+      viewer.isEmbedded() && platform.isChrome()
+    );
 
     /** @private @const */
-    this.geolocationSupported_ = viewerSupportsGeolocation &&
-        ('geolocation' in win.navigator);
+    this.geolocationSupported_ =
+      viewerSupportsGeolocation && 'geolocation' in win.navigator;
 
     /** @private @const */
     this.supportsPermissions_ = 'permissions' in win.navigator;
@@ -129,8 +130,7 @@ export class UserLocationService {
    */
   createRequestedObservable_() {
     const observable = new Observable();
-    observable.add(
-        position => this.handleLocationAvailable_(position));
+    observable.add(position => this.handleLocationAvailable_(position));
     return observable;
   }
 
@@ -186,7 +186,6 @@ export class UserLocationService {
     const {navigator} = this.win_;
     const permissionQuery = navigator.permissions.query({name: 'geolocation'});
     permissionQuery.then(permissionStatus => {
-
       permissionStatus.addEventListener('change', e => {
         const permissionStatus = devAssert(e.target);
 
@@ -217,9 +216,11 @@ export class UserLocationService {
    */
   getOverride_() {
     const {localDev, userLocationOverride} = getMode(this.win_);
-    if (!userLocationOverride ||
-        !(isCanary(this.win_) || localDev) ||
-        !/^[\w-,]+$/.test(userLocationOverride)) {
+    if (
+      !userLocationOverride ||
+      !(isCanary(this.win_) || localDev) ||
+      !/^[\w-,]+$/.test(userLocationOverride)
+    ) {
       return null;
     }
 
@@ -241,8 +242,7 @@ export class UserLocationService {
    */
   getLocation(opt_poll) {
     if (!this.geolocationSupported_) {
-      return Promise.resolve(
-          new UserLocation(UserLocationSource.UNSUPPORTED));
+      return Promise.resolve(new UserLocation(UserLocationSource.UNSUPPORTED));
     }
 
     if (opt_poll && this.firstRequestedDeferred_) {
@@ -283,9 +283,11 @@ export class UserLocationService {
       if (error == PositionError.PLATFORM_UNSUPPORTED) {
         position = new UserLocation(UserLocationSource.UNSUPPORTED);
       }
-      if (error == PositionError.POSITION_UNAVAILABLE ||
-          error == PositionError.PERMISSION_DENIED ||
-          error == PositionError.TIMEOUT) {
+      if (
+        error == PositionError.POSITION_UNAVAILABLE ||
+        error == PositionError.PERMISSION_DENIED ||
+        error == PositionError.TIMEOUT
+      ) {
         position = new UserLocation(UserLocationSource.UNAVAILABLE);
       }
       observable.fire(position);
@@ -313,33 +315,34 @@ export class UserLocationService {
     }
 
     const {navigator} = this.win_;
-    navigator.geolocation.getCurrentPosition(position => {
-      const {latitude: lat, longitude: lon} = position.coords;
-      resolve(new UserLocation(UserLocationSource.GEOLOCATION, lat, lon));
-    }, error => {
-      const {code} = error;
-      if (code == error.POSITION_UNAVAILABLE) {
-        reject(PositionError.POSITION_UNAVAILABLE);
-        return;
-      }
-      if (code == error.PERMISSION_DENIED) {
-        reject(PositionError.PERMISSION_DENIED);
-        return;
-      }
-      // TODO(cvializ): On Chrome the latency for this can be really high!
-      // Do we need a first-class intermediate state,
-      // or is on="deny: ..." enough?
-      if (code == error.TIMEOUT) {
-        reject(PositionError.TIMEOUT);
-        return;
-      }
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const {latitude: lat, longitude: lon} = position.coords;
+        resolve(new UserLocation(UserLocationSource.GEOLOCATION, lat, lon));
+      },
+      error => {
+        const {code} = error;
+        if (code == error.POSITION_UNAVAILABLE) {
+          reject(PositionError.POSITION_UNAVAILABLE);
+          return;
+        }
+        if (code == error.PERMISSION_DENIED) {
+          reject(PositionError.PERMISSION_DENIED);
+          return;
+        }
+        if (code == error.TIMEOUT) {
+          reject(PositionError.TIMEOUT);
+          return;
+        }
 
-      reject(null);
-    }, {
-      timeout: config.timeout || DEFAULT_TIMEOUT,
-      maximumAge: config.maximumAge || DEFAULT_MAXIMUM_AGE,
-      precision: config.precision || DEFAULT_PRECISION,
-    });
+        reject(null);
+      },
+      {
+        timeout: config.timeout || DEFAULT_TIMEOUT,
+        maximumAge: config.maximumAge || DEFAULT_MAXIMUM_AGE,
+        precision: config.precision || DEFAULT_PRECISION,
+      }
+    );
 
     return promise;
   }

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -1,0 +1,288 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Deferred} from '../../../src/utils/promise';
+import {Observable} from '../../../src/observable';
+import {PositionError} from './position-error';
+import {Services} from '../../../src/services';
+import {devAssert} from '../../../src/log';
+
+/**
+ * @typedef {{
+ *   lat: number,
+ *   lon: number
+ * }}
+ */
+export let UserLocationDef;
+
+/**
+ * @typedef {{
+ *   fallback: UserLocationDef=,
+ *   maxAge: number=,
+ *   precision: string=,
+ *   timeout: number=
+ * }}
+ */
+export let UserLocationConfigDef;
+
+/**
+ * The reported position will be at most this many milliseconds old.
+ */
+const DEFAULT_MAXIMUM_AGE = 60000;
+
+/**
+ * The timeout attribute denotes the maximum length of time that is allowed to
+ * pass between calling getCurrentPosition and calling its success callback.
+ * At this time, the error callback will be called with code TIMEOUT.
+ */
+const DEFAULT_TIMEOUT = 30000;
+
+/**
+ * For now, precision should remain 'low', since 'high' precision typically
+ * requires more battery-intensive hardware to be activated, and is not
+ * needed for the use-cases we currently support, like "deals near me".
+ */
+const DEFAULT_PRECISION = 'low';
+
+export class UserLocationService {
+  /**
+   * @param {!AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private */
+    this.initialized_ = false;
+
+    /** @private {?UserLocationDef} */
+    this.cachedLocation_ = null;
+
+    /** @private */
+    this.requestedObservable_ = this.createRequestedObservable_();
+
+    /** @private */
+    this.firstRequestedDeferred_ = new Deferred();
+
+    const win = ampdoc.getWin();
+    /** @private @const */
+    this.win_ = win;
+
+    const viewer = Services.viewerForDoc(ampdoc);
+    const platform = Services.platformFor(win);
+    const viewerSupportsGeolocation =
+        !(viewer.isEmbedded() && platform.isChrome());
+
+    /** @private @const */
+    this.geolocationSupported_ = viewerSupportsGeolocation &&
+        ('geolocation' in win.navigator);
+
+    /** @private @const */
+    this.supportsPermissions_ = 'permissions' in win.navigator;
+  }
+
+  /**
+   * @return {!Observable}
+   * @private
+   */
+  createRequestedObservable_() {
+    const observable = new Observable();
+    observable.add(
+        (position, error) => this.handleLocationAvailable_(position, error));
+    return observable;
+  }
+
+  /**
+   *
+   * @param {?UserLocationDef} position
+   * @param {PositionError=} error
+   * @private
+   */
+  handleLocationAvailable_(position, error) {
+    if (position) {
+      this.cachedLocation_ = position;
+    }
+    this.handleFirstRequested_(position, error);
+  }
+
+  /**
+   * Exposes the location data or error condition to async AMP services like
+   * variable substitution. Those services call `getLocation`, which returns
+   * the `firstRequestedDeferred.promise`, and this method resolves
+   * that Promise.
+   *
+   * TODO(cvializ)
+   * If the user purges their location permission from allowed
+   * If the user purges their location permission from blocked to prompt
+   * etc
+   *
+   * @param {?UserLocationDef} position
+   * @param {PositionError=} error
+   * @private
+   */
+  handleFirstRequested_(position, error) {
+    if (!this.firstRequestedDeferred_) {
+      return;
+    }
+
+    if (error) {
+      // TODO(cvializ): should we not expose the error code?
+      this.firstRequestedDeferred_.reject(error);
+      return;
+    }
+
+    this.firstRequestedDeferred_.resolve(position);
+  }
+
+  /**
+   * @private
+   */
+  initialize_() {
+    this.initialized_ = true;
+    this.setupPermissionListener_();
+  }
+
+  /**
+   * Listen for changes in the geolocation permission.
+   * @private
+   */
+  setupPermissionListener_() {
+    if (!this.supportsPermissions_) {
+      return;
+    }
+
+    const {navigator} = this.win_;
+    const permissionQuery = navigator.permissions.query({name: 'geolocation'});
+    permissionQuery.then(permissionStatus => {
+
+      permissionStatus.addEventListener('change', e => {
+        const permissionStatus = devAssert(e.target);
+
+        const {state} = permissionStatus;
+        if (state === PermissionStatus.GRANTED) {
+          return;
+        }
+
+        this.purge();
+      });
+    });
+  }
+
+  /**
+   * Remove variables from global AMP state.
+   */
+  purge() {
+    this.cachedLocation_ = null;
+    this.firstRequestedDeferred_ = this.createRequestedObservable_();
+  }
+
+  /**
+   * Called to retrieve the user location after the user has requested it.
+   * This will wait for the location to become available if necessary.
+   * @return {!Promise<?UserLocationDef>}
+   */
+  getLocation() {
+    if (!this.geolocationSupported_) {
+      return Promise.reject(PositionError.PLATFORM_UNSUPPORTED);
+    }
+
+    if (this.firstRequestedDeferred_) {
+      return this.firstRequestedDeferred_.promise;
+    }
+
+    // NOTE: This may be reached with a `null` cachedLocation if the user
+    // removes geolocation permission after allowing it.
+    return Promise.resolve(this.cachedLocation_);
+  }
+
+  /**
+   * Specifically requests the user's location from the HTML Standard
+   * Geolocation API. Causes a browser prompt ot appear if the user
+   * has not approved the domain for Geolocation permission.
+   *
+   * The promise from this method resolves for the requesting component, but
+   * not for other amp-user-location elements or for runtime services
+   * like variable substitution.
+   *
+   * Variable substitution is notified through the `getLocation` method.
+   *
+   * @param {!UserLocationConfigDef} config
+   * @param {(!UserLocationDef|string)=} opt_override
+   * @return {!Promise<!UserLocationDef>}
+   */
+  requestLocation(config, opt_override) {
+    const observable = this.requestedObservable_;
+    const locationDeferred = new Deferred();
+    const {promise} = locationDeferred;
+
+    const resolve = location => {
+      observable.fire(location);
+      locationDeferred.resolve(location);
+    };
+
+    const reject = error => {
+      observable.fire(null, error);
+      locationDeferred.reject(error);
+    };
+
+    if (!this.geolocationSupported_) {
+      reject(PositionError.PLATFORM_UNSUPPORTED);
+      return promise;
+    }
+
+    if (opt_override === 'error') {
+      reject(PositionError.POSITION_UNAVAILABLE);
+      return promise;
+    }
+
+    if (!this.initialized_) {
+      this.initialize_();
+    }
+
+    if (opt_override) {
+      resolve(opt_override);
+      return promise;
+    }
+
+    const {navigator} = this.win_;
+    navigator.geolocation.getCurrentPosition(position => {
+      const {latitude: lat, longitude: lon} = position.coords;
+      resolve({lat, lon});
+    }, error => {
+      const {code} = error;
+      if (code == error.POSITION_UNAVAILABLE) {
+        reject(PositionError.POSITION_UNAVAILABLE);
+        return;
+      }
+      if (code == error.PERMISSION_DENIED) {
+        reject(PositionError.PERMISSION_DENIED);
+        return;
+      }
+      // TODO(cvializ): On Chrome the latency for this can be really high!
+      // Do we need a first-class intermediate state,
+      // or is on="deny: ..." enough?
+      if (code == error.TIMEOUT) {
+        reject(PositionError.TIMEOUT);
+        return;
+      }
+
+      reject();
+    }, {
+      timeout: config.timeout || DEFAULT_TIMEOUT,
+      maximumAge: config.maximumAge || DEFAULT_MAXIMUM_AGE,
+      precision: config.precision || DEFAULT_PRECISION,
+    });
+
+    return promise;
+  }
+}

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -29,7 +29,7 @@ import {isCanary} from '../../../src/experiments';
 
 /**
  * @typedef {{
- *   fallback: UserLocation,
+ *   fallback: ({lat: number, lon: number}|undefined),
  *   maximumAge: number,
  *   precision: string,
  *   timeout: number
@@ -363,12 +363,16 @@ export class UserLocationService {
 
 /**
  * @param {*} error
- * @param {UserLocation=} fallback
+ * @param {{lat: number, lon: number}} fallback
  * @return {!Promise}
  */
 function handleErrorFallback(error, fallback = undefined) {
   if (fallback) {
-    error.fallback = fallback;
+    error.fallback = new UserLocation(
+      UserLocationSource.FALLBACK,
+      fallback.lat,
+      fallback.lon
+    );
   }
   return Promise.reject(error);
 }

--- a/extensions/amp-user-location/0.1/user-location.js
+++ b/extensions/amp-user-location/0.1/user-location.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @dict @extends {JsonObject} */
+export class UserLocation {
+  /**
+   * @param {UserLocationSource} source
+   * @param {number=} lat
+   * @param {number=} lon
+   */
+  constructor(source, lat = undefined, lon = undefined) {
+    /** @const */
+    this['lat'] = lat;
+
+    /** @const */
+    this['lon'] = lon;
+
+    /** @const */
+    this['source'] = source;
+  }
+}
+
+/** @enum {string} */
+export const UserLocationSource = {
+  DEBUG: 'debug',
+  FALLBACK: 'fallback',
+  GEOLOCATION: 'geolocation',
+  UNAVAILABLE: 'unavailable',
+  UNSUPPORTED: 'unsupported',
+};
+
+const LOCATION_SEPARATOR = ',';
+
+/**
+ *
+ * @param {string} location
+ * @return {{lat: number, lon: number}}
+ */
+export function parseLocationString(location) {
+  const split = location.split(LOCATION_SEPARATOR);
+  const lat = Number(split[0]);
+  const lon = Number(split[1]);
+  return {lat, lon};
+}

--- a/extensions/amp-user-location/0.1/user-location.js
+++ b/extensions/amp-user-location/0.1/user-location.js
@@ -17,19 +17,19 @@
 /** @dict @extends {JsonObject} */
 export class UserLocation {
   /**
-   * @param {UserLocationSource} source
+   * @param {!UserLocationSource} source
    * @param {number=} lat
    * @param {number=} lon
    */
   constructor(source, lat = undefined, lon = undefined) {
     /** @const */
+    this['source'] = source;
+
+    /** @const */
     this['lat'] = lat;
 
     /** @const */
     this['lon'] = lon;
-
-    /** @const */
-    this['source'] = source;
   }
 }
 

--- a/extensions/amp-user-location/amp-user-location.md
+++ b/extensions/amp-user-location/amp-user-location.md
@@ -1,0 +1,106 @@
+---
+$category: presentation
+formats:
+  - ads-analytics
+  - websites
+  - dynamic-content
+teaser:
+  text: Request the user's precise location.
+---
+<!--
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# `amp-user-location`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Requests the user's location and provides it to AMP components.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td>Experimental. The `amp-user-location` experiment must be enabled to use this component.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-user-location" src="https://cdn.ampproject.org/v0/amp-user-location-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>nodisplay</td>
+  </tr>
+  <!-- TODO(cvializ) -->
+  <!-- <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td>FILL THIS IN</td>
+  </tr> -->
+</table>
+
+## Behavior
+
+The `amp-user-location` component can be used in combination with other components to
+send the user's location as part of other AMP components' requests. For example, to send the user's
+location with a form or an analytics request, the Variable Substitution variables can be used.
+
+## Attributes
+
+The `amp-user-location` component only requires an `id` attribute.
+
+## AMP Actions
+
+`amp-user-location` exposes the `request` action. This action is required to send the user's location
+to another AMP component. This will cause the browser to prompt the user to approve location access
+for the current domain, if the user has not already.
+
+```html
+<button on="tap: location.request()">Use my location</button>
+<amp-user-location id="location" on="approve:…" layout="nodisplay">
+</amp-user-location>
+```
+
+## AMP Events
+
+`amp-user-location` exposes the following events
+
+<table>
+<tr>
+<th width="30%">Event</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><code>approve</code></td>
+<td>This event is fired when the user triggers the `request` action and then approves the browser prompt to access their location, or the user has previously approved the prompt.</td>
+</tr>
+<tr>
+<td><code>deny</code></td>
+<td>This event is fired when the user triggers the `request` action and then denies the browser prompt to access their location, or the user has previously denied the prompt.</td>
+</tr>
+<td><code>error</code></td>
+<td>This event is fired when the user triggers the `request` action and and error occurs. This can happen if the browser takes too long to retrieve the location information, if the hardware is unavailable, or other errors occur.</td>
+</tr>
+</table>
+
+## Variable Substitution
+
+The user's location is also available via AMP variable substitution:
+
+`AMP_USER_LOCATION` or `${ampUserLocation}` returns the latitude and longitude separated by a comma.
+`AMP_USER_LOCATION(LAT)` or `${ampUserLocation(LAT)}` returns the latitude.
+`AMP_USER_LOCATION(LON)` or `${ampUserLocation(LON)}` returns the longitude.
+
+
+## Validation
+See [amp-user-location rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-user-location/validator-amp-user-location.protoascii) in the AMP validator specification.

--- a/extensions/amp-user-location/amp-user-location.md
+++ b/extensions/amp-user-location/amp-user-location.md
@@ -1,5 +1,5 @@
 ---
-$category: presentation
+$category@: presentation
 formats:
   - ads-analytics
   - websites

--- a/extensions/amp-user-location/amp-user-location.md
+++ b/extensions/amp-user-location/amp-user-location.md
@@ -82,7 +82,7 @@ for the current domain, if the user has not already.
 </tr>
 <tr>
 <td><code>approve</code></td>
-<td>This event is fired when the user triggers the `request` action and then approves the browser prompt to access their location, or the user has previously approved the prompt.</td>
+<td>This event is fired when the user triggers the `request` action and then approves the browser prompt to access their location, or the user has previously approved the prompt. The `event` object contains `lat` `lon` and `source` properties.</td><!-- TODO(cvializ): add description of the properties -->
 </tr>
 <tr>
 <td><code>deny</code></td>
@@ -100,6 +100,7 @@ The user's location is also available via AMP variable substitution:
 `AMP_USER_LOCATION` or `${ampUserLocation}` returns the latitude and longitude separated by a comma.
 `AMP_USER_LOCATION(LAT)` or `${ampUserLocation(LAT)}` returns the latitude.
 `AMP_USER_LOCATION(LON)` or `${ampUserLocation(LON)}` returns the longitude.
+`AMP_USER_LOCATION(SOURCE)` or `${ampUserLocation(SOURCE)}` returns the source.
 
 
 ## Validation

--- a/extensions/amp-user-location/amp-user-location.md
+++ b/extensions/amp-user-location/amp-user-location.md
@@ -82,7 +82,7 @@ for the current domain, if the user has not already.
 </tr>
 <tr>
 <td><code>approve</code></td>
-<td>This event is fired when the user triggers the `request` action and then approves the browser prompt to access their location, or the user has previously approved the prompt. The `event` object contains `lat` `lon` and `source` properties.</td><!-- TODO(cvializ): add description of the properties -->
+<td>This event is fired when the user triggers the `request` action and then approves the browser prompt to access their location, or the user has previously approved the prompt. The `event` object contains `lat` `lon` and `source` properties.</td>
 </tr>
 <tr>
 <td><code>deny</code></td>
@@ -100,8 +100,11 @@ The user's location is also available via AMP variable substitution:
 `AMP_USER_LOCATION` or `${ampUserLocation}` returns the latitude and longitude separated by a comma.
 `AMP_USER_LOCATION(LAT)` or `${ampUserLocation(LAT)}` returns the latitude.
 `AMP_USER_LOCATION(LON)` or `${ampUserLocation(LON)}` returns the longitude.
-`AMP_USER_LOCATION(SOURCE)` or `${ampUserLocation(SOURCE)}` returns the source.
+`AMP_USER_LOCATION(SOURCE)` or `${ampUserLocation(SOURCE)}` returns the source. The source may be one of `debug`, `fallback`, `geolocation`, `unavailable`, or `unsupported`.
 
+The `AMP_USER_LOCATION_POLL` or `${ampUserLocationPoll}` substitution is also available with the same
+syntax as above. It will wait for the location to be requested before resolving, and will prevent a
+request from occurring until that time. Polling is useful when the location is required for the request.
 
 ## Validation
 See [amp-user-location rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-user-location/validator-amp-user-location.protoascii) in the AMP validator specification.

--- a/extensions/amp-user-location/validator-amp-user-location.protoascii
+++ b/extensions/amp-user-location/validator-amp-user-location.protoascii
@@ -35,3 +35,27 @@ tags: {  # <amp-user-location>
   }
   attr_lists: "mandatory-id-attr"
 }
+tags: {  # amp-user-location (json)
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-user-location extension .json script"
+  requires_extension: amp-user-location"
+  mandatory_parent: "AMP-USER-LOCATION"
+  attrs: {
+    disabled_by: "transformed"
+    name: "nonce"
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-user-location"
+}

--- a/extensions/amp-user-location/validator-amp-user-location.protoascii
+++ b/extensions/amp-user-location/validator-amp-user-location.protoascii
@@ -1,0 +1,37 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-user-location
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-user-location"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-user-location>
+  html_format: AMP
+  tag_name: "AMP-USER-LOCATION"
+  requires_extension: "amp-user-location"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-user-location"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+  attr_lists: "mandatory-id-attr"
+}

--- a/extensions/amp-user-location/validator-amp-user-location.protoascii
+++ b/extensions/amp-user-location/validator-amp-user-location.protoascii
@@ -29,7 +29,7 @@ tags: {  # <amp-user-location>
   tag_name: "AMP-USER-LOCATION"
   requires_extension: "amp-user-location"
   attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-user-location"
+  spec_url: "https://amp.dev/documentation/components/amp-user-location"
   amp_layout: {
     supported_layouts: NODISPLAY
   }

--- a/extensions/amp-user-location/validator-amp-user-location.protoascii
+++ b/extensions/amp-user-location/validator-amp-user-location.protoascii
@@ -39,7 +39,7 @@ tags: {  # amp-user-location (json)
   html_format: AMP
   tag_name: "SCRIPT"
   spec_name: "amp-user-location extension .json script"
-  requires_extension: amp-user-location"
+  requires_extension: "amp-user-location"
   mandatory_parent: "AMP-USER-LOCATION"
   attrs: {
     disabled_by: "transformed"

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -652,14 +652,33 @@ Provides the approximate, country level, location of the user provided by the [`
 
 #### User Location
 
-Provides the latitude and longitude coordinates exposed by [`amp-user-location`](../extensions/amp-user-location/amp-user-location.md#variable-substitution) extension. Note that this data is unavailable until the user has approved location access.
+`AMP_USER_LOCATION` and `AMP_USER_LOCATION_POLL` provide the latitude and longitude coordinates exposed by [`amp-user-location`](../extensions/amp-user-location/amp-user-location.md#variable-substitution) extension. Note that this data is `undefined` until the user has approved location access. The `POLL` variant will not resolve until the user has interacted with a UI element that requests their location.
 
-* **platform variable**: AMP_USER_LOCATION
+* **platform variable**: `AMP_USER_LOCATION`
   *  Example: <br>
   ```html
+   <!--
+     When the user encounters the pixel, the location will be sent
+     if the user has approved through the amp-user-location component.
+     If the user has not approved, the pixel will send the request
+     with the location as the empty string.
+    -->
    <amp-pixel src="https://foo.com/pixel?location=AMP_USER_LOCATION"></amp-pixel>
   ```
+* **platform variable**: `AMP_USER_LOCATION_POLL`
+*  Example: <br>
+```html
+  <!--
+    When the user encounters the pixel, the location will not be sent
+    until the user has requested their location  through the amp-user-location
+    component. If the user does not approve, the pixel will not send the
+    request. If the user denies, the pixel will send the empty string.
+  -->
+  <amp-pixel src="https://foo.com/pixel?location=AMP_USER_LOCATION_POLL"></amp-pixel>
+```
 * **amp-analytics variable**: `${ampUserLocation}`
+  * Example value: `40.712776,-74.005974`
+* **amp-analytics variable**: `${ampUserLocationPoll}`
   * Example value: `40.712776,-74.005974`
 
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -255,6 +255,7 @@ The tables below list the available URL variables grouped by type of usage. Furt
 | [Client ID](#client-id) | `CLIENT_ID` | `${clientId}` |
 | [Extra URL Parameters](#extra-url-parameters) | N/A | `${extraUrlParams}` |
 | [Geolocation](#geolocation) | `AMP_GEO` | `${ampGeo}` |
+| [User Location](#user-location) | `AMP_USER_LOCATION` | `${ampUserLocation}` |
 | [Page View ID](#page-view-id) | `PAGE_VIEW_ID` | `${pageViewId}` |
 | [Query Parameter](#query-parameter) | `QUERY_PARAM` | `${queryParam}` |
 | [Random](#random) | `RANDOM` | `${random}` |
@@ -649,6 +650,19 @@ Provides the approximate, country level, location of the user provided by the [`
 * **amp-analytics variable**: `${ampGeo}`
   * Example value: `ca`
 
+#### User Location
+
+Provides the latitude and longitude coordinates exposed by [`amp-user-location`](../extensions/amp-user-location/amp-user-location.md#variable-substitution) extension. Note that this data is unavailable until the user has approved location access.
+
+* **platform variable**: AMP_USER_LOCATION
+  *  Example: <br>
+  ```html
+   <amp-pixel src="https://foo.com/pixel?location=AMP_USER_LOCATION"></amp-pixel>
+  ```
+* **amp-analytics variable**: `${ampUserLocation}`
+  * Example value: `40.712776,-74.005974`
+
+
 #### Horizontal Scroll Boundary
 
 Provides the horizontal scroll boundary that triggered a scroll event. This variable is only available in a `trigger` of type `scroll`. The value of the boundary may be rounded based on the precision supported by the extension. For example, a boundary with value `1` and precision of `5` will result in value of var to be 0.
@@ -687,7 +701,7 @@ requested attribute names and the object values are the elements' values for tho
 
 #### Initial Scroll Depth
 
-Provides the scroll depth at the time the element was loaded, relative to the target. The value returned will be top/inside/bottom, indicating whether the target was scrolled inside the viewport, was offscreen above the top of the viewport, or was offscreen below the bottom of the viewport. 
+Provides the scroll depth at the time the element was loaded, relative to the target. The value returned will be top/inside/bottom, indicating whether the target was scrolled inside the viewport, was offscreen above the top of the viewport, or was offscreen below the bottom of the viewport.
 
 * **platform variable**: N/A
 * **amp-analytics variable**: `${initialScrollDepth}`

--- a/src/mode.js
+++ b/src/mode.js
@@ -105,6 +105,8 @@ function getMode_(win) {
     filter: hashQuery['filter'],
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
+    // amp-user-location override
+    userLocationOverride: hashQuery['amp-user-location'],
     minified: IS_MINIFIED,
     // Whether document is in an amp-lite viewer. It signal that the user
     // would prefer to use less bandwidth.

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -399,16 +399,10 @@ export class GlobalVariableSource extends VariableSource {
     // Attempt to returns user location data if available, otherwise null.
     this.setAsync('AMP_USER_LOCATION', /** @type {AsyncResolverDef} */(type => {
       // Type may be "","lat","lon", and undefined
-      return this.getUserLocation_(userLocation => {
-        if (type === 'LAT') {
-          return userLocation.lat;
-        }
-        if (type === 'LON') {
-          return userLocation.lon;
-        }
-        userAssert(type === '' || typeof type === 'undefined',
-            'The value passed to AMP_USER_LOCATION() is not valid: ' + type);
-        return `${userLocation.lon},${userLocation.lat}`;
+      return this.getUserLocation_(userLocationService => {
+        return userLocationService.getLocation().then(position => {
+          return consumeUserLocation(position, 'AMP_USER_LOCATION', type);
+        });
       }, 'AMP_USER_LOCATION');
     }));
 
@@ -416,19 +410,37 @@ export class GlobalVariableSource extends VariableSource {
     // and waits for the user to approve.
     this.setAsync('AMP_USER_LOCATION_POLL', /** @type {AsyncResolverDef} */(type => {
       // Type may be "","lat","lon", and undefined
-      return this.getUserLocation_(userLocation => {
-        if (type === 'LAT') {
-          return userLocation.lat;
-        }
-        if (type === 'LON') {
-          return userLocation.lon;
-        }
-        userAssert(type === '' || typeof type === 'undefined',
-            'The value passed to AMP_USER_LOCATION_POLL()' +
-            ' is not valid: ' + type);
-        return `${userLocation.lon},${userLocation.lat}`;
-      }, 'AMP_USER_LOCATION_POLL', /*opt_poll*/true);
+      return this.getUserLocation_(userLocationService => {
+        const promise = userLocationService.getLocation(/*opt_poll*/ true);
+        return promise.then(position => {
+          return consumeUserLocation(position, 'AMP_USER_LOCATION_POLL', type);
+        });
+      }, 'AMP_USER_LOCATION_POLL');
     }));
+
+    /**
+     * @param {!../../extensions/amp-user-location/0.1/user-location-service.UserLocation} position
+     * @param {string} expr
+     * @param {string} type
+     */
+    function consumeUserLocation(position, expr, type) {
+      if (type === 'SOURCE') {
+        return position['source'];
+      }
+      if (type === 'LAT') {
+        return position['lat'];
+      }
+      if (type === 'LON') {
+        return position['lon'];
+      }
+      userAssert(type === '' || typeof type === 'undefined',
+          'The value passed to %s is not valid: %s', expr, type);
+
+      if (position['source'] !== 'geolocation') {
+        return '';
+      }
+      return `${position['lat']},${position['lon']}`;
+    }
 
     // Returns incoming share tracking fragment.
     this.setAsync(
@@ -844,21 +856,18 @@ export class GlobalVariableSource extends VariableSource {
    * Resolves the value via the user location service.
    * @param {function(Object<string, string>)} getter
    * @param {string} expr
-   * @param {boolean=} opt_poll
    * @return {!Promise<Object<string,(string|Array<string>)>>}
    * @template T
    * @private
    */
-  getUserLocation_(getter, expr, opt_poll) {
+  getUserLocation_(getter, expr) {
     const element = this.ampdoc.getHeadNode();
     return Services.userLocationForDocOrNull(element)
-        .then(userLocationService => userLocationService.getLocation(opt_poll))
-        .then(location => {
+        .then(userLocationService => {
           userAssert(location,
-              'To use variable %s, amp-user-location should be configured ' +
-              'and requested by the user',
+              'To use variable %s, amp-user-location should be configured',
               expr);
-          return getter(location);
+          return getter(userLocationService);
         });
   }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -397,26 +397,36 @@ export class GlobalVariableSource extends VariableSource {
     );
 
     // Attempt to returns user location data if available, otherwise null.
-    this.setAsync('AMP_USER_LOCATION', /** @type {AsyncResolverDef} */(type => {
-      // Type may be "","lat","lon", and undefined
-      return this.getUserLocation_(userLocationService => {
-        return userLocationService.getLocation().then(position => {
-          return consumeUserLocation(position, 'AMP_USER_LOCATION', type);
-        });
-      }, 'AMP_USER_LOCATION');
-    }));
+    this.setAsync(
+      'AMP_USER_LOCATION',
+      /** @type {AsyncResolverDef} */ (type => {
+        // Type may be "","lat","lon", and undefined
+        return this.getUserLocation_(userLocationService => {
+          return userLocationService.getLocation().then(position => {
+            return consumeUserLocation(position, 'AMP_USER_LOCATION', type);
+          });
+        }, 'AMP_USER_LOCATION');
+      })
+    );
 
     // Returns user location data only if available,
     // and waits for the user to approve.
-    this.setAsync('AMP_USER_LOCATION_POLL', /** @type {AsyncResolverDef} */(type => {
-      // Type may be "","lat","lon", and undefined
-      return this.getUserLocation_(userLocationService => {
-        const promise = userLocationService.getLocation(/*opt_poll*/ true);
-        return promise.then(position => {
-          return consumeUserLocation(position, 'AMP_USER_LOCATION_POLL', type);
-        });
-      }, 'AMP_USER_LOCATION_POLL');
-    }));
+    this.setAsync(
+      'AMP_USER_LOCATION_POLL',
+      /** @type {AsyncResolverDef} */ (type => {
+        // Type may be "","lat","lon", and undefined
+        return this.getUserLocation_(userLocationService => {
+          const promise = userLocationService.getLocation(/*opt_poll*/ true);
+          return promise.then(position => {
+            return consumeUserLocation(
+              position,
+              'AMP_USER_LOCATION_POLL',
+              type
+            );
+          });
+        }, 'AMP_USER_LOCATION_POLL');
+      })
+    );
 
     /**
      * @param {!../../extensions/amp-user-location/0.1/user-location-service.UserLocation} position
@@ -433,8 +443,12 @@ export class GlobalVariableSource extends VariableSource {
       if (type === 'LON') {
         return position['lon'];
       }
-      userAssert(type === '' || typeof type === 'undefined',
-          'The value passed to %s is not valid: %s', expr, type);
+      userAssert(
+        type === '' || typeof type === 'undefined',
+        'The value passed to %s is not valid: %s',
+        expr,
+        type
+      );
 
       if (position['source'] !== 'geolocation') {
         return '';
@@ -862,13 +876,16 @@ export class GlobalVariableSource extends VariableSource {
    */
   getUserLocation_(getter, expr) {
     const element = this.ampdoc.getHeadNode();
-    return Services.userLocationForDocOrNull(element)
-        .then(userLocationService => {
-          userAssert(location,
-              'To use variable %s, amp-user-location should be configured',
-              expr);
-          return getter(userLocationService);
-        });
+    return Services.userLocationForDocOrNull(element).then(
+      userLocationService => {
+        userAssert(
+          location,
+          'To use variable %s, amp-user-location should be configured',
+          expr
+        );
+        return getter(userLocationService);
+      }
+    );
   }
 
   /**

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -849,7 +849,7 @@ export class GlobalVariableSource extends VariableSource {
     return Services.userLocationForDocOrNull(element).then(
       userLocationService => {
         userAssert(
-          location,
+          userLocationService,
           'To use variable %s, amp-user-location should be configured',
           expr
         );

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -402,9 +402,10 @@ export class GlobalVariableSource extends VariableSource {
       /** @type {AsyncResolverDef} */ (type => {
         // Type may be "","lat","lon", and undefined
         return this.getUserLocation_(userLocationService => {
-          return userLocationService.getLocation().then(position => {
-            return consumeUserLocation(position, 'AMP_USER_LOCATION', type);
-          });
+          return userLocationService.getReplacementLocation(
+            'AMP_USER_LOCATION',
+            type
+          );
         }, 'AMP_USER_LOCATION');
       })
     );
@@ -416,45 +417,14 @@ export class GlobalVariableSource extends VariableSource {
       /** @type {AsyncResolverDef} */ (type => {
         // Type may be "","lat","lon", and undefined
         return this.getUserLocation_(userLocationService => {
-          const promise = userLocationService.getLocation(/*opt_poll*/ true);
-          return promise.then(position => {
-            return consumeUserLocation(
-              position,
-              'AMP_USER_LOCATION_POLL',
-              type
-            );
-          });
+          return userLocationService.getReplacementLocation(
+            'AMP_USER_LOCATION_POLL',
+            type,
+            /*opt_poll*/ true
+          );
         }, 'AMP_USER_LOCATION_POLL');
       })
     );
-
-    /**
-     * @param {!../../extensions/amp-user-location/0.1/user-location-service.UserLocation} position
-     * @param {string} expr
-     * @param {string} type
-     */
-    function consumeUserLocation(position, expr, type) {
-      if (type === 'SOURCE') {
-        return position['source'];
-      }
-      if (type === 'LAT') {
-        return position['lat'];
-      }
-      if (type === 'LON') {
-        return position['lon'];
-      }
-      userAssert(
-        type === '' || typeof type === 'undefined',
-        'The value passed to %s is not valid: %s',
-        expr,
-        type
-      );
-
-      if (position['source'] !== 'geolocation') {
-        return '';
-      }
-      return `${position['lat']},${position['lon']}`;
-    }
 
     // Returns incoming share tracking fragment.
     this.setAsync(

--- a/src/services.js
+++ b/src/services.js
@@ -678,10 +678,10 @@ export class Services {
    * Returns a promise for the geo service or a promise for null if
    * the service is not available on the current page.
    * @param {!Element|!ShadowRoot} element
-   * @return {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationDef>}
+   * @return {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationService>}
    */
   static userLocationForDocOrNull(element) {
-    return /** @type {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationDef>} */ (
+    return /** @type {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationService>} */ (
       getElementServiceIfAvailableForDoc(
           element, 'user-location', 'amp-user-location', true));
   }

--- a/src/services.js
+++ b/src/services.js
@@ -678,10 +678,10 @@ export class Services {
    * Returns a promise for the geo service or a promise for null if
    * the service is not available on the current page.
    * @param {!Element|!ShadowRoot} element
-   * @return {!Promise<?../extensions/amp-user-location/0.1/amp-user-location.UserLocationDef>}
+   * @return {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationDef>}
    */
   static userLocationForDocOrNull(element) {
-    return /** @type {!Promise<?../extensions/amp-user-location/0.1/amp-user-location.UserLocationDef>} */ (
+    return /** @type {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationDef>} */ (
       getElementServiceIfAvailableForDoc(
           element, 'user-location', 'amp-user-location', true));
   }

--- a/src/services.js
+++ b/src/services.js
@@ -675,6 +675,18 @@ export class Services {
   }
 
   /**
+   * Returns a promise for the geo service or a promise for null if
+   * the service is not available on the current page.
+   * @param {!Element|!ShadowRoot} element
+   * @return {!Promise<?../extensions/amp-user-location/0.1/amp-user-location.UserLocationDef>}
+   */
+  static userLocationForDocOrNull(element) {
+    return /** @type {!Promise<?../extensions/amp-user-location/0.1/amp-user-location.UserLocationDef>} */ (
+      getElementServiceIfAvailableForDoc(
+          element, 'user-location', 'amp-user-location', true));
+  }
+
+  /**
    * Unlike most service getters, passing `Node` is necessary for some FIE-scope
    * services since sometimes we only have the FIE Document for context.
    * @param {!Element|!ShadowRoot} element

--- a/src/services.js
+++ b/src/services.js
@@ -681,9 +681,12 @@ export class Services {
    * @return {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationService>}
    */
   static userLocationForDocOrNull(element) {
-    return /** @type {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationService>} */ (
-      getElementServiceIfAvailableForDoc(
-          element, 'user-location', 'amp-user-location', true));
+    return /** @type {!Promise<?../extensions/amp-user-location/0.1/user-location-service.UserLocationService>} */ (getElementServiceIfAvailableForDoc(
+      element,
+      'user-location',
+      'amp-user-location',
+      true
+    ));
   }
 
   /**

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -209,7 +209,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       // Restrict the number of replacement params to globalVaraibleSource
       // Please consider adding the logic to amp-analytics instead.
       // Please contact @lannka or @zhouyx if the test fail.
-      expect(variables.length).to.equal(69);
+      expect(variables.length).to.equal(71);
     });
   });
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -442,6 +442,14 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/21791',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/21792',
   },
+  {
+    id: 'amp-user-location',
+    name:
+      'Expose the browser geolocation API for latitude and longitude ' +
+      'access after user interaction and approval',
+    spec: 'https://github.com/ampproject/amphtml/issues/8929',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/22177',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Implements #8929.

Geolocation access is mediated by the `UserLocationService` which handles the interactions with the Geolocation API and maintains the state to be requested and accessed by both the `amp-user-location` AMP component and the `url-replacements` service.

Tests (>90% coverage) and documentation are part of this PR. Initially this feature is behind an experiment while we evaluate and test the component.

/to @alanorozco @sparhami 
/cc @jeffjose 