### PR TITLE
Launch the force prerender experiment for canary and 1% of prod traffic.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -27,7 +27,7 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-date-picker": 1,
-  "amp-force-prerender-visible-elements": 1,
+  "amp-force-prerender-visible-elements": 0.01,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,
   "amp-list-load-more": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -27,6 +27,7 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-date-picker": 1,
+  "amp-force-prerender-visible-elements": 1,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,
   "amp-list-load-more": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -28,6 +28,7 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-date-picker": 1,
+  "amp-force-prerender-visible-elements": 0.01,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,
   "amp-list-load-more": 1,


### PR DESCRIPTION
Launch the `amp-force-prerender-visible-elements` experiment for canary and 1% of prod traffic.

#21791