### PR TITLE
✅ Make sure amp-autocomplete example validates

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -482,7 +482,9 @@
 
     <h2>Templates in search context</h2>
     <p>Plain Text, Submit on enter</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
         <fieldset>
             <label>
                 <span>Search for</span>
@@ -503,7 +505,9 @@
     </form>
 
     <p>Rich Text, Template Child, Default Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
         <fieldset>
             <label>
                 <span>Search for</span>
@@ -544,7 +548,9 @@
     </form>
 
     <p>Rich Text, Template Child, Custom Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
         <fieldset>
             <label>
                 <span>Search for</span>
@@ -588,7 +594,9 @@
     </form>
 
     <p>Rich Text, Template Attribute, Default Value Property</p>
-    <form method="get" action-xhr="/form/search-json/get" target="_blank">
+    <form method="post"
+        action-xhr="/form/echo-json/post"
+        target="_blank">
         <fieldset>
             <label>
                 <span>Search for</span>

--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -54,7 +54,7 @@ tags: {  # <amp-autocomplete>
     name: "src"
     value_url: {
       protocol: "https"
-      allow_relative: false
+      allow_relative: true
     }
   }
   attrs: { name: "submit-on-enter" }


### PR DESCRIPTION
- Replace invalid form attributes with an endpoint that both works and validates
- Allow relative URLs in the `src` attribute on `amp-autocomplete`