### PR TITLE
🏗🐛 Fix logic used to determine the branch creation point on Travis

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -52,12 +52,12 @@ exports.gitTravisMasterBaseline = function() {
 };
 
 /**
- * Shortens a commit SHA to 7 characters for human readability.
+ * Shortens a commit SHA to 9 characters (git default) for human readability.
  * @param {string} sha 40 characters SHA.
- * @return {string} 7 characters SHA.
+ * @return {string} 9 characters SHA.
  */
 exports.shortSha = function(sha) {
-  return sha.substr(0, 7);
+  return sha.substr(0, 9);
 };
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -19,7 +19,6 @@
  * @fileoverview Provides functions for executing various git commands.
  */
 
-const colors = require('ansi-colors');
 const {
   isTravisBuild,
   isTravisPullRequestBuild,
@@ -27,8 +26,6 @@ const {
   travisPullRequestSha,
 } = require('./travis');
 const {getStdout} = require('./exec');
-
-const commitLogMaxCount = 100;
 
 /**
  * Returns the commit at which the current branch was forked off of master.
@@ -90,22 +87,17 @@ exports.gitDiffStatMaster = function() {
 
 /**
  * Returns a detailed log of commits included in a PR check, starting with (and
- * including) the branch point off of master. Limited to at most 100 commits to
- * keep the output sane.
+ * including) the branch point off of master. Limited to commits in the past
+ * 30 days to keep the output sane.
  *
  * @return {string}
  */
 exports.gitDiffCommitLog = function() {
   const branchCreationPoint = exports.gitBranchCreationPoint();
-  let commitLog = getStdout(`git -c color.ui=always log --graph \
+  const commitLog = getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
 -%C(yellow)%d%C(reset) %C(reset)%s%C(reset) %C(green)(%cr)%C(reset)" \
---abbrev-commit ${branchCreationPoint}^...HEAD \
---max-count=${commitLogMaxCount}`).trim();
-  if (commitLog.split('\n').length >= commitLogMaxCount) {
-    commitLog += `\n${colors.yellow('WARNING:')} Truncating commit log, \
-since it is longer than ${colors.cyan(commitLogMaxCount)} commits.`;
-  }
+--abbrev-commit ${branchCreationPoint}^...HEAD --since "30 days ago"`).trim();
   return commitLog;
 };
 

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -37,11 +37,9 @@ const {getStdout} = require('./exec');
 exports.gitBranchCreationPoint = function() {
   if (isTravisBuild()) {
     const traviPrSha = travisPullRequestSha();
-    const boundaryCommits = getStdout(
-      `git rev-list --boundary ${traviPrSha}...master | grep "^-"`
+    return getStdout(
+      `git rev-list --boundary ${traviPrSha}...master | grep "^-" | head -n 1 | cut -c2-`
     ).trim();
-    const firstBoundaryCommit = boundaryCommits.split('\n')[0];
-    return firstBoundaryCommit.slice(1);
   }
   return gitMergeBaseLocalMaster();
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -39,8 +39,9 @@ const commitLogMaxCount = 100;
  */
 exports.gitBranchCreationPoint = function() {
   if (isTravisBuild()) {
+    const traviPrSha = travisPullRequestSha();
     const boundaryCommits = getStdout(
-      'git rev-list --boundary HEAD...master | grep "^-"'
+      `git rev-list --boundary ${traviPrSha}...master | grep "^-"`
     ).trim();
     const firstBoundaryCommit = boundaryCommits.split('\n')[0];
     return firstBoundaryCommit.slice(1);

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -53,12 +53,12 @@ exports.gitTravisMasterBaseline = function() {
 };
 
 /**
- * Shortens a commit SHA to 9 characters (git default) for human readability.
+ * Shortens a commit SHA to 7 characters for human readability.
  * @param {string} sha 40 characters SHA.
- * @return {string} 9 characters SHA.
+ * @return {string} 7 characters SHA.
  */
 exports.shortSha = function(sha) {
-  return sha.substr(0, 9);
+  return sha.substr(0, 7);
 };
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -18,11 +18,11 @@
 const colors = require('ansi-colors');
 const requestPromise = require('request-promise');
 const {
+  gitBranchCreationPoint,
   gitBranchName,
   gitCommitHash,
   gitDiffCommitLog,
   gitDiffStatMaster,
-  gitMergeBaseMaster,
   gitTravisMasterBaseline,
   shortSha,
 } = require('../git');
@@ -71,11 +71,12 @@ function printChangeSummary(fileName) {
   const filesChanged = gitDiffStatMaster();
   console.log(filesChanged);
 
-  const branchPoint = gitMergeBaseMaster();
+  const branchCreationPoint = gitBranchCreationPoint();
   console.log(
-    `${fileLogPrefix} Commit log since branch ` +
-      `${colors.cyan(gitBranchName())} was forked from ` +
-      `${colors.cyan('master')} at ${colors.cyan(shortSha(branchPoint))}:`
+    `${fileLogPrefix} Commit log since branch`,
+    `${colors.cyan(gitBranchName())} was forked from`,
+    `${colors.cyan('master')} at`,
+    `${colors.cyan(shortSha(branchCreationPoint))}:`
   );
   console.log(gitDiffCommitLog() + '\n');
 }


### PR DESCRIPTION
There's a bug in the logic used to determine the PR branch creation point on Travis. It works for branches with a single merge point with `master`, but it breaks down when a branch has been merged multiple times.

This PR fixes the logic by listing all the common ancestors of the PR branch and `master` using [`git rev-list --boundary`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---boundary), and picking the most recent one.

For example, the PR branch in [this](https://travis-ci.org/ampproject/amphtml/jobs/533426874#L426) Travis job was forked at `57dcee4eb` after which two merge commits were done. The current logic is returning an incorrect branch point way back in the past. The new logic returns the correct branch point.

Follow up to #19954