### PR TITLE
🐛 Turn on the `amphtml-internal/unused-private-field` rule, fix errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -77,7 +77,7 @@
     "amphtml-internal/prefer-destructuring": 2,
     "amphtml-internal/query-selector": 2,
     "amphtml-internal/todo-format": 0,
-    "amphtml-internal/unused-private-field": 0,
+    "amphtml-internal/unused-private-field": 2,
     "amphtml-internal/vsync": 0,
     "chai-expect/missing-assertion": 2,
     "chai-expect/no-inner-compare": 2,

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -43,7 +43,7 @@ export class PositionObserver {
     this.win_ = win;
     /** @private {?Observable} */
     this.positionObservable_ = null;
-    /** @private {!Element} */
+    /** @protected {!Element} */
     this.scrollingElement_ = getScrollingElement(this.win_);
     /** @private {?LayoutRectDef} */
     this.viewportRect_ = null;

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -98,7 +98,7 @@ export class RealTimeConfigManager {
     /** @private {?RtcConfigDef} */
     this.rtcConfig_ = null;
 
-    /** @private !../../../src/service/ampdoc-impl.AmpDoc */
+    /** @protected {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampDoc_ = this.a4aElement_.getAmpDoc();
 
     /** @private {?CONSENT_POLICY_STATE} */

--- a/extensions/amp-a4a/0.1/refresh-manager.js
+++ b/extensions/amp-a4a/0.1/refresh-manager.js
@@ -201,7 +201,7 @@ export class RefreshManager {
     /** @const @private {!Element} */
     this.element_ = a4a.element;
 
-    /** @const @private {string} */
+    /** @const @protected {string} */
     this.adType_ = this.element_.getAttribute('type').toLowerCase();
 
     /** @const @private {?number} */
@@ -213,7 +213,7 @@ export class RefreshManager {
     /** @const @private {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);
 
-    /** @private {?(number|string)} */
+    /** @protected {?(number|string)} */
     this.refreshTimeoutId_ = null;
 
     /** @private {?(number|string)} */

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -129,7 +129,7 @@ export class SignatureVerifier {
      * the performance system will be used; otherwise Date.now() will be
      * returned.
      *
-     * @private @const {function(): number}
+     * @protected @const {function(): number}
      */
     this.getNow_ =
       win.performance && win.performance.now

--- a/extensions/amp-access/0.1/amp-access-other.js
+++ b/extensions/amp-access/0.1/amp-access-other.js
@@ -31,7 +31,7 @@ export class AccessOtherAdapter {
     /** @const */
     this.ampdoc = ampdoc;
 
-    /** @const @private {!./amp-access-source.AccessTypeAdapterContextDef} */
+    /** @const @protected {!./amp-access-source.AccessTypeAdapterContextDef} */
     this.context_ = context;
 
     /** @private {?JsonObject} */

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -75,7 +75,7 @@ export class AccessServerAdapter {
     /** @private @const {!../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = Services.viewerForDoc(ampdoc);
 
-    /** @const @private {!../../../src/service/xhr-impl.Xhr} */
+    /** @const @protected {!../../../src/service/xhr-impl.Xhr} */
     this.xhr_ = Services.xhrFor(ampdoc.win);
 
     /** @const @private {!../../../src/service/timer-impl.Timer} */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -166,7 +166,7 @@ export class SafeframeHostApi {
       creativeSize
     ));
 
-    /** @private {?Promise} */
+    /** @protected {?Promise} */
     this.delay_ = null;
 
     /** @private {../../../src/service/viewport/viewport-impl.Viewport} */

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -67,8 +67,10 @@ export class AnalyticsRoot {
     /** @private {?./scroll-manager.ScrollManager} */
     this.scrollManager_ = null;
 
+    /** @private {?Promise} */
     this.usingHostAPIPromise_ = null;
 
+    /** @restricted {!../../../src/inabox/host-services.VisibilityInterface} */
     this.hostVisibilityService_ = null;
   }
 

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -222,7 +222,6 @@ export class AmpAnimation extends AMP.BaseElement {
    * @param {?../../../src/service/action-impl.ActionInvocation=} opt_invocation
    * @return {?Promise}
    * @private
-   * @visibleForTesting
    */
   startAction_(opt_invocation) {
     // The animation has been triggered, but there's no guarantee that it

--- a/extensions/amp-animation/0.1/parsers/css-expr-ast.js
+++ b/extensions/amp-animation/0.1/parsers/css-expr-ast.js
@@ -664,7 +664,7 @@ export class CssTranslateNode extends CssFuncNode {
         ? ['w', 'h', 'z']
         : null
     );
-    /** @const @private {string} */
+    /** @const @protected {string} */
     this.suffix_ = suffix;
   }
 }

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -49,7 +49,7 @@ class AmpCarousel extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private {number} */
+    /** @protected {number} */
     this.advanceCount_ = 1;
 
     /** @private {?Carousel} */

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -38,7 +38,7 @@ export class CarouselAccessibility {
    * }} config
    */
   constructor({win, element, scrollContainer, runMutate, stoppable}) {
-    /** @private @const */
+    /** @protected @const */
     this.win_ = win;
 
     /** @private @const */

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -213,7 +213,7 @@ export class Carousel {
     /** @private {!Array<!Element>} */
     this.afterSpacers_ = [];
 
-    /** @private {!Array<!Element>} */
+    /** @protected {!Array<!Element>} */
     this.allSpacers_ = [];
 
     /**
@@ -227,7 +227,7 @@ export class Carousel {
      * The offset from the start edge for the element at the current index.
      * This is used to preserve relative scroll position when updating the UI
      * after things have moved (e.g. on rotate).
-     * @private {number}
+     * @protected {number}
      */
     this.currentElementOffset_ = 0;
 

--- a/extensions/amp-bind/0.1/amp-bind-macro.js
+++ b/extensions/amp-bind/0.1/amp-bind-macro.js
@@ -46,7 +46,7 @@ export class AmpBindMacro extends AMP.BaseElement {
   /**
    * @return {string} Returns a string to identify this tag. May not be unique
    *     if the element name is not unique.
-   * @private
+   * @protected
    */
   getName_() {
     return (

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -143,7 +143,7 @@ export class AmpGwdRuntimeService {
    *     the service.
    */
   constructor(ampdoc, opt_win) {
-    /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    /** @const @protected {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = ampdoc;
 
     /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -155,7 +155,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     /** @private {?Element} */
     this.mask_ = null;
 
-    /** @private {?Element} */
+    /** @protected {?Element} */
     this.navControls_ = null;
 
     /** @private {?Element} */
@@ -170,7 +170,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     /** @private  {?Element} */
     this.gallery_ = null;
 
-    /** @private  {?Element} */
+    /** @protected  {?Element} */
     this.topBar_ = null;
 
     /** @private {!LightboxControlsModes} */

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
@@ -75,7 +75,7 @@ export class LightboxCaption {
     /** @private @const */
     this.textContainer_ = textContainer;
 
-    /** @private @const */
+    /** @protected @const */
     this.overflowMask_ = overflowMask;
 
     /** @private @const */

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-controls.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-controls.js
@@ -108,7 +108,7 @@ export class LightboxControls {
     /** @private @const */
     this.element_ = element;
 
-    /** @private @const */
+    /** @protected @const */
     this.measureMutateElement_ = measureMutateElement;
 
     this.element_.addEventListener('click', event => {

--- a/extensions/amp-live-list/0.1/poller.js
+++ b/extensions/amp-live-list/0.1/poller.js
@@ -52,7 +52,7 @@ export class Poller {
 
     /**
      * For testing purposes.
-     * @private {?Promise}
+     * @visibleForTesting {?Promise}
      */
     this.lastWorkPromise_ = null;
   }

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -480,7 +480,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
   }
 
   /**
-   * @private
+   * @protected
    */
   maybeUninstallPositionObserver_() {
     if (this.positionObserver_) {

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -213,7 +213,7 @@ export class SystemLayer {
     /** @private @const {!Window} */
     this.win_ = win;
 
-    /** @private @const {!Element} */
+    /** @protected @const {!Element} */
     this.parentEl_ = parentEl;
 
     /** @private {boolean} */

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -802,10 +802,10 @@ class MediaBasedAdvancement extends AdvancementConfig {
     /** @private {!Array<!UnlistenDef>} */
     this.unlistenFns_ = [];
 
-    /** @private {?UnlistenDef} */
+    /** @protected {?UnlistenDef} */
     this.unlistenEndedFn_ = null;
 
-    /** @private {?UnlistenDef} */
+    /** @protected {?UnlistenDef} */
     this.unlistenTimeupdateFn_ = null;
 
     /** @private {?../../../src/video-interface.VideoInterface} */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -67,7 +67,7 @@ export class StoryAnalyticsService {
    * @param {!Element} element
    */
   constructor(win, element) {
-    /** @private @const {!Window} */
+    /** @protected @const {!Window} */
     this.win_ = win;
 
     /** @private @const {!Element} */

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -62,7 +62,7 @@ export class Storage {
 
   /**
    * @return {!Storage}
-   * @private
+   * @protected
    */
   start_() {
     this.listenToBroadcasts_();

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -46,7 +46,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     /** @const {!Window} */
     this.win = win;
 
-    /** @private {!../vsync-impl.Vsync} */
+    /** @protected {!../vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(win);
 
     const doc = this.win.document;

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -98,7 +98,7 @@ export class Vsync {
     /** @private {?Promise} */
     this.nextFramePromise_ = null;
 
-    /** @private {?function()} */
+    /** @protected {?function()} */
     this.nextFrameResolver_ = null;
 
     /** @const {!Function} */


### PR DESCRIPTION
#15075 added a new lint rule called `amphtml-internal/unused-private-field` to ensure that all private class fields are correctly annotated. Since then, the rule has sat around for a while in warning mode and then gotten turned off.

This PR re-enables the rule and updates annotations that aren't supposed to be `@private`.

**Note:** Most of the annotations I've changed are obviously supposed to be `@protected`, `@restricted`, or `@visibleForTesting`. However, a small handful of fields are either not being used anywhere, or are being exposed to external code in some way. In the interest of not touching code, I've gone ahead and marked them `@protected`.