### PR TITLE
🏗♻️ Refactor / clean up the `watch` logic used for extensions

### DIFF
--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -67,7 +67,7 @@ async function performBuild(watch) {
       buildAlp({watch}),
       buildExaminer({watch}),
       buildWebWorker({watch}),
-      buildExtensions({bundleOnlyIfListedInFiles: !watch, watch}),
+      buildExtensions({watch}),
       compileAllUnminifiedTargets(watch),
     ]);
   });

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -127,7 +127,6 @@ function compileCss(watch, opt_compileAll) {
   return promise
     .then(() =>
       buildExtensions({
-        bundleOnlyIfListedInFiles: false,
         compileOnlyCss: true,
         compileAll: opt_compileAll,
       })

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -18,7 +18,6 @@ const colors = require('ansi-colors');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const gulpWatch = require('gulp-watch');
 const log = require('fancy-log');
 const {
   buildAlp,
@@ -276,22 +275,6 @@ async function buildExperiments(options) {
   const path = 'tools/experiments';
   const htmlPath = path + '/experiments.html';
   const jsPath = path + '/experiments.js';
-  let {watch} = options;
-  if (watch === undefined) {
-    watch = argv.watch || argv.w;
-  }
-
-  // Building extensions is a 2 step process because of the renaming
-  // and CSS inlining. This watcher watches the original file, copies
-  // it to the destination and adds the CSS.
-  if (watch) {
-    // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
-    copy.watch = false;
-    gulpWatch(path + '/*', function() {
-      buildExperiments(copy);
-    });
-  }
 
   // Build HTML.
   const html = fs.readFileSync(htmlPath, 'utf8');
@@ -349,22 +332,6 @@ async function buildLoginDoneVersion(version, options) {
   const buildDir = `build/all/amp-access-${version}/`;
   const htmlPath = path + 'amp-login-done.html';
   const jsPath = path + 'amp-login-done.js';
-  let {watch} = options;
-  if (watch === undefined) {
-    watch = argv.watch || argv.w;
-  }
-
-  // Building extensions is a 2 step process because of the renaming
-  // and CSS inlining. This watcher watches the original file, copies
-  // it to the destination and adds the CSS.
-  if (watch) {
-    // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
-    copy.watch = false;
-    gulpWatch(path + '/*', function() {
-      buildLoginDoneVersion(version, copy);
-    });
-  }
 
   // Build HTML.
   const html = fs.readFileSync(htmlPath, 'utf8');

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -23,7 +23,6 @@ const log = require('fancy-log');
 const {
   buildAlp,
   buildExaminer,
-  buildExperiments,
   buildWebWorker,
   compileAllMinifiedTargets,
   compileJs,
@@ -265,6 +264,68 @@ function buildWebPushPublisherFile(version, fileName, watch, options) {
         fs.writeFileSync('dist/v0/' + fileName + '.html', fileContents);
       }
     });
+}
+
+/**
+ * Build all the AMP experiments.html/js.
+ *
+ * @param {!Object} options
+ */
+async function buildExperiments(options) {
+  options = options || {};
+  const path = 'tools/experiments';
+  const htmlPath = path + '/experiments.html';
+  const jsPath = path + '/experiments.js';
+  let {watch} = options;
+  if (watch === undefined) {
+    watch = argv.watch || argv.w;
+  }
+
+  // Building extensions is a 2 step process because of the renaming
+  // and CSS inlining. This watcher watches the original file, copies
+  // it to the destination and adds the CSS.
+  if (watch) {
+    // Do not set watchers again when we get called by the watcher.
+    const copy = Object.create(options);
+    copy.watch = false;
+    gulpWatch(path + '/*', function() {
+      buildExperiments(copy);
+    });
+  }
+
+  // Build HTML.
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const minHtml = html.replace(
+    '/dist.tools/experiments/experiments.js',
+    `https://${hostname}/v0/experiments.js`
+  );
+  gulp
+    .src(htmlPath)
+    .pipe(file('experiments.cdn.html', minHtml))
+    .pipe(gulp.dest('dist.tools/experiments/'));
+
+  // Build JS.
+  const js = fs.readFileSync(jsPath, 'utf8');
+  const builtName = 'experiments.max.js';
+  const minifiedName = 'experiments.js';
+  return toPromise(
+    gulp
+      .src(path + '/*.js')
+      .pipe(file(builtName, js))
+      .pipe(gulp.dest('build/experiments/'))
+  ).then(function() {
+    return compileJs(
+      './build/experiments/',
+      builtName,
+      './dist.tools/experiments/',
+      {
+        watch: false,
+        minify: options.minify || argv.minify,
+        includePolyfills: true,
+        minifiedName,
+      }
+    );
+  });
 }
 
 /**

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -270,7 +270,7 @@ function buildWebPushPublisherFile(version, fileName, watch, options) {
  *
  * @param {!Object} options
  */
-async function buildExperiments(options) {
+function buildExperiments(options) {
   options = options || {};
   const path = 'tools/experiments';
   const htmlPath = path + '/experiments.html';
@@ -316,7 +316,7 @@ async function buildExperiments(options) {
  *
  * @param {!Object} options
  */
-async function buildLoginDone(options) {
+function buildLoginDone(options) {
   return buildLoginDoneVersion('0.1', options);
 }
 
@@ -326,7 +326,7 @@ async function buildLoginDone(options) {
  * @param {string} version
  * @param {!Object} options
  */
-async function buildLoginDoneVersion(version, options) {
+function buildLoginDoneVersion(version, options) {
   options = options || {};
   const path = `extensions/amp-access/${version}/`;
   const buildDir = `build/all/amp-access-${version}/`;
@@ -374,15 +374,11 @@ async function buildLoginDoneVersion(version, options) {
 }
 
 module.exports = {
-  buildExperiments,
-  buildLoginDone,
   dist,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */
 
-buildExperiments.description = 'Builds experiments.html/js';
-buildLoginDone.description = 'Builds login-done.html/js';
 dist.description = 'Build production binaries';
 dist.flags = {
   pseudo_names:

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -17,7 +17,6 @@
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const log = require('fancy-log');
-const minimatch = require('minimatch');
 const watch = require('gulp-watch');
 const wrappers = require('../compile-wrappers');
 const {
@@ -56,7 +55,6 @@ const MINIMAL_EXTENSION_SET = [
  *   loadPriority: ?string,
  *   cssBinaries: ?Array<string>,
  *   extraGlobs?Array<string>,
- *   bundleOnlyIfListedInFiles: ?boolean
  * }}
  */
 const ExtensionOption = {}; // eslint-disable-line no-unused-vars
@@ -357,21 +355,10 @@ function buildExtension(
   if (options.compileOnlyCss && !hasCss) {
     return Promise.resolve();
   }
-  const path = 'extensions/' + name + '/' + version;
-  const jsPath = path + '/' + name + '.js';
-  const jsTestPath = path + '/test/test-' + name + '.js';
-  if (argv.files && options.bundleOnlyIfListedInFiles) {
-    const passedFiles = Array.isArray(argv.files) ? argv.files : [argv.files];
-    const shouldBundle = passedFiles.some(glob => {
-      return minimatch(jsPath, glob) || minimatch(jsTestPath, glob);
-    });
-    if (!shouldBundle) {
-      return Promise.resolve();
-    }
-  }
   // Use a separate watcher for extensions to copy / inline CSS and compile JS
   // instead of relying on the watcher used by compileUnminifiedJs, which only
   // recompiles JS.
+  const path = 'extensions/' + name + '/' + version;
   const optionsCopy = Object.create(options);
   if (options.watch) {
     optionsCopy.watch = false;

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -369,22 +369,21 @@ function buildExtension(
       return Promise.resolve();
     }
   }
-  // Building extensions is a 2 step process because of the renaming
-  // and CSS inlining. This watcher watches the original file, copies
-  // it to the destination and adds the CSS.
+  // Use a separate watcher for extensions to copy / inline CSS and compile JS
+  // instead of relying on the watcher used by compileUnminifiedJs, which only
+  // recompiles JS.
+  const optionsCopy = Object.create(options);
   if (options.watch) {
-    // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
-    copy.watch = false;
+    optionsCopy.watch = false;
     watch(path + '/*', function() {
-      buildExtension(name, version, latestVersion, hasCss, copy);
+      buildExtension(name, version, latestVersion, hasCss, optionsCopy);
     });
   }
   let promise = Promise.resolve();
   if (hasCss) {
     mkdirSync('build');
     mkdirSync('build/css');
-    promise = buildExtensionCss(path, name, version, options);
+    promise = buildExtensionCss(path, name, version, optionsCopy);
     if (options.compileOnlyCss) {
       return promise;
     }
@@ -393,7 +392,7 @@ function buildExtension(
     if (argv.single_pass) {
       return Promise.resolve();
     } else {
-      return buildExtensionJs(path, name, version, latestVersion, options);
+      return buildExtensionJs(path, name, version, latestVersion, optionsCopy);
     }
   });
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -475,14 +475,7 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       });
   }
 
-  // Due to the two step build process for extensions, compileJs() is called
-  // twice, once with options.watch set to true and, once with it set to false.
-  // However, we do not need to call rebundle() twice. This avoids the duplicate
-  // compile seen when you run `gulp watch` and touch a file.
-  // TODO (rsimha): Figure out why this is needed and simplify buildExtension().
-  return options.watch === false
-    ? Promise.resolve()
-    : performBundle(/* failOnError */ true);
+  return performBundle(/* failOnError */ true);
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -676,68 +676,6 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
 }
 
 /**
- * Build all the AMP experiments.html/js.
- *
- * @param {!Object} options
- */
-async function buildExperiments(options) {
-  options = options || {};
-  const path = 'tools/experiments';
-  const htmlPath = path + '/experiments.html';
-  const jsPath = path + '/experiments.js';
-  let {watch} = options;
-  if (watch === undefined) {
-    watch = argv.watch || argv.w;
-  }
-
-  // Building extensions is a 2 step process because of the renaming
-  // and CSS inlining. This watcher watches the original file, copies
-  // it to the destination and adds the CSS.
-  if (watch) {
-    // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
-    copy.watch = false;
-    gulpWatch(path + '/*', function() {
-      buildExperiments(copy);
-    });
-  }
-
-  // Build HTML.
-  const html = fs.readFileSync(htmlPath, 'utf8');
-  const minHtml = html.replace(
-    '/dist.tools/experiments/experiments.js',
-    `https://${hostname}/v0/experiments.js`
-  );
-  gulp
-    .src(htmlPath)
-    .pipe(file('experiments.cdn.html', minHtml))
-    .pipe(gulp.dest('dist.tools/experiments/'));
-
-  // Build JS.
-  const js = fs.readFileSync(jsPath, 'utf8');
-  const builtName = 'experiments.max.js';
-  const minifiedName = 'experiments.js';
-  return toPromise(
-    gulp
-      .src(path + '/*.js')
-      .pipe(file(builtName, js))
-      .pipe(gulp.dest('build/experiments/'))
-  ).then(function() {
-    return compileJs(
-      './build/experiments/',
-      builtName,
-      './dist.tools/experiments/',
-      {
-        watch: false,
-        minify: options.minify || argv.minify,
-        includePolyfills: true,
-        minifiedName,
-      }
-    );
-  });
-}
-
-/**
  * Build ALP JS.
  *
  * @param {!Object} options
@@ -815,7 +753,6 @@ function toPromise(readable) {
 module.exports = {
   buildAlp,
   buildExaminer,
-  buildExperiments,
   buildWebWorker,
   compileAllMinifiedTargets,
   compileAllUnminifiedTargets,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,11 +18,6 @@
 
 const gulp = require('gulp-help')(require('gulp'));
 const {
-  buildExperiments,
-  buildLoginDone,
-  dist,
-} = require('./build-system/tasks/dist');
-const {
   compileAccessExpr,
   compileBindExpr,
   compileCssExpr,
@@ -48,6 +43,7 @@ const {css} = require('./build-system/tasks/css');
 const {csvifySize} = require('./build-system/tasks/csvify-size');
 const {depCheck} = require('./build-system/tasks/dep-check');
 const {devDashboardTests} = require('./build-system/tasks/dev-dashboard-tests');
+const {dist} = require('./build-system/tasks/dist');
 const {e2e} = require('./build-system/tasks/e2e');
 const {firebase} = require('./build-system/tasks/firebase');
 const {getZindex} = require('./build-system/tasks/get-zindex');
@@ -71,8 +67,6 @@ const {visualDiff} = require('./build-system/tasks/visual-diff');
 gulp.task('ava', ava);
 gulp.task('babel-plugin-tests', babelPluginTests);
 gulp.task('build', build);
-gulp.task('build-experiments', buildExperiments);
-gulp.task('build-login-done', buildLoginDone);
 gulp.task('bundle-size', bundleSize);
 gulp.task('caches-json', cachesJson);
 gulp.task('changelog', changelog);


### PR DESCRIPTION
This PR does the following:
- Moves `buildExperiments()` from `build-system/tasks/helpers.js` to `build-system/tasks/dist.js` (should've been done in #22109)
- Removes unused `watch` logic from `buildExperiments` and cleans up unused `gulp` task (copy-pasted in #923)
- Removes unused `watch` logic from `buildLoginDoneVersion` and cleans up unused `gulp` task  (copy-pasted in #1330)
- Simplifies the `watch` logic for extensions by using a separate watcher to rebuild an extension when any file in its directory is modified (see #47, #12900, #12911, and #22635)
- Removes the obsolete `bundleOnlyIfListedInFiles` option used to selectively build extensions (added in #3091) now that we have `--extensions` and `--extensions_from` (added in #13203, #13249, and #17129)

Follow up to #47, #923, #1330, #3091, #12900, #12911, #13203, #13249, #17129, #22109, and #22635