### PR TITLE
validator.amp.dev is live, update links

### DIFF
--- a/extensions/amp-viewer-integration/integrating-viewer-with-amp-doc-guide.md
+++ b/extensions/amp-viewer-integration/integrating-viewer-with-amp-doc-guide.md
@@ -22,7 +22,7 @@ This document explains the communication between a Viewer and AMP documents by u
 
 <img src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-viewer-integration/img/intro.png" height="300px"></img>
 
-A Viewer is a container in which you can view AMP Documents. An AMP Document is a document created with the AMPHTML library and validated by the [AMP Validator](https://validator.ampproject.org/).
+A Viewer is a container in which you can view AMP Documents. An AMP Document is a document created with the AMPHTML library and validated by the [AMP Validator](https://validator.amp.dev/).
 
 ## How the AMP Viewer Integration API works
 In this section, you'll learn how the AMP Viewer and AMP document establish connections to communicate in mobile web and in webview.

--- a/validator/chromeextension/popup-validator.html
+++ b/validator/chromeextension/popup-validator.html
@@ -233,7 +233,7 @@ limitations under the License.
           });
         }
         function processResult(validationResult, toolbar, content, url) {
-          const webuiDomain = 'validator.ampproject.org';
+          const webuiDomain = 'validator.amp.dev';
           const webuiUrl = 'https://' + webuiDomain + '/#url=' + encodeURI(url);
           const errors = validationResult.errors;
           var validationErrors = [];

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -5992,7 +5992,7 @@ amp.validator.ValidationResult.prototype.outputToTerminal = function(
   }
   if (errorCategoryFilter === null && errors.length !== 0) {
     terminal.info(
-        'See also https://validator.ampproject.org/#url=' +
+        'See also https://validator.amp.dev/#url=' +
         encodeURIComponent(goog.uri.utils.removeFragment(url)));
   }
 };

--- a/validator/webui/README.md
+++ b/validator/webui/README.md
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 # Validator Web UI
 
-If you'd like to use the web UI, simply visit [validator.ampproject.org](https://validator.ampproject.org/).
+If you'd like to use the web UI, simply visit [validator.amp.dev](https://validator.amp.dev/).
 
 ## Running your own Web UI
 
@@ -30,7 +30,7 @@ $ ./serve-standalone
 Then visit your own instance at http://127.0.0.1:8765/.
 
 If you'd like to run exactly the code that is running at
-[validator.ampproject.org](https://validator.ampproject.org/), that's an
+[validator.amp.dev](https://validator.amp.dev/), that's an
 Appengine app - please refer to the instructions in serve.go.
 
 ## Passing in documents from URL
@@ -54,4 +54,4 @@ By default this tool will assume you want to validate an `AMPHTML` document. If 
 
 If you wish to use both the `doc=` and `htmlFormat=` together make sure to include an `&` between the key-value pairs.
 
-Putting it all together allows you to create links like [this example.](https://validator.ampproject.org/#htmlFormat=AMP4ADS&doc=PCFkb2N0eXBlIGh0bWw%2BCjxodG1sIOKaoTRhZHM%2BCjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8bWV0YSBuYW1lPSJ2aWV3cG9ydCIgY29udGVudD0id2lkdGg9ZGV2aWNlLXdpZHRoLG1pbmltdW0tc2NhbGU9MSI%2BCiAgPHN0eWxlIGFtcDRhZHMtYm9pbGVycGxhdGU%2BYm9keXt2aXNpYmlsaXR5OmhpZGRlbn08L3N0eWxlPgogIDxzY3JpcHQgYXN5bmMgc3JjPSJodHRwczovL2Nkbi5hbXBwcm9qZWN0Lm9yZy9hbXA0YWRzLXYwLmpzIj48L3NjcmlwdD4KPC9oZWFkPgo8Ym9keT4KCTxhbXAtaW1nIHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBzcmM9Imh0dHA6Ly9wbGFjZWtpdHRlbi5jb20vNTAwLzUwMCI%2BPC9hbXAtaW1nPgogIAk8aDE%2BQ2F0cyBhcmUgY29vbC48L2gxPgo8L2JvZHk%2BCjwvaHRtbD4)
+Putting it all together allows you to create links like [this example.](https://validator.amp.dev/#htmlFormat=AMP4ADS&doc=PCFkb2N0eXBlIGh0bWw%2BCjxodG1sIOKaoTRhZHM%2BCjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8bWV0YSBuYW1lPSJ2aWV3cG9ydCIgY29udGVudD0id2lkdGg9ZGV2aWNlLXdpZHRoLG1pbmltdW0tc2NhbGU9MSI%2BCiAgPHN0eWxlIGFtcDRhZHMtYm9pbGVycGxhdGU%2BYm9keXt2aXNpYmlsaXR5OmhpZGRlbn08L3N0eWxlPgogIDxzY3JpcHQgYXN5bmMgc3JjPSJodHRwczovL2Nkbi5hbXBwcm9qZWN0Lm9yZy9hbXA0YWRzLXYwLmpzIj48L3NjcmlwdD4KPC9oZWFkPgo8Ym9keT4KCTxhbXAtaW1nIHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBzcmM9Imh0dHA6Ly9wbGFjZWtpdHRlbi5jb20vNTAwLzUwMCI%2BPC9hbXAtaW1nPgogIAk8aDE%2BQ2F0cyBhcmUgY29vbC48L2gxPgo8L2JvZHk%2BCjwvaHRtbD4)

--- a/validator/webui/README.md
+++ b/validator/webui/README.md
@@ -27,7 +27,7 @@ $ go build serve-standalone.go
 $ ./serve-standalone
 ```
 
-Then visit your own instance at http://127.0.0.1:8765/.
+Then visit your own instance at `http://127.0.0.1:8765/`.
 
 If you'd like to run exactly the code that is running at
 [validator.amp.dev](https://validator.amp.dev/), that's an

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -44,7 +44,7 @@
 <body unresolved>
   <webui-mainpage></webui-mainpage>
 <script>
-if (location.href.match(/^https:\/\/validator.ampproject.org\/.*/)) {
+if (location.href.match(/^https:\/\/validator.amp.dev\/.*/)) {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/validator/webui/serve-standalone.go
+++ b/validator/webui/serve-standalone.go
@@ -138,7 +138,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		req.Header.Add("User-Agent",
 			"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC19V) "+
 				"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile "+
-				"Safari/537.36 (compatible; validator.ampproject.org)")
+				"Safari/537.36 (compatible; validator.amp.dev)")
 		resp, err := netClient.Do(req)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),

--- a/validator/webui/serve.go
+++ b/validator/webui/serve.go
@@ -61,7 +61,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	req.Header.Add("User-Agent",
 		"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC19V) "+
 			"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile "+
-			"Safari/537.36 (compatible; validator.ampproject.org)")
+			"Safari/537.36 (compatible; validator.amp.dev)")
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),


### PR DESCRIPTION
Update validation links for the Validator Web UI from validator.ampproject.org to validator.amp.dev now that validator.amp.dev is live.