### PR TITLE
Remove duplicated polyfill import.

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -20,9 +20,6 @@
  * Invariant: Service getters never return null for registered services.
  */
 
-// src/polyfills.js must be the first import.
-import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
-
 import {Deferred} from './utils/promise';
 import {dev, devAssert} from './log';
 import {toWin} from './types';

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// Requires polyfills in immediate side effect.
-import '../polyfills';
-
 import {installServiceInEmbedScope, registerServiceBuilder} from '../service';
 import {reportError} from '../error';
 import {user} from '../log';


### PR DESCRIPTION
Are they intentionally imported?

timer-impl.js is only compiled in main binary, so removing the import should be a no-op.

polyfill in service.js gets browserified in every extension, while closure compiler is smart enough to strip them off from each extension.