### PR TITLE
Allow input tags in amp-autocomplete to have no "type" attribute.

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -1,27 +1,97 @@
 <!doctype html>
 <html ⚡>
+
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>AMP Autocomplete Demo</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-boilerplate>
+    body {
+      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      animation: -amp-start 8s steps(1, end) 0s 1 normal both
+    }
+
+    @-webkit-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-moz-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-ms-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-o-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+  </style><noscript>
+    <style amp-boilerplate>
+      body {
+        -webkit-animation: none;
+        -moz-animation: none;
+        -ms-animation: none;
+        animation: none
+      }
+    </style>
+  </noscript>
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <style amp-custom>
     body {
-        padding: 15px;
+      padding: 15px;
     }
+
     .custom-population {
-        padding-top: 4px;
-        font: 8pt 'Courier New', Courier, monospace;
+      padding-top: 4px;
+      font: 8pt 'Courier New', Courier, monospace;
     }
+
     input[name=favoriteState] {
       width: 2em;
     }
+
     .out-of-stock {
       text-align: right;
       text-transform: uppercase;
@@ -30,224 +100,215 @@
     }
   </style>
   <script>
-      (self.AMP=self.AMP||[]).push((AMP) => {
-        AMP.toggleExperiment('amp-autocomplete', true);
-      });
+    (self.AMP = self.AMP || []).push((AMP) => {
+      AMP.toggleExperiment('amp-autocomplete', true);
+    });
   </script>
 </head>
+
 <body>
-    <h1>Autocomplete</h1>
-    <h2>Select Event</h2>
-    <p>min-characters = 0</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json"
-        on="select:AMP.setState({inputSelect: event.value})">
-          <input type="text" name="input2" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <h1>Autocomplete</h1>
+  <h2>Select Event</h2>
+  <p>min-characters = 0</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json"
+      on="select:AMP.setState({inputSelect: event.value})">
+      <input name="input2" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input2}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input2}}
+      </template>
     </div>
-    </form>
-    <p [text]="'Hello ' + inputSelect">Hello World</p>
+  </form>
+  <p [text]="'Hello ' + inputSelect">Hello World</p>
 
-    <h2>Disable browser autofill</h2>
-    <p>form has no autocomplete attr</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <label for="frmEmailA">Personal Email</label>
-      <input type="text" name="email" id="frmEmailA" placeholder="name@example.com" required autocomplete="email"><br>
+  <h2>Disable browser autofill</h2>
+  <p>form has no autocomplete attr</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <label for="frmEmailA">Personal Email</label>
+    <input name="email" id="frmEmailA" placeholder="name@example.com" required autocomplete="email"><br>
 
-      <label for="frmEmailB">Autocomplete Email</label>
-      <amp-autocomplete filter="substring" min-characters="0">
-        <input type="text" name="email" id="frmEmailB" placeholder="name@example.com" required autocomplete="email">  
-        <script type="application/json">
+    <label for="frmEmailB">Autocomplete Email</label>
+    <amp-autocomplete filter="substring" min-characters="0">
+      <input name="email" id="frmEmailB" placeholder="name@example.com" required autocomplete="email">
+      <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
-    </form>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
+  </form>
 
-    <p>form has autocomplete="on"</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="on">
-      <label for="frmEmailC">Personal Email</label>
-      <input type="text" name="email" id="frmEmailC" placeholder="name@example.com" required autocomplete="email"><br>
+  <p>form has autocomplete="on"</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="on">
+    <label for="frmEmailC">Personal Email</label>
+    <input name="email" id="frmEmailC" placeholder="name@example.com" required autocomplete="email"><br>
 
-      <label for="frmEmailD">Autocomplete Email</label>
-      <amp-autocomplete filter="substring" min-characters="0">
-        <input type="text" name="email" id="frmEmailD" placeholder="name@example.com" required autocomplete="email">  
-        <script type="application/json">
+    <label for="frmEmailD">Autocomplete Email</label>
+    <amp-autocomplete filter="substring" min-characters="0">
+      <input name="email" id="frmEmailD" placeholder="name@example.com" required autocomplete="email">
+      <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
-    </form>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
+  </form>
 
-    <p>form and input have autocomplete="off"</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="off">
-      <label for="frmEmailE">Personal Email</label>
-      <input type="text" name="email" id="frmEmailE" placeholder="name@example.com" required autocomplete="off"><br>
+  <p>form and input have autocomplete="off"</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="off">
+    <label for="frmEmailE">Personal Email</label>
+    <input name="email" id="frmEmailE" placeholder="name@example.com" required autocomplete="off"><br>
 
-      <label for="frmEmailF">Autocomplete Email</label>
-      <amp-autocomplete filter="substring" min-characters="0">
-        <input type="text" name="email" id="frmEmailF" placeholder="name@example.com" required autocomplete="email">  
-        <script type="application/json">
+    <label for="frmEmailF">Autocomplete Email</label>
+    <amp-autocomplete filter="substring" min-characters="0">
+      <input name="email" id="frmEmailF" placeholder="name@example.com" required autocomplete="email">
+      <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
-    </form>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
+  </form>
 
-    <h2>Attributes</h2>
-    <p>no attributes</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" src="autocomplete-cities.example.json">
-          <input type="text" name="input1" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <h2>Attributes</h2>
+  <p>no attributes</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" src="autocomplete-cities.example.json">
+      <input name="input1" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input1}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input1}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>min-characters = 0</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
-          <input type="text" name="input2" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>min-characters = 0</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
+      <input name="input2" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input2}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input2}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>min-characters = 3</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="3" src="autocomplete-cities.example.json">
-          <input type="text" name="input3" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>min-characters = 3</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" min-characters="3" src="autocomplete-cities.example.json">
+      <input name="input3" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input3}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input3}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>max-entries = 3</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" max-entries="3" src="autocomplete-cities.example.json">
-          <input type="text" name="input4" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>max-entries = 3</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" max-entries="3" src="autocomplete-cities.example.json">
+      <input name="input4" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input4}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input4}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>max-entries = 10, min-characters = 0</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" max-entries="10" min-characters="0"  src="autocomplete-cities.example.json">
-          <input type="text" name="input5" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>max-entries = 10, min-characters = 0</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" max-entries="10" min-characters="0" src="autocomplete-cities.example.json">
+      <input type="text" name="input5" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input5}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input5}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>submit-on-enter</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring"
-        src="autocomplete-cities.example.json" submit-on-enter>
-          <input type="text" name="input6" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>submit-on-enter</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" src="autocomplete-cities.example.json" submit-on-enter>
+      <input type="text" name="input6" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input6}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input6}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <h2>Filters</h2>
-    <p>substring</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="0"
-        src="autocomplete-cities.example.json" submit-on-enter>
-          <input type="text" name="input7" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <h2>Filters</h2>
+  <p>substring</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
+      <input type="text" name="input7" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input7}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input7}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>prefix</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="prefix" min-characters="0"
-        src="autocomplete-cities.example.json" submit-on-enter>
-          <input type="text" name="input8" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>prefix</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="prefix" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
+      <input type="text" name="input8" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input8}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input8}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>token-prefix</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="token-prefix" min-characters="0"
-        src="autocomplete-cities.example.json" submit-on-enter>
-          <input type="text" name="input9" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>token-prefix</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="token-prefix" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
+      <input type="text" name="input9" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input9}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input9}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>fuzzy</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="fuzzy" min-characters="0"
-        src="autocomplete-cities.example.json" submit-on-enter>
-          <input type="text" name="input9" required>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+  <p>fuzzy</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="fuzzy" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
+      <input type="text" name="input9" required>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-        <template type="amp-mustache">
-            Success! {{input9}}
-        </template>
+      <template type="amp-mustache">
+        Success! {{input9}}
+      </template>
     </div>
-    </form>
+  </form>
 
-    <p>none to inline data</p>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="none" min-characters="0"
-        [src]="manualFilterData" submit-on-enter>
-          <input type="text" name="input10" required
-            on="input-debounced:AMP.setState({ manualFilterData:
+  <p>none to inline data</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="none" min-characters="0" [src]="manualFilterData" submit-on-enter>
+      <input type="text" name="input10" required on="input-debounced:AMP.setState({ manualFilterData:
               { 'items' : [event.value + ' 1', event.value + ' 2', event.value + ' 3'] } })">
-          <script type=application/json>
-           { "items" : [] }
-          </script>
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
+      <script type=application/json> { "items" : [] } </script> </amp-autocomplete> <input name="submit-button"
+        type="submit" value="Submit">
     <div submit-success>
         <template type="amp-mustache">
             Success! {{input10}}
@@ -287,229 +348,210 @@
                           "أخضر", "أزرق", "بني", "برتقالى"]
                         }
                     </script>
