### PR TITLE
🐛 amp-carousel: hide next/prev in type=carousel for screen readers

### DIFF
--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -74,7 +74,7 @@ export class BaseCarousel extends AMP.BaseElement {
     button.tabIndex = 0;
     button.classList.add('amp-carousel-button');
     button.classList.add(className);
-    button.setAttribute('role', 'button');
+    button.setAttribute('role', this.buttonsAriaRole());
     button.onkeydown = event => {
       if (event.key == Keys.ENTER || event.key == Keys.SPACE) {
         if (!event.defaultPrevented) {
@@ -86,6 +86,16 @@ export class BaseCarousel extends AMP.BaseElement {
     button.onclick = onInteraction;
 
     return button;
+  }
+
+  /**
+   * The ARIA role for the controls. Either `button` or `presentation` based
+   * on usage.
+   * @return {string}
+   */
+  buttonsAriaRole() {
+    // Subclasses may override.
+    return 'button';
   }
 
   /**

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -100,6 +100,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_ = this.buildButton('amp-carousel-button-next', () => {
       this.interactionNext();
     });
+    this.updateButtonTitles();
     this.element.appendChild(this.nextButton_);
   }
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -92,6 +92,7 @@ export class BaseCarousel extends AMP.BaseElement {
    * The ARIA role for the controls. Either `button` or `presentation` based
    * on usage.
    * @return {string}
+   * @protected
    */
   buttonsAriaRole() {
     // Subclasses may override.

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -99,6 +99,18 @@ export class AmpScrollableCarousel extends BaseCarousel {
   }
 
   /** @override */
+  buttonsAriaRole() {
+    /**
+     * In scrollable carousel, the next/previous buttons add no functionality
+     * for screen readers as scrollable carousel is just a horizontally
+     * scrollable div which ATs navigate just like any other content.
+     * To avoid confusion, we therefore set the role to presentation for the
+     * controls in this case.
+     */
+    return 'presentation';
+  }
+
+  /** @override */
   layoutCallback() {
     if (!this.useLayers_) {
       this.doLayout_(this.pos_);

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -111,9 +111,12 @@ describes.realWin(
             .true;
           expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
             .false;
-          // has a11y titles for the controls
-          expect(impl.nextButton_.title).to.not.be.empty;
-          expect(impl.prevButton_.title).to.not.be.empty;
+          // Controls are hidden from screen readers as they do not provide
+          // any functionality for scrollable carousel.
+          // ATs see this is a scrolling div and can scroll it as user navigates
+          // items just fine (unlike type=slide which requires next/prev)
+          expect(impl.nextButton_.getAttribute('role')).equal('presentation');
+          expect(impl.prevButton_.getAttribute('role')).equal('presentation');
         });
       }
     );

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -111,6 +111,9 @@ describes.realWin(
             .true;
           expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
             .false;
+          // has a11y titles for the controls
+          expect(impl.nextButton_.title).to.not.be.empty;
+          expect(impl.prevButton_.title).to.not.be.empty;
         });
       }
     );

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -381,6 +381,10 @@ describes.realWin(
         expect(impl.hasPrev()).to.be.true;
         expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
         expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+
+        // Verify aria roles for the button
+        expect(impl.nextButton_.getAttribute('role')).equal('button');
+        expect(impl.prevButton_.getAttribute('role')).equal('button');
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/21071

In scrollable carousel, the next/previous buttons add no functionality for screen readers as scrollable carousel is just a horizontally scrollable div which ATs navigate just like any other content.

To avoid confusion, we therefore set the role to presentation for the controls in this case.
