### PR TITLE
🐛Fix variable service race.

### DIFF
--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -21,6 +21,7 @@ import {dict} from '../../../src/utils/object';
 import {getConsentPolicyState} from '../../../src/consent';
 import {
   getServiceForDoc,
+  getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
 import {isArray, isFiniteNumber} from '../../../src/types';
@@ -315,6 +316,17 @@ export function installVariableServiceForTesting(ampdoc) {
  */
 export function variableServiceForDoc(elementOrAmpDoc) {
   return getServiceForDoc(elementOrAmpDoc, 'amp-analytics-variables');
+}
+
+/**
+ * @param {!Element|!ShadowRoot|!../../../src/service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+ * @return {!Promise<!VariableService>}
+ */
+export function variableServicePromiseForDoc(elementOrAmpDoc) {
+  return /** @type {!Promise<!VariableService>} */ (getServicePromiseForDoc(
+    elementOrAmpDoc,
+    'amp-analytics-variables'
+  ));
 }
 
 /**


### PR DESCRIPTION
Introduced _another_ bug in #22300. When loading new amp docs into shadow shell shell service registration is asynchronous, but I was trying to retrieve the service synchronously. This changes amp-analytics to wait for a promise of this service.

All other analytics files can continue to use the sync method as their creating analytics element will have waited for promise to resolve.