### PR TITLE
🐛✅Update failing autocomplete e2e test

### DIFF
--- a/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
@@ -109,7 +109,7 @@ describes.endtoend('amp-autocomplete', {
     await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
     await expect(controller.getElementProperty(renderedResults, 'children'))
-        .to.have.length(0);
+        .to.have.length(1);
     const input = await controller.findElement('#input');
     await expect(controller.getElementProperty(input, 'value'))
         .to.equal('apple');


### PR DESCRIPTION
Update expected e2e test outcome based on a feature change to "re-renders results to an active item on blur so that if the element gain focus again, it will display updated suggestions" in #22054 