### PR TITLE
Add Intent-to-Deprecate and Intent-to-Remove templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -4,7 +4,6 @@ about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
 assignees: cramforce
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -4,6 +4,7 @@ about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
 assignees: cramforce
+
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/intent-to-deprecate--i2d-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-deprecate--i2d-.md
@@ -12,12 +12,12 @@ Replace/remove all of the text in brackets, including this text.
 
 See https://github.com/ampproject/amphtml/blob/master/spec/amp-versioning-policy.md for details on AMP's deprecation policy, instructions on filling out this I2D template and how to get help if you have questions.
 
-You will file a separate Intent-to-Remove (I2R) after the feature has been deprecated and you are ready to remove the feature.
+If your feature can be removed immediately after deprecation, you can use this issue to track removal as well (changing the title to "Intent-to-Deprecate-and-Remove" and adding the "INTENT TO REMOVE" label).  Otherwise you will file a separate Intent-to-Remove (I2R) issue after the feature has been deprecated and you are ready to remove the feature.
 -->
 
 ## Summary
 <!--
-Provide a brief description of the feature you are planning on deprecating and a concrete plan for deprecating the feature.  Provide an initial plan for removing the deprecated feature; you will file a separate Intent-to-Remove with a detailed removal plan later. 
+Provide a brief description of the feature you are planning on deprecating and a concrete plan for deprecating the feature.  Provide the detailed removal plan if the feature is ready for immediate removal after deprecation, otherwise provide an initial plan for removing the deprecated feature and file a separate Intent-to-Remove issue after this issue is approved.
 -->
 
 ## Motivation

--- a/.github/ISSUE_TEMPLATE/intent-to-deprecate--i2d-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-deprecate--i2d-.md
@@ -1,0 +1,46 @@
+---
+name: Intent-to-deprecate (I2D)
+about: Proposes deprecating an existing AMP feature.
+title: 'Intent-to-Deprecate: <feature being deprecated>'
+labels: INTENT TO DEPRECATE
+assignees: ''
+
+---
+
+<!--
+Replace/remove all of the text in brackets, including this text.
+
+See https://github.com/ampproject/amphtml/blob/master/spec/amp-versioning-policy.md for details on AMP's deprecation policy, instructions on filling out this I2D template and how to get help if you have questions.
+
+You will file a separate Intent-to-Remove (I2R) after the feature has been deprecated and you are ready to remove the feature.
+-->
+
+## Summary
+<!--
+Provide a brief description of the feature you are planning on deprecating and a concrete plan for deprecating the feature.  Provide an initial plan for removing the deprecated feature; you will file a separate Intent-to-Remove with a detailed removal plan later. 
+-->
+
+## Motivation
+<!--
+Explain why this feature needs to be deprecated and eventually removed.
+-->
+
+## Impact on existing users
+<!--
+How seriously would the removal of this feature break sites that currently use AMP?  If available what is the estimated usage of this feature?
+-->
+
+## Alternative implementation suggestion for developers using AMP
+<!--
+When the feature you are deprecating is removed, how would developers using AMP achieve similar functionality?
+-->
+
+## Additional context
+<!--
+Add any other information that may help people understand your I2D.
+-->
+
+<!--
+Add anyone to this cc line that you want to notify about this I2D.
+-->
+/cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-remove--i2r-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-remove--i2r-.md
@@ -12,7 +12,7 @@ Replace/remove all of the text in brackets, including this text.
 
 See https://github.com/ampproject/amphtml/blob/master/spec/amp-versioning-policy.md for details on AMP's deprecation policy, instructions on filling out this I2R template and how to get help if you have questions.
 
-You will file your Intent-to-Deprecate (I2D) for the feature that is being removed is approved.
+This I2R should be created after your Intent-to-Deprecate (I2D) for the feature was approved.
 -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/intent-to-remove--i2r-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-remove--i2r-.md
@@ -1,0 +1,43 @@
+---
+name: Intent-to-remove (I2R)
+about: Rollout plan for removal of a deprecated feature that was described in an I2D.
+title: 'Intent-to-Remove: <feature being removed>'
+labels: INTENT TO REMOVE
+assignees: ''
+
+---
+
+<!--
+Replace/remove all of the text in brackets, including this text.
+
+See https://github.com/ampproject/amphtml/blob/master/spec/amp-versioning-policy.md for details on AMP's deprecation policy, instructions on filling out this I2R template and how to get help if you have questions.
+
+You will file your Intent-to-Deprecate (I2D) for the feature that is being removed is approved.
+-->
+
+## Summary
+<!--
+Provide a brief description of the deprecated feature you are removing.
+
+Link to the Intent-to-Deprecate (I2D) describing more context on the deprecation.
+-->
+
+## Rollout plan
+<!--
+Detail the steps you will use to remove this deprecated feature.
+-->
+
+## Alternative implementation suggestion for developers using AMP
+<!--
+When the feature you are deprecating is removed, how can developers using AMP achieve similar functionality?
+-->
+
+## Additional context
+<!--
+Add any other information that may help people understand the I2R.
+-->
+
+<!--
+Add anyone to this cc line that you want to notify about this I2R.
+-->
+/cc @ampproject/wg-approvers


### PR DESCRIPTION
Adds new Intent-to-Deprecate and Intent-to-Remove issue templates as part of the updated removal process being updated in #22114.

These templates are inspired by the [Chromium feature removal process/templates](https://www.chromium.org/blink/removing-features).

/cc @ampproject/tsc @honeybadgerdontcare @twifkak @ithinkihaveacat 