### PR TITLE
✨ Add new <meta name="amp-experiments-opt-out">

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -509,6 +509,25 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
+# AMP & AMP4ADS metadata, name=amp-experiments-opt-out
+# https://github.com/lannka/amphtml/blob/master/tools/experiments/README.md
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "META"
+  spec_name: "meta name=amp-experiments-opt-out"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "content"
+    mandatory: true
+  }
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-experiments-opt-out"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
 # AMP metadata, name=amp-3p-iframe-src
 tags: {
   html_format: AMP


### PR DESCRIPTION
Certain experiments are will be enabled by default (eg, the new blurry image placeholders). This provides a way for publishers to opt-out of the experiment.

We considered whether to reuse the `amp-experiments-opt-in` meta tag, but we found opting-out using an opt-in was confusing. This provides a more natural way.