### PR TITLE
🏗 Don't run unit tests on local changes for large refactors

### DIFF
--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -29,12 +29,20 @@ const {
   stopTimer,
   timedExecOrDie: timedExecOrDieBase} = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
+const {gitDiffNameOnlyMaster} = require('../git');
 const {isTravisPullRequestBuild} = require('../travis');
 
 const FILENAME = 'local-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie =
   (cmd, unusedFileName) => timedExecOrDieBase(cmd, FILENAME);
+
+const LARGE_REFACTOR_THRESHOLD = 50;
+
+function isLargeRefactor() {
+  const filesChanged = gitDiffNameOnlyMaster();
+  return filesChanged.length >= LARGE_REFACTOR_THRESHOLD;
+}
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -61,9 +69,10 @@ function main() {
     }
     downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    if (buildTargets.has('RUNTIME') ||
-        buildTargets.has('BUILD_SYSTEM') ||
-        buildTargets.has('UNIT_TEST')) {
+    if (!isLargeRefactor() &&
+        (buildTargets.has('RUNTIME') ||
+         buildTargets.has('BUILD_SYSTEM') ||
+         buildTargets.has('UNIT_TEST'))) {
       timedExecOrDie('gulp test --unit --nobuild --headless --local-changes');
     }
 


### PR DESCRIPTION
With #15461 and #15585, we started running `gulp test --unit --local-changes` on Travis before running all unit tests. This helps us fail early when a PR breaks unit tests. However, in the case of large refactors, it results in wasted time by rerunning a large number of tests twice.

In this PR, we skip directly to running all unit tests when a PR is flagged as a large refactor (# files changed >= 50).

This addresses the "future work" suggestion at https://github.com/ampproject/amphtml/pull/15585#pullrequestreview-123414218 (it only took a year!)

Follow up to #15461
Follow up to #15585