### PR TITLE
Fix popHistory leading to an undefined stackIndex.

### DIFF
--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -920,7 +920,7 @@ export class HistoryBindingVirtual_ {
    * `popHistory`
    *
    *   Request:  {'stackIndex': string}
-   *   Response: undefined | {'stackIndex': string}
+   *   Response: undefined | boolean | {'stackIndex': string}
    *
    * @override
    */
@@ -932,10 +932,13 @@ export class HistoryBindingVirtual_ {
     return this.viewer_
       .sendMessageAwaitResponse('popHistory', message)
       .then(response => {
+        let newState = /** @type {!HistoryStateDef} */ (response);
         // Return the new stack index if response is undefined.
-        const newState =
-          /** @type {!HistoryStateDef} */ (response ||
-          dict({'stackIndex': this.stackIndex_ - 1}));
+        if (!newState || newState.stackIndex === undefined) {
+          newState = /** @type {!HistoryStateDef} */ (dict({
+            'stackIndex': this.stackIndex_ - 1,
+          }));
+        }
         this.updateHistoryState_(newState);
         return newState;
       });


### PR DESCRIPTION
_Disclaimer: the internal viewer code is pretty hard to read and this might be happening with other viewer <-> runtime messages. I only tested `pushHistory` and `popHistory`. A better fix might happen in google3, feel free to suggest this during the review. However, I believe it's worth checking in a fix on our side in the meantime._
__

`history-impl` code expects the runtime <-> viewer `popHistory` message to return a `HistoryStateDef=`, but it sometimes returns a `boolean`.
This PR fixes it by considering the `boolean` as `undefined`, and uses a fallback `stackIndex`.
Otherwise, `stackIndex` would be undefined, and introduce various bugs in the `history-impl` code.

This fixes two bugs:

- Can't close the `amp-story-page-attachment` within a viewer
- Within a viewer, the following would fail for `amp-sidebar`:
  1. Open sidebar
  2. Close sidebar through a close button
  3. Open sidebar
  4. Click browser back: should close the sidebar, but will navigate back to the SRP

(No idea why it's displaying roman letters but it looks cool)

cc @sparhami about `amp-sidebar`

Fixes #22619