### PR TITLE
🏗 Clean up describes-e2e

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -253,7 +253,7 @@ function describeEnv(factory) {
         }
 
         if (!isTravisBuild()) {
-          uninstallRepl(global, env);
+          uninstallRepl();
         }
       });
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -30,7 +30,7 @@ const {SeleniumWebDriverController} = require('./selenium-webdriver-controller')
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
 const TIMEOUT = 20000;
-
+const SETUP_TIMEOUT = 30000;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 
 /**
@@ -238,9 +238,10 @@ function describeEnv(factory) {
       this.timeout(TIMEOUT);
       let rootBeforeEachTimeout;
       beforeEach(async function() {
+        this.timeout(SETUP_TIMEOUT);
         rootBeforeEachTimeout = setTimeout(() => {
           log('Timed out in root level before each');
-        }, TIMEOUT);
+        }, SETUP_TIMEOUT);
         await fixture.setup(env);
 
         // don't install for CI

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -234,7 +234,11 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      beforeEach(async() => {
+      beforeEach(async function() {
+        setTimeout(() => {
+          throw new Error('Timed out in root level before each');
+        }, TIMEOUT);
+
         await fixture.setup(env);
         installRepl(global, env);
       });

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -235,17 +235,17 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      beforeEach(async function(done) {
-        setTimeout(() => {
+      let rootBeforeEachTimeout;
+      beforeEach(async function() {
+        rootBeforeEachTimeout = setTimeout(() => {
           log('Timed out in root level before each');
-          done();
         }, TIMEOUT);
-
         await fixture.setup(env);
         installRepl(global, env);
       });
 
       afterEach(async function() {
+        clearTimeout(rootBeforeEachTimeout);
         clearLastExpectError();
         clearTimeout(asyncErrorTimerId);
         await fixture.teardown(env);

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -17,6 +17,7 @@
 // import to install chromedriver
 require('chromedriver'); // eslint-disable-line no-unused-vars
 
+const log = require('fancy-log');
 const puppeteer = require('puppeteer');
 const {AmpDriver, AmpdocEnvironment} = require('./amp-driver');
 const {Builder, Capabilities} = require('selenium-webdriver');
@@ -234,9 +235,10 @@ function describeEnv(factory) {
       const env = Object.create(variant);
       let asyncErrorTimerId;
       this.timeout(TIMEOUT);
-      beforeEach(async function() {
+      beforeEach(async function(done) {
         setTimeout(() => {
-          throw new Error('Timed out in root level before each');
+          log('Timed out in root level before each');
+          done();
         }, TIMEOUT);
 
         await fixture.setup(env);


### PR DESCRIPTION
- Fix all existing `beforeEach` errors by increasing its timeout to 30s. Keep test timeout at 20s.
- Remove multiple fixture support when there's just one.
- Await `setup()` and `teardown()`, which are async.
- Clean up TODOs.