### PR TITLE
Add a variant tagspec for style amp-custom

### DIFF
--- a/validator/package.json
+++ b/validator/package.json
@@ -18,5 +18,5 @@
     "google-closure-compiler": "20180506.0.0",
     "google-closure-library": "20180506.0.0",
     "jasmine": "3.1.0"
-  },
+  }
 }

--- a/validator/package.json
+++ b/validator/package.json
@@ -19,7 +19,4 @@
     "google-closure-library": "20180506.0.0",
     "jasmine": "3.1.0"
   },
-  "dependencies": {
-    "gulp": "^4.0.2"
-  }
 }

--- a/validator/package.json
+++ b/validator/package.json
@@ -18,5 +18,8 @@
     "google-closure-compiler": "20180506.0.0",
     "google-closure-library": "20180506.0.0",
     "jasmine": "3.1.0"
+  },
+  "dependencies": {
+    "gulp": "^4.0.2"
   }
 }

--- a/validator/testdata/feature_tests/css_lengthcheck.html
+++ b/validator/testdata/feature_tests/css_lengthcheck.html
@@ -26,7 +26,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <style amp-custom-lencheck>0123456789</style>
+  <style amp-custom-length-check>0123456789</style>
   <link rel="canonical" href="./regular-html-version.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>

--- a/validator/testdata/feature_tests/css_lengthcheck.html
+++ b/validator/testdata/feature_tests/css_lengthcheck.html
@@ -1,0 +1,37 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+    Demonstrates the use of <style amp-custom-length-check> which can be
+    used if you want to see how many bytes are present in your style tag
+    as the validator sees it. If present, this tag will always report an
+    error as it requires -1 or fewer bytes in the tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom-lencheck>0123456789</style>
+  <link rel="canonical" href="./regular-html-version.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  Hello, world.
+  <div style="replace_inline_style"></div>
+</body>
+</html>

--- a/validator/testdata/feature_tests/css_lengthcheck.html
+++ b/validator/testdata/feature_tests/css_lengthcheck.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/validator/testdata/feature_tests/css_lengthcheck.html
+++ b/validator/testdata/feature_tests/css_lengthcheck.html
@@ -32,6 +32,5 @@
 </head>
 <body>
   Hello, world.
-  <div style="replace_inline_style"></div>
 </body>
 </html>

--- a/validator/testdata/feature_tests/css_lengthcheck.out
+++ b/validator/testdata/feature_tests/css_lengthcheck.out
@@ -1,6 +1,6 @@
 FAIL
 |  <!--
-|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.

--- a/validator/testdata/feature_tests/css_lengthcheck.out
+++ b/validator/testdata/feature_tests/css_lengthcheck.out
@@ -1,0 +1,42 @@
+FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      Demonstrates the use of <style amp-custom-length-check> which can be
+|      used if you want to see how many bytes are present in your style tag
+|      as the validator sees it. If present, this tag will always report an
+|      error as it requires -1 or fewer bytes in the tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-custom-lencheck>0123456789</style>
+>>   ^~~~~~~~~
+feature_tests/css_lengthcheck.html:29:2 The attribute 'amp-custom-lencheck' may not appear in tag 'style amp-custom'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets) [DISALLOWED_HTML]
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|  </head>
+|  <body>
+|    Hello, world.
+|    <div style="replace_inline_style"></div>
+>>   ^~~~~~~~~
+feature_tests/css_lengthcheck.html:35:2 CSS syntax error in tag 'div' - incomplete declaration. [GENERIC]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/css_lengthcheck.out
+++ b/validator/testdata/feature_tests/css_lengthcheck.out
@@ -35,8 +35,5 @@ feature_tests/css_lengthcheck.html:29:2 The author stylesheet specified in tag '
 |  </head>
 |  <body>
 |    Hello, world.
-|    <div style="replace_inline_style"></div>
->>   ^~~~~~~~~
-feature_tests/css_lengthcheck.html:35:2 CSS syntax error in tag 'div' - incomplete declaration. [GENERIC]
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/css_lengthcheck.out
+++ b/validator/testdata/feature_tests/css_lengthcheck.out
@@ -27,9 +27,9 @@ FAIL
 |    <meta charset="utf-8">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1">
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
-|    <style amp-custom-lencheck>0123456789</style>
+|    <style amp-custom-length-check>0123456789</style>
 >>   ^~~~~~~~~
-feature_tests/css_lengthcheck.html:29:2 The attribute 'amp-custom-lencheck' may not appear in tag 'style amp-custom'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets) [DISALLOWED_HTML]
+feature_tests/css_lengthcheck.html:29:2 The author stylesheet specified in tag 'style amp-custom-length-check' is too long - document contains 10 bytes whereas the limit is -1 bytes. [AUTHOR_STYLESHEET_PROBLEM]
 |    <link rel="canonical" href="./regular-html-version.html">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |  </head>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1343,9 +1343,9 @@ tags: {
     value_casei: "text/css"
   }
   cdata: {
+    # This will always cause the tagspec matching to fail.
     max_bytes: -1
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
 }
 tags: {
   html_format: AMP

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1313,6 +1313,40 @@ tags: {  # Special custom 'author' spreadsheet for AMP
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
 }
+# This variant of <style amp-custom> is designed to help developers see how
+# close they are to the byte limit, even if the page is passing. By changing
+# the attribute to <style amp-custom-length-check>, this tagspec will be used
+# to match errors. It cannot pass however as it has a cdata.max_bytes set to
+# -1. As a result, it will always fail and report the length found in the
+# tag's cdata. This is a small hack, and may be deleted in the future if there
+# are problems maintaining it. Deleting this tagspec will of course never
+# break any valid AMP documents as if it matches, the page will be invalid.
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  disabled_by: "transformed"
+  tag_name: "STYLE"
+  spec_name: "style amp-custom-length-check"
+  unique: true
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "amp-custom-length-check"
+    mandatory: true
+    value: ""
+    dispatch_key: NAME_DISPATCH
+  }
+  attrs: { name: "nonce" }
+  attrs: {  # This is a default, but it doesn't hurt.
+    name: "type"
+    value_casei: "text/css"
+  }
+  cdata: {
+    max_bytes: -1
+  }
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+}
 tags: {
   html_format: AMP
   html_format: ACTIONS


### PR DESCRIPTION
Add a variant tagspec for style amp-custom that allows a developer to count the CSS length present in a document that is otherwise passing validation.

Helps with #22315 

For review, I suggest taking a look at the test case `.out` first whose error message demonstrates what this tries to accomplish.