### PR TITLE
Replacing story attachment data-dark-mode with theme.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment-header.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment-header.css
@@ -24,7 +24,7 @@
   z-index: 1 !important;
 }
 
-.i-amphtml-story-page-attachment-dark-mode {
+.i-amphtml-story-page-attachment-theme-dark {
   background: rgba(32, 33, 37, 1) !important;
 }
 
@@ -38,7 +38,7 @@
   cursor: pointer !important;
 }
 
-.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-close-button {
+.i-amphtml-story-page-attachment-theme-dark .i-amphtml-story-page-attachment-close-button {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(255, 255, 255, 0.54)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
 }
 
@@ -46,6 +46,7 @@
   font-family: 'Roboto', sans-serif !important;
   width: calc(100% - 80px) !important;
   padding-right: 40px !important;
+  color: rgba(0, 0, 0, 0.87) !important;
   font-size: 16px !important;
   line-height: 40px !important;
   overflow: hidden !important;
@@ -54,6 +55,6 @@
   white-space: nowrap !important;
 }
 
-.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-title {
+.i-amphtml-story-page-attachment-theme-dark .i-amphtml-story-page-attachment-title {
   color: #fff !important;
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -44,7 +44,7 @@ amp-story-page-attachment.i-amphtml-story-page-attachment-open {
   transition: background 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 
-.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-container {
+.i-amphtml-story-page-attachment-theme-dark .i-amphtml-story-page-attachment-container {
   background: rgba(32, 33, 37, 1) !important;
 }
 
@@ -53,7 +53,7 @@ amp-story-page-attachment.i-amphtml-story-page-attachment-open {
   background: rgba(255, 255, 255, 0.92) !important;
 }
 
-.i-amphtml-story-page-attachment-dark-mode .i-amphtml-story-page-attachment-container[hidden] {
+.i-amphtml-story-page-attachment-theme-dark .i-amphtml-story-page-attachment-container[hidden] {
   background: rgba(32, 33, 37, 0.82) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -38,6 +38,9 @@ import {resetStyles, setImportantStyles, toggle} from '../../../src/style';
 /** @const {number} */
 const TOGGLE_THRESHOLD_PX = 50;
 
+/** @const {string} */
+const DARK_THEME_CLASS = 'i-amphtml-story-page-attachment-theme-dark';
+
 /**
  * @enum {number}
  */
@@ -151,9 +154,8 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
 
     const theme = this.element.getAttribute('theme');
     if (theme && AttachmentTheme.DARK === theme.toLowerCase()) {
-      const darkThemeClass = 'i-amphtml-story-page-attachment-theme-dark';
-      this.headerEl_.classList.add(darkThemeClass);
-      this.element.classList.add(darkThemeClass);
+      this.headerEl_.classList.add(DARK_THEME_CLASS);
+      this.element.classList.add(DARK_THEME_CLASS);
     }
 
     createShadowRootWithStyle(headerShadowRootEl, this.headerEl_, CSS);

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -49,6 +49,14 @@ const AttachmentState = {
 };
 
 /**
+ * @enum {string}
+ */
+const AttachmentTheme = {
+  LIGHT: 'light', // default
+  DARK: 'dark',
+};
+
+/**
  * Drawer's template.
  * @param {!Element} element
  * @return {!Element}
@@ -141,9 +149,11 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
       ).textContent = this.element.getAttribute('data-title');
     }
 
-    if (this.element.hasAttribute('data-dark-mode')) {
-      this.headerEl_.classList.add('i-amphtml-story-page-attachment-dark-mode');
-      this.element.classList.add('i-amphtml-story-page-attachment-dark-mode');
+    const theme = this.element.getAttribute('theme');
+    if (theme && AttachmentTheme.DARK === theme.toLowerCase()) {
+      const darkThemeClass = 'i-amphtml-story-page-attachment-theme-dark';
+      this.headerEl_.classList.add(darkThemeClass);
+      this.element.classList.add(darkThemeClass);
     }
 
     createShadowRootWithStyle(headerShadowRootEl, this.headerEl_, CSS);

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -861,14 +861,6 @@ Default: "Swipe up"
 <amp-story-page-attachment layout="nodisplay" data-cta-text="Read more">...</amp-story-page-attachment>
 ```
 
-#### `data-dark-mode`
-
-Enables dark mode for the page attachment header and content background.
-
-```html
-<amp-story-page-attachment layout="nodisplay" data-dark-mode>...</amp-story-page-attachment>
-```
-
 #### `data-title`
 
 Displays the provided title in the page attachment header.


### PR DESCRIPTION
Addressing https://github.com/ampproject/amphtml/pull/22506#issuecomment-497786504

- Removing the documentation until this rolls out to production
- New opt in for the dark theme:
```
<amp-story-page-attachment theme="dark">
```

cc @abouraya FYI