### PR TITLE
♻️✅ Export `isDisabled` helper

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -148,9 +148,8 @@ function isSubmitButton(element) {
 /**
  * Checks if a field is disabled.
  * @param {!Element} element
- * @private
  */
-function isDisabled(element) {
+export function isDisabled(element) {
   if (element.disabled) {
     return true;
   }

--- a/test/unit/test-form.js
+++ b/test/unit/test-form.js
@@ -389,29 +389,29 @@ describes.fakeWin('isDisabled', {}, env => {
   });
 
   describe('elements with ancestral fieldset', () => {
-    let element, fieldset;
+    let element, elementAncestralFieldset;
 
     beforeEach(() => {
-      fieldset = doc.createElement('fieldset');
       element = doc.createElement('input');
-      fieldset.appendChild(element);
+      elementAncestralFieldset = doc.createElement('fieldset');
+      elementAncestralFieldset.appendChild(element);
     });
 
     it('returns true for enabled elements with disabled ancestral fieldset', () => {
       element.disabled = false;
-      fieldset.disabled = true;
+      elementAncestralFieldset.disabled = true;
       expect(isDisabled(element)).to.be.true;
     });
 
     it('returns false for enabled elements with enabled ancestral fieldset', () => {
       element.disabled = false;
-      fieldset.disabled = false;
+      elementAncestralFieldset.disabled = false;
       expect(isDisabled(element)).to.be.false;
     });
 
     it('returns true for disabled elements with enabled ancestral fieldset', () => {
       element.disabled = true;
-      fieldset.disabled = false;
+      elementAncestralFieldset.disabled = false;
       expect(isDisabled(element)).to.be.true;
     });
   });

--- a/test/unit/test-form.js
+++ b/test/unit/test-form.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getFormAsObject} from '../../src/form.js';
+import {getFormAsObject, isDisabled} from '../../src/form.js';
 
 describes.realWin('getFormAsObject', {}, env => {
   let form;
@@ -31,6 +31,19 @@ describes.realWin('getFormAsObject', {}, env => {
     input.value = 'bar';
     input.disabled = true;
     form.appendChild(input);
+
+    expect(getFormAsObject(form)).to.be.an('object').that.is.empty;
+  });
+
+  it('excludes input with disabled ancestral fieldset', () => {
+    const fieldset = env.win.document.createElement('fieldset');
+    fieldset.disabled = true;
+    const input = env.win.document.createElement('input');
+    input.type = 'text';
+    input.name = 'foo';
+    input.value = 'bar';
+    fieldset.appendChild(input);
+    form.appendChild(fieldset);
 
     expect(getFormAsObject(form)).to.be.an('object').that.is.empty;
   });
@@ -347,5 +360,35 @@ describes.realWin('getFormAsObject', {}, env => {
     expect(formDataObject)
       .to.have.property('foo2')
       .that.has.deep.members(['bar']);
+  });
+});
+
+describes.fakeWin('isDisabled', {}, env => {
+  let doc;
+
+  beforeEach(() => {
+    doc = env.win.document;
+  });
+
+  it('returns true for disabled elements', () => {
+    const disabled = doc.createElement('input');
+
+    disabled.disabled = false;
+    expect(isDisabled(disabled)).to.be.false;
+
+    disabled.disabled = true;
+    expect(isDisabled(disabled)).to.be.true;
+  });
+
+  it('returns true for elements with disabled ancestral fieldset', () => {
+    const fieldset = doc.createElement('fieldset');
+    const input = doc.createElement('input');
+    fieldset.appendChild(input);
+
+    fieldset.disabled = true;
+    expect(isDisabled(input)).to.be.true;
+
+    fieldset.disabled = false;
+    expect(isDisabled(input)).to.be.false;
   });
 });

--- a/test/unit/test-form.js
+++ b/test/unit/test-form.js
@@ -370,25 +370,49 @@ describes.fakeWin('isDisabled', {}, env => {
     doc = env.win.document;
   });
 
-  it('returns true for disabled elements', () => {
-    const disabled = doc.createElement('input');
+  describe('elements without ancestral fieldset', () => {
+    let element;
 
-    disabled.disabled = false;
-    expect(isDisabled(disabled)).to.be.false;
+    beforeEach(() => {
+      element = doc.createElement('input');
+    });
 
-    disabled.disabled = true;
-    expect(isDisabled(disabled)).to.be.true;
+    it('returns true for disabled elements', () => {
+      element.disabled = true;
+      expect(isDisabled(element)).to.be.true;
+    });
+
+    it('returns false for enabled elements', () => {
+      element.disabled = false;
+      expect(isDisabled(element)).to.be.false;
+    });
   });
 
-  it('returns true for elements with disabled ancestral fieldset', () => {
-    const fieldset = doc.createElement('fieldset');
-    const input = doc.createElement('input');
-    fieldset.appendChild(input);
+  describe('elements with ancestral fieldset', () => {
+    let element, fieldset;
 
-    fieldset.disabled = true;
-    expect(isDisabled(input)).to.be.true;
+    beforeEach(() => {
+      fieldset = doc.createElement('fieldset');
+      element = doc.createElement('input');
+      fieldset.appendChild(element);
+    });
 
-    fieldset.disabled = false;
-    expect(isDisabled(input)).to.be.false;
+    it('returns true for enabled elements with disabled ancestral fieldset', () => {
+      element.disabled = false;
+      fieldset.disabled = true;
+      expect(isDisabled(element)).to.be.true;
+    });
+
+    it('returns false for enabled elements with enabled ancestral fieldset', () => {
+      element.disabled = false;
+      fieldset.disabled = false;
+      expect(isDisabled(element)).to.be.false;
+    });
+
+    it('returns true for disabled elements with enabled ancestral fieldset', () => {
+      element.disabled = true;
+      fieldset.disabled = false;
+      expect(isDisabled(element)).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
The `isDisabled` helper will be used to determine if an element should
skip the dirtiness check.

This is a part of #22534.

/cc @cvializ @GoTcWang 
