### PR TITLE
✨ Add referrer presence signals to the config rewriter varGroups.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/gtag.js
+++ b/extensions/amp-analytics/0.1/vendors/gtag.js
@@ -26,6 +26,8 @@ export const GTAG_CONFIG = /** @type {!JsonObject} */ ({
         'gclsrc': 'QUERY_PARAM(gclsrc)',
         'hasGcl': '$IF(QUERY_PARAM(gclid), 1, 0)',
         'hasDcl': '$IF(QUERY_PARAM(dclid), 1, 0)',
+        'hasExtRef': '$IF(EXTERNAL_REFERRER, 1, 0)',
+        'hasDocRef': '$IF(DOCUMENT_REFERRER, 1, 0)',
         'enabled': true,
       },
     },


### PR DESCRIPTION
Gtag needs to know if navigation happened from amp CDN. Existing signal for this is presence of document referrer and absence of external referrer.

