### PR TITLE
Fix sidebar opening for Firefox.

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -32,7 +32,7 @@ amp-sidebar {
 
 amp-sidebar[side="left"] {
   left: 0 !important;
-  transform: translateX(-100%) !important;
+  transform: translateX(-100%);
   animation-name: i-amphtml-sidebar-slide-out-left;
 }
 
@@ -42,7 +42,7 @@ amp-sidebar[side="left"][open] {
 
 amp-sidebar[side="right"] {
   right: 0 !important;
-  transform: translateX(100%) !important;
+  transform: translateX(100%);
   animation-name: i-amphtml-sidebar-slide-out-right;
 }
 


### PR DESCRIPTION
- Remove `!important` from translate rules, since they are not
overridden by animation properties in Firefox.

Fixes #22553
