### PR TITLE
Remove 'amp-consent' experiment flag pr2

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -27,7 +27,6 @@
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
-  "amp-consent": 1,
   "amp-date-picker": 1,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -28,7 +28,6 @@
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
-  "amp-consent": 1,
   "amp-date-picker": 1,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,


### PR DESCRIPTION
This is a follow up PR to #22306. 

I can't have them removed in same PR because there's a presubmit check for that. 
However it is fine this time because we've removed the check for 'amp-consent' experiment in production code long time ago. 