### PR TITLE
✨Support lightbox gallery crop animation.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -925,11 +925,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     let imageAnimation;
 
     const measure = () => {
-      const srcCropEl = closestAncestorElementBySelector(srcImg, 'amp-img');
-      const targetCropEl = closestAncestorElementBySelector(
-        targetImg,
-        'amp-img'
-      );
+      const srcCropEl =
+        closestAncestorElementBySelector(srcImg, 'amp-img') || srcImg;
+      const targetCropEl =
+        closestAncestorElementBySelector(targetImg, 'amp-img') || targetImg;
 
       duration = this.getTransitionDurationFromElements_(srcImg, targetImg);
       motionDuration = MOTION_DURATION_RATIO * duration;
@@ -939,9 +938,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
           styleContainer: this.getAmpDoc().getHeadNode(),
           transitionContainer: this.getAmpDoc().getBody(),
           srcImg,
-          srcCropRect: (srcCropEl || srcImg)./*OK*/ getBoundingClientRect(),
+          srcCropRect: srcCropEl./*OK*/ getBoundingClientRect(),
           targetImg,
-          targetCropRect: (targetCropEl || targetImg)./*OK*/ getBoundingClientRect(),
+          targetCropRect: targetCropEl./*OK*/ getBoundingClientRect(),
           styles: {
             'animationDuration': `${motionDuration}ms`,
             // Matches z-index for `.i-amphtml-lbg`.

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -939,9 +939,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
           styleContainer: this.getAmpDoc().getHeadNode(),
           transitionContainer: this.getAmpDoc().getBody(),
           srcImg,
-          srcCropRect: (srcCropEl || srcImg).getBoundingClientRect(),
+          srcCropRect: (srcCropEl || srcImg)./*OK*/ getBoundingClientRect(),
           targetImg,
-          targetCropRect: (targetCropEl || targetImg).getBoundingClientRect(),
+          targetCropRect: (targetCropEl || targetImg)./*OK*/ getBoundingClientRect(),
           styles: {
             'animationDuration': `${motionDuration}ms`,
             // Matches z-index for `.i-amphtml-lbg`.

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -925,6 +925,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     let imageAnimation;
 
     const measure = () => {
+      const srcCropEl = closestAncestorElementBySelector(srcImg, 'amp-img');
+      const targetCropEl = closestAncestorElementBySelector(
+        targetImg,
+        'amp-img'
+      );
+
       duration = this.getTransitionDurationFromElements_(srcImg, targetImg);
       motionDuration = MOTION_DURATION_RATIO * duration;
       // Prepare the actual image animation.
@@ -933,9 +939,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
           styleContainer: this.getAmpDoc().getHeadNode(),
           transitionContainer: this.getAmpDoc().getBody(),
           srcImg,
+          srcCropRect: (srcCropEl || srcImg).getBoundingClientRect(),
           targetImg,
-          srcImgRect: undefined,
-          targetImgRect: undefined,
+          targetCropRect: (targetCropEl || targetImg).getBoundingClientRect(),
           styles: {
             'animationDuration': `${motionDuration}ms`,
             // Matches z-index for `.i-amphtml-lbg`.

--- a/test/manual/amp-lightbox-gallery.amp.html
+++ b/test/manual/amp-lightbox-gallery.amp.html
@@ -22,6 +22,10 @@
       object-fit: none;
     }
 
+    .scale-2x img {
+      transform: scale(2);
+    }
+
     footer {
       position: fixed;
       position: sticky;
@@ -56,6 +60,14 @@
   </amp-img>
 
   <h2>Test with single src, object-fit: cover</h2>
+  <h3>Test with a scale, causing a crop</h3>
+  <amp-img width=120 height=200
+    class="object-fit-cover scale-2x"
+    lightbox
+    src="https://ampbyexample-com.cdn.ampproject.org/i/s/ampbyexample.com/img/clean-2.jpg">
+  </amp-img>
+  
+
   <h3>Expand horizontally</h3>
   <amp-img width=120 height=200
     class="object-fit-cover"


### PR DESCRIPTION
The heavy lifting is already done in the animations library, the only thing left wiring it up on the AMP side. This will allow animations like on this demo page: https://sparhami.github.io/animations/docs/demo/zoom-crop/, where the container (in this case, `<amp-img>` can be used to crop the image to an interesting part.