### PR TITLE
📖 Connatix Player extension: fix broken documentation page

### DIFF
--- a/extensions/amp-connatix-player/amp-connatix-player.md
+++ b/extensions/amp-connatix-player/amp-connatix-player.md
@@ -1,19 +1,5 @@
-<!--
-  1. Change "category" below to one of:
-       ads-analytics
-       dynamic-content
-       layout
-       media
-       presentation
-       social
-
-  2. Remove any of the "formats" that don't apply.
-     You can also add the "ads" and "stories" formats if they apply.
-
-  3. And remove this comment! (no empty lines before "---")
--->
 ---
-$category: media
+$category@: media
 formats:
   - websites
 teaser:


### PR DESCRIPTION
There was a leftover comment (auto generated) that wasn't removed which causes the page to render the licence agreement.
Also fixed the category attribute