### PR TITLE
✨amp-experiment 1.0: Removed the "No mutations" limitation

### DIFF
--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -233,7 +233,7 @@ describes.sandboxed('allocateVariant', {}, env => {
     });
   });
 
-  it('should check that has at least one mutation', () => {
+  it('should allow variants with no mutations', () => {
     allowConsoleError(() => {
       expect(() => {
         allocateVariant(ampdoc, 'name', {
@@ -244,7 +244,7 @@ describes.sandboxed('allocateVariant', {}, env => {
             },
           },
         });
-      }).to.throw(/one mutation/);
+      }).to.not.throw();
     });
   });
 

--- a/extensions/amp-experiment/1.0/variant.js
+++ b/extensions/amp-experiment/1.0/variant.js
@@ -242,11 +242,4 @@ function assertVariant(variant, experimentName, variantName) {
     variant['mutations'] && isArray(variant['mutations']),
     `${experimentName}.variants.${variantName} must have a mutations array.`
   );
-
-  // Assert the variant has mutations
-  userAssert(
-    variant['mutations'].length > 0,
-    `${experimentName}.variants.${variantName} mutations` +
-      ' must have at least one mutation.'
-  );
 }


### PR DESCRIPTION
relates to #20225
relates to #21705

This allows variants to have zero mutations. We are allowing this, as often times people like to use a "control variant". This should differ from the base page, because often times users are charged by the analytics pings, thus this allows users to not get ALL the information of the base page, and just a fraction of it.