### PR TITLE
Add OT link in amp-script documentation

### DIFF
--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -32,7 +32,10 @@ Allows rendering of custom UI components running on third-party JavaScript.
 <table>
   <tr>
     <td><strong>Availability</strong></td>
-    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+    <td>
+      <a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a><br/>
+      This component is available under Origin Trial. To sign up for an Origin Trial please sign up at bit.ly/amp-script-trial.
+    </td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -33,7 +33,7 @@ Allows rendering of custom UI components running on third-party JavaScript.
   <tr>
     <td><strong>Availability</strong></td>
     <td>
-      <a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a><br/>
+      <a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental#origin-trials">Origin Trial</a><br/>
       This component is available under Origin Trial. To sign up for an Origin Trial please sign up at bit.ly/amp-script-trial.
     </td>
   </tr>


### PR DESCRIPTION
This PR is dependent on me landing a definition of OT in amp.dev.

Will add a link to the OT definition and edit this PR then. 