### PR TITLE
allow cookie writer macros

### DIFF
--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -17,13 +17,14 @@
 import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
 import {Services} from '../../../src/services';
 import {getMode} from '../../../src/mode';
-import {getNameArgs, variableServiceForDoc} from './variables';
+import {variableServiceForDoc} from './variables';
 import {hasOwn} from '../../../src/utils/object';
 import {isInFie} from '../../../src/friendly-iframe-embed';
 import {isObject} from '../../../src/types';
 import {isProxyOrigin} from '../../../src/url';
 import {setCookie} from '../../../src/cookies';
 import {user} from '../../../src/log';
+import {variableServiceFor} from './variables';
 
 const TAG = 'amp-analytics/cookie-writer';
 

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -17,14 +17,13 @@
 import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
 import {Services} from '../../../src/services';
 import {getMode} from '../../../src/mode';
-import {variableServiceForDoc} from './variables';
 import {hasOwn} from '../../../src/utils/object';
 import {isInFie} from '../../../src/friendly-iframe-embed';
 import {isObject} from '../../../src/types';
 import {isProxyOrigin} from '../../../src/url';
 import {setCookie} from '../../../src/cookies';
 import {user} from '../../../src/log';
-import {variableServiceFor} from './variables';
+import {variableServiceForDoc} from './variables';
 
 const TAG = 'amp-analytics/cookie-writer';
 

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -27,11 +27,6 @@ import {user} from '../../../src/log';
 
 const TAG = 'amp-analytics/cookie-writer';
 
-const EXPAND_WHITELIST = {
-  'QUERY_PARAM': true,
-  'LINKER_PARAM': true,
-};
-
 const RESERVED_KEYS = {
   'referrerDomains': true,
   'enabled': true,
@@ -163,18 +158,6 @@ export class CookieWriter {
       return false;
     }
 
-    const str = cookieConfig['value'];
-    // Make sure that only QUERY_PARAM and LINKER_PARAM is supported
-    const {name} = getNameArgs(str);
-    if (!EXPAND_WHITELIST[name]) {
-      user().error(
-        TAG,
-        `cookie value ${str} not supported. ` +
-          'Only QUERY_PARAM and LINKER_PARAM is supported'
-      );
-      return false;
-    }
-
     return true;
   }
 
@@ -188,7 +171,7 @@ export class CookieWriter {
     // Note: Have to use `expandStringAsync` because QUERY_PARAM can wait for
     // trackImpressionPromise and resolve async
     return this.urlReplacementService_
-      .expandStringAsync(cookieValue, this.bindings_, EXPAND_WHITELIST)
+      .expandStringAsync(cookieValue, this.bindings_)
       .then(value => {
         // Note: We ignore empty cookieValue, that means currently we don't
         // provide a way to overwrite or erase existing cookie

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -205,50 +205,6 @@ describes.realWin(
           expect(expandAndWriteSpy).to.not.be.called;
         });
       });
-
-      it('Resolve when cookie value is not supported', () => {
-        const config = dict({
-          'cookies': {
-            'testId': {
-              'value': 'RANDOM',
-            },
-            'testId1': {
-              'value': 'static',
-            },
-            'testId2': {
-              'value': 'QUERY_PARAM(abc)-suf',
-            },
-            'testId3': {
-              'value': 'pre-QUERY_PARAM(abc)',
-            },
-          },
-        });
-        const cookieWriter = new CookieWriter(win, element, config);
-        expectAsyncConsoleError(
-          TAG +
-            ' cookie value RANDOM not supported. ' +
-            'Only QUERY_PARAM and LINKER_PARAM is supported'
-        );
-        expectAsyncConsoleError(
-          TAG +
-            ' cookie value static not supported. ' +
-            'Only QUERY_PARAM and LINKER_PARAM is supported'
-        );
-        expectAsyncConsoleError(
-          TAG +
-            ' cookie value QUERY_PARAM(abc)-suf not ' +
-            'supported. Only QUERY_PARAM and LINKER_PARAM is supported'
-        );
-        expectAsyncConsoleError(
-          TAG +
-            ' cookie value pre-QUERY_PARAM(abc) not ' +
-            'supported. Only QUERY_PARAM and LINKER_PARAM is supported'
-        );
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
-        return cookieWriter.write().then(() => {
-          expect(expandAndWriteSpy).to.not.be.called;
-        });
-      });
     });
   }
 );
@@ -293,6 +249,15 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
           'bCookie': {
             'value': 'LINKER_PARAM(b,c)',
           },
+          'testId1': {
+            'value': 'static',
+          },
+          'testId2': {
+            'value': '$SUBSTR(QUERY_PARAM(a),1)-suf',
+          },
+          'testId3': {
+            'value': 'pre-TIMESTAMPQUERY_PARAM(abc)',
+          },
         },
       })
     );
@@ -300,6 +265,9 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
       const cookies = win.document.cookie.split(';');
       expect(cookies).to.include('aCookie=123');
       expect(cookies).to.include('bCookie=b-c');
+      expect(cookies).to.include('testId1=static');
+      expect(cookies).to.include('testId2=23-suf');
+      expect(cookies).to.include('testId3=pre-1514793600000');
     });
   });
 


### PR DESCRIPTION
Closes #22328 

We discussed more on this topic. Given that we only write cookie on pub origin, it makes sense for publisher to write any cookie value. 

Few concerns: 
1. No whitelist or blacklist is applied. Basically one can choose to write any user information they can get to the cookie. 
2. The feature can be misused. One can write unnecessary information or static string to the cookie. 

Note these can be achieved on non AMP pages already. 

to @jeffjose want to get your idea on this as well. 