-                </amp-autocomplete>
-            </label><br>
-            <label>
-                <span>Your favorite color (in English)</span>
-                <amp-autocomplete filter="prefix" min-characters="0">
-                    <input type="text" required>
-                    <script type="application/json">
+    </amp-autocomplete>
+    </label><br>
+    <label>
+      <span>Your favorite color (in English)</span>
+      <amp-autocomplete filter="prefix" min-characters="0">
+        <input type="text" required>
+        <script type="application/json">
                         { "items" : ["white", "black", "red", "yellow",
                         "green", "blue", "brown", "orange"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <label>
-                <span>Your favorite color (in Arabic and English)</span>
-                <amp-autocomplete filter="prefix" min-characters="0">
-                    <input type="text" required>
-                    <script type="application/json">
+      </amp-autocomplete>
+    </label>
+    <label>
+      <span>Your favorite color (in Arabic and English)</span>
+      <amp-autocomplete filter="prefix" min-characters="0">
+        <input type="text" required>
+        <script type="application/json">
                         { "items" : ["أبيض", "white", "أسود", "black", "أحمر", "red", "أصفر", "yellow", "أخضر", 
                         "green", "أزرق", "blue", "بني", "brown", "برتقالى", "orange"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit">
-        </fieldset>
+      </amp-autocomplete>
+    </label>
+    <input name="submit-button" type="submit" value="Submit">
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
-                to confirm!
-            </template>
-        </div>
-        <div submit-error>
-            <template type="amp-mustache">
-                Oops! {{name}}, We apologies something went wrong. Please try again later.
-            </template>
-        </div>
-    </form>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
+        to confirm!
+      </template>
+    </div>
+    <div submit-error>
+      <template type="amp-mustache">
+        Oops! {{name}}, We apologies something went wrong. Please try again later.
+      </template>
+    </div>
+  </form>
 
-    <p>Remote data (with small data)</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your hometown</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    src="autocomplete-cities.example.json">
-                    <input type="text" name="city" required>
-                </amp-autocomplete>
-            </label>
-            <label>
-                <span>Favorite state</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    src="autocomplete-states.example.json">
-                    <input type="text" name="favoriteState" required>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit">
-        </fieldset>
+  <p>Remote data (with small data)</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your hometown</span>
+        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
+          <input type="text" name="city" required>
+        </amp-autocomplete>
+      </label>
+      <label>
+        <span>Favorite state</span>
+        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-states.example.json">
+          <input type="text" name="favoriteState" required>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit">
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Mailing a postcard to {{city}}.
-            </template>
-        </div>
-    </form>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Mailing a postcard to {{city}}.
+      </template>
+    </div>
+  </form>
 
-    <p>Both data sources provided (should cause warning and display remote data)</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your hometown</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    src="autocomplete-cities.example.json">
-                    <input type="text" name="city" required>
-                    <script type="application/json">
+  <p>Both data sources provided (should cause warning and display remote data)</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your hometown</span>
+        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
+          <input type="text" name="city" required>
+          <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit">
-        </fieldset>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit">
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Mailing a postcard to {{city}}.
-            </template>
-        </div>
-    </form>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Mailing a postcard to {{city}}.
+      </template>
+    </div>
+  </form>
 
-    <p>Neither data sources provided (should cause warning)</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your hometown</span>
-                <amp-autocomplete filter="substring" min-characters="0">
-                    <input type="text" name="city" required>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit">
-        </fieldset>
+  <p>Neither data sources provided (should cause warning)</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your hometown</span>
+        <amp-autocomplete filter="substring" min-characters="0">
+          <input type="text" name="city" required>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit">
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Mailing a postcard to {{city}}.
-            </template>
-        </div>
-    </form>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Mailing a postcard to {{city}}.
+      </template>
+    </div>
+  </form>
 
-    <p>Dynamic data, changing json path</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your hometown</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    src="autocomplete-cities.example.json"
-                    [src]="srcUrl">
-                    <input type="text" name="value" required>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit"><br>
-        </fieldset>
+  <p>Dynamic data, changing json path</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your hometown</span>
+        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json" [src]="srcUrl">
+          <input type="text" name="value" required>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit"><br>
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Mailing a postcard to {{value}}.
-            </template>
-        </div>
-    </form>
-    <button on="tap:AMP.setState({ srcUrl: 'autocomplete-countries.example.json' })">Suggest countries</button>
-    <button on="tap:AMP.setState({ srcUrl: 'autocomplete-cities.example.json' })">Suggest US cities</button>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Mailing a postcard to {{value}}.
+      </template>
+    </div>
+  </form>
+  <button on="tap:AMP.setState({ srcUrl: 'autocomplete-countries.example.json' })">Suggest countries</button>
+  <button on="tap:AMP.setState({ srcUrl: 'autocomplete-cities.example.json' })">Suggest US cities</button>
 
-    <p>Dynamic data, changing json object</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your message</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    [src]="srcJson">
-                    <input type="text" name="value" required>
-                    <script type="application/json">
+  <p>Dynamic data, changing json object</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your message</span>
+        <amp-autocomplete filter="substring" min-characters="0" [src]="srcJson">
+          <input type="text" name="value" required>
+          <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit"><br>
-        </fieldset>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit"><br>
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Thanks for submitting "{{value}}".
-            </template>
-        </div>
-    </form>
-    <button on="tap:AMP.setState({ srcJson: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
-    <button on="tap:AMP.setState({ srcJson: { 'items' : ['hello a', 'hello b', 'hello c'] } })">Suggest hellos</button>
+    <div submit-success>
+      <template type="amp-mustache">
+        Thanks for submitting "{{value}}".
+      </template>
+    </div>
+  </form>
+  <button on="tap:AMP.setState({ srcJson: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
+  <button on="tap:AMP.setState({ srcJson: { 'items' : ['hello a', 'hello b', 'hello c'] } })">Suggest hellos</button>
 
-    <p>Dynamic data, changing json path and object</p>
-    <form method="post"
-        action-xhr="/form/echo-json/post"
-        target="_blank">
-        <fieldset>
-            <label>
-                <span>Your hometown</span>
-                <amp-autocomplete filter="substring" min-characters="0"
-                    [src]="srcData">
-                    <input type="text" name="value" required>
-                    <script type="application/json">
+  <p>Dynamic data, changing json path and object</p>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <fieldset>
+      <label>
+        <span>Your hometown</span>
+        <amp-autocomplete filter="substring" min-characters="0" [src]="srcData">
+          <input type="text" name="value" required>
+          <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input name="submit-button" type="submit" value="Submit"><br>
-        </fieldset>
+        </amp-autocomplete>
+      </label>
+      <input name="submit-button" type="submit" value="Submit"><br>
+    </fieldset>
 
-        <div submit-success>
-            <template type="amp-mustache">
-                Success! Mailing a postcard to {{value}}.
-            </template>
-        </div>
-    </form>
-    <button on="tap:AMP.setState({ srcData: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
-    <button on="tap:AMP.setState({ srcData: 'autocomplete-cities.example.json' })">Suggest US cities</button>
+    <div submit-success>
+      <template type="amp-mustache">
+        Success! Mailing a postcard to {{value}}.
+      </template>
+    </div>
+  </form>
+  <button on="tap:AMP.setState({ srcData: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
+  <button on="tap:AMP.setState({ srcData: 'autocomplete-cities.example.json' })">Suggest US cities</button>
 
 
-    <h2>Templates in search context</h2>
-    <p>Plain Text, Submit on enter</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
-        <fieldset>
-            <label>
-                <span>Search for</span>
-                <amp-autocomplete filter="token-prefix" submit-on-enter>
-                    <input type="search" name="term" required>
-                    <script type="application/json">
+  <h2>Templates in search context</h2>
+  <p>Plain Text, Submit on enter</p>
+  <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <fieldset>
+      <label>
+        <span>Search for</span>
+        <amp-autocomplete filter="token-prefix" submit-on-enter>
+          <input type="search" name="term" required>
+          <script type="application/json">
                         { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input type="submit" value="Search">
-        </fieldset>
-        <div submit-success>
-            <template type="amp-mustache">
-                <div>Here are the results for the search: {{term}}</div>
-            </template>
-        </div>
-    </form>
+        </amp-autocomplete>
+      </label>
+      <input type="submit" value="Search">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        <div>Here are the results for the search: {{term}}</div>
+      </template>
+    </div>
+  </form>
 
-    <p>Rich Text, Template Child, Default Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
-        <fieldset>
-            <label>
-                <span>Search for</span>
-                <amp-autocomplete filter="token-prefix" min-characters="0">
-                    <input type="search" name="term" required>
-                    <script type="application/json">
+  <p>Rich Text, Template Child, Default Value Property</p>
+  <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <fieldset>
+      <label>
+        <span>Search for</span>
+        <amp-autocomplete filter="token-prefix" min-characters="0">
+          <input type="search" name="term" required>
+          <script type="application/json">
                         { "items" : [
                             {
                                 "value" : "Albany, New York",
@@ -526,31 +568,31 @@
                             }
                         ] }
                     </script>
-                    <template type="amp-mustache" id="amp-template-default">
-                        <div class="city-item" data-value="{{value}}">
-                            <div>{{value}}</div>
-                            <div class="custom-population">Population: {{population}}</div>
-                        </div>
-                        </template>
-                </amp-autocomplete>
-            </label>
-            <input type="submit" value="Search">
-        </fieldset>
-        <div submit-success>
-            <template type="amp-mustache">
-                <div>Here are the results for the search: {{term}}</div>
-            </template>
-        </div>
-    </form>
+          <template type="amp-mustache" id="amp-template-default">
+            <div class="city-item" data-value="{{value}}">
+              <div>{{value}}</div>
+              <div class="custom-population">Population: {{population}}</div>
+            </div>
+          </template>
+        </amp-autocomplete>
+      </label>
+      <input type="submit" value="Search">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        <div>Here are the results for the search: {{term}}</div>
+      </template>
+    </div>
+  </form>
 
-    <p>Rich Text, Template Child, Custom Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
-        <fieldset>
-            <label>
-                <span>Search for</span>
-                <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
-                    <input type="search" name="term" required>
-                    <script type="application/json">
+  <p>Rich Text, Template Child, Custom Value Property</p>
+  <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <fieldset>
+      <label>
+        <span>Search for</span>
+        <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
+          <input type="search" name="term" required>
+          <script type="application/json">
                         { "items" : [
                             {
                                 "city" : "Albany",
@@ -570,32 +612,31 @@
                             }
                         ] }
                     </script>
-                    <template type="amp-mustache" id="amp-template-custom">
-                        <div class="city-item" data-value="{{city}}, {{state}}">
-                            <div>{{city}}, {{state}}</div>
-                            <div class="custom-population">Population: {{population}}</div>
-                        </div>
-                    </template>
-                </amp-autocomplete>
-            </label>
-            <input type="submit" value="Search">
-        </fieldset>
-        <div submit-success>
-            <template type="amp-mustache">
-                <div>Here are the results for the search: {{term}}</div>
-            </template>
-        </div>
-    </form>
+          <template type="amp-mustache" id="amp-template-custom">
+            <div class="city-item" data-value="{{city}}, {{state}}">
+              <div>{{city}}, {{state}}</div>
+              <div class="custom-population">Population: {{population}}</div>
+            </div>
+          </template>
+        </amp-autocomplete>
+      </label>
+      <input type="submit" value="Search">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        <div>Here are the results for the search: {{term}}</div>
+      </template>
+    </div>
+  </form>
 
-    <p>Rich Text, Template Attribute, Default Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
-        <fieldset>
-            <label>
-                <span>Search for</span>
-                <amp-autocomplete filter="token-prefix" min-characters="0"
-                    template="amp-template-default">
-                    <input type="search" name="term" required>
-                    <script type="application/json">
+  <p>Rich Text, Template Attribute, Default Value Property</p>
+  <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <fieldset>
+      <label>
+        <span>Search for</span>
+        <amp-autocomplete filter="token-prefix" min-characters="0" template="amp-template-default">
+          <input type="search" name="term" required>
+          <script type="application/json">
                         { "items" : [
                             {
                                 "value" : "Albany, New York",
@@ -612,22 +653,22 @@
                             }
                         ] }
                     </script>
-                </amp-autocomplete>
-            </label>
-            <input type="submit" value="Search">
-        </fieldset>
-        <div submit-success>
-            <template type="amp-mustache">
-                <div>Here are the results for the search: {{term}}</div>
-            </template>
-        </div>
-    </form>
+        </amp-autocomplete>
+      </label>
+      <input type="submit" value="Search">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        <div>Here are the results for the search: {{term}}</div>
+      </template>
+    </div>
+  </form>
 
-    <h2>'Disabled' attribute</h2>
-    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-      <amp-autocomplete filter="substring" min-characters="0">
-        <input type="text">
-          <script type="application/json">
+  <h2>'Disabled' attribute</h2>
+  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+    <amp-autocomplete filter="substring" min-characters="0">
+      <input type="text">
+      <script type="application/json">
             { "items" : [ { "value" : "apple",
                             "disabled" : "true" },
                           { "value" : "orange" },
@@ -635,21 +676,22 @@
                             "disabled" : "true" },
                           { "value" : "banana" } ] }
           </script>
-        <template type="amp-mustache">
-          {{#disabled}}
-            <div data-disabled>
-              {{value}}
-              <span class="out-of-stock">out of stock</span>
-            </div>
-          {{/disabled}}
-          {{^disabled}}
-            <div data-value="{{value}}">
-              {{value}}
-            </div>
-          {{/disabled}}
-        </template> 
-      </amp-autocomplete>
-      <input name="submit-button" type="submit" value="Submit">
-    </form>
+      <template type="amp-mustache">
+        {{#disabled}}
+        <div data-disabled>
+          {{value}}
+          <span class="out-of-stock">out of stock</span>
+        </div>
+        {{/disabled}}
+        {{^disabled}}
+        <div data-value="{{value}}">
+          {{value}}
+        </div>
+        {{/disabled}}
+      </template>
+    </amp-autocomplete>
+    <input name="submit-button" type="submit" value="Submit">
+  </form>
 </body>
+
 </html>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -1,97 +1,27 @@
 <!doctype html>
 <html ⚡>
-
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>AMP Autocomplete Demo</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>
-    body {
-      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      animation: -amp-start 8s steps(1, end) 0s 1 normal both
-    }
-
-    @-webkit-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-moz-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-ms-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-o-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-  </style><noscript>
-    <style amp-boilerplate>
-      body {
-        -webkit-animation: none;
-        -moz-animation: none;
-        -ms-animation: none;
-        animation: none
-      }
-    </style>
-  </noscript>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <style amp-custom>
     body {
-      padding: 15px;
+        padding: 15px;
     }
-
     .custom-population {
-      padding-top: 4px;
-      font: 8pt 'Courier New', Courier, monospace;
+        padding-top: 4px;
+        font: 8pt 'Courier New', Courier, monospace;
     }
-
     input[name=favoriteState] {
       width: 2em;
     }
-
     .out-of-stock {
       text-align: right;
       text-transform: uppercase;
@@ -100,215 +30,224 @@
     }
   </style>
   <script>
-    (self.AMP = self.AMP || []).push((AMP) => {
-      AMP.toggleExperiment('amp-autocomplete', true);
-    });
+      (self.AMP=self.AMP||[]).push((AMP) => {
+        AMP.toggleExperiment('amp-autocomplete', true);
+      });
   </script>
 </head>
-
 <body>
-  <h1>Autocomplete</h1>
-  <h2>Select Event</h2>
-  <p>min-characters = 0</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json"
-      on="select:AMP.setState({inputSelect: event.value})">
+    <h1>Autocomplete</h1>
+    <h2>Select Event</h2>
+    <p>min-characters = 0</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json"
+        on="select:AMP.setState({inputSelect: event.value})">
       <input name="input2" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input2}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input2}}
+        </template>
     </div>
-  </form>
-  <p [text]="'Hello ' + inputSelect">Hello World</p>
+    </form>
+    <p [text]="'Hello ' + inputSelect">Hello World</p>
 
-  <h2>Disable browser autofill</h2>
-  <p>form has no autocomplete attr</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <label for="frmEmailA">Personal Email</label>
+    <h2>Disable browser autofill</h2>
+    <p>form has no autocomplete attr</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <label for="frmEmailA">Personal Email</label>
     <input name="email" id="frmEmailA" placeholder="name@example.com" required autocomplete="email"><br>
 
-    <label for="frmEmailB">Autocomplete Email</label>
-    <amp-autocomplete filter="substring" min-characters="0">
+      <label for="frmEmailB">Autocomplete Email</label>
+      <amp-autocomplete filter="substring" min-characters="0">
       <input name="email" id="frmEmailB" placeholder="name@example.com" required autocomplete="email">
-      <script type="application/json">
+        <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
-  </form>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
+    </form>
 
-  <p>form has autocomplete="on"</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="on">
-    <label for="frmEmailC">Personal Email</label>
+    <p>form has autocomplete="on"</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="on">
+      <label for="frmEmailC">Personal Email</label>
     <input name="email" id="frmEmailC" placeholder="name@example.com" required autocomplete="email"><br>
 
-    <label for="frmEmailD">Autocomplete Email</label>
-    <amp-autocomplete filter="substring" min-characters="0">
+      <label for="frmEmailD">Autocomplete Email</label>
+      <amp-autocomplete filter="substring" min-characters="0">
       <input name="email" id="frmEmailD" placeholder="name@example.com" required autocomplete="email">
-      <script type="application/json">
+        <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
-  </form>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
+    </form>
 
-  <p>form and input have autocomplete="off"</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="off">
-    <label for="frmEmailE">Personal Email</label>
+    <p>form and input have autocomplete="off"</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank" autocomplete="off">
+      <label for="frmEmailE">Personal Email</label>
     <input name="email" id="frmEmailE" placeholder="name@example.com" required autocomplete="off"><br>
 
-    <label for="frmEmailF">Autocomplete Email</label>
-    <amp-autocomplete filter="substring" min-characters="0">
+      <label for="frmEmailF">Autocomplete Email</label>
+      <amp-autocomplete filter="substring" min-characters="0">
       <input name="email" id="frmEmailF" placeholder="name@example.com" required autocomplete="email">
-      <script type="application/json">
+        <script type="application/json">
           { "items" : ["Email 1", "Email 2", "Email 3"]}
         </script>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
-  </form>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
+    </form>
 
-  <h2>Attributes</h2>
-  <p>no attributes</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" src="autocomplete-cities.example.json">
+    <h2>Attributes</h2>
+    <p>no attributes</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" src="autocomplete-cities.example.json">
       <input name="input1" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input1}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input1}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>min-characters = 0</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
+    <p>min-characters = 0</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
       <input name="input2" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input2}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input2}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>min-characters = 3</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" min-characters="3" src="autocomplete-cities.example.json">
+    <p>min-characters = 3</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="3" src="autocomplete-cities.example.json">
       <input name="input3" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input3}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input3}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>max-entries = 3</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" max-entries="3" src="autocomplete-cities.example.json">
