### PR TITLE
🏗 Re add IE11 to our CI in blocking mode

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -90,7 +90,6 @@ const unitTestOnSaucePaths = [
 
 const integrationTestPaths = [
   'test/integration/**/*.js',
-  'test/unit/test-error.js',
   'extensions/**/test/integration/**/*.js',
 ];
 

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -108,13 +108,11 @@ function getConfig() {
     saucelabsBrowsers = argv.saucelabs ?
     // With --saucelabs, integration tests are run on this set of browsers.
       [
-        'SL_IE_11',
         'SL_Chrome',
         'SL_Firefox',
-        // TODO(amp-infra): Restore this once tests are stable again.
-        // 'SL_Safari_11',
         'SL_Edge_17',
         'SL_Safari_12',
+        'SL_IE_11',
         // TODO(amp-infra): Evaluate and add more platforms here.
         //'SL_Chrome_Android_7',
         //'SL_iOS_11',
@@ -398,7 +396,7 @@ async function runTests() {
     const browsers = {stable: [], beta: []};
     for (const browserId of saucelabsBrowsers) {
       browsers[
-          (browserId.toLowerCase().endsWith('_beta') || browserId == 'SL_IE_11')
+          browserId.toLowerCase().endsWith('_beta')
             ? 'beta' : 'stable']
           .push(browserId);
     }

--- a/test/integration/test-configuration.js
+++ b/test/integration/test-configuration.js
@@ -17,7 +17,7 @@
 import {AmpEvents} from '../../src/amp-events';
 import {createFixtureIframe} from '../../testing/iframe.js';
 
-describe.configure().enableIe().run('Configuration', function() {
+describe.configure().run('Configuration', function() {
   let fixture;
   beforeEach(() => {
     return createFixtureIframe('test/fixtures/configuration.html', 500)


### PR DESCRIPTION
1. Clean up integration test run on IE
- Skip `integration/test-configuration.js` on IE because it fails
- Remove `unit/test-error.js` from integration test run

Now there are zero tests that have opted into IE.

2. Make IE tests blocking
- Move browser from beta/non-blocking batch to stable/blocking, for a total of 5 stable browsers
- Because batch size is set to 4, move IE to the end of the list so it runs in its own batch (just for in case)

cc/ @lannka @torch2424 