### PR TITLE
Update docs/template for new cherry pick approvers

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -3,7 +3,6 @@ name: Cherry-pick template
 about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
-assignees: cramforce
 ---
 
 <!--
@@ -77,4 +76,4 @@ TIP: A few sentences summarizing the problem and impact.
 
 ---
 
-/cc @cramforce
+/cc @ampproject/wg-approvers @ampproject/cherry-pick-approvers

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -57,8 +57,12 @@ If you run into any issues or have any questions when requesting a cherry pick, 
 
 - Ensure there is a GitHub issue filed for the problem that needs to be resolved *before* filing the cherry pick request issue.
 - File the cherry pick request issue using the [Cherry pick request template](https://github.com/ampproject/amphtml/issues/new?title=%F0%9F%8C%B8%20Cherry%20pick%20request%20for%20%3CYOUR_ISSUE_NUMBER%3E%20into%20%3CRELEASE_ISSUE_NUMBER%3E%20%28Pending%29&template=cherry_pick_template.md).  Follow the instructions in the template, providing all of the requested data.  **Make sure you fill out this issue completely or your cherry pick may not be seen or acted upon.**
-- **The [TL](../GOVERNANCE.md) or their designate is the only person who may approve cherry picks.**  The TL/designate will update the issue with their decision about whether your fix warrants a cherry pick.  You should be available to respond to any questions the TL/designate has regarding your request.
-- If the TL/designate approves the cherry pick, the person currently handling releases (onduty) will work with you to ensure the cherry pick is made.
+- Get the necessary approval for your cherry pick (indicated via comments on the cherry pick request issue).
+  - For cherry picks into canary, at least one member of the [Approvers WG](https://github.com/orgs/ampproject/teams/wg-approvers/members) must approve the cherry pick.
+  - For cherry picks into prod:
+    - if the fix is a clean rollback that does not require any other changes, at least one member of the [Approvers WG](https://github.com/orgs/ampproject/teams/wg-approvers/members) must approve the cherry pick.
+    - otherwise, at least one member from the [Cherry Pick Approvers group](https://github.com/orgs/ampproject/teams/cherry-pick-approvers/members) must approve the cherry pick.
+- After the cherry pick has been approved, the person currently handling releases (onduty) will work with you to ensure the cherry pick is made.
 - **Once the cherry pick is made you are responsible for verifying that the cherry pick you requested fixes the reported issue and that it does not cause other issues.**
 
 **If you are requesting a cherry pick to fix an issue in production** it is very likely you will *also* need a cherry pick into the canary release since otherwise the problem your cherry pick addresses would reappear as soon as the canary release is pushed to production.  Work with the onduty person to determine if you need a cherry pick to both and make sure your cherry pick request issue reflects what you determine.


### PR DESCRIPTION
Updates who can approve cherry picks based on TSC guidance in #22089.

Fixes #22089 (and partial fix for https://github.com/ampproject/meta/issues/18).

/cc @ampproject/wg-approvers @ampproject/cherry-pick-approvers 