+    <p>max-entries = 3</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" max-entries="3" src="autocomplete-cities.example.json">
       <input name="input4" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input4}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input4}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>max-entries = 10, min-characters = 0</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" max-entries="10" min-characters="0" src="autocomplete-cities.example.json">
-      <input type="text" name="input5" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <p>max-entries = 10, min-characters = 0</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" max-entries="10" min-characters="0"  src="autocomplete-cities.example.json">
+          <input type="text" name="input5" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input5}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input5}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>submit-on-enter</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" src="autocomplete-cities.example.json" submit-on-enter>
-      <input type="text" name="input6" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <p>submit-on-enter</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring"
+        src="autocomplete-cities.example.json" submit-on-enter>
+          <input type="text" name="input6" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input6}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input6}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <h2>Filters</h2>
-  <p>substring</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
-      <input type="text" name="input7" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <h2>Filters</h2>
+    <p>substring</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0"
+        src="autocomplete-cities.example.json" submit-on-enter>
+          <input type="text" name="input7" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input7}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input7}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>prefix</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="prefix" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
-      <input type="text" name="input8" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <p>prefix</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="prefix" min-characters="0"
+        src="autocomplete-cities.example.json" submit-on-enter>
+          <input type="text" name="input8" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input8}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input8}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>token-prefix</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="token-prefix" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
-      <input type="text" name="input9" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <p>token-prefix</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="token-prefix" min-characters="0"
+        src="autocomplete-cities.example.json" submit-on-enter>
+          <input type="text" name="input9" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input9}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input9}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>fuzzy</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="fuzzy" min-characters="0" src="autocomplete-cities.example.json" submit-on-enter>
-      <input type="text" name="input9" required>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
+    <p>fuzzy</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="fuzzy" min-characters="0"
+        src="autocomplete-cities.example.json" submit-on-enter>
+          <input type="text" name="input9" required>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
-      <template type="amp-mustache">
-        Success! {{input9}}
-      </template>
+        <template type="amp-mustache">
+            Success! {{input9}}
+        </template>
     </div>
-  </form>
+    </form>
 
-  <p>none to inline data</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="none" min-characters="0" [src]="manualFilterData" submit-on-enter>
-      <input type="text" name="input10" required on="input-debounced:AMP.setState({ manualFilterData:
+    <p>none to inline data</p>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="none" min-characters="0"
+        [src]="manualFilterData" submit-on-enter>
+          <input type="text" name="input10" required
+            on="input-debounced:AMP.setState({ manualFilterData:
               { 'items' : [event.value + ' 1', event.value + ' 2', event.value + ' 3'] } })">
-      <script type=application/json> { "items" : [] } </script> </amp-autocomplete> <input name="submit-button"
-        type="submit" value="Submit">
+          <script type=application/json>
+           { "items" : [] }
+          </script>
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
     <div submit-success>
         <template type="amp-mustache">
             Success! {{input10}}
@@ -348,210 +287,229 @@
                           "أخضر", "أزرق", "بني", "برتقالى"]
                         }
                     </script>
-    </amp-autocomplete>
-    </label><br>
-    <label>
-      <span>Your favorite color (in English)</span>
-      <amp-autocomplete filter="prefix" min-characters="0">
-        <input type="text" required>
-        <script type="application/json">
+                </amp-autocomplete>
+            </label><br>
+            <label>
+                <span>Your favorite color (in English)</span>
+                <amp-autocomplete filter="prefix" min-characters="0">
+                    <input type="text" required>
+                    <script type="application/json">
                         { "items" : ["white", "black", "red", "yellow",
                         "green", "blue", "brown", "orange"] }
                     </script>
