### PR TITLE
Fix invisible amp-sidebar in AMP4EMAIL

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -172,18 +172,20 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   border-top: 1px solid transparent !important;
 }
 
-
 /**
- * Most transferred fixed elements are hidden when a lightbox is opened. This
- * prevents fixed elements from being displayed on top of lightboxes.
+ * Hide the fixed layer when a lightbox is opened. This prevents buggy UX where
+ * fixed elements are displayed on top of lightboxes...
  */
+#i-amphtml-wrapper + body {
+  visibility: visible;
+}
 #i-amphtml-wrapper + body[i-amphtml-lightbox] {
   visibility: hidden;
 }
 /**
- * The exception to the above is descendants of lightboxes, which we only
- * want to display when a lightbox is open (the opposite behavior!).
- * See fixed-layer.js#enterLightbox() for details.
+ * ...except for fixed-position descendants of lightboxes, which we only want
+ * to show when a lightbox is open. Note this is the opposite visibility of
+ * the fixed layer itself! See fixed-layer.js#enterLightbox() for details.
  */
 #i-amphtml-wrapper + body .i-amphtml-lightbox-element {
   visibility: hidden;

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -32,7 +32,6 @@ import {dev, user} from '../log';
 import {endsWith} from '../string';
 import {isExperimentOn} from '../experiments';
 import {remove} from '../utils/array';
-import {toWin} from '../types';
 
 const TAG = 'FixedLayer';
 
@@ -130,10 +129,7 @@ export class FixedLayer {
       transferLayer.setLightboxMode(true);
     }
 
-    if (
-      opt_lightbox &&
-      opt_onComplete
-    ) {
+    if (opt_lightbox && opt_onComplete) {
       opt_onComplete.then(() => {
         this.scanNode_(
           dev().assertElement(opt_lightbox),

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -131,7 +131,6 @@ export class FixedLayer {
     }
 
     if (
-      isExperimentOn(this.ampdoc.win, 'fixed-elements-in-lightbox') &&
       opt_lightbox &&
       opt_onComplete
     ) {
@@ -153,12 +152,10 @@ export class FixedLayer {
       transferLayer.setLightboxMode(false);
     }
 
-    if (isExperimentOn(this.ampdoc.win, 'fixed-elements-in-lightbox')) {
-      const fes = remove(this.elements_, fe => !!fe.lightboxed);
-      this.returnFixedElements_(fes);
-      if (!this.elements_.length) {
-        this.unobserveHiddenMutations_();
-      }
+    const fes = remove(this.elements_, fe => !!fe.lightboxed);
+    this.returnFixedElements_(fes);
+    if (!this.elements_.length) {
+      this.unobserveHiddenMutations_();
     }
   }
 
@@ -941,12 +938,6 @@ class TransferLayerBody {
     /** @private @const {!./vsync-impl.Vsync} */
     this.vsync_ = vsync;
 
-    /** @private @const {boolean} */
-    this.isLightboxExperimentOn_ = isExperimentOn(
-      toWin(doc.defaultView),
-      'fixed-elements-in-lightbox'
-    );
-
     /** @private @const {!Element} */
     this.layer_ = doc.body.cloneNode(/* deep */ false);
     this.layer_.removeAttribute('style');
@@ -972,13 +963,7 @@ class TransferLayerBody {
       padding: 'none',
       transform: 'none',
       transition: 'none',
-      visibility: 'visible',
     };
-    // This experiment uses a CSS rule for toggling transfer layer visibility,
-    // which has lower specificity than an inline style.
-    if (this.isLightboxExperimentOn_) {
-      delete styles.visibility;
-    }
     setStyles(this.layer_, assertDoesNotContainDisplay(styles));
     setInitialDisplay(this.layer_, 'block');
     doc.documentElement.appendChild(this.layer_);
@@ -993,16 +978,10 @@ class TransferLayerBody {
   setLightboxMode(on) {
     this.vsync_.mutate(() => {
       const root = this.getRoot();
-      if (this.isLightboxExperimentOn_) {
-        if (on) {
-          root.setAttribute(LIGHTBOX_MODE_ATTR, '');
-        } else {
-          root.removeAttribute(LIGHTBOX_MODE_ATTR);
-        }
+      if (on) {
+        root.setAttribute(LIGHTBOX_MODE_ATTR, '');
       } else {
-        // Legacy behavior is to hide transfer layer when entering lightbox
-        // and unhide when exiting.
-        setStyle(root, 'visibility', on ? 'hidden' : 'visible');
+        root.removeAttribute(LIGHTBOX_MODE_ATTR);
       }
     });
   }

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -398,12 +398,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/20394',
   },
   {
-    id: 'fixed-elements-in-lightbox',
-    name: 'Transfer fixed elements in lightboxes for smooth iOS scrolling',
-    spec: 'https://github.com/ampproject/amphtml/issues/20964',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/20965',
-  },
-  {
     id: 'amp-img-auto-sizes',
     name: 'Automatically generates sizes for amp-img if not given',
     spec: 'https://github.com/ampproject/amphtml/issues/19513',


### PR DESCRIPTION
### Bug
amp-sidebar is invisible when opened. Affects iOS in "email" and "actions" specs.

The is due to the non-traditional CSS boilerplate which causes the fixed layer to be hidden: 
```html
<style amp4email-boilerplate>body{visibility:hidden}</style>
```

Tthe regression happened in https://github.com/ampproject/amphtml/pull/20954/files#diff-a244d3899d7cb3930087a9d566a46af9R963, which stopped overriding the "visibility" style on the fixed layer. 

### Fix
Use higher-specificity CSS to override the boilerplate rule and make sure the transfer layer is visible when intended:
```css
#i-amphtml-wrapper + body {
  visibility: visible;
}
```

This PR also cleans up the `fixed-elements-in-lightbox` experiment code guards.

`b/133327438`

/to @jridgewell 