### PR TITLE
✨amp-consent: Allowed passing the consent string through a macro

### DIFF
--- a/examples/a4a-consent.amp.html
+++ b/examples/a4a-consent.amp.html
@@ -7,15 +7,18 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js">
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
-
-  </script>
 
   <style amp-custom>
     h1 {
       margin: 1rem;
     }
+
+    amp-consent {
+      background-color: rgba(0,0,0,0.25);
+    }
+
   </style>
 </head>
 <body>
@@ -41,25 +44,22 @@
 
   <h1>A4A Examples</h1>
 
-  <h2>Fake ad network (Not Blocked by Consent)</h2>
-  <amp-ad width="300" height="400"
-                      type="fake"
-                      id='i-amphtml-demo-id'
-                      data-vars-analytics-var="bar"
-                      src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
-    <div placeholder></div>
-    <div fallback></div>
+  <h2>Doubleclick with RTC (Blocked _till_responded)</h2>
+  <amp-ad data-block-on-consent='_till_responded'
+    width="320" height="50"
+    type="doubleclick"
+    data-slot="/4119129/mobile_ad_banner"
+    rtc-config='{"vendors": {"fakeVendor": {"SLOT_ID": "1"}}, "urls": ["https://localhost:4443/posts?slot_id=1&consent_state=CONSENT_STATE&consent_string=CONSENT_STRING"], "timeoutMillis": 500}'>
   </amp-ad>
 
-  <h2>Fake ad network (Blocked by Consent)</h2>
-  <amp-ad width="300" height="400"
-                      type="fake"
-                      id='i-amphtml-demo-id'
-                      data-vars-analytics-var="bar"
-                      data-block-on-consent
-                      src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
-    <div placeholder></div>
-    <div fallback></div>
+  <h2>Doubleclick with RTC (Blocked by _till_accepted)</h2>
+  <amp-ad data-block-on-consent='_till_accepted'
+    width="320" height="50"
+    type="doubleclick"
+    data-slot="/4119129/mobile_ad_banner"
+    rtc-config='{"vendors": {"fakeVendor": {"SLOT_ID": "1"}}, "urls": ["https://localhost:4443/posts?slot_id=1&consent_state=CONSENT_STATE&consent_string=CONSENT_STRING"], "timeoutMillis": 500}'>
+    </amp-ad>
+
   </amp-ad>
 
 </body>

