### PR TITLE
🏗 Update the build target logic used during PR checks

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -200,39 +200,40 @@ function areValidBuildTargets(buildTargets, fileName) {
 }
 
 /**
- * Returns a set of build targets contained in a PR. Used to determine which
- * checks to perform / tests to run.
+ * Populates buildTargets with a set of build targets contained in a PR after
+ * making sure they are valid. Used to determine which checks to perform / tests
+ * to run during PR builds.
+ * @param {!Set<string>} buildTargets
  * @param {string} fileName
- * @return {!Set<string>}
+ * @return {boolean}
  */
-function determineBuildTargets(fileName = 'build-targets.js') {
+function determineBuildTargets(buildTargets, fileName = 'build-targets.js') {
   const filesChanged = gitDiffNameOnlyMaster();
-  const targetSet = new Set();
+  buildTargets.clear;
   for (const file of filesChanged) {
     let matched = false;
     targetMatchers.forEach(matcher => {
       if (matcher.func(file)) {
-        matcher.targets.forEach(target => targetSet.add(target));
+        matcher.targets.forEach(target => buildTargets.add(target));
         matched = true;
       }
     });
     if (!matched) {
-      targetSet.add('RUNTIME'); // Default to RUNTIME for files that don't match a target.
+      buildTargets.add('RUNTIME'); // Default to RUNTIME for files that don't match a target.
     }
   }
   const fileLogPrefix = colors.bold(colors.yellow(`${fileName}:`));
   console.log(
     `${fileLogPrefix} Detected build targets:`,
     colors.cyan(
-      Array.from(targetSet)
+      Array.from(buildTargets)
         .sort()
         .join(', ')
     )
   );
-  return targetSet;
+  return areValidBuildTargets(buildTargets, fileName);
 }
 
 module.exports = {
-  areValidBuildTargets,
   determineBuildTargets,
 };

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -27,195 +27,172 @@ const path = require('path');
 const {gitDiffNameOnlyMaster} = require('../git');
 
 /**
- * Determines whether the given file belongs to the Validator webui,
- * that is, the 'VALIDATOR_WEBUI' target.
- * @param {string} filePath
- * @return {boolean}
+ * A mapping of functions that match a given file to one or more build targets.
  */
-function isValidatorWebuiFile(filePath) {
-  return filePath.startsWith('validator/webui');
-}
+const targetMatchers = [
+  {
+    targets: ['AVA'],
+    func: file => {
+      return (
+        file == 'build-system/tasks/ava.js' ||
+        file.startsWith('build-system/tasks/csvify-size/') ||
+        file.startsWith('build-system/tasks/get-zindex/') ||
+        file.startsWith('build-system/tasks/prepend-global/')
+      );
+    },
+  },
+  {
+    targets: ['BABEL_PLUGIN', 'RUNTIME'], // Test the runtime for babel plugin changes.
+    func: file => {
+      return (
+        file == 'build-system/tasks/babel-plugin-tests.js' ||
+        file.startsWith('build-system/babel-plugins/')
+      );
+    },
+  },
+  {
+    targets: ['CACHES_JSON'],
+    func: file => {
+      return (
+        file == 'build-system/tasks/json-check.js' || file == 'caches.json'
+      );
+    },
+  },
+  {
+    targets: ['DEV_DASHBOARD'],
+    func: file => {
+      return (
+        file == 'build-system/tasks/dev-dashboard-tests.js' ||
+        file == 'build-system/app.js' ||
+        file.startsWith('build-system/app-index/')
+      );
+    },
+  },
+  {
+    targets: ['DOCS'],
+    func: file => {
+      return (
+        file == 'build-system/tasks/check-links.js' ||
+        (path.extname(file) == '.md' && !file.startsWith('examples/'))
+      );
+    },
+  },
+  {
+    targets: ['E2E_TEST'],
+    func: file => {
+      return (
+        file.startsWith('build-system/tasks/e2e/') ||
+        config.e2eTestPaths.some(pattern => {
+          return minimatch(file, pattern);
+        })
+      );
+    },
+  },
+  {
+    targets: ['FLAG_CONFIG'],
+    func: file => {
+      return file.startsWith('build-system/global-configs/');
+    },
+  },
+  {
+    targets: ['INTEGRATION_TEST'],
+    func: file => {
+      return (
+        file.startsWith('build-system/tasks/runtime-test/') ||
+        config.integrationTestPaths.some(pattern => {
+          return minimatch(file, pattern);
+        })
+      );
+    },
+  },
+  {
+    targets: ['UNIT_TEST'],
+    func: file => {
+      return (
+        file.startsWith('build-system/tasks/runtime-test/') ||
+        config.unitTestPaths.some(pattern => {
+          return minimatch(file, pattern);
+        })
+      );
+    },
+  },
+  {
+    targets: ['VALIDATOR', 'RUNTIME'], // Test the runtime for validator changes.
+    func: file => {
+      if (file.startsWith('validator/webui/')) {
+        return false;
+      }
+      if (file.startsWith('validator/')) {
+        return true;
+      }
+      // validator files for each extension
+      if (!file.startsWith('extensions/')) {
+        return false;
+      }
+      const pathArray = path.dirname(file).split(path.sep);
+      if (pathArray.length < 2) {
+        // At least 2 with ['extensions', '{$name}']
+        return false;
+      }
+      // Validator files take the form of validator-.*\.(html|out|protoascii)
+      const name = path.basename(file);
+      return (
+        name.startsWith('validator-') &&
+        (name.endsWith('.out') ||
+          name.endsWith('.html') ||
+          name.endsWith('.protoascii'))
+      );
+    },
+  },
+  {
+    targets: ['VALIDATOR_WEBUI'],
+    func: file => {
+      return file.startsWith('validator/webui/');
+    },
+  },
+  {
+    targets: ['VISUAL_DIFF'],
+    func: file => {
+      return (
+        file.startsWith('build-system/tasks/visual-diff/') ||
+        file.startsWith('examples/visual-tests/') ||
+        file == 'test/visual-diff/visual-tests'
+      );
+    },
+  },
+];
 
 /**
- * Determines whether the given file belongs to the build system,
- * that is, the 'BUILD_SYSTEM' target.
- * @param {string} filePath
- * @return {boolean}
- */
-function isBuildSystemFile(filePath) {
-  return (
-    (filePath.startsWith('build-system') &&
-      // Exclude textproto from build-system since we want it to trigger
-      // tests and type check.
-      path.extname(filePath) != '.textproto' &&
-      // Exclude config files from build-system since we want it to trigger
-      // the flag config check.
-      !isFlagConfig(filePath) &&
-      // Exclude the dev dashboard from build-system, since we want it to
-      // trigger the devDashboard check
-      !isDevDashboardFile(filePath) &&
-      // Exclude visual diff files from build-system since we want it to trigger
-      // visual diff tests.
-      !isVisualDiffFile(filePath)) ||
-    // OWNERS.yaml files should trigger build system to run tests
-    isOwnersFile(filePath)
-  );
-}
-
-/**
- * Determines whether the given file belongs to the build system, but also
- * affects the runtime.
- * @param {string} filePath
- * @return {boolean}
- */
-function isBuildSystemAndRuntimeFile(filePath) {
-  return (
-    isBuildSystemFile(filePath) &&
-    // These build system files are involved in the compilation/bundling and
-    // are likely to affect the runtime as well.
-    (filePath.startsWith('build-system/babel-plugins') ||
-      filePath.startsWith('build-system/runner'))
-  );
-}
-
-/**
- * Determines whether the given file belongs to the validator,
- * that is, the 'VALIDATOR' target. This assumes (but does not
- * check) that the file is not part of 'VALIDATOR_WEBUI'.
- * @param {string} filePath
- * @return {boolean}
- */
-function isValidatorFile(filePath) {
-  if (filePath.startsWith('validator/')) {
-    return true;
-  }
-
-  // validator files for each extension
-  if (!filePath.startsWith('extensions/')) {
-    return false;
-  }
-
-  const pathArray = path.dirname(filePath).split(path.sep);
-  if (pathArray.length < 2) {
-    // At least 2 with ['extensions', '{$name}']
-    return false;
-  }
-
-  // Validator files take the form of validator-.*\.(html|out|protoascii)
-  const name = path.basename(filePath);
-  return (
-    name.startsWith('validator-') &&
-    (name.endsWith('.out') ||
-      name.endsWith('.html') ||
-      name.endsWith('.protoascii'))
-  );
-}
-
-/**
- * Determines if the given path has a OWNERS.yaml basename.
- * @param {string} filePath
- * @return {boolean}
- */
-function isOwnersFile(filePath) {
-  return path.basename(filePath) === 'OWNERS.yaml';
-}
-
-/**
- * Determines if the given file is a markdown file containing documentation.
- * @param {string} filePath
- * @return {boolean}
- */
-function isDocFile(filePath) {
-  return path.extname(filePath) == '.md' && !filePath.startsWith('examples/');
-}
-
-/**
- * Determines if the given file is related to the visual diff tests.
- * @param {string} filePath
- * @return {boolean}
- */
-function isVisualDiffFile(filePath) {
-  const filename = path.basename(filePath);
-  return (
-    filename == 'visual-diff.js' ||
-    filename == 'visual-tests' ||
-    filePath.startsWith('examples/visual-tests/')
-  );
-}
-
-/**
- * Determines if the given file is a unit test.
- * @param {string} filePath
- * @return {boolean}
- */
-function isUnitTest(filePath) {
-  return config.unitTestPaths.some(pattern => {
-    return minimatch(filePath, pattern);
-  });
-}
-
-/**
- * Determines if the given file is,
- * a file concerning the dev dashboard
- * Concerning the dev dashboard
- * @param {string} filePath
- * @return {boolean}
- */
-function isDevDashboardFile(filePath) {
-  return (
-    filePath === 'build-system/app.js' ||
-    filePath.startsWith('build-system/app-index/')
-  );
-}
-
-/**
- * Determines if the given file is an integration test.
- * @param {string} filePath
- * @return {boolean}
- */
-function isIntegrationTest(filePath) {
-  return config.integrationTestPaths.some(pattern => {
-    return minimatch(filePath, pattern);
-  });
-}
-
-/**
- * Determines if the given file contains flag configurations, by comparing it
- * against the well-known json config filenames for prod and canary.
- * @param {string} filePath
- * @return {boolean}
- */
-function isFlagConfig(filePath) {
-  const filename = path.basename(filePath);
-  return filename == 'prod-config.json' || filename == 'canary-config.json';
-}
-
-/**
- * Validate build targets.
- * Exit early if flag-config files are mixed with runtime files.
+ * Returns false if flag config files are mixed with any other files.
  * @param {!Set<string>} buildTargets
  * @param {string} fileName
  * @return {boolean}
  */
 function areValidBuildTargets(buildTargets, fileName) {
   const files = gitDiffNameOnlyMaster();
-  if (buildTargets.has('FLAG_CONFIG') && buildTargets.has('RUNTIME')) {
-    console.log(
-      fileName,
-      colors.red('ERROR:'),
-      'Looks like your PR contains',
-      colors.cyan('{prod|canary}-config.json'),
-      'in addition to some other files.  Config and code are not kept in',
-      'sync, and config needs to be backwards compatible with code for at',
-      'least two weeks.  See #8188'
-    );
-    const nonFlagConfigFiles = files.filter(file => !isFlagConfig(file));
-    const fileLogPrefix = colors.bold(colors.yellow(`${fileName}:`));
+  const fileLogPrefix = colors.bold(colors.yellow(`${fileName}:`));
+  if (buildTargets.has('FLAG_CONFIG') && buildTargets.size > 1) {
     console.log(
       fileLogPrefix,
       colors.red('ERROR:'),
-      'Please move these files to a separate PR:',
-      colors.cyan(nonFlagConfigFiles.join(', '))
+      'Looks like your PR contains',
+      colors.cyan('{prod|canary}-config.json'),
+      'in addition to other files.'
+    );
+    console.log(
+      fileLogPrefix,
+      colors.red('ERROR:'),
+      'AMP config files need to be backward compatible with source code for at',
+      'least two weeks. See https://github.com/ampproject/amphtml/issues/8188.'
+    );
+    const nonFlagConfigFiles = files.filter(
+      file => !file.startsWith('build-system/global-configs/')
+    );
+    console.log(
+      fileLogPrefix,
+      colors.red('ERROR:'),
+      'Please move these files to a separate PR:\n',
+      colors.cyan(nonFlagConfigFiles.join('\n '))
     );
     return false;
   }
@@ -223,54 +200,35 @@ function areValidBuildTargets(buildTargets, fileName) {
 }
 
 /**
- * Determines the targets that will be executed by the main method of
- * this script. The order within this function matters.
+ * Returns a set of build targets contained in a PR. Used to determine which
+ * checks to perform / tests to run.
+ * @param {string} fileName
  * @return {!Set<string>}
  */
-function determineBuildTargets() {
-  const filePaths = gitDiffNameOnlyMaster();
-
-  if (filePaths.length == 0) {
-    return new Set([
-      'BUILD_SYSTEM',
-      'VALIDATOR_WEBUI',
-      'VALIDATOR',
-      'RUNTIME',
-      'UNIT_TEST',
-      'DEV_DASHBOARD',
-      'INTEGRATION_TEST',
-      'DOCS',
-      'FLAG_CONFIG',
-      'VISUAL_DIFF',
-    ]);
-  }
+function determineBuildTargets(fileName = 'build-targets.js') {
+  const filesChanged = gitDiffNameOnlyMaster();
   const targetSet = new Set();
-  for (const p of filePaths) {
-    if (isBuildSystemFile(p)) {
-      targetSet.add('BUILD_SYSTEM');
-      if (isBuildSystemAndRuntimeFile(p)) {
-        targetSet.add('RUNTIME');
+  for (const file of filesChanged) {
+    let matched = false;
+    targetMatchers.forEach(matcher => {
+      if (matcher.func(file)) {
+        matcher.targets.forEach(target => targetSet.add(target));
+        matched = true;
       }
-    } else if (isValidatorWebuiFile(p)) {
-      targetSet.add('VALIDATOR_WEBUI');
-    } else if (isValidatorFile(p)) {
-      targetSet.add('VALIDATOR');
-    } else if (isDocFile(p)) {
-      targetSet.add('DOCS');
-    } else if (isFlagConfig(p)) {
-      targetSet.add('FLAG_CONFIG');
-    } else if (isUnitTest(p)) {
-      targetSet.add('UNIT_TEST');
-    } else if (isDevDashboardFile(p)) {
-      targetSet.add('DEV_DASHBOARD');
-    } else if (isIntegrationTest(p)) {
-      targetSet.add('INTEGRATION_TEST');
-    } else if (isVisualDiffFile(p)) {
-      targetSet.add('VISUAL_DIFF');
-    } else {
-      targetSet.add('RUNTIME');
+    });
+    if (!matched) {
+      targetSet.add('RUNTIME'); // Default to RUNTIME for files that don't match a target.
     }
   }
+  const fileLogPrefix = colors.bold(colors.yellow(`${fileName}:`));
+  console.log(
+    `${fileLogPrefix} Detected build targets:`,
+    colors.cyan(
+      Array.from(targetSet)
+        .sort()
+        .join(', ')
+    )
+  );
   return targetSet;
 }
 

--- a/build-system/pr-check/build.js
+++ b/build-system/pr-check/build.js
@@ -43,7 +43,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
   if (
     !runYarnChecks(FILENAME) ||
     !areValidBuildTargets(buildTargets, FILENAME)
@@ -61,10 +61,9 @@ function main() {
     printChangeSummary(FILENAME);
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('UNIT_TEST') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('BUILD_SYSTEM') ||
       buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST') ||
+      buildTargets.has('E2E_TEST') ||
       buildTargets.has('VISUAL_DIFF')
     ) {
       timedExecOrDie('gulp update-packages');
@@ -72,10 +71,10 @@ function main() {
       uploadBuildOutput(FILENAME);
     } else {
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Build ') +
-          'because this commit does not affect the runtime, build system, ' +
-          'test files, or visual diff files'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Build'),
+        'because this commit does not affect the runtime, flag configs,',
+        'integration tests, end-to-end tests, or visual diff tests.'
       );
     }
   }

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -36,30 +36,41 @@ const FILENAME = 'checks.js';
 const timedExecOrDie = (cmd, unusedFileName) =>
   timedExecOrDieBase(cmd, FILENAME);
 
-function runCommonChecks() {
-  timedExecOrDie('gulp lint');
-  timedExecOrDie('gulp presubmit');
-  timedExecOrDie('gulp ava');
-  timedExecOrDie('gulp babel-plugin-tests');
-  timedExecOrDie('gulp caches-json');
-  timedExecOrDie('gulp json-syntax');
-}
-
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
-    runCommonChecks();
+    timedExecOrDie('gulp lint');
+    timedExecOrDie('gulp presubmit');
+    timedExecOrDie('gulp ava');
+    timedExecOrDie('gulp babel-plugin-tests');
+    timedExecOrDie('gulp caches-json');
+    timedExecOrDie('gulp json-syntax');
     timedExecOrDie('gulp dev-dashboard-tests');
     timedExecOrDie('gulp dep-check');
     timedExecOrDie('gulp check-types');
   } else {
     printChangeSummary(FILENAME);
-    timedExecOrDie('gulp update-packages');
     reportAllExpectedTests(buildTargets);
-    runCommonChecks();
+    timedExecOrDie('gulp update-packages');
+
+    timedExecOrDie('gulp lint');
+    timedExecOrDie('gulp presubmit');
+
+    if (buildTargets.has('AVA')) {
+      timedExecOrDie('gulp ava');
+    }
+
+    if (buildTargets.has('BABEL_PLUGIN')) {
+      timedExecOrDie('gulp babel-plugin-tests');
+    }
+
+    if (buildTargets.has('CACHES_JSON')) {
+      timedExecOrDie('gulp caches-json');
+      timedExecOrDie('gulp json-syntax');
+    }
 
     // Check document links only for PR builds.
     if (buildTargets.has('DOCS')) {
@@ -70,7 +81,7 @@ function main() {
       timedExecOrDie('gulp dev-dashboard-tests');
     }
 
-    if (buildTargets.has('RUNTIME') || buildTargets.has('BUILD_SYSTEM')) {
+    if (buildTargets.has('RUNTIME')) {
       timedExecOrDie('gulp dep-check');
       timedExecOrDie('gulp check-types');
     }

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -44,7 +44,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
   if (
     !runYarnChecks(FILENAME) ||
     !areValidBuildTargets(buildTargets, FILENAME)
@@ -63,10 +63,8 @@ function main() {
     printChangeSummary(FILENAME);
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('UNIT_TEST') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('FLAG_CONFIG')
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
     ) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --fortesting');
@@ -75,10 +73,10 @@ function main() {
     } else {
       timedExecOrDie('gulp bundle-size --on_skipped_build');
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Dist, Bundle Size ') +
-          'because this commit does not affect the runtime, build system, ' +
-          'test files, or visual diff files'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Dist, Bundle Size'),
+        'because this commit does not affect the runtime, flag configs,',
+        'or integration tests'
       );
     }
   }

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -24,16 +24,13 @@
 
 const colors = require('ansi-colors');
 const {
-  areValidBuildTargets,
-  determineBuildTargets,
-} = require('./build-targets');
-const {
   printChangeSummary,
   startTimer,
   stopTimer,
   timedExecOrDie: timedExecOrDieBase,
   uploadDistOutput,
 } = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../travis');
 const {runYarnChecks} = require('./yarn-checks');
 
@@ -44,11 +41,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
-  if (
-    !runYarnChecks(FILENAME) ||
-    !areValidBuildTargets(buildTargets, FILENAME)
-  ) {
+  if (!runYarnChecks(FILENAME)) {
     stopTimer(FILENAME, FILENAME, startTime);
     process.exitCode = 1;
     return;
@@ -61,6 +54,13 @@ function main() {
     uploadDistOutput(FILENAME);
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    if (!determineBuildTargets(buildTargets, FILENAME)) {
+      stopTimer(FILENAME, FILENAME, startTime);
+      process.exitCode = 1;
+      return;
+    }
+
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -24,7 +24,6 @@
 const colors = require('ansi-colors');
 const {
   downloadBuildOutput,
-  downloadDistOutput,
   printChangeSummary,
   startTimer,
   stopTimer,
@@ -40,31 +39,28 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
-    downloadDistOutput(FILENAME);
+    downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp e2e --nobuild --headless');
   } else {
     printChangeSummary(FILENAME);
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('UNIT_TEST') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('BUILD_SYSTEM') ||
       buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('VISUAL_DIFF')
+      buildTargets.has('E2E_TEST')
     ) {
       downloadBuildOutput(FILENAME);
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp e2e --nobuild --headless');
     } else {
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('End to End Tests ') +
-          'because this commit does not affect the runtime, build system, ' +
-          'test files, or visual diff files'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('End to End Tests'),
+        'because this commit does not affect the runtime, flag configs,',
+        'or end-to-end tests'
       );
     }
   }

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -39,7 +39,6 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
@@ -47,6 +46,9 @@ async function main() {
     timedExecOrDie('gulp e2e --nobuild --headless');
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    determineBuildTargets(buildTargets, FILENAME);
+
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -39,7 +39,6 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
@@ -48,6 +47,8 @@ function main() {
     timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    determineBuildTargets(buildTargets, FILENAME);
 
     if (
       !buildTargets.has('RUNTIME') &&

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -39,7 +39,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
@@ -50,45 +50,37 @@ function main() {
     printChangeSummary(FILENAME);
 
     if (
-      !(
-        buildTargets.has('RUNTIME') ||
-        buildTargets.has('BUILD_SYSTEM') ||
-        buildTargets.has('UNIT_TEST') ||
-        buildTargets.has('INTEGRATION_TEST')
-      )
+      !buildTargets.has('RUNTIME') &&
+      !buildTargets.has('FLAG_CONFIG') &&
+      !buildTargets.has('UNIT_TEST') &&
+      !buildTargets.has('INTEGRATION_TEST')
     ) {
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Local Tests ') +
-          'because this commit not affect the runtime, build system, ' +
-          'unit test files, or integration test files.'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Local Tests'),
+        'because this commit not affect the runtime, flag configs,',
+        'unit tests, or integration tests.'
       );
       stopTimer(FILENAME, FILENAME, startTime);
       return;
     }
+
     downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('UNIT_TEST')
-    ) {
+
+    if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
       timedExecOrDie('gulp test --unit --nobuild --headless --local-changes');
     }
 
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
+      buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('INTEGRATION_TEST')
     ) {
       timedExecOrDie('gulp test --integration --nobuild --headless --coverage');
     }
 
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('UNIT_TEST')
-    ) {
+    if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
       timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
     }
   }

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -41,7 +41,6 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadDistOutput(FILENAME);
@@ -54,6 +53,9 @@ async function main() {
     stopSauceConnect(FILENAME);
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    determineBuildTargets(buildTargets, FILENAME);
+
     if (
       !buildTargets.has('RUNTIME') &&
       !buildTargets.has('FLAG_CONFIG') &&

--- a/build-system/pr-check/single-pass-tests.js
+++ b/build-system/pr-check/single-pass-tests.js
@@ -38,7 +38,6 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
@@ -48,6 +47,9 @@ function main() {
     );
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    determineBuildTargets(buildTargets, FILENAME);
+
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||

--- a/build-system/pr-check/single-pass-tests.js
+++ b/build-system/pr-check/single-pass-tests.js
@@ -38,20 +38,19 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --fortesting --single_pass --pseudo_names');
     timedExecOrDie(
-      'gulp test --integration ' +
-        '--nobuild --compiled --single_pass --headless'
+      'gulp test --integration --nobuild --compiled --single_pass --headless'
     );
   } else {
     printChangeSummary(FILENAME);
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
+      buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('INTEGRATION_TEST')
     ) {
       timedExecOrDie('gulp update-packages');
@@ -62,10 +61,10 @@ function main() {
       );
     } else {
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Single Pass Tests ') +
-          'because this commit does not affect the runtime, build system, ' +
-          'or integration test files.'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Single Pass Tests'),
+        'because this commit does not affect the runtime, flag configs,',
+        'or integration tests.'
       );
     }
   }

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -38,40 +38,35 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp validator');
     timedExecOrDie('gulp validator-webui');
   } else {
     printChangeSummary(FILENAME);
-    let ranTests = false;
 
     if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('VALIDATOR')
+      !buildTargets.has('RUNTIME') &&
+      !buildTargets.has('VALIDATOR') &&
+      !buildTargets.has('VALIDATOR_WEBUI')
     ) {
-      timedExecOrDie('gulp validator');
-      ranTests = true;
-    }
-
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('VALIDATOR_WEBUI')
-    ) {
-      timedExecOrDie('gulp validator-webui');
-      ranTests = true;
-    }
-
-    if (!ranTests) {
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Validator Tests ') +
-          'because this commit does not affect the runtime, build system, ' +
-          'validator, or validator web UI.'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Validator Tests'),
+        'because this commit does not affect the runtime, validator,',
+        'or validator web UI.'
       );
+      stopTimer(FILENAME, FILENAME, startTime);
+      return;
+    }
+
+    if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR')) {
+      timedExecOrDie('gulp validator');
+    }
+
+    if (buildTargets.has('VALIDATOR_WEBUI')) {
+      timedExecOrDie('gulp validator-webui');
     }
   }
 

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -40,7 +40,6 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
@@ -49,6 +48,9 @@ function main() {
     timedExecOrDie('gulp visual-diff --nobuild --master');
   } else {
     printChangeSummary(FILENAME);
+    const buildTargets = new Set();
+    determineBuildTargets(buildTargets, FILENAME);
+
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     if (
       buildTargets.has('RUNTIME') ||

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -40,7 +40,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
 
   if (!isTravisPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
@@ -52,10 +52,8 @@ function main() {
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     if (
       buildTargets.has('RUNTIME') ||
-      buildTargets.has('BUILD_SYSTEM') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('VISUAL_DIFF') ||
-      buildTargets.has('FLAG_CONFIG')
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('VISUAL_DIFF')
     ) {
       downloadBuildOutput(FILENAME);
       timedExecOrDie('gulp update-packages');
@@ -63,11 +61,10 @@ function main() {
     } else {
       timedExecOrDie('gulp visual-diff --nobuild --empty');
       console.log(
-        `${FILELOGPREFIX} Skipping ` +
-          colors.cyan('Visual Diff Tests ') +
-          'because this commit does not affect the ' +
-          'runtime, build system, integration test files, ' +
-          'visual diff test files, or flag config files.'
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Visual Diff Tests'),
+        'because this commit does not affect the runtime, flag configs,',
+        'or visual diff tests.'
       );
     }
   }

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -51,7 +51,7 @@ async function prCheck(cb) {
   };
 
   const startTime = startTimer(FILENAME, FILENAME);
-  const buildTargets = determineBuildTargets();
+  const buildTargets = determineBuildTargets(FILENAME);
   printChangeSummary(FILENAME);
 
   if (
@@ -63,13 +63,26 @@ async function prCheck(cb) {
 
   runCheck('gulp lint --local-changes');
   runCheck('gulp presubmit');
-  runCheck('gulp ava');
-  runCheck('gulp babel-plugin-tests');
-  runCheck('gulp caches-json');
-  runCheck('gulp json-syntax');
+
+  if (buildTargets.has('AVA')) {
+    runCheck('gulp ava');
+  }
+
+  if (buildTargets.has('BABEL_PLUGIN')) {
+    runCheck('gulp babel-plugin-tests');
+  }
+
+  if (buildTargets.has('CACHES_JSON')) {
+    runCheck('gulp caches-json');
+    runCheck('gulp json-syntax');
+  }
 
   if (buildTargets.has('DOCS')) {
     runCheck('gulp check-links');
+  }
+
+  if (buildTargets.has('DEV_DASHBOARD')) {
+    runCheck('gulp dev-dashboard-tests');
   }
 
   if (buildTargets.has('RUNTIME')) {
@@ -81,19 +94,23 @@ async function prCheck(cb) {
     runCheck('gulp test --unit --local-changes --headless');
   }
 
-  if (buildTargets.has('RUNTIME') || buildTargets.has('INTEGRATION_TEST')) {
+  if (
+    buildTargets.has('RUNTIME') ||
+    buildTargets.has('FLAG_CONFIG') ||
+    buildTargets.has('INTEGRATION_TEST')
+  ) {
     if (!argv.nobuild) {
       runCheck('gulp clean');
       runCheck('gulp dist --fortesting');
     }
-    runCheck('gulp test --nobuild --integration --headless');
+    runCheck('gulp test --nobuild --compiled --integration --headless');
   }
 
   if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR')) {
     runCheck('gulp validator');
   }
 
-  if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR_WEBUI')) {
+  if (buildTargets.has('VALIDATOR_WEBUI')) {
     runCheck('gulp validator-webui');
   }
 

--- a/build-system/tasks/runtime-test/status-report.js
+++ b/build-system/tasks/runtime-test/status-report.js
@@ -37,8 +37,8 @@ const TEST_TYPE_SUBTYPES = new Map([
   // TODO(danielrozenberg): add 'e2e' tests.
 ]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
-  ['integration', ['RUNTIME', 'BUILD_SYSTEM', 'INTEGRATION_TEST']],
-  ['unit', ['RUNTIME', 'BUILD_SYSTEM', 'UNIT_TEST']],
+  ['integration', ['RUNTIME', 'FLAG_CONFIG', 'INTEGRATION_TEST']],
+  ['unit', ['RUNTIME', 'UNIT_TEST']],
 ]);
 
 function inferTestType() {


### PR DESCRIPTION
This PR does the following:
- Simplifies the process by which build targets are determined
- Rolls `BUILD_SYSTEM` into `RUNTIME` (the runtime must be built and tested for all build system changes)
- Re-evaluates the checks / tests that must be run for each target (the [original logic](https://github.com/ampproject/amphtml/pull/5157/files) is outdated)
- Determines build targets only during PR builds (push builds do everything, irrespective of targets)
- Verifies build targets for all jobs in the `build` stage (to detect races where they're [valid](https://travis-ci.org/ampproject/amphtml/jobs/533964805#L314) for some jobs in a PR and [invalid](https://travis-ci.org/ampproject/amphtml/jobs/533964804#L307) for others) (reported by @gmajoulet)

Follow up to #22319
Follow up to #20921
Companion PR to #22380