### PR TITLE
🐛Fix usage of `getElementsByTagName` on ShadowRoot.

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/ad-tracker.js
@@ -168,7 +168,7 @@ export class AdTracker {
  * @return {!Array<!Element>}
  */
 export function getExistingAds(ampdoc) {
-  return [].slice.call(ampdoc.getRootNode().getElementsByTagName('AMP-AD'))
+  return [].slice.call(ampdoc.getRootNode().querySelectorAll('AMP-AD'))
       .filter(ad => {
         // Filters out AMP-STICKY-AD.
         if (ad.parentElement && ad.parentElement.tagName == 'AMP-STICKY-AD') {

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -63,8 +63,7 @@ export class AnchorAdStrategy {
    * @private
    */
   hasExistingStickyAd_() {
-    return this.ampdoc.getRootNode()
-        .getElementsByTagName('AMP-STICKY-AD').length > 0;
+    return !!this.ampdoc.getRootNode().querySelector('AMP-STICKY-AD');
   }
 
   /**


### PR DESCRIPTION
`getElementsByTagName` (and several other methods) do not exist on `ShadowRoot`s, even though the externs claim they do. Will fix that separately.

See https://github.com/ampproject/amphtml/issues/17614#issuecomment-492346630
For #17614