### PR TITLE
🐛 Fix link to the amp-iframe origin policy

### DIFF
--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -194,7 +194,7 @@ export class Transport {
         parseUrlDeprecated(this.win_.location.href).origin,
         'Origin of iframe request must not be equal to the document origin.' +
         ' See https://github.com/ampproject/' +
-        ' amphtml/blob/master/spec/amp-iframe-origin-policy.md for details.');
+        'amphtml/blob/master/spec/amp-iframe-origin-policy.md for details.');
 
     /** @const {!Element} */
     const iframe = this.win_.document.createElement('iframe');


### PR DESCRIPTION
Fix link to the amp-iframe origin policy.

Without the fix - https://i.imgur.com/Wv7IqgR.png