### PR TITLE
[DRAFT] amp-insticator extension

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -478,6 +478,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-insticator',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC
+  },
+  {
     name: 'amp-izlesene',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/amp-insticator.amp.html
+++ b/examples/amp-insticator.amp.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-insticator example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-insticator {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-insticator" src="https://cdn.ampproject.org/v0/amp-insticator-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-insticator data-embed-id="5bf0548f-a332-4934-9d35-c9ca9e93d4ff"></amp-insticator>
+</body>
+</html>

--- a/extensions/amp-insticator/0.1/amp-insticator.js
+++ b/extensions/amp-insticator/0.1/amp-insticator.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+/* ++++++++++ --------------- IMPORTS --------------- ++++++++++ */
+import { Layout } from '../../../src/layout';
+import { setStyles } from '../../../src/style';
+
+
+
+/* ++++++++++ --------------- EXPORT AMP-INSTICATOR --------------- ++++++++++ */
+export class AmpInsticator extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.iFrameElement = null; // amp requirement
+
+    /** @private {!Object} */
+    this.url = {
+      ads: 'https://drhn9v8cwg89y.cloudfront.net',
+      embed: 'https://d3lcz8vpax4lo2.cloudfront.net'
+    }
+  }
+
+
+  // ~~~~~ AMP METHODs ~~~~~ //
+  /**
+   * @param {boolean=} onLayout
+   * @override
+   */
+  preconnectCallback(onLayout) {
+    // define preconnect
+    const { preconnect } = this;
+    // host where we store advertising settings code
+    preconnect.url(this.url.ads);
+    // host we serve the core embed application from
+    preconnect.url(this.url.embed);
+  }
+
+  /** @override */
+  buildCallback() {
+    // create markup structure
+    const template = this.createTemplate(this.createInitialMarkup());
+    // append markup structure to DOM
+    this.appendElement(this.element, template);
+  }
+
+  /** @override */
+  layoutCallback() {
+    // get data attribute from the amp-insticator tag
+    const embedId = this.element.getAttribute('data-embed-id');
+    // store DOM elements
+    const insticatorContainer = this.element.querySelector('#insticator-container');
+    const embedIframe = this.iFrameElement = this.element.querySelector('#insticator-iframe');
+    const embedApp = this.createElement(this.element.ownerDocument, 'div', { id: 'app' });
+    const embedScript = this.createElement(this.element.ownerDocument, 'script', { type: 'text/javascript', src: `${this.url.embed}/embed-code/${embedId}.js` });
+
+    // append iframe
+    this.appendElement(this.element.querySelector('#insticator-embed'), embedIframe);
+
+    // append content to iframe
+    this.appendElement(embedIframe.contentWindow.document.body, embedApp);
+    this.appendElement(embedIframe.contentWindow.document.head, embedScript);
+
+    // append ads
+    this.getRequest(`${this.url.ads}/test/ad_settings/${embedId}.js`, (ads) => this.appendAds(ads));
+
+    // apply custom styles
+    setStyles(insticatorContainer, { 'text-align': 'center' });
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.CONTAINER;
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iFrameElement) {
+      removeElement(this.iFrameElement);
+      this.iFrameElement= null;
+    }
+    return true; // Call layoutCallback again.
+  }
+
+
+  // ----- CUSTOM FUNCTIONs ----- //
+  /**
+   * Make get request to get ads data.
+   * @param {!string} file
+   * @param {function(Object)} callback
+   */
+  getRequest(file, callback) {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = () => xhr.readyState == 4 && xhr.status == 200 ? callback(JSON.parse(xhr.responseText)) : null;
+    xhr.open('GET', file, true);
+    xhr.send();
+  }
+
+  /**
+   * Create markup structure.
+   * @param {!string} domString
+   * @return {!Element}
+   */
+  createTemplate(domString) {
+    const template = document.createElement('template');
+    template.innerHTML = domString;
+    return template.content;
+  }
+
+  /**
+   * Create an element with attributes.
+   * @param {!Element} location
+   * @param {!string} el
+   * @param {!Object} attrs
+   * @return {!Element}
+   */
+  createElement(location, el, attrs) {
+    const newEl = location.createElement(el);
+    Object.entries(attrs).forEach(attr => newEl.setAttribute(attr[0], attr[1]));
+    return newEl;
+  }
+
+  /**
+   * Append a node to a specified parent node.
+   * @param {!Element} location
+   * @param {!Element} el
+   */
+  appendElement(location, el) {
+    location.appendChild(el);
+  }
+
+  /**
+   * Append ads.
+   * @param {!Object} ads
+   */
+  appendAds(ads) {
+    Object.entries(ads).forEach(ad => this.appendElement(this.element.querySelector(`#div-insticator-ad-${ad[0][ad[0].length -1]}`), this.createElement(this.element.ownerDocument, 'amp-ad', ad[1])));
+  }
+
+  /**
+   * @return {!string}
+   */
+  createInitialMarkup() {
+    return `
+      <div id="insticator-container">
+        <div id="div-insticator-ad-1"></div>
+        <div id="insticator-embed">
+          <iframe id="insticator-iframe" scrolling="no" frameborder="0" allowtransparency="true"></iframe>
+        </div>
+        <div id="div-insticator-ad-2"></div>
+      </div>
+    `;
+  }
+}
+
+
+
+/* ++++++++++ --------------- EXTEND AMP --------------- ++++++++++ */
+AMP.extension('amp-insticator', '0.1', AMP => {
+  AMP.registerElement('amp-insticator', AmpInsticator);
+});

