### PR TITLE
🏗🐛 Fixes for `gulp pr-check`

### DIFF
--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -20,7 +20,12 @@ const {
   areValidBuildTargets,
   determineBuildTargets,
 } = require('../pr-check/build-targets');
-const {printChangeSummary, timedExec} = require('../pr-check/utils');
+const {
+  printChangeSummary,
+  startTimer,
+  stopTimer,
+  timedExec,
+} = require('../pr-check/utils');
 const {runYarnChecks} = require('../pr-check/yarn-checks');
 
 const FILENAME = 'pr-check.js';
@@ -32,6 +37,7 @@ const FILENAME = 'pr-check.js';
  */
 async function prCheck(cb) {
   const failTask = () => {
+    stopTimer(FILENAME, FILENAME, startTime);
     const err = new Error('Local PR check failed. See logs above.');
     err.showStack = false;
     cb(err);
@@ -44,9 +50,10 @@ async function prCheck(cb) {
     }
   };
 
+  const startTime = startTimer(FILENAME, FILENAME);
+  const buildTargets = determineBuildTargets();
   printChangeSummary(FILENAME);
 
-  const buildTargets = determineBuildTargets();
   if (
     !runYarnChecks(FILENAME) ||
     !areValidBuildTargets(buildTargets, FILENAME)
@@ -89,6 +96,8 @@ async function prCheck(cb) {
   if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR_WEBUI')) {
     runCheck('gulp validator-webui');
   }
+
+  stopTimer(FILENAME, FILENAME, startTime);
 }
 
 module.exports = {


### PR DESCRIPTION
When a local PR check (`gulp pr-check`) fails, it prints a cryptic failure message at the end.

Changes in this PR:
- Return a proper exit status and print a message when a check fails
- Run yarn and build target checks first
- Print total running time

Split off from #22348
Addresses https://github.com/ampproject/amphtml/pull/22348#issuecomment-493554080