### PR TITLE
🐛adding fa query param to ad url for adsense auto anchor elements

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -337,7 +337,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const pfx = enclosingContainers.includes(
         ValidAdContainerTypes['AMP-FX-FLYING-CARPET']) ||
         enclosingContainers.includes(ValidAdContainerTypes['AMP-STICKY-AD']);
-    const parameters = {
+    // Indicates that element is anchor ad for amp auto ads
+    const fa = this.element.getAttribute('data-fa');
+    const parameters = Object.assign({
       'client': adClientId,
       'format': format,
       'w': this.size_.width,
@@ -372,7 +374,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Package code (also known as URL group) that was used to
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),
-    };
+    }, fa && {fa});
 
     const experimentIds = [];
     const identityPromise = Services.timerFor(this.win)

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -374,7 +374,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Package code (also known as URL group) that was used to
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),
-    }, fa && {'fa': fa});
+    }, fa ? {'fa': fa} : null);
 
     const experimentIds = [];
     const identityPromise = Services.timerFor(this.win)

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -374,7 +374,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Package code (also known as URL group) that was used to
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),
-    }, fa && {fa});
+    }, fa && {'fa': fa});
 
     const experimentIds = [];
     const identityPromise = Services.timerFor(this.win)

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -88,13 +88,14 @@ export class AnchorAdStrategy {
    * @private
    */
   placeStickyAd_() {
+    const type = this.baseAttributes_['type'];
     const viewportWidth =
         Services.viewportForDoc(this.ampdoc).getWidth();
     const attributes = /** @type {!JsonObject} */ (
       Object.assign(dict(), this.baseAttributes_, dict({
         'width': String(viewportWidth),
         'height': '100',
-      })));
+      }), (type === 'adsense' && {'data-fa': '1'}) || null));
     const doc = this.ampdoc.win.document;
     const ampAd = createElementWithAttributes(
         doc, 'amp-ad', attributes);


### PR DESCRIPTION
adding fa param to ad url indicates whether it is classified as an anchor ad from adsense auto ads.