--- a/extensions/amp-insticator/0.1/test/test-amp-insticator.js
+++ b/extensions/amp-insticator/0.1/test/test-amp-insticator.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-insticator';
+
+describes.realWin('amp-insticator', {
+  amp: {
+    extensions: ['amp-insticator'],
+  },
+}, env => {
+
+  let win;
+  let element;
+
+  beforeEach(() => {
+    win = env.win;
+    element = win.document.createElement('amp-insticator');
+    win.document.body.appendChild(element);
+  });
+
+  it('should have hello world when built', () => {
+    element.build();
+    expect(element.querySelector('div').textContent).to.equal('hello world');
+  });
+});

--- a/extensions/amp-insticator/0.1/test/validator-amp-insticator.html
+++ b/extensions/amp-insticator/0.1/test/validator-amp-insticator.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-insticator example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-insticator {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-insticator" src="https://cdn.ampproject.org/v0/amp-insticator-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-insticator layout="responsive" width="150" height="80"></amp-insticator>
+</body>
+</html>

--- a/extensions/amp-insticator/0.1/test/validator-amp-insticator.out
+++ b/extensions/amp-insticator/0.1/test/validator-amp-insticator.out
@@ -1,0 +1,21 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-insticator example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-insticator {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-insticator" src="https://cdn.ampproject.org/v0/amp-insticator-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-insticator layout="responsive" width="150" height="80"></amp-insticator>
+|  </body>
+|  </html>

--- a/extensions/amp-insticator/amp-insticator.md
+++ b/extensions/amp-insticator/amp-insticator.md
@@ -1,0 +1,73 @@
+---
+$category@: dynamic-content
+formats:
+  - websites
+teaser:
+  text: Displays an Insticator embed.
+---
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-insticator
+
+Displays an <a href="https://www.insticator.com">Insticator</a> embed.
+
+<table>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-insticator" src="https://cdn.ampproject.org/v0/amp-insticator-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-insticator/">Annotated code example for amp-insticator</a></td>
+  </tr>
+</table>
+
+[TOC]
+
+## Behavior
+
+Implement the below element into your website code in the location you wish to see it visually appear on your website.
+
+Example:
+```html
+<amp-insticator
+    data-embed-id="06538eab-6e13-4e71-8584-8501a8e85f7b">
+</amp-insticator>
+```
+
+This element will generate an <a href="https://www.insticator.com">Insticator</a> embed, a white-labeled content engagement unit. The unit will pose contextually relevant quiz and poll questions to your audience while monetizing via accompanying advertisements.
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><strong>data-embed-id</strong></td>
+    <td>Unique identifier of your custom embed.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://www.ampproject.org/docs/reference/common_attributes">common attributes</a> extended to AMP components.</td>
+  </tr>
+</table>
+
+
+## Validation
+See [amp-insticator rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-insticator/validator-amp-insticator.protoascii) in the AMP validator specification.

--- a/extensions/amp-insticator/validator-amp-insticator.protoascii
+++ b/extensions/amp-insticator/validator-amp-insticator.protoascii
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-insticator
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-insticator"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-insticator>
+  html_format: AMP
+  tag_name: "AMP-INSTICATOR"
+  requires_extension: "amp-insticator"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-insticator"
+  amp_layout: {
+    supported_layouts: RESPONSIVE
+  }
+}


### PR DESCRIPTION
This is a proposed implementation of #22027 to get a confirmation before going ahead with the full implementation of the `<amp-insticator>` extension.

As suggested in [this comment](https://github.com/ampproject/amphtml/issues/22027#issuecomment-487653844) `<amp-insticator> `creates an iframe that handles the content and places amp-ad above and below the iframe (all still contained within `<amp-insticator>`).

We are using a data-embed-uuid attribute to fetch a specific content and ad’s settings.

Currently, we fetch generic ads settings for demonstration purposes. This will change in full implementation.

cc @aghassemi 
cc @lannka 
