### PR TITLE
🐛 Page layout improvements

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -441,7 +441,6 @@ export class AmpStoryPage extends AMP.BaseElement {
     return Promise.all([
       this.beforeVisible(),
       this.waitForMediaLayout_(),
-      this.markPageAsLoaded_(),
       this.mediaPoolPromise_,
     ]);
   }
@@ -495,8 +494,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.addEventListener('error', resolve, true /* useCapture */);
       });
     });
-
-    return Promise.all(mediaPromises);
+    return Promise.all(mediaPromises).then(() => this.markPageAsLoaded_());
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -226,17 +226,6 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private @const {!../../../src/service/resources-impl.Resources} */
     this.resources_ = Services.resourcesForDoc(getAmpdoc(this.win.document));
 
-    const pageLoadDeferred = new Deferred();
-
-    /** @private @const {!Promise} */
-    this.pageLoadPromise_ = pageLoadDeferred.promise;
-
-    /** @private @const {!function(*)} */
-    this.pageLoadResolveFn_ = pageLoadDeferred.resolve;
-
-    /** @private @const {!function(*)} */
-    this.pageLoadRejectFn_ = pageLoadDeferred.reject;
-
     const deferred = new Deferred();
 
     /** @private @const {!Promise<!MediaPool>} */
@@ -444,15 +433,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.waitForMediaLayout_().then(
-      () => {
-        this.pageLoadResolveFn_(this.markPageAsLoaded_());
-      },
-      reason => {
-        this.pageLoadRejectFn_(reason);
-      }
-    );
-
     upgradeBackgroundAudio(this.element);
     this.muteAllMedia();
     this.getViewport().onResize(
@@ -460,8 +440,8 @@ export class AmpStoryPage extends AMP.BaseElement {
     );
     return Promise.all([
       this.beforeVisible(),
+      this.waitForMediaLayout_,
       this.mediaPoolPromise_,
-      this.pageLoadPromise_,
     ]);
   }
 
@@ -577,11 +557,6 @@ export class AmpStoryPage extends AMP.BaseElement {
         debouncePrepareForAnimation(el, null /* unlisten */);
       }
     });
-  }
-
-  /** @return {!Promise} */
-  whenLoaded() {
-    return this.pageLoadPromise_;
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -440,7 +440,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     );
     return Promise.all([
       this.beforeVisible(),
-      this.waitForMediaLayout_,
+      this.waitForMediaLayout_(),
       this.mediaPoolPromise_,
     ]);
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -441,6 +441,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     return Promise.all([
       this.beforeVisible(),
       this.waitForMediaLayout_(),
+      this.markPageAsLoaded_(),
       this.mediaPoolPromise_,
     ]);
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -229,10 +229,8 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private @const {!Promise} */
     this.mediaLayoutPromise_ = this.waitForMediaLayout_();
 
-    /** @private @const {!Promise} */
-    this.pageLoadPromise_ = this.mediaLayoutPromise_.then(() => {
-      this.markPageAsLoaded_();
-    });
+    /** @private @const {?Promise} */
+    this.pageLoadPromise_ = null;
 
     const deferred = new Deferred();
 
@@ -300,6 +298,9 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.pageLoadPromise_ = this.mediaLayoutPromise_.then(() => {
+      this.markPageAsLoaded_();
+    });
     this.delegateVideoAutoplay();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -71,6 +71,12 @@ import {toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
 
 /**
+ * CSS class for an amp-story-page that indicates the entire page is loaded.
+ * @const {string}
+ */
+const PAGE_LOADED_CLASS_NAME = 'i-amphtml-story-page-loaded';
+
+/**
  * Selectors for media elements.
  * Only get the page media: direct children of amp-story-page (ie:
  * background-audio), or descendant of amp-story-grid-layer. That excludes media
@@ -488,7 +494,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.addEventListener('error', resolve, true /* useCapture */);
       });
     });
-    return Promise.all(mediaPromises);
+    return Promise.all(mediaPromises).then(() => this.markPageAsLoaded_());
   }
 
   /**
@@ -549,6 +555,20 @@ export class AmpStoryPage extends AMP.BaseElement {
         // Run in case target never changes size.
         debouncePrepareForAnimation(el, null /* unlisten */);
       }
