### PR TITLE
🐛amp-call-tracking: Made the 'phoneNumber' field optional

### DIFF
--- a/extensions/amp-call-tracking/0.1/amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/amp-call-tracking.js
@@ -91,7 +91,7 @@ export class AmpCallTracking extends AMP.BaseElement {
         } else {
           user().warn(
             TAG,
-            'Response must contain a non-empty phoneNumber field %s',
+            'Response does not contain a phoneNumber field %s. Call tracking was not applied.',
             this.element
           );
         }

--- a/extensions/amp-call-tracking/0.1/amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/amp-call-tracking.js
@@ -17,7 +17,9 @@
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {user, userAssert} from '../../../src/log';
+import {user} from '../../../src/log';
+
+const TAG = 'amp-call-tracking';
 
 /**
  * Bookkeeps all unique URL requests so that no URL is called twice.
@@ -82,15 +84,17 @@ export class AmpCallTracking extends AMP.BaseElement {
       .expandUrlAsync(user().assertString(this.configUrl_))
       .then(url => fetch_(this.win, url))
       .then(data => {
-        userAssert(
-          'phoneNumber' in data,
-          'Response must contain a non-empty phoneNumber field %s',
-          this.element
-        );
-
-        this.hyperlink_.setAttribute('href', `tel:${data['phoneNumber']}`);
-        this.hyperlink_.textContent =
-          data['formattedPhoneNumber'] || data['phoneNumber'];
+        if (data['phoneNumber']) {
+          this.hyperlink_.setAttribute('href', `tel:${data['phoneNumber']}`);
+          this.hyperlink_.textContent =
+            data['formattedPhoneNumber'] || data['phoneNumber'];
+        } else {
+          user().warn(
+            TAG,
+            'Response must contain a non-empty phoneNumber field %s',
+            this.element
+          );
+        }
       });
   }
 }

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -123,7 +123,7 @@ describes.realWin(
       });
     });
 
-    it('should fail when response does not contain a phoneNumber field', () => {
+    it('should warn when response does not contain a phoneNumber field', () => {
       const url = 'https://example.com/test.json';
 
       const defaultNumber = '123456';
@@ -131,13 +131,17 @@ describes.realWin(
 
       mockXhrResponse(url, {});
 
-      return expect(
-        getCallTrackingEl({
-          url,
-          defaultNumber,
-          defaultContent,
-        })
-      ).rejectedWith(/Response must contain a non-empty phoneNumber field/);
+      return getCallTrackingEl({
+        url,
+        defaultNumber,
+        defaultContent,
+      }).then(callTrackingEl => {
+        expectHyperlinkToBe(
+          callTrackingEl,
+          `tel:${defaultNumber}`,
+          defaultContent
+        );
+      });
     });
   }
 );


### PR DESCRIPTION
closes #20551

This makes the phone number optional, and simply warns if there is no response from the call-tacking API. Allowing the phone number link still work 😄 