### PR TITLE
✨ Introduce LiveStoryManager

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -477,8 +477,8 @@ export class AmpStoryPage extends AMP.BaseElement {
           case 'amp-img':
           case 'amp-anim':
             whenUpgradedToCustomElement(mediaEl)
-                .then(el => el.signals().whenSignal(CommonSignals.LOAD_END))
-                .then(resolve, resolve);
+              .then(el => el.signals().whenSignal(CommonSignals.LOAD_END))
+              .then(resolve, resolve);
             break;
           case 'amp-audio':
           case 'amp-video':

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -54,6 +54,7 @@ import {
   iterateCursor,
   matches,
   scopedQuerySelectorAll,
+  whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev} from '../../../src/log';
@@ -475,10 +476,9 @@ export class AmpStoryPage extends AMP.BaseElement {
         switch (mediaEl.tagName.toLowerCase()) {
           case 'amp-img':
           case 'amp-anim':
-            mediaEl
-              .signals()
-              .whenSignal(CommonSignals.LOAD_END)
-              .then(resolve, resolve);
+            whenUpgradedToCustomElement(mediaEl)
+                .then(el => el.signals().whenSignal(CommonSignals.LOAD_END))
+                .then(resolve, resolve);
             break;
           case 'amp-audio':
           case 'amp-video':

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -965,11 +965,11 @@ export class AmpStory extends AMP.BaseElement {
     // Do not block the layout callback on the completion of these promises, as
     // that prevents descendents from being laid out (and therefore loaded).
     storyLayoutPromise
-        .then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
-        .then(() => {
-          this.markStoryAsLoaded_();
-          this.initializeLiveStory_();
-        });
+      .then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
+      .then(() => {
+        this.markStoryAsLoaded_();
+        this.initializeLiveStory_();
+      });
 
     return storyLayoutPromise;
   }
@@ -983,12 +983,15 @@ export class AmpStory extends AMP.BaseElement {
       this.liveStoryManager_ = new LiveStoryManager(this);
       this.liveStoryManager_.build();
 
-      this.storeService_.dispatch(Action.ADD_TO_ACTIONS_WHITELIST,
-          [{tagOrTarget: 'AMP-LIVE-LIST', method: 'update'}]);
+      this.storeService_.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, [
+        {tagOrTarget: 'AMP-LIVE-LIST', method: 'update'},
+      ]);
 
       this.element.addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
-        this.liveStoryManager_.update(target,
-            this.element.querySelectorAll('amp-story-page:not([ad])'));
+        this.liveStoryManager_.update(
+          target,
+          this.element.querySelectorAll('amp-story-page:not([ad])')
+        );
       });
     }
   }

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {addAttributesToElement} from '../../../src/dom';
+import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {htmlFor} from '../../../src/static-template';
 
 /**
  * Property used for storing id of custom slot. This custom slot can be used to
@@ -40,21 +39,28 @@ export class LiveStoryManager {
    * configuration and appends it to the DOM.
    */
   build() {
-    const listId = userAssert(this.storyEl_.getAttribute('dynamic-live-list'),
-        'Story must contain dynamic-live-list to build an amp-live-list');
-    const liveListEl = htmlFor(this.storyEl_)`<amp-live-list></amp-live-list>`;
-    addAttributesToElement(liveListEl,
-        dict({
-          'id': listId,
-          'data-poll-interval':
-            this.storyEl_.getAttribute('data-poll-interval') || 15000,
-          'sort': 'ascending',
-          'disable-scrolling': '',
-          'disable-pagination': '',
-          'auto-insert': '',
-        }));
-    liveListEl[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = userAssert(this.storyEl_.id,
-        'Story must contain id to build an amp-live-list');
+    const listId = userAssert(
+      this.storyEl_.getAttribute('dynamic-live-list'),
+      'amp-story element must contain the dynamic-live-list attribute to ' +
+        'use the live story functionality.'
+    );
+    const liveListEl = createElementWithAttributes(
+      this.ampStory_.win.document,
+      'amp-live-list',
+      dict({
+        'id': listId,
+        'data-poll-interval':
+          this.storyEl_.getAttribute('data-poll-interval') || 15000,
+        'sort': 'ascending',
+        'disable-scrolling': '',
+        'disable-pagination': '',
+        'auto-insert': '',
+      })
+    );
+    liveListEl[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = userAssert(
+      this.storyEl_.id,
+      'amp-story must contain id to use the live story functionality'
+    );
 
     this.storyEl_.insertBefore(liveListEl, this.storyEl_.firstElementChild);
   }
@@ -66,17 +72,20 @@ export class LiveStoryManager {
    * @param {!NodeList<!Element>} currentPages
    */
   update(updatedStoryEl, currentPages) {
-    const newPageEls = devAssert(updatedStoryEl,
-        'No updated story EventTarget was found.')
-        .querySelectorAll('amp-story-page.amp-live-list-item-new');
+    const newPageEls = devAssert(
+      updatedStoryEl,
+      'No updated story EventTarget was found.'
+    ).querySelectorAll('amp-story-page.amp-live-list-item-new');
 
     let lastPageEl = currentPages[currentPages.length - 1];
 
-    const pageImplPromises = Array.prototype.map.call(newPageEls,
-        pageEl => pageEl.getImpl());
+    const pageImplPromises = Array.prototype.map.call(newPageEls, pageEl =>
+      pageEl.getImpl()
+    );
 
     Promise.all(pageImplPromises).then(pages => {
       pages.forEach(page => {
+        // New amp-story-pages are always appended last.
         this.storyEl_.insertBefore(page.element, lastPageEl.nextElementSibling);
         this.ampStory_.addPage(page);
         this.ampStory_.insertPage(lastPageEl.id, page.element.id);
@@ -85,4 +94,3 @@ export class LiveStoryManager {
     });
   }
 }
-

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -28,6 +28,7 @@ export class LiveStoryManager {
    */
   constructor(ampStory) {
     this.ampStory_ = ampStory;
+    this.storyEl_ = ampStory.element;
   }
 
   /**
@@ -41,23 +42,20 @@ export class LiveStoryManager {
         'amp-live-list', dict({
           'id': liveListId,
           'data-poll-interval':
-            this.ampStory_.element.getAttribute('data-poll-interval') || 15000,
+            this.storyEl_.getAttribute('data-poll-interval') || 15000,
           'sort': 'ascending',
           'disable-scrolling': '',
           'disable-pagination': '',
           'auto-insert': '',
         }));
-    liveListEl[AMP_LIVE_LIST_CUSTOM_SLOT_ID] =
-      userAssert(this.ampStory_.element.id,
-          'Story must contain id to build an amp-live-list');
+    liveListEl[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = userAssert(this.storyEl_.id,
+        'Story must contain id to build an amp-live-list');
 
-    this.ampStory_.element.insertBefore(liveListEl,
-        this.ampStory_.element.firstElementChild);
+    this.storyEl_.insertBefore(liveListEl, this.storyEl_.firstElementChild);
 
-    this.ampStory_.element.addEventListener(AmpEvents.DOM_UPDATE,
-        ({target}) => {
-          this.updateStory_(target);
-        });
+    this.storyEl_.addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
+      this.updateStory_(target);
+    });
   }
 
   /**
@@ -72,11 +70,11 @@ export class LiveStoryManager {
         .filter(page => page.classList.contains('amp-live-list-item-new'));
 
     const currentPages =
-      this.ampStory_.element.querySelectorAll('amp-story-page:not([ad])');
+      this.storyEl_.querySelectorAll('amp-story-page:not([ad])');
     let lastPage = currentPages[currentPages.length - 1];
 
     newPages.forEach(newPage => {
-      this.ampStory_.element.insertBefore(newPage, lastPage.nextElementSibling);
+      this.storyEl_.insertBefore(newPage, lastPage.nextElementSibling);
 
       newPage.getImpl().then(page => {
         this.ampStory_.addPage(page);

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AMP_LIVE_LIST_CUSTOM_SLOT_ID,
+} from '../../amp-live-list/0.1/live-list-manager';
+import {AmpEvents} from '../../../src/amp-events';
+import {createElementWithAttributes} from '../../../src/dom';
+import {dict} from '../../../src/utils/object';
+import {userAssert} from '../../../src/log';
+
+export class LiveStoryManager {
+  /**
+   * @param {!./amp-story.AmpStory} ampStory
+   */
+  constructor(ampStory) {
+    this.ampStory_ = ampStory;
+  }
+
+  /**
+   * Initializes an amp-live-list component with the story-specific
+   * configuration and appends it to the DOM.
+   *
+   * @param {string} liveListId
+   */
+  build(liveListId) {
+    const liveListEl = createElementWithAttributes(this.ampStory_.win.document,
+        'amp-live-list', dict({
+          'id': liveListId,
+          'data-poll-interval':
+            this.ampStory_.element.getAttribute('data-poll-interval') || 15000,
+          'sort': 'ascending',
+          'disable-scrolling': '',
+          'disable-pagination': '',
+          'auto-insert': '',
+        }));
+    liveListEl[AMP_LIVE_LIST_CUSTOM_SLOT_ID] =
+      userAssert(this.ampStory_.element.id,
+          'Story must contain id to build an amp-live-list');
+
+    this.ampStory_.element.insertBefore(liveListEl,
+        this.ampStory_.element.firstElementChild);
+
+    this.ampStory_.element.addEventListener(AmpEvents.DOM_UPDATE,
+        ({target}) => {
+          this.updateStory_(target);
+        });
+  }
+
+  /**
+   * Updates the client amp-story with the changes from the server document.
+   *
+   * @param {!Element} updatedStoryEl
+   * @private
+   */
+  updateStory_(updatedStoryEl) {
+    const newPages =
+    ([].slice.call(updatedStoryEl.querySelectorAll('amp-story-page')))
+        .filter(page => page.classList.contains('amp-live-list-item-new'));
+
+    const currentPages =
+      this.ampStory_.element.querySelectorAll('amp-story-page:not([ad])');
+    let lastPage = currentPages[currentPages.length - 1];
+
+    newPages.forEach(newPage => {
+      this.ampStory_.element.insertBefore(newPage, lastPage.nextElementSibling);
+
+      newPage.getImpl().then(page => {
+        this.ampStory_.addPage(page);
+        this.ampStory_.insertPage(lastPage.id, newPage.id);
+      });
+
+      lastPage = newPage;
+    });
+  }
+}
+

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -15,9 +15,9 @@
  */
 
 import {addAttributesToElement} from '../../../src/dom';
+import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
-import {userAssert} from '../../../src/log';
 
 /**
  * Property used for storing id of custom slot. This custom slot can be used to
@@ -62,12 +62,13 @@ export class LiveStoryManager {
   /**
    * Updates the client amp-story with the changes from the server document.
    *
-   * @param {!Element} updatedStoryEl
+   * @param {?EventTarget} updatedStoryEl
    * @param {!NodeList<!Element>} currentPages
    */
   update(updatedStoryEl, currentPages) {
-    const newPageEls = updatedStoryEl.querySelectorAll(
-        'amp-story-page.amp-live-list-item-new');
+    const newPageEls = devAssert(updatedStoryEl,
+        'No updated story EventTarget was found.')
+        .querySelectorAll('amp-story-page.amp-live-list-item-new');
 
     let lastPageEl = currentPages[currentPages.length - 1];
 

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -95,18 +95,25 @@ describes.realWin('LiveStoryManager', {amp: true}, env => {
     });
   });
 
-  it('should append new page to client from server in update', () => {
+  it('should append new page from server to client in update', () => {
     const currentPages = createPages(ampStory.element, 2, ['cover', 'page-1']);
+    const pagesImplPromises = Array.prototype.map.call(currentPages, pageEl =>
+      pageEl.getImpl()
+    );
+    Promise.all(pagesImplPromises).then(pages => {
+      ampStory.pages_ = pages;
+    });
     expect(ampStory.element.children.length).to.equal(2);
 
     const fromServerStoryEl = win.document.createElement('amp-story');
     const fromServerStory = new AmpStory(fromServerStoryEl);
-    const fromServerPages = createPages(fromServerStory.element, 2, [
+    const fromServerPages = createPages(fromServerStory.element, 3, [
       'cover',
       'page-1',
-      'page-3',
+      'page-2',
     ]);
     const fromServerLastPage = fromServerPages[fromServerPages.length - 1];
+    // This would normally get added by AmpLiveList.
     fromServerLastPage.classList.add('amp-live-list-item-new');
 
     liveStoryManager.build();
@@ -117,17 +124,22 @@ describes.realWin('LiveStoryManager', {amp: true}, env => {
 
   it('should append new page at the end', () => {
     const currentPages = createPages(ampStory.element, 2, ['cover', 'page-1']);
+    const pagesImplPromises = Array.prototype.map.call(currentPages, pageEl =>
+      pageEl.getImpl()
+    );
+    Promise.all(pagesImplPromises).then(pages => {
+      ampStory.pages_ = pages;
+    });
     expect(ampStory.element.children.length).to.equal(2);
 
     const fromServerStoryEl = win.document.createElement('amp-story');
     const fromServerStory = new AmpStory(fromServerStoryEl);
-    const fromServerPages = createPages(fromServerStory.element, 2, [
+    const fromServerPages = createPages(fromServerStory.element, 3, [
       'cover',
-      'page-3',
+      'page-2',
       'page-1',
     ]);
-    const fromServerNewPage =
-      fromServerPages[fromServerPages.getIndexOf('page-3')];
+    const fromServerNewPage = fromServerPages[fromServerPages.length - 1];
     // This would normally get added by AmpLiveList.
     fromServerNewPage.classList.add('amp-live-list-item-new');
 

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -19,7 +19,7 @@ import {AmpStoryPage} from '../amp-story-page';
 import {LiveStoryManager} from '../live-story-manager';
 import {addAttributesToElement} from '../../../../src/dom';
 
-describes.realWin('amp-story-embedded-component', {amp: true}, env => {
+describes.realWin('LiveStoryManager', {amp: true}, env => {
   let win;
   let liveStoryManager;
   let ampStory;

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStory} from '../amp-story';
+import {AmpStoryPage} from '../amp-story-page';
+import {LiveStoryManager} from '../live-story-manager';
+import {addAttributesToElement} from '../../../../src/dom';
+
+describes.realWin('amp-story-embedded-component', {amp: true}, env => {
+  let win;
+  let liveStoryManager;
+  let ampStory;
+  let storyEl;
+
+  /**
+   * @param {!Element} container
+   * @param {number} count
+   * @param {Array<string>=} opt_ids
+   * @return {!Array<!Element>}
+   */
+  function createPages(container, count, opt_ids) {
+    return Array(count).fill(undefined).map((unused, i) => {
+      const page = win.document.createElement('amp-story-page');
+      page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
+      const storyPage = new AmpStoryPage(page);
+      page.getImpl = () => Promise.resolve(storyPage);
+      sandbox.stub(storyPage, 'mutateElement').callsFake(fn => fn());
+      container.appendChild(page);
+      return page;
+    });
+  }
+
+  beforeEach(() => {
+    win = env.win;
+    storyEl = win.document.createElement('amp-story');
+    addAttributesToElement(storyEl,
+        {'id': 'testStory', 'dynamic-live-list': 'storyLiveList'});
+    ampStory = new AmpStory(storyEl);
+    liveStoryManager = new LiveStoryManager(ampStory);
+  });
+
+  it('should build a dynamic live-list', () => {
+    liveStoryManager.build();
+
+    const liveListEl = ampStory.element.querySelector('amp-live-list');
+    expect(liveListEl).to.exist;
+  });
+
+  it('live-list id should correspond to attribute dynamic-live-list', () => {
+    liveStoryManager.build();
+    const storyAttr = ampStory.element.getAttribute('dynamic-live-list');
+
+    const liveListEl = ampStory.element.querySelector('amp-live-list');
+    expect(storyAttr).to.equal(liveListEl.id);
+  });
+
+  it('should throw if no dynamic-live-list attr is set', () => {
+    ampStory.element.setAttribute('dynamic-live-list', '');
+
+    allowConsoleError(() => { expect(() => {
+      liveStoryManager.build();
+    }).to.throw(/Story must contain dynamic-live-list to build an amp-live-list/); });
+  });
+
+  it('should throw if no story id is set', () => {
+    ampStory.element.setAttribute('id', '');
+
+    allowConsoleError(() => { expect(() => {
+      liveStoryManager.build();
+    }).to.throw(/Story must contain id to build an amp-live-list/); });
+  });
+
+
+  it('should append new page from server on update', () => {
+    const currentPages = createPages(ampStory.element, 2, ['cover', 'page-1']);
+    expect(ampStory.element.children.length).to.equal(2);
+
+    const fromServerStoryEl = win.document.createElement('amp-story');
+    const fromServerStory = new AmpStory(fromServerStoryEl);
+    const fromServerPages =
+      createPages(fromServerStory.element, 2, ['cover', 'page-1', 'page-3']);
+    const fromServerLastPage = fromServerPages[fromServerPages.length - 1];
+    fromServerLastPage.classList.add('amp-live-list-item-new');
+
+    liveStoryManager.build();
+    liveStoryManager.update(fromServerStory.element, currentPages);
+
+    expect(ampStory.element.children.length).to.equal(3);
+
+    const fromClientLastPage =
+        ampStory.element.querySelector('amp-story-page:last-of-type');
+
+    expect(fromClientLastPage.id).to.equal(fromServerLastPage.id);
+  });
+});


### PR DESCRIPTION
Master issue #21714
Closes #21719

Introduces LiveStoryManager, which will be in charge of all live story-specific logic.
In particular, it:
* Builds an `amp-live-list` component with the story-specific configuration and appends it to the DOM.
* Listens to `AmpLiveList#Update` action and appends a new page to the DOM (if any).

More follow up PRs will be sent:
* handle the progress bar with the new updates
* show a button that when clicked will take a user to the new page
* tests for LiveStoryManager