+    });
+  }
+
+  /** @private */
+  markPageAsLoaded_() {
+    dispatch(
+      this.win,
+      this.element,
+      EventType.PAGE_LOADED,
+      /* payload */ undefined,
+      {bubbles: true}
+    );
+    this.mutateElement(() => {
+      this.element.classList.add(PAGE_LOADED_CLASS_NAME);
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -71,12 +71,6 @@ import {toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
 
 /**
- * CSS class for an amp-story-page that indicates the entire page is loaded.
- * @const {string}
- */
-const PAGE_LOADED_CLASS_NAME = 'i-amphtml-story-page-loaded';
-
-/**
  * Selectors for media elements.
  * Only get the page media: direct children of amp-story-page (ie:
  * background-audio), or descendant of amp-story-grid-layer. That excludes media
@@ -494,7 +488,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         mediaEl.addEventListener('error', resolve, true /* useCapture */);
       });
     });
-    return Promise.all(mediaPromises).then(() => this.markPageAsLoaded_());
+    return Promise.all(mediaPromises);
   }
 
   /**
@@ -555,20 +549,6 @@ export class AmpStoryPage extends AMP.BaseElement {
         // Run in case target never changes size.
         debouncePrepareForAnimation(el, null /* unlisten */);
       }
-    });
-  }
-
-  /** @private */
-  markPageAsLoaded_() {
-    dispatch(
-      this.win,
-      this.element,
-      EventType.PAGE_LOADED,
-      /* payload */ undefined,
-      {bubbles: true}
-    );
-    this.mutateElement(() => {
-      this.element.classList.add(PAGE_LOADED_CLASS_NAME);
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -226,10 +226,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private @const {!../../../src/service/resources-impl.Resources} */
     this.resources_ = Services.resourcesForDoc(getAmpdoc(this.win.document));
 
-    /** @private @const {!Promise} */
-    this.mediaLayoutPromise_ = this.waitForMediaLayout_();
+    /** @private {?Promise} */
+    this.mediaLayoutPromise_ = null;
 
-    /** @private @const {?Promise} */
+    /** @private {?Promise} */
     this.pageLoadPromise_ = null;
 
     const deferred = new Deferred();
@@ -298,9 +298,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.pageLoadPromise_ = this.mediaLayoutPromise_.then(() => {
-      this.markPageAsLoaded_();
-    });
     this.delegateVideoAutoplay();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
@@ -442,6 +439,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    this.mediaLayoutPromise_ = this.waitForMediaLayout_();
+    this.pageLoadPromise_ = this.mediaLayoutPromise_.then(() => {
+      this.markPageAsLoaded_();
+    });
     upgradeBackgroundAudio(this.element);
     this.muteAllMedia();
     this.getViewport().onResize(
@@ -568,7 +569,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     });
   }
 
-  /** @return {!Promise} */
+  /** @return {?Promise} */
   whenLoaded() {
     return this.pageLoadPromise_;
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1052,7 +1052,9 @@ export class AmpStory extends AMP.BaseElement {
         : [this.pages_[0]];
 
     const storyLoadPromise = Promise.all(
-      pagesToWaitFor.filter(page => !!page).map(page => page.whenLoaded())
+      pagesToWaitFor
+        .filter(page => !!page)
+        .map(page => page.element.signals().whenSignal(CommonSignals.LOAD_END))
     );
 
     return this.timer_
@@ -2214,8 +2216,9 @@ export class AmpStory extends AMP.BaseElement {
     // Once the media pool is ready, registers and preloads the background
     // audio, and then gets the swapped element from the DOM to mute/unmute/play
     // it programmatically later.
-    this.activePage_
-      .whenLoaded()
+    this.activePage_.element
+      .signals()
+      .whenSignal(CommonSignals.LOAD_END)
       .then(() => {
         backgroundAudioEl = /** @type {!HTMLMediaElement} */ (backgroundAudioEl);
         this.mediaPool_.register(backgroundAudioEl);

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -115,17 +115,6 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     });
   });
 
-  it('should mark page as loaded after media is loaded', () => {
-    const waitForMediaLayoutSpy = sandbox.spy(page, 'waitForMediaLayout_');
-    const markPageAsLoadedSpy = sandbox.spy(page, 'markPageAsLoaded_');
-    page.buildCallback();
-    return page.layoutCallback().then(() => {
-      expect(markPageAsLoadedSpy).to.have.been.calledAfter(
-        waitForMediaLayoutSpy
-      );
-    });
-  });
-
   it('should start the animations if needed when state becomes active', () => {
     // Adding an element that has to be animated.
     const animatedEl = win.document.createElement('div');

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -115,6 +115,17 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     });
   });
 
