### PR TITLE
✨Add Consent State Macro into Comscore's Vendor Script

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -73,7 +73,7 @@
   "comscore": {
     "host": "https://sb.scorecardresearch.com",
     "base": "https://sb.scorecardresearch.com/b?",
-    "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=1000001&cs_pv=_page_view_id_&c12=_client_id_&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
+    "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=1000001&cs_amp_consent=&cs_pv=_page_view_id_&c12=_client_id_&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
   },
   "cxense": {
     "host": "https://scomcluster.cxense.com",

--- a/extensions/amp-analytics/0.1/vendors/comscore.js
+++ b/extensions/amp-analytics/0.1/vendors/comscore.js
@@ -24,6 +24,8 @@ export const COMSCORE_CONFIG = /** @type {!JsonObject} */ ({
     'pageview':
       '${base}c1=2' +
       '&c2=${c2}' +
+      '&cs_consent=${consentState}' +
+      '&cs_ucfr=$IF(${consentState}, $IF($REPLACE(${consentState}, insufficient,), $IF($REPLACE(${consentState}, sufficient,), , 1), 0) , )' + 
       '&cs_pv=${pageViewId}' +
       '&c12=${clientId(comScore)}' +
       '&rn=${random}' +

--- a/extensions/amp-analytics/0.1/vendors/comscore.js
+++ b/extensions/amp-analytics/0.1/vendors/comscore.js
@@ -24,8 +24,7 @@ export const COMSCORE_CONFIG = /** @type {!JsonObject} */ ({
     'pageview':
       '${base}c1=2' +
       '&c2=${c2}' +
-      '&cs_consent=${consentState}' +
-      '&cs_ucfr=$IF(${consentState}, $IF($REPLACE(${consentState}, insufficient,), $IF($REPLACE(${consentState}, sufficient,), , 1), 0) , )' + 
+      '&cs_amp_consent=${consentState}' +
       '&cs_pv=${pageViewId}' +
       '&c12=${clientId(comScore)}' +
       '&rn=${random}' +


### PR DESCRIPTION

# Description

- Adding the consentState Macro into Comscore's UDM Tag as 'cs_amp_consent' 
- Comscore Jira ticket: [TAG-4790]
- Note: Cannot find Comscore's CLA agreement. Sent two emails to cla-submissions@google.com and have not received a response. Please advise

