### PR TITLE
🐛 Enable type checking for `3p/environment.js`

### DIFF
--- a/3p/environment.js
+++ b/3p/environment.js
@@ -189,6 +189,7 @@ function instrumentEntryPoints(win) {
     const args = Array.prototype.slice.call(arguments);
     /**
      * @return {*}
+     * @suppress {uselessCode}
      */
     function wrapper() {
       next();
@@ -268,8 +269,7 @@ function minTime(time) {
  * Installs embed state listener.
  */
 export function installEmbedStateListener() {
-  /** @suppress {deprecated} */
   listenParent(window, 'embed-state', function(data) {
-    inViewport = data.inViewport;
+    inViewport = data['inViewport'];
   });
 }

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -103,8 +103,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     'third_party/inputmask/',
     'node_modules/',
     'build/patched-module/',
-    // Can't seem to suppress `(0, win.eval)` suspicious code warning
-    '3p/environment.js',
     // Generated code.
     'extensions/amp-access/0.1/access-expr-impl.js',
   ];


### PR DESCRIPTION
In #5114, type checking was disabled for `3p/environment.js` due to warnings that couldn't be suppressed. See https://github.com/ampproject/amphtml/pull/5114#discussion_r79574510 and https://github.com/ampproject/amphtml/pull/5114#discussion_r79609847.

https://github.com/ampproject/amphtml/blob/855c753e38f026bc03430628b805944979e5e18c/build-system/tasks/compile.js#L334-L335

This PR enables type checking for the file, and suppresses / fixes the three warnings / errors that were returned by `gulp check-types`.

```
3p/environment.js:197: WARNING - Suspicious code. This code lacks side-effects. Is there a bug?
        return (0, win.eval /*NOT OK but whatcha gonna do.*/).call(win, fn); // lgtm [js/useless-expression]
                ^

3p/environment.js:272: WARNING - @suppress annotation not allowed here. See https://github.com/google/closure-compiler/wiki/@suppress-annotations
  listenParent(window, 'embed-state', function(data) {
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

3p/environment.js:273: ERROR - Cannot do '.' access on a dict
    inViewport = data.inViewport;
                      ^^^^^^^^^^
```
