### PR TITLE
🐛 Fixed spelling inconsistency in extensions/amp-animation/0.1/css-expr-impl.js

### DIFF
--- a/extensions/amp-animation/0.1/parsers/css-expr-impl.js
+++ b/extensions/amp-animation/0.1/parsers/css-expr-impl.js
@@ -61,7 +61,7 @@ import * as ast from './css-expr-ast';
 
         options: {
             ranges: boolean           (optional: true ==> token location info will include a .range[] member)
-            flex: boolean             (optional: true ==> flex-like lexing behaviour where the rules are tested exhaustively to find the longest match)
+            flex: boolean             (optional: true ==> flex-like lexing behavior where the rules are tested exhaustively to find the longest match)
             backtrack_lexer: boolean  (optional: true ==> lexer regexes are tested in order and for each matching regex the action code is invoked; the lexer terminates the scan when a token is returned by the action code)
         },
 


### PR DESCRIPTION
-Changed the spelling of the word "behaviour" to the English spelling "behavior"
-Closes issue #18080