### PR TITLE
🐛 Fix `.codecov.yaml`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,16 +1,13 @@
-# Settings for https://codecov.io integration
-
-# See https://docs.codecov.io/docs/pull-request-comments
-comment: off
-
-# See https://docs.codecov.io/v4.3.0/docs/commit-status
-coverage:
+comment: off # https://docs.codecov.io/docs/pull-request-comments
+coverage: # https://docs.codecov.io/docs/commit-status
   status:
     project:
-      base: auto # Use base commit for PRs, parent commit for push builds
-      target: auto # Target same coverage as the base / parent commit
-      threshold: 100 # Passing check no matter what the coverage is
+      default:
+        base: auto # Use base commit for PRs, parent commit for push builds
+        target: auto # Target same coverage as the base / parent commit
+        threshold: 100 # Passing check no matter what the coverage is
     patch:
-      base: auto # Use base commit for PRs, parent commit for push builds
-      target: 100 # Target 100% coverage for diffs
-      threshold: 100 # Passing check no matter what the coverage is
+      default:
+        base: auto # Use base commit for PRs, parent commit for push builds
+        target: 100 # Target 100% coverage for diffs
+        threshold: 100 # Passing check no matter what the coverage is

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,13 @@
-comment: off # https://docs.codecov.io/docs/pull-request-comments
-coverage: # https://docs.codecov.io/docs/commit-status
+comment: off
+coverage:
   status:
     project:
       default:
-        base: auto # Use base commit for PRs, parent commit for push builds
-        target: auto # Target same coverage as the base / parent commit
-        threshold: 100 # Passing check no matter what the coverage is
+        base: auto
+        target: auto
+        threshold: 100
     patch:
       default:
-        base: auto # Use base commit for PRs, parent commit for push builds
-        target: 100 # Target 100% coverage for diffs
-        threshold: 100 # Passing check no matter what the coverage is
+        base: auto
+        target: 100
+        threshold: 100


### PR DESCRIPTION
We recently enabled PR statuses from `codecov` in order to improve AMP's code coverage. It appears the settings in `.codecov.yaml` are not taking effect.

**PR comments:**
- Comments are supposed to be disabled. Yet they're being posted. For example: https://github.com/ampproject/amphtml/pull/22494#issuecomment-497895188

https://github.com/ampproject/amphtml/blob/9c4ec350f095981c343c2f2197490e1dd260fd20/.codecov.yml#L3-L4


**PR statuses:**
- The failure threshold is supposed to be 100% (so all PRs pass). Yet, PRs are failing when coverage reduces by even a fraction of a percent. For example: https://github.com/ampproject/amphtml/pull/22494#event-2382422032

https://github.com/ampproject/amphtml/blob/9c4ec350f095981c343c2f2197490e1dd260fd20/.codecov.yml#L6-L16

This PR rewrites the `.codecov.yaml` file using the latest recommended format at https://docs.codecov.io/docs 