### PR TITLE
🐛Improvements to Permutive amp-analytics config

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -324,7 +324,8 @@
     "track": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_",
     "pageview": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&e=Pageview&_ep_isp_info=%24ip_isp_info&_ep_geo_info=%24ip_geo_info&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_",
     "engagement": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&e=PageviewEngagement&_ep_engaged_time=5&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_",
-    "completion": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&e=PageviewEngagement&_ep_completion=0.25&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_"
+    "completion": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&e=PageviewEngagement&_ep_completion=0.25&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_",
+    "custom": "https://!namespace.amp.permutive.com/track?k=!key&i=_client_id_&it=amp&e=!event&_ep_client.type=amp&_ep_client.title=_title_&_ep_client.domain=_canonical_host_&_ep_client.url=_canonical_url_&_ep_client.referrer=_document_referrer_&_ep_client.user_agent=_user_agent_",
   },
   "piStats": {
     "host": "https://events.pi-stats.com",

--- a/extensions/amp-analytics/0.1/vendors/permutive.js
+++ b/extensions/amp-analytics/0.1/vendors/permutive.js
@@ -38,7 +38,7 @@ export const PERMUTIVE_CONFIG = /** @type {!JsonObject} */ ({
       'request': 'pageview',
     },
     'trackEngagement': {
-      'on': 'visible',
+      'on': 'timer',
       'timerSpec': {
         'interval': 5,
         'maxTimerLength': 600,

--- a/extensions/amp-analytics/0.1/vendors/permutive.js
+++ b/extensions/amp-analytics/0.1/vendors/permutive.js
@@ -31,6 +31,7 @@ export const PERMUTIVE_CONFIG = /** @type {!JsonObject} */ ({
       '&_ep_geo_info=%24ip_geo_info',
     'engagement': '${track}&e=PageviewEngagement&_ep_engaged_time=5',
     'completion': '${track}&e=PageviewEngagement&_ep_completion=0.25',
+    'custom': '${track}&e=${event}',
   },
   'triggers': {
     'trackPageview': {


### PR DESCRIPTION
This PR makes two minor improvements to Permutive's amp-analytics configuration:
- Bug fix: use `timer` trigger for tracking page engagement
- Adds additional request type for _custom_ events