### PR TITLE
Differentiate 'render-start' msg and RENDER_START signal

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -97,8 +97,8 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         expect(iframe.style.visibility).to.equal('hidden');
         return initPromise.then(() => {
           expect(iframe.style.visibility).to.equal('');
-          expect(renderStartedSpy).to.not.be.called;
-          expect(signals.get('render-start')).to.be.null;
+          // Should signal RENDER_START at toggling visibility even w/o msg
+          expect(signals.get('render-start')).to.be.ok;
         });
       });
 
@@ -277,7 +277,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         };
       }).then(() => {
         expect(iframe.style.visibility).to.equal('');
-        expect(renderStartedSpy).to.not.be.called;
+        expect(renderStartedSpy).to.be.calledOnce;
       });
     });
 

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -25,24 +25,35 @@ export const CommonSignals = {
   BUILT: 'built',
 
   /**
-   * The initial contents of an element/document/embed have been loaded.
-   */
-  INI_LOAD: 'ini-load',
-
-  /**
-   * The element has been loaded.
-   */
-  LOAD_END: 'load-end',
-
-  /**
    * The element has started loading.
+   * LOAD_START triggers at the start of the layoutCallback.
    */
   LOAD_START: 'load-start',
 
   /**
    * Rendering has been confirmed to have been started.
+   * RENDER_START is an optional signal, implemented by ads, shadowdoc.
+   * The signal instruct the content has started rendering, and is related
+   * to toggle visibility.
    */
   RENDER_START: 'render-start',
+
+  /**
+   * The element has been loaded.
+   * LOAD_END triggers at the end of the layoutCallback.
+   *
+   */
+  LOAD_END: 'load-end',
+
+  /**
+   * The initial contents of an element/document/embed have been loaded.
+   * INI_LOAD is an optional signal, implemented by ads, story.
+   * It instructs that all critical resources has been loade, and is related
+   * to more acurate measurement.
+   * Note: Based on the implementation, INI_LOAD can trigger before or after
+   * LOAD_END.
+   */
+  INI_LOAD: 'ini-load',
 
   /**
    * The element has been unlaid out.

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -55,7 +55,7 @@ export const CommonSignals = {
    * INI_LOAD is an optional signal, implemented by ads, story, and elements
    * that consist of other resources.
    * It instructs that all critical resources has been loaded, and can be used
-   * for more acurate visibility measurement.
+   * for more accurate visibility measurement.
    * When an element doesn't consist multiple child resources, LOAD_END signal
    * can be used to indicate resource load completion.
    * Note: Based on the implementation, INI_LOAD can trigger before or after

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -32,9 +32,14 @@ export const CommonSignals = {
 
   /**
    * Rendering has been confirmed to have been started.
-   * RENDER_START is an optional signal, implemented by ads, shadowdoc.
-   * The signal instruct the content has started rendering, and is related
-   * to toggle visibility.
+   * It is a signal to indicate meaningful display (e.g. text could be displayed
+   * CSS is correctly installed/applied).
+   *
+   * Elements can optionally implement RENDER_START signal. (e.g. ad, shadowdoc)
+   * if it want to define its own meaningful display time and toggle visibility.
+   *
+   * Simpler elements's RENDER_START can be equal to the start of the
+   * buildCallback
    */
   RENDER_START: 'render-start',
 
@@ -47,9 +52,12 @@ export const CommonSignals = {
 
   /**
    * The initial contents of an element/document/embed have been loaded.
-   * INI_LOAD is an optional signal, implemented by ads, story.
-   * It instructs that all critical resources has been loade, and is related
-   * to more acurate measurement.
+   * INI_LOAD is an optional signal, implemented by ads, story, and elements
+   * that consist of other resources.
+   * It instructs that all critical resources has been loaded, and can be used
+   * for more acurate visibility measurement.
+   * When an element doesn't consist multiple child resources, LOAD_END signal
+   * can be used to indicate resource load completion.
    * Note: Based on the implementation, INI_LOAD can trigger before or after
    * LOAD_END.
    */

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -429,6 +429,7 @@ export class FriendlyIframeEmbed {
     } else {
       this.signals_.signal(CommonSignals.RENDER_START);
     }
+    // Common signal RENDER_START indicates time to toggle visibility
     setStyle(this.iframe, 'visibility', '');
     if (this.win.document && this.win.document.body) {
       this.win.document.documentElement.classList.add('i-amphtml-fie');


### PR DESCRIPTION
I found the common signals to be a bit confusing. Added some comments to the file and also reorder the signals based on trigger time. 

Ads support a renderStart API which listens to 'render-start' msg from iframe. This could help AMP runtime to display an ad at a more accurate time. The `RENDER_START` signal is different. It is a signal that's used to tell AMP runtime and other components the ad is now visible. 

In the PR, I separate the concept between 'render-start' msg and RENDER_START signal. Should make the code easier to understand. And the PR fixes the issue where RENDER_START signal is not triggered at iframe on load event. 