### PR TITLE
✨ Support multi entitlement pingback in amp-subscriptions

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -312,6 +312,11 @@ export class GoogleSubscriptionsPlatform {
     return false;
   }
 
+  /** @override */
+  pingbackReturnsAllEntitlements() {
+    return false;
+  }
+
   /**
    * Performs the pingback to the subscription platform
    */

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -509,16 +509,22 @@ export class SubscriptionService {
    */
   performPingback_() {
     if (this.viewTrackerPromise_) {
+      const localPlatform = this.platformStore_.getLocalPlatform();
       return this.viewTrackerPromise_
         .then(() => {
-          return this.platformStore_.getGrantEntitlement();
-        })
-        .then(grantStateEntitlement => {
-          const localPlatform = this.platformStore_.getLocalPlatform();
-          if (localPlatform.isPingbackEnabled()) {
-            localPlatform.pingback(
-              grantStateEntitlement || Entitlement.empty('local')
+          if (localPlatform.pingbackReturnsAllEntitlements()) {
+            return this.platformStore_.getAllPlatformsEntitlements();
+          }
+          return this.platformStore_
+            .getGrantEntitlement()
+            .then(
+              grantStateEntitlement =>
+                grantStateEntitlement || Entitlement.empty('local')
             );
+        })
+        .then(resolveEntitlements => {
+          if (localPlatform.isPingbackEnabled()) {
+            localPlatform.pingback(resolveEntitlements);
           }
         });
     }

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -41,6 +41,11 @@ export class LocalSubscriptionBasePlatform {
     /** @protected {!JsonObject} */
     this.serviceConfig_ = platformConfig;
 
+    /** @private @const {boolean} */
+    this.pingbackAllEntitlements_ = !!this.serviceConfig_[
+      'pingbackAllEntitlements'
+    ];
+
     /** @protected @const {!./service-adapter.ServiceAdapter} */
     this.serviceAdapter_ = serviceAdapter;
 
@@ -194,6 +199,14 @@ export class LocalSubscriptionBasePlatform {
    * @return {!Promise|undefined}
    */
   pingback(unusedEntitlement) {}
+
+  /**
+   * @override
+   * @return {boolean}
+   */
+  pingbackReturnsAllEntitlements() {
+    return this.pingbackAllEntitlements_;
+  }
 
   /** @override */
   isPingbackEnabled() {

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -337,10 +337,9 @@ export class PlatformStore {
 
   /**
    * Returns entitlements when all services are done fetching them.
-   * @private
    * @return {!Promise<!Array<!./entitlement.Entitlement>>}
    */
-  getAllPlatformsEntitlements_() {
+  getAllPlatformsEntitlements() {
     if (this.allResolvedPromise_) {
       return this.allResolvedPromise_.promise;
     }
@@ -383,7 +382,7 @@ export class PlatformStore {
    * @return {!Promise<!./subscription-platform.SubscriptionPlatform>}
    */
   selectPlatform() {
-    return this.getAllPlatformsEntitlements_().then(() => {
+    return this.getAllPlatformsEntitlements().then(() => {
       // TODO(@prateekbh): explain why sometimes a quick resolve is possible vs
       // waiting for all entitlement.
       return this.selectApplicablePlatform_();

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -64,6 +64,12 @@ export class SubscriptionPlatform {
   isPingbackEnabled() {}
 
   /**
+   * True if pingback returns all entitlments
+   * @return {boolean}
+   */
+  pingbackReturnsAllEntitlements() {}
+
+  /**
    * Performs the pingback to the subscription platform.
    * @param {!./entitlement.Entitlement} unusedSelectedPlatform
    * @return {!Promise|undefined}

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -98,6 +98,23 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     expect(localSubscriptionPlatform.getBaseScore()).to.be.equal(99);
   });
 
+  it('should default to single entitlement pingback', () => {
+    expect(localSubscriptionPlatform.pingbackReturnsAllEntitlements()).to.be
+      .false;
+  });
+
+  it('pingbackReturnsAllEntitlements should "pingbackAllEntitlements" config value', () => {
+    const testConfig = Object.assign({}, serviceConfig.services[0], {
+      'pingbackAllEntitlements': true,
+    });
+    const testLocalPlatform = localSubscriptionPlatformFactory(
+      ampdoc,
+      testConfig,
+      serviceAdapter
+    );
+    expect(testLocalPlatform.pingbackReturnsAllEntitlements()).to.be.true;
+  });
+
   it('Should not allow prerender', () => {
     expect(localSubscriptionPlatform.isPrerenderSafe()).to.be.false;
   });

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -250,7 +250,7 @@ describes.realWin('Platform store', {}, () => {
       () => {
         const fakeResult = [entitlementsForService1, entitlementsForService2];
         const getAllPlatformsStub = sandbox
-          .stub(platformStore, 'getAllPlatformsEntitlements_')
+          .stub(platformStore, 'getAllPlatformsEntitlements')
           .callsFake(() => Promise.resolve(fakeResult));
         const selectApplicablePlatformStub = sandbox
           .stub(platformStore, 'selectApplicablePlatform_')

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -217,6 +217,11 @@ export class ViewerSubscriptionPlatform {
   }
 
   /** @override */
+  pingbackReturnsAllEntitlements() {
+    return this.platform_.pingbackReturnsAllEntitlements();
+  }
+
+  /** @override */
   pingback(selectedPlatform) {
     this.platform_.pingback(selectedPlatform);
   }


### PR DESCRIPTION
This PR allows the `amp-subscriptions` pingback to return all entitlements (as opposed to just the one that granted access).

Changes:

1. Expose the `getAllPlatformsEntitlements` method in `platform-store.js`
2. Add a `pingbackReturnsAllEntitlements` method to `SubscriptionPlatform`
3. Modify `amp-subscriptions` to return all entitlements if `pingbackAllEntitlements` is true in the local platform config
4. Tests for the above
5. Add stub `pingbackReturnsAllEntitlements` to `amp-subscriptions-google`