+  it('should mark page as loaded after media is loaded', () => {
+    const waitForMediaLayoutSpy = sandbox.spy(page, 'waitForMediaLayout_');
+    const markPageAsLoadedSpy = sandbox.spy(page, 'markPageAsLoaded_');
+    page.buildCallback();
+    return page.layoutCallback().then(() => {
+      expect(markPageAsLoadedSpy).to.have.been.calledAfter(
+        waitForMediaLayoutSpy
+      );
+    });
+  });
+
   it('should start the animations if needed when state becomes active', () => {
     // Adding an element that has to be animated.
     const animatedEl = win.document.createElement('div');

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -107,6 +107,14 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     });
   });
 
+  it('should call waitForMedia after layoutCallback resolves', () => {
+    const spy = sandbox.spy(page, 'waitForMediaLayout_');
+    page.buildCallback();
+    return page.layoutCallback().then(() => {
+      expect(spy).to.have.been.calledOnce;
+    });
+  });
+
   it('should start the animations if needed when state becomes active', () => {
     // Adding an element that has to be animated.
     const animatedEl = win.document.createElement('div');

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -26,6 +26,7 @@ import {ActionTrust} from '../../../../src/action-constants';
 import {AmpStory} from '../amp-story';
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryConsent} from '../amp-story-consent';
+import {CommonSignals} from '../../../../src/common-signals';
 import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../../../../src/service/localization';
 import {MediaType} from '../media-pool';
@@ -939,12 +940,19 @@ describes.realWin(
           .resolves();
 
         createPages(story.element, 2, ['cover', 'page-1']);
-        return story.layoutCallback().then(() => {
-          expect(story.backgroundAudioEl_).to.exist;
-          expect(story.backgroundAudioEl_.src).to.equal(src);
-          expect(registerStub).to.have.been.calledOnce;
-          expect(preloadStub).to.have.been.calledOnce;
-        });
+        story
+          .layoutCallback()
+          .then(() =>
+            story.activePage_.element
+              .signals()
+              .whenSignal(CommonSignals.LOAD_END)
+          )
+          .then(() => {
+            expect(story.backgroundAudioEl_).to.exist;
+            expect(story.backgroundAudioEl_.src).to.equal(src);
+            expect(registerStub).to.have.been.calledOnce;
+            expect(preloadStub).to.have.been.calledOnce;
+          });
       });
 
       it('should bless the media on unmute', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -66,6 +66,9 @@ describes.realWin(
         .map((unused, i) => {
           const page = win.document.createElement('amp-story-page');
           page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
+          page.signals = () => ({
+            whenSignal: () => Promise.resolve(),
+          });
           container.appendChild(page);
           return page;
         });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -66,9 +66,6 @@ describes.realWin(
         .map((unused, i) => {
           const page = win.document.createElement('amp-story-page');
           page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
-          page.signals = () => ({
-            whenSignal: () => Promise.resolve(),
-          });
           container.appendChild(page);
           return page;
         });
@@ -942,7 +939,6 @@ describes.realWin(
           .resolves();
 
         createPages(story.element, 2, ['cover', 'page-1']);
-
         return story.layoutCallback().then(() => {
           expect(story.backgroundAudioEl_).to.exist;
           expect(story.backgroundAudioEl_.src).to.equal(src);


### PR DESCRIPTION
Related to #21714

Moves `waitForMediaLayout` to `AmpStoryPage#layoutCallback` and replaces `AmpStoryPage#whenLoaded` with `CommonSignals.LOAD_END`.

`markPageAsLoaded_` is running in AmpStoryPage's constructor and it's causing errors when trying to append a new page with the LiveListManager. This is because `markPageAsLoaded` uses `resources`, but `resources` is not present for elements that haven't been attached to the DOM yet.

In the case of LiveListManager, the page is first initialized by calling `importNode`, and then it's appended to the DOM at a later time.

We can use this opportunity to get rid of the custom `whenLoaded` event in AmpStoryPage, and to use the standard `whenSignals(CommonSignals.LOAD_END)`.




