### PR TITLE
♻️Added comment on generating `.out` files for validator

### DIFF
--- a/ads/beaverads.js
+++ b/ads/beaverads.js
@@ -23,13 +23,19 @@ import {loadScript, validateData} from '../3p/3p';
 export function beaverads(global, data) {
   validateData(data, ['blockId']);
 
-  const url = 'https://code.beaverads.com/data/' +
-      encodeURIComponent(data['blockId']) + '.js?async=1&div=c';
+  const url =
+    'https://code.beaverads.com/data/' +
+    encodeURIComponent(data['blockId']) +
+    '.js?async=1&div=c';
 
-  loadScript(global, url, () => {
-    global.context.renderStart();
-  }, () => {
-    global.context.noContentAvailable();
-  });
-
+  loadScript(
+    global,
+    url,
+    () => {
+      global.context.renderStart();
+    },
+    () => {
+      global.context.noContentAvailable();
+    }
+  );
 }

--- a/contributing/component-validator-rules.md
+++ b/contributing/component-validator-rules.md
@@ -457,7 +457,7 @@ Optionally, you may add more than one valid variant and/or invalid examples.
 
 ## Test Output files
 
-After creating your validator html file, You need to create the corresponding `.out` file to act as your test results which is used to verify if the validator is still validating correctly for your extension. Todo this, navigate to the root of the project, `amphtml/` and run `gulp validator --update_tests`. This shoudl generate a matching `.out` file, and for this example, it would be:
+After creating your validator html file, You need to create the corresponding `.out` file to act as your test results. These are used to verify if the validator is validating your extension correctly. To do this, navigate to the root of the project, `amphtml/` and run `gulp validator --update_tests`. This should generate a matching `.out` file, and for this example, it would be:
 
 <pre>
 amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>

--- a/contributing/component-validator-rules.md
+++ b/contributing/component-validator-rules.md
@@ -457,9 +457,13 @@ Optionally, you may add more than one valid variant and/or invalid examples.
 
 ## Test Output files
 
-For each test file, also add a matching output file which will display the
-validator output for the test case. If you only added valid examples, this file
-should contain a single line:
+After creating your validator html file, You need to create the corresponding `.out` file to act as your test results which is used to verify if the validator is still validating correctly for your extension. Todo this, navigate to the root of the project, `amphtml/` and run `gulp validator --update_tests`. This shoudl generate a matching `.out` file, and for this example, it would be:
+
+<pre>
+amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
+</pre>
+
+After generating the `.out` file, you should check it's contents that it gives the correct validation results/errors. If you only added valid examples, this file should contain a single line:
 
 ```
 PASS


### PR DESCRIPTION
closes #22373 

I noticed we need to run `gulp validator --update_tests` to update our `.out` files for tests when building #22176 . Thus, I mentioned it in the docs 😄 