### PR TITLE
🐛 Copy sourcemap file for aliased bundles

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -134,6 +134,10 @@ function declareExtensionVersionAlias(name, version, latestVersion, options) {
     'name': name,
     'file': name + '-' + latestVersion + '.js',
   };
+  extensionAliasFilePath[name + '-' + version + '.js.map'] = {
+    'name': name,
+    'file': name + '-' + latestVersion + '.js.map',
+  };
   if (options.hasCss) {
     extensionAliasFilePath[name + '-' + version + '.css'] = {
       'name': name,


### PR DESCRIPTION
The extension `amp-sticky-ad-0.1` is in a special category of aliased bundles, where the old source code has been deleted, and we just copy the code from the current `1.0` version into the `0.1` alias. While doing so, we were neglecting to copy the sourcemap file.

This PR fixes the bug by copying the sourcemap file in addition to the JS and CSS files.

Fixes #17518 