### PR TITLE
✨I2I: add Request Headers to XHR Requests on AMP-Form #21949

### DIFF
--- a/examples/amp-form-custom-headers.amp.html
+++ b/examples/amp-form-custom-headers.amp.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html ⚡ allow-viewer-render-template>
+<head>
+    <meta charset="utf-8">
+    <title>Add headers to Forms Examples in AMP</title>
+    <link rel="canonical" href="//example.com" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <style amp-custom>
+      
+  </style>
+</head>
+<body>
+    <!-- Read state/token from a request -->
+    <amp-state id="appState">
+        <script type="application/json">
+            {
+            "accessToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6WyJhZG1pbl9hcGlwcm9kdXRvcyIsImFkbWluX2FwaXByb2R1dG9zIl0sImp0aSI6ImI3N2U3ZTI2YTVkNjRkODY5YTAxYzBkODFiZDljNDRiIiwibmJmIjoxNTQ2ODE3MzY4LCJleHAiOjE1NDY4MTg1NjgsImlhdCI6MTU0NjgxNzM2OCwiaXNzIjoiRXhlbXBsb0lzc3VlciIsImF1ZCI6IkV4ZW1wbG9BdWRpZW5jZSJ9.pYh_-pNvPThUbDmS9Q5cfaGHrrlN-EAb8Jz8n4dhF6ddA40_kj8EuVedy_z4Q2ADMLews7mbqij7WGYsmZtfOhA2x2uxkL5w_ChOsU0_WcKlLmBed7QY4lUukizNutNlzzpIzeQe1LGqAlq5Y2xCVScfv5oghzGZ8cgXNwk7Z8PY9Ykjp0ipUBO1ara1nwGOwFzx0KVKCzj7sCoHe6pX43IQOdlviJ57EGQfu96vwvgozzS8Ppgu0rsOHkQu_fnWCfABpTX_zznUXsMLuRYDft1OWjb1zE-cq2l1APCor7vrWDRliCh-nQ-j09AGqE_7UZCNRBhLS48384sWmmx7Sw"
+            }
+        </script>
+    </amp-state>
+              
+    <!-- set x-access-token value with amp-bind/amp-state     -->
+    <form method="POST"
+            headers="{'x-access-token' : 'passAccessTokenHere', 'x-my-custom-header' : 'I Love AMP' }"
+            action-xhr="/form/echo-json/post">
+            <fieldset>
+                <label>
+                    <span>Your name</span>
+                    <input type="text" name="name" id="name2" required>
+                </label>
+                <input type="submit" value="Ok">
+            </fieldset>
+            <div submit-success>
+                <template type="amp-mustache">
+                    Success!
+                </template>
+            </div>
+            <div submit-error>
+                <template type="amp-mustache">
+                    Oops! {{name}}, We apologies something went wrong. Please try again later.
+                </template>
+            </div>
+    </form>
+    
+    </body>
+    </html>

--- a/examples/amp-form-custom-headers.amp.html
+++ b/examples/amp-form-custom-headers.amp.html
@@ -15,7 +15,7 @@
   </style>
 </head>
 <body>
-    <!-- Read state/token from a request -->
+    <!-- The accessToken will be returned from another request and will bind to form headers -->
     <amp-state id="appState">
         <script type="application/json">
             {
@@ -23,10 +23,12 @@
             }
         </script>
     </amp-state>
-              
+force 
+<a on="tap:AMP.setState({ appState: { accessToken: 'test' } })">set accessToken</a>     
     <!-- set x-access-token value with amp-bind/amp-state     -->
     <form method="POST"
-            headers="{'x-access-token' : 'passAccessTokenHere', 'x-my-custom-header' : 'I Love AMP' }"
+            [headers]="{'x-access-token' : appState.accessToken, 'x-my-custom-header' : 'I Love AMP' }"
+            headers=""
             action-xhr="/form/echo-json/post">
             <fieldset>
                 <label>

--- a/examples/amp-form-custom-headers.amp.html
+++ b/examples/amp-form-custom-headers.amp.html
@@ -23,8 +23,7 @@
             }
         </script>
     </amp-state>
-force 
-<a on="tap:AMP.setState({ appState: { accessToken: 'test' } })">set accessToken</a>     
+force <a on="tap:AMP.setState({ appState: { accessToken: 'test' } })">set accessToken</a>     
     <!-- set x-access-token value with amp-bind/amp-state     -->
     <form method="POST"
             [headers]="{'x-access-token' : appState.accessToken, 'x-my-custom-header' : 'I Love AMP' }"

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -265,6 +265,9 @@ function createElementRules_() {
         },
       },
     },
+    'AMP-FORM': {
+      'headers': null,
+    },
     'AMP-GOOGLE-DOCUMENT-EMBED': {
       'src': null,
       'title': null,

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -71,7 +71,6 @@ import {triggerAnalyticsEvent} from '../../../src/analytics';
 /** @type {string} */
 const TAG = 'amp-form';
 
-
 /**
  * A list of external dependencies that can be included in forms.
  * @type {!Array<string>}

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -171,6 +171,15 @@ export class AmpForm {
     /** @const @private {string} */
     this.target_ = this.form_.getAttribute('target');
 
+    this.customHeaders_ = this.form_.getAttribute('headers');
+    if(this.customHeaders_) {
+      try {
+        this.customHeaders_ = JSON.parse(this.customHeaders_.replace(/'/g, '"'));
+      } catch (e) {
+          return false;
+      }
+    }
+
     /** @private {?string} */
     this.xhrAction_ = this.getXhrUrl_('action-xhr');
 
@@ -284,7 +293,7 @@ export class AmpForm {
         'body': body,
         'method': method,
         'credentials': 'include',
-        'headers': dict({'Accept': 'application/json'}),
+        'headers': Object.assign(dict({'Accept': 'application/json'}), this.customHeaders_),
       }),
     };
 

--- a/extensions/amp-form/validator-amp-form.protoascii
+++ b/extensions/amp-form/validator-amp-form.protoascii
@@ -30,3 +30,22 @@ tags: {  # amp-form
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-form
+  # Accepted form elements can be found in validator-main.protoascii
+  # under section "4.10 Forms"
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-form"
+    version: "0.1"
+    version: "latest"
+    deprecated_allow_duplicates: true
+    requires_usage: GRANDFATHERED
+  }
+  # <amp-bind>
+  attrs: { name: "[headers]" }
+  attr_lists: "common-extension-attrs"
+}


### PR DESCRIPTION
add custom request headers to an AMP-FORM xhr request.

Some APIs needs that some params be set via request headers.
