### PR TITLE
Revert deferral of [src] local data render until layout

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -84,12 +84,6 @@ export class AmpList extends AMP.BaseElement {
     this.renderPass_ = new Pass(this.win, () => this.doRenderPass_());
 
     /**
-     * Local data queued for render from `src` mutation before layoutCallback.
-     * @private {?Array}
-     */
-    this.prelayoutLocalData_ = null;
-
-    /**
      * Latest fetched items to render and the promise resolver and rejecter
      * to be invoked on render success or fail, respectively.
      * @private {?RenderItems}
@@ -224,16 +218,7 @@ export class AmpList extends AMP.BaseElement {
       this.initializeLoadMoreElements_();
     }
 
-    // Don't fetch if `src` is empty string.
-    if (!!this.element.getAttribute('src')) {
-      return this.fetchList_();
-    } else if (this.prelayoutLocalData_) {
-      return this.scheduleRender_(this.prelayoutLocalData_);
-    }
-    // Clean up any "prelayout" data now that we're laid out.
-    this.prelayoutLocalData_ = null;
-
-    return Promise.resolve();
+    return this.fetchList_();
   }
 
   /**
@@ -324,14 +309,8 @@ export class AmpList extends AMP.BaseElement {
       // Remove the 'src' now that local data is used to render the list.
       this.element.setAttribute('src', '');
       const array = /** @type {!Array} */ (isArray(data) ? data : [data]);
-      // Defer to render in layoutCallback() before first layout.
-      if (this.layoutCompleted_) {
-        this.resetIfNecessary_(/* isFetch */ false);
-        return this.scheduleRender_(array);
-      } else {
-        this.prelayoutLocalData_ = array;
-      }
-      return Promise.resolve();
+      this.resetIfNecessary_(/* isFetch */ false);
+      return this.scheduleRender_(array, /* append */ false);
     };
 
     const src = mutations['src'];
@@ -603,7 +582,6 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   scheduleRender_(data, opt_append, opt_payload) {
-    devAssert(this.layoutCompleted_);
     dev().info(TAG, 'schedule:', this.element, data);
 
     const deferred = new Deferred();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -387,11 +387,11 @@ describes.repeated(
             });
           });
 
-          it('fetch should not be called if `src` is missing or empty', () => {
+          it('fetch should resolve if `src` is empty', () => {
             const spy = sandbox.spy(list, 'fetchList_');
             element.setAttribute('src', '');
             return list.layoutCallback().then(() => {
-              expect(spy).to.not.be.called;
+              expect(spy).to.be.called;
             });
           });
 
@@ -721,9 +721,10 @@ describes.repeated(
             );
           });
 
-          it('should not render if [src] mutates with data (before layout)', () => {
-            // Not allowed before layout.
-            listMock.expects('scheduleRender_').never();
+          // Unlike [src] mutations with URLs, local data mutations should
+          // always render immediately.
+          it('should render if [src] mutates with data (before layout)', () => {
+            listMock.expects('scheduleRender_').once();
 
             element.setAttribute('src', 'https://new.com/list.json');
             list.mutatedAttributesCallback({'src': [{title: 'Title1'}]});


### PR DESCRIPTION
Fixes #22552 by partially reverting #22227.

Allows `amp-list` that's mutated by `[src]` with local data but have zero size (width or height == 0) to render. 