### PR TITLE
🏗 Enable `noDefaults: true` for `jsdoc/check-types`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,7 +85,7 @@
     "google-camelcase/google-camelcase": 2,
     "jsdoc/check-param-names": 2,
     "jsdoc/check-tag-names": 2,
-    "jsdoc/check-types": 2,
+    "jsdoc/check-types": [2, { "noDefaults": true }],
     "jsdoc/require-param": 2,
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,


### PR DESCRIPTION
This PR unblocks #22489, which upgrades `eslint-plugin-jsdoc` to v7.

A similar change will have to be made in `ampproject/amp-github-apps` before https://github.com/ampproject/amp-github-apps/pull/133 can be merged.

For context, see https://github.com/ampproject/amphtml/pull/22421#issuecomment-494963105
