### PR TITLE
Force build additional components during prerendering if needed.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -845,6 +845,8 @@ amp-list[load-more] [load-more-end]
  * amp-story
  */
 amp-story[standalone], amp-story-page {
+  /* Ensures amp-story and amp-story-page have a height and are prerendered. */
+  min-height: 1px !important;
   display: block !important;
   height: 100% !important;
   margin: 0 !important;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -322,13 +322,14 @@ export class Resource {
   /**
    * Requests the resource's element to be built. See {@link AmpElement.build}
    * for details.
+   * @param {boolean=} buildGranted
    * @return {?Promise}
    */
-  build() {
+  build(buildGranted = false) {
     if (
       this.isBuilding_ ||
       !this.element.isUpgraded() ||
-      !this.resources_.grantBuildPermission()
+      (!buildGranted && !this.resources_.grantBuildPermission())
     ) {
       return null;
     }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -322,14 +322,14 @@ export class Resource {
   /**
    * Requests the resource's element to be built. See {@link AmpElement.build}
    * for details.
-   * @param {boolean=} buildGranted
+   * @param {boolean=} force
    * @return {?Promise}
    */
-  build(buildGranted = false) {
+  build(force = false) {
     if (
       this.isBuilding_ ||
       !this.element.isUpgraded() ||
-      (!buildGranted && !this.resources_.grantBuildPermission())
+      (!force && !this.resources_.grantBuildPermission())
     ) {
       return null;
     }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1777,8 +1777,8 @@ export class Resources {
         const r = this.resources_[i];
         // TODO(dvoytenko): This extra build has to be merged with the
         // scheduleLayoutOrPreload_ method below.
-        if (!r.isBuilt() && !r.hasOwner() && r.isDisplayed() &&
-            r.overlaps(loadRect)) {
+        if (!r.isBuilt() && !r.hasOwner() && r.hasBeenMeasured() &&
+            r.isDisplayed() && r.overlaps(loadRect)) {
           this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true,
               /* scheduleWhenBuilt */ undefined, /* buildGranted */ true);
         }

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -23,6 +23,7 @@ import {Signals} from '../../src/utils/signals';
 import {VisibilityState} from '../../src/visibility-state';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {loadPromise} from '../../src/event-helper';
+import {toggleExperiment} from '../../src/experiments';
 
 /*eslint "google-camelcase/google-camelcase": 0*/
 describe('Resources', () => {
@@ -1141,6 +1142,7 @@ describe('Resources discoverWork', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox;
+    toggleExperiment(window, 'amp-force-prerender-visible-elements', true);
     resources = new Resources(new AmpDocSingle(window));
     viewportMock = sandbox.mock(resources.viewport_);
 
@@ -1163,6 +1165,7 @@ describe('Resources discoverWork', () => {
   });
 
   afterEach(() => {
+    toggleExperiment(window, 'amp-force-prerender-visible-elements', false);
     viewportMock.verify();
     sandbox.restore();
   });
@@ -1530,8 +1533,12 @@ describe('Resources discoverWork', () => {
     const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
     sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
-    resource1.element.isBuilt = sandbox.stub()
-        .onFirstCall().returns(true).onSecondCall().returns(false);
+    resource1.element.isBuilt = sandbox
+      .stub()
+      .onFirstCall()
+      .returns(true)
+      .onSecondCall()
+      .returns(false);
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
     resource1.build = sandbox.spy();
@@ -1542,7 +1549,7 @@ describe('Resources discoverWork', () => {
     expect(buildResourceSpy).calledWithExactly(
       resource1,
       /* schedulePass */ true,
-      /* buildGranted */ false
+      /* force */ false
     );
   });
 
@@ -1551,8 +1558,12 @@ describe('Resources discoverWork', () => {
     sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = false;
     resource1.element.nextSibling = {};
-    resource1.element.isBuilt = sandbox.stub()
-        .onFirstCall().returns(false).onSecondCall().returns(true);
+    resource1.element.isBuilt = sandbox
+      .stub()
+      .onFirstCall()
+      .returns(false)
+      .onSecondCall()
+      .returns(true);
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
     resource1.build = sandbox.spy();
@@ -1600,7 +1611,7 @@ describe('Resources discoverWork', () => {
     expect(schedulePassStub).to.be.calledOnce;
   });
 
-  it('should force build resources durig discoverWork layout phase', () => {
+  it('should force build resources during discoverWork layout phase', () => {
     const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
     sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
@@ -1616,10 +1627,16 @@ describe('Resources discoverWork', () => {
     expect(resource1.build).to.be.calledTwice;
     // discoverWork_ phase 1 build.
     expect(buildResourceSpy).calledWithExactly(
-        resource1, /* schedulePass */ true, /* buildGranted */ false);
+      resource1,
+      /* schedulePass */ true,
+      /* force */ false
+    );
     // discoverWork_ phase 4 layout grants build.
     expect(buildResourceSpy).calledWithExactly(
-        resource1, /* schedulePass */ true, /* buildGranted */ true);
+      resource1,
+      /* schedulePass */ true,
+      /* force */ true
+    );
   });
 
   describe('getResourcesInRect', () => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -434,6 +434,14 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/22059',
     cleanupIssue: 'TODO',
   },
+  {
+    id: 'amp-force-prerender-visible-elements',
+    name:
+      'Force builds the AMP elements that are visible and in the viewport ' +
+      'during prerendering, beyond the 20 elements limit.',
+    spec: 'https://github.com/ampproject/amphtml/issues/21791',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/21792',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Alternative implementation to https://github.com/ampproject/amphtml/pull/21555, suggested by @dvoytenko 

AMP prerendering builds 20 elements, so that the content above the fold is already loaded and rendered when a user opens an AMP document.
This PR forces the build for elements beyond this limit of 20, if they are in the defined viewport area that is used to layout the elements during prerendering.

Fixes #21432