### PR TITLE
🏗♻️🚮🐛 Refactor `compile()` in `build-system/tasks/helpers.js`

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -141,11 +141,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       entryModuleFilename = entryModuleFilenames;
       entryModuleFilenames = [entryModuleFilename];
     }
-    // If undefined/null or false then we're ok executing the deletions
-    // and mkdir.
-    if (!options.preventRemoveAndMakeDir) {
-      cleanupBuildDir();
-    }
     const unneededFiles = [
       'build/fake-module/third_party/babel/custom-babel-helpers.js',
     ];

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -358,7 +358,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     };
 
     // For now do type check separately
-    if (options.checkTypes || options.typeCheckOnly) {
+    if (options.typeCheckOnly) {
       // Don't modify compilation_level to a lower level since
       // it won't do strict type checking if its whitespace only.
       compilerOptions.define.push('TYPECHECK_ONLY=true');

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -19,7 +19,7 @@ const {
   buildAlp,
   buildExaminer,
   buildWebWorker,
-  compile,
+  compileAllUnminifiedTargets,
   compileJs,
   printConfigHelp,
   printNobuildHelp,
@@ -69,7 +69,7 @@ async function performBuild(watch) {
       buildExaminer({watch}),
       buildWebWorker({watch}),
       buildExtensions({bundleOnlyIfListedInFiles: !watch, watch}),
-      compile(watch),
+      compileAllUnminifiedTargets(watch),
     ]);
   });
 }

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -37,7 +37,6 @@ async function checkTypes() {
   // little incremental value.
   /*buildExperiments({
     minify: true,
-    checkTypes: true,
     preventRemoveAndMakeDir: true,
   });*/
   const compileSrcs = [

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -35,10 +35,7 @@ async function checkTypes() {
   maybeInitializeExtensions();
   // Disabled to improve type check performance, since this provides
   // little incremental value.
-  /*buildExperiments({
-    minify: true,
-    preventRemoveAndMakeDir: true,
-  });*/
+  // buildExperiments({minify: true});
   const compileSrcs = [
     './src/amp.js',
     './src/amp-shadow.js',

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -33,9 +33,6 @@ async function checkTypes() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   maybeInitializeExtensions();
-  // Disabled to improve type check performance, since this provides
-  // little incremental value.
-  // buildExperiments({minify: true});
   const compileSrcs = [
     './src/amp.js',
     './src/amp-shadow.js',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -88,7 +88,7 @@ async function dist() {
           buildAlp({minify: true, watch: false}),
           buildExaminer({minify: true, watch: false}),
           buildWebWorker({minify: true, watch: false}),
-          buildExtensions({minify: true}),
+          buildExtensions({minify: true, watch: false}),
           buildExperiments({minify: true, watch: false}),
           buildLoginDone({minify: true, watch: false}),
           buildWebPushPublisherFiles({minify: true, watch: false}),

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -25,7 +25,7 @@ const {
   buildExaminer,
   buildExperiments,
   buildWebWorker,
-  compile,
+  compileAllMinifiedTargets,
   compileJs,
   enableLocalTesting,
   endBuildStep,
@@ -81,7 +81,7 @@ async function dist() {
       })
       .then(() => {
         return Promise.all([
-          compile(false, true),
+          compileAllMinifiedTargets(),
           // NOTE: When adding a line here,
           // consider whether you need to include polyfills
           // and whether you need to init logging (initLogConstructor).
@@ -109,13 +109,10 @@ async function dist() {
             enableLocalTesting('dist/v0.js'),
             enableLocalTesting('dist/amp4ads-v0.js'),
             enableLocalTesting('dist/shadow-v0.js'),
+            enableLocalTesting('dist.3p/current-min/f.js'),
+            argv.single_pass ?
+              Promise.resolve() : enableLocalTesting('dist/v0-esm.js'),
           ]);
-          // TODO(#18934, erwinm): Re-enable when the ESM build is fixed.
-          // .then(() => {
-          //   if (!argv.single_pass) {
-          //     return enableLocalTesting('dist/v0-esm.js')
-          //   }
-          // });
         }
       }).then(() => {
         if (argv.esm) {
@@ -126,10 +123,6 @@ async function dist() {
           ]);
         } else {
           return Promise.resolve();
-        }
-      }).then(() => {
-        if (argv.fortesting) {
-          return enableLocalTesting('dist.3p/current-min/f.js');
         }
       }).then(() => exitCtrlcHandler(handlerProcess));
 }

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -81,22 +81,17 @@ async function dist() {
       })
       .then(() => {
         return Promise.all([
-          compile(false, true, true),
+          compile(false, true),
           // NOTE: When adding a line here,
           // consider whether you need to include polyfills
           // and whether you need to init logging (initLogConstructor).
-          buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true}),
-          buildExaminer({
-            minify: true, watch: false, preventRemoveAndMakeDir: true}),
-          buildWebWorker({
-            minify: true, watch: false, preventRemoveAndMakeDir: true}),
-          buildExtensions({minify: true, preventRemoveAndMakeDir: true}),
-          buildExperiments({
-            minify: true, watch: false, preventRemoveAndMakeDir: true}),
-          buildLoginDone({
-            minify: true, watch: false, preventRemoveAndMakeDir: true}),
-          buildWebPushPublisherFiles({
-            minify: true, watch: false, preventRemoveAndMakeDir: true}),
+          buildAlp({minify: true, watch: false}),
+          buildExaminer({minify: true, watch: false}),
+          buildWebWorker({minify: true, watch: false}),
+          buildExtensions({minify: true}),
+          buildExperiments({minify: true, watch: false}),
+          buildLoginDone({minify: true, watch: false}),
+          buildWebPushPublisherFiles({minify: true, watch: false}),
           copyCss(),
         ]);
       }).then(() => {
@@ -240,7 +235,6 @@ function buildWebPushPublisherFile(version, fileName, watch, options) {
           includePolyfills: true,
           minify: options.minify || argv.minify,
           minifiedName,
-          preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
           extraGlobs: [
             tempBuildDir + '*.js',
           ],
@@ -335,7 +329,6 @@ async function buildLoginDoneVersion(version, options) {
           includePolyfills: true,
           minify: options.minify || argv.minify,
           minifiedName,
-          preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
           latestName,
           extraGlobs: [
             buildDir + 'amp-login-done-0.1.max.js',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -70,17 +70,15 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
  *
  * @param {boolean} watch
  * @param {boolean} shouldMinify
- * @param {boolean=} opt_preventRemoveAndMakeDir
  * @return {!Promise}
  */
-function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
+function compile(watch, shouldMinify) {
   const promises = [
     compileJs('./3p/', 'integration.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
           minifiedName: 'f.js',
           watch,
           minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           externs: ['./ads/ads.extern.js'],
           include3pDirectories: true,
           includePolyfills: true,
@@ -90,7 +88,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'ampcontext-v0.js',
           watch,
           minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           externs: ['./ads/ads.extern.js'],
           include3pDirectories: true,
           includePolyfills: false,
@@ -100,7 +97,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'iframe-transport-client-v0.js',
           watch,
           minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           externs: ['./ads/ads.extern.js'],
           include3pDirectories: true,
           includePolyfills: false,
@@ -110,7 +106,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'recaptcha.js',
           watch,
           minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           externs: [],
           include3pDirectories: true,
           includePolyfills: true,
@@ -120,7 +115,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
       minifiedName: 'v0.js',
       includePolyfills: true,
       watch,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
       minify: shouldMinify,
       wrapper: wrappers.mainBinary,
       singlePassCompilation: argv.single_pass,
@@ -134,7 +128,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           watch,
           extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
           compilationLevel: 'WHITESPACE_ONLY',
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: false,
         }),
   ];
@@ -151,7 +144,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           includePolyfills: true,
           includeOnlyESMLevelPolyfills: true,
           watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
           wrapper: wrappers.mainBinary,
         }));
@@ -163,7 +155,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'shadow-v0.js',
           includePolyfills: true,
           watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
         })
     );
