### PR TITLE
✨ Add WebEngage as an analytics vendor

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -109,6 +109,7 @@
       <option>umenganalytics</option>
       <option>upscore</option>
       <option>vponanalytics</option>
+      <option>webengage</option>
       <option>webtrekk</option>
       <option>webtrekk_v2</option>
     </select>
@@ -1598,6 +1599,30 @@ For complete documentation and additional examples please see: https://marketing
   </script>
 </amp-analytics>
 <!-- Vpon Analytics example -->
+
+<!-- start WebEngage Analytics example -->
+<amp-analytics type="webengage" id="webengage" >
+  <script type="application/json">
+    {
+      "vars": {
+        "licenseCode": "~134105385"
+      },
+      "requests": {
+        "weClick": {
+          "baseUrl": "${base}&eventName=Element Clicked&element=test1"
+        }
+      },
+      "triggers": {
+        "weClickTrigger": {
+          "on": "click",
+          "selector": "#test1",
+          "request": "weClick"
+        }
+      }
+    }
+  </script>
+</amp-analytics>
+<!-- end WebEngage Analytics example -->
 </div>
 
 <div class="logo"></div>

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -125,7 +125,6 @@ describes.realWin('amp-analytics', {
           config.triggers = {};
         });
 
-        console.log('all config values', config);
         for (const name in config.requests) {
           it('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -125,6 +125,7 @@ describes.realWin('amp-analytics', {
           config.triggers = {};
         });
 
+        console.log('config', config);
         for (const name in config.requests) {
           it('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -125,7 +125,7 @@ describes.realWin('amp-analytics', {
           config.triggers = {};
         });
 
-        console.log('config', config);
+        console.log('config values', config);
         for (const name in config.requests) {
           it('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -125,7 +125,7 @@ describes.realWin('amp-analytics', {
           config.triggers = {};
         });
 
-        console.log('config values', config);
+        console.log('all config values', config);
         for (const name in config.requests) {
           it('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -450,6 +450,10 @@
     "elementInteract": "https://tags-dmp.vpadn.com/et?t=_timestamp_&sdkn=j&sdkv=1.2.0&lk=!licence_key&en=UTF-8&ctid=_client_id_&ev=element_interact&pl={\"name\":\"!category\",\"action\":\"!action\",\"value\":\"!label\"}&is_amp=1&page_id=_page_view_id_",
     "event": "https://tags-dmp.vpadn.com/et?t=_timestamp_&sdkn=j&sdkv=1.2.0&lk=!licence_key&en=UTF-8&ctid=_client_id_&ev=!ev_name&pl=!payload&is_amp=1&page_id=_page_view_id_"
   },
+  "webengage": {
+    "base": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application",
+    "wePageview": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application&eventName=Page Viewed"
+  },
   "webtrekk": {
     "trackURL": "https://!trackDomain/!trackId/wt",
     "parameterPrefix": "?p=432,!contentId,1,_screen_width_x_screen_height_,_screen_color_depth_,1,_timestamp_,_document_referrer_,_viewport_width_x_viewport_height_,0&tz=_timezone_&eid=_client_id_&la=_browser_language_",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -451,8 +451,8 @@
     "event": "https://tags-dmp.vpadn.com/et?t=_timestamp_&sdkn=j&sdkv=1.2.0&lk=!licence_key&en=UTF-8&ctid=_client_id_&ev=!ev_name&pl=!payload&is_amp=1&page_id=_page_view_id_"
   },
   "webengage": {
-    "base": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application",
-    "wePageview": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application&eventName=Page Viewed"
+    "base": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application&isAmp=1",
+    "wePageview": "https://c.webengage.com/amp?licenseCode=!licenseCode&luid=_client_id_&pageUrl=_canonical_url_&pageTitle=_title_&referrer=_document_referrer_&vh=_viewport_height_&vw=_viewport_width_&category=application&eventName=Page Viewed&isAmp=1"
   },
   "webtrekk": {
     "trackURL": "https://!trackDomain/!trackId/wt",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -100,6 +100,7 @@ import {UPSCORE_CONFIG} from './vendors/upscore';
 import {REPPUBLIKA_CONFIG} from './vendors/reppublika';
 import {NAVEGG_CONFIG} from './vendors/navegg';
 import {VPONANALYTICS_CONFIG} from './vendors/vponanalytics';
+import {WEBENGAGE_CONFIG} from './vendors/webengage';
 
 /**
  * @const {!JsonObject}
@@ -246,6 +247,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
   'umenganalytics': UMENGANALYTICS_CONFIG,
   'upscore': UPSCORE_CONFIG,
   'vponanalytics': VPONANALYTICS_CONFIG,
+  'webengage': WEBENGAGE_CONFIG,
   'webtrekk': WEBTREKK_CONFIG,
   'webtrekk_v2': WEBTREKK_V2_CONFIG,
 });

--- a/extensions/amp-analytics/0.1/vendors/webengage.js
+++ b/extensions/amp-analytics/0.1/vendors/webengage.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const WEBENGAGE_CONFIG = /** @type {!JsonObject} */ ({
+  'requests': {
+    'base':
+      'https://c.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId(we_luid)}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application',
+    'wePageview': {
+      'baseUrl': '${base}&eventName=Page Viewed',
+    },
+  },
+  'extraUrlParams': {
+    'isAmp': 1,
+  },
+  'triggers': {
+    'wePageviewTrigger': {
+      'on': 'visible',
+      'request': 'wePageview',
+    },
+  },
+});


### PR DESCRIPTION
Resolves #22124 . Adds WebEngage as an amp-analytics vendor option.
@lannka