### PR TITLE
🏗🐛 Rename `version` to `internalRuntimeVersion` in AmpPass.java

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -194,7 +194,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     }
 
     String name = buildQualifiedName(n);
-    if (!name.equals("version$$module$src$internal_version()")) {
+    if (!name.equals("internalRuntimeVersion$$module$src$internal_version()")) {
       return;
     }
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -371,9 +371,9 @@ public class AmpPassTest extends CompilerTestCase {
   @Test public void testAmpVersionReplacement() throws Exception {
     test(
         LINE_JOINER.join(
-            "var a = `test${version$$module$src$internal_version()}ing`;",
-            "var b = 'test' + version$$module$src$internal_version() + 'ing';",
-            "var c = version$$module$src$internal_version();"),
+            "var a = `test${internalRuntimeVersion$$module$src$internal_version()}ing`;",
+            "var b = 'test' + internalRuntimeVersion$$module$src$internal_version() + 'ing';",
+            "var c = internalRuntimeVersion$$module$src$internal_version();"),
         LINE_JOINER.join(
             "var a = `test${'123'}ing`;",
             "var b = 'test' + '123' + 'ing';",


### PR DESCRIPTION
In #22216, `version()` from `src/internal_version.js` was renamed to `internalRuntimeVersion()`. This PR makes up for that change in AmpPass.java.

Addresses https://github.com/ampproject/amphtml/pull/22216#issuecomment-491106311 and fixes [this](https://travis-ci.org/ampproject/amphtml/jobs/530499265#L1945-L1958) test failure

Follow up to #22216
