### PR TITLE
🐛 FIX: Allow empty string as rendered template

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -575,7 +575,7 @@ export class AmpList extends AMP.BaseElement {
       .then(
         response => {
           userAssert(
-            response && response['html'],
+            response && typeof response['html'] === 'string',
             'Expected response with format {html: <string>}. Received: ',
             response
           );


### PR DESCRIPTION
Mustache templates rendering as empty strings is a totally valid case. 

However, an empty string is falsy, and would fail the current assertion. 

/review @alabiaga 
/cc @GoTcWang 