### PR TITLE
🏗 Add a check for the default `gulp` executable path

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -34,7 +34,7 @@ const gulpHelpUrl =
 const yarnExecutable = 'npx yarn';
 const gulpExecutable = 'npx gulp';
 
-const updatesNeeded = [];
+const updatesNeeded = new Set();
 
 // Color formatting libraries may not be available when this script is run.
 function red(text) {
@@ -123,7 +123,7 @@ function checkNodeVersion() {
               cyan('https://nodejs.org/en/download/package-manager'),
               yellow('for instructions.')
             );
-            updatesNeeded.push('node');
+            updatesNeeded.add('node');
           } else {
             console.log(
               green('Detected'),
@@ -194,7 +194,7 @@ function checkYarnVersion() {
       cyan('https://yarnpkg.com/docs/install'),
       yellow('for instructions.')
     );
-    updatesNeeded.push('yarn');
+    updatesNeeded.add('yarn');
   } else {
     console.log(
       green('Detected'),
@@ -217,11 +217,23 @@ function getYarnStableVersion(infoJson) {
   }
 }
 
-function checkGlobalGulp() {
+function getParentShellPath() {
+  const nodePath = process.env.PATH;
+  const pathSeparator = process.platform == 'win32' ? ';' : ':';
+  // nodejs adds a few extra variables to $PATH, ending with '../../bin/node-gyp-bin'.
+  // See https://github.com/nodejs/node-convergence-archive/blob/master/deps/npm/lib/utils/lifecycle.js#L81-L85
+  return nodePath.split(`node-gyp-bin${pathSeparator}`).pop();
+}
+
+function runGulpChecks() {
   const firstInstall = !fs.existsSync('node_modules');
   const globalPackages = getStdout(yarnExecutable + ' global list').trim();
   const globalGulp = globalPackages.match(/"gulp@.*" has binaries/);
   const globalGulpCli = globalPackages.match(/"gulp-cli@.*" has binaries/);
+  const defaultGulpPath = getStdout('which gulp', {
+    'env': {'PATH': getParentShellPath()},
+  }).trim();
+  const wrongGulp = !defaultGulpPath.includes('yarn');
   if (globalGulp) {
     console.log(
       yellow('WARNING: Detected a global install of'),
@@ -240,7 +252,7 @@ function checkGlobalGulp() {
       cyan(gulpHelpUrl),
       yellow('for more information.')
     );
-    updatesNeeded.push('gulp');
+    updatesNeeded.add('gulp');
   } else if (!globalGulpCli) {
     console.log(
       yellow('WARNING: Could not find'),
@@ -250,7 +262,36 @@ function checkGlobalGulp() {
       yellow('⤷ To install it, run'),
       cyan('"yarn global add gulp-cli"') + yellow('.')
     );
-  } else if (!firstInstall) {
+    console.log(
+      yellow('⤷ See'),
+      cyan(gulpHelpUrl),
+      yellow('for more information.')
+    );
+    updatesNeeded.add('gulp-cli');
+  }
+  if (wrongGulp) {
+    console.log(
+      yellow('WARNING: Found'),
+      cyan('gulp'),
+      yellow('in an unexpected location:'),
+      cyan(defaultGulpPath) + yellow('. (The location usually contains'),
+      cyan('yarn'),
+      yellow('in the path.)')
+    );
+    console.log(
+      yellow('⤷ To fix this, consider removing'),
+      cyan(defaultGulpPath),
+      yellow('from your default'),
+      cyan('$PATH') + yellow(', or deleting it.')
+    );
+    console.log(
+      yellow('⤷ Run'),
+      cyan('"which gulp"'),
+      yellow('for more information.')
+    );
+    updatesNeeded.add('gulp');
+  }
+  if (!firstInstall) {
     const gulpVersions = getStdout(gulpExecutable + ' --version').trim();
     const gulpVersion = gulpVersions.match(/Local version[:]? (.*?)$/);
     if (gulpVersion && gulpVersion.length == 2) {
@@ -279,16 +320,16 @@ function main() {
   }
   ensureYarn();
   return checkNodeVersion().then(() => {
-    checkGlobalGulp();
+    runGulpChecks();
     checkYarnVersion();
-    if (!process.env.TRAVIS && updatesNeeded.length > 0) {
+    if (!process.env.TRAVIS && updatesNeeded.size > 0) {
       console.log(
-        yellow('\nWARNING: Detected missing updates for'),
-        cyan(updatesNeeded.join(', '))
+        yellow('\nWARNING: Detected problems with'),
+        cyan(Array.from(updatesNeeded).join(', '))
       );
       console.log(
         yellow('⤷ Continuing install in'),
-        cyan('5'),
+        cyan('10'),
         yellow('seconds...')
       );
       console.log(
@@ -303,7 +344,7 @@ function main() {
       setTimeout(() => {
         console.log(yellow('\nAttempting to install packages...'));
         resolver();
-      }, 5000);
+      }, 10000);
       return deferred;
     }
   });

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -34,6 +34,8 @@ const gulpHelpUrl =
 const yarnExecutable = 'npx yarn';
 const gulpExecutable = 'npx gulp';
 
+const warningDelaySecs = 10;
+
 const updatesNeeded = new Set();
 
 // Color formatting libraries may not be available when this script is run.
@@ -329,7 +331,7 @@ function main() {
       );
       console.log(
         yellow('⤷ Continuing install in'),
-        cyan('10'),
+        cyan(warningDelaySecs),
         yellow('seconds...')
       );
       console.log(
@@ -344,7 +346,7 @@ function main() {
       setTimeout(() => {
         console.log(yellow('\nAttempting to install packages...'));
         resolver();
-      }, 10000);
+      }, warningDelaySecs * 1000);
       return deferred;
     }
   });

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -28,8 +28,8 @@ const shellFlag = process.platform == 'win32' ? '/C' : '-c';
  * Spawns the given command in a child process with the given options.
  *
  * @param {string} cmd
- * @param {<Object>} options
- * @return {<Object>} Process info.
+ * @param {?Object} options
+ * @return {!Object}
  */
 function spawnProcess(cmd, options) {
   return childProcess.spawnSync(shellCmd, [shellFlag, cmd], options);
@@ -39,49 +39,50 @@ function spawnProcess(cmd, options) {
  * Executes the provided command with the given options, returning the process
  * object.
  *
- * @param {string} cmd Command line to execute.
- * @param {<Object>} options
- * @return {<Object>} Process info.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {!Object}
  */
-exports.exec = function(cmd, options) {
+function exec(cmd, options) {
   options = options || {'stdio': 'inherit'};
   return spawnProcess(cmd, options);
-};
+}
 
 /**
  * Executes the provided shell script in an asynchronous process.
  *
  * @param {string} script
- * @param {<Object>} options
+ * @param {?Object} options
  */
-exports.execScriptAsync = function(script, options) {
+function execScriptAsync(script, options) {
   return childProcess.spawn(shellCmd, [shellFlag, script], options);
-};
+}
 
 /**
  * Executes the provided command, and terminates the program in case of failure.
  *
- * @param {string} cmd Command line to execute.
- * @param {<Object>} options Extra options to send to the process.
+ * @param {string} cmd
+ * @param {?Object} options
  */
-exports.execOrDie = function(cmd, options) {
-  const p = exports.exec(cmd, options);
+function execOrDie(cmd, options) {
+  const p = exec(cmd, options);
   if (p.status != 0) {
     process.exit(p.status);
   }
-};
+}
 
 /**
  * Executes the provided command, returning the process object.
  * @param {string} cmd
+ * @param {?Object} options
  * @return {!Object}
  */
-function getOutput(cmd) {
+function getOutput(cmd, options = {}) {
   const p = spawnProcess(cmd, {
-    'cwd': process.cwd(),
-    'env': process.env,
-    'stdio': 'pipe',
-    'encoding': 'utf-8',
+    'cwd': options.cwd || process.cwd(),
+    'env': options.env || process.env,
+    'stdio': options.stdio || 'pipe',
+    'encoding': options.encoding || 'utf-8',
   });
   return p;
 }
@@ -89,17 +90,27 @@ function getOutput(cmd) {
 /**
  * Executes the provided command, returning its stdout.
  * @param {string} cmd
+ * @param {?Object} options
  * @return {string}
  */
-exports.getStdout = function(cmd) {
-  return getOutput(cmd).stdout;
-};
+function getStdout(cmd, options) {
+  return getOutput(cmd, options).stdout;
+}
 
 /**
  * Executes the provided command, returning its stderr.
  * @param {string} cmd
+ * @param {?Object} options
  * @return {string}
  */
-exports.getStderr = function(cmd) {
-  return getOutput(cmd).stderr;
+function getStderr(cmd, options) {
+  return getOutput(cmd, options).stderr;
+}
+
+module.exports = {
+  exec,
+  execOrDie,
+  execScriptAsync,
+  getStderr,
+  getStdout,
 };


### PR DESCRIPTION
This PR detects if there's a possibly incorrect version of `gulp` somewhere in the user's `$PATH`, and prints a warning before carrying on.

The `gulp` checks in `check-package-manager.js`:
- ...  are only triggered during `yarn` (which is run much less frequently), and don't slow down actual invocations of `gulp`
- ... do not prevent the `yarn` command from running even if they find problems