### PR TITLE
🏗🐛 Mark `--local-changes` test status as skipped for large refactors

### DIFF
--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -29,7 +29,6 @@ const {
   stopTimer,
   timedExecOrDie: timedExecOrDieBase} = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {gitDiffNameOnlyMaster} = require('../git');
 const {isTravisPullRequestBuild} = require('../travis');
 
 const FILENAME = 'local-tests.js';
@@ -37,12 +36,6 @@ const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie =
   (cmd, unusedFileName) => timedExecOrDieBase(cmd, FILENAME);
 
-const LARGE_REFACTOR_THRESHOLD = 50;
-
-function isLargeRefactor() {
-  const filesChanged = gitDiffNameOnlyMaster();
-  return filesChanged.length >= LARGE_REFACTOR_THRESHOLD;
-}
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -69,10 +62,9 @@ function main() {
     }
     downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    if (!isLargeRefactor() &&
-        (buildTargets.has('RUNTIME') ||
-         buildTargets.has('BUILD_SYSTEM') ||
-         buildTargets.has('UNIT_TEST'))) {
+    if (buildTargets.has('RUNTIME') ||
+        buildTargets.has('BUILD_SYSTEM') ||
+        buildTargets.has('UNIT_TEST')) {
       timedExecOrDie('gulp test --unit --nobuild --headless --local-changes');
     }
 

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -29,6 +29,8 @@ const {isTravisBuild} = require('../../travis');
 const extensionsCssMapPath = 'EXTENSIONS_CSS_MAP';
 
 const ROOT_DIR = path.resolve(__dirname, '../../../');
+const LARGE_REFACTOR_THRESHOLD = 50;
+
 /**
  * Extracts a mapping from CSS files to JS files from a well known file
  * generated during `gulp css`.
@@ -226,8 +228,19 @@ function refreshKarmaWdCache() {
   exec('node ./node_modules/wd/scripts/build-browser-scripts.js');
 }
 
+/**
+ * Returns true if the PR is a large refactor.
+ * (Used to skip testing local changes.)
+ * @return {boolean}
+ */
+function isLargeRefactor() {
+  const filesChanged = gitDiffNameOnlyMaster();
+  return filesChanged.length >= LARGE_REFACTOR_THRESHOLD;
+}
+
 module.exports = {
   getAdTypes,
+  isLargeRefactor,
   refreshKarmaWdCache,
   unitTestsToRun,
 };

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -27,6 +27,12 @@ const opn = require('opn');
 const path = require('path');
 const webserver = require('gulp-webserver');
 const {
+  getAdTypes,
+  isLargeRefactor,
+  refreshKarmaWdCache,
+  unitTestsToRun,
+} = require('./helpers');
+const {
   reportTestErrored,
   reportTestFinished,
   reportTestSkipped,
@@ -36,7 +42,6 @@ const {app} = require('../../test-server');
 const {build} = require('../build');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
 const {css} = require('../css');
-const {getAdTypes, refreshKarmaWdCache, unitTestsToRun} = require('./helpers');
 const {getStdout} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
 
@@ -258,6 +263,11 @@ async function runTests() {
       c.reporters = ['mocha'];
     }
   } else if (argv['local-changes']) {
+    if (isLargeRefactor()) {
+      log(green('INFO:'),
+          'Skipping tests on local changes because this is a large refactor.');
+      return reportTestSkipped();
+    }
     const testsToRun = unitTestsToRun(config.unitTestPaths);
     if (testsToRun.length == 0) {
       log(green('INFO:'),


### PR DESCRIPTION
In #22320, we skipped running unit tests on local changes for large refactors. However, this leaves the Github status in an incomplete state.

This PR moves the logic to `build-system/tasks/runtime-test/helpers.js`, so we can mark the status as skipped if needed.

Follow up to #22320