### PR TITLE
✨ FEATURE: record form field's submitted value

### DIFF
--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -144,7 +144,7 @@ export class FormDirtiness {
     if (
       isFieldEmpty(field) ||
       isFieldDefault(field) ||
-      this.hasFieldBeenSubmitted_(field)
+      this.isFieldSameAsLastSubmission_(field)
     ) {
       this.removeDirtyField_(field.name);
     } else {
@@ -159,7 +159,7 @@ export class FormDirtiness {
    * @return {boolean}
    * @private
    */
-  hasFieldBeenSubmitted_(field) {
+  isFieldSameAsLastSubmission_(field) {
     const {name, value} = field;
     return this.submittedFormData_.get(name) === value;
   }

--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -45,8 +45,8 @@ export class FormDirtiness {
     /** @private {!Object<string, boolean>} */
     this.isFieldNameDirty_ = map();
 
-    /** @private {!FormData} */
-    this.submittedFormData_ = this.takeFormDataSnapshot_();
+    /** @private {?FormData} */
+    this.submittedFormData_ = null;
 
     /** @private {boolean} */
     this.isSubmitting_ = false;
@@ -160,6 +160,9 @@ export class FormDirtiness {
    * @private
    */
   isFieldSameAsLastSubmission_(field) {
+    if (!this.submittedFormData_) {
+      return false;
+    }
     const {name, value} = field;
     return this.submittedFormData_.get(name) === value;
   }

--- a/extensions/amp-form/0.1/test/test-form-dirtiness.js
+++ b/extensions/amp-form/0.1/test/test-form-dirtiness.js
@@ -15,6 +15,7 @@
  */
 
 import {DIRTINESS_INDICATOR_CLASS, FormDirtiness} from '../form-dirtiness';
+import {Services} from '../../../../src/services';
 
 function getForm(doc) {
   const form = doc.createElement('form');
@@ -36,7 +37,12 @@ describes.realWin('form-dirtiness', {}, env => {
   beforeEach(() => {
     doc = env.win.document;
     form = getForm(doc);
-    dirtinessHandler = new FormDirtiness(form);
+    sandbox.stub(Services, 'platformFor').returns({
+      isIos() {
+        return false;
+      },
+    });
+    dirtinessHandler = new FormDirtiness(form, env.win);
   });
 
   describe('ignored elements', () => {
@@ -98,6 +104,15 @@ describes.realWin('form-dirtiness', {}, env => {
       changeInput(textField, 'changed');
       expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
     });
+
+    it('removes dirtiness class when its value matches the submitted value', () => {
+      changeInput(textField, 'submitted');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitSuccess();
+      changeInput(textField, 'submitted');
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
   });
 
   describe('textarea changes', () => {
@@ -122,6 +137,15 @@ describes.realWin('form-dirtiness', {}, env => {
     it('adds dirtiness class when textarea is changed', () => {
       changeInput(textarea, 'changed');
       expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('removes dirtiness class when its value matches the submitted value', () => {
+      changeInput(textarea, 'submitted');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitSuccess();
+      changeInput(textarea, 'submitted');
+
+      expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
     });
   });
 

--- a/extensions/amp-form/0.1/test/test-form-dirtiness.js
+++ b/extensions/amp-form/0.1/test/test-form-dirtiness.js
@@ -191,17 +191,30 @@ describes.realWin('form-dirtiness', {}, env => {
   });
 
   describe('#onSubmitSuccess', () => {
-    it('clears the dirtiness class', () => {
-      const input = doc.createElement('input');
+    let input;
+
+    beforeEach(() => {
+      input = doc.createElement('input');
       input.type = 'text';
       input.name = 'text';
       form.appendChild(input);
+    });
 
+    it('clears the dirtiness class', () => {
       changeInput(input, 'changed');
       dirtinessHandler.onSubmitting();
       dirtinessHandler.onSubmitSuccess();
 
       expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('tracks new changes after the form has been submitted', () => {
+      changeInput(input, 'changed');
+      dirtinessHandler.onSubmitting();
+      dirtinessHandler.onSubmitSuccess();
+      changeInput(input, 'changed again');
+
+      expect(form).to.have.class(DIRTINESS_INDICATOR_CLASS);
     });
   });
 });


### PR DESCRIPTION
This is used for the `amp-form-dirty` check. A form field is not dirty
when the value matches its submitted value.

Part of #22534.

/cc @GoTcWang @cvializ 