### PR TITLE
📖 Add email to amp-lightbox supported formats

### DIFF
--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -3,6 +3,7 @@ $category@: layout
 formats:
   - websites
   - ads
+  - email
 teaser:
   text: Displays elements in a full-viewport “lightbox” modal.
 ---


### PR DESCRIPTION
`<amp-lightbox>` is already supported in the validator and spec:

https://github.com/ampproject/amphtml/blob/1e66423afab615a0df5d36ad43757bd29379a554/extensions/amp-lightbox/validator-amp-lightbox.protoascii#L30-L32

This is to fix the amp.dev page which currently 404s: https://amp.dev/documentation/components/amp-lightbox?format=email