### PR TITLE
Make sure SR reads index of list options in amp-autocomplete

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -64,9 +64,7 @@ class AmpAccordion extends AMP.BaseElement {
     this.action_ = null;
 
     /** @private {number|string} */
-    this.suffix_ = element.id
-      ? element.id
-      : Math.floor(Math.random() * Math.floor(100));
+    this.prefix_ = element.id ? element.id : Math.floor(Math.random() * 100);
   }
 
   /** @override */
@@ -109,7 +107,7 @@ class AmpAccordion extends AMP.BaseElement {
         // we need to make sure that each accordion has a unique ID.
         // In case the accordion doesn't have an ID we use a
         // random number to ensure uniqueness.
-        contentId = this.suffix_ + '_AMP_content_' + index;
+        contentId = this.prefix_ + '_AMP_content_' + index;
         content.setAttribute('id', contentId);
       }
 

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -203,7 +203,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       );
     }
     this.inputElement_.setAttribute('dir', 'auto');
-    this.inputElement_.setAttribute('aria-autocomplete', 'list');
+    this.inputElement_.setAttribute('aria-autocomplete', 'both');
     this.inputElement_.setAttribute('role', 'combobox');
 
     userAssert(this.inputElement_.form, `${TAG} should be inside a <form> tag`);
@@ -876,6 +876,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
         this.resetActiveElement_();
         newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
         newActiveElement.setAttribute('aria-selected', 'true');
+        if (!newActiveElement.hasAttribute('id')) {
+          newActiveElement.setAttribute('id', 'autocomplete-selected');
+        }
+        this.inputElement_.setAttribute(
+          'aria-activedescendant',
+          newActiveElement.getAttribute('id')
+        );
         this.activeIndex_ = activeIndex;
         this.activeElement_ = newActiveElement;
       }
@@ -916,6 +923,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
       false
     );
     this.activeElement_.removeAttribute('aria-selected');
+    if (this.activeElement_.getAttribute('id') === 'autocomplete-selected') {
+      this.activeElement_.removeAttribute('id');
+    }
+    this.inputElement_.removeAttribute('aria-activedescendent');
     this.activeElement_ = null;
     this.activeIndex_ = -1;
   }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -133,6 +133,14 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.activeElement_ = null;
 
     /**
+     * The element id if present or random number.
+     * @private {number|string}
+     */
+    this.prefix_ = element.id
+      ? element.id
+      : Math.floor(Math.random() * Math.floor(100));
+
+    /**
      * The reference to the <div> that contains template-rendered children.
      * @private {?Element}
      */
@@ -876,13 +884,16 @@ export class AmpAutocomplete extends AMP.BaseElement {
         this.resetActiveElement_();
         newActiveElement.classList.add('i-amphtml-autocomplete-item-active');
         newActiveElement.setAttribute('aria-selected', 'true');
-        if (!newActiveElement.hasAttribute('id')) {
-          newActiveElement.setAttribute('id', 'autocomplete-selected');
+        let elementId = newActiveElement.getAttribute('id');
+        if (!elementId) {
+          // To ensure that we pass Accessibility audits -
+          // we need to make sure that each item element has a unique ID.
+          // In case the autocomplete doesn't have an ID we use a
+          // random number to ensure uniqueness.
+          elementId = this.prefix_ + '_AMP_content_' + activeIndex;
+          newActiveElement.setAttribute('id', elementId);
         }
-        this.inputElement_.setAttribute(
-          'aria-activedescendant',
-          newActiveElement.getAttribute('id')
-        );
+        this.inputElement_.setAttribute('aria-activedescendant', elementId);
         this.activeIndex_ = activeIndex;
         this.activeElement_ = newActiveElement;
       }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -136,9 +136,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
      * The element id if present or random number.
      * @private {number|string}
      */
-    this.prefix_ = element.id
-      ? element.id
-      : Math.floor(Math.random() * Math.floor(100));
+    this.prefix_ = element.id ? element.id : Math.floor(Math.random() * 100);
 
     /**
      * The reference to the <div> that contains template-rendered children.


### PR DESCRIPTION
- Add aria attributes to autocomplete to identify the `aria-activedescendent` for reading and indexing selected values properly.
- Change `aria-autocomplete` from `list` to `both` to suggest that there are both list items provided and that the selected value is updated inline in the input field.
- Follow up with some related comments with `amp-accordian` suggested in #18534