### PR TITLE
🐛 `amp-script` Remove AMP cors requirement for author code

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -111,9 +111,8 @@ export class AmpScript extends AMP.BaseElement {
 
     const xhr = Services.xhrFor(this.win);
     const fetchPromise = Promise.all([
-      // `workerUrl` is from CDN, so no need for `ampCors`.
       xhr.fetchText(workerUrl, {ampCors: false}).then(r => r.text()),
-      xhr.fetchText(authorUrl).then(r => r.text()),
+      xhr.fetchText(authorUrl, {ampCors: false}).then(r => r.text()),
       getElementServiceForDoc(this.element, TAG, TAG),
     ]).then(results => {
       const workerScript = results[0];


### PR DESCRIPTION
Removes `AMP-Access-Control-Allow-Source-Origin` header requirement for author code loaded within `amp-script`.

Addresses: #22170
