### PR TITLE
🏗 Retry tests before failing them on Travis

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -242,8 +242,10 @@ module.exports = {
   client: {
     mocha: {
       reporter: 'html',
-      // Longer timeout on Travis; fail quickly at local.
+      // Longer timeout on Travis; fail quickly during local runs.
       timeout: isTravisBuild() ? 10000 : 2000,
+      // Run tests up to 3 times before failing them on Travis.
+      retries: isTravisBuild() ? 2 : 0,
     },
     captureConsole: false,
     verboseLogging: false,


### PR DESCRIPTION
During CI builds, we run [~15000](https://travis-ci.org/ampproject/amphtml/builds/530045204) tests on Travis.

- [~9500](https://travis-ci.org/ampproject/amphtml/jobs/530045211#L1566) unit tests (local)
- [~3700](https://travis-ci.org/ampproject/amphtml/jobs/530045212#L1929) unit tests (sauce labs)
- [~350](https://travis-ci.org/ampproject/amphtml/jobs/530045211#L1540) integration tests (local)
- [~270](https://travis-ci.org/ampproject/amphtml/jobs/530045209#L1947) integration tests (local, single pass)
- [~600](https://travis-ci.org/ampproject/amphtml/jobs/530045212#L1968) integration tests (sauce labs)
- [~350](https://travis-ci.org/ampproject/amphtml/jobs/530045212#L1988) integration tests (sauce labs, beta browsers)

Often times, a single-digit number of tests will fail due to timing issues, and the Travis job needs to be retried to get a green build. This is frustrating for developers, and expensive due to wasted resources.

In this PR, we change the default number of test retries from 0 to 2 for Travis CI runs.
- This will be a no-op for most tests, but will greatly reduce the incidence of one or two flaky tests bringing down an entire Travis CI build.
- This will also be a no-op for genuine, repeatable test failures, for which we are guaranteed a failed build.

This should result in less random flakiness on Travis, and increase our trust in CI builds.

Partial fix for #14360