### PR TITLE
🐛Fix broken args in expander.

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -215,7 +215,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       win.location.href = 'https://example.com/?test=yes';
       return check(
         '$IF(QUERY_PARAM(test), 1.$SUBSTR(TIMESTAMP, 0, 10)QUERY_PARAM(test), ``)',
-        '%201.123456789yes'
+        '1.123456789yes'
       );
     });
 

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -230,6 +230,15 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         CLIENT_ID: 'amp-12345',
       }));
 
+    it('should not trim right of string before macro', () => {
+      sandbox.useFakeTimers(123456789);
+      win.location.href = 'https://example.com/?test=yes';
+      return check(
+        '$IF(QUERY_PARAM(test), foo TIMESTAMP, ``)',
+        'foo%20123456789'
+      );
+    });
+
     it('default works without first arg', () => check('$DEFAULT(,two)', 'two'));
 
     it('default works without first arg length', () =>

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -219,6 +219,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       );
     });
 
+    it('handles consecutive macros w/o parens in inner arguments', () => {
+      sandbox.useFakeTimers(123456789);
+      win.location.href = 'https://example.com/?test=yes';
+      return check('$IF(QUERY_PARAM(test), 1.TIMESTAMP, ``)', '1.123456789');
+    });
+
     it('handles string + macro as inner argument', () =>
       check('$REPLACE(testCLIENT_ID(scope), amp-, ``)', 'test12345', {
         CLIENT_ID: 'amp-12345',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -210,6 +210,20 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       return expect(expanded).to.eventually.equal(output);
     }
 
+    it('handles consecutive macros in inner arguments', () => {
+      sandbox.useFakeTimers(123456789);
+      win.location.href = 'https://example.com/?test=yes';
+      return check(
+        '$IF(QUERY_PARAM(test), 1.$SUBSTR(TIMESTAMP, 0, 10)QUERY_PARAM(test), ``)',
+        '%201.123456789yes'
+      );
+    });
+
+    it('handles string + macro as inner argument', () =>
+      check('$REPLACE(testCLIENT_ID(scope), amp-, ``)', 'test12345', {
+        CLIENT_ID: 'amp-12345',
+      }));
+
     it('default works without first arg', () => check('$DEFAULT(,two)', 'two'));
 
     it('default works without first arg length', () =>

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -147,6 +147,12 @@ export class Expander {
 
       while (urlIndex < url.length && matchIndex <= matches.length) {
         if (match && urlIndex === match.start) {
+          // Collect any chars that may be prefixing the macro, if we are in
+          // a nested context trim the args.
+          if (builder.trim().length) {
+            results.push(numOfPendingCalls ? builder.trimStart() : builder);
+          }
+
           // If we know we are at the start of a macro, we figure out how to
           // resolve it, and move our pointer to after the token.
           let binding;
@@ -171,12 +177,6 @@ export class Expander {
 
           urlIndex = match.stop + 1;
           match = matches[++matchIndex];
-
-          // Collect any chars that may be prefixing the macro, if we are in
-          // a nested context trim the args.
-          if (builder.trim().length) {
-            results.push(numOfPendingCalls ? builder.trim() : builder);
-          }
 
           if (url[urlIndex] === '(') {
             // When we see a `(` we know we need to resolve one level deeper

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -229,7 +229,7 @@ export class Expander {
           // Support existing two comma format by pushing an empty string as
           // argument. eg CLIENT_ID(__ga,,ga-url)
           if (url[urlIndex + 1] === ',') {
-            results.push(['']);
+            args.push(['']);
             urlIndex++;
           }
           builder = '';

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -172,26 +172,23 @@ export class Expander {
           urlIndex = match.stop + 1;
           match = matches[++matchIndex];
 
+          // Collect any chars that may be prefixing the macro, if we are in
+          // a nested context trim the args.
+          if (builder.trim().length) {
+            results.push(numOfPendingCalls ? builder.trim() : builder);
+          }
+
           if (url[urlIndex] === '(') {
             // When we see a `(` we know we need to resolve one level deeper
             // before continuing. We push the binding in the stack for
-            // resolution later, collect any chars that may be prefixing the
-            // macro, and then make the recursive call.
+            // resolution later, and then make the recursive call.
             urlIndex++;
             numOfPendingCalls++;
             stack.push(binding);
-            // Trim space in between args that builder has collected.
-            if (builder.trim().length) {
-              results.push(builder.trim());
-            }
             results.push(evaluateNextLevel(/* encode */ false));
           } else {
             // Many macros do not take arguments, in this case we do not need to
-            // recurse, we just store any prefix and start resolution in it's
-            // position
-            if (builder.length) {
-              results.push(builder);
-            }
+            // recurse, we just start resolution in it's position.
             results.push(this.evaluateBinding_(binding));
           }
 

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -442,7 +442,7 @@ export class Expander {
    * passed to a function.apply call. Will not wait for any promise to resolve.
    * This will cast all arguments to string before calling the macro.
    *  [[Result of BAR, Result of BAR], 123]. => ['resultresult', '123']
-   * @param {!Array<!Array>} argsArray
+   * @param {Array<!Array>|undefined} argsArray
    */
   processArgsSync_(argsArray) {
     if (!argsArray) {


### PR DESCRIPTION
The expander works by walking the input string. When it sees a macro it pushes the promise of a value (async) or the immediate resulting value (sync) into an array, that will be joined at the end of string or the next `)`. 

For example in a async call:
`'abcMACROdef' => ['abc', Promise, 'def'] `

This can become a problem in nested context because this array is what is passed to the function that resolves the function through `function.apply`. 
`'OUTER(INNER)' => OUTER.apply([INNER]) // good`
`'OUTER(foo, INNER)' => OUTER.apply(['foo', INNER]) // good`  
`'OUTER(fooINNER, bar)' => OUTER.apply(['foo', INNER, 'bar']) // bad - three args passed to OUTER instead of two`

This fix changes this to use an array of arrays, where we can keep track of each argument in its own array, and therefore pass the correct number of args. The inner array(s) are then flattened before passing to `.apply()`. 

`'OUTER(fooINNER, bar)' => [['foo', INNER], ['bar']] => flatten =>` 
`OUTER.apply(['fooINNER', 'bar'] // good :)` 

An added bonus is that this casts any argument to a string before invoking the function :) This should help us with any changes to preserve types.

Also added a bunch of comments since this code is hairy, and its fresh in my mind for now.
  
Closes #20816 