### PR TITLE
Story page attachment dark mode.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment-header.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment-header.css
@@ -24,6 +24,10 @@
   z-index: 1 !important;
 }
 
+.i-amphtml-story-page-attachment-dark-mode {
+  background: rgba(32, 33, 37, 1) !important;
+}
+
 .i-amphtml-story-page-attachment-close-button {
   display: block !important;
   margin: 8px !important;
@@ -32,6 +36,10 @@
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(0, 0, 0, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
   color: rgba(0, 0, 0, 0.87) !important;
   cursor: pointer !important;
+}
+
+.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-close-button {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(255, 255, 255, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
 }
 
 .i-amphtml-story-page-attachment-title {
@@ -44,4 +52,8 @@
   text-align: center !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
+}
+
+.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-title {
+  color: #fff !important;
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -44,9 +44,17 @@ amp-story-page-attachment.i-amphtml-story-page-attachment-open {
   transition: background 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 
+.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-container {
+  background: rgba(32, 33, 37, 1) !important;
+}
+
 .i-amphtml-story-page-attachment-container[hidden] {
   display: block !important;
   background: rgba(255, 255, 255, 0.92) !important;
+}
+
+.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-container[hidden] {
+  background: rgba(32, 33, 37, 0.82) !important;
 }
 
 .i-amphtml-story-page-attachment-content {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -141,6 +141,11 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
       ).textContent = this.element.getAttribute('data-title');
     }
 
+    if (this.element.hasAttribute('data-dark-mode')) {
+      this.headerEl_.classList.add('i-amphtml-story-page-attachment-dark-mode');
+      this.element.classList.add('i-amphtml-story-page-attachment-dark-mode');
+    }
+
     createShadowRootWithStyle(headerShadowRootEl, this.headerEl_, CSS);
     templateEl.insertBefore(headerShadowRootEl, templateEl.firstChild);
 


### PR DESCRIPTION
Creates a dark mode for the `amp-story-page-attachment` component.

```
<amp-story-page-attachment layout="nodisplay" data-dark-mode>
  ...
</amp-story-page-attachment>
```

Masterbug #20209
Feature #22204

![image](https://user-images.githubusercontent.com/1492044/58356025-2418ed00-7e44-11e9-8275-822b2990d745.png)
