### PR TITLE
🏗 Consolidate AMP's code coverage PR statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,8 +9,8 @@ coverage:
     project:
       base: auto # Use base commit for PRs, parent commit for push builds
       target: auto # Target same coverage as the base / parent commit
-      threshold: 10 # Total project coverage must be within 10% of base / parent commit
+      threshold: 100 # Passing check no matter what the coverage is
     patch:
       base: auto # Use base commit for PRs, parent commit for push builds
       target: 100 # Target 100% coverage for diffs
-      threshold: 50 # Patch coverage must be within 50% of target (at least 50%)
+      threshold: 100 # Passing check no matter what the coverage is

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,26 +7,10 @@ comment: off
 coverage:
   status:
     project:
-      default: off
-      unit_tests:
-        flags: unit_tests
-        target: auto
-        threshold: 100 # Passing check no matter what the coverage is
-        base: auto
-      integration_tests:
-        flags: integration_tests
-        target: auto
-        threshold: 100 # Passing check no matter what the coverage is
-        base: auto
+      base: auto # Use base commit for PRs, parent commit for push builds
+      target: auto # Target same coverage as the base / parent commit
+      threshold: 10 # Total project coverage must be within 10% of base / parent commit
     patch:
-      default: off
-      unit_tests:
-        flags: unit_tests
-        target: 100 # Target 100% coverage for diffs
-        threshold: 100 # Passing check no matter what the coverage is
-        base: auto
-      integration_tests:
-        flags: integration_tests
-        target: 100 # Target 100% coverage for diffs
-        threshold: 100 # Passing check no matter what the coverage is
-        base: auto
+      base: auto # Use base commit for PRs, parent commit for push builds
+      target: 100 # Target 100% coverage for diffs
+      threshold: 50 # Patch coverage must be within 50% of target (at least 50%)


### PR DESCRIPTION
We recently started showing project level and patch level code coverage for `amphtml` PRs as separate statuses for unit and integration tests .

![image](https://user-images.githubusercontent.com/26553114/58580062-46cb4d00-821a-11e9-9f18-351def5bfd20.png)

This PR consolidates the project and patch level coverage numbers into one status each (thereby giving PR authors a choice in whether to test their code with unit tests or integration tests)

**Future work:**
- Set minimum code coverage thresholds. For example:
    - No PR may reduce the project level coverage by more than 10% (in practice, this is hard to do, since you'd either have to add ~5000 lines of code with zero test coverage, or delete a whole lot of tests)
    - Every PR must make sure that at least 50% of the lines of code added / changed by the PR are covered by at least one unit or integration test (the goal is to cause project level code coverage to gradually increase from the current 78%)