### PR TITLE
✨ FEATURE: AMP form dirtiness indicator class

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -28,6 +28,7 @@ import {
   FORM_VERIFY_PARAM,
   getFormVerifier,
 } from './form-verifiers';
+import {FormDirtiness} from './form-dirtiness';
 import {FormEvents} from './form-events';
 import {FormSubmitService} from './form-submit-service';
 import {SOURCE_ORIGIN_PARAM, addParamsToUrl} from '../../../src/url';
@@ -194,6 +195,9 @@ export class AmpForm {
         inputs[i]
       );
     }
+
+    /** @const @private {!./form-dirtiness.FormDirtiness} */
+    this.dirtinessHandler_ = new FormDirtiness(this.form_);
 
     /** @const @private {!./form-validators.FormValidator} */
     this.validator_ = getFormValidator(this.form_);
@@ -536,6 +540,8 @@ export class AmpForm {
       AsyncInputClasses.ASYNC_INPUT
     );
 
+    this.dirtinessHandler_.onSubmitting();
+
     // Do any assertions we may need to do
     // For NonXhrGET
     // That way we can determine if
@@ -557,6 +563,7 @@ export class AmpForm {
         const shouldSubmitFormElement = !event;
 
         this.handleNonXhrGet_(shouldSubmitFormElement);
+        this.dirtinessHandler_.onSubmitSuccess();
         return Promise.resolve();
       }
 
