### PR TITLE
🐛 Suppress expected LGTM alerts that can't be fixed

### DIFF
--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -10,7 +10,7 @@
             'input to nameframe');
       }
       document.open();
-      document.write(name_data.creative);
+      document.write(name_data.creative); // lgtm [js/eval-like-call] lgtm [js/xss]
       document.close();
       delete name_data.creative;
       window.name = JSON.stringify(name_data);

--- a/3p/remote.html
+++ b/3p/remote.html
@@ -7,7 +7,7 @@
 var v = location.search.substr(1);
 if (!(/^\d+(-canary)?$/.test(v))) return;
 var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
-document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>'); // lgtm [js/eval-like-call]
 })();
 </script>
 </head>

--- a/validator/chromeextension/content_script.js
+++ b/validator/chromeextension/content_script.js
@@ -30,7 +30,7 @@ globals.ampCaches = [
       }
     },
     'isAmpCache': function() {
-      return window.location.hostname.endsWith('cdn.ampproject.org');
+      return window.location.hostname.endsWith('cdn.ampproject.org'); // lgtm [js/incomplete-url-substring-sanitization]
     },
   },
 ];

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -51,8 +51,8 @@ function getUrl(url) {
  */
 amp.validator.isAmpCacheUrl = function(url) {
   return (
-    url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 ||
-    url.toLowerCase().indexOf('amp.cloudflare.com') !== -1);
+    url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 || // lgtm [js/incomplete-url-substring-sanitization]
+    url.toLowerCase().indexOf('amp.cloudflare.com') !== -1); // lgtm [js/incomplete-url-substring-sanitization]
 };
 
 /**


### PR DESCRIPTION
In #22488, we fixed all the  security, correctness, and maintainability issues in our code detected via static analysis from LGTM.com.

This PR suppresses the remaining [issues](https://lgtm.com/projects/g/ampproject/amphtml/alerts/?mode=tree) that are expected and can't be fixed.

**Files:**

- [3p/nameframe.max.html](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/7eaee60d39c77ab949affe0cca4ab838af597148/files/3p/nameframe.max.html?sort=name&dir=ASC&mode=heatmap#x78f351d75e4e421a:1)
- [3p/remote.html](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/7eaee60d39c77ab949affe0cca4ab838af597148/files/3p/remote.html?sort=name&dir=ASC&mode=heatmap#xc096312c4d8092a5:1)
- [validator/chromeextension/content_script.js](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/7eaee60d39c77ab949affe0cca4ab838af597148/files/validator/chromeextension/content_script.js?sort=name&dir=ASC&mode=heatmap#x5cf43fd482805b6d:1)
- [validator/engine/validator-in-browser.js](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/7eaee60d39c77ab949affe0cca4ab838af597148/files/validator/engine/validator-in-browser.js?sort=name&dir=ASC&mode=heatmap#x3984ae434b1bcff3:1)

**Rules that were suppressed:**
- [js/xss](https://lgtm.com/rules/2022121412/)
- [js/eval-like-call](https://lgtm.com/rules/7850085/)
- [js/incomplete-url-substring-sanitization](https://lgtm.com/rules/1507070716205/)