### PR TITLE
add browsers option to e2e task

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -34,9 +34,11 @@ const SUB = ' ';
 const TEST_TIMEOUT = 20000;
 const SETUP_TIMEOUT = 30000;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
+const defaultBrowsers = new Set(['chrome', 'firefox']);
 
 /**
  * @typedef {{
+ *  browsers: string,
  *  headless: boolean,
  *  engine: string,
  * }}
@@ -277,11 +279,17 @@ function describeEnv(factory) {
     }
 
     function createBrowserDescribe() {
-      spec.browsers.forEach(browserName => {
-        describe(browserName, function() {
-          createVariantDescribe(browserName);
-        });
-      });
+      const {browsers} = getConfig();
+
+      const allowedBrowsers = browsers ?
+          new Set(browsers.split(',').map(x => x.trim())) : defaultBrowsers;
+
+      spec.browsers.filter(x => allowedBrowsers.has(x))
+          .forEach(browserName => {
+            describe(browserName, function() {
+              createVariantDescribe(browserName);
+            });
+          });
     }
 
     function createVariantDescribe(browserName) {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -281,15 +281,17 @@ function describeEnv(factory) {
     function createBrowserDescribe() {
       const {browsers} = getConfig();
 
-      const allowedBrowsers = browsers ?
-          new Set(browsers.split(',').map(x => x.trim())) : defaultBrowsers;
+      const allowedBrowsers = browsers
+        ? new Set(browsers.split(',').map(x => x.trim()))
+        : defaultBrowsers;
 
-      spec.browsers.filter(x => allowedBrowsers.has(x))
-          .forEach(browserName => {
-            describe(browserName, function() {
-              createVariantDescribe(browserName);
-            });
+      spec.browsers
+        .filter(x => allowedBrowsers.has(x))
+        .forEach(browserName => {
+          describe(browserName, function() {
+            createVariantDescribe(browserName);
           });
+        });
     }
 
     function createVariantDescribe(browserName) {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -99,6 +99,7 @@ async function e2e() {
   require('@babel/register');
   const {describes} = require('./helper');
   describes.configure({
+    browsers: argv.browsers,
     engine: argv.engine,
     headless: argv.headless,
   });
@@ -163,6 +164,8 @@ module.exports = {
 
 e2e.description = 'Runs e2e tests';
 e2e.flags = {
+  'browsers': '  Run only the specified browser tests. Options are ' +
+      '`chrome`, `firefox`.',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -164,8 +164,9 @@ module.exports = {
 
 e2e.description = 'Runs e2e tests';
 e2e.flags = {
-  'browsers': '  Run only the specified browser tests. Options are ' +
-      '`chrome`, `firefox`.',
+  'browsers':
+    '  Run only the specified browser tests. Options are ' +
+    '`chrome`, `firefox`.',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',


### PR DESCRIPTION
This allows a user of the command to filter only suites that have a
matching enumerated browser.

This Fixes https://github.com/ampproject/amphtml/issues/22432