### PR TITLE
Fixes typo in amp-access and amp-subscriptions docs

### DIFF
--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -53,7 +53,7 @@ similar features to `amp-access`. However, it supports a more specialized access
 paywall protocol. Some notable notable differences are:
 
 1. The `amp-subscriptions` entitlements response is similar to the amp-access
-authorization, but it is striclty defined and standardized.
+authorization, but it is strictly defined and standardized.
 2. The `amp-subscriptions` extension allows multiple services to be configured
 for the page to participate in access/paywall decisions. They are executed
 concurrently and prioritized based on which service returns the positive response.

--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -64,7 +64,7 @@ and in many features builds on top of `amp-access`. However, it's a much more
 specialized version of access/paywall protocol. Some of the key differences are:
 
 1. The `amp-subscriptions` entitlements response is similar to the amp-access
-authorization, but it's striclty defined and standardized.
+authorization, but it's strictly defined and standardized.
 2. The `amp-subscriptions` extension allows multiple services to be configured
 for the page to participate in access/paywall decisions. Services are executed
 concurrently and prioritized based on which service returns the positive response.


### PR DESCRIPTION
Fixes the typos pointed out in PR #19148.

/cc @dcmoore-gd @ampproject/wg-access-subscriptions 
