### PR TITLE
Remove position: absolute when measuring fluid creative height.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1081,15 +1081,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @private
    */
   setCssPosition_(position) {
-    return this.measureMutateElement(
-        /** MEASURER */ () => {
-          this.getResource().measure();
-        },
-        /** MUTATOR */ () => {
-          setImportantStyles(this.element, {position});
-        },
-        this.element
-    );
+    return this.mutateElement(() => {
+      setImportantStyles(this.element, {position});
+    }, this.element);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -96,7 +96,7 @@ import {
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
 import {parseQueryString} from '../../../src/url';
-import {setStyles} from '../../../src/style';
+import {setImportantStyles, setStyles} from '../../../src/style';
 import {stringHash32} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
 import {utf8Decode} from '../../../src/utils/bytes';
@@ -1065,10 +1065,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               this.fireFluidDelayedImpression();
               this.reattemptToExpandFluidCreative_ = false;
             })
-        .catch(() => {
-          this.reattemptToExpandFluidCreative_ = true;
-          this.setCssPosition_('absolute');
-        });
+            .catch(() => {
+              this.reattemptToExpandFluidCreative_ = true;
+              this.setCssPosition_('absolute');
+            });
       });
     }
     return Promise.resolve();
@@ -1076,7 +1076,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /**
    * Sets the CSS 'position' property of this.element.
-   * @param {string} The CSS position value.
+   * @param {string} position The CSS position value.
    * @return {!Promise} A promise that resolves when mutation is complete.
    * @private
    */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1058,17 +1058,38 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             this.element.getAttribute('data-amp-slot-index'));
         return Promise.reject('Cannot access body of friendly frame');
       }
-      return this.attemptChangeHeight(
-          this.iframe.contentWindow.document.body./*OK*/clientHeight)
-          .then(() => {
-            this.fireFluidDelayedImpression();
-            this.reattemptToExpandFluidCreative_ = false;
-          })
-          .catch(() => {
-            this.reattemptToExpandFluidCreative_ = true;
-          });
+      return this.setCssPosition_('static').then(() => {
+        return this.attemptChangeHeight(
+            this.iframe.contentWindow.document.body./*OK*/clientHeight)
+            .then(() => {
+              this.fireFluidDelayedImpression();
+              this.reattemptToExpandFluidCreative_ = false;
+            })
+        .catch(() => {
+          this.reattemptToExpandFluidCreative_ = true;
+          this.setCssPosition_('absolute');
+        });
+      });
     }
     return Promise.resolve();
+  }
+
+  /**
+   * Sets the CSS 'position' property of this.element.
+   * @param {string} The CSS position value.
+   * @return {!Promise} A promise that resolves when mutation is complete.
+   * @private
+   */
+  setCssPosition_(position) {
+    return this.measureMutateElement(
+        /** MEASURER */ () => {
+          this.getResource().measure();
+        },
+        /** MUTATOR */ () => {
+          setImportantStyles(this.element, {position});
+        },
+        this.element
+    );
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -227,9 +227,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should fire delayed impression ping', () => {
     createScaffoldingForFluidRendering(impl, sandbox);
     const connectMessagingChannelSpy =
-          sandbox.spy(impl.safeframeApi_,
+          sandbox./*OK*/spy(impl.safeframeApi_,
               'connectMessagingChannel');
-    const onFluidResizeSpy = sandbox.spy(impl.safeframeApi_,
+    const onFluidResizeSpy = sandbox./*OK*/spy(impl.safeframeApi_,
         'onFluidResize_');
     return impl.adPromise_.then(() => {
       return impl.layoutCallback().then(() => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -301,9 +301,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
-    const measureMutateElementStub = sandbox.stub(impl, 'measureMutateElement');
+    const mutateElementStub = sandbox.stub(impl, 'mutateElement');
     attemptChangeHeightStub.returns(Promise.resolve());
-    measureMutateElementStub.returns(Promise.resolve());
+    mutateElementStub.returns(Promise.resolve());
     sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
     impl.buildCallback();
     impl.isFluidRequest_ = true;
@@ -320,9 +320,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
-    const measureMutateElementStub = sandbox.stub(impl, 'measureMutateElement');
+    const mutateElementStub = sandbox.stub(impl, 'mutateElement');
     attemptChangeHeightStub.returns(Promise.reject());
-    measureMutateElementStub.returns(Promise.resolve());
+    mutateElementStub.returns(Promise.resolve());
     sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
     impl.buildCallback();
     impl.isFluidRequest_ = true;


### PR DESCRIPTION
The presence of `position: absolute` on the slot element interferes with our ability to correctly measure the size of fluid creatives. Ad slots with fluid creatives resize themselves by taking up the maximum width available and setting their height to match the height of the creative's body element. This height is different if `position: absolute` is present (due to the element being removed from the normal document flow). So in the current way we measure and resize:

1) Add `i-amphtml-layout-awaiting-size` to slot element, which adds `position: absolute`
2) Measure height H from creative's body element
3) Set slot height to H
4) Remove `i-amphtml-layout-awaiting-size` from slot element, which removes `position: absolute`

H may be too large for the available width, since the element is returned to the normal document flow in step 4. The change here solves this by removing `position: absolute` right before step 2.

(This is a duplicate of #21944 which was closed due to some git-related weirdness.)