### PR TITLE
Remove the confusing "force3p" string in a4a envelope.

### DIFF
--- a/build-system/server-a4a-template.html
+++ b/build-system/server-a4a-template.html
@@ -17,7 +17,7 @@
   <div style="background: #eee; overflow: hidden;; height: OFFSET;">scroll down to see the ad</div>
 
   <amp-ad
-      layout="responsive" width="AD_WIDTH" height="AD_HEIGHT"
+      width="AD_WIDTH" height="AD_HEIGHT"
       id="i-amphtml-demo-id"
       type="fake"
       a4a-conversion="true"

--- a/build-system/server-a4a-template.html
+++ b/build-system/server-a4a-template.html
@@ -10,7 +10,6 @@
 </head>
 <body>
   <h1>A4A Envelope</h1>
-  <div>3p: FORCE3P</div>
   <div>url: AD_URL</div>
   <div>size: AD_WIDTHxAD_HEIGHT</div>
 


### PR DESCRIPTION
Also change amp-ad layout to fixed size to match the description.