### PR TITLE
Clean up: remove copies of CSS files under /build/. 

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -75,9 +75,7 @@ function compileCss(watch, opt_compileAll) {
    */
   function writeCss(css, originalCssFilename, jsFilename, cssFilename) {
     return toPromise(
-      gulp
-        .src(`css/${originalCssFilename}`)
-        .pipe(file(jsFilename, 'export const cssText = ' + JSON.stringify(css)))
+      file(jsFilename, 'export const cssText = ' + JSON.stringify(css), {src: true})
         .pipe(gulp.dest('build'))
         .on('end', function() {
           mkdirSync('build');

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -68,14 +68,15 @@ function compileCss(watch, opt_compileAll) {
    * Writes CSS to build folder
    *
    * @param {string} css
-   * @param {string} originalCssFilename
    * @param {string} jsFilename
    * @param {string} cssFilename
    * @return {Promise}
    */
-  function writeCss(css, originalCssFilename, jsFilename, cssFilename) {
+  function writeCss(css, jsFilename, cssFilename) {
     return toPromise(
-      file(jsFilename, 'export const cssText = ' + JSON.stringify(css), {src: true})
+      file(jsFilename, 'export const cssText = ' + JSON.stringify(css), {
+        src: true,
+      })
         .pipe(gulp.dest('build'))
         .on('end', function() {
           mkdirSync('build');
@@ -92,7 +93,7 @@ function compileCss(watch, opt_compileAll) {
    */
   function writeCssEntryPoint(path, outJs, outCss) {
     return jsifyCssAsync(`css/${path}`).then(css =>
-      writeCss(css, path, outJs, outCss)
+      writeCss(css, outJs, outCss)
     );
   }
 

--- a/src/service/video/install-autoplay-styles.js
+++ b/src/service/video/install-autoplay-styles.js
@@ -16,7 +16,7 @@
 
 import {installStylesForDoc} from '../../style-installer';
 // Source for this constant is css/video-autoplay.css
-import {cssText} from '../../../build/video-autoplay.css.js';
+import {cssText} from '../../../build/video-autoplay.css';
 
 /**
  * @param  {!../ampdoc-impl.AmpDoc} ampdoc


### PR DESCRIPTION
They're duplicates of /build/css/*, which caused naming conflict for js imports.


