### PR TITLE
🐛amp-recaptcha-input: Added support for error returning null

### DIFF
--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -165,12 +165,18 @@ function actionTypeHandler(win, grecaptcha, data) {
           );
         },
         function(err) {
-          user().error(TAG, '%s', err.message);
+          let message =
+            'There was an error running ' +
+            'execute() on the reCAPTCHA script.';
+          if (err) {
+            message = err.toString();
+          }
+          user().error(TAG, '%s', message);
           iframeMessagingClient./*OK*/ sendMessage(
             'amp-recaptcha-error',
             dict({
               'id': data.id,
-              'error': err.message,
+              'error': message,
             })
           );
         }


### PR DESCRIPTION
relates to #22279

This fixes the error handler throwing an error when the err that is returned by the reCAPTCHA script is null.

EDIT: Confirmed with team directly, error can be null

# Example

**If I put the test code:**

![Screen Shot 2019-05-22 at 5 25 51 PM](https://user-images.githubusercontent.com/1448289/58217552-24847d00-7cb8-11e9-953e-3925c3be5069.png)

**It shows the error can be null:**

![Screen Shot 2019-05-22 at 5 25 31 PM](https://user-images.githubusercontent.com/1448289/58217550-24847d00-7cb8-11e9-9b2f-d17a9bef382e.png)

**Just proof the script is loaded correctly:**

![Screen Shot 2019-05-22 at 5 24 42 PM](https://user-images.githubusercontent.com/1448289/58217549-24847d00-7cb8-11e9-8334-7dd1431bc33e.png)
