### PR TITLE
Fix friendly embedding on amp-ad, and reenable test-amp-ad-fake.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@
           "deprecated",
           "export",
           "final",
+	  "nocollapse",
           "package",
           "restricted",
           "suppress",

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -207,6 +207,7 @@ export class Bind {
   /**
    * @param {!Window} embedWin
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(embedWin, 'bind', new Bind(ampdoc, embedWin));

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -190,6 +190,7 @@ export class AmpGwdRuntimeService {
   /**
    * @param {!Window} embedWin
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -281,6 +281,7 @@ export class ActionService {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -61,6 +61,7 @@ export class HiddenObserver {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -179,6 +179,7 @@ export class Navigation {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -84,6 +84,7 @@ export class StandardActions {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -170,6 +170,7 @@ export class Timer {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} unusedAmpDoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, unusedAmpDoc) {
     installServiceInEmbedScope(embedWin, TAG, new Timer(embedWin));

--- a/src/service/url-impl.js
+++ b/src/service/url-impl.js
@@ -54,6 +54,7 @@ export class Url {
   /**
    * @param {!Window} embedWin
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @nocollapse
    */
   static installInEmbedWindow(embedWin, ampdoc) {
     installServiceInEmbedScope(

--- a/test/integration/test-amp-ad-fake.js
+++ b/test/integration/test-amp-ad-fake.js
@@ -35,7 +35,7 @@ describe('A4A', function() {
     },
     () => {
       // TODO(@zombifer, #21545): Unskip flaky test
-      it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
+      it('should layout amp-img, amp-pixel, amp-analytics', () => {
         // See amp4test.js for creative content
         return Promise.all([
           RequestBank.withdraw('image'),

--- a/test/integration/test-amp-ad-fake.js
+++ b/test/integration/test-amp-ad-fake.js
@@ -35,36 +35,38 @@ describe('A4A', function() {
     },
     () => {
       // TODO(@zombifer, #21545): Unskip flaky test
-      it('should layout amp-img, amp-pixel, amp-analytics', () => {
-        // See amp4test.js for creative content
-        return Promise.all([
-          RequestBank.withdraw('image'),
-          RequestBank.withdraw('pixel'),
-          RequestBank.withdraw('analytics'),
-        ]).then(reqs => {
-          const imageReq = reqs[0];
-          const pixelReq = reqs[1];
-          const analyticsReq = reqs[2];
-          expect(imageReq.url).to.equal('/');
-          expect(pixelReq.url).to.equal('/foo?cid=');
-          expect(analyticsReq.url).to.match(/^\/bar\?/);
-          const queries = parseQueryString(
-            analyticsReq.url.substr('/bar'.length)
-          );
-          expect(queries).to.include({
-            title: 'AMP TEST', // ${title},
-            cid: '', // ${clientId(a)}
-            navTiming: '0', // ${navTiming(requestStart,requestStart)}
-            navType: '0', // ${navType}
-            navRedirectCount: '0', // ${navRedirectCount}
+      it.configure()
+        .skipFirefox()
+        .run('should layout amp-img, amp-pixel, amp-analytics', () => {
+          // See amp4test.js for creative content
+          return Promise.all([
+            RequestBank.withdraw('image'),
+            RequestBank.withdraw('pixel'),
+            RequestBank.withdraw('analytics'),
+          ]).then(reqs => {
+            const imageReq = reqs[0];
+            const pixelReq = reqs[1];
+            const analyticsReq = reqs[2];
+            expect(imageReq.url).to.equal('/');
+            expect(pixelReq.url).to.equal('/foo?cid=');
+            expect(analyticsReq.url).to.match(/^\/bar\?/);
+            const queries = parseQueryString(
+              analyticsReq.url.substr('/bar'.length)
+            );
+            expect(queries).to.include({
+              title: 'AMP TEST', // ${title},
+              cid: '', // ${clientId(a)}
+              navTiming: '0', // ${navTiming(requestStart,requestStart)}
+              navType: '0', // ${navType}
+              navRedirectCount: '0', // ${navRedirectCount}
+            });
+            expect(queries['ampdocUrl']).to.contain(
+              'http://localhost:9876/amp4test/compose-doc?'
+            );
+            expect(queries['canonicalUrl']).to.equal('http://nonblocking.io/');
+            expect(queries['img']).to.contain('/deposit/image'); // ${htmlAttr(amp-img,src)}
           });
-          expect(queries['ampdocUrl']).to.contain(
-            'http://localhost:9876/amp4test/compose-doc?'
-          );
-          expect(queries['canonicalUrl']).to.equal('http://nonblocking.io/');
-          expect(queries['img']).to.contain('/deposit/image'); // ${htmlAttr(amp-img,src)}
         });
-      });
     }
   );
 

--- a/test/integration/test-amp-ad-fake.js
+++ b/test/integration/test-amp-ad-fake.js
@@ -92,8 +92,7 @@ describe('A4A', function() {
       `,
     },
     env => {
-      // TODO(@zombifer, #21545): Unskip flaky test
-      it.skip('p[text]', function*() {
+      it('p[text]', function*() {
         // Wait for the amp-ad to construct its child iframe.
         const ad = env.win.document.getElementById('i-amphtml-demo-id');
         yield poll('amp-ad > iframe', () => ad.querySelector('iframe'));


### PR DESCRIPTION
See #22572. Seems like it's now failing due to a regression (function being stripped from compiled code).