### PR TITLE
Fills navigation path with skipped pages

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -438,13 +438,17 @@ export class AmpStory extends AMP.BaseElement {
 
     if (isExperimentOn(this.win, 'amp-story-branching')) {
       this.registerAction('goToPage', invocation => {
-        const {args} = invocation;
+        const {args, caller} = invocation;
         if (args) {
+          const targetPageId = args['id'];
           this.storeService_.dispatch(
             Action.SET_ADVANCEMENT_MODE,
             AdvancementMode.GO_TO_PAGE
           );
-          this.switchTo_(args['id'], NavigationDirection.NEXT);
+          if (caller.classList.contains('i-amphtml-story-new-page-control')) {
+            this.fillStoryNavigationPath_(targetPageId);
+          }
+          this.switchTo_(targetPageId, NavigationDirection.NEXT);
         }
       });
     }
@@ -1484,6 +1488,24 @@ export class AmpStory extends AMP.BaseElement {
       this.storyNavigationPath_
     );
     return this.getPageById(targetPageId);
+  }
+
+  /**
+   * Fills navigation path with pages skipped due to jumping to the latest
+   * update. These would've been otherwise filled by normal navigation.
+   * @param {string} targetPageId
+   * @private
+   */
+  fillStoryNavigationPath_(targetPageId) {
+    const pagesIds = this.storeService_.get(StateProperty.PAGE_IDS);
+    const skippedPages = pagesIds.slice(
+      pagesIds.indexOf(this.activePage_.element.id) + 1,
+      pagesIds.indexOf(targetPageId)
+    );
+
+    skippedPages.forEach(id => {
+      this.storyNavigationPath_.push(id);
+    });
   }
 
   /**


### PR DESCRIPTION
#21714

Currently the behavior for branching makes it so that when you go back on a page you jumped to using the `goToPage` action, it takes you to the page you jumped from (top of the navigation path stack). 

e.g. I'm on page A, and jump to page X using the `goToPage` action. Pressing back will take me to page A.

For live stories, we want it so when you go from page A to the most recent update X and go back, you go to the previous page W, and not go to page A.

This PR makes it so that when the jump is caused by the "show new updates" button in a live story, it fills the navigation path with pages skipped due to jumping to the latest update. These would've been otherwise filled by normal navigation.