### PR TITLE
📖amp-lightbox-gallery: update the broken example link

### DIFF
--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -37,7 +37,7 @@ Provides a "lightbox” experience. Upon user interaction, a UI component expand
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-lightbox-gallery/">amp-lightbox-gallery</a> sample.</td>
+    <td>See AMP By Example's <a href="https://amp.dev/documentation/examples/components/amp-lightbox-gallery/">amp-lightbox-gallery</a> sample.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Due to https://github.com/ampproject/docs/issues/2089, the redirect was broken, Changing link to point directly to the main site.