### PR TITLE
fix transform for `internalRuntimeVersion` for multipass

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -194,7 +194,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     }
 
     String name = buildQualifiedName(n);
-    if (!name.equals("version$$module$src$internal_version()")) {
+    if (!name.equals("internalRuntimeVersion$$module$src$internal_version()")) {
       return;
     }
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -35,7 +35,7 @@ public class AmpPassTest extends CompilerTestCase {
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
     return new AmpPass(compiler, /* isProd */ true, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements, "123");
+        prodAssignmentReplacements, "123", false);
   }
 
   @Override protected int getNumRepetitions() {
@@ -371,9 +371,9 @@ public class AmpPassTest extends CompilerTestCase {
   @Test public void testAmpVersionReplacement() throws Exception {
     test(
         LINE_JOINER.join(
-            "var a = `test${version$$module$src$internal_version()}ing`;",
-            "var b = 'test' + version$$module$src$internal_version() + 'ing';",
-            "var c = version$$module$src$internal_version();"),
+            "var a = `test${internalRuntimeVersion$$module$src$internal_version()}ing`;",
+            "var b = 'test' + internalRuntimeVersion$$module$src$internal_version() + 'ing';",
+            "var c = internalRuntimeVersion$$module$src$internal_version();"),
         LINE_JOINER.join(
             "var a = `test${'123'}ing`;",
             "var b = 'test' + '123' + 'ing';",

--- a/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
@@ -29,7 +29,7 @@ public class AmpPassTestEnvTest extends CompilerTestCase {
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
     return new AmpPass(compiler, /* isProd */ false, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements, "123");
+        prodAssignmentReplacements, "123", false);
   }
 
   @Override protected int getNumRepetitions() {


### PR DESCRIPTION
with the rename of `version` to `internalRuntimeVersion` we need to update the transform in AmpPass with the correct fully qualified name