@@ -175,7 +166,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'video-iframe-integration-v0.js',
           includePolyfills: false,
           watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
         }));
   }
@@ -190,7 +180,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
             includePolyfills: true,
             extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
             watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
             minify: shouldMinify,
           }));
     }
@@ -202,7 +191,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           minifiedName: 'amp4ads-host-v0.js',
           includePolyfills: false,
           watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
         })
     );
@@ -217,7 +205,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
           includePolyfills: true,
           extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
           watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
         }));
   }
@@ -667,7 +654,6 @@ async function buildExperiments(options) {
               minify: options.minify || argv.minify,
               includePolyfills: true,
               minifiedName,
-              preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
             });
       });
 }
@@ -685,7 +671,6 @@ function buildAlp(options) {
     minify: options.minify || argv.minify,
     includePolyfills: true,
     minifiedName: 'alp.js',
-    preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
   });
 }
 
@@ -702,7 +687,6 @@ function buildExaminer(options) {
     minify: options.minify || argv.minify,
     includePolyfills: true,
     minifiedName: 'examiner.js',
-    preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
   });
 }
 
@@ -719,7 +703,6 @@ function buildWebWorker(options) {
     includePolyfills: true,
     watch: opts.watch,
     minify: opts.minify || argv.minify,
-    preventRemoveAndMakeDir: opts.preventRemoveAndMakeDir,
   });
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -71,16 +71,13 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
  * @param {boolean} watch
  * @param {boolean} shouldMinify
  * @param {boolean=} opt_preventRemoveAndMakeDir
