### PR TITLE
🏗♻️ Refactor post-compilation config writes

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -27,7 +27,6 @@ const {
   buildWebWorker,
   compileAllMinifiedTargets,
   compileJs,
-  enableLocalTesting,
   endBuildStep,
   hostname,
   mkdirSync,
@@ -103,17 +102,6 @@ async function dist() {
         await stopNailgunServer(closureNailgunPort);
       }).then(() => {
         return copyAliasExtensions();
-      }).then(() => {
-        if (argv.fortesting) {
-          return Promise.all([
-            enableLocalTesting('dist/v0.js'),
-            enableLocalTesting('dist/amp4ads-v0.js'),
-            enableLocalTesting('dist/shadow-v0.js'),
-            enableLocalTesting('dist.3p/current-min/f.js'),
-            argv.single_pass ?
-              Promise.resolve() : enableLocalTesting('dist/v0-esm.js'),
-          ]);
-        }
       }).then(() => {
         if (argv.esm) {
           return Promise.all([

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -317,6 +317,12 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         if (options.latestName) {
           name = `${name} → ${options.latestName}`;
         }
+        if (options.singlePassCompilation) {
+          altMainBundles.forEach(bundle => {
+            name = `${name}, ${bundle.name}.js`;
+          });
+          name = `${name}, and all extensions`;
+        }
         endBuildStep('Minified', name, startTime);
       })
       .then(() => {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -315,13 +315,13 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
       .then(() => {
         let name = minifiedName;
         if (options.latestName) {
-          name = `${name} → ${options.latestName}`;
+          name += ` → ${options.latestName}`;
         }
         if (options.singlePassCompilation) {
           altMainBundles.forEach(bundle => {
-            name = `${name}, ${bundle.name}.js`;
+            name += `, ${bundle.name}.js`;
           });
-          name = `${name}, and all extensions`;
+          name += ', and all extensions';
         }
         endBuildStep('Minified', name, startTime);
       })
@@ -331,7 +331,7 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         }
       })
       .then(() => {
-        if (options.singlePassCompilation) {
+        if (argv.fortesting && options.singlePassCompilation) {
           const promises = [];
           altMainBundles.forEach(bundle => {
             promises.push(enableLocalTesting(`dist/${bundle.name}.js`));

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -61,6 +61,24 @@ const EXTENSION_BUNDLE_MAP = {
   ],
 };
 
+const UNMINIFIED_TARGETS = [
+  'amp.js',
+  'amp-esm.js',
+  'amp-shadow.js',
+  'amp-inabox.js',
+  'alp.max.js',
+  'integration.js',
+];
+
+const MINIFIED_TARGETS = [
+  'v0.js',
+  'v0-esm.js',
+  'shadow-v0.js',
+  'amp4ads-v0.js',
+  'alp.js',
+  'f.js',
+];
+
 const hostname = argv.hostname || 'cdn.ampproject.org';
 const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
@@ -281,9 +299,10 @@ function appendToCompiledFile(srcFilename, destFilePath) {
 function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
   const startTime = Date.now();
   const entryPoint = path.join(srcDir, srcFilename);
-  return closureCompile(entryPoint, destDir, options.minifiedName, options)
+  const {minifiedName} = options;
+  return closureCompile(entryPoint, destDir, minifiedName, options)
       .then(function() {
-        const destPath = path.join(destDir, options.minifiedName);
+        const destPath = path.join(destDir, minifiedName);
         appendToCompiledFile(srcFilename, destPath);
         fs.writeFileSync(
             path.join(destDir, 'version.txt'), internalRuntimeVersion);
@@ -294,11 +313,18 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         }
       })
       .then(() => {
-        let name = options.minifiedName;
+        let name = minifiedName;
         if (options.latestName) {
           name = `${name} → ${options.latestName}`;
         }
         endBuildStep('Minified', name, startTime);
+      })
+      .then(() => {
+        if (argv.fortesting && MINIFIED_TARGETS.includes(minifiedName)) {
+          return enableLocalTesting(`${destDir}/${minifiedName}`);
+        } else {
+          return Promise.resolve();
+        }
       });
 }
 
@@ -403,7 +429,13 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
           }
           endBuildStep('Compiled', name, startTime);
         })
-        .then(() => maybeEnableLocalTesting(destFilename));
+        .then(() => {
+          if (UNMINIFIED_TARGETS.includes(destFilename)) {
+            return enableLocalTesting(`${destDir}/${destFilename}`);
+          } else {
+            return Promise.resolve();
+          }
+        });
   }
 
   if (options.watch) {
@@ -426,32 +458,6 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
     // This is the default options.watch === true case, and also covers the
     // `gulp build` / `gulp dist` cases where options.watch is undefined.
     return rebundle(/* failOnError */ true);
-  }
-}
-
-/**
- * Enables local testing mode for various target files
- * @param {string} destFilename
- */
-function maybeEnableLocalTesting(destFilename) {
-  if (process.env.NODE_ENV === 'development') {
-    if (destFilename === 'amp.js') {
-      return enableLocalTesting('dist/amp.js');
-    } else if (destFilename === 'amp-esm.js') {
-      return enableLocalTesting('dist/amp-esm.js');
-    } else if (destFilename === 'amp4ads-v0.js') {
-      return enableLocalTesting('dist/amp4ads-v0.js');
-    } else if (destFilename === 'integration.js') {
-      return enableLocalTesting('dist.3p/current/integration.js');
-    } else if (destFilename === 'amp-shadow.js') {
-      return enableLocalTesting('dist/amp-shadow.js');
-    } else if (destFilename === 'amp-inabox.js') {
-      return enableLocalTesting('dist/amp-inabox.js');
-    } else {
-      return Promise.resolve();
-    }
-  } else {
-    return Promise.resolve();
   }
 }
 

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -22,6 +22,7 @@ const exec = BBPromise.promisify(childProcess.exec);
 const colors = require('ansi-colors');
 const fs = BBPromise.promisifyAll(require('fs'));
 const log = require('fancy-log');
+const path = require('path');
 const {isTravisBuild} = require('../../travis');
 
 const {red, cyan} = colors;
@@ -155,7 +156,10 @@ function applyConfig(
       })
       .then(() => {
         if (!isTravisBuild()) {
-          log('Wrote', cyan(config), 'AMP config to', cyan(target));
+          const details = '(' + cyan(config) +
+              (opt_localDev ? ', ' + cyan('localDev') : '') +
+              (opt_fortesting ? ', ' + cyan('test') : '') + ')';
+          log('Applied AMP config', details, 'to', cyan(path.basename(target)));
         }
       });
 }
@@ -168,9 +172,6 @@ function applyConfig(
  */
 function enableLocalDev(config, target, configJson) {
   let LOCAL_DEV_AMP_CONFIG = {localDev: true};
-  if (!isTravisBuild()) {
-    log('Enabled local development mode in', cyan(target));
-  }
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
     const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^https?:\/\//) ?


### PR DESCRIPTION
This PR does the following:
- Writes `AMP_CONFIG` to each AMP target immediately after compilation
- Separates the minified, unminified, and single pass code paths for config writes
- Fixes incorrect / missing items in the list of targets 

Addresses https://github.com/ampproject/amphtml/pull/22147#pullrequestreview-234090110
Follow up to #22147
