### PR TITLE
amp form submit-error action fix

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -690,7 +690,7 @@ export class AmpForm {
         }).then(
             resp => this.handleSsrTemplateSuccess_(resp, request),
             error => this.handleSsrTemplateFailure_(
-                /** @type {!JsonObject} */ (error)));
+                /** @type {!Error} */ (error)));
   }
 
   /**
@@ -718,14 +718,17 @@ export class AmpForm {
 
   /**
    * Handles viewer render template failure.
-   * @param {!JsonObject} error
+   * @param {!Error} error
    */
   handleSsrTemplateFailure_(error) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
+    const errorJsonObject = dict({
+      'error': error.message,
+    });
     return tryResolve(() => {
-      this.renderTemplate_(error || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_ERROR, error);
+      this.renderTemplate_(errorJsonObject || {}).then(() => {
+        this.triggerAction_(FormEvents.SUBMIT_ERROR, errorJsonObject);
       });
     });
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -690,7 +690,7 @@ export class AmpForm {
         }).then(
             resp => this.handleSsrTemplateSuccess_(resp, request),
             error => this.handleSsrTemplateFailure_(
-                /** @type {!Error} */ (error)));
+                /** @type {!JsonObject} */ (error)));
   }
 
   /**
@@ -718,17 +718,14 @@ export class AmpForm {
 
   /**
    * Handles viewer render template failure.
-   * @param {!Error} error
+   * @param {!JsonObject} error
    */
   handleSsrTemplateFailure_(error) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
-    const errorJsonObject = dict({
-      'error': error.message,
-    });
     return tryResolve(() => {
-      this.renderTemplate_(errorJsonObject || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_ERROR, errorJsonObject);
+      this.renderTemplate_(error || {}).then(() => {
+        this.triggerAction_(FormEvents.SUBMIT_ERROR, error);
       });
     });
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -615,7 +615,7 @@ export class AmpForm {
       'error': error.message,
     });
     this.renderTemplate_(errorJsonObject).then(() => {
-      this.triggerAction_(FormEvents.SUBMIT_ERROR, error);
+      this.triggerAction_(FormEvents.SUBMIT_ERROR, errorJsonObject);
     });
   }
 
@@ -690,7 +690,7 @@ export class AmpForm {
         }).then(
             resp => this.handleSsrTemplateSuccess_(resp, request),
             error => this.handleSsrTemplateFailure_(
-                /** @type {!JsonObject} */ (error)));
+                /** @type {!Error} */ (error)));
   }
 
   /**
@@ -718,16 +718,16 @@ export class AmpForm {
 
   /**
    * Handles viewer render template failure.
-   * @param {!JsonObject} error
+   * @param {!Error} error
    */
   handleSsrTemplateFailure_(error) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
     const errorJsonObject = dict({
-      'error': error['message'],
+      'error': error.message,
     });
     return tryResolve(() => {
-      this.renderTemplate_(error || {}).then(() => {
+      this.renderTemplate_(errorJsonObject || {}).then(() => {
         this.triggerAction_(FormEvents.SUBMIT_ERROR, errorJsonObject);
       });
     });
@@ -1002,7 +1002,7 @@ export class AmpForm {
   /**
    * Triggers either a submit-success or submit-error action with response data.
    * @param {!FormEvents} name
-   * @param {?Object} detail
+   * @param {!JsonObject|!Array<{message: string, name: string}>|null} detail
    * @private
    */
   triggerAction_(name, detail) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -723,9 +723,12 @@ export class AmpForm {
   handleSsrTemplateFailure_(error) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
+    const errorJsonObject = dict({
+      'error': error.message,
+    });
     return tryResolve(() => {
       this.renderTemplate_(error || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_ERROR, error);
+        this.triggerAction_(FormEvents.SUBMIT_ERROR, errorJsonObject);
       });
     });
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -724,7 +724,7 @@ export class AmpForm {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
     const errorJsonObject = dict({
-      'error': error.message,
+      'error': error['message'],
     });
     return tryResolve(() => {
       this.renderTemplate_(error || {}).then(() => {


### PR DESCRIPTION
Update the action invocation on submit error event data not to be the error object as in the context of AMP.setState action, the postMessage will not be successful as error objects are non cloneable.

b131633888