### PR TITLE
📖 Add frontmatter key to experimental components

### DIFF
--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -4,6 +4,7 @@ formats:
  - websites
 teaser:
   text: Suggests completed results corresponding to the user input as they type into the input field.
+experimental: true
 ---
 <!--
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.

--- a/extensions/amp-base-carousel/amp-base-carousel.md
+++ b/extensions/amp-base-carousel/amp-base-carousel.md
@@ -4,6 +4,7 @@ formats:
   - websites
 teaser:
   text: Displays multiple similar pieces of content along a horizontal axis or vertical axis.
+experimental: true
 ---
 <!---
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.
@@ -121,7 +122,7 @@ The media queries are evaluated from left to right, with the first matching medi
   <tr>
     <td width="40%"><strong><code>snap-by</code></strong></td>
     <td>A number, defaults to <code>1</code>. This determines the granularity of snapping and is useful when using
-    <code>visible-count</code>. This 
+    <code>visible-count</code>. This
   </tr>
 </table>
 

--- a/extensions/amp-google-vrview-image/amp-google-vrview-image.md
+++ b/extensions/amp-google-vrview-image/amp-google-vrview-image.md
@@ -5,6 +5,7 @@ formats:
   - stories
 teaser:
   text: Displays a VR image.
+experimental: true
 ---
 <!---
 Copyright 2016 The AMP HTML Authors. All Rights Reserved.

--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -4,6 +4,7 @@ formats:
   - websites
 teaser:
   text: Dynamically loads more documents recommended for the user.
+experimental: true
 ---
 <!---
 Copyright 2018 The AMP HTML Authors. All Rights Reserved.
@@ -28,7 +29,7 @@ Dynamically loads more documents recommended for the user.
 <table>
   <tr>
     <td><strong>Availability</strong></td>
-    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a> <a href="https://github.com/ampproject/amphtml/blob/3a06c99f259b66998b61935a5ee5f0075481bfd2/tools/experiments/README.md#enable-an-experiment-for-a-particular-document"> (Document opt-in allowed)</a></td>
+    <td><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a> <a href="https://github.com/ampproject/amphtml/blob/3a06c99f259b66998b61935a5ee5f0075481bfd2/tools/experiments/README.md#enable-an-experiment-for-a-particular-document"> (Document opt-in allowed)</a></td>
   </tr>
   <tr>
     <td><strong>Required Script</strong></td>

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -4,6 +4,7 @@ formats:
   - websites
 teaser:
   text: Provides zooming and panning for arbitrary content.
+experimental: true
 ---
 <!---
 Copyright 2018 The AMP HTML Authors. All Rights Reserved.
@@ -30,7 +31,7 @@ Provides zooming and panning for arbitrary content.
 <table>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><div><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+    <td><div><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a></td>
   </tr>
   <tr>
     <td><strong>Required Script</strong></td>

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -4,7 +4,6 @@ formats:
   - websites
 teaser:
   text: Provides zooming and panning for arbitrary content.
-experimental: true
 ---
 <!---
 Copyright 2018 The AMP HTML Authors. All Rights Reserved.
@@ -31,7 +30,7 @@ Provides zooming and panning for arbitrary content.
 <table>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><div><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a></td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td><strong>Required Script</strong></td>

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -4,6 +4,7 @@ formats:
   - websites
 teaser:
   text: Allows rendering of custom UI components running on third-party JavaScript.
+experimental: true
 ---
 # amp-script
 

--- a/extensions/amp-truncate-text/amp-truncate-text.md
+++ b/extensions/amp-truncate-text/amp-truncate-text.md
@@ -5,6 +5,7 @@ formats:
   - email
 teaser:
   text: Truncates text with an ellipsis, optionally showing an overflow element.
+experimental: true
 ---
 <!--
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.
@@ -31,7 +32,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><div><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a>; You must turn on the `amp-truncate-text` experiment to use this component.</div></td>
+    <td><div><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a>; You must turn on the `amp-truncate-text` experiment to use this component.</div></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>

--- a/extensions/amp-user-location/amp-user-location.md
+++ b/extensions/amp-user-location/amp-user-location.md
@@ -6,6 +6,7 @@ formats:
   - dynamic-content
 teaser:
   text: Request the user's precise location.
+experimental: true
 ---
 <!--
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -4,6 +4,7 @@ formats:
   - websites
 teaser:
   text: Displays visualizations created by using Vega visualization grammar.
+experimental: true
 ---
 <!---
 Copyright 2016 The AMP HTML Authors. All Rights Reserved.
@@ -28,7 +29,7 @@ Displays visualizations created using <a href="https://vega.github.io/vega/">Veg
 <table>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+    <td><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>


### PR DESCRIPTION
The [experiments page](https://amp.dev/documentation/guides-and-tutorials/learn/experimental) on amp.dev now dynamically lists experimental components if they have a frontmatter key of `experimental` or `origin_trial`.

This adds `experimental` to: `amp-autocomplete`, `amp-base-carousel`, `amp-google-vrview-image`, `amp-next-page`, `amp-pan-zoom`, `amp-script`, `amp-truncate-text`, `amp-user-location` and `amp-viz-vega`.

/cc @CrystalOnScript @sebastianbenz 