### PR TITLE
Add separate iframe transport URLs for Canary

### DIFF
--- a/extensions/amp-analytics/0.1/iframe-transport-vendors.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-vendors.js
@@ -22,13 +22,20 @@
  * This object is separated from vendors.js to be shared with extensions
  * other than amp-analytics, for instance amp-ad-exit.
  *
- * @const {!JsonObject}
+ * @const {!Object}
  */
-export const IFRAME_TRANSPORTS = /** @type {!JsonObject} */ ({
+const prodConfig = {
   'bg': 'https://tpc.googlesyndication.com/b4a/b4a-runner.html',
   'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
+};
+/**
+ * Canary config override
+ *
+ * @const {!Object}
+ */
+const canaryConfig = Object.assign({}, prodConfig, {
+  'bg': 'https://tpc.googlesyndication.com/b4a/experimental/b4a-runner.html',
 });
 
-export const IFRAME_TRANSPORTS_CANARY = Object.assign(
-    {}, IFRAME_TRANSPORTS,
-    {bg: 'https://tpc.googlesyndication.com/b4a/experimental/b4a-runner.html'});
+export const IFRAME_TRANSPORTS = /** @type {!JsonObject} */ (prodConfig);
+export const IFRAME_TRANSPORTS_CANARY = /** @type {!JsonObject} */ (canaryConfig);

--- a/extensions/amp-analytics/0.1/iframe-transport-vendors.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-vendors.js
@@ -29,7 +29,6 @@ export const IFRAME_TRANSPORTS = /** @type {!JsonObject} */ ({
   'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
 });
 
-export const IFRAME_TRANSPORTS_CANARY = /** @type {!JsonObject} */ ({
-  'bg': 'https://tpc.googlesyndication.com/b4a/experimental/b4a-runner.html',
-  'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
-});
+export const IFRAME_TRANSPORTS_CANARY = Object.assign(
+    {}, IFRAME_TRANSPORTS,
+    {bg: 'https://tpc.googlesyndication.com/b4a/experimental/b4a-runner.html'});

--- a/extensions/amp-analytics/0.1/iframe-transport-vendors.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-vendors.js
@@ -28,3 +28,8 @@ export const IFRAME_TRANSPORTS = /** @type {!JsonObject} */ ({
   'bg': 'https://tpc.googlesyndication.com/b4a/b4a-runner.html',
   'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
 });
+
+export const IFRAME_TRANSPORTS_CANARY = /** @type {!JsonObject} */ ({
+  'bg': 'https://tpc.googlesyndication.com/b4a/experimental/b4a-runner.html',
+  'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
+});

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -270,7 +270,8 @@ ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 
 mergeIframeTransportConfig(
   ANALYTICS_CONFIG,
-  isCanary(self) ? IFRAME_TRANSPORTS_CANARY : IFRAME_TRANSPORTS);
+  isCanary(self) ? IFRAME_TRANSPORTS_CANARY : IFRAME_TRANSPORTS
+);
 
 /**
  * Merges iframe transport config.

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -269,8 +269,8 @@ ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;
 
 mergeIframeTransportConfig(
-    ANALYTICS_CONFIG,
-    isCanary(self) ? IFRAME_TRANSPORTS_CANARY : IFRAME_TRANSPORTS);
+  ANALYTICS_CONFIG,
+  isCanary(self) ? IFRAME_TRANSPORTS_CANARY : IFRAME_TRANSPORTS);
 
 /**
  * Merges iframe transport config.

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import {IFRAME_TRANSPORTS} from './iframe-transport-vendors';
+import {
+  IFRAME_TRANSPORTS,
+  IFRAME_TRANSPORTS_CANARY,
+} from './iframe-transport-vendors';
 import {getMode} from '../../../src/mode';
 import {hasOwn} from '../../../src/utils/object';
+import {isCanary} from '../../../src/experiments';
 
 // Disable auto-sorting of imports from here on.
 /* eslint-disable sort-imports-es6-autofix/sort-imports-es6 */
@@ -264,7 +268,9 @@ ANALYTICS_CONFIG['adobeanalytics_nativeConfig']
 ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;
 
-mergeIframeTransportConfig(ANALYTICS_CONFIG, IFRAME_TRANSPORTS);
+mergeIframeTransportConfig(
+    ANALYTICS_CONFIG,
+    isCanary(self) ? IFRAME_TRANSPORTS_CANARY : IFRAME_TRANSPORTS);
 
 /**
  * Merges iframe transport config.


### PR DESCRIPTION
Adding a separate JSON Object (IFRAME_TRANSPORTS_CANARY) in iframe-transport-vendors.js to represent sources to be loaded into iframe when using iframe transport in Canary. 

Adding conditional logic in vendors.js to use IFRAME_TRANSPORTS_CANARY when in Canary and IFRAME_TRANSPORTS, otherwise.

This will help vendors test changes in Canary without altering the source in live traffic.