### PR TITLE
✨ Adds generator for JSON version of the validator spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+  - pip install --user protobuf
 branches:
   only:
     - master
@@ -28,7 +29,6 @@ addons:
       - google-cloud-sdk
       - openssl
       - protobuf-compiler
-      - python-protobuf
   chrome: stable
   hosts:
     - ads.localhost

--- a/validator/README.md
+++ b/validator/README.md
@@ -50,11 +50,12 @@ the edges. Below are instructions for Linux Ubuntu 14.
 
 Install these packages using apt-get:
 
-* npm
-* openjdk-7-jre
-* protobuf-compiler
-* python-protobuf
-* python2.7
+* `npm`
+* `openjdk-7-jre`
+* `protobuf-compiler`
+* `python2.7`
+
+Then use pip to `pip install protobuf`.
 
 In addition, install Node.js v4.4.2. E.g.,
   [by downloading](https://nodejs.org/en/download/) or

--- a/validator/build.py
+++ b/validator/build.py
@@ -81,12 +81,12 @@ def CheckPrereqs():
     Die('Expected libprotoc 2.5.0 or newer, saw: %s' % libprotoc_version)
 
   # Ensure that the Python protobuf package is installed.
-  for m in ['descriptor', 'text_format']:
+  for m in ['descriptor', 'text_format', 'json_format']:
     module = 'google.protobuf.%s' % m
     try:
       __import__(module)
     except ImportError:
-      Die('%s not found. Try "apt-get install python-protobuf" or follow the install instructions at https://github.com/ampproject/amphtml/blob/master/validator/README.md#installation' % module)
+      Die('%s not found. Try "pip install protobuf" or follow the install instructions at https://github.com/ampproject/amphtml/blob/master/validator/README.md#installation' % module)
 
   # Ensure that yarn is installed.
   try:

--- a/validator/build.py
+++ b/validator/build.py
@@ -215,7 +215,7 @@ def GenValidatorProtoGeneratedJs(out_dir):
 
 
 def GenValidatorGeneratedJs(out_dir):
-  """Calls validator_gen_js to generate validator-generated.js.
+  """Calls validator_gen_js to generate validator-generated.js and validator-generated.json.
 
   Args:
     out_dir: directory name of the output directory. Must not have slashes,
@@ -229,6 +229,7 @@ def GenValidatorGeneratedJs(out_dir):
   # are checked by CheckPrereqs.
   # pylint: disable=g-import-not-at-top
   from google.protobuf import text_format
+  from google.protobuf import json_format
   from google.protobuf import descriptor
   from dist import validator_pb2
   import validator_gen_js
@@ -245,6 +246,18 @@ def GenValidatorGeneratedJs(out_dir):
       out=out)
   out.append('')
   f = open('%s/validator-generated.js' % out_dir, 'w')
+  f.write('\n'.join(out))
+  f.close()
+
+  out = []
+  validator_gen_js.GenerateValidatorGeneratedJson(
+      specfile='%s/validator.protoascii' % out_dir,
+      validator_pb2=validator_pb2,
+      text_format=text_format,
+      json_format=json_format,
+      out=out)
+  out.append('')
+  f = open('%s/validator-generated.json' % out_dir, 'w')
   f.write('\n'.join(out))
   f.close()
   logging.info('... done')

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -894,3 +894,26 @@ def GenerateValidatorGeneratedJs(specfile, validator_pb2, generate_proto_only,
     out.PopIndent()
     out.Line('}')
     out.Line('')
+
+
+def GenerateValidatorGeneratedJson(specfile, validator_pb2, text_format,
+                                   json_format, out):
+  """Generates a JSON file with definitions from validator.protoascii.
+
+  This method reads the specfile and emits JSON to out.
+
+  Args:
+    specfile: Path to validator.protoascii, the specfile to generate
+        Javascript from.
+    validator_pb2: The proto2 Python module generated from validator.proto.
+    text_format: The text_format module from the protobuf package, e.g.
+        google.protobuf.text_format.
+    json_format: The json_format module from the protobuf package, e.g.
+        google.protobuf.json_format.
+    out: a list of lines to output (without the newline characters), to
+        which this function will append.
+  """
+
+  rules = validator_pb2.ValidatorRules()
+  text_format.Merge(open(specfile).read(), rules)
+  out.append(json_format.MessageToJson(rules))


### PR DESCRIPTION
This makes it easier to consume by scripts to e.g. pull the list of all tags allowed by a specific format or generate autocomplete definitions for playground.amp.dev.