-      </amp-autocomplete>
-    </label>
-    <label>
-      <span>Your favorite color (in Arabic and English)</span>
-      <amp-autocomplete filter="prefix" min-characters="0">
-        <input type="text" required>
-        <script type="application/json">
+                </amp-autocomplete>
+            </label>
+            <label>
+                <span>Your favorite color (in Arabic and English)</span>
+                <amp-autocomplete filter="prefix" min-characters="0">
+                    <input type="text" required>
+                    <script type="application/json">
                         { "items" : ["أبيض", "white", "أسود", "black", "أحمر", "red", "أصفر", "yellow", "أخضر", 
                         "green", "أزرق", "blue", "بني", "brown", "برتقالى", "orange"] }
                     </script>
-      </amp-autocomplete>
-    </label>
-    <input name="submit-button" type="submit" value="Submit">
-    </fieldset>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit">
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
-        to confirm!
-      </template>
-    </div>
-    <div submit-error>
-      <template type="amp-mustache">
-        Oops! {{name}}, We apologies something went wrong. Please try again later.
-      </template>
-    </div>
-  </form>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
+                to confirm!
+            </template>
+        </div>
+        <div submit-error>
+            <template type="amp-mustache">
+                Oops! {{name}}, We apologies something went wrong. Please try again later.
+            </template>
+        </div>
+    </form>
 
-  <p>Remote data (with small data)</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your hometown</span>
-        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
-          <input type="text" name="city" required>
-        </amp-autocomplete>
-      </label>
-      <label>
-        <span>Favorite state</span>
-        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-states.example.json">
-          <input type="text" name="favoriteState" required>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit">
-    </fieldset>
+    <p>Remote data (with small data)</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your hometown</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    src="autocomplete-cities.example.json">
+                    <input type="text" name="city" required>
+                </amp-autocomplete>
+            </label>
+            <label>
+                <span>Favorite state</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    src="autocomplete-states.example.json">
+                    <input type="text" name="favoriteState" required>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit">
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Mailing a postcard to {{city}}.
-      </template>
-    </div>
-  </form>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Mailing a postcard to {{city}}.
+            </template>
+        </div>
+    </form>
 
-  <p>Both data sources provided (should cause warning and display remote data)</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your hometown</span>
-        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json">
-          <input type="text" name="city" required>
-          <script type="application/json">
+    <p>Both data sources provided (should cause warning and display remote data)</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your hometown</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    src="autocomplete-cities.example.json">
+                    <input type="text" name="city" required>
+                    <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit">
-    </fieldset>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit">
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Mailing a postcard to {{city}}.
-      </template>
-    </div>
-  </form>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Mailing a postcard to {{city}}.
+            </template>
+        </div>
+    </form>
 
-  <p>Neither data sources provided (should cause warning)</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your hometown</span>
-        <amp-autocomplete filter="substring" min-characters="0">
-          <input type="text" name="city" required>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit">
-    </fieldset>
+    <p>Neither data sources provided (should cause warning)</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your hometown</span>
+                <amp-autocomplete filter="substring" min-characters="0">
+                    <input type="text" name="city" required>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit">
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Mailing a postcard to {{city}}.
-      </template>
-    </div>
-  </form>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Mailing a postcard to {{city}}.
+            </template>
+        </div>
+    </form>
 
-  <p>Dynamic data, changing json path</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your hometown</span>
-        <amp-autocomplete filter="substring" min-characters="0" src="autocomplete-cities.example.json" [src]="srcUrl">
-          <input type="text" name="value" required>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit"><br>
-    </fieldset>
+    <p>Dynamic data, changing json path</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your hometown</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    src="autocomplete-cities.example.json"
+                    [src]="srcUrl">
+                    <input type="text" name="value" required>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit"><br>
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Mailing a postcard to {{value}}.
-      </template>
-    </div>
-  </form>
-  <button on="tap:AMP.setState({ srcUrl: 'autocomplete-countries.example.json' })">Suggest countries</button>
-  <button on="tap:AMP.setState({ srcUrl: 'autocomplete-cities.example.json' })">Suggest US cities</button>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Mailing a postcard to {{value}}.
+            </template>
+        </div>
+    </form>
+    <button on="tap:AMP.setState({ srcUrl: 'autocomplete-countries.example.json' })">Suggest countries</button>
+    <button on="tap:AMP.setState({ srcUrl: 'autocomplete-cities.example.json' })">Suggest US cities</button>
 
-  <p>Dynamic data, changing json object</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your message</span>
-        <amp-autocomplete filter="substring" min-characters="0" [src]="srcJson">
-          <input type="text" name="value" required>
-          <script type="application/json">
+    <p>Dynamic data, changing json object</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your message</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    [src]="srcJson">
+                    <input type="text" name="value" required>
+                    <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit"><br>
-    </fieldset>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit"><br>
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Thanks for submitting "{{value}}".
-      </template>
-    </div>
-  </form>
-  <button on="tap:AMP.setState({ srcJson: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
-  <button on="tap:AMP.setState({ srcJson: { 'items' : ['hello a', 'hello b', 'hello c'] } })">Suggest hellos</button>
+        <div submit-success>
+            <template type="amp-mustache">
+                Thanks for submitting "{{value}}".
+            </template>
+        </div>
+    </form>
+    <button on="tap:AMP.setState({ srcJson: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
+    <button on="tap:AMP.setState({ srcJson: { 'items' : ['hello a', 'hello b', 'hello c'] } })">Suggest hellos</button>
 
-  <p>Dynamic data, changing json path and object</p>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <fieldset>
-      <label>
-        <span>Your hometown</span>
-        <amp-autocomplete filter="substring" min-characters="0" [src]="srcData">
-          <input type="text" name="value" required>
-          <script type="application/json">
+    <p>Dynamic data, changing json path and object</p>
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
+        <fieldset>
+            <label>
+                <span>Your hometown</span>
+                <amp-autocomplete filter="substring" min-characters="0"
+                    [src]="srcData">
+                    <input type="text" name="value" required>
+                    <script type="application/json">
                       { "items" : ["hello a", "hello b", "hello c"] }
                     </script>
-        </amp-autocomplete>
-      </label>
-      <input name="submit-button" type="submit" value="Submit"><br>
-    </fieldset>
+                </amp-autocomplete>
+            </label>
+            <input name="submit-button" type="submit" value="Submit"><br>
+        </fieldset>
 
-    <div submit-success>
-      <template type="amp-mustache">
-        Success! Mailing a postcard to {{value}}.
-      </template>
-    </div>
-  </form>
-  <button on="tap:AMP.setState({ srcData: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
-  <button on="tap:AMP.setState({ srcData: 'autocomplete-cities.example.json' })">Suggest US cities</button>
+        <div submit-success>
+            <template type="amp-mustache">
+                Success! Mailing a postcard to {{value}}.
+            </template>
+        </div>
+    </form>
+    <button on="tap:AMP.setState({ srcData: { 'items' : ['apple', 'banana', 'coconut']} })">Suggest fruit</button>
+    <button on="tap:AMP.setState({ srcData: 'autocomplete-cities.example.json' })">Suggest US cities</button>
 
 
-  <h2>Templates in search context</h2>
-  <p>Plain Text, Submit on enter</p>
-  <form method="get" action-xhr="/form/search-json/get" target="_blank">
-    <fieldset>
-      <label>
-        <span>Search for</span>
-        <amp-autocomplete filter="token-prefix" submit-on-enter>
-          <input type="search" name="term" required>
-          <script type="application/json">
+    <h2>Templates in search context</h2>
+    <p>Plain Text, Submit on enter</p>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" submit-on-enter>
+                    <input type="search" name="term" required>
+                    <script type="application/json">
                         { "items" : ["apple", "pineapple", "coconut", "pine apple"] }
                     </script>
-        </amp-autocomplete>
-      </label>
-      <input type="submit" value="Search">
-    </fieldset>
-    <div submit-success>
-      <template type="amp-mustache">
-        <div>Here are the results for the search: {{term}}</div>
-      </template>
-    </div>
-  </form>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
 
-  <p>Rich Text, Template Child, Default Value Property</p>
-  <form method="get" action-xhr="/form/search-json/get" target="_blank">
-    <fieldset>
-      <label>
-        <span>Search for</span>
-        <amp-autocomplete filter="token-prefix" min-characters="0">
-          <input type="search" name="term" required>
-          <script type="application/json">
+    <p>Rich Text, Template Child, Default Value Property</p>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" min-characters="0">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
                         { "items" : [
                             {
                                 "value" : "Albany, New York",
@@ -568,31 +526,31 @@
                             }
                         ] }
                     </script>
-          <template type="amp-mustache" id="amp-template-default">
-            <div class="city-item" data-value="{{value}}">
-              <div>{{value}}</div>
-              <div class="custom-population">Population: {{population}}</div>
-            </div>
-          </template>
-        </amp-autocomplete>
-      </label>
-      <input type="submit" value="Search">
-    </fieldset>
-    <div submit-success>
-      <template type="amp-mustache">
-        <div>Here are the results for the search: {{term}}</div>
-      </template>
-    </div>
-  </form>
+                    <template type="amp-mustache" id="amp-template-default">
+                        <div class="city-item" data-value="{{value}}">
+                            <div>{{value}}</div>
+                            <div class="custom-population">Population: {{population}}</div>
+                        </div>
+                        </template>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
 
-  <p>Rich Text, Template Child, Custom Value Property</p>
-  <form method="get" action-xhr="/form/search-json/get" target="_blank">
-    <fieldset>
-      <label>
-        <span>Search for</span>
-        <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
-          <input type="search" name="term" required>
-          <script type="application/json">
+    <p>Rich Text, Template Child, Custom Value Property</p>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" filter-value="city" min-characters="0">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
                         { "items" : [
                             {
                                 "city" : "Albany",
@@ -612,31 +570,32 @@
                             }
                         ] }
                     </script>
-          <template type="amp-mustache" id="amp-template-custom">
-            <div class="city-item" data-value="{{city}}, {{state}}">
-              <div>{{city}}, {{state}}</div>
-              <div class="custom-population">Population: {{population}}</div>
-            </div>
-          </template>
-        </amp-autocomplete>
-      </label>
-      <input type="submit" value="Search">
-    </fieldset>
-    <div submit-success>
-      <template type="amp-mustache">
-        <div>Here are the results for the search: {{term}}</div>
-      </template>
-    </div>
-  </form>
+                    <template type="amp-mustache" id="amp-template-custom">
+                        <div class="city-item" data-value="{{city}}, {{state}}">
+                            <div>{{city}}, {{state}}</div>
+                            <div class="custom-population">Population: {{population}}</div>
+                        </div>
+                    </template>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
 