--- a/examples/a4a-consent.amp.html
+++ b/examples/a4a-consent.amp.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js">
+  <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+
+  </script>
+
+  <style amp-custom>
+    h1 {
+      margin: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- _ping_ example -->
+  <amp-consent id='ABC' layout='nodisplay' type='_ping_'>
+    <script type="application/json">
+      {
+            "consents": {},
+            "postPromptUI": "postPromptUI",
+            "clientConfig": {
+              "CMP_id": "test_id",
+              "other_info": "test_info"
+            }
+          }
+    </script>
+    <div id="postPromptUI">
+      Post Prompt UI
+      <button on="tap:ABC.prompt(consent=_ping_)" role="button">Manage</button>
+    </div>
+  </amp-consent>
+  <!-- End _ping_ example -->
+
+  <h1>A4A Examples</h1>
+
+  <h2>Fake ad network (Not Blocked by Consent)</h2>
+  <amp-ad width="300" height="400"
+                      type="fake"
+                      id='i-amphtml-demo-id'
+                      data-vars-analytics-var="bar"
+                      src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <h2>Fake ad network (Blocked by Consent)</h2>
+  <amp-ad width="300" height="400"
+                      type="fake"
+                      id='i-amphtml-demo-id'
+                      data-vars-analytics-var="bar"
+                      data-block-on-consent
+                      src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+</body>
+</html>
+

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -630,9 +630,6 @@ export class AmpA4A extends AMP.BaseElement {
           checkStillCurrent();
           const consentPolicyId = super.getConsentPolicy();
 
-          // TODO torch2424
-          getConsentPolicyInfo(this.element, consentPolicyId);
-
           if (consentPolicyId) {
 
             const consentStatePromise = getConsentPolicyState(
@@ -647,7 +644,7 @@ export class AmpA4A extends AMP.BaseElement {
               this.element,
               consentPolicyId
             ).catch(err => {
-              user().error(TAG, 'Error determining consent sttring', err);
+              user().error(TAG, 'Error determining consent string', err);
               return null;
             });
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -663,11 +663,14 @@ export class AmpA4A extends AMP.BaseElement {
         /** @return {!Promise<?string>} */
         .then(consentResponse => {
           checkStillCurrent();
-          console.log(consentResponse);
+
+          const consentState = consentResponse[0];
+          const consentString = consentResponse[1];
+
           return /** @type {!Promise<?string>} */(this.getAdUrl(
             consentState, this.tryExecuteRealTimeConfig_(
-              consentResponse[0],
-              consentResponse[1]
+              consentState,
+              consentString
           )));
         })
         // This block returns the (possibly empty) response to the XHR request.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -48,7 +48,10 @@ import {
   incrementLoadingAds,
   is3pThrottled,
 } from '../../amp-ad/0.1/concurrent-load';
-import {getConsentPolicyState} from '../../../src/consent';
+import {
+  getConsentPolicyState,
+  getConsentPolicyInfo
+} from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 import {getMode} from '../../../src/mode';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
@@ -622,23 +625,50 @@ export class AmpA4A extends AMP.BaseElement {
           }
         })
         // Possibly block on amp-consent.
-        /** @return {!Promise<?CONSENT_POLICY_STATE>} */
+        /** @return {!Promise<array>} */
         .then(() => {
           checkStillCurrent();
           const consentPolicyId = super.getConsentPolicy();
-          return consentPolicyId ?
-            getConsentPolicyState(this.element, consentPolicyId)
-                .catch(err => {
-                  user().error(TAG, 'Error determining consent state', err);
-                  return CONSENT_POLICY_STATE.UNKNOWN;
-                }) : Promise.resolve(null);
+
+          // TODO torch2424
+          getConsentPolicyInfo(this.element, consentPolicyId);
+
+          if (consentPolicyId) {
+
+            const consentStatePromise = getConsentPolicyState(
+              this.element,
+              consentPolicyId
+            ).catch(err => {
+                user().error(TAG, 'Error determining consent state', err);
+                return CONSENT_POLICY_STATE.UNKNOWN;
+            });
+
+            const consentStringPromise = getConsentPolicyInfo(
+              this.element,
+              consentPolicyId
+            ).catch(err => {
+              user().error(TAG, 'Error determining consent sttring', err);
+              return null;
+            });
+
+            return Promise.all([
+              consentStatePromise,
+              consentStringPromise
+            ]);
+          }
+
+          return Promise.resolve([null, null]);
         })
         // This block returns the ad URL, if one is available.
         /** @return {!Promise<?string>} */
-        .then(consentState => {
+        .then(consentResponse => {
           checkStillCurrent();
+          console.log(consentResponse);
           return /** @type {!Promise<?string>} */(this.getAdUrl(
-              consentState, this.tryExecuteRealTimeConfig_(consentState)));
+            consentState, this.tryExecuteRealTimeConfig_(
+              consentResponse[0],
+              consentResponse[1]
+          )));
         })
         // This block returns the (possibly empty) response to the XHR request.
         /** @return {!Promise<?Response>} */
@@ -1701,14 +1731,15 @@ export class AmpA4A extends AMP.BaseElement {
    * If it is not supported by the network, but the publisher has included
    * the rtc-config attribute on the amp-ad element, warn.
    * @param {?CONSENT_POLICY_STATE} consentState
+   * @param {?string} consentString
    * @return {Promise<!Array<!rtcResponseDef>>|undefined}
    */
-  tryExecuteRealTimeConfig_(consentState) {
+  tryExecuteRealTimeConfig_(consentState, consentString) {
     if (!!AMP.RealTimeConfigManager) {
       try {
         return new AMP.RealTimeConfigManager(this)
             .maybeExecuteRealTimeConfig(
-                this.getCustomRealTimeConfigMacros_(), consentState);
+                this.getCustomRealTimeConfigMacros_(), consentState, consentString);
       } catch (err) {
         user().error(TAG, 'Could not perform Real Time Config.', err);
       }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -49,8 +49,8 @@ import {
   is3pThrottled,
 } from '../../amp-ad/0.1/concurrent-load';
 import {
+  getConsentPolicyInfo,
   getConsentPolicyState,
-  getConsentPolicyInfo
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 import {getMode} from '../../../src/mode';
@@ -633,16 +633,16 @@ export class AmpA4A extends AMP.BaseElement {
           if (consentPolicyId) {
 
             const consentStatePromise = getConsentPolicyState(
-              this.element,
-              consentPolicyId
+                this.element,
+                consentPolicyId
             ).catch(err => {
-                user().error(TAG, 'Error determining consent state', err);
-                return CONSENT_POLICY_STATE.UNKNOWN;
+              user().error(TAG, 'Error determining consent state', err);
+              return CONSENT_POLICY_STATE.UNKNOWN;
             });
 
             const consentStringPromise = getConsentPolicyInfo(
-              this.element,
-              consentPolicyId
+                this.element,
+                consentPolicyId
             ).catch(err => {
               user().error(TAG, 'Error determining consent string', err);
               return null;
@@ -650,7 +650,7 @@ export class AmpA4A extends AMP.BaseElement {
 
             return Promise.all([
               consentStatePromise,
-              consentStringPromise
+              consentStringPromise,
             ]);
           }
 
@@ -665,10 +665,10 @@ export class AmpA4A extends AMP.BaseElement {
           const consentString = consentResponse[1];
 
           return /** @type {!Promise<?string>} */(this.getAdUrl(
-            consentState, this.tryExecuteRealTimeConfig_(
-              consentState,
-              consentString
-          )));
+              consentState, this.tryExecuteRealTimeConfig_(
+                  consentState,
+                  consentString
+              )));
         })
         // This block returns the (possibly empty) response to the XHR request.
         /** @return {!Promise<?Response>} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1739,9 +1739,9 @@ export class AmpA4A extends AMP.BaseElement {
       try {
         return new AMP.RealTimeConfigManager(this)
             .maybeExecuteRealTimeConfig(
-              this.getCustomRealTimeConfigMacros_(),
-              consentState,
-              consentString
+                this.getCustomRealTimeConfigMacros_(),
+                consentState,
+                consentString
             );
       } catch (err) {
         user().error(TAG, 'Could not perform Real Time Config.', err);

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -625,7 +625,7 @@ export class AmpA4A extends AMP.BaseElement {
           }
         })
         // Possibly block on amp-consent.
-        /** @return {!Promise<array>} */
+        /** @return {!Promise<Array<Promise>>} */
         .then(() => {
           checkStillCurrent();
           const consentPolicyId = super.getConsentPolicy();
@@ -1739,7 +1739,10 @@ export class AmpA4A extends AMP.BaseElement {
       try {
         return new AMP.RealTimeConfigManager(this)
             .maybeExecuteRealTimeConfig(
-                this.getCustomRealTimeConfigMacros_(), consentState, consentString);
+              this.getCustomRealTimeConfigMacros_(),
+              consentState,
+              consentString
+            );
       } catch (err) {
         user().error(TAG, 'Could not perform Real Time Config.', err);
       }

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -103,6 +103,9 @@ export class RealTimeConfigManager {
 
     /** @private {?CONSENT_POLICY_STATE} */
     this.consentState_ = null;
+
+    /** @private {?string} */
+    this.consentString_ = null;
   }
 
   /**
@@ -162,14 +165,16 @@ export class RealTimeConfigManager {
    * @param {!Object<string, !../../../src/service/variable-source.AsyncResolverDef>} customMacros The ad-network specified macro
    *   substitutions available to use.
    * @param {?CONSENT_POLICY_STATE} consentState
+   * @param {?string} consentString
    * @return {Promise<!Array<!rtcResponseDef>>|undefined}
    * @visibleForTesting
    */
-  maybeExecuteRealTimeConfig(customMacros, consentState) {
+  maybeExecuteRealTimeConfig(customMacros, consentState, consentString) {
     if (!this.validateRtcConfig_(this.a4aElement_.element)) {
       return;
     }
     this.consentState_ = consentState;
+    this.consentString_ = consentString;
     this.modifyRtcConfigForConsentStateSettings();
     customMacros = this.assignMacros(customMacros);
     this.rtcStartTime_ = Date.now();
@@ -255,6 +260,7 @@ export class RealTimeConfigManager {
   assignMacros(macros) {
     macros['TIMEOUT'] = () => this.rtcConfig_.timeoutMillis;
     macros['CONSENT_STATE'] = () => this.consentState_;
+    macros['CONSENT_STRING'] = () => this.consentString_;
     return macros;
   }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2021,7 +2021,8 @@ describe('amp-a4a', () => {
     });
 
     describe('consent integration', () => {
-      let fixture, a4aElement, a4a;
+
+      let fixture, a4aElement, a4a, consentString;
       beforeEach(() => createIframePromise().then(f => {
         fixture = f;
         setupForAdTesting(fixture);
@@ -2030,6 +2031,7 @@ describe('amp-a4a', () => {
             {name: 'ad'});
         a4aElement = createA4aElement(fixture.doc);
         a4a = new MockA4AImpl(a4aElement);
+        consentString = 'test-consent-string'
         toggleExperiment(a4a.win, 'amp-consent', true);
         return fixture;
       }));
@@ -2042,8 +2044,18 @@ describe('amp-a4a', () => {
         sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
             .returns(Promise.resolve({
               whenPolicyResolved: () => policyPromise,
+              getConsentStringInfo: () => consentString
             }));
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+
+        const getAdUrlSpy = sandbox.spy(
+          a4a,
+          'getAdUrl'
+        );
+        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+          a4a,
+          'tryExecuteRealTimeConfig_'
+        );
+
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         // allow ad promise to start execution, unfortunately timer is only way.
@@ -2051,8 +2063,13 @@ describe('amp-a4a', () => {
           expect(getAdUrlSpy).to.not.be.called;
           inResolver(CONSENT_POLICY_STATE.SUFFICIENT);
           return a4a.layoutCallback().then(() => {
-            expect(getAdUrlSpy.withArgs(CONSENT_POLICY_STATE.SUFFICIENT))
-                .calledOnce;
+            expect(getAdUrlSpy.withArgs(
+              CONSENT_POLICY_STATE.SUFFICIENT
+            )).calledOnce;
+            expect(tryExecuteRealTimeConfigSpy.withArgs(
+              CONSENT_POLICY_STATE.SUFFICIENT,
+              consentString
+            )).calledOnce;
           });
         });
       });
@@ -2075,13 +2092,28 @@ describe('amp-a4a', () => {
             .returns(Promise.resolve({
               whenPolicyResolved: () =>
                 Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT),
+              getConsentStringInfo: () => consentString
             }));
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+
+        const getAdUrlSpy = sandbox.spy(
+          a4a,
+          'getAdUrl'
+        );
+        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+          a4a,
+          'tryExecuteRealTimeConfig_'
+        );
+
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          expect(getAdUrlSpy.withArgs(CONSENT_POLICY_STATE.SUFFICIENT))
-              .calledOnce;
+          expect(getAdUrlSpy.withArgs(
+            CONSENT_POLICY_STATE.SUFFICIENT
+          )).calledOnce;
+          expect(tryExecuteRealTimeConfigSpy.withArgs(
+            CONSENT_POLICY_STATE.SUFFICIENT,
+            consentString
+          )).calledOnce;
         });
       });
 
@@ -2092,13 +2124,30 @@ describe('amp-a4a', () => {
         sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
             .returns(Promise.resolve({
               whenPolicyResolved: () => {throw new Error('consent err!');},
+              getConsentStringInfo: () => {throw new Error('consent err!');}
             }));
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+
+        const getAdUrlSpy = sandbox.spy(
+          a4a,
+          'getAdUrl'
+        );
+        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+          a4a,
+          'tryExecuteRealTimeConfig_'
+        );
+
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          expect(getAdUrlSpy.withArgs(CONSENT_POLICY_STATE.UNKNOWN))
-              .calledOnce;
+
+          expect(getAdUrlSpy.withArgs(
+            CONSENT_POLICY_STATE.UNKNOWN
+          )).calledOnce;
+          expect(tryExecuteRealTimeConfigSpy.withArgs(
+            CONSENT_POLICY_STATE.UNKNOWN,
+            null
+          )).calledOnce;
+
         });
       });
     });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2031,7 +2031,7 @@ describe('amp-a4a', () => {
             {name: 'ad'});
         a4aElement = createA4aElement(fixture.doc);
         a4a = new MockA4AImpl(a4aElement);
-        consentString = 'test-consent-string'
+        consentString = 'test-consent-string';
         toggleExperiment(a4a.win, 'amp-consent', true);
         return fixture;
       }));
@@ -2044,16 +2044,16 @@ describe('amp-a4a', () => {
         sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
             .returns(Promise.resolve({
               whenPolicyResolved: () => policyPromise,
-              getConsentStringInfo: () => consentString
+              getConsentStringInfo: () => consentString,
             }));
 
         const getAdUrlSpy = sandbox.spy(
-          a4a,
-          'getAdUrl'
+            a4a,
+            'getAdUrl'
         );
         const tryExecuteRealTimeConfigSpy = sandbox.spy(
-          a4a,
-          'tryExecuteRealTimeConfig_'
+            a4a,
+            'tryExecuteRealTimeConfig_'
         );
 
         a4a.buildCallback();
@@ -2064,11 +2064,11 @@ describe('amp-a4a', () => {
           inResolver(CONSENT_POLICY_STATE.SUFFICIENT);
           return a4a.layoutCallback().then(() => {
             expect(getAdUrlSpy.withArgs(
-              CONSENT_POLICY_STATE.SUFFICIENT
+                CONSENT_POLICY_STATE.SUFFICIENT
             )).calledOnce;
             expect(tryExecuteRealTimeConfigSpy.withArgs(
-              CONSENT_POLICY_STATE.SUFFICIENT,
-              consentString
+                CONSENT_POLICY_STATE.SUFFICIENT,
+                consentString
             )).calledOnce;
           });
         });
@@ -2092,27 +2092,27 @@ describe('amp-a4a', () => {
             .returns(Promise.resolve({
               whenPolicyResolved: () =>
                 Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT),
-              getConsentStringInfo: () => consentString
+              getConsentStringInfo: () => consentString,
             }));
 
         const getAdUrlSpy = sandbox.spy(
-          a4a,
-          'getAdUrl'
+            a4a,
+            'getAdUrl'
         );
         const tryExecuteRealTimeConfigSpy = sandbox.spy(
-          a4a,
-          'tryExecuteRealTimeConfig_'
+            a4a,
+            'tryExecuteRealTimeConfig_'
         );
 
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           expect(getAdUrlSpy.withArgs(
-            CONSENT_POLICY_STATE.SUFFICIENT
+              CONSENT_POLICY_STATE.SUFFICIENT
           )).calledOnce;
           expect(tryExecuteRealTimeConfigSpy.withArgs(
-            CONSENT_POLICY_STATE.SUFFICIENT,
-            consentString
+              CONSENT_POLICY_STATE.SUFFICIENT,
+              consentString
           )).calledOnce;
         });
       });
@@ -2124,16 +2124,16 @@ describe('amp-a4a', () => {
         sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
             .returns(Promise.resolve({
               whenPolicyResolved: () => {throw new Error('consent err!');},
-              getConsentStringInfo: () => {throw new Error('consent err!');}
+              getConsentStringInfo: () => {throw new Error('consent err!');},
             }));
 
         const getAdUrlSpy = sandbox.spy(
-          a4a,
-          'getAdUrl'
+            a4a,
+            'getAdUrl'
         );
         const tryExecuteRealTimeConfigSpy = sandbox.spy(
-          a4a,
-          'tryExecuteRealTimeConfig_'
+            a4a,
+            'tryExecuteRealTimeConfig_'
         );
 
         a4a.buildCallback();
@@ -2141,11 +2141,11 @@ describe('amp-a4a', () => {
         return a4a.layoutCallback().then(() => {
 
           expect(getAdUrlSpy.withArgs(
-            CONSENT_POLICY_STATE.UNKNOWN
+              CONSENT_POLICY_STATE.UNKNOWN
           )).calledOnce;
           expect(tryExecuteRealTimeConfigSpy.withArgs(
-            CONSENT_POLICY_STATE.UNKNOWN,
-            null
+              CONSENT_POLICY_STATE.UNKNOWN,
+              null
           )).calledOnce;
 
         });


### PR DESCRIPTION
closes #22197

This creates a `CONSENT_STRING` macro to be sent through a4a RTC 😄 

# Example

`a4a-consent.amp.html`

![Screen Shot 2019-05-14 at 3 35 35 PM](https://user-images.githubusercontent.com/1448289/57736739-f373cf00-765d-11e9-947b-4c034085d467.png)