@@ -888,6 +895,7 @@ export class AmpForm {
         this.setState_(FormState.SUBMIT_SUCCESS);
         this.renderTemplate_(json || {}).then(() => {
           this.triggerAction_(FormEvents.SUBMIT_SUCCESS, json);
+          this.dirtinessHandler_.onSubmitSuccess();
         });
       },
       error => {
@@ -929,6 +937,7 @@ export class AmpForm {
     return tryResolve(() => {
       this.renderTemplate_(json).then(() => {
         this.triggerAction_(FormEvents.SUBMIT_ERROR, json);
+        this.dirtinessHandler_.onSubmitError();
       });
     });
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -28,7 +28,6 @@ import {
   FORM_VERIFY_PARAM,
   getFormVerifier,
 } from './form-verifiers';
-import {FormDirtiness} from './form-dirtiness';
 import {FormEvents} from './form-events';
 import {FormSubmitService} from './form-submit-service';
 import {SOURCE_ORIGIN_PARAM, addParamsToUrl} from '../../../src/url';
@@ -195,9 +194,6 @@ export class AmpForm {
         inputs[i]
       );
     }
-
-    /** @const @private {!./form-dirtiness.FormDirtiness} */
-    this.dirtinessHandler_ = new FormDirtiness(this.form_);
 
     /** @const @private {!./form-validators.FormValidator} */
     this.validator_ = getFormValidator(this.form_);
@@ -540,8 +536,6 @@ export class AmpForm {
       AsyncInputClasses.ASYNC_INPUT
     );
 
-    this.dirtinessHandler_.onSubmitting();
-
     // Do any assertions we may need to do
     // For NonXhrGET
     // That way we can determine if
@@ -563,7 +557,6 @@ export class AmpForm {
         const shouldSubmitFormElement = !event;
 
         this.handleNonXhrGet_(shouldSubmitFormElement);
-        this.dirtinessHandler_.onSubmitSuccess();
         return Promise.resolve();
       }
 
@@ -895,7 +888,6 @@ export class AmpForm {
         this.setState_(FormState.SUBMIT_SUCCESS);
         this.renderTemplate_(json || {}).then(() => {
           this.triggerAction_(FormEvents.SUBMIT_SUCCESS, json);
-          this.dirtinessHandler_.onSubmitSuccess();
         });
       },
       error => {
@@ -937,7 +929,6 @@ export class AmpForm {
     return tryResolve(() => {
       this.renderTemplate_(json).then(() => {
         this.triggerAction_(FormEvents.SUBMIT_ERROR, json);
-        this.dirtinessHandler_.onSubmitError();
       });
     });
   }

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -36,7 +36,7 @@ export class FormDirtiness {
     /** @private {boolean} */
     this.isSubmitting_ = false;
 
-    this.installEventListeners_();
+    this.installEventHandlers_();
   }
 
   /**
@@ -67,7 +67,7 @@ export class FormDirtiness {
   /**
    * @private
    */
-  installEventListeners_() {
+  installEventHandlers_() {
     this.form_.addEventListener('input', this.onInput_.bind(this));
     this.form_.addEventListener('reset', this.onReset_.bind(this));
   }

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -20,6 +20,12 @@ import {map} from '../../../src/utils/object';
 
 export const DIRTINESS_INDICATOR_CLASS = 'amp-form-dirty';
 
+/** @private {!Object<string, boolean>} */
+const SUPPORTED_TYPES = {
+  'text': true,
+  'textarea': true,
+};
+
 export class FormDirtiness {
   /**
    * @param {!HTMLFormElement} form
@@ -69,14 +75,8 @@ export class FormDirtiness {
    * @private
    */
   updateDirtinessClass_() {
-    if (this.dirtyFieldCount_ == 0 || this.isSubmitting_) {
-      // `Element.classList.remove` will not throw an error if the class does
-      // not already exist
-      this.form_.classList.remove(DIRTINESS_INDICATOR_CLASS);
-    } else {
-      // `Element.classList.add` will no-op if the class already exists
-      this.form_.classList.add(DIRTINESS_INDICATOR_CLASS);
-    }
+    const isDirty = this.dirtyFieldCount_ > 0 && !this.isSubmitting_;
+    this.form_.classList.toggle(DIRTINESS_INDICATOR_CLASS, isDirty);
   }
 
   /**
@@ -161,7 +161,7 @@ function shouldSkipDirtinessCheck(field) {
   const {type, name, hidden} = field;
 
   // TODO: add support for radio buttons, checkboxes, and dropdown menus
-  if (type !== 'text' && type !== 'textarea') {
+  if (!SUPPORTED_TYPES[type]) {
     return true;
   }
 

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -124,7 +124,7 @@ export class FormDirtiness {
    */
   removeDirtyField_(fieldName) {
     if (this.isFieldNameDirty_[fieldName]) {
-      delete this.isFieldNameDirty_[fieldName];
+      this.isFieldNameDirty_[fieldName] = false;
       --this.dirtyFieldCount_;
     }
   }

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -67,6 +67,20 @@ export class FormDirtiness {
   /**
    * @private
    */
+  updateDirtinessClass_() {
+    if (this.dirtyFieldCount_ == 0 || this.isSubmitting_) {
+      // `Element.classList.remove` will not throw an error if the class does
+      // not already exist
+      this.form_.classList.remove(DIRTINESS_INDICATOR_CLASS);
+    } else {
+      // `Element.classList.add` will no-op if the class already exists
+      this.form_.classList.add(DIRTINESS_INDICATOR_CLASS);
+    }
+  }
+
+  /**
+   * @private
+   */
   installEventHandlers_() {
     this.form_.addEventListener('input', this.onInput_.bind(this));
     this.form_.addEventListener('reset', this.onReset_.bind(this));
@@ -135,20 +149,6 @@ export class FormDirtiness {
   clearDirtyFields_() {
     this.isFieldNameDirty_ = {};
     this.dirtyFieldCount_ = 0;
-  }
-
-  /**
-   * @private
-   */
-  updateDirtinessClass_() {
-    if (this.dirtyFieldCount_ == 0 || this.isSubmitting_) {
-      // `Element.classList.remove` will not throw an error if the class does
-      // not already exist
-      this.form_.classList.remove(DIRTINESS_INDICATOR_CLASS);
-    } else {
-      // `Element.classList.add` will no-op if the class already exists
-      this.form_.classList.add(DIRTINESS_INDICATOR_CLASS);
-    }
   }
 }
 

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -47,7 +47,8 @@ export class FormDirtiness {
   }
 
   /**
-   * Processes dirtiness state when a form is being submitted.
+   * Processes dirtiness state when a form is being submitted. This puts the
+   * form in a "submitting" state, and temporarily clears the dirtiness state.
    */
   onSubmitting() {
     this.isSubmitting_ = true;
@@ -55,7 +56,8 @@ export class FormDirtiness {
   }
 
   /**
-   * Processes dirtiness state when the form submission fails.
+   * Processes dirtiness state when the form submission fails. This clears the
+   * "submitting" state and reverts the form's dirtiness state.
    */
   onSubmitError() {
     this.isSubmitting_ = false;
@@ -63,7 +65,8 @@ export class FormDirtiness {
   }
 
   /**
-   * Processes dirtiness state when the form submission succeeds.
+   * Processes dirtiness state when the form submission succeeds. This clears
+   * the "submitting" state and the form's overall dirtiness.
    */
   onSubmitSuccess() {
     this.isSubmitting_ = false;
@@ -72,6 +75,8 @@ export class FormDirtiness {
   }
 
   /**
+   * Adds the `amp-form-dirty` class when there are dirty fields and the form
+   * is not being submitted, otherwise removes the class.
    * @private
    */
   updateDirtinessClass_() {
@@ -88,6 +93,8 @@ export class FormDirtiness {
   }
 
   /**
+   * Listens to form field value changes, determines the field's dirtiness, and
+   * updates the form's overall dirtiness.
    * @param {!Event} event
    * @private
    */
@@ -98,6 +105,7 @@ export class FormDirtiness {
   }
 
   /**
+   * Listens to the form reset event, and clears the overall dirtiness.
    * @param {!Event} unusedEvent
    * @private
    */
@@ -107,6 +115,7 @@ export class FormDirtiness {
   }
 
   /**
+   * Determine the given field's dirtiness.
    * @param {!Element} field
    * @private
    */
@@ -123,6 +132,8 @@ export class FormDirtiness {
   }
 
   /**
+   * Mark the field as dirty and increase the overall dirty field count, if the
+   * field is previously clean.
    * @param {string} fieldName
    * @private
    */
@@ -134,6 +145,8 @@ export class FormDirtiness {
   }
 
   /**
+   * Mark the field as clean and decrease the overall dirty field count, if the
+   * field is previously dirty.
    * @param {string} fieldName
    * @private
    */
@@ -145,6 +158,7 @@ export class FormDirtiness {
   }
 
   /**
+   * Clears the dirty field name map and counter.
    * @private
    */
   clearDirtyFields_() {
@@ -154,6 +168,9 @@ export class FormDirtiness {
 }
 
 /**
+ * Returns true if the form should be subject to dirtiness check. Unsupported
+ * elements, disabled elements, hidden elements, or elements without the `name`
+ * attribute are skipped.
  * @param {!Element} field
  * @return {boolean}
  */

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -27,13 +27,13 @@ export class FormDirtiness {
     /** @private @const {!HTMLFormElement} */
     this.form_ = form;
 
-    /** @private @const {number} */
+    /** @private {number} */
     this.dirtyFieldCount_ = 0;
 
-    /** @private @const {!Object<string, boolean>} */
+    /** @private {!Object<string, boolean>} */
     this.isFieldNameDirty_ = {};
 
-    /** @private @const {boolean} */
+    /** @private {boolean} */
     this.isSubmitting_ = false;
 
     this.installEventListeners_();

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev} from '../../../src/log';
+import {isDisabled, isFieldDefault, isFieldEmpty} from '../../../src/form';
+
+export const DIRTINESS_INDICATOR_CLASS = 'amp-form-dirty';
+
+export class FormDirtiness {
+  /**
+   * @param {!HTMLFormElement} form
+   */
+  constructor(form) {
+    /** @private @const {!HTMLFormElement} */
+    this.form_ = form;
+
+    /** @private @const {number} */
+    this.dirtyFieldCount_ = 0;
+
+    /** @private @const {!Object<string, boolean>} */
+    this.isFieldNameDirty_ = {};
+
+    /** @private @const {boolean} */
+    this.isSubmitting_ = false;
+
+    this.installEventListeners_();
+  }
+
+  /**
+   * Processes dirtiness state when a form is being submitted.
+   */
+  onSubmitting() {
+    this.isSubmitting_ = true;
+    this.updateDirtinessClass_();
+  }
+
+  /**
+   * Processes dirtiness state when the form submission fails.
+   */
+  onSubmitError() {
+    this.isSubmitting_ = false;
+    this.updateDirtinessClass_();
+  }
+
+  /**
+   * Processes dirtiness state when the form submission succeeds.
+   */
+  onSubmitSuccess() {
+    this.isSubmitting_ = false;
+    this.clearDirtyFields_();
+    this.updateDirtinessClass_();
+  }
+
+  /**
+   * @private
+   */
+  installEventListeners_() {
+    this.form_.addEventListener('input', this.onInput_.bind(this));
+    this.form_.addEventListener('reset', this.onReset_.bind(this));
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   */
+  onInput_(event) {
+    const field = dev().assertElement(event.target);
+    this.checkDirtinessAfterUserInteraction_(field);
+    this.updateDirtinessClass_();
+  }
+
+  /**
+   * @param {!Event} unusedEvent
+   * @private
+   */
+  onReset_(unusedEvent) {
+    this.clearDirtyFields_();
+    this.updateDirtinessClass_();
+  }
+
+  /**
+   * @param {!Element} field
+   * @private
+   */
+  checkDirtinessAfterUserInteraction_(field) {
+    if (shouldSkipDirtinessCheck(field)) {
+      return;
+    }
+
+    if (isFieldEmpty(field) || isFieldDefault(field)) {
+      this.removeDirtyField_(field.name);
+    } else {
+      this.addDirtyField_(field.name);
+    }
+  }
+
+  /**
+   * @param {string} fieldName
+   * @private
+   */
+  addDirtyField_(fieldName) {
+    if (!this.isFieldNameDirty_[fieldName]) {
+      this.isFieldNameDirty_[fieldName] = true;
+      ++this.dirtyFieldCount_;
+    }
+  }
+
+  /**
+   * @param {string} fieldName
+   * @private
+   */
+  removeDirtyField_(fieldName) {
+    if (this.isFieldNameDirty_[fieldName]) {
+      delete this.isFieldNameDirty_[fieldName];
+      --this.dirtyFieldCount_;
+    }
+  }
+
+  /**
+   * @private
+   */
+  clearDirtyFields_() {
+    this.isFieldNameDirty_ = {};
+    this.dirtyFieldCount_ = 0;
+  }
+
+  /**
+   * @private
+   */
+  updateDirtinessClass_() {
+    if (this.dirtyFieldCount_ == 0 || this.isSubmitting_) {
+      // `Element.classList.remove` will not throw an error if the class does
+      // not already exist
+      this.form_.classList.remove(DIRTINESS_INDICATOR_CLASS);
+    } else {
+      // `Element.classList.add` will no-op if the class already exists
+      this.form_.classList.add(DIRTINESS_INDICATOR_CLASS);
+    }
+  }
+}
+
+/**
+ * @param {!Element} field
+ * @return {boolean}
+ */
+function shouldSkipDirtinessCheck(field) {
+  const {type, name, hidden} = field;
+
+  // TODO: add support for radio buttons, checkboxes, and dropdown menus
+  if (type !== 'text' && type !== 'textarea') {
+    return true;
+  }
+
+  return !name || hidden || isDisabled(field);
+}

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -16,6 +16,7 @@
 
 import {dev} from '../../../src/log';
 import {isDisabled, isFieldDefault, isFieldEmpty} from '../../../src/form';
+import {map} from '../../../src/utils/object';
 
 export const DIRTINESS_INDICATOR_CLASS = 'amp-form-dirty';
 
@@ -31,7 +32,7 @@ export class FormDirtiness {
     this.dirtyFieldCount_ = 0;
 
     /** @private {!Object<string, boolean>} */
-    this.isFieldNameDirty_ = {};
+    this.isFieldNameDirty_ = map();
 
     /** @private {boolean} */
     this.isSubmitting_ = false;
@@ -147,7 +148,7 @@ export class FormDirtiness {
    * @private
    */
   clearDirtyFields_() {
-    this.isFieldNameDirty_ = {};
+    this.isFieldNameDirty_ = map();
     this.dirtyFieldCount_ = 0;
   }
 }

--- a/extensions/amp-form/0.1/test/test-form-dirtiness.js
+++ b/extensions/amp-form/0.1/test/test-form-dirtiness.js
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DIRTINESS_INDICATOR_CLASS, FormDirtiness} from '../form-dirtiness';
+
+function getForm(doc) {
+  const form = doc.createElement('form');
+  form.setAttribute('method', 'POST');
+  doc.body.appendChild(form);
+
+  return form;
+}
+
+function changeInput(element, value) {
+  element.value = value;
+  const event = new Event('input', {bubbles: true});
+  element.dispatchEvent(event);
+}
+
+describes.realWin('form-dirtiness', {}, env => {
+  let doc, form, dirtinessHandler;
+
+  beforeEach(() => {
+    doc = env.win.document;
+    form = getForm(doc);
+    dirtinessHandler = new FormDirtiness(form);
+  });
+
+  describe('ignored elements', () => {
+    it('does not add dirtiness class if a nameless element changes', () => {
+      const nameless = doc.createElement('input');
+      form.appendChild(nameless);
+
+      changeInput(nameless, 'changed');
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('does not add dirtiness class if a hidden element changes', () => {
+      const hidden = doc.createElement('input');
+      hidden.name = 'name';
+      hidden.hidden = true;
+      form.appendChild(hidden);
+
+      changeInput(hidden, 'changed');
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('does not add dirtiness class if a disabled element changes', () => {
+      const disabled = doc.createElement('input');
+      disabled.name = 'name';
+      disabled.disabled = true;
+      form.appendChild(disabled);
+
+      changeInput(disabled, 'changed');
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+
+  describe('text field changes', () => {
+    let textField;
+
+    beforeEach(() => {
+      // Element is inserted as HTML so that the `defaultValue` property is
+      // generated correctly, since it returns "the default value as
+      // **originally specified in the HTML** that created this object."
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties
+      const html = '<input name="name" type="text" value="default">';
+      form.insertAdjacentHTML('afterbegin', html);
+      textField = form.querySelector('input');
+    });
+
+    it('removes dirtiness class when text field is in default state', () => {
+      changeInput(textField, textField.defaultValue);
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('removes dirtiness class when text field is empty', () => {
+      changeInput(textField, '');
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('adds dirtiness class when text field is changed', () => {
+      changeInput(textField, 'changed');
+      expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+
+  describe('textarea changes', () => {
+    let textarea;
+
+    beforeEach(() => {
+      const html = '<textarea name="comment">default</textarea>';
+      form.insertAdjacentHTML('afterbegin', html);
+      textarea = form.querySelector('textarea');
+    });
+
+    it('removes dirtiness class when textarea is in default state', () => {
+      changeInput(textarea, textarea.defaultValue);
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('removes dirtiness class when textarea is empty', () => {
+      changeInput(textarea, '');
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('adds dirtiness class when textarea is changed', () => {
+      changeInput(textarea, 'changed');
+      expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+
+  describe('#onSubmitting', () => {
+    it('clears the dirtiness class', () => {
+      const input = doc.createElement('input');
+      input.type = 'text';
+      input.name = 'text';
+      form.appendChild(input);
+
+      changeInput(input, 'changed');
+      dirtinessHandler.onSubmitting();
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+
+  describe('#onSubmitError', () => {
+    let input;
+
+    beforeEach(() => {
+      input = doc.createElement('input');
+      input.type = 'text';
+      input.name = 'text';
+      form.appendChild(input);
+    });
+
+    it('adds the dirtiness class if the form was dirty before submitting', () => {
+      changeInput(input, 'changed');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitError();
+
+      expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('does not add the dirtiness class if the form was clean before submitting', () => {
+      changeInput(input, '');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitError();
+
+      expect(form).to.have.not.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+
+  describe('#onSubmitSuccess', () => {
+    it('clears the dirtiness class', () => {
+      const input = doc.createElement('input');
+      input.type = 'text';
+      input.name = 'text';
+      form.appendChild(input);
+
+      changeInput(input, 'changed');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitSuccess();
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
+});


### PR DESCRIPTION
This currently supports detecting the dirtiness of text-typed `<input>`
and `<textarea>`. This does not take the submitted value into account
yet.

This is part of #22534.

/cc @GoTcWang @cvializ 