-  <p>Rich Text, Template Attribute, Default Value Property</p>
-  <form method="get" action-xhr="/form/search-json/get" target="_blank">
-    <fieldset>
-      <label>
-        <span>Search for</span>
-        <amp-autocomplete filter="token-prefix" min-characters="0" template="amp-template-default">
-          <input type="search" name="term" required>
-          <script type="application/json">
+    <p>Rich Text, Template Attribute, Default Value Property</p>
+    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+        <fieldset>
+            <label>
+                <span>Search for</span>
+                <amp-autocomplete filter="token-prefix" min-characters="0"
+                    template="amp-template-default">
+                    <input type="search" name="term" required>
+                    <script type="application/json">
                         { "items" : [
                             {
                                 "value" : "Albany, New York",
@@ -653,22 +612,22 @@
                             }
                         ] }
                     </script>
-        </amp-autocomplete>
-      </label>
-      <input type="submit" value="Search">
-    </fieldset>
-    <div submit-success>
-      <template type="amp-mustache">
-        <div>Here are the results for the search: {{term}}</div>
-      </template>
-    </div>
-  </form>
+                </amp-autocomplete>
+            </label>
+            <input type="submit" value="Search">
+        </fieldset>
+        <div submit-success>
+            <template type="amp-mustache">
+                <div>Here are the results for the search: {{term}}</div>
+            </template>
+        </div>
+    </form>
 
-  <h2>'Disabled' attribute</h2>
-  <form method="post" action-xhr="/form/echo-json/post" target="_blank">
-    <amp-autocomplete filter="substring" min-characters="0">
-      <input type="text">
-      <script type="application/json">
+    <h2>'Disabled' attribute</h2>
+    <form method="post" action-xhr="/form/echo-json/post" target="_blank">
+      <amp-autocomplete filter="substring" min-characters="0">
+        <input type="text">
+          <script type="application/json">
             { "items" : [ { "value" : "apple",
                             "disabled" : "true" },
                           { "value" : "orange" },
@@ -676,22 +635,21 @@
                             "disabled" : "true" },
                           { "value" : "banana" } ] }
           </script>