- * @param {boolean=} opt_checkTypes
  * @return {!Promise}
  */
-function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
-  opt_checkTypes) {
+function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir) {
   const promises = [
     compileJs('./3p/', 'integration.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
           minifiedName: 'f.js',
-          checkTypes: opt_checkTypes,
           watch,
           minify: shouldMinify,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
@@ -91,7 +88,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     compileJs('./3p/', 'ampcontext-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
           minifiedName: 'ampcontext-v0.js',
-          checkTypes: opt_checkTypes,
           watch,
           minify: shouldMinify,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
@@ -102,7 +98,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     compileJs('./3p/', 'iframe-transport-client-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
           minifiedName: 'iframe-transport-client-v0.js',
-          checkTypes: opt_checkTypes,
           watch,
           minify: shouldMinify,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
@@ -113,7 +108,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     compileJs('./3p/', 'recaptcha.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
           minifiedName: 'recaptcha.js',
-          checkTypes: opt_checkTypes,
           watch,
           minify: shouldMinify,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
@@ -125,7 +119,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
       toName: 'amp.js',
       minifiedName: 'v0.js',
       includePolyfills: true,
-      checkTypes: opt_checkTypes,
       watch,
       preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
       minify: shouldMinify,
@@ -157,7 +150,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
           minifiedName: 'v0-esm.js',
           includePolyfills: true,
           includeOnlyESMLevelPolyfills: true,
-          checkTypes: opt_checkTypes,
           watch,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
@@ -165,96 +157,88 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
         }));
   }*/
 
-  // We don't rerun type check for the shadow entry point for now.
-  if (!opt_checkTypes) {
-    if (!argv.single_pass && (!watch || argv.with_shadow)) {
-      promises.push(
-          compileJs('./src/', 'amp-shadow.js', './dist', {
-            minifiedName: 'shadow-v0.js',
-            includePolyfills: true,
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-          })
-      );
-    }
+  if (!argv.single_pass && (!watch || argv.with_shadow)) {
+    promises.push(
+        compileJs('./src/', 'amp-shadow.js', './dist', {
+          minifiedName: 'shadow-v0.js',
+          includePolyfills: true,
+          watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+        })
+    );
+  }
 
-    if (!watch || argv.with_video_iframe_integration) {
-      promises.push(
-          compileJs('./src/', 'video-iframe-integration.js', './dist', {
-            minifiedName: 'video-iframe-integration-v0.js',
-            includePolyfills: false,
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-          }));
-    }
+  if (!watch || argv.with_video_iframe_integration) {
+    promises.push(
+        compileJs('./src/', 'video-iframe-integration.js', './dist', {
+          minifiedName: 'video-iframe-integration-v0.js',
+          includePolyfills: false,
+          watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+        }));
+  }
 
-    if (!watch || argv.with_inabox) {
-      if (!argv.single_pass) {
-        promises.push(
-            // Entry point for inabox runtime.
-            compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-              toName: 'amp-inabox.js',
-              minifiedName: 'amp4ads-v0.js',
-              includePolyfills: true,
-              extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-              checkTypes: opt_checkTypes,
-              watch,
-              preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-              minify: shouldMinify,
-            }));
-      }
-      promises.push(
-
-          // inabox-host
-          compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-            toName: 'amp-inabox-host.js',
-            minifiedName: 'amp4ads-host-v0.js',
-            includePolyfills: false,
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-          })
-      );
-    }
-
-    if (argv.with_inabox_lite) {
+  if (!watch || argv.with_inabox) {
+    if (!argv.single_pass) {
       promises.push(
           // Entry point for inabox runtime.
-          compileJs('./src/inabox/', 'amp-inabox-lite.js', './dist', {
-            toName: 'amp-inabox-lite.js',
-            minifiedName: 'amp4ads-lite-v0.js',
+          compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+            toName: 'amp-inabox.js',
+            minifiedName: 'amp4ads-v0.js',
             includePolyfills: true,
             extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-            checkTypes: opt_checkTypes,
             watch,
             preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
             minify: shouldMinify,
           }));
     }
+    promises.push(
 
-    thirdPartyFrames.forEach(frameObject => {
-      promises.push(
-          thirdPartyBootstrap(
-              frameObject.max, frameObject.min, shouldMinify)
-      );
-    });
-
-    if (watch) {
-      thirdPartyFrames.forEach(frameObject => {
-        gulpWatch(frameObject.max, function() {
-          thirdPartyBootstrap(
-              frameObject.max, frameObject.min, shouldMinify);
-        });
-      });
-    }
-
-    return Promise.all(promises);
+        // inabox-host
+        compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+          toName: 'amp-inabox-host.js',
+          minifiedName: 'amp4ads-host-v0.js',
+          includePolyfills: false,
+          watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+        })
+    );
   }
