### PR TITLE
Ensure that the waitForBody yields at the earliest possible time when body is opened

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -22,7 +22,6 @@ import {
 } from './css';
 import {dev, devAssert} from './log';
 import {dict} from './utils/object';
-import {onDocumentReady} from './document-ready';
 import {startsWith} from './string';
 import {toWin} from './types';
 
@@ -90,24 +89,6 @@ export function waitForChildPromise(parent, checkFunc) {
 }
 
 /**
- * Waits for document's head to be available.
- * @param {!Document} doc
- * @param {function()} callback
- */
-export function waitForHead(doc, callback) {
-  waitForChild(doc.documentElement, () => !!doc.body, callback);
-}
-
-/**
- * Waits for the document's head to be available.
- * @param {!Document} doc
- * @return {!Promise}
- */
-export function waitForHeadPromise(doc) {
-  return new Promise(resolve => waitForHead(doc, resolve));
-}
-
-/**
  * Waits for document's body to be available and ready.
  * Will be deprecated soon; use {@link AmpDoc#waitForBodyOpen} or
  * @{link DocumentState#onBodyAvailable} instead.
@@ -115,7 +96,7 @@ export function waitForHeadPromise(doc) {
  * @param {function()} callback
  */
 export function waitForBodyOpen(doc, callback) {
-  onDocumentReady(doc, () => waitForHead(doc, callback));
+  waitForChild(doc.documentElement, () => !!doc.body, callback);
 }
 
 /**

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -769,7 +769,7 @@ describes.sandboxed('DOM', {}, env => {
         setTimeout(() => {
           doc.body = {};
         }, 50);
-        dom.waitForBody(doc, () => {
+        dom.waitForBodyOpen(doc, () => {
           try {
             expect(doc.body).to.exist;
             resolve();

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -747,6 +747,38 @@ describes.sandboxed('DOM', {}, env => {
         });
       });
     });
+
+    it('should yield body asap even if doc is not complete', () => {
+      return new Promise((resolve, reject) => {
+        const doc = {
+          readyState: 'loading',
+          body: null,
+          documentElement: {
+            ownerDocument: {
+              defaultView: {
+                setInterval() {
+                  return window.setInterval.apply(window, arguments);
+                },
+                clearInterval() {
+                  return window.clearInterval.apply(window, arguments);
+                },
+              },
+            },
+          },
+        };
+        setTimeout(() => {
+          doc.body = {};
+        }, 50);
+        dom.waitForBody(doc, () => {
+          try {
+            expect(doc.body).to.exist;
+            resolve();
+          } catch (e) {
+            reject(new Error("body doesn't exist"));
+          }
+        });
+      });
+    });
   });
 
   describe('getDataParamsFromAttributes', () => {

--- a/test/unit/test-element-service.js
+++ b/test/unit/test-element-service.js
@@ -41,7 +41,6 @@ describe('getElementServiceIfAvailable()', () => {
   let setIntervalCallback;
 
   beforeEach(() => {
-    let readyState = 'loading';
     doc = {
       head: {},
       body: {},
@@ -55,8 +54,7 @@ describe('getElementServiceIfAvailable()', () => {
       setInterval: callback => {
         setIntervalCallback = callback;
       },
-      clearInterval: () => {
-      },
+      clearInterval: () => {},
     };
     doc.defaultView = win;
 


### PR DESCRIPTION
TODO:

- [x] Submit fix all new uses of waitForBody where the complete body is expected (#22344).
- [x] Rename `waitForBody` to `waitForBodyOpen` (#22347).
- [x] Submit this PR.
- [ ] Exhale.

