### PR TITLE
🏗 Log Karma results when zero tests are detected

### DIFF
--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -617,9 +617,8 @@ async function runTests() {
         const result = browser.lastResult;
         // Prevent cases where Karma detects zero tests and still passes. #16851.
         if (result.total == 0) {
-          log(
-            red('ERROR: Zero tests detected by Karma. Something went wrong.')
-          );
+          log(red('ERROR: Zero tests detected by Karma.'));
+          log(red(JSON.stringify(result)));
           reportTestErrored().finally(() => {
             if (!argv.watch) {
               process.exit(1);


### PR DESCRIPTION
Karma tests on occasionally return a failure with zero tests. Currently, it's not clear why this happened. (Disconnection? Error?)

This PR logs the `browser.lastResult` JSON object returned by Karma to aid in debugging.

Related to #16851
Follow up to #16878