### PR TITLE
🐛 Add max width to amp-twitter

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -946,3 +946,7 @@ amp-story-page .i-amphtml-story-page-open-attachment-label {
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
   white-space: nowrap !important;
 }
+
+amp-story-page amp-twitter {
+  max-width: 500px !important;
+}

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -298,21 +298,6 @@ amp-story-page[distance="2"] {
   display: none !important;
 }
 
-/**
- * Click shield to make sure click events are never swallowed by videos on
- * Safari iOS 11.2, which would prevent the user from navigating through the
- * story.
- * See #14401
- */
-amp-story-grid-layer amp-video::after {
-  content: "" !important;
-  position: absolute !important;
-  height: 100% !important;
-  width: 100% !important;
-  top: 0 !important;
-  left: 0 !important;
-}
-
 /** Call to action layer, positioned at the bottom 20% of the screen. */
 amp-story-cta-layer {
   display: block !important;
@@ -337,6 +322,31 @@ amp-story-grid-layer {
   z-index: 2 !important;
   /** Make sure grid layer does not act as a click shield on elements underneath */
   pointer-events: none !important;
+}
+
+/**
+ * Click shield to make sure click events are never swallowed by videos on
+ * Safari iOS 11.2, which would prevent the user from navigating through the
+ * story.
+ * See #14401
+ */
+ amp-story-grid-layer amp-video::after {
+  content: "" !important;
+  position: absolute !important;
+  height: 100% !important;
+  width: 100% !important;
+  top: 0 !important;
+  left: 0 !important;
+}
+
+/**
+ * Adds a width limit to make sure amp-twitter element only takes required
+ * space, otherwise it takes whole width and causes a tooltip trigger in blank
+ * space.
+ * See #22334
+ */
+amp-story-grid-layer amp-twitter {
+  max-width: 500px !important;
 }
 
 amp-story-grid-layer > * {
@@ -945,8 +955,4 @@ amp-story-page .i-amphtml-story-page-open-attachment-label {
   text-overflow: ellipsis !important;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
   white-space: nowrap !important;
-}
-
-amp-story-page amp-twitter {
-  max-width: 500px !important;
 }


### PR DESCRIPTION
Twitter embed applies a `width: 100%` on responsive layouts for the iframe, but the tweet itself only has a `max-width` of `500px`. This yields to some blank space being clickable which might be confusing to users.
Before:
![image](https://user-images.githubusercontent.com/5449100/57867944-0a3a3300-77d0-11e9-81a8-ab20e316e4b8.png)
After:
![image](https://user-images.githubusercontent.com/5449100/57867955-132b0480-77d0-11e9-9df8-4867f306181a.png)
