### PR TITLE
🏗 Restore text coloring in Travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ addons:
       - python-protobuf
       - openssl
       - google-cloud-sdk
+      # Use unbuffer (from expect-dev) for log coloring (github.com/travis-ci/travis-ci/issues/7967)
+      - expect-dev
   chrome: stable
   hosts:
     - ads.localhost
@@ -45,47 +47,47 @@ jobs:
     - stage: build
       name: "Build"
       script:
-        - node build-system/pr-check/build.js
+        - unbuffer node build-system/pr-check/build.js
     - stage: build
       name: "Checks"
       script:
-        - node build-system/pr-check/checks.js
+        - unbuffer node build-system/pr-check/checks.js
     - stage: build
       name: "Validator Tests"
       script:
-        - node build-system/pr-check/validator-tests.js
+        - unbuffer node build-system/pr-check/validator-tests.js
     - stage: build
       name: "Dist, Bundle Size"
       script:
-        - node build-system/pr-check/dist-bundle-size.js
+        - unbuffer node build-system/pr-check/dist-bundle-size.js
     - stage: test
       name: "Single Pass Tests"
       script:
-        - node build-system/pr-check/single-pass-tests.js
+        - unbuffer node build-system/pr-check/single-pass-tests.js
     - stage: test
       name: "Visual Diff Tests"
       script:
-        - node build-system/pr-check/visual-diff-tests.js
+        - unbuffer node build-system/pr-check/visual-diff-tests.js
     - stage: test
       name: "Local Tests"
       script:
-        - node build-system/pr-check/local-tests.js
+        - unbuffer node build-system/pr-check/local-tests.js
     - stage: test
       name: "Remote (Sauce Labs) Tests"
       script:
-        - node build-system/pr-check/remote-tests.js
+        - unbuffer node build-system/pr-check/remote-tests.js
       after_script:
         - build-system/sauce_connect/stop_sauce_connect.sh
     - stage: test
       name: "[NON-BLOCKING] End to End Tests"
       script:
-        - node build-system/pr-check/e2e-tests.js
+        - unbuffer node build-system/pr-check/e2e-tests.js
   fast_finish: true
 
   # TODO(ampproject/wg-infra): remove when these tests stabilize
   allow_failures:
     - script:
-      - node build-system/pr-check/e2e-tests.js
+      - unbuffer node build-system/pr-check/e2e-tests.js
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ branches:
 addons:
   apt:
     packages:
-      - protobuf-compiler
-      - python-protobuf
-      - openssl
-      - google-cloud-sdk
       # Use unbuffer (from expect-dev) for log coloring (github.com/travis-ci/travis-ci/issues/7967)
       - expect-dev
+      - google-cloud-sdk
+      - openssl
+      - protobuf-compiler
+      - python-protobuf
   chrome: stable
   hosts:
     - ads.localhost


### PR DESCRIPTION
Text coloring is broken on Travis push builds because of how secret environment variables are processed. 

This PR implements the workaround in https://github.com/travis-ci/travis-ci/issues/7967#issuecomment-424521694 to restore text coloring.

Fixes #10117