### PR TITLE
🖍 Make story page viewport units public, for usage in publisher styles

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -91,7 +91,7 @@ amp-story-access[type=blocking].i-amphtml-story-access-visible::before {
 
 [type=notification] .i-amphtml-story-access-container {
   box-shadow: 0 -1px 2px 1px rgba(0, 0, 0, 0.12) !important;
-  max-height: calc(var(--amp-story-page-vh, 1vh) * 20) !important; /** 20vh */
+  max-height: calc(var(--story-page-vh, 1vh) * 20) !important; /** 20vh */
 }
 
 .i-amphtml-story-access-header {

--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -91,7 +91,7 @@ amp-story-access[type=blocking].i-amphtml-story-access-visible::before {
 
 [type=notification] .i-amphtml-story-access-container {
   box-shadow: 0 -1px 2px 1px rgba(0, 0, 0, 0.12) !important;
-  max-height: calc(var(--i-amphtml-story-vh, 1vh) * 20) !important; /** 20vh */
+  max-height: calc(var(--amp-story-page-vh, 1vh) * 20) !important; /** 20vh */
 }
 
 .i-amphtml-story-access-header {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -66,12 +66,12 @@ amp-story {
 }
 
 html.i-amphtml-story-standalone {
-  font-size: calc(2.5 * var(--i-amphtml-story-vmax, 8px));
+  font-size: calc(2.5 * var(--amp-story-page-vmax, 8px));
 }
 
 html.i-amphtml-story-standalone,
 html.i-amphtml-story-standalone body {
-  font-size: calc(2.5 * var(--i-amphtml-story-vh, 8px));
+  font-size: calc(2.5 * var(--amp-story-page-vh, 8px));
   height: 100% !important;
   margin: 0 !important;
   padding: 0 !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -66,12 +66,12 @@ amp-story {
 }
 
 html.i-amphtml-story-standalone {
-  font-size: calc(2.5 * var(--amp-story-page-vmax, 8px));
+  font-size: calc(2.5 * var(--story-page-vmax, 8px));
 }
 
 html.i-amphtml-story-standalone,
 html.i-amphtml-story-standalone body {
-  font-size: calc(2.5 * var(--amp-story-page-vh, 8px));
+  font-size: calc(2.5 * var(--story-page-vh, 8px));
   height: 100% !important;
   margin: 0 !important;
   padding: 0 !important;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -533,10 +533,10 @@ export class AmpStory extends AMP.BaseElement {
     // ../../../extensions/amp-animation/0.1/web-animations.js
     this.mutateElement(() => {
       styleEl.textContent = styleEl.textContent
-        .replace(/([\d.]+)vh/gim, 'calc($1 * var(--i-amphtml-story-vh))')
-        .replace(/([\d.]+)vw/gim, 'calc($1 * var(--i-amphtml-story-vw))')
-        .replace(/([\d.]+)vmin/gim, 'calc($1 * var(--i-amphtml-story-vmin))')
-        .replace(/([\d.]+)vmax/gim, 'calc($1 * var(--i-amphtml-story-vmax))');
+        .replace(/([\d.]+)vh/gim, 'calc($1 * var(--amp-story-page-vh))')
+        .replace(/([\d.]+)vw/gim, 'calc($1 * var(--amp-story-page-vw))')
+        .replace(/([\d.]+)vmin/gim, 'calc($1 * var(--amp-story-page-vmin))')
+        .replace(/([\d.]+)vmax/gim, 'calc($1 * var(--amp-story-page-vmax))');
     });
   }
 
@@ -584,10 +584,10 @@ export class AmpStory extends AMP.BaseElement {
         mutate: state => {
           this.win.document.documentElement.setAttribute(
             'style',
-            `--i-amphtml-story-vh: ${px(state.vh)};` +
-              `--i-amphtml-story-vw: ${px(state.vw)};` +
-              `--i-amphtml-story-vmin: ${px(state.vmin)};` +
-              `--i-amphtml-story-vmax: ${px(state.vmax)};`
+            `--amp-story-page-vh: ${px(state.vh)};` +
+              `--amp-story-page-vw: ${px(state.vw)};` +
+              `--amp-story-page-vmin: ${px(state.vmin)};` +
+              `--amp-story-page-vmax: ${px(state.vmax)};`
           );
         },
       },

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -533,10 +533,10 @@ export class AmpStory extends AMP.BaseElement {
     // ../../../extensions/amp-animation/0.1/web-animations.js
     this.mutateElement(() => {
       styleEl.textContent = styleEl.textContent
-        .replace(/([\d.]+)vh/gim, 'calc($1 * var(--amp-story-page-vh))')
-        .replace(/([\d.]+)vw/gim, 'calc($1 * var(--amp-story-page-vw))')
-        .replace(/([\d.]+)vmin/gim, 'calc($1 * var(--amp-story-page-vmin))')
-        .replace(/([\d.]+)vmax/gim, 'calc($1 * var(--amp-story-page-vmax))');
+        .replace(/([\d.]+)vh/gim, 'calc($1 * var(--story-page-vh))')
+        .replace(/([\d.]+)vw/gim, 'calc($1 * var(--story-page-vw))')
+        .replace(/([\d.]+)vmin/gim, 'calc($1 * var(--story-page-vmin))')
+        .replace(/([\d.]+)vmax/gim, 'calc($1 * var(--story-page-vmax))');
     });
   }
 
@@ -584,10 +584,10 @@ export class AmpStory extends AMP.BaseElement {
         mutate: state => {
           this.win.document.documentElement.setAttribute(
             'style',
-            `--amp-story-page-vh: ${px(state.vh)};` +
-              `--amp-story-page-vw: ${px(state.vw)};` +
-              `--amp-story-page-vmin: ${px(state.vmin)};` +
-              `--amp-story-page-vmax: ${px(state.vmax)};`
+            `--story-page-vh: ${px(state.vh)};` +
+              `--story-page-vw: ${px(state.vw)};` +
+              `--story-page-vmin: ${px(state.vmin)};` +
+              `--story-page-vmax: ${px(state.vmax)};`
           );
         },
       },


### PR DESCRIPTION
We internally use `--i-amphtml-story-vw`, `--i-amphtml-story-vh`, `--i-amphtml-story-vmin`, and `--i-amphtml-story-vmax` to represent the size of the story page, rather than the viewport.  Publishers have requested this as well, so this PR renames it to be public (and perhaps make more sense externally). 