-      <template type="amp-mustache">
-        {{#disabled}}
-        <div data-disabled>
-          {{value}}
-          <span class="out-of-stock">out of stock</span>
-        </div>
-        {{/disabled}}
-        {{^disabled}}
-        <div data-value="{{value}}">
-          {{value}}
-        </div>
-        {{/disabled}}
-      </template>
-    </amp-autocomplete>
-    <input name="submit-button" type="submit" value="Submit">
-  </form>
+        <template type="amp-mustache">
+          {{#disabled}}
+            <div data-disabled>
+              {{value}}
+              <span class="out-of-stock">out of stock</span>
+            </div>
+          {{/disabled}}
+          {{^disabled}}
+            <div data-value="{{value}}">
+              {{value}}
+            </div>
+          {{/disabled}}
+        </template> 
+      </amp-autocomplete>
+      <input name="submit-button" type="submit" value="Submit">
+    </form>
 </body>
-
 </html>

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -170,15 +170,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
       `${TAG} should contain exactly one <input> child`
     );
     this.inputElement_ = /** @type {!HTMLInputElement} */ (inputElements[0]);
-    userAssert(
-      this.inputElement_.hasAttribute('type'),
-      `${TAG} requires the "type" attribute on <input>`
-    );
-    const inputType = this.inputElement_.getAttribute('type');
-    userAssert(
-      inputType === 'text' || inputType === 'search',
-      `${TAG} requires the "type=text|search" attribute on <input>`
-    );
+    if (this.inputElement_.hasAttribute('type')) {
+      const inputType = this.inputElement_.getAttribute('type');
+      userAssert(
+        inputType === 'text' || inputType === 'search',
+        `${TAG} requires the "type" attribute to be "text" or "search" if present on <input>`
+      );
+    }
     this.inputElement_.setAttribute('dir', 'auto');
 
     userAssert(this.inputElement_.form, `${TAG} should be inside a <form> tag`);

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -6,7 +6,6 @@
   You may obtain a copy of the License at
  
       http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS-IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,98 +19,30 @@
 
 <!doctype html>
 <html ⚡>
-
 <head>
   <meta charset="utf-8">
   <title>amp-autocomplete example</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>
-    body {
-      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      animation: -amp-start 8s steps(1, end) 0s 1 normal both
-    }
-
-    @-webkit-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-moz-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-ms-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @-o-keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-
-    @keyframes -amp-start {
-      from {
-        visibility: hidden
-      }
-
-      to {
-        visibility: visible
-      }
-    }
-  </style><noscript>
-    <style amp-boilerplate>
-      body {
-        -webkit-animation: none;
-        -moz-animation: none;
-        -ms-animation: none;
-        animation: none
-      }
-    </style>
-  </noscript>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
-
 <body>
-  <form method="post" action-xhr="https://example.com/subscribe">
+  <form method="post" action-xhr="https://example.com/subscribe"> 
     <!-- Valid: input and script tags as direct child to FORM -->
     <amp-autocomplete>
       <input>
       <script type="application/json"> {} </script>
-    </amp-autocomplete>
+    </amp-autocomplete>  
 
     <!-- Valid: input and src attr as direct child to FORM -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
-    </amp-autocomplete>
+    </amp-autocomplete>  
 
     <!-- Valid: input and [src] attr as direct child to FORM -->
     <amp-autocomplete [src]="foo.bar">
@@ -122,18 +53,18 @@
     <amp-autocomplete>
       <input type="text">
       <script type="application/json"> {} </script>
-    </amp-autocomplete>
+    </amp-autocomplete>  
 
     <!-- Valid: input tag with type "search" and script tag -->
     <amp-autocomplete>
       <input type="search">
       <script type="application/json"> {} </script>
-    </amp-autocomplete>
+    </amp-autocomplete>  
 
     <!-- Valid: input tag with type "search" and src attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
-    </amp-autocomplete>
+    </amp-autocomplete>  
 
     <!-- Valid: deeply nested with FORM still as ancestor -->
     <div>
@@ -142,7 +73,7 @@
           <amp-autocomplete>
             <input>
             <script type="application/json"> {} </script>
-          </amp-autocomplete>
+          </amp-autocomplete>  
         </div>
       </div>
     </div>
@@ -153,7 +84,7 @@
         <div>
           <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
             <input>
-          </amp-autocomplete>
+          </amp-autocomplete>  
         </div>
       </div>
     </div>
@@ -172,18 +103,18 @@
     <!-- Valid: amp-component with static data and filter=token-prefix attribute -->
     <amp-autocomplete filter="token-prefix">
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=token-prefix attribute -->
     <amp-autocomplete filter="token-prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
     </amp-autocomplete>
-
+  
     <!-- Valid: amp-component with static data and filter=substring attribute -->
     <amp-autocomplete filter="substring">
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=substring attribute -->
@@ -194,7 +125,7 @@
     <!-- Valid: amp-component with static data and filter=fuzzy attribute -->
     <amp-autocomplete filter="fuzzy">
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=fuzzy attribute -->
@@ -205,9 +136,9 @@
     <!-- Valid: amp-component with static data and filter=none attribute -->
     <amp-autocomplete filter="none">
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
-
+    
     <!-- Valid: amp-component with remote data and filter=none attribute -->
     <amp-autocomplete filter="none" src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
@@ -216,7 +147,7 @@
     <!-- Valid: amp-component with static data and filter=custom and filter-expr attribute -->
     <amp-autocomplete filter="custom" filter-expr="true">
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=custom and filter-expr attribute -->
@@ -227,18 +158,18 @@
     <!-- Valid: amp-component with static data and min-characters attribute -->
     <amp-autocomplete min-characters=3>
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and min-characters attribute -->
     <amp-autocomplete min-characters=3 src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
-    </amp-autocomplete>
+  </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and max-entries attribute -->
     <amp-autocomplete max-entries=10>
       <input>
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and max-entries attribute -->
@@ -249,8 +180,8 @@
     <!-- Valid: amp-component with static data and suggest-first attribute -->
     <amp-autocomplete suggest-first>
       <input>
-      <script type="application/json"> {} </script>
-    </amp-autocomplete>
+        <script type="application/json"> {} </script>
+    </amp-autocomplete>  
 
     <!-- Valid: amp-component with remote data and suggest-first attribute -->
     <amp-autocomplete suggest-first src="https://data.com/articles.json?ref=CANONICAL_URL">
@@ -260,13 +191,13 @@
     <!-- Valid: amp-component with static data and submit-on-enter attribute -->
     <amp-autocomplete submit-on-enter>
       <input>
-      <script type="application/json"> {} </script>
-    </amp-autocomplete>
+        <script type="application/json"> {} </script>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with remote data and submit-on-enter attribute -->
     <amp-autocomplete submit-on-enter src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with static data and rich content template -->
     <amp-autocomplete>
@@ -274,51 +205,51 @@
       <script type="application/json"> {} </script>
       <template type="amp-mustache" id="amp-template-default">
         <div class="city-item" data-value="{{value}}">
-          <div>{{value}}</div>
-          <div class="custom-population">Population: {{population}}</div>
+            <div>{{value}}</div>
+            <div class="custom-population">Population: {{population}}</div>        
         </div>
       </template>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with remote data and rich content template -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
       <template type="amp-mustache" id="amp-template-default">
         <div class="city-item" data-value="{{value}}">
-          <div>{{value}}</div>
-          <div class="custom-population">Population: {{population}}</div>
+            <div>{{value}}</div>
+            <div class="custom-population">Population: {{population}}</div>        
         </div>
       </template>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with remote data and rich content template -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
       <template type="amp-mustache" id="amp-template-default">
         {{#disabled}}
-        <div data-disabled>
-          <b>{{value}}</b>
-        </div>
+          <div data-disabled>
+            <b>{{value}}</b>
+          </div>
         {{/disabled}}
         {{^disabled}}
         <div class="city-item" data-value="{{value}}">
-          <div>{{value}}</div>
-          <div class="custom-population">Population: {{population}}</div>
+            <div>{{value}}</div>
+            <div class="custom-population">Population: {{population}}</div>        
         </div>
         {{/disabled}}
       </template>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with static data and template attr -->
     <amp-autocomplete template="my-template-id">
       <input>
       <script type="application/json"> {} </script>
-    </amp-autocomplete>
-
+    </amp-autocomplete> 
+    
     <!-- Valid: amp-component with remote data and template attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL" template="my-template-id">
       <input>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Valid: amp-component with static data and template script child -->
     <amp-autocomplete>
@@ -330,8 +261,8 @@
           <div class="custom-population">Population: {{population}}</div>        
         </div>
       </script>
-    </amp-autocomplete>
-
+    </amp-autocomplete> 
+    
     <!-- Valid: amp-component with remote data and template attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
       <input>
@@ -342,13 +273,13 @@
           <div class="custom-population">Population: {{population}}</div>        
         </div>
       </script>
-    </amp-autocomplete>
+    </amp-autocomplete> 
 
     <!-- Invalid: width is mistyped -->
     <amp-autocomplete widht=100>
       <input>
-      <script type="application/json"> {} </script>
-    </amp-autocomplete>
+        <script type="application/json"> {} </script>
+    </amp-autocomplete>  
 
     <!-- Invalid: responsive layout is not supported -->
     <amp-autocomplete layout="responsive">
@@ -359,7 +290,7 @@
     <!-- Invalid: amp-autocomplete with invalid input types -->
     <amp-autocomplete widht=100>
       <input type="button">
-      <script type="application/json"> {} </script>
+        <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
@@ -397,5 +328,4 @@
   </amp-autocomplete>
 
 </body>
-
 </html>

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -20,55 +20,129 @@
 
 <!doctype html>
 <html ⚡>
+
 <head>
   <meta charset="utf-8">
   <title>amp-autocomplete example</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-boilerplate>
+    body {
+      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      animation: -amp-start 8s steps(1, end) 0s 1 normal both
+    }
+
+    @-webkit-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-moz-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-ms-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @-o-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+
+    @keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+
+      to {
+        visibility: visible
+      }
+    }
+  </style><noscript>
+    <style amp-boilerplate>
+      body {
+        -webkit-animation: none;
+        -moz-animation: none;
+        -ms-animation: none;
+        animation: none
+      }
+    </style>
+  </noscript>
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
+
 <body>
-  <form method="post" action-xhr="https://example.com/subscribe"> 
+  <form method="post" action-xhr="https://example.com/subscribe">
     <!-- Valid: input and script tags as direct child to FORM -->
     <amp-autocomplete>
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
-    </amp-autocomplete>  
+    </amp-autocomplete>
 
     <!-- Valid: input and src attr as direct child to FORM -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
-    </amp-autocomplete>  
+      <input>
+    </amp-autocomplete>
 
     <!-- Valid: input and [src] attr as direct child to FORM -->
     <amp-autocomplete [src]="foo.bar">
+      <input>
+    </amp-autocomplete>
+
+    <!-- Valid: input tag with type "text" and script tag -->
+    <amp-autocomplete>
       <input type="text">
-    </amp-autocomplete>  
+      <script type="application/json"> {} </script>
+    </amp-autocomplete>
 
     <!-- Valid: input tag with type "search" and script tag -->
     <amp-autocomplete>
       <input type="search">
       <script type="application/json"> {} </script>
-    </amp-autocomplete>  
+    </amp-autocomplete>
 
     <!-- Valid: input tag with type "search" and src attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="search">
-    </amp-autocomplete>  
+      <input>
+    </amp-autocomplete>
 
     <!-- Valid: deeply nested with FORM still as ancestor -->
     <div>
       <div>
         <div>
           <amp-autocomplete>
-            <input type="search">
+            <input>
             <script type="application/json"> {} </script>
-          </amp-autocomplete>  
+          </amp-autocomplete>
         </div>
       </div>
     </div>
@@ -78,177 +152,177 @@
       <div>
         <div>
           <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-            <input type="search">
-          </amp-autocomplete>  
+            <input>
+          </amp-autocomplete>
         </div>
       </div>
     </div>
 
     <!-- Valid: amp-component with static data and filter=prefix attribute -->
     <amp-autocomplete filter="prefix">
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=prefix attribute -->
     <amp-autocomplete filter="prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and filter=token-prefix attribute -->
     <amp-autocomplete filter="token-prefix">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=token-prefix attribute -->
     <amp-autocomplete filter="token-prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
-        <input type="text">
+      <input>
     </amp-autocomplete>
-  
+
     <!-- Valid: amp-component with static data and filter=substring attribute -->
     <amp-autocomplete filter="substring">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=substring attribute -->
     <amp-autocomplete filter="substring" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and filter=fuzzy attribute -->
     <amp-autocomplete filter="fuzzy">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=fuzzy attribute -->
     <amp-autocomplete filter="fuzzy" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and filter=none attribute -->
     <amp-autocomplete filter="none">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
-    
+
     <!-- Valid: amp-component with remote data and filter=none attribute -->
     <amp-autocomplete filter="none" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and filter=custom and filter-expr attribute -->
     <amp-autocomplete filter="custom" filter-expr="true">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and filter=custom and filter-expr attribute -->
     <amp-autocomplete filter="custom" filter-expr="true" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and min-characters attribute -->
     <amp-autocomplete min-characters=3>
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and min-characters attribute -->
     <amp-autocomplete min-characters=3 src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
-  </amp-autocomplete>
+      <input>
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and max-entries attribute -->
     <amp-autocomplete max-entries=10>
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and max-entries attribute -->
     <amp-autocomplete max-entries=10 src="https://data.com/articles.json?ref=CANONICAL_URL">
-        <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and suggest-first attribute -->
     <amp-autocomplete suggest-first>
-        <input type="text">
-        <script type="application/json"> {} </script>
-    </amp-autocomplete>  
+      <input>
+      <script type="application/json"> {} </script>
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and suggest-first attribute -->
     <amp-autocomplete suggest-first src="https://data.com/articles.json?ref=CANONICAL_URL">
-        <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and submit-on-enter attribute -->
     <amp-autocomplete submit-on-enter>
-        <input type="text">
-        <script type="application/json"> {} </script>
-    </amp-autocomplete> 
+      <input>
+      <script type="application/json"> {} </script>
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and submit-on-enter attribute -->
     <amp-autocomplete submit-on-enter src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
-    </amp-autocomplete> 
+      <input>
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and rich content template -->
     <amp-autocomplete>
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
       <template type="amp-mustache" id="amp-template-default">
         <div class="city-item" data-value="{{value}}">
-            <div>{{value}}</div>
-            <div class="custom-population">Population: {{population}}</div>        
+          <div>{{value}}</div>
+          <div class="custom-population">Population: {{population}}</div>
         </div>
       </template>
-    </amp-autocomplete> 
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and rich content template -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
       <template type="amp-mustache" id="amp-template-default">
         <div class="city-item" data-value="{{value}}">
-            <div>{{value}}</div>
-            <div class="custom-population">Population: {{population}}</div>        
+          <div>{{value}}</div>
+          <div class="custom-population">Population: {{population}}</div>
         </div>
       </template>
-    </amp-autocomplete> 
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with remote data and rich content template -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
       <template type="amp-mustache" id="amp-template-default">
         {{#disabled}}
-          <div data-disabled>
-            <b>{{value}}</b>
-          </div>
+        <div data-disabled>
+          <b>{{value}}</b>
+        </div>
         {{/disabled}}
         {{^disabled}}
         <div class="city-item" data-value="{{value}}">
-            <div>{{value}}</div>
-            <div class="custom-population">Population: {{population}}</div>        
+          <div>{{value}}</div>
+          <div class="custom-population">Population: {{population}}</div>
         </div>
         {{/disabled}}
       </template>
-    </amp-autocomplete> 
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and template attr -->
     <amp-autocomplete template="my-template-id">
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
-    </amp-autocomplete> 
-    
+    </amp-autocomplete>
+
     <!-- Valid: amp-component with remote data and template attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL" template="my-template-id">
-      <input type="text">
-    </amp-autocomplete> 
+      <input>
+    </amp-autocomplete>
 
     <!-- Valid: amp-component with static data and template script child -->
     <amp-autocomplete>
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
       <script type="text/plain" template="amp-mustache">
         <div class="city-item" data-value="{{value}}">
@@ -256,11 +330,11 @@
           <div class="custom-population">Population: {{population}}</div>        
         </div>
       </script>
-    </amp-autocomplete> 
-    
+    </amp-autocomplete>
+
     <!-- Valid: amp-component with remote data and template attr -->
     <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
       <script type="text/plain" template="amp-mustache">
         <div class="city-item" data-value="{{value}}">
@@ -268,53 +342,60 @@
           <div class="custom-population">Population: {{population}}</div>        
         </div>
       </script>
-    </amp-autocomplete> 
+    </amp-autocomplete>
 
     <!-- Invalid: width is mistyped -->
     <amp-autocomplete widht=100>
-        <input type="text">
-        <script type="application/json"> {} </script>
-    </amp-autocomplete>  
+      <input>
+      <script type="application/json"> {} </script>
+    </amp-autocomplete>
 
     <!-- Invalid: responsive layout is not supported -->
     <amp-autocomplete layout="responsive">
-        <input type="text">
-        <script type="application/json"> {} </script>
+      <input>
+      <script type="application/json"> {} </script>
+    </amp-autocomplete>
+
+    <!-- Invalid: amp-autocomplete with invalid input types -->
+    <amp-autocomplete widht=100>
+      <input type="button">
+      <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
     <amp-autocomplete filter="custom">
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
     <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
 
     <!-- Invalid: amp-autocomplete with unexpected filter -->
     <amp-autocomplete filter="random">
-      <input type="text">
+      <input>
       <script type="application/json"> {} </script>
     </amp-autocomplete>
 
     <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
     <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
-      <input type="text">
+      <input>
     </amp-autocomplete>
   </form>
 
   <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
   <amp-autocomplete>
-    <input type="text">
+    <input>
     <script type="application/json"> {} </script>
   </amp-autocomplete>
 
   <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
   <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-    <input type="text">
+    <input>
   </amp-autocomplete>
 
 </body>
+
 </html>

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -6,6 +6,7 @@
   You may obtain a copy of the License at
  
       http://www.apache.org/licenses/LICENSE-2.0
+      
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS-IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -7,6 +7,7 @@ FAIL
 |    You may obtain a copy of the License at
 |   
 |        http://www.apache.org/licenses/LICENSE-2.0
+|        
 |    Unless required by applicable law or agreed to in writing, software
 |    distributed under the License is distributed on an "AS-IS" BASIS,
 |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -279,7 +280,7 @@ FAIL
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:279:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:280:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |          <script type="application/json"> {} </script>
 |      </amp-autocomplete>  
@@ -287,7 +288,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:279:4 The attribute 'w
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:285:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:286:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -295,17 +296,17 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:285:4 The specified la
 |      <!-- Invalid: amp-autocomplete with invalid input types -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:291:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:292:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="button">
 >>       ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:292:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:293:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:298:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -313,14 +314,14 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:303:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:304:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:308:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:309:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -328,7 +329,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:308:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:314:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:315:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |    </form>
@@ -336,7 +337,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:314:4 The attribute 'f
 |    <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
 |    <amp-autocomplete>
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:320:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:321:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |      <script type="application/json"> {} </script>
 |    </amp-autocomplete>
@@ -344,7 +345,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:320:2 The tag 'amp-aut
 |    <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
 |    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:326:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:327:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |    </amp-autocomplete>
 |

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -21,55 +21,129 @@ FAIL
 |
 |  <!doctype html>
 |  <html ⚡>
+|
 |  <head>
 |    <meta charset="utf-8">
 |    <title>amp-autocomplete example</title>
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-boilerplate>
+|      body {
+|        -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        animation: -amp-start 8s steps(1, end) 0s 1 normal both
+|      }
+|
+|      @-webkit-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-moz-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-ms-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-o-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|
+|        to {
+|          visibility: visible
+|        }
+|      }
+|    </style><noscript>
+|      <style amp-boilerplate>
+|        body {
+|          -webkit-animation: none;
+|          -moz-animation: none;
+|          -ms-animation: none;
+|          animation: none
+|        }
+|      </style>
+|    </noscript>
 |    <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
 |    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
 |    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
+|
 |  <body>
-|    <form method="post" action-xhr="https://example.com/subscribe"> 
+|    <form method="post" action-xhr="https://example.com/subscribe">
 |      <!-- Valid: input and script tags as direct child to FORM -->
 |      <amp-autocomplete>
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>  
+|      </amp-autocomplete>
 |
 |      <!-- Valid: input and src attr as direct child to FORM -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
-|      </amp-autocomplete>  
+|        <input>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: input and [src] attr as direct child to FORM -->
 |      <amp-autocomplete [src]="foo.bar">
+|        <input>
+|      </amp-autocomplete>
+|
+|      <!-- Valid: input tag with type "text" and script tag -->
+|      <amp-autocomplete>
 |        <input type="text">
-|      </amp-autocomplete>  
+|        <script type="application/json"> {} </script>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: input tag with type "search" and script tag -->
 |      <amp-autocomplete>
 |        <input type="search">
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>  
+|      </amp-autocomplete>
 |
 |      <!-- Valid: input tag with type "search" and src attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="search">
-|      </amp-autocomplete>  
+|        <input>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: deeply nested with FORM still as ancestor -->
 |      <div>
 |        <div>
 |          <div>
 |            <amp-autocomplete>
-|              <input type="search">
+|              <input>
 |              <script type="application/json"> {} </script>
-|            </amp-autocomplete>  
+|            </amp-autocomplete>
 |          </div>
 |        </div>
 |      </div>
@@ -79,177 +153,177 @@ FAIL
 |        <div>
 |          <div>
 |            <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|              <input type="search">
-|            </amp-autocomplete>  
+|              <input>
+|            </amp-autocomplete>
 |          </div>
 |        </div>
 |      </div>
 |
 |      <!-- Valid: amp-component with static data and filter=prefix attribute -->
 |      <amp-autocomplete filter="prefix">
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=prefix attribute -->
 |      <amp-autocomplete filter="prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and filter=token-prefix attribute -->
 |      <amp-autocomplete filter="token-prefix">
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=token-prefix attribute -->
 |      <amp-autocomplete filter="token-prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|          <input type="text">
+|        <input>
 |      </amp-autocomplete>
-|    
+|
 |      <!-- Valid: amp-component with static data and filter=substring attribute -->
 |      <amp-autocomplete filter="substring">
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=substring attribute -->
 |      <amp-autocomplete filter="substring" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and filter=fuzzy attribute -->
 |      <amp-autocomplete filter="fuzzy">
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=fuzzy attribute -->
 |      <amp-autocomplete filter="fuzzy" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and filter=none attribute -->
 |      <amp-autocomplete filter="none">
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
-|      
+|
 |      <!-- Valid: amp-component with remote data and filter=none attribute -->
 |      <amp-autocomplete filter="none" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and filter=custom and filter-expr attribute -->
 |      <amp-autocomplete filter="custom" filter-expr="true">
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=custom and filter-expr attribute -->
 |      <amp-autocomplete filter="custom" filter-expr="true" src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and min-characters attribute -->
 |      <amp-autocomplete min-characters=3>
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and min-characters attribute -->
 |      <amp-autocomplete min-characters=3 src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
-|    </amp-autocomplete>
+|        <input>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and max-entries attribute -->
 |      <amp-autocomplete max-entries=10>
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+|        <input>
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and max-entries attribute -->
 |      <amp-autocomplete max-entries=10 src="https://data.com/articles.json?ref=CANONICAL_URL">
-|          <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and suggest-first attribute -->
 |      <amp-autocomplete suggest-first>
-|          <input type="text">
-|          <script type="application/json"> {} </script>
-|      </amp-autocomplete>  
+|        <input>
+|        <script type="application/json"> {} </script>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and suggest-first attribute -->
 |      <amp-autocomplete suggest-first src="https://data.com/articles.json?ref=CANONICAL_URL">
-|          <input type="text">
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and submit-on-enter attribute -->
 |      <amp-autocomplete submit-on-enter>
-|          <input type="text">
-|          <script type="application/json"> {} </script>
-|      </amp-autocomplete> 
+|        <input>
+|        <script type="application/json"> {} </script>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and submit-on-enter attribute -->
 |      <amp-autocomplete submit-on-enter src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
-|      </amp-autocomplete> 
+|        <input>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and rich content template -->
 |      <amp-autocomplete>
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
 |        <template type="amp-mustache" id="amp-template-default">
 |          <div class="city-item" data-value="{{value}}">
-|              <div>{{value}}</div>
-|              <div class="custom-population">Population: {{population}}</div>        
+|            <div>{{value}}</div>
+|            <div class="custom-population">Population: {{population}}</div>
 |          </div>
 |        </template>
-|      </amp-autocomplete> 
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and rich content template -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |        <template type="amp-mustache" id="amp-template-default">
 |          <div class="city-item" data-value="{{value}}">
-|              <div>{{value}}</div>
-|              <div class="custom-population">Population: {{population}}</div>        
+|            <div>{{value}}</div>
+|            <div class="custom-population">Population: {{population}}</div>
 |          </div>
 |        </template>
-|      </amp-autocomplete> 
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and rich content template -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |        <template type="amp-mustache" id="amp-template-default">
 |          {{#disabled}}
-|            <div data-disabled>
-|              <b>{{value}}</b>
-|            </div>
+|          <div data-disabled>
+|            <b>{{value}}</b>
+|          </div>
 |          {{/disabled}}
 |          {{^disabled}}
 |          <div class="city-item" data-value="{{value}}">
-|              <div>{{value}}</div>
-|              <div class="custom-population">Population: {{population}}</div>        
+|            <div>{{value}}</div>
+|            <div class="custom-population">Population: {{population}}</div>
 |          </div>
 |          {{/disabled}}
 |        </template>
-|      </amp-autocomplete> 
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and template attr -->
 |      <amp-autocomplete template="my-template-id">
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete> 
-|      
+|      </amp-autocomplete>
+|
 |      <!-- Valid: amp-component with remote data and template attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL" template="my-template-id">
-|        <input type="text">
-|      </amp-autocomplete> 
+|        <input>
+|      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and template script child -->
 |      <amp-autocomplete>
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
 |        <script type="text/plain" template="amp-mustache">
 |          <div class="city-item" data-value="{{value}}">
@@ -257,11 +331,11 @@ FAIL
 |            <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </script>
-|      </amp-autocomplete> 
-|      
+|      </amp-autocomplete>
+|
 |      <!-- Valid: amp-component with remote data and template attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
-|        <input type="text">
+|        <input>
 |        <script type="application/json"> {} </script>
 |        <script type="text/plain" template="amp-mustache">
 |          <div class="city-item" data-value="{{value}}">
@@ -269,69 +343,80 @@ FAIL
 |            <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </script>
-|      </amp-autocomplete> 
+|      </amp-autocomplete>
 |
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:274:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
-|          <input type="text">
-|          <script type="application/json"> {} </script>
-|      </amp-autocomplete>  
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:348:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input>
+|        <script type="application/json"> {} </script>
+|      </amp-autocomplete>
 |
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:280:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
-|          <input type="text">
-|          <script type="application/json"> {} </script>
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
+|        <input>
+|        <script type="application/json"> {} </script>
+|      </amp-autocomplete>
+|
+|      <!-- Invalid: amp-autocomplete with invalid input types -->
+|      <amp-autocomplete widht=100>
+>>     ^~~~~~~~~
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:360:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input type="button">
+>>       ^~~~~~~~~
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:361:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+|        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:286:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
-|        <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:292:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
-|        <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:372:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
-|        <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:303:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
-|        <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+|        <input>
 |      </amp-autocomplete>
 |    </form>
 |
 |    <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
 |    <amp-autocomplete>
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:309:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
-|      <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+|      <input>
 |      <script type="application/json"> {} </script>
 |    </amp-autocomplete>
 |
 |    <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
 |    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:315:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
-|      <input type="text">
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:395:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+|      <input>
 |    </amp-autocomplete>
 |
 |  </body>
+|
 |  </html>

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -348,7 +348,7 @@ FAIL
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:348:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:348:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -356,7 +356,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:348:4 The attribute 'w
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -364,7 +364,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified la
 |      <!-- Invalid: amp-autocomplete with invalid input types -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:360:4 The attribute 'widht' may not appear in tag 'amp-autocomplete with src attribute'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:360:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="button">
 >>       ^~~~~~~~~
 amp-autocomplete/0.1/test/validator-amp-autocomplete.html:361:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
@@ -374,7 +374,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:361:6 The attribute 't
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -382,14 +382,14 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:372:4 The attribute 'filter-expr' in tag 'amp-autocomplete with src attribute' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:372:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -397,7 +397,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'filter' in tag 'amp-autocomplete with src attribute' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |    </form>
@@ -405,7 +405,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'f
 |    <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
 |    <amp-autocomplete>
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |      <script type="application/json"> {} </script>
 |    </amp-autocomplete>
@@ -413,7 +413,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-aut
 |    <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
 |    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:395:2 The tag 'amp-autocomplete with src attribute' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:395:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |    </amp-autocomplete>
 |

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -7,7 +7,6 @@ FAIL
 |    You may obtain a copy of the License at
 |   
 |        http://www.apache.org/licenses/LICENSE-2.0
-|
 |    Unless required by applicable law or agreed to in writing, software
 |    distributed under the License is distributed on an "AS-IS" BASIS,
 |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,98 +20,30 @@ FAIL
 |
 |  <!doctype html>
 |  <html ⚡>
-|
 |  <head>
 |    <meta charset="utf-8">
 |    <title>amp-autocomplete example</title>
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-|    <style amp-boilerplate>
-|      body {
-|        -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|        -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|        -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-|        animation: -amp-start 8s steps(1, end) 0s 1 normal both
-|      }
-|
-|      @-webkit-keyframes -amp-start {
-|        from {
-|          visibility: hidden
-|        }
-|
-|        to {
-|          visibility: visible
-|        }
-|      }
-|
-|      @-moz-keyframes -amp-start {
-|        from {
-|          visibility: hidden
-|        }
-|
-|        to {
-|          visibility: visible
-|        }
-|      }
-|
-|      @-ms-keyframes -amp-start {
-|        from {
-|          visibility: hidden
-|        }
-|
-|        to {
-|          visibility: visible
-|        }
-|      }
-|
-|      @-o-keyframes -amp-start {
-|        from {
-|          visibility: hidden
-|        }
-|
-|        to {
-|          visibility: visible
-|        }
-|      }
-|
-|      @keyframes -amp-start {
-|        from {
-|          visibility: hidden
-|        }
-|
-|        to {
-|          visibility: visible
-|        }
-|      }
-|    </style><noscript>
-|      <style amp-boilerplate>
-|        body {
-|          -webkit-animation: none;
-|          -moz-animation: none;
-|          -ms-animation: none;
-|          animation: none
-|        }
-|      </style>
-|    </noscript>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |    <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
 |    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
 |    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
-|
 |  <body>
-|    <form method="post" action-xhr="https://example.com/subscribe">
+|    <form method="post" action-xhr="https://example.com/subscribe"> 
 |      <!-- Valid: input and script tags as direct child to FORM -->
 |      <amp-autocomplete>
 |        <input>
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: input and src attr as direct child to FORM -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
-|      </amp-autocomplete>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: input and [src] attr as direct child to FORM -->
 |      <amp-autocomplete [src]="foo.bar">
@@ -123,18 +54,18 @@ FAIL
 |      <amp-autocomplete>
 |        <input type="text">
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: input tag with type "search" and script tag -->
 |      <amp-autocomplete>
 |        <input type="search">
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: input tag with type "search" and src attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
-|      </amp-autocomplete>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: deeply nested with FORM still as ancestor -->
 |      <div>
@@ -143,7 +74,7 @@ FAIL
 |            <amp-autocomplete>
 |              <input>
 |              <script type="application/json"> {} </script>
-|            </amp-autocomplete>
+|            </amp-autocomplete>  
 |          </div>
 |        </div>
 |      </div>
@@ -154,7 +85,7 @@ FAIL
 |          <div>
 |            <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |              <input>
-|            </amp-autocomplete>
+|            </amp-autocomplete>  
 |          </div>
 |        </div>
 |      </div>
@@ -173,18 +104,18 @@ FAIL
 |      <!-- Valid: amp-component with static data and filter=token-prefix attribute -->
 |      <amp-autocomplete filter="token-prefix">
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=token-prefix attribute -->
 |      <amp-autocomplete filter="token-prefix" src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
 |      </amp-autocomplete>
-|
+|    
 |      <!-- Valid: amp-component with static data and filter=substring attribute -->
 |      <amp-autocomplete filter="substring">
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=substring attribute -->
@@ -195,7 +126,7 @@ FAIL
 |      <!-- Valid: amp-component with static data and filter=fuzzy attribute -->
 |      <amp-autocomplete filter="fuzzy">
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=fuzzy attribute -->
@@ -206,9 +137,9 @@ FAIL
 |      <!-- Valid: amp-component with static data and filter=none attribute -->
 |      <amp-autocomplete filter="none">
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
-|
+|      
 |      <!-- Valid: amp-component with remote data and filter=none attribute -->
 |      <amp-autocomplete filter="none" src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
@@ -217,7 +148,7 @@ FAIL
 |      <!-- Valid: amp-component with static data and filter=custom and filter-expr attribute -->
 |      <amp-autocomplete filter="custom" filter-expr="true">
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and filter=custom and filter-expr attribute -->
@@ -228,18 +159,18 @@ FAIL
 |      <!-- Valid: amp-component with static data and min-characters attribute -->
 |      <amp-autocomplete min-characters=3>
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and min-characters attribute -->
 |      <amp-autocomplete min-characters=3 src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
-|      </amp-autocomplete>
+|    </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with static data and max-entries attribute -->
 |      <amp-autocomplete max-entries=10>
 |        <input>
-|        <script type="application/json"> {} </script>
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Valid: amp-component with remote data and max-entries attribute -->
@@ -250,8 +181,8 @@ FAIL
 |      <!-- Valid: amp-component with static data and suggest-first attribute -->
 |      <amp-autocomplete suggest-first>
 |        <input>
-|        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|          <script type="application/json"> {} </script>
+|      </amp-autocomplete>  
 |
 |      <!-- Valid: amp-component with remote data and suggest-first attribute -->
 |      <amp-autocomplete suggest-first src="https://data.com/articles.json?ref=CANONICAL_URL">
@@ -261,13 +192,13 @@ FAIL
 |      <!-- Valid: amp-component with static data and submit-on-enter attribute -->
 |      <amp-autocomplete submit-on-enter>
 |        <input>
-|        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|          <script type="application/json"> {} </script>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with remote data and submit-on-enter attribute -->
 |      <amp-autocomplete submit-on-enter src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with static data and rich content template -->
 |      <amp-autocomplete>
@@ -275,51 +206,51 @@ FAIL
 |        <script type="application/json"> {} </script>
 |        <template type="amp-mustache" id="amp-template-default">
 |          <div class="city-item" data-value="{{value}}">
-|            <div>{{value}}</div>
-|            <div class="custom-population">Population: {{population}}</div>
+|              <div>{{value}}</div>
+|              <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </template>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with remote data and rich content template -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
 |        <template type="amp-mustache" id="amp-template-default">
 |          <div class="city-item" data-value="{{value}}">
-|            <div>{{value}}</div>
-|            <div class="custom-population">Population: {{population}}</div>
+|              <div>{{value}}</div>
+|              <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </template>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with remote data and rich content template -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
 |        <template type="amp-mustache" id="amp-template-default">
 |          {{#disabled}}
-|          <div data-disabled>
-|            <b>{{value}}</b>
-|          </div>
+|            <div data-disabled>
+|              <b>{{value}}</b>
+|            </div>
 |          {{/disabled}}
 |          {{^disabled}}
 |          <div class="city-item" data-value="{{value}}">
-|            <div>{{value}}</div>
-|            <div class="custom-population">Population: {{population}}</div>
+|              <div>{{value}}</div>
+|              <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |          {{/disabled}}
 |        </template>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with static data and template attr -->
 |      <amp-autocomplete template="my-template-id">
 |        <input>
 |        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
-|
+|      </amp-autocomplete> 
+|      
 |      <!-- Valid: amp-component with remote data and template attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL" template="my-template-id">
 |        <input>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Valid: amp-component with static data and template script child -->
 |      <amp-autocomplete>
@@ -331,8 +262,8 @@ FAIL
 |            <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </script>
-|      </amp-autocomplete>
-|
+|      </amp-autocomplete> 
+|      
 |      <!-- Valid: amp-component with remote data and template attr -->
 |      <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 |        <input>
@@ -343,20 +274,20 @@ FAIL
 |            <div class="custom-population">Population: {{population}}</div>        
 |          </div>
 |        </script>
-|      </amp-autocomplete>
+|      </amp-autocomplete> 
 |
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:348:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:279:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
-|        <script type="application/json"> {} </script>
-|      </amp-autocomplete>
+|          <script type="application/json"> {} </script>
+|      </amp-autocomplete>  
 |
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:285:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_LAYOUT_PROBLEM]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -364,17 +295,17 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:354:4 The specified la
 |      <!-- Invalid: amp-autocomplete with invalid input types -->
 |      <amp-autocomplete widht=100>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:360:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:291:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input type="button">
 >>       ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:361:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
-|        <script type="application/json"> {} </script>
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:292:6 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+|          <script type="application/json"> {} </script>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:297:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -382,14 +313,14 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:366:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:372:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:303:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:308:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |        <script type="application/json"> {} </script>
 |      </amp-autocomplete>
@@ -397,7 +328,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:377:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete filter="random" src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:314:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete) [DISALLOWED_HTML]
 |        <input>
 |      </amp-autocomplete>
 |    </form>
@@ -405,7 +336,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:383:4 The attribute 'f
 |    <!-- Invalid: amp-autocomplete with static data without FORM ancestor -->
 |    <amp-autocomplete>
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:320:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |      <script type="application/json"> {} </script>
 |    </amp-autocomplete>
@@ -413,10 +344,9 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:389:2 The tag 'amp-aut
 |    <!-- Invalid: amp-autocomplete with remote data without FORM ancestor -->
 |    <amp-autocomplete src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:395:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:326:2 The tag 'amp-autocomplete' may only appear as a descendant of tag 'form'. (see https://amp.dev/documentation/components/amp-autocomplete) [AMP_TAG_PROBLEM]
 |      <input>
 |    </amp-autocomplete>
 |
 |  </body>
-|
 |  </html>

--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -24,10 +24,10 @@ tags: {  # amp-autocomplete
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-autocomplete src>
+tags: {  # <amp-autocomplete>
   html_format: AMP
   tag_name: "AMP-AUTOCOMPLETE"
-  spec_name: "amp-autocomplete with src attribute"
+  spec_name: "amp-autocomplete"
   requires_extension: "amp-autocomplete"
   mandatory_ancestor: "FORM"
   attrs: {
@@ -47,6 +47,7 @@ tags: {  # <amp-autocomplete src>
     name: "filter-expr"
     requires_extension: "amp-bind"
   }
+  attrs: { name: "filter-value" }
   attrs: { name: "max-entries" }
   attrs: { name: "min-characters" }
   attrs: {


### PR DESCRIPTION
This change is because input tags without `type` [default to `type=text`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).

- Still enforces `type="text|search"` if `type` is present on the `input` tag.
- Confirms that this is not a breaking change to any functionality (by removing `type` attributes from some `input` tags in the example and validator html files
- Updates validator and tests