### PR TITLE
✅ Fix amp-img integration test on IE 11

### DIFF
--- a/test/fixtures/images-ie.html
+++ b/test/fixtures/images-ie.html
@@ -16,7 +16,7 @@
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="/dist/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
   <h1>AMP #0</h1>

--- a/test/fixtures/images-ie.html
+++ b/test/fixtures/images-ie.html
@@ -16,7 +16,7 @@
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="/dist/amp.js"></script>
+  <script async src="/dist/v0.js"></script>
 </head>
 <body>
   <h1>AMP #0</h1>

--- a/test/fixtures/images-ie.html
+++ b/test/fixtures/images-ie.html
@@ -19,8 +19,8 @@
   <script async src="/dist/amp.js"></script>
 </head>
 <body>
-<h1>AMP #0</h1>
-<p>IE Edge Case</p>  
+  <h1>AMP #0</h1>
+  <p>IE Edge Case</p>  
   <amp-img id="img4" srcset="/examples/img/hero@1x.jpg 641w, /examples/img/hero@2x.jpg 1282w" width=641 height=480 layout="responsive"></amp-img>  
 </body>
 </html>

--- a/test/fixtures/images-ie.html
+++ b/test/fixtures/images-ie.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    h1 {color: red}
+    body {
+      max-width: 527px;
+      font-family: Arial;
+    }
+    amp-extended-sample.i-amphtml-element {
+      display: block;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="/dist/amp.js"></script>
+</head>
+<body>
+<h1>AMP #0</h1>
+<p>IE Edge Case</p>  
+  <amp-img id="img4" srcset="/examples/img/hero@1x.jpg 641w, /examples/img/hero@2x.jpg 1282w" width=641 height=480 layout="responsive"></amp-img>  
+</body>
+</html>

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -35,7 +35,7 @@
   None
   <p>
     <amp-img id="img2" src="/examples/img/sample.jpg" width=527 height=193 layout="nodisplay"></amp-img>
-  </p>  
+  </p>
 
   <p>
     Lorem ipsum dolor sit amet

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -16,7 +16,7 @@
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="/dist/amp.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
 <h1>AMP #0</h1>
@@ -36,6 +36,9 @@
   <p>
     <amp-img id="img2" src="/examples/img/sample.jpg" width=527 height=193 layout="nodisplay"></amp-img>
   </p>
+
+  <p>IE Edge Case</p>  
+  <amp-img id="img4" srcset="/examples/img/hero@1x.jpg 641w, /examples/img/hero@2x.jpg 1282w" width=641 height=480 layout="responsive"></amp-img>  
 
   <p>
     Lorem ipsum dolor sit amet

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -16,7 +16,7 @@
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="/dist/amp.js"></script>
 </head>
 <body>
 <h1>AMP #0</h1>
@@ -35,10 +35,7 @@
   None
   <p>
     <amp-img id="img2" src="/examples/img/sample.jpg" width=527 height=193 layout="nodisplay"></amp-img>
-  </p>
-
-  <p>IE Edge Case</p>  
-  <amp-img id="img4" srcset="/examples/img/hero@1x.jpg 641w, /examples/img/hero@2x.jpg 1282w" width=641 height=480 layout="responsive"></amp-img>  
+  </p>  
 
   <p>
     Lorem ipsum dolor sit amet

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -117,9 +117,11 @@ describe
   .run('Internet Explorer edge cases', () => {
     let fixture;
     beforeEach(() => {
-      return createFixtureIframe('test/fixtures/images.html', 500).then(f => {
-        fixture = f;
-      });
+      return createFixtureIframe('test/fixtures/images-ie.html', 500).then(
+        f => {
+          fixture = f;
+        }
+      );
     });
 
     // IE doesn't support the srcset attribute, so if the developer

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -114,7 +114,7 @@ describe
 describe
   .configure()
   .ifIe()
-  .run('Internet Explorer edge cases', () => {
+  .run('Rendering of amp-img - Internet Explorer edge cases', () => {
     let fixture;
     beforeEach(() => {
       return createFixtureIframe('test/fixtures/images-ie.html', 500).then(

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -138,8 +138,13 @@ describe
   });
 
 function waitForImageToLoad(document) {
-  return poll('wait for img4 to load', () => {
-    const img = document.querySelector('img[amp-img-id="img4"]');
-    return img !== null;
-  });
+  return poll(
+    'wait for img4 to load',
+    () => {
+      const img = document.querySelector('img[amp-img-id="img4"]');
+      return img !== null;
+    },
+    () => {},
+    8000
+  );
 }

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -18,6 +18,7 @@ import {AmpEvents} from '../../src/amp-events';
 import {
   createFixtureIframe,
   expectBodyToBecomeVisible,
+  poll,
 } from '../../testing/iframe.js';
 
 describe
@@ -106,36 +107,37 @@ describe
         expect(ampImage.querySelectorAll('img').length).to.equal(1);
       });
     });
-
-    const body = `
-  <amp-img id="img0" srcset="/examples/img/hero@1x.jpg 641w,
-                   /examples/img/hero@2x.jpg 1282w"
-    width=641 height=480 layout=responsive></amp-img>
-  `;
-
-    describes.integration(
-      'Internet Explorer edge cases',
-      {
-        body,
-      },
-      env => {
-        let win;
-        beforeEach(() => {
-          win = env.win;
-        });
-
-        // IE doesn't support the srcset attribute, so if the developer
-        // provides a srcset but no src to amp-img, it should set the src
-        // attribute to the first entry in srcset.
-        it.configure()
-          .ifIe()
-          .run('should guarantee src if srcset is not supported', () => {
-            const ampImg = win.document.getElementById('img0');
-            const img = ampImg.querySelector('img');
-            expect(img.getAttribute('src')).to.equal(
-              '/examples/img/hero@1x.jpg'
-            );
-          });
-      }
-    );
   });
+
+// Move IE tests into its own `describe()`
+// so that Mocha picks up its 'ifIe()' configuration
+describe
+  .configure()
+  .ifIe()
+  .run('Internet Explorer edge cases', () => {
+    let fixture;
+    beforeEach(() => {
+      return createFixtureIframe('test/fixtures/images.html', 500).then(f => {
+        fixture = f;
+      });
+    });
+
+    // IE doesn't support the srcset attribute, so if the developer
+    // provides a srcset but no src to amp-img, it should set the src
+    // attribute to the first entry in srcset.
+    it('should guarantee src if srcset is not supported', () => {
+      const imageLoadedPromise = waitForImageToLoad(fixture.doc);
+      return imageLoadedPromise.then(() => {
+        const ampImg = fixture.doc.getElementById('img4');
+        const img = ampImg.querySelector('img[amp-img-id="img4"]');
+        expect(img.getAttribute('src')).to.equal('/examples/img/hero@1x.jpg');
+      });
+    });
+  });
+
+function waitForImageToLoad(document) {
+  return poll('wait for img4 to load', () => {
+    const img = document.querySelector('img[amp-img-id="img4"]');
+    return img !== null;
+  });
+}

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -349,6 +349,9 @@ function describeEnv(factory) {
       if (spec.retryOnSaucelabs) {
         d = d.retryOnSaucelabs(spec.retryOnSaucelabs);
       }
+      if (spec.ifIe) {
+        d = d.ifIe();
+      }
       d.run(SUB, function() {
         if (spec.timeout) {
           this.timeout(spec.timeout);


### PR DESCRIPTION
- Fixes bug where Mocha was skipping an `amp-img` integration test that opted into IE 11 due to an overridden test config
- Fixes test itself that timed out by adding a poll and using an html test fixture that uses minified build