### PR TITLE
🏗 Use minified build for visual diff tests

### DIFF
--- a/build-system/pr-check/build.js
+++ b/build-system/pr-check/build.js
@@ -63,8 +63,7 @@ function main() {
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('E2E_TEST') ||
-      buildTargets.has('VISUAL_DIFF')
+      buildTargets.has('E2E_TEST')
     ) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp build --fortesting');
@@ -74,7 +73,7 @@ function main() {
         `${FILELOGPREFIX} Skipping`,
         colors.cyan('Build'),
         'because this commit does not affect the runtime, flag configs,',
-        'integration tests, end-to-end tests, or visual diff tests.'
+        'integration tests, or end-to-end tests.'
       );
     }
   }

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -64,7 +64,8 @@ function main() {
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
+      buildTargets.has('INTEGRATION_TEST') ||
+      buildTargets.has('VISUAL_DIFF')
     ) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --fortesting');
@@ -76,7 +77,7 @@ function main() {
         `${FILELOGPREFIX} Skipping`,
         colors.cyan('Dist, Bundle Size'),
         'because this commit does not affect the runtime, flag configs,',
-        'or integration tests'
+        'integration tests, or visual diff tests.'
       );
     }
   }

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -24,7 +24,7 @@
 const atob = require('atob');
 const colors = require('ansi-colors');
 const {
-  downloadBuildOutput,
+  downloadDistOutput,
   printChangeSummary,
   startTimer,
   stopTimer,
@@ -42,7 +42,7 @@ function main() {
   const startTime = startTimer(FILENAME, FILENAME);
 
   if (!isTravisPullRequestBuild()) {
-    downloadBuildOutput(FILENAME);
+    downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     timedExecOrDie('gulp visual-diff --nobuild --master');
@@ -57,7 +57,7 @@ function main() {
       buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('VISUAL_DIFF')
     ) {
-      downloadBuildOutput(FILENAME);
+      downloadDistOutput(FILENAME);
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp visual-diff --nobuild');
     } else {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -135,7 +135,8 @@ function setPercyTargetCommit() {
  */
 async function launchWebServer() {
   webServerProcess_ = execScriptAsync(
-    `gulp serve --host ${HOST} --port ${PORT} ${process.env.WEBSERVER_QUIET}`,
+    `gulp serve --compiled --host ${HOST} --port ${PORT} ` +
+      `${process.env.WEBSERVER_QUIET}`,
     {
       stdio: argv.webserver_debug
         ? ['ignore', process.stdout, process.stderr]
@@ -826,20 +827,20 @@ async function performVisualTests() {
 async function ensureOrBuildAmpRuntimeInTestMode_() {
   if (argv.nobuild) {
     const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":true\b/.test(
-      fs.readFileSync('dist/amp.js', 'utf8')
+      fs.readFileSync('dist/v0.js', 'utf8')
     );
     if (!isInTestMode) {
       log(
         'fatal',
         'The AMP runtime was not built in test mode. Run',
-        colors.cyan('gulp build --fortesting'),
+        colors.cyan('gulp dist --fortesting'),
         'or remove the',
         colors.cyan('--nobuild'),
         'option from this command'
       );
     }
   } else {
-    execOrDie('gulp build --fortesting');
+    execOrDie('gulp dist --fortesting');
   }
 }
 


### PR DESCRIPTION
This PR makes the visual tests use minified builds when run locally and on Travis.

TODO: Resolve conflicts with #22397 before merging this.

Fixes #22391