### PR TITLE
Sanitize arguments in expression evaluation

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -305,8 +305,8 @@ export class Bind {
     for (const key in scope) {
       const value = scope[key];
       if (value instanceof Error || typeof value == 'function') {
-        user().warn(TAG, Removing unsupported object type (Error, Function) in '
-            + 'postMessage context: %s', value);
+        user().warn(TAG, 'Removing unsupported object type (Error, Function) '
+            + 'in postMessage context: %s', value);
         delete scope[key];
       }
     }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -305,7 +305,7 @@ export class Bind {
     for (const key in scope) {
       const value = scope[key];
       if (value instanceof Error || typeof value == 'function') {
-        user().warn('Removing unsupported object type (Error, Function) in '
+        user().warn(TAG, Removing unsupported object type (Error, Function) in '
             + 'postMessage context: %s', value);
         delete scope[key];
       }

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -664,6 +664,24 @@ describe.configure().ifChrome().run('Bind', function() {
       expect(bind.setStateWithExpression).to.be.calledTwice;
     });
 
+    it('should sanitize scope for expression evaluation', () => {
+      const sanitizeScope = sandbox.spy(bind, 'sanitizeScope_');
+      const element = createElement(env, container, '[text]="onePlusOne"');
+      expect(element.textContent).to.equal('');
+      const error = new Error('This error object should be sanitized');
+      const func = new Function();
+      // Given the unsupport Error and function objects are in the scope.
+      const scope = {one: 1, error, func};
+      const promise = onBindReadyAndSetStateWithExpression(
+          env, bind, '{"onePlusOne": one + one}', scope);
+      return promise.then(() => {
+        // Expect unsupported objects to be sanitized.
+        expect(sanitizeScope).to.be.calledOnce;
+        expect(scope).to.deep.equal({one: 1});
+        expect(element.textContent).to.equal('2');
+      });
+    });
+
     it('should support parsing exprs in setStateWithExpression()', () => {
       const element = createElement(env, container, '[text]="onePlusOne"');
       expect(element.textContent).to.equal('');


### PR DESCRIPTION
Sanitize error and function objects from scope object used in expression evaluation. Such objects are [not supported](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) in the [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage). 
b131633888