### PR TITLE
Resolve macros in VariableService.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -922,7 +922,7 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-analytics/0.1/config.js',
       'extensions/amp-analytics/0.1/cookie-writer.js',
       'extensions/amp-analytics/0.1/requests.js',
-      'extensions/amp-analytics/0.1/varibles.js',
+      'extensions/amp-analytics/0.1/variables.js',
     ],
   },
   '\\.expandInputValueSync\\(': {

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -922,6 +922,7 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-analytics/0.1/config.js',
       'extensions/amp-analytics/0.1/cookie-writer.js',
       'extensions/amp-analytics/0.1/requests.js',
+      'extensions/amp-analytics/0.1/varibles.js',
     ],
   },
   '\\.expandInputValueSync\\(': {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -288,8 +288,8 @@ export class AmpAnalytics extends AMP.BaseElement {
         const expansionOptions = this.expansionOptions_(
           dict({}),
           trigger,
-          undefined,
-          true
+          undefined /* opt_iterations */,
+          true /* opt_noEncode */
         );
         const TAG = this.getName_();
         if (!trigger) {
@@ -346,7 +346,11 @@ export class AmpAnalytics extends AMP.BaseElement {
             } else if (trigger['selector']) {
               // Expand the selector using variable expansion.
               return this.variableService_
-                .expandTemplate(trigger['selector'], expansionOptions)
+                .expandTemplate(
+                  trigger['selector'],
+                  expansionOptions,
+                  this.element
+                )
                 .then(selector => {
                   trigger['selector'] = selector;
                   this.addTrigger_(trigger);
@@ -733,7 +737,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    */
   expandTemplateWithUrlParams_(spec, expansionOptions) {
     return this.variableService_
-      .expandTemplate(spec, expansionOptions)
+      .expandTemplate(spec, expansionOptions, this.element)
       .then(key =>
         Services.urlReplacementsForDoc(this.element).expandUrlAsync(
           key,

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -222,7 +222,7 @@ export class LinkerManager {
   expandTemplateWithUrlParams_(template, expansionOptions) {
     const bindings = this.variableService_.getMacros(this.element_);
     return this.variableService_
-      .expandTemplate(template, expansionOptions)
+      .expandTemplate(template, expansionOptions, this.element_)
       .then(expanded => {
         const urlReplacements = Services.urlReplacementsForDoc(this.element_);
         return urlReplacements.expandUrlAsync(expanded, bindings);

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -164,7 +164,11 @@ export class RequestHandler {
 
       this.requestOriginPromise_ = this.variableService_
         // expand variables in request origin
-        .expandTemplate(this.requestOrigin_, requestOriginExpansionOpt)
+        .expandTemplate(
+          this.requestOrigin_,
+          requestOriginExpansionOpt,
+          this.element_
+        )
         // substitute in URL values e.g. DOCUMENT_REFERRER -> https://example.com
         .then(expandedRequestOrigin => {
           return this.urlReplacementService_.expandUrlAsync(

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -129,7 +129,6 @@ export class RequestHandler {
     this.lastTrigger_ = trigger;
     const bindings = this.variableService_.getMacros(this.element_);
     bindings['RESOURCE_TIMING'] = getResourceTiming(
-      this.ampdoc_,
       this.element_,
       trigger['resourceTimingSpec'],
       this.startTime_

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -140,7 +140,9 @@ export class RequestHandler {
       this.baseUrlTemplatePromise_ = this.variableService_.expandTemplate(
         this.baseUrl,
         expansionOption,
-        this.element_
+        this.element_,
+        bindings,
+        this.whiteList_
       );
 
       this.baseUrlPromise_ = this.baseUrlTemplatePromise_.then(baseUrl => {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -130,6 +130,7 @@ export class RequestHandler {
     const bindings = this.variableService_.getMacros(this.element_);
     bindings['RESOURCE_TIMING'] = getResourceTiming(
       this.ampdoc_,
+      this.element_,
       trigger['resourceTimingSpec'],
       this.startTime_
     );
@@ -139,7 +140,8 @@ export class RequestHandler {
 
       this.baseUrlTemplatePromise_ = this.variableService_.expandTemplate(
         this.baseUrl,
-        expansionOption
+        expansionOption,
+        this.element_
       );
 
       this.baseUrlPromise_ = this.baseUrlTemplatePromise_.then(baseUrl => {
@@ -182,6 +184,7 @@ export class RequestHandler {
       params,
       expansionOption,
       bindings,
+      this.element_,
       this.whiteList_
     ).then(params => {
       return dict({
@@ -410,7 +413,7 @@ export function expandPostMessage(
   expansionOption.freezeVar('extraUrlParams');
 
   const basePromise = variableService
-    .expandTemplate(msg, expansionOption)
+    .expandTemplate(msg, expansionOption, element)
     .then(base => {
       return urlReplacementService.expandStringAsync(base, bindings);
     });
@@ -427,7 +430,8 @@ export function expandPostMessage(
       urlReplacementService,
       params,
       expansionOption,
-      bindings
+      bindings,
+      element
     ).then(extraUrlParams => {
       return defaultSerializer(expandedMsg, [
         dict({'extraUrlParams': extraUrlParams}),
@@ -443,6 +447,7 @@ export function expandPostMessage(
  * @param {!Object} params
  * @param {!./variables.ExpansionOptions} expansionOption
  * @param {!Object} bindings
+ * @param {!Element} element
  * @param {!Object=} opt_whitelist
  * @return {!Promise<!Object>}
  * @private
@@ -453,6 +458,7 @@ function expandExtraUrlParams(
   params,
   expansionOption,
   bindings,
+  element,
   opt_whitelist
 ) {
   const requestPromises = [];
@@ -469,7 +475,7 @@ function expandExtraUrlParams(
 
     if (typeof value === 'string') {
       const request = variableService
-        .expandTemplate(value, option)
+        .expandTemplate(value, option, element)
         .then(value =>
           urlReplacements.expandStringAsync(value, bindings, opt_whitelist)
         )

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -168,7 +168,9 @@ export class RequestHandler {
         .expandTemplate(
           this.requestOrigin_,
           requestOriginExpansionOpt,
-          this.element_
+          this.element_,
+          bindings,
+          this.whiteList_
         )
         // substitute in URL values e.g. DOCUMENT_REFERRER -> https://example.com
         .then(expandedRequestOrigin => {

--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -244,21 +244,21 @@ function filterEntries(entries, resourceDefs) {
  * single string.
  * @param {!Array<!PerformanceResourceTiming>} entries
  * @param {!JsonObject} resourceTimingSpec
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element amp-analytics element.
  * @return {!Promise<string>}
  */
-function serialize(entries, resourceTimingSpec, ampdoc) {
+function serialize(entries, resourceTimingSpec, element) {
   const resources = resourceTimingSpec['resources'];
   const encoding = resourceTimingSpec['encoding'];
 
-  const variableService = variableServiceForDoc(ampdoc);
+  const variableService = variableServiceForDoc(element);
   const format = (val, relativeTo = 0) =>
     Math.round(val - relativeTo).toString(encoding['base'] || 10);
 
   const promises = filterEntries(entries, resources)
     .map(({entry, name}) => entryToExpansionOptions(entry, name, format))
     .map(expansion =>
-      variableService.expandTemplate(encoding['entry'], expansion)
+      variableService.expandTemplate(encoding['entry'], expansion, element)
     );
   return Promise.all(promises).then(vars => vars.join(encoding['delim']));
 }
@@ -266,10 +266,11 @@ function serialize(entries, resourceTimingSpec, ampdoc) {
 /**
  * Serializes resource timing entries according to the resource timing spec.
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element amp-analytics element.
  * @param {!JsonObject} resourceTimingSpec
  * @return {!Promise<string>}
  */
-function serializeResourceTiming(ampdoc, resourceTimingSpec) {
+function serializeResourceTiming(ampdoc, element, resourceTimingSpec) {
   const {win} = ampdoc;
   // Check that the performance timing API exists before and that the spec is
   // valid before proceeding. If not, we simply return an empty string.
@@ -304,19 +305,20 @@ function serializeResourceTiming(ampdoc, resourceTimingSpec) {
     return Promise.resolve('');
   }
   // Yield the thread in case iterating over all resources takes a long time.
-  return yieldThread(() => serialize(entries, resourceTimingSpec, ampdoc));
+  return yieldThread(() => serialize(entries, resourceTimingSpec, element));
 }
 
 /**
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element amp-analytics element.
  * @param {!JsonObject|undefined} spec resource timing spec.
  * @param {number} startTime start timestamp.
  * @return {!Promise<string>}
  */
-export function getResourceTiming(ampdoc, spec, startTime) {
+export function getResourceTiming(ampdoc, element, spec, startTime) {
   // Only allow collecting timing within 1s
   if (spec && Date.now() < startTime + 60 * 1000) {
-    return serializeResourceTiming(ampdoc, spec);
+    return serializeResourceTiming(ampdoc, element, spec);
   } else {
     return Promise.resolve('');
   }

--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -265,13 +265,12 @@ function serialize(entries, resourceTimingSpec, element) {
 
 /**
  * Serializes resource timing entries according to the resource timing spec.
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!Element} element amp-analytics element.
  * @param {!JsonObject} resourceTimingSpec
  * @return {!Promise<string>}
  */
-function serializeResourceTiming(ampdoc, element, resourceTimingSpec) {
-  const {win} = ampdoc;
+function serializeResourceTiming(element, resourceTimingSpec) {
+  const {win} = element.getAmpDoc();
   // Check that the performance timing API exists before and that the spec is
   // valid before proceeding. If not, we simply return an empty string.
   if (
@@ -309,16 +308,15 @@ function serializeResourceTiming(ampdoc, element, resourceTimingSpec) {
 }
 
 /**
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!Element} element amp-analytics element.
  * @param {!JsonObject|undefined} spec resource timing spec.
  * @param {number} startTime start timestamp.
  * @return {!Promise<string>}
  */
-export function getResourceTiming(ampdoc, element, spec, startTime) {
+export function getResourceTiming(element, spec, startTime) {
   // Only allow collecting timing within 1s
   if (spec && Date.now() < startTime + 60 * 1000) {
-    return serializeResourceTiming(ampdoc, element, spec);
+    return serializeResourceTiming(element, spec);
   } else {
     return Promise.resolve('');
   }

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -794,20 +794,6 @@ describes.realWin(
         ':not(p)',
         'p:nth-child(2)',
       ].map(selectorExpansionTest);
-
-      it('does not expands selector with platform variable', () => {
-        const tracker = ins.root_.getTracker('click', ClickEventTracker);
-        const addStub = sandbox.stub(tracker, 'add');
-        const analytics = getAnalyticsTag({
-          requests: {foo: 'https://example.com/bar'},
-          triggers: [{on: 'click', selector: '${title}', request: 'foo'}],
-        });
-        return waitForNoSendRequest(analytics).then(() => {
-          expect(addStub).to.be.calledOnce;
-          const config = addStub.args[0][2];
-          expect(config['selector']).to.equal('TITLE');
-        });
-      });
     });
 
     describe('optout by function', () => {

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -190,7 +190,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     windowInterface.getUserLanguage.returns('en-US');
     sandbox.useFakeTimers(1533329483292);
     sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
-    doc.title = 'TEST TITLE';
+    doc.title = 'TEST PAGE';
     const config = {
       linkers: {
         enabled: true,
@@ -219,7 +219,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       const finalUrl =
         'https://www.source.com/dest' +
         '?a=1' +
-        '&testLinker1=1*1pgvkob*_key*VEVTVCUyMFRJVExF*gclid*MjM0' +
+        '&testLinker1=1*15chdxd*_key*VEVTVCBQQUdF*gclid*MjM0' +
         '&testLinker2=1*1u4ugj3*foo*YmFy';
       expect(clickAnchor(origUrl)).to.equal(finalUrl);
       expect(navigateTo(origUrl)).to.equal(finalUrl);

--- a/extensions/amp-analytics/0.1/test/test-resource-timing.js
+++ b/extensions/amp-analytics/0.1/test/test-resource-timing.js
@@ -103,20 +103,19 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     expectedResult
   ) {
     sandbox.stub(win.performance, 'getEntriesByType').returns(fakeEntries);
-    return getResourceTiming(
-      ampdoc,
-      element,
-      resourceTimingSpec,
-      Date.now()
-    ).then(result => {
-      expect(result).to.equal(expectedResult);
-    });
+    return getResourceTiming(element, resourceTimingSpec, Date.now()).then(
+      result => {
+        expect(result).to.equal(expectedResult);
+      }
+    );
   };
 
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
-    element = env.win.document.documentElement;
+    element = document.createElement('amp-analytics');
+    element.getAmpDoc = () => ampdoc;
+    env.win.document.body.appendChild(element);
     installVariableServiceForTesting(ampdoc);
     installLinkerReaderService(win);
   });
@@ -614,13 +613,13 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     const spec = newResourceTimingSpec();
     spec['encoding']['entry'] = '${initiatorType}.${startTime}.${duration}';
 
-    return getResourceTiming(ampdoc, element, spec, Date.now())
+    return getResourceTiming(element, spec, Date.now())
       .then(result => {
         expect(result).to.equal('link.100.400');
         expect(spec['responseAfter']).to.equal(600);
 
         // Check resource timings a second time.
-        return getResourceTiming(ampdoc, element, spec, Date.now());
+        return getResourceTiming(element, spec, Date.now());
       })
       .then(result => {
         expect(result).to.equal('script.200.500');

--- a/extensions/amp-analytics/0.1/test/test-resource-timing.js
+++ b/extensions/amp-analytics/0.1/test/test-resource-timing.js
@@ -89,6 +89,7 @@ export function newPerformanceResourceTiming(
 describes.realWin('resourceTiming', {amp: true}, env => {
   let win;
   let ampdoc;
+  let element;
 
   /**
    * @param {!Array<!PerformanceResourceTiming} fakeEntries
@@ -102,35 +103,45 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     expectedResult
   ) {
     sandbox.stub(win.performance, 'getEntriesByType').returns(fakeEntries);
-    return getResourceTiming(ampdoc, resourceTimingSpec, Date.now()).then(
-      result => {
-        expect(result).to.equal(expectedResult);
-      }
-    );
+    return getResourceTiming(
+      ampdoc,
+      element,
+      resourceTimingSpec,
+      Date.now()
+    ).then(result => {
+      expect(result).to.equal(expectedResult);
+    });
   };
 
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
+    element = env.win.document.documentElement;
     installVariableServiceForTesting(ampdoc);
     installLinkerReaderService(win);
   });
 
   it('should return empty if the performance API is not supported', () => {
-    return getResourceTiming(ampdoc, newResourceTimingSpec(), Date.now()).then(
-      result => {
-        expect(result).to.equal('');
-      }
-    );
+    return getResourceTiming(
+      ampdoc,
+      element,
+      newResourceTimingSpec(),
+      Date.now()
+    ).then(result => {
+      expect(result).to.equal('');
+    });
   });
 
   it('should return empty when resource timing is not supported', () => {
     // Performance API (ampdoc.performance) doesn't support resource timing.
-    return getResourceTiming(ampdoc, newResourceTimingSpec(), Date.now()).then(
-      result => {
-        expect(result).to.equal('');
-      }
-    );
+    return getResourceTiming(
+      ampdoc,
+      element,
+      newResourceTimingSpec(),
+      Date.now()
+    ).then(result => {
+      expect(result).to.equal('');
+    });
   });
 
   it('should return empty when start time has passed 1s', () => {
@@ -144,9 +155,11 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     );
     const spec = newResourceTimingSpec();
     sandbox.stub(win.performance, 'getEntriesByType').returns([entry]);
-    return getResourceTiming(win, spec, Date.now() - 60 * 1000).then(result => {
-      expect(result).to.equal('');
-    });
+    return getResourceTiming(win, element, spec, Date.now() - 60 * 1000).then(
+      result => {
+        expect(result).to.equal('');
+      }
+    );
   });
 
   it('should return empty if resourceTimingSpec is empty', () => {
@@ -601,13 +614,13 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     const spec = newResourceTimingSpec();
     spec['encoding']['entry'] = '${initiatorType}.${startTime}.${duration}';
 
-    return getResourceTiming(ampdoc, spec, Date.now())
+    return getResourceTiming(ampdoc, element, spec, Date.now())
       .then(result => {
         expect(result).to.equal('link.100.400');
         expect(spec['responseAfter']).to.equal(600);
 
         // Check resource timings a second time.
-        return getResourceTiming(ampdoc, spec, Date.now());
+        return getResourceTiming(ampdoc, element, spec, Date.now());
       })
       .then(result => {
         expect(result).to.equal('script.200.500');

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -109,6 +109,14 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       return check('MACRO(a,b)', 'MACRO(a,b)', {});
     });
 
+    it('does not handle nested macros using ${} syntax', () => {
+      // VariableService.expandTemplate's regex cannot parse nested ${}.
+      return check('${a${b}}', '}', {
+        'a': 'TITLE',
+        'b': 'TITLE',
+      });
+    });
+
     it('supports macro args', () =>
       check('${foo}', 'AAA(BBB(1))', {
         'foo': 'AAA(BBB(1))',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -28,6 +28,8 @@ import {
   linkerReaderServiceFor,
 } from '../linker-reader';
 
+const fakeElement = document.documentElement;
+
 describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
   let variables;
 
@@ -59,11 +61,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     };
 
     function check(template, expected, vars) {
-      const actual = variables.expandTemplateSync(
+      const actual = variables.expandTemplate(
         template,
-        new ExpansionOptions(vars)
+        new ExpansionOptions(vars),
+        fakeElement
       );
-      expect(actual).to.equal(expected);
+      expect(actual).to.eventually.equal(expected);
     }
 
     it('expands nested vars (encode once)', () => {
@@ -71,11 +74,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     });
 
     it('expands nested vars (no encode)', () => {
-      const actual = variables.expandTemplateSync(
+      const actual = variables.expandTemplate(
         '${a}',
-        new ExpansionOptions(vars, undefined, true)
+        new ExpansionOptions(vars, undefined, true),
+        fakeElement
       );
-      expect(actual).to.equal('https://www.google.com/a?b=1&c=2');
+      expect(actual).to.eventually.equal('https://www.google.com/a?b=1&c=2');
     });
 
     it('expands complicated string', () => {
@@ -132,11 +136,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         'freeze': 'error',
       });
       vars.freezeVar('freeze');
-      const actual = variables.expandTemplateSync(
+      const actual = variables.expandTemplate(
         '${fooParam(foo,bar)}${nonfreeze}${freeze}',
-        vars
+        vars,
+        fakeElement
       );
-      expect(actual).to.equal('QUERY_PARAM(foo,bar)${freeze}');
+      expect(actual).to.eventually.equal('QUERY_PARAM(foo,bar)${freeze}');
     });
 
     it('expands array vars', () => {
@@ -178,11 +183,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         expectAsyncConsoleError(
           /Maximum depth reached while expanding variables/
         );
-        const actual = variables.expandTemplateSync(
+        const actual = variables.expandTemplate(
           '${1}',
-          new ExpansionOptions(recursiveVars, 5)
+          new ExpansionOptions(recursiveVars, 5),
+          fakeElement
         );
-        expect(actual).to.equal('123412%24%7B3%7D');
+        expect(actual).to.eventually.equal('123412%24%7B3%7D');
       });
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -115,6 +115,9 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       })
         .then(() =>
           // TODO: fix this, should be 'AAA(BBB(1,2))'
+          // This is a resutl of `getNameArgs` strange behavior. Leaving here as
+          // pseudo documentation. We mostly avoid this problem, as now we expand any
+          // valid macros when they are seen in `Variables#expandTemplate`.
           check('${foo}', 'AAA(BBB(1%2C2))', {
             'foo': 'AAA(BBB(1,2))',
           })
@@ -126,7 +129,8 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
           })
         )
         .then(() =>
-          // TODO: fix this, should be 'AAA(1,2)%26BBB(3,4)%26CCC(5,6)%26DDD(7,8)'
+          // TODO: fix this, should be 'AAA(1,2)%26BBB(3,4)%26CCC(5,6)%26DDD(7,8)
+          // See comment about getNameArgs above.
           check('${all}', 'AAA(1%2C2)%26BBB(3%2C4)%26CCC(5%2C6)%26DDD(7,8)', {
             'a': 'AAA',
             'b': 'BBB',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -114,8 +114,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         'foo': 'AAA(BBB(1))',
       })
         .then(() =>
-          // TODO: fix this, should be 'AAA(BBB(1,2))'
-          // This is a resutl of `getNameArgs` strange behavior. Leaving here as
+          // This is a result of `getNameArgs` strange behavior. Leaving here as
           // pseudo documentation. We mostly avoid this problem, as now we expand any
           // valid macros when they are seen in `Variables#expandTemplate`.
           check('${foo}', 'AAA(BBB(1%2C2))', {
@@ -129,7 +128,6 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
           })
         )
         .then(() =>
-          // TODO: fix this, should be 'AAA(1,2)%26BBB(3,4)%26CCC(5,6)%26DDD(7,8)
           // See comment about getNameArgs above.
           check('${all}', 'AAA(1%2C2)%26BBB(3%2C4)%26CCC(5%2C6)%26DDD(7,8)', {
             'a': 'AAA',

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -240,8 +240,8 @@ export class VariableService {
    * @param {string} template The template to expand.
    * @param {!ExpansionOptions} options configuration to use for expansion.
    * @param {!Element} element amp-analytics element.
-   * @param {?} opt_bindings
-   * @param {?} opt_whitelist
+   * @param {!JsonObject=} opt_bindings
+   * @param {!Object=} opt_whitelist
    * @return {!Promise<string>} The expanded string.
    */
   expandTemplate(template, options, element, opt_bindings, opt_whitelist) {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -189,11 +189,6 @@ export class VariableService {
     /** @const @private {!./linker-reader.LinkerReader} */
     this.linkerReader_ = linkerReaderServiceFor(this.ampdoc_.win);
 
-    /** @const @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
-    this.urlReplacementService_ = Services.urlReplacementsForDoc(
-      this.ampdoc_.getHeadNode()
-    );
-
     this.register_('$DEFAULT', defaultMacro);
     this.register_('$SUBSTR', substrMacro);
     this.register_('$TRIM', value => value.trim());
@@ -211,8 +206,6 @@ export class VariableService {
       '$EQUALS',
       (firstValue, secValue) => firstValue === secValue
     );
-    // TODO(ccordry): Make sure this stays a window level service when this
-    // VariableService is migrated to document level.
     this.register_('LINKER_PARAM', (name, id) =>
       this.linkerReader_.get(name, id)
     );
@@ -285,7 +278,7 @@ export class VariableService {
       }
 
       const bindings = this.getMacros();
-      const urlReplacements = this.urlReplacementService_;
+      const urlReplacements = Services.urlReplacementsForDoc(element);
       const whitelist = element.hasAttribute('sandbox')
         ? SANDBOX_AVAILABLE_VARS
         : undefined;

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -277,7 +277,7 @@ export class VariableService {
         );
       }
 
-      const bindings = this.getMacros();
+      const bindings = this.getMacros(element);
       const urlReplacements = Services.urlReplacementsForDoc(element);
       const whitelist = element.hasAttribute('sandbox')
         ? SANDBOX_AVAILABLE_VARS
@@ -312,6 +312,7 @@ export class VariableService {
    * @param {string} str
    * @param {RegExp} regex
    * @param {Function} replacer
+   * @return {!Promise<string>}
    */
   asyncStringReplace_(str, regex, replacer) {
     const stringBuilder = [];
@@ -441,3 +442,23 @@ export function stringToBool(str) {
     str !== 'undefined'
   );
 }
+
+// ${some_macro(${a}, ${another_macro(${b}))}
+// // config
+// {
+//   final: ${some_macro(${a}, ${another_macro(${b}))},
+//   a: 'foo',
+//   b: [1, 2, 3],
+// }
+
+// 1st match in asyncStringReplace_ => 'some_macro(${a}, ${another_macro(${b}))}';
+// 2nd match => 'a'
+// 3rd match => 'another_macro(${b})'
+// 4th match => 'b'
+
+// // This should work
+// {
+//   top: ${some_macro(${a}, ${b})},
+//   b: ${another_macro(${c})},
+//   c: '123',
+// }

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -236,6 +236,8 @@ export class VariableService {
   }
 
   /**
+   * Converts templates from ${} format to MACRO() and resolves any platform
+   * level macros when encountered.
    * @param {string} template The template to expand.
    * @param {!ExpansionOptions} options configuration to use for expansion.
    * @param {!Element} element amp-analytics element.

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -442,23 +442,3 @@ export function stringToBool(str) {
     str !== 'undefined'
   );
 }
-
-// ${some_macro(${a}, ${another_macro(${b}))}
-// // config
-// {
-//   final: ${some_macro(${a}, ${another_macro(${b}))},
-//   a: 'foo',
-//   b: [1, 2, 3],
-// }
-
-// 1st match in asyncStringReplace_ => 'some_macro(${a}, ${another_macro(${b}))}';
-// 2nd match => 'a'
-// 3rd match => 'another_macro(${b})'
-// 4th match => 'b'
-
-// // This should work
-// {
-//   top: ${some_macro(${a}, ${b})},
-//   b: ${another_macro(${c})},
-//   c: '123',
-// }

--- a/src/string.js
+++ b/src/string.js
@@ -172,3 +172,26 @@ export function trimStart(str) {
 
   return (str + '_').trim().slice(0, -1);
 }
+
+/**
+ * Wrapper around String.replace that handles asynchronous resolution.
+ * @param {string} str
+ * @param {RegExp} regex
+ * @param {Function} replacer
+ * @return {!Promise<string>}
+ */
+export function asyncStringReplace(str, regex, replacer) {
+  const stringBuilder = [];
+  let lastIndex = 0;
+
+  str.replace(regex, (match, key, matchIndex) => {
+    stringBuilder.push(str.slice(lastIndex, matchIndex));
+    // Store the promise in it's eventual string position.
+    const replacementPromise = replacer(match, key);
+    stringBuilder.push(replacementPromise);
+    lastIndex = matchIndex + match.length;
+  });
+
+  stringBuilder.push(str.slice(lastIndex));
+  return Promise.all(stringBuilder).then(resolved => resolved.join(''));
+}

--- a/src/string.js
+++ b/src/string.js
@@ -183,11 +183,19 @@ export function trimStart(str) {
 export function asyncStringReplace(str, regex, replacer) {
   const stringBuilder = [];
   let lastIndex = 0;
-
-  str.replace(regex, (match, key, matchIndex) => {
+  str.replace(regex, function() {
+    // String.prototype.replace will pass 3 to n number of arguments to the
+    // callback function based on how many capture groups the regex may or may
+    // not contain. We know that the match will always be first, and the
+    // index will always be second to last.
+    const match = arguments[0];
+    const matchIndex = arguments[arguments.length - 2];
     stringBuilder.push(str.slice(lastIndex, matchIndex));
     // Store the promise in it's eventual string position.
-    const replacementPromise = replacer(match, key);
+    const replacementPromise =
+      typeof replacer === 'function'
+        ? replacer.apply(null, arguments)
+        : replacer;
     stringBuilder.push(replacementPromise);
     lastIndex = matchIndex + match.length;
   });

--- a/test/manual/amp-analytics/analytics-nested.html
+++ b/test/manual/amp-analytics/analytics-nested.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Analytics</title>
+  <link rel="canonical" href="analytics.amp.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+</head>
+<body>
+  <!-- 
+    Macros in `vars` are now resolved asynchronously before macros in `requests`. As a result 
+    it is possible to have expensive macros in `vars` that will delay macro resolution in requests
+    by a meaningful amount of time. In the example below `ts2` will be resolved slightly ahead of `ts1`.
+    This would be further delayed if there were more complicated nested macros inside of the `vars` config.
+
+    RESOURCE_TIMING will only resolve to anything other than an empty string as part of a request. This
+    excludes this macro from selectors.
+
+    Our regex for finding macros in the ${} format will not work when nested. See broken below.
+
+    Multiple ${} are fine as long as they are not nested, see adjacent below.
+
+    You can use the ${} format in conjuction with nested macros, as long as there are no nested ${}.
+    See combo below.
+   -->
+  <amp-analytics>
+    <script type="application/json">
+      {
+        "requests": {
+          "base": "https://www.example.com",
+          "complicated": "${base}?ts1=TIMESTAMP&ts2=${ts2}&n=${nested}&b=${broken}&c=${combo}&a=${adjacent}"
+        },
+        "triggers": {
+          "visible": {
+            "on": "visible",
+            "request": "complicated"
+          }
+        },
+        "vars": {
+          "ts2": "TIMESTAMP",
+          "nested": "$IF(QUERY_PARAM(foo), QUERY_PARAM(foo), default)",
+          "broken": "${queryParam(foo), ${a}}",
+          "combo": "${deeper}",
+          "deeper":  "${nested}",
+          "adjacent": "${ts2}sometext${ts2}"
+        }
+      }
+    </script> 
+  </amp-analytics>
+  <h1>Nested macros in analytics</h1>
+</body>

--- a/test/unit/test-string.js
+++ b/test/unit/test-string.js
@@ -15,6 +15,7 @@
  */
 
 import {
+  asyncStringReplace,
   camelCaseToDash,
   dashToCamelCase,
   endsWith,
@@ -155,5 +156,14 @@ describe('trimEnd', () => {
 
   it('should keep leading whitespace characters', () => {
     expect(trimEnd('\n\tabc')).to.equal('\n\tabc');
+  });
+});
+
+describe('asyncStringReplace', () => {
+  it('should replace asynchronously', () => {
+    const result = asyncStringReplace('the quick brown fox', /brown/, () =>
+      Promise.resolve('red')
+    );
+    expect(result).to.eventually.equal('the quick red fox');
   });
 });

--- a/test/unit/test-string.js
+++ b/test/unit/test-string.js
@@ -160,10 +160,40 @@ describe('trimEnd', () => {
 });
 
 describe('asyncStringReplace', () => {
-  it('should replace asynchronously', () => {
+  it('should replace with string as callback', () => {
+    const result = asyncStringReplace('the quick brown fox', /brown/, 'red');
+    return expect(result).to.eventually.equal('the quick red fox');
+  });
+
+  it('should replace with sync function as callback', () => {
+    const result = asyncStringReplace(
+      'the quick brown fox',
+      /brown/,
+      () => 'red'
+    );
+    return expect(result).to.eventually.equal('the quick red fox');
+  });
+
+  it('should replace with no capture groups', () => {
     const result = asyncStringReplace('the quick brown fox', /brown/, () =>
       Promise.resolve('red')
     );
-    expect(result).to.eventually.equal('the quick red fox');
+    return expect(result).to.eventually.equal('the quick red fox');
+  });
+
+  it('should replace with one capture group', () => {
+    const result = asyncStringReplace('item 798', /item (\d*)/, (match, p1) =>
+      Promise.resolve(p1)
+    );
+    return expect(result).to.eventually.equal('798');
+  });
+
+  it('should replace with two capture groups', () => {
+    const result = asyncStringReplace(
+      'John Smith',
+      /(\w+)\s(\w+)/,
+      (match, p1, p2) => Promise.resolve(`${p2}, ${p1}`)
+    );
+    return expect(result).to.eventually.equal('Smith, John');
   });
 });


### PR DESCRIPTION
Closes #21751 

Changes `VariableService.expandTemplate` to resolve macros through the `UrlReplacementService` as it encounters them. This avoids the problem of the `variableService` encoding certain macros before they are resolved. `$`, `(` and `,` would be encoded in nested macros etc.

One note: I had to pass the element along everywhere this is called to check if `amp-analytics` is sandboxed. I am open to other suggestions on how this could be accomplished.