+
+  if (argv.with_inabox_lite) {
+    promises.push(
+        // Entry point for inabox runtime.
+        compileJs('./src/inabox/', 'amp-inabox-lite.js', './dist', {
+          toName: 'amp-inabox-lite.js',
+          minifiedName: 'amp4ads-lite-v0.js',
+          includePolyfills: true,
+          extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+          watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+        }));
+  }
+
+  thirdPartyFrames.forEach(frameObject => {
+    promises.push(
+        thirdPartyBootstrap(
+            frameObject.max, frameObject.min, shouldMinify)
+    );
+  });
+
+  if (watch) {
+    thirdPartyFrames.forEach(frameObject => {
+      gulpWatch(frameObject.max, function() {
+        thirdPartyBootstrap(
+            frameObject.max, frameObject.min, shouldMinify);
+      });
+    });
+  }
+
+  return Promise.all(promises);
 }
 
 /**
@@ -684,7 +668,6 @@ async function buildExperiments(options) {
               includePolyfills: true,
               minifiedName,
               preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-              checkTypes: options.checkTypes,
             });
       });
 }


### PR DESCRIPTION
Today, there is one giant function called `compile()` in `build-system/tasks/helpers.js` that compiles the various AMP build targets in minified and unminified modes. 

This PR does the following:
- Removes the obsolete `checkTypes` option (added in #3539, made obsolete by #4931)
- Removes the obsolete `preventRemoveAndMakeDir` option (added in #2880, but never used as `false`)
- Reorganizes `compile()` into `compileAllMinifiedTargets()` and `compileAllUnminifiedTargets()`
- Applies a strict order to the compilation of `v0.js` and `v0-esm.js`, thereby fixing the race in #18934

Follow up to #3539 and #4931
Follow up to #2880
Fixes #18934