### PR TITLE
getHighestAvailableDomain helper method

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -180,10 +180,10 @@ function trySetCookie(win, name, value, expirationTime, domain) {
  */
 function checkOriginForSettingCookie(win, options, name) {
   if (options && options.allowOnProxyOrigin) {
-    if (!options.domain) {
+    if (options.highestAvailableDomain) {
       throw new Error(
-        'Should specify domain explicitly when setting cookie ' +
-          'on proxy origin'
+        'Could not support higestAvailable Domain on proxy origin, ' +
+        'specify domain explicitly'
       );
     }
     return;

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -167,10 +167,8 @@ export function getHighestAvailableDomain(win) {
 function trySetCookie(win, name, value, expirationTime, domain) {
   // We do not allow setting cookies on the domain that contains both
   // the cdn. and www. hosts.
-  if (
-    domain == 'ampproject.org' ||
-    domain == parseUrlDeprecated(urls.cdn).hostname.toLowerCase()
-  ) {
+  // Note: we need to allow cdn.ampproject.org in order to optin to experiments
+  if (domain == 'ampproject.org') {
     // Actively delete them.
     value = 'delete';
     expirationTime = 0;

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -94,9 +94,6 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
     domain = opt_options.domain;
   } else if (opt_options && opt_options.highestAvailableDomain) {
     domain = getHighestAvailableDomain(win);
-    if (!domain) {
-      return;
-    }
   }
   trySetCookie(win, name, value, expirationTime, domain);
 }

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -115,9 +115,9 @@ export function getHighestAvailableDomain(win) {
   // Note: The same logic applies to shadow docs. Where all shadow docs are
   // considered to be in the same origin. And only the <meta> from
   // shell will be respected. (Header from shadow doc will be removed)
-  const metaTag = win.document.head.querySelector(
-    "meta[name='amp-cookie-scope']"
-  );
+  const metaTag =
+    win.document.head &&
+    win.document.head.querySelector("meta[name='amp-cookie-scope']");
 
   if (metaTag) {
     // The content value could be an empty string. Return null instead
@@ -151,7 +151,14 @@ export function getHighestAvailableDomain(win) {
     }
   }
 
-  // higestAvailableDomain cannot be found
+  // Proxy origin w/o <meta name='amp-cookie-scope>
+  // We cannot calculate the etld+1 without the public suffix list.
+  // Return null instead.
+  // Note: This should not affect cookie writing because we don't allow writing
+  // cookie to highestAvailableDomain on proxy origin
+  // In the case of link decoration on proxy origin,
+  // we expect the correct meta tag to be
+  // set by publisher or cache order for AMP runtime to find all subdomains.
   return null;
 }
 

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -22,8 +22,9 @@ import {
   tryDecodeUriComponent,
 } from './url';
 import {urls} from './config';
+import { url } from 'inspector';
 
-const TEST_COOKIE_NAME = '-amp-cookie-test-tmp';
+const TEST_COOKIE_NAME = '-test-amp-cookie-tmp';
 
 /**
  * Returns the value of the cookie. The cookie access is restricted and must
@@ -111,6 +112,10 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
  */
 export function getHighestAvailableDomain(win) {
   // <meta name='amp-cookie-scope'>. Need to respect the meta first.
+
+  // Note: The same logic applies to shadow docs. Where all shadow docs are
+  // considered to be in the same origin. And only the <meta> from
+  // shell will be respected. (Header from shadow doc will be removed)
   const metaTag = win.document.head.querySelector(
     "meta[name='amp-cookie-scope']"
   );
@@ -170,7 +175,8 @@ export function getHighestAvailableDomain(win) {
 function trySetCookie(win, name, value, expirationTime, domain) {
   // We do not allow setting cookies on the domain that contains both
   // the cdn. and www. hosts.
-  if (domain == 'ampproject.org' || domain == 'cdn.ampproject.org') {
+  if (domain == 'ampproject.org' ||
+      parseUrlDeprecated(urls.cdn).hostname.toLowerCase()) {
     // Actively delete them.
     value = 'delete';
     expirationTime = 0;

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -96,7 +96,7 @@ function tryGetDocumentCookieNoInline(win) {
 export function setCookie(win, name, value, expirationTime, opt_options) {
   checkOriginForSettingCookie(win, opt_options, name);
   let domain = undefined;
-  // Respect explicitily set domain over higestAvailabeDomain
+  // Respect explicitly set domain over higestAvailabeDomain
   if (opt_options && opt_options.domain) {
     domain = opt_options.domain;
   } else if (opt_options && opt_options.highestAvailableDomain) {
@@ -234,7 +234,7 @@ function checkOriginForSettingCookie(win, options, name) {
 }
 
 /**
- * Return a temporaty cookie name for testing only
+ * Return a temporary cookie name for testing only
  * @param {!Window} win
  * @return {string}
  */
@@ -242,7 +242,7 @@ function getTempCookieName(win) {
   let testCookieName = TEST_COOKIE_NAME;
   const counter = 0;
   while (getCookie(win, testCookieName)) {
-    // test cookie name conflit, append counter to test cookie name
+    // test cookie name conflict, append counter to test cookie name
     testCookieName = TEST_COOKIE_NAME + counter;
   }
   return testCookieName;

--- a/test/unit/test-cookies.js
+++ b/test/unit/test-cookies.js
@@ -79,35 +79,35 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
     expect(doc.cookie).to.equal('c%261=v%261');
   });
 
-  it('getHigestAvailableDomain without meta tag', () => {
+  it('getHighestAvailableDomain without meta tag', () => {
     // Proxy Origin
-    win.location.href = 'https://foo-bar.cdn.ampproject.org/c/foo.bar.com';
+    win.location = 'https://foo-bar.cdn.ampproject.org/c/foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.be.null;
 
-    win.location.href = 'https://bar.com';
+    win.location = 'https://bar.com';
     expect(getHighestAvailableDomain(win)).to.equal('bar.com');
-    win.location.href = 'https://bar.net';
+    win.location = 'https://bar.net';
     expect(getHighestAvailableDomain(win)).to.equal('bar.net');
-    win.location.href = 'https://foo.bar.com';
+    win.location = 'https://foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.equal('bar.com');
     doc.publicSuffixList = ['bar.com'];
-    win.location.href = 'https://bar.com';
+    win.location = 'https://bar.com';
     expect(getHighestAvailableDomain(win)).to.be.null;
-    win.location.href = 'https://bar.net';
+    win.location = 'https://bar.net';
     expect(getHighestAvailableDomain(win)).to.equal('bar.net');
-    win.location.href = 'https://foo.bar.com';
+    win.location = 'https://foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.equal('foo.bar.com');
     expect(doc.cookie).to.equal('');
 
     // Special case, has test cookie name conflict
-    win.location.href = 'https://foo.bar.com';
+    win.location = 'https://foo.bar.com';
     doc.cookie = '-amp-cookie-test-tmp=test';
     expect(getHighestAvailableDomain(win)).to.equal('foo.bar.com');
     expect(doc.cookie).to.equal('-amp-cookie-test-tmp=test');
   });
 
   it('getHigestAvaibleDomain in valid meta tag', () => {
-    win.location.href = 'https://abc.foo.bar.com';
+    win.location = 'https://abc.foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.equal('bar.com');
     let meta = doc.createElement('meta');
     meta.setAttribute('name', 'amp-cookie-scope');
@@ -116,7 +116,7 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
     expect(getHighestAvailableDomain(win)).to.equal('foo.bar.com');
 
     meta.remove();
-    win.location.href = 'https://abc-foo-bar.cdn.ampproject.org/c/foo.bar.com';
+    win.location = 'https://abc-foo-bar.cdn.ampproject.org/c/foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.be.null;
     meta = doc.createElement('meta');
     meta.setAttribute('name', 'amp-cookie-scope');
@@ -126,7 +126,7 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
   });
 
   it('getHigestAvaibleDomain with invalid meta tag', () => {
-    win.location.href = 'https://foo.bar.com';
+    win.location = 'https://foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.equal('bar.com');
     let meta = doc.createElement('meta');
     meta.setAttribute('name', 'amp-cookie-scope');
@@ -135,7 +135,7 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
     expect(getHighestAvailableDomain(win)).to.equal('foo.bar.com');
 
     meta.remove();
-    win.location.href = 'https://foo-bar.cdn.ampproject.org/c/foo.bar.com';
+    win.location = 'https://foo-bar.cdn.ampproject.org/c/foo.bar.com';
     expect(getHighestAvailableDomain(win)).to.be.null;
     meta = doc.createElement('meta');
     meta.setAttribute('name', 'amp-cookie-scope');
@@ -147,7 +147,7 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
   it('should write the cookie to the right domain on origin', () => {
     function test(url, targetDomain, opt_allowProxyOrigin) {
       expect(doc.cookie).to.equal('');
-      win.location.href = url;
+      win.location = url;
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
         highestAvailableDomain: true,
         allowOnProxyOrigin: opt_allowProxyOrigin,
@@ -175,7 +175,7 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
   });
 
   it('write cookie to right domain on proxy', () => {
-    win.location.href = 'https://foo.cdn.ampproject.org/test.html';
+    win.location = 'https://foo.cdn.ampproject.org/test.html';
     setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
       domain: 'foo.cdn.ampproject.org',
       allowOnProxyOrigin: true,
@@ -191,17 +191,17 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
 
-    win.location.href = 'https://CDN.ampproject.org/test.html';
+    win.location = 'https://CDN.ampproject.org/test.html';
     expect(() => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
 
-    win.location.href = 'https://foo.bar.cdn.ampproject.org/test.html';
+    win.location = 'https://foo.bar.cdn.ampproject.org/test.html';
     expect(() => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/in depth check/);
 
-    win.location.href = 'http://&&&.CDN.ampproject.org/test.html';
+    win.location = 'http://&&&.CDN.ampproject.org/test.html';
     expect(() => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/in depth check/);

--- a/test/unit/test-cookies.js
+++ b/test/unit/test-cookies.js
@@ -167,12 +167,13 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/in depth check/);
 
-    // Must have domain specified when allowOnProxyOrigin
+    // Can't use higestAvailableDomain when allowOnProxyOrigin
     expect(() => {
       setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
         allowOnProxyOrigin: true,
+        highestAvailableDomain: true,
       });
-    }).to.throw(/Should specify domain explicitly/);
+    }).to.throw(/specify domain explicitly/);
 
     // Cannot write to 'ampproject.org'
     setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {

--- a/test/unit/test-cookies.js
+++ b/test/unit/test-cookies.js
@@ -224,16 +224,5 @@ describes.fakeWin('test-cookies', {amp: true}, env => {
         'expires=Thu, 01 Jan 1970 00:00:00 GMT'
     );
     expect(doc.cookie).to.equal('');
-
-    // Cannot write to 'cdn.ampproject.org'
-    setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
-      domain: 'cdn.ampproject.org',
-      allowOnProxyOrigin: true,
-    });
-    expect(doc.lastSetCookieRaw).to.equal(
-      `c%261=delete; path=/; domain=cdn.ampproject.org; ` +
-        'expires=Thu, 01 Jan 1970 00:00:00 GMT'
-    );
-    expect(doc.cookie).to.equal('');
   });
 });

--- a/test/unit/test-cookies.js
+++ b/test/unit/test-cookies.js
@@ -14,142 +14,175 @@
  * limitations under the License.
  */
 
-import {getCookie, setCookie} from '../../src/cookies';
+import * as lolex from 'lolex';
+import {BASE_CID_MAX_AGE_MILLIS} from '../../src/service/cid-impl';
+import {
+  getCookie,
+  getHighestAvailableDomain,
+  setCookie,
+} from '../../src/cookies';
 
-describe('cookies', () => {
-  function expectCookie(cookiesString, cookieName, opt_locationHref) {
-    return expect(
-      getCookie(
-        {
-          document: {
-            cookie: cookiesString,
-          },
-        },
-        cookieName
-      )
-    );
-  }
+describes.fakeWin('test-cookies', {amp: true}, env => {
+  let win;
+  let clock;
+  let doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    clock = lolex.install({
+      target: window,
+      now: new Date('2018-01-01T08:00:00Z'),
+    });
+  });
+
+  afterEach(() => {
+    clock.uninstall();
+  });
 
   it('should return null for no cookie, malformed, or not found', () => {
-    expectCookie(null, 'c1').to.be.null;
-    expectCookie(undefined, 'c1').to.be.null;
-    expectCookie('', 'c1').to.be.null;
-    expectCookie('c1', 'c1').to.be.null;
-    expectCookie('e2=1', 'c1').to.be.null;
+    expect(doc.cookie).to.equal('');
+    expect(getCookie(win, 'c1')).to.be.null;
+    expect(getCookie(win, 'c1')).to.be.null;
+    doc.cookie = 'c1';
+    expect(getCookie(win, 'c1')).to.be.null;
+    doc.cookie = 'e2=1';
+    expect(getCookie(win, 'c1')).to.be.null;
   });
 
   it('should return value when found', () => {
-    expectCookie('c1=1', 'c1').to.equal('1');
-    expectCookie(' c1 = 1 ', 'c1').to.equal('1');
-    expectCookie('c1=1;c2=2', 'c1').to.equal('1');
-    expectCookie('c1=1;c2=2', 'c2').to.equal('2');
+    doc.cookie = 'c1=1';
+    expect(getCookie(win, 'c1')).to.equal('1');
+    doc.cookie = ' c2 = 2 ';
+    expect(doc.cookie).to.equal('c1=1; c2 = 2 ');
+    expect(getCookie(win, 'c1')).to.equal('1');
+    expect(getCookie(win, 'c2')).to.equal('2');
   });
 
   it('should return value for an escaped cookie name', () => {
-    expectCookie('c%26=1', 'c&').to.equal('1');
+    doc.cookie = 'c%26=1';
+    expect(doc.cookie).to.equal('c%26=1');
+    expect(getCookie(win, 'c&')).to.equal('1');
   });
 
   it('should return an unescaped value', () => {
-    expectCookie('c1=1%26', 'c1').to.equal('1&');
+    doc.cookie = 'c1=1%26';
+    expect(doc.cookie).to.equal('c1=1%26');
+    expect(getCookie(win, 'c1')).to.equal('1&');
   });
 
   it('should write the cookie', () => {
-    const doc = {};
-    setCookie(
-      {
-        document: doc,
-        location: {
-          href: 'https://www.example.com/test',
-        },
-      },
-      'c&1',
-      'v&1',
-      1447383159853
+    setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS);
+    expect(doc.lastSetCookieRaw).to.equal(
+      'c%261=v%261; path=/; expires=Tue, 01 Jan 2019 08:00:00 GMT'
     );
-    expect(doc.cookie).to.equal(
-      'c%261=v%261; path=/; expires=Fri, 13 Nov 2015 02:52:39 GMT'
-    );
+    expect(doc.cookie).to.equal('c%261=v%261');
   });
 
-  it('should write the cookie to the right domain', () => {
-    function test(hostname, targetDomain, opt_noset, opt_allowOnProxyOrigin) {
-      let cookie;
-      const doc = {
-        set cookie(val) {
-          // Delete cookies on ampproject.org
-          if (
-            val.indexOf(
-              'domain=ampproject.org; ' +
-                'expires=Thu, 01 Jan 1970 00:00:00 GMT'
-            ) != -1
-          ) {
-            cookie = undefined;
-            return;
-          }
-          if (val.indexOf('; domain=' + targetDomain) != -1) {
-            cookie = val;
-          }
-        },
-        get cookie() {
-          return cookie;
-        },
-      };
-      setCookie(
-        {
-          document: doc,
-          location: {
-            hostname,
-            href: 'https://' + hostname + '/test.html',
-          },
-        },
-        'c&1',
-        'v&1',
-        1447383159853,
-        {
-          highestAvailableDomain: true,
-          allowOnProxyOrigin: !!opt_allowOnProxyOrigin,
-        }
+  it('getHigestAvailableDomain on origin', () => {
+    win.location.href = 'https://bar.com';
+    expect(getHighestAvailableDomain(win)).to.equal('bar.com');
+    win.location.href = 'https://bar.net';
+    expect(getHighestAvailableDomain(win)).to.equal('bar.net');
+    win.location.href = 'https://foo.bar.com';
+    expect(getHighestAvailableDomain(win)).to.equal('bar.com');
+    doc.publicSufficList = ['bar.com'];
+    win.location.href = 'https://bar.com';
+    expect(getHighestAvailableDomain(win)).to.be.null;
+    win.location.href = 'https://bar.net';
+    expect(getHighestAvailableDomain(win)).to.equal('bar.net');
+    win.location.href = 'https://foo.bar.com';
+    expect(getHighestAvailableDomain(win)).to.equal('foo.bar.com');
+  });
+
+  it('getHigestAvaibleDomain on proxy origin', () => {
+    win.location.href = 'https://foo.cdn.ampproject.org';
+    expect(getHighestAvailableDomain(win)).to.be.null;
+    const meta = doc.createElement('meta');
+    meta.setAttribute('name', 'amp-cookie-scope');
+    meta.setAttribute('content', 'example.com');
+    doc.head.appendChild(meta);
+    expect(getHighestAvailableDomain(win)).to.equal('example.com');
+  });
+
+  it('should write the cookie to the right domain on origin', () => {
+    function test(url, targetDomain, opt_allowProxyOrigin) {
+      expect(doc.cookie).to.equal('');
+      win.location.href = url;
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
+        highestAvailableDomain: true,
+        allowOnProxyOrigin: opt_allowProxyOrigin,
+      });
+      expect(doc.lastSetCookieRaw).to.equal(
+        `c%261=v%261; path=/; domain=${targetDomain}; ` +
+          'expires=Tue, 01 Jan 2019 08:00:00 GMT'
       );
-      if (opt_noset) {
-        expect(cookie).to.be.undefined;
-      } else {
-        expect(cookie).to.equal(
-          'c%261=v%261; path=/; domain=' +
-            targetDomain +
-            '; expires=Fri, 13 Nov 2015 02:52:39 GMT'
-        );
-      }
+      expect(doc.cookie).to.equal('c%261=v%261');
+      // Erase cookie
+      setCookie(win, 'c&1', 'v&1', Date.now() - 1000, {
+        highestAvailableDomain: true,
+        allowOnProxyOrigin: opt_allowProxyOrigin,
+      });
+      expect(doc.cookie).to.equal('');
     }
-    test('www.example.com', 'example.com');
-    test('123.www.example.com', 'example.com');
-    test('example.com', 'example.com');
-    test('www.example.com', 'www.example.com');
-    test('123.www.example.com', '123.www.example.com');
-    test('www.example.net', 'example.com', true);
-    test('example.net', 'example.com', true);
-    test('cdn.ampproject.org', 'ampproject.org', true, true);
+
+    //example.com
+    test('https://www.example.com/test.html', 'example.com');
+    test('https://123.www.example.com/test.html', 'example.com');
+    test('https://example.com/test.html', 'example.com');
+    test('https://www.example.net', 'example.net');
+    doc.publicSufficList = ['example.com'];
+    test('https://123.www.example.com/test.html', 'www.example.com');
+  });
+
+  it('write cookie to right domain on proxy', () => {
+    win.location.href = 'https://foo.cdn.ampproject.org/test.html';
+    setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
+      domain: 'foo.cdn.ampproject.org',
+      allowOnProxyOrigin: true,
+    });
+    expect(doc.lastSetCookieRaw).to.equal(
+      `c%261=v%261; path=/; domain=foo.cdn.ampproject.org; ` +
+        'expires=Tue, 01 Jan 2019 08:00:00 GMT'
+    );
+    expect(doc.cookie).to.equal('c%261=v%261');
+
+    // Fail if allowOnProxyOrigin is false
     expect(() => {
-      test('cdn.ampproject.org', 'ampproject.org', true);
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+
+    win.location.href = 'https://CDN.ampproject.org/test.html';
     expect(() => {
-      test('CDN.ampproject.org', 'ampproject.org', true);
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+
+    win.location.href = 'https://foo.bar.cdn.ampproject.org/test.html';
     expect(() => {
-      test('CDN.ampproject.org', 'AMPproject.org', true);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    test('www.ampproject.org', 'www.ampproject.org');
-    test('cdn.ampproject.org', 'cdn.ampproject.org', false, true);
-    expect(() => {
-      test('cdn.ampproject.org', 'cdn.ampproject.org', false);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    expect(() => {
-      test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/in depth check/);
+
+    win.location.href = 'http://&&&.CDN.ampproject.org/test.html';
     expect(() => {
-      test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {});
     }).to.throw(/in depth check/);
+
+    // Must have domain specified when allowOnProxyOrigin
     expect(() => {
-      test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
-    }).to.throw(/in depth check/);
+      setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
+        allowOnProxyOrigin: true,
+      });
+    }).to.throw(/Should specify domain explicitly/);
+
+    // Cannot write to 'ampproject.org'
+    setCookie(win, 'c&1', 'v&1', Date.now() + BASE_CID_MAX_AGE_MILLIS, {
+      domain: 'ampproject.org',
+      allowOnProxyOrigin: true,
+    });
+    expect(doc.lastSetCookieRaw).to.equal(
+      `c%261=delete; path=/; domain=ampproject.org; ` +
+        'expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    );
+    expect(doc.cookie).to.equal('');
   });
 });

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -115,6 +115,7 @@ export class FakeWindow {
 
     /** @private {!Array<string>} */
     this.cookie_ = [];
+    this.document.publicSufficList = [];
     this.document.lastSetCookieRaw; // used to verify cookie settings like expiration time etc
     Object.defineProperty(this.document, 'cookie', {
       get: () => {
@@ -126,8 +127,19 @@ export class FakeWindow {
       },
       set: value => {
         this.document.lastSetCookieRaw = value;
-        const cookie = value.match(/^([^=]*)=([^;]*)/);
+        let cookie = value.match(/^([^=]*)=([^;]*)/);
+        if (!cookie) {
+          // couldn't find the match. Treat cookie as single value.
+          cookie = [value, null];
+        }
         const expiresMatch = value.match(/expires=([^;]*)(;|$)/);
+        const domainMatch = value.match(/domain=([^;]*)/);
+        const domain = domainMatch ? domainMatch[1] : '';
+        if (this.document.publicSufficList.indexOf(domain) >= 0) {
+          // Can't set cookie to etld
+          this.document.lastSetCookieRaw = '';
+          return;
+        }
         const expires = expiresMatch ? Date.parse(expiresMatch[1]) : Infinity;
         let i = 0;
         for (; i < this.cookie_.length; i += 2) {

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -115,7 +115,7 @@ export class FakeWindow {
 
     /** @private {!Array<string>} */
     this.cookie_ = [];
-    this.document.publicSufficList = [];
+    this.document.publicSuffixList = [];
     this.document.lastSetCookieRaw; // used to verify cookie settings like expiration time etc
     Object.defineProperty(this.document, 'cookie', {
       get: () => {
@@ -135,7 +135,7 @@ export class FakeWindow {
         const expiresMatch = value.match(/expires=([^;]*)(;|$)/);
         const domainMatch = value.match(/domain=([^;]*)/);
         const domain = domainMatch ? domainMatch[1] : '';
-        if (this.document.publicSufficList.indexOf(domain) >= 0) {
+        if (this.document.publicSuffixList.indexOf(domain) >= 0) {
           // Can't set cookie to etld
           this.document.lastSetCookieRaw = '';
           return;


### PR DESCRIPTION
Introduce the `getHighestAvailableDomain` function so it can be reused by linker manager.

New behavior:
1. Expect option.domain to be explicitly specified if we want to write to proxyOrigin
2. option.domain value overrides the `highestAvailableDomain=true`. 

Rewrite test-cookies.js. 

Hope to keep the PR size small. I'll submit the linker manager change in a seperate PR. 