### PR TITLE
amp-form: Reduce typecasts, clean up

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -862,8 +862,8 @@ export class AmpForm {
     }
     return promise.then(responseJson => {
       this.triggerFormSubmitInAnalytics_('amp-form-submit-error');
-      this.maybeHandleRedirect_(e.response);
       this.handleSubmitFailure_(e, responseJson);
+      this.maybeHandleRedirect_(e.response);
     });
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -831,6 +831,23 @@ export class AmpForm {
   }
 
   /**
+   * Transition the form to the submit success state.
+   * @param {!Promise<!JsonObject>} jsonPromise
+   * @return {!Promise}
+   * @private visible for testing
+   */
+  handleSubmitSuccess_(jsonPromise) {
+    return jsonPromise.then(json => {
+      this.setState_(FormState.SUBMIT_SUCCESS);
+      this.renderTemplate_(json || {}).then(() => {
+        this.triggerAction_(FormEvents.SUBMIT_SUCCESS, json);
+      });
+    }, error => {
+      user().error(TAG, 'Failed to parse response JSON: %s', error);
+    });
+  }
+
+  /**
    * @param {*} e
    * @return {!Promise}
    * @private
@@ -851,23 +868,6 @@ export class AmpForm {
   }
 
   /**
-   * Transition the form to the submit success state.
-   * @param {!Promise<!JsonObject>} jsonPromise
-   * @return {!Promise}
-   * @private visible for testing
-   */
-  handleSubmitSuccess_(jsonPromise) {
-    return jsonPromise.then(json => {
-      this.setState_(FormState.SUBMIT_SUCCESS);
-      this.renderTemplate_(json || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_SUCCESS, json);
-      });
-    }, error => {
-      user().error(TAG, 'Failed to parse response JSON: %s', error);
-    });
-  }
-
-  /**
    * Transition the form the the submit error state.
    * @param {*} error
    * @param {!JsonObject} json
@@ -875,8 +875,8 @@ export class AmpForm {
    * @private
    */
   handleSubmitFailure_(error, json) {
-    user().error(TAG, 'Form submission failed: %s', error);
     this.setState_(FormState.SUBMIT_ERROR);
+    user().error(TAG, 'Form submission failed: %s', error);
     return tryResolve(() => {
       this.renderTemplate_(json).then(() => {
         this.triggerAction_(FormEvents.SUBMIT_ERROR, json);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -2532,12 +2532,12 @@ describes.repeated('', {
 
           const getValueError = new Error('amp-async-input-error');
           getValueStub.returns(Promise.reject(getValueError));
-          const handlePresubmitErrorStub =
-            sandbox.stub(ampForm, 'handlePresubmitError_');
 
+          const stub = sandbox.stub(ampForm, 'handleSubmitFailure_');
           return ampForm.submit_(ActionTrust.HIGH).then(() => {
-            expect(handlePresubmitErrorStub).to.be.called;
-            expect(handlePresubmitErrorStub).to.be.calledWith(getValueError);
+            expect(stub).to.be.called;
+            expect(stub).to.be.calledWith(getValueError,
+                {'error': 'amp-async-input-error'});
           });
         });
       });


### PR DESCRIPTION
- Reduces number of type casts (a source of bugs e.g. #22221)
- Fixes code dupe across `handlePresubmitFailure_`, `handleXhrSubmitFailure_` and `handleSsrTemplateFailure_`
- Other minor clean up

/to @cvializ 