### PR TITLE
✨🖍🐛 Lightbox captions changes.

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,141 +1,144 @@
 selector                                                                                                  |   z-index      |   file
 ---                                                                                                       |   ---          |   ---
-.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/1.0/amp-story-consent.css
 .i-amphtml-story-share-icon::before                                                                       |   -1           |   extensions/amp-story/0.1/amp-story-share.css
 amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                          |   -1           |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/0.1/amp-story-consent.css
-.i-amphtml-story-bookend-inner::before                                                                    |   -1           |   extensions/amp-story/0.1/amp-story-bookend.css
-.i-amphtml-story-access-logo::before                                                                      |   -1           |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-carousel-spacer                                                                                |   -1           |   extensions/amp-carousel/0.2/carousel.css
+.i-amphtml-carousel-spacer                                                                                |   -1           |   extensions/amp-base-carousel/0.1/carousel.css
+.i-amphtml-story-media-query-matcher                                                                      |   -1           |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/1.0/amp-story-consent.css
 .i-amphtml-story-bookend-inner::before                                                                    |   -1           |   extensions/amp-story/1.0/amp-story-bookend.css
-amp-story-page                                                                                            |   0            |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.i-amphtml-story-access-logo::before                                                                      |   -1           |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-bookend-inner::before                                                                    |   -1           |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/0.1/amp-story-consent.css
+[i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                      |   0            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
 .amp-video-docked-placeholder-background                                                                  |   0            |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-image-lightbox-container                                                                       |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-0%                                                                                                        |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-.i-amphtml-story-access-content                                                                           |   0            |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-overflow .i-amphtml-lbg-desc-mask                                   |   0            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
-.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after             |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/0.1/amp-story-consent.css
-amp-story-page                                                                                            |   0            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/0.1/amp-story-desktop.css
+amp-story-page                                                                                            |   0            |   extensions/amp-story/0.1/amp-story.css
 .i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/1.0/amp-story-consent.css
-.i-amphtml-story-background-overlay                                                                       |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
-i-amphtml-video-mask                                                                                      |   1            |   css/video-autoplay.css
+.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after             |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+amp-story-page                                                                                            |   0            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-access-content                                                                           |   0            |   extensions/amp-story/1.0/amp-story-access.css
+0%                                                                                                        |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-image-lightbox-container                                                                       |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-background                                                                               |   0            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.i-amphtml-image-lightbox-viewer-image                                                                    |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-story-background.active                                                                        |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
 .i-amphtml-image-slider-label-wrapper                                                                     |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
 .i-amphtml-image-slider-right-mask                                                                        |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
-.i-amphtml-layout-size-defined > [placeholder]                                                            |   1            |   css/amp.css
-.i-amphtml-expanded-mode amp-twitter                                                                      |   1            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-standard .i-amphtml-lbg-desc-mask                                   |   1            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
-.i-amphtml-lbg-top-bar                                                                                    |   1            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
-amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/1.0/amp-story-consent.css
-div.i-amphtml-story-share-pill-container                                                                  |   1            |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-story-page-attachment-header                                                                   |   1            |   extensions/amp-story/1.0/amp-story-page-attachment-header.css
-.i-amphtml-loading-container                                                                              |   1            |   css/amp.css
-amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-glass-pane                                                                                     |   1            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
-.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/1.0/amp-story-hint.css
-.i-amphtml-story-bookend-fullbleed::before                                                                |   1            |   extensions/amp-story/0.1/amp-story-bookend.css
-.i-amphtml-story-background.active                                                                        |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
-.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/0.1/amp-story-consent.css
-.amp-video-eq                                                                                             |   1            |   css/video-autoplay.css
 .i-amphtml-story-background-overlay::after                                                                |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
-.i-amphtml-image-lightbox-viewer                                                                          |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-layout-size-defined > [fallback]                                                               |   1            |   css/amp.css
+.i-amphtml-story-background-overlay                                                                       |   1            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.i-amphtml-lbg-caption-scroll                                                                             |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+[i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                        |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+.i-amphtml-loading-container                                                                              |   1            |   css/amp.css
+.i-amphtml-carousel-arrow-next-slot                                                                       |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.i-amphtml-carousel-arrow-prev-slot                                                                       |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.amp-video-eq                                                                                             |   1            |   css/video-autoplay.css
+.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/1.0/amp-story-consent.css
+i-amphtml-video-mask                                                                                      |   1            |   css/video-autoplay.css
+.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/0.1/amp-story-hint.css
+.i-amphtml-glass-pane                                                                                     |   1            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-bookend-fullbleed::before                                                                |   1            |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                       |   1            |   extensions/amp-story/1.0/amp-story.css
+amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-story-page-attachment-header                                                                   |   1            |   extensions/amp-story/1.0/amp-story-page-attachment-header.css
+.i-amphtml-layout-size-defined > [placeholder]                                                            |   1            |   css/amp.css
+.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/1.0/amp-story-hint.css
 .i-amphtml-story-background-overlay                                                                       |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
 .i-amphtml-story-background-overlay::after                                                                |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
 .i-amphtml-story-background.active                                                                        |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
-.i-amphtml-image-lightbox-viewer-image                                                                    |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/0.1/amp-story-hint.css
-.i-amphtml-layout-size-defined > [fallback]                                                               |   1            |   css/amp.css
+.i-amphtml-image-lightbox-viewer                                                                          |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
 div.i-amphtml-story-top                                                                                   |   1            |   extensions/amp-story/0.1/amp-story-desktop.css
-amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/0.1/amp-story-consent.css
-.i-amphtml-story-access-header                                                                            |   2            |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-lbg-top-bar                                                                                    |   1            |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
 .i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/1.0/amp-story-hint.css
-.i-amphtml-story-bookend-active amp-story-page[active]::after                                             |   2            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-image-lightbox-caption                                                                         |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/1.0/amp-story-consent.css
-.i-amphtml-story-bookend-active > amp-story-page[active]::after                                           |   2            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-expanded-mode amp-story-grid-layer                                                             |   auto         |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-image-slider-hint                                                                              |   2            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/0.1/amp-story-consent.css
+amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/1.0/amp-story.css
+amp-consent                                                                                               |   initial      |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-image-lightbox-caption                                                                         |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-loader-moving-line                                                                             |   2            |   css/amp.css
+.i-amphtml-story-access-header                                                                            |   2            |   extensions/amp-story/1.0/amp-story-access.css
 .i-amphtml-element > [overflow]                                                                           |   2            |   css/amp.css
 amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-loader-moving-line                                                                             |   2            |   css/amp.css
+amp-consent                                                                                               |   initial      |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-bookend-active > amp-story-page[active]::after                                           |   2            |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-bookend-active amp-story-page[active]::after                                             |   2            |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/0.1/amp-story-hint.css
-.i-amphtml-image-slider-bar                                                                               |   3            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-expanded-mode amp-story-grid-layer *                                                           |   auto         |   extensions/amp-story/1.0/amp-story.css
 amp-story-page[active] .i-amphtml-story-page-open-attachment                                              |   3            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-image-slider-bar                                                                               |   3            |   extensions/amp-image-slider/0.1/amp-image-slider.css
 amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/0.1/amp-story.css
 amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before   |   4            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
 amp-story-page-attachment                                                                                 |   4            |   extensions/amp-story/1.0/amp-story-page-attachment.css
-100%                                                                                                      |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
 .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before            |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/1.0/amp-story.css
-amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                          |   10           |   extensions/amp-date-picker/0.1/amp-date-picker.css
+100%                                                                                                      |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
 .amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
-.amp-autocomplete-results                                                                                 |   10           |   extensions/amp-autocomplete/0.1/amp-autocomplete.css
+amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                          |   10           |   extensions/amp-date-picker/0.1/amp-date-picker.css
+.i-amphtml-autocomplete-results                                                                           |   10           |   extensions/amp-autocomplete/0.1/amp-autocomplete.css
+.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/0.1/amp-story.css
 amp-sticky-ad                                                                                             |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
 amp-sticky-ad-top-padding                                                                                 |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
 amp-app-banner                                                                                            |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
 .amp-app-banner-dismiss-button                                                                            |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
 i-amphtml-app-banner-top-padding                                                                          |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-amp-user-notification                                                                                     |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
+amp-image-lightbox                                                                                        |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
 amp-live-list > [update]                                                                                  |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
 i-amphtml-ad-close-header                                                                                 |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
 amp-lightbox                                                                                              |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-amp-image-lightbox                                                                                        |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+amp-user-notification                                                                                     |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
 .i-amphtml-jank-meter                                                                                     |   1000         |   css/amp.css
 .i-amphtml-image-lightbox-trans                                                                           |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
 .i-amphtml-story-page-play-button                                                                         |   10000        |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/1.0/amp-story-system-layer.css
 .i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/0.1/amp-story-system-layer.css
 .i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/1.0/amp-story-info-dialog.css
-.i-amphtml-ad-overlay-container                                                                           |   100001       |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
-.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/0.1/amp-story-bookend.css
-.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/0.1/amp-story-info-dialog.css
-.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-story-share-menu                                                                               |   100001       |   extensions/amp-story/0.1/amp-story-share-menu.css
 .i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/1.0/amp-story-bookend.css
+.i-amphtml-ad-overlay-container                                                                           |   100001       |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
 .i-amphtml-story-focused-state-layer                                                                      |   100001       |   extensions/amp-story/1.0/amp-story-tooltip.css
 .i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/0.1/amp-story-system-layer.css
-.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                      |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-toast                                                                                    |   100002       |   extensions/amp-story/0.1/amp-story.css
-amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-desktop-panels .i-amphtml-story-share-pill-container                                     |   100002       |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/0.1/amp-story-info-dialog.css
+.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/0.1/amp-story-bookend.css
+.i-amphtml-story-share-menu                                                                               |   100001       |   extensions/amp-story/0.1/amp-story-share-menu.css
 [desktop] .i-amphtml-story-button-container                                                               |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
 amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                         |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                      |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
 [desktop] .i-amphtml-story-top                                                                            |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
-.i-amphtml-story-opacity-mask                                                                             |   100003       |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-share-menu                                                                               |   100003       |   extensions/amp-story/1.0/amp-story-share-menu.css
+.i-amphtml-story-toast                                                                                    |   100002       |   extensions/amp-story/0.1/amp-story.css
+.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                         |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/0.1/amp-story-desktop.css
+amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/0.1/amp-story.css
 amp-story-access                                                                                          |   100003       |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-opacity-mask                                                                             |   100003       |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-story-consent                                                                                  |   100003       |   extensions/amp-story/0.1/amp-story-consent.css
+.i-amphtml-story-share-menu                                                                               |   100003       |   extensions/amp-story/1.0/amp-story-share-menu.css
 .i-amphtml-story-toast                                                                                    |   100004       |   extensions/amp-story/1.0/amp-story.css
 amp-story-access[type=blocking]                                                                           |   100004       |   extensions/amp-story/1.0/amp-story-access.css
 .i-amphtml-story-consent                                                                                  |   100005       |   extensions/amp-story/1.0/amp-story-consent.css
 .i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
 .i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
-amp-consent                                                                                               |   initial      |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
-amp-consent                                                                                               |   initial      |   extensions/amp-story/0.1/amp-story.css
-.i-amphtml-expanded-mode amp-story-grid-layer                                                             |   auto         |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-expanded-mode amp-story-grid-layer *                                                           |   auto         |   extensions/amp-story/1.0/amp-story.css
 .i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/0.1/amp-story-unsupported-browser-layer.css
+.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
 .i-amphtml-story-experiment-error                                                                         |   999999       |   extensions/amp-story/0.1/amp-story.css
 amp-subscriptions-dialog                                                                                  |   2147483641   |   extensions/amp-subscriptions/0.1/amp-subscriptions.css
+amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                  |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
 .i-amphtml-lbg                                                                                            |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
 .amp-video-docked-shadow                                                                                  |   2147483643   |   extensions/amp-video-docking/0.1/amp-video-docking.css
 .i-amphtml-consent-ui-mask                                                                                |   2147483644   |   extensions/amp-consent/0.1/amp-consent.css
 .i-amphtml-video-docked                                                                                   |   2147483644   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-video-docked-overlay                                                                           |   2147483645   |   extensions/amp-video-docking/0.1/amp-video-docking.css
 amp-consent                                                                                               |   2147483645   |   extensions/amp-consent/0.1/amp-consent.css
-.amp-video-docked-controls                                                                                |   2147483646   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.i-amphtml-video-docked-overlay                                                                           |   2147483645   |   extensions/amp-video-docking/0.1/amp-video-docking.css
 .amp-apester-fullscreen                                                                                   |   2147483646   |   extensions/amp-apester-media/0.1/amp-apester-media.css
-.amp-access-scroll-bar                                                                                    |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
+.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.amp-video-docked-controls                                                                                |   2147483646   |   extensions/amp-video-docking/0.1/amp-video-docking.css
 amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.amp-access-scroll-bar                                                                                    |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import './lightbox-caption.css';
+
 amp-lightbox-gallery .amp-carousel-button {
   display: none;
 }
@@ -157,60 +159,8 @@ amp-lightbox-gallery amp-carousel {
   animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
-.i-amphtml-lbg-controls.i-amphtml-lbg-fade-out
- {
+.i-amphtml-lbg-controls.i-amphtml-lbg-fade-out {
   animation: fadeOut linear 0.4s 1 forwards;
-}
-
-.i-amphtml-lbg-desc-box {
-  position: absolute !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-  color: #ffffff;
-}
-
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-standard {
-  background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.5));
-  max-height: 6rem !important;
-  transition: max-height ease-out 0.3s !important;
-  overflow: hidden !important;
-}
-
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-overflow {
-  overflow-y: auto !important;
-  -webkit-overflow-scrolling: touch !important;
-  max-height: 100% !important;
-  transition: max-height ease-out 0.7s !important;
-}
-
-.i-amphtml-lbg-desc-mask {
-  width: 100% !important;
-  position: fixed !important;
-  bottom: 0 !important;
-}
-
-.i-amphtml-lbg-desc-text {
-  padding: 20px !important;
-  position: relative !important;
-  z-index: 1 !important;
-}
-
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-overflow .i-amphtml-lbg-desc-text {
-  padding-top: 40px !important;
-}
-
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-standard .i-amphtml-lbg-desc-mask {
-  z-index: 1 !important;
-  height: 1rem !important;
-  background: linear-gradient(transparent, rgba(0,0,0,0.9));
-  transition: background-color ease-out 0.5s !important;
-}
-.i-amphtml-lbg-desc-box.i-amphtml-lbg-overflow .i-amphtml-lbg-desc-mask {
-  background-color: rgba(0,0,0,0.4) !important;
-  top: 0 !important;
-  z-index: 0 !important;
-  transition: background-color ease-in 0.4s !important;
 }
 
 .i-amphtml-lbg[gallery-view] .i-amphtml-lbg-gallery {
@@ -278,7 +228,8 @@ amp-lightbox-gallery amp-carousel {
   }
 }
 
-.i-amphtml-lbg[gallery-view] .i-amphtml-lbg-button-gallery {
+.i-amphtml-lbg[gallery-view] .i-amphtml-lbg-button-gallery,
+.i-amphtml-lbg[gallery-view] .i-amphtml-lbg-caption {
   display: none;
 }
 
@@ -310,11 +261,4 @@ amp-lightbox-gallery .i-amphtml-slide-item > * {
     opacity: 0;
     visibility: hidden;
    }
-}
-
-@keyframes slideUp {
-  from { max-height: 6rem; }
-  to {
-    max-height: 100%;
-  }
 }

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -16,6 +16,27 @@
 
 @import './lightbox-caption.css';
 
+[i-amphtml-lbg-fade] {
+  animation-fill-mode: forwards;
+  /* Keep in sync with FADE_DURATION */
+  animation-duration: 400ms;
+}
+
+[i-amphtml-lbg-fade="in"] {
+  animation-name: fadeIn;
+}
+
+[i-amphtml-lbg-fade="out"] {
+  animation-name: fadeOut;
+}
+
+amp-lightbox-gallery[i-amphtml-lbg-fade] {
+  position: relative;
+  /* The highest z-index supported by most browsers - 5. See: css/Z_INDEX.md */
+  z-index: 2147483642;
+  animation-timing-function: cubic-bezier(0.8, 0, 0.2, 1);
+}
+
 amp-lightbox-gallery .amp-carousel-button {
   display: none;
 }
@@ -150,17 +171,17 @@ amp-lightbox-gallery amp-carousel {
   }
 }
 
-.i-amphtml-lbg-controls.i-amphtml-lbg-hidden {
+.i-amphtml-lbg-controls:not([i-amphtml-lbg-fade]) {
   opacity: 0;
   visibility: hidden;
 }
 
-.i-amphtml-lbg-controls.i-amphtml-lbg-fade-in {
-  animation: fadeIn ease-in 0.4s 1 forwards;
+.i-amphtml-lbg-controls[i-amphtml-lbg-fade="in"] {
+  animation-timing-function: ease-in;
 }
 
-.i-amphtml-lbg-controls.i-amphtml-lbg-fade-out {
-  animation: fadeOut linear 0.4s 1 forwards;
+.i-amphtml-lbg-controls[i-amphtml-lbg-fade="out"] {
+  animation-timing-function: linear;
 }
 
 .i-amphtml-lbg[gallery-view] .i-amphtml-lbg-gallery {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -967,7 +967,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   open(element, expandDescription = false) {
     return this.openLightboxGallery_(
         dev().assertElement(element),
-        expandDescription,
+        expandDescription
     ).then(() => {
       return this.history_.push(this.close_.bind(this));
     }).then(historyId => {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -39,7 +39,7 @@ import {
   scopedQuerySelectorAll,
 } from '../../../src/dom';
 import {clamp} from '../../../src/utils/math';
-import {dev, devAssert, userAssert} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getData, isLoaded, listen} from '../../../src/event-helper';
@@ -993,9 +993,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const expandDescription = args['expandDescription'];
     const target = id ? this.getAmpDoc().getElementById(id) :
       invocation.caller;
-    userAssert(target,
-        'amp-lightbox-gallery.open: element with id: %s not found', id);
-    this.open(target, expandDescription);
+    this.open(
+        user().assertElement(target,
+            'amp-lightbox-gallery.open: element with id: %s not found', id),
+        expandDescription);
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -39,7 +39,7 @@ import {
   scopedQuerySelectorAll,
 } from '../../../src/dom';
 import {clamp} from '../../../src/utils/math';
-import {dev, devAssert, user} from '../../../src/log';
+import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getData, isLoaded, listen} from '../../../src/event-helper';
@@ -993,10 +993,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const expandDescription = args['expandDescription'];
     const target = id ? this.getAmpDoc().getElementById(id) :
       invocation.caller;
-    this.open(
-        user().assertElement(target,
-            'amp-lightbox-gallery.open: element with id: %s not found', id),
-        expandDescription);
+    userAssert(target,
+        'amp-lightbox-gallery.open: element with id: %s not found', id);
+    this.open(dev().assertElement(target), expandDescription);
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
@@ -1,0 +1,77 @@
+.i-amphtml-lbg-caption-scroll {
+  position: absolute !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  z-index: 1;
+  /* 
+   * Make sure we do not overlap with the buttons. This is not applied to
+   * `.i-amphtml-lbg-caption-text` to avoid expanding the hit area when
+   * collapsed.
+   */
+  padding-top: 40px !important;
+  box-sizing: border-box !important;
+  color: #ffffff;
+  text-shadow: 1px 0 5px rgba(0, 0, 0, 0.4) !important;
+  overflow: hidden !important;
+  /* 40px padding top, plus 20px padding top/bottom for the caption text. */
+  max-height: calc(80px + 3rem) !important;
+  transition: max-height ease-out 0.3s !important;
+  /* Prevent clicks on this on the padding from expanding the caption. */
+  pointer-events: none !important;
+}
+
+.i-amphtml-lbg-caption-text {
+  padding: 20px !important;
+  pointer-events: all !important;
+}
+
+.i-amphtml-lbg-caption-text:empty {
+  display: none !important;
+}
+
+[i-amphtml-lbg-caption-state="clip"] {
+  /* Fade out the text, using an approximated exponential gradient. */
+  mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.0) 0rem,
+    rgba(0, 0, 0, 0.2) 1rem,
+    rgba(0, 0, 0, 0.55) 2rem,
+    rgba(0, 0, 0, 1.0) 3rem
+  );
+}
+
+[i-amphtml-lbg-caption-state="expand"]  {
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch !important;
+  max-height: 100% !important;
+  transition: max-height ease-out 0.7s !important;
+  /* Fade out the text, using an approximated exponential gradient. */
+  mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.0) 0px,
+    rgba(0, 0, 0, 0.2) 20px,
+    rgba(0, 0, 0, 0.55) 40px,
+    rgba(0, 0, 0, 1.0) 60px
+  );
+}
+
+.i-amphtml-lbg-caption-mask {
+  min-height: 1rem;
+  width: 100% !important;
+  position: fixed !important;
+  bottom: 0 !important;
+  pointer-events: all !important;
+}
+
+[i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask {
+  z-index: 1 !important;
+  background: transparent !important;
+  transition: background-color ease-out 0.5s !important;
+}
+
+[i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask {
+  background-color: rgba(0,0,0,0.4) !important;
+  top: 0 !important;
+  z-index: 0 !important;
+  transition: background-color ease-in 0.4s !important;
+}

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .i-amphtml-lbg-caption-scroll {
   position: absolute !important;
   left: 0 !important;

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {htmlFor} from '../../../src/static-template';
+
+/**
+ * @enum {string}
+ */
+export const OverflowState = {
+  NONE: 'none',
+  CLIP: 'clip',
+  EXPAND: 'expand',
+};
+
+/**
+ * Manages lightbox captions, handling expansion and collapsing.
+ */
+export class LightboxCaption {
+  /**
+   * @param {!Document} doc
+   * @param {function(function(), function())} measureMutateElement
+   * @return {!LightboxCaption} A LightboxCaption instance.
+   */
+  static build(doc, measureMutateElement) {
+    const element = htmlFor(doc)`
+      <div class="i-amphtml-lbg-caption">
+        <div class="i-amphtml-lbg-caption-scroll">
+          <div class="i-amphtml-lbg-caption-text"></div>
+        </div>
+        <div class="i-amphtml-lbg-caption-mask"></div>
+      </div>`;
+
+    return new LightboxCaption(
+        element,
+        element.querySelector('.i-amphtml-lbg-caption-scroll'),
+        element.querySelector('.i-amphtml-lbg-caption-text'),
+        element.querySelector('.i-amphtml-lbg-caption-mask'),
+        measureMutateElement);
+  }
+
+  /**
+   * @param {!Element} element
+   * @param {!Element} scrollContainer
+   * @param {!Element} textContainer
+   * @param {!Element} overflowMask
+   * @param {function(function(), function())} measureMutateElement
+   */
+  constructor(
+    element,
+    scrollContainer,
+    textContainer,
+    overflowMask,
+    measureMutateElement) {
+
+    /** @private @const */
+    this.element_ = element;
+
+    /** @private @const */
+    this.scrollContainer_ = scrollContainer;
+
+    /** @private @const */
+    this.textContainer_ = textContainer;
+
+    /** @private @const */
+    this.overflowMask_ = overflowMask;
+
+    /** @private @const */
+    this.measureMutateElement_ = measureMutateElement;
+  }
+
+  /**
+   * @return {!Element} The description box Element.
+   */
+  getElement() {
+    return this.element_;
+  }
+
+  /**
+   * @param {string} content The content for the caption.
+   */
+  setContent(content) {
+    this.textContainer_./*OK*/innerText = content;
+  }
+
+  /**
+   * @param {!OverflowState} state
+   */
+  setOverflowState(state) {
+    this.scrollContainer_.setAttribute('i-amphtml-lbg-caption-state', state);
+  }
+
+  /**
+   * @return {!OverflowState} state
+   */
+  getOverflowState() {
+    return this.scrollContainer_.getAttribute('i-amphtml-lbg-caption-state');
+  }
+
+  /**
+   * Gets the `OverflowState` to use,
+   * @param {string} overflowState The current overflow state.
+   * @param {boolean} overflows Whether or not the description overflows its
+   *    container.
+   * @param {boolean=} requestExpansion The requested expansion state.
+   * @return {!OverflowState} The new state.
+   * @private
+   */
+  nextOverflowState_(
+    overflowState,
+    overflows,
+    requestExpansion
+  ) {
+    const isExpanded = overflowState == OverflowState.EXPAND;
+    const expand = requestExpansion !== undefined ?
+      requestExpansion :
+      !isExpanded;
+    // If we are already expanded, we know we have some overflow, even if
+    // we are not currently "overflowing".
+    const hasOverflow = isExpanded || overflows;
+
+    if (!hasOverflow) {
+      return OverflowState.NONE;
+    }
+
+    return expand ?
+      OverflowState.EXPAND :
+      OverflowState.CLIP;
+  }
+
+  /**
+   * Toggles the description overflow state.
+   * @param {boolean=} requestExpansion If specified, whether the
+   *    description should be expanded or collapsed. If not specfied, the
+   *    current state is toggled.
+   */
+  toggleOverflow(requestExpansion) {
+    const {
+      scrollContainer_,
+      overflowMask_,
+    } = this;
+    let descriptionOverflows;
+
+    const measureOverflowState = () => {
+      // The height of the description without overflow is set to 4 rem.
+      // The height of the overflow mask is set to 1 rem. We allow 3 lines
+      // for the description and consider it to have overflow if more than 3
+      // lines of text.
+      descriptionOverflows = scrollContainer_./*OK*/scrollHeight
+          - scrollContainer_./*OK*/clientHeight
+          >= overflowMask_./*OK*/clientHeight;
+    };
+
+    const mutateOverflowState = () => {
+      const overflowState = this.getOverflowState();
+      const newState = this.nextOverflowState_(
+          overflowState, descriptionOverflows, requestExpansion);
+
+      this.setOverflowState(newState);
+      if (newState != OverflowState.EXPAND) {
+        scrollContainer_./*OK*/scrollTop = 0;
+      }
+    };
+
+    this.measureMutateElement_(measureOverflowState, mutateOverflowState);
+  }
+
+}

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {dev} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 
 /**
@@ -35,19 +36,18 @@ export class LightboxCaption {
    * @return {!LightboxCaption} A LightboxCaption instance.
    */
   static build(doc, measureMutateElement) {
-    const element = htmlFor(doc)`
+    const el = htmlFor(doc)`
       <div class="i-amphtml-lbg-caption">
         <div class="i-amphtml-lbg-caption-scroll">
           <div class="i-amphtml-lbg-caption-text"></div>
         </div>
         <div class="i-amphtml-lbg-caption-mask"></div>
       </div>`;
-
     return new LightboxCaption(
-        element,
-        element.querySelector('.i-amphtml-lbg-caption-scroll'),
-        element.querySelector('.i-amphtml-lbg-caption-text'),
-        element.querySelector('.i-amphtml-lbg-caption-mask'),
+        el,
+        dev().assertElement(el.querySelector('.i-amphtml-lbg-caption-scroll')),
+        dev().assertElement(el.querySelector('.i-amphtml-lbg-caption-text')),
+        dev().assertElement(el.querySelector('.i-amphtml-lbg-caption-mask')),
         measureMutateElement);
   }
 
@@ -106,7 +106,8 @@ export class LightboxCaption {
    * @return {!OverflowState} state
    */
   getOverflowState() {
-    return this.scrollContainer_.getAttribute('i-amphtml-lbg-caption-state');
+    return /** @type {OverflowState} */ (
+      this.scrollContainer_.getAttribute('i-amphtml-lbg-caption-state'));
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {htmlFor} from '../../../src/static-template';
 
 /**

--- a/test/manual/amp-lightbox-gallery-launch-captions.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch-captions.amp.html
@@ -1,0 +1,101 @@
+<!--
+  ## Introduction
+
+The amp-lightbox-gallery component provides a "lightbox” experience for AMP components (e.g., amp-img, amp-carousel). When the user interacts with the AMP element, a UI component expands to fill the viewport until it is closed by the user. Currently, only images are supported.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="/components/amp-lightbox-gallery/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <title>amp-lightbox-gallery</title>
+  <!-- ## Setup -->
+  <!-- Import the amp-lightbox-gallery component in the header.  -->
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <!-- Optionally import the amp-carousel component in the header if you are using lightbox with carousel. -->
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    figure {
+      margin: 10px 0;
+    }
+
+    .truncate {
+      max-height: 2rem;
+      overflow: hidden;
+    }
+
+    amp-img[lightbox] {
+      cursor: pointer;
+    }
+
+    .container {
+      margin: 0 6% 0 6%;
+    }
+  </style>
+</head>
+<body>
+  <amp-lightbox-gallery layout="nodisplay" id="lg"></amp-lightbox-gallery>
+
+  <h2>Open with expanded caption</h2>
+  <!-- You can tell the lightbox to open with the captions already expanded. -->
+
+  <div class="container">
+    <figure>
+      <amp-img
+        on="tap:lg.open(expandDescription = true)"
+        lightbox="caption"
+        src="https://picsum.photos/300/200"
+        width="300"
+        height="200"
+        layout="responsive"></amp-img>
+      <figcaption class="image truncate">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </figcaption>
+    </figure>
+
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+
+    <figure>
+      <amp-img
+        on="tap:lg.open(expandDescription = true)"
+        lightbox="caption"
+        src="https://picsum.photos/400/300"
+        width="400"
+        height="300"
+        layout="responsive"></amp-img>
+      <figcaption class="image truncate">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </figcaption>
+    </figure>
+
+    <figure>
+      <amp-img
+        on="tap:lg.open(expandDescription = true)"
+        lightbox="caption"
+        src="https://picsum.photos/400/300"
+        width="400"
+        height="300"
+        layout="responsive"></amp-img>
+      <figcaption class="image truncate">
+        Short caption.
+      </figcaption>
+    </figure>
+  </div>
+  
+</body>
+</html>


### PR DESCRIPTION
- Refactor lightbox captions into a separate file.
- Fix downwards movement at the start of the captions expanding by
having consistent padding both before and after the expansion.
- Allow opening lightbox with the captions already expanded via an
action.
- Apply captions fading mask when switching slides, which is less
jarring when the new slide's captions are overflowing.
- Keep the close and gallery view buttons visible when the caption is
expanded. This is important when opening when captions already expanded.
  * Added a fade out effect to the top of the text, so it does not clash
  with the buttons.
- Change the caption fade out mask to use `mask-image` instead of a
gradient. This works well when the captions are overlaying the image
(e.g. if you enter pan-zoom mode or the image is in portrait).
  * Add a text-shadow around the captions as a replacement, so when the
  captions are on top of an image, they are still readable. This also
  improves the contrast when the captions are expanded.
- Fix stacking order bug when fading in.

The existing version of the lightbox (without opening with expanded captions) can be tested here:
https://output.jsbin.com/vebebuy

The change can be tested here:
https://amp-polish.firebaseapp.com/manual/amp-lightbox-gallery-launch-captions.amp.html