### PR TITLE
Ban getServiceForDoc() in extensions/* paths.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -301,6 +301,30 @@ const forbiddenTerms = {
       'src/service/video/autoplay.js',
     ],
   },
+  'getServiceForDoc': {
+    message: 'Synchronous access to element services is unreliable. '
+        + 'Use getServicePromiseForDoc() instead.',
+    whitelist: [
+      // Do not whitelist additional "extensions/*" paths.
+      // TODO(#22414): Remove paths as they are migrated off of sync API.
+      'extensions/amp-analytics/0.1/instrumentation.js',
+      'extensions/amp-analytics/0.1/variables.js',
+      'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
+      'extensions/amp-live-list/0.1/live-list-manager.js',
+      'extensions/amp-next-page/0.1/next-page-service.js',
+      'extensions/amp-position-observer/0.1/amp-position-observer.js',
+      'extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js',
+      'extensions/amp-user-notification/0.1/test/test-amp-user-notification.js',
+      'extensions/amp-video-docking/0.1/amp-video-docking.js',
+      'extensions/amp-web-push/0.1/amp-web-push-config.js',
+      'src/chunk.js',
+      'src/service.js',
+      'src/service/cid-impl.js',
+      'src/service/origin-experiments-impl.js',
+      'src/services.js',
+      'testing/test-helper.js',
+    ],
+  },
   'initLogConstructor|setReportError': {
     message: 'Should only be called from JS binary entry files.',
     whitelist: [

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -302,8 +302,9 @@ const forbiddenTerms = {
     ],
   },
   'getServiceForDoc': {
-    message: 'Synchronous access to element services is unreliable. '
-        + 'Use getServicePromiseForDoc() instead.',
+    message:
+      'Synchronous access to element services is unreliable. ' +
+      'Use getServicePromiseForDoc() instead.',
     whitelist: [
       // Do not whitelist additional "extensions/*" paths.
       // TODO(#22414): Remove paths as they are migrated off of sync API.

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -15,9 +15,10 @@
  */
 
 import {Deferred} from '../utils/promise';
+import {Services} from '../services';
 import {dev, devAssert, userAssert} from '../log';
 import {getMode} from '../mode';
-import {getService, getServiceForDoc, registerServiceBuilder} from '../service';
+import {getService, registerServiceBuilder} from '../service';
 import {rootNodeFor, scopedQuerySelector} from '../dom';
 
 /**
@@ -53,7 +54,7 @@ export class BaseTemplate {
     this.win = element.ownerDocument.defaultView || win;
 
     /** @private @const */
-    this.viewer_ = getServiceForDoc(this.element, 'viewer');
+    this.viewer_ = Services.viewerForDoc(this.element, 'viewer');
 
     this.compileCallback();
   }

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -54,7 +54,7 @@ export class BaseTemplate {
     this.win = element.ownerDocument.defaultView || win;
 
     /** @private @const */
-    this.viewer_ = Services.viewerForDoc(this.element, 'viewer');
+    this.viewer_ = Services.viewerForDoc(this.element);
 
     this.compileCallback();
   }

--- a/src/services.js
+++ b/src/services.js
@@ -268,6 +268,7 @@ export class Services {
   }
 
   /**
+   * TODO(#22414): Remove this in favor of the async API.
    * Returns a service to register callbacks we wish to execute when an
    * amp-form is submitted. This is the sync version used by amp-form only, all
    * other extensions should use `formSubmitPromiseForDoc` below.


### PR DESCRIPTION
Partial for #22414. Next is to start migrating extension code to use the async API.

/to @calebcordry /cc @jridgewell 