### PR TITLE
Fix story render service during prerendering.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -85,6 +85,7 @@ import {
   createElementWithAttributes,
   isRTL,
   scopedQuerySelectorAll,
+  whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {
   computedStyle,
@@ -963,6 +964,16 @@ export class AmpStory extends AMP.BaseElement {
       .then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
       .then(() => this.markStoryAsLoaded_());
 
+    // Story is being prerendered: resolve the layoutCallback when the first
+    // page is built. Other pages will only build if the document becomes
+    // visible.
+    if (!Services.viewerForDoc(this.element).hasBeenVisible()) {
+      return whenUpgradedToCustomElement(firstPageEl).then(() =>
+        firstPageEl.whenBuilt()
+      );
+    }
+
+    // Will resolve when all pages are built.
     return storyLayoutPromise;
   }
 


### PR DESCRIPTION
The new story render service waits for the signal `CommonSignals.LOAD_END` from the `<amp-story>` component. This signal will trigger when `amp-story.layoutCallback()` resolves. Until then, the story will be hidden.

However, `amp-story.layoutCallback()` will wait for all the pages to build, which might not happen in prerendering because of the 20 elements limit.

This PR introduces a change that, during prerendering, resolves `amp-story.layoutCallback()` once the first `amp-story-page` builds so the story render service can display it.