### PR TITLE
🏗  Upload codecov reports only for runtime changes

### DIFF
--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -86,7 +86,9 @@ function main() {
       timedExecOrDie('gulp test --unit --nobuild --headless --coverage');
     }
 
-    timedExecOrDie('gulp codecov-upload');
+    if (buildTargets.has('RUNTIME')) {
+      timedExecOrDie('gulp codecov-upload');
+    }
   }
 
   stopTimer(FILENAME, FILENAME, startTime);


### PR DESCRIPTION
Since code coverage is measured only for the runtime, it makes sense to upload coverage reports only for runtime changes.

<img width="1144" alt="" src="https://user-images.githubusercontent.com/26553114/58524951-f57a7980-8197-11e9-963f-3d86160fd227.png">


This prevents cases where partial coverage reports are are uploaded. For example, if a PR runs only integration tests, but not unit tests.

Follow up to #22515