### PR TITLE
🐛Various fixes for amp-base-carousel.

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.css
@@ -90,7 +90,7 @@ amp-base-carousel[i-amphtml-carousel-hide-buttons] .i-amphtml-carousel-arrow-nex
   background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path  d="M10,7.4 L14.6,12 L10,16.6" fill="none" stroke="#fff" stroke-width="2px" stroke-linejoin="round" stroke-linecap="round" /></svg>');
 }
 
-.i-amphtml-carousel-slotted > .i-amphtml-replaced-content {
+amp-base-carousel .i-amphtml-carousel-slotted > .i-amphtml-replaced-content {
   /*
    * Apply contain object-fit to all replaced content to avoid distorted ratios.
    */

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -185,11 +185,15 @@ class AmpCarousel extends AMP.BaseElement {
     this.element.addEventListener('indexchange', event => {
       this.onIndexChanged_(event);
     });
-    this.prevArrowSlot_.addEventListener('click', () => {
-      this.carousel_.prev(ActionSource.GENERIC_HIGH_TRUST);
+    this.prevArrowSlot_.addEventListener('click', event => {
+      if (event.target != event.currentTarget) {
+        this.carousel_.prev(ActionSource.GENERIC_HIGH_TRUST);
+      }
     });
-    this.nextArrowSlot_.addEventListener('click', () => {
-      this.carousel_.next(ActionSource.GENERIC_HIGH_TRUST);
+    this.nextArrowSlot_.addEventListener('click', event => {
+      if (event.target != event.currentTarget) {
+        this.carousel_.next(ActionSource.GENERIC_HIGH_TRUST);
+      }
     });
 
     this.carousel_.updateSlides(this.slides_);
@@ -352,7 +356,7 @@ class AmpCarousel extends AMP.BaseElement {
    */
   updateUi_() {
     const index = this.carousel_.getCurrentIndex();
-    const loop = this.carousel_.getLoop();
+    const loop = this.carousel_.isLooping();
     // TODO(sparhami) for Shadow DOM, we will need to get the assigned nodes
     // instead.
     iterateCursor(this.prevArrowSlot_.children, child => {

--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -22,7 +22,10 @@ const MIN_AUTO_ADVANCE_INTERVAL = 1000;
 
 /**
  * @typedef {{
- *   advance: function(number, !ActionSource=),
+ *   advance: function(number, {
+ *     actionSource: (!ActionSource|undefined),
+ *     allowWrap: (boolean|undefined),
+ *   }),
  * }}
  */
 let AdvanceDef;
@@ -219,7 +222,10 @@ export class AutoAdvance {
       return;
     }
 
-    this.advanceable_.advance(this.autoAdvanceCount_, ActionSource.AUTOPLAY);
+    this.advanceable_.advance(this.autoAdvanceCount_, {
+      actionSource: ActionSource.AUTOPLAY,
+      allowWrap: true,
+    });
     this.advances_ += this.autoAdvanceCount_;
   }
 

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -805,10 +805,13 @@ export class Carousel {
    *    start, false otherwise.
    */
   isAtEnd() {
+    if (this.isLooping()) {
+      return false;
+    }
+
     const el = this.scrollContainer_;
-    return (
-      !this.isLooping() && el.scrollLeft + el.offsetWidth >= el.scrollWidth
-    );
+    const {width} = el./*OK*/ getBoundingClientRect();
+    return el./*OK*/ scrollLeft + width >= el./*OK*/ scrollWidth;
   }
 
   /**
@@ -816,7 +819,11 @@ export class Carousel {
    *    end, false otherwise.
    */
   isAtStart() {
-    return !this.isLooping() && this.scrollContainer_.scrollLeft <= 0;
+    if (this.isLooping()) {
+      return false;
+    }
+
+    return this.scrollContainer_./*OK*/ scrollLeft <= 0;
   }
 
   /**


### PR DESCRIPTION
- Only go to the next item when the carousel arrow itself is clicked
rather than the element that contains the arrow (which is full height).
- Disable looping when there are less than 3x slides compared to the
visible count, since the UI does not behave  correctly. The threshold for this
can be reduced, but requires more work.
- Add an `allowWrap` option to `advance`. This is used to prevent the
next/prev arrows from looping (when looping is disabled) if they are quickly
clicked before they are disabled. Autoadvance is still allowed to wrap
when looping is disabled.
- Use the `scrollend` event, when available, to immediately restore the
scrolling reference point. This ne feature allows us to determine when
scrolling ends directly instead of waiting for a gap after a scroll
event.
  * We currently wait 200ms after the last scroll, which appears to be
  the minimum value that works for Android / iOS.
  * This greatly reduces the chance that a user could hit the end point
  of a looping carousel when swiping quickly and continuously.
  * https://www.chromestatus.com/feature/5650553247891456
- Fix the buttons not being disabled properly when looping visible count is >= 2
  or using mixed-lengths.
  * Check that the scroll position is at the end, since we may never
  have the last slide as the current index.
- Fix race condition when switching between looping and non-looping
during a scree resize, where the current index would not be updated correctly.
- Fix scroll position calculation (for restoring later), which was
incorrectly adding `containerStart` instead of subtracting. This causes
the position to be resotred incorrectly when the carousel is not aligned
at the edge of the window.
- Fix the movement of slides to the left/right when there is a visible
count other than one. Previously, too many slides would be moved to the
right, and not enough moved to the left.