### PR TITLE
✨amp-experiment: Select Multiple Elements with `querySelectorAll`

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -19,10 +19,11 @@
 </head>
 <body>
   <h1>Title TBD</h1>
+  <h2>Subtitle to test multiple elements</h2>
 
   <ul>
     <li><a href="#amp-x-background-color-test=yellow" target="_blank">#amp-x-background-color-test=yellow</a></li>
-    <li><a href="#amp-x-background-color-test=green" target="_blank">#amp-x-background-color-test=green</a></li>
+    <li><a href="#amp-x-background-color-test=red" target="_blank">#amp-x-background-color-test=red</a></li>
   </ul>
 
   <amp-experiment>
@@ -36,7 +37,7 @@
               "mutations": [
                 {
                   "type": "attributes",
-                  "target": "h1",
+                  "target": "h1, h2",
                   "attributeName": "style",
                   "value": "background-color: #FFFF00"
                 }
@@ -47,7 +48,7 @@
               "mutations": [
                 {
                   "type": "attributes",
-                  "target": "h1",
+                  "target": "h1, h2",
                   "attributeName": "style",
                   "value": "background-color: #FF0000"
                 }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -275,7 +275,7 @@ export class AmpExperiment extends AMP.BaseElement {
         const mutationRecord = parseMutation(mutation, this.win.document);
 
         totalMutations += mutationRecord.mutations;
-        if(totalMutations > MAX_MUTATIONS) {
+        if (totalMutations > MAX_MUTATIONS) {
           const numMutationsError =
             'Max number of mutations for the total ' +
             `applied experiments exceeded: ${totalMutations} > ` +
@@ -284,7 +284,9 @@ export class AmpExperiment extends AMP.BaseElement {
           throw new Error(numMutationsError);
         }
 
-        mutationOperations = mutationOperations.concat(mutationRecord.mutations);
+        mutationOperations = mutationOperations.concat(
+          mutationRecord.mutations
+        );
       });
       mutationOperations.forEach(mutationOperation => mutationOperation());
     });

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -97,7 +97,6 @@ export class AmpExperiment extends AMP.BaseElement {
         /** @private @const {!Promise<!Object<string, ?string>>} */
         const experimentVariants = Promise.all(variants)
           .then(() => {
-            this.validateExperimentToVariant_(config, experimentToVariant);
             const applyExperimentsPromise = this.applyExperimentVariants_(
               config,
               experimentToVariant
@@ -178,42 +177,6 @@ export class AmpExperiment extends AMP.BaseElement {
   }
 
   /**
-   * Function to run validations and limitations on the current
-   * chosen Experiment / variant combination.
-   *
-   * @param {!JsonObject} config
-   * @param {!Object<string, ?string>} experimentToVariant
-   */
-  validateExperimentToVariant_(config, experimentToVariant) {
-    // Ensure that the current experiment / variant
-    // combination does not exceed the maximum mutations.
-    // NOTE: We are not validating the entire config,
-    // As that would take more time, and affect the user,
-    // vs. help the developer.
-    let totalMutations = 0;
-    const experimentToVariantKeys = Object.keys(experimentToVariant);
-
-    for (let i = 0; i < experimentToVariantKeys.length; i++) {
-      const experimentKey = experimentToVariantKeys[i];
-      const variantKey = experimentToVariant[experimentKey];
-      const variant =
-        /** @type {!JsonObject} */ (config[experimentKey]['variants'][
-          variantKey
-        ]);
-      totalMutations += variant['mutations'].length;
-    }
-
-    if (totalMutations > MAX_MUTATIONS) {
-      const numMutationsError =
-        'Max number of mutations for the total ' +
-        `applied experiments exceeded: ${totalMutations} > ` +
-        MAX_MUTATIONS;
-      user().error(TAG, numMutationsError);
-      throw new Error(numMutationsError);
-    }
-  }
-
-  /**
    * Passes the given experiment and variant pairs to the correct handler,
    * to apply the experiment to the document.
    * Experiment with no variant assigned (null) will be skipped.
@@ -274,7 +237,7 @@ export class AmpExperiment extends AMP.BaseElement {
       variantObject['mutations'].forEach(mutation => {
         const mutationRecord = parseMutation(mutation, this.win.document);
 
-        totalMutations += mutationRecord.mutations;
+        totalMutations += mutationRecord.mutations.length;
         if (totalMutations > MAX_MUTATIONS) {
           const numMutationsError =
             'Max number of mutations for the total ' +

--- a/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
@@ -31,7 +31,7 @@ export class AllowedAttributeMutationEntry {
    * @return {boolean}
    */
   validate(mutationRecord, element) {
-    if (mutationRecord['value']) {
+    if (mutationRecord['value'] && element) {
       return true;
     }
   }

--- a/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
@@ -27,9 +27,10 @@ export class AllowedAttributeMutationEntry {
    * for the attribute change. Subclasses
    * may override.
    * @param {!Object} mutationRecord
+   * @param {!Element} element
    * @return {boolean}
    */
-  validate(mutationRecord) {
+  validate(mutationRecord, element) {
     if (mutationRecord['value']) {
       return true;
     }
@@ -39,9 +40,10 @@ export class AllowedAttributeMutationEntry {
    * Function to apply the mutation.
    * Subclasses may override
    * @param {!Object} mutationRecord
+   * @param {!Element} element
    */
-  mutate(mutationRecord) {
-    mutationRecord['targetElement'].setAttribute(
+  mutate(mutationRecord, element) {
+    element.setAttribute(
       mutationRecord['attributeName'],
       mutationRecord['value']
     );

--- a/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
@@ -33,7 +33,7 @@ const TAG = 'amp-experiment allowed-mutations';
 export function getAllowedAttributeMutationEntry(
   mutationRecord,
   element,
-  stringifiedMutation,
+  stringifiedMutation
 ) {
   // Assert the mutation attribute is one of the following keys
   const mutationAttributeName = mutationRecord['attributeName'];
@@ -58,7 +58,8 @@ export function getAllowedAttributeMutationEntry(
   }
 
   if (!allowedAttributeMutationEntry) {
-    const error = `Mutation ${stringifiedMutation} has an unsupported attributeName` +
+    const error =
+      `Mutation ${stringifiedMutation} has an unsupported attributeName` +
       ` for the element ${element}.`;
     user().error(TAG, error);
     throw new Error(error);

--- a/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
@@ -26,12 +26,14 @@ const TAG = 'amp-experiment allowed-mutations';
  * Function to validate the attribute mutation
  * should be allowed, and return its mutation
  * @param {!Object} mutationRecord
+ * @param {!Element} element
  * @param {string} stringifiedMutation
  * @return {!./allowed-attribute-mutation-entry.AllowedAttributeMutationEntry}
  */
 export function getAllowedAttributeMutationEntry(
   mutationRecord,
-  stringifiedMutation
+  element,
+  stringifiedMutation,
 ) {
   // Assert the mutation attribute is one of the following keys
   const mutationAttributeName = mutationRecord['attributeName'];
@@ -42,7 +44,7 @@ export function getAllowedAttributeMutationEntry(
   );
 
   // Find our allow list entry
-  const mutationTagName = mutationRecord['targetElement'].tagName.toLowerCase();
+  const mutationTagName = element.tagName.toLowerCase();
 
   // Search through the allow list for our
   // Allowed attribute entry
@@ -56,7 +58,8 @@ export function getAllowedAttributeMutationEntry(
   }
 
   if (!allowedAttributeMutationEntry) {
-    const error = `Mutation ${stringifiedMutation} has an unsupported attributeName.`;
+    const error = `Mutation ${stringifiedMutation} has an unsupported attributeName` +
+      ` for the element ${element}.`;
     user().error(TAG, error);
     throw new Error(error);
   }

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -15,8 +15,8 @@
  */
 
 import {getAllowedAttributeMutationEntry} from './attribute-allow-list/attribute-allow-list';
-import {isObject} from '../../../src/types';
-import {toArray} from '../../../src/types';
+import {isObject, toArray} from '../../../src/types';
+
 import {user, userAssert} from '../../../src/log';
 
 const TAG = 'amp-experiment mutation-parser';

--- a/extensions/amp-experiment/1.0/mutation-parser.js
+++ b/extensions/amp-experiment/1.0/mutation-parser.js
@@ -89,7 +89,7 @@ export function parseMutation(mutation, document) {
 
     // TODO (torch2424): Remove this NOOP after reviews
     // This is done to allow for small(er) PRS
-    mutationRecord.mutate = () => {};
+    mutationRecord.mutations.push(() => {});
   }
 
   return mutationRecord;

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as variant from '../variant';
 import * as mutation from '../mutation-parser';
+import * as variant from '../variant';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -199,7 +199,7 @@ describes.realWin(
 
         // Stub parsing mutation records
         sandbox.stub(mutation, 'parseMutation').returns({
-          mutations: new Array(10).fill(() => {})
+          mutations: new Array(10).fill(() => {}),
         });
 
         expectAsyncConsoleError(/Max number of mutations/);

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -15,6 +15,7 @@
  */
 
 import * as variant from '../variant';
+import * as mutation from '../mutation-parser';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -172,18 +173,18 @@ describes.realWin(
 
     it(
       'should throw if the chosen experiment / ' +
-        'variant config has too many mutations',
+        'variant config has too many mutation operations',
       () => {
         const tooManyMutationsConfig = {
           'experiment-1': {
             variants: {
               'variant-a': {
                 weight: 50,
-                mutations: new Array(200).fill({}),
+                mutations: new Array(20).fill({}),
               },
               'variant-b': {
                 weight: 50,
-                mutations: new Array(200).fill({}),
+                mutations: new Array(20).fill({}),
               },
             },
           },
@@ -195,6 +196,11 @@ describes.realWin(
           JSON.stringify(tooManyMutationsConfig)
         );
         stubAllocateVariant(sandbox, tooManyMutationsConfig);
+
+        // Stub parsing mutation records
+        sandbox.stub(mutation, 'parseMutation').returns({
+          mutations: new Array(10).fill(() => {})
+        });
 
         expectAsyncConsoleError(/Max number of mutations/);
         return experiment.buildCallback().then(
@@ -213,7 +219,6 @@ describes.realWin(
       stubAllocateVariant(sandbox, config);
 
       const applyStub = sandbox.stub(experiment, 'applyMutations_');
-      sandbox.stub(experiment, 'validateExperimentToVariant_');
 
       experiment.buildCallback();
       return Services.variantsForDocOrNull(ampdoc.getHeadNode())

--- a/extensions/amp-experiment/1.0/test/test-attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-allow-list.js
@@ -30,10 +30,12 @@ const ORIGINAL_ALLOW_LIST = {
 };
 
 describes.realWin('amp-experiment attribute-allow-list', {}, () => {
-  function getAllowedAttributeMutationEntryParams(opt_attributeName, opt_value) {
-
+  function getAllowedAttributeMutationEntryParams(
+    opt_attributeName,
+    opt_value
+  ) {
     const element = {
-      tagName: 'DIV'
+      tagName: 'DIV',
     };
 
     const params = [];

--- a/extensions/amp-experiment/1.0/test/test-attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-allow-list.js
@@ -30,15 +30,23 @@ const ORIGINAL_ALLOW_LIST = {
 };
 
 describes.realWin('amp-experiment attribute-allow-list', {}, () => {
-  function getAttributeMutation(opt_attributeName, opt_value) {
-    return {
+  function getAllowedAttributeMutationEntryParams(opt_attributeName, opt_value) {
+
+    const element = {
+      tagName: 'DIV'
+    };
+
+    const params = [];
+    params[0] = {
       type: 'attributes',
-      targetElement: {
-        tagName: 'DIV',
-      },
+      targetElements: [element],
       attributeName: opt_attributeName || 'style',
       value: opt_value || 'color: #FF0000',
     };
+    params[1] = element;
+    params[2] = MUTATION_NAME;
+
+    return params;
   }
 
   class FakeAllowedAttributeMutationEntry extends AllowedAttributeMutationEntry {}
@@ -49,9 +57,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
   });
 
   it('should allow a valid attribute, value', () => {
-    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry(
-      getAttributeMutation(),
-      MUTATION_NAME
+    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry.apply(
+      null,
+      getAllowedAttributeMutationEntryParams()
     );
 
     expect(allowedAttributeMutationEntry).to.be.ok;
@@ -66,9 +74,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
       '*': new AllowedAttributeMutationEntry(),
     };
 
-    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry(
-      getAttributeMutation(testAttributeName),
-      MUTATION_NAME
+    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry.apply(
+      null,
+      getAllowedAttributeMutationEntryParams(testAttributeName)
     );
 
     expect(allowedAttributeMutationEntry).to.be.ok;
@@ -83,9 +91,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
       'div': new AllowedAttributeMutationEntry(),
     };
 
-    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry(
-      getAttributeMutation(testAttributeName),
-      MUTATION_NAME
+    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry.apply(
+      null,
+      getAllowedAttributeMutationEntryParams(testAttributeName)
     );
 
     expect(allowedAttributeMutationEntry).to.be.ok;
@@ -100,9 +108,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
       '*': new FakeAllowedAttributeMutationEntry(),
     };
 
-    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry(
-      getAttributeMutation(testAttributeName),
-      MUTATION_NAME
+    const allowedAttributeMutationEntry = getAllowedAttributeMutationEntry.apply(
+      null,
+      getAllowedAttributeMutationEntryParams(testAttributeName)
     );
 
     expect(allowedAttributeMutationEntry).to.be.ok;
@@ -119,9 +127,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
 
     expectAsyncConsoleError(/attributeName/);
     try {
-      getAllowedAttributeMutationEntry(
-        getAttributeMutation(testAttributeName),
-        MUTATION_NAME
+      getAllowedAttributeMutationEntry.apply(
+        null,
+        getAllowedAttributeMutationEntryParams(testAttributeName)
       );
       expect(false).to.be.ok;
     } catch (e) {
@@ -137,9 +145,9 @@ describes.realWin('amp-experiment attribute-allow-list', {}, () => {
 
     expectAsyncConsoleError(/attributeName/);
     try {
-      getAllowedAttributeMutationEntry(
-        getAttributeMutation(testAttributeName),
-        MUTATION_NAME
+      getAllowedAttributeMutationEntry.apply(
+        null,
+        getAllowedAttributeMutationEntryParams(testAttributeName)
       );
       expect(false).to.be.ok;
     } catch (e) {

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -44,7 +44,11 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
     return `.${targetClass}`;
   }
 
-  function getAttributeMutation(opt_attributeName, opt_value, opt_numberOfElements) {
+  function getAttributeMutation(
+    opt_attributeName,
+    opt_value,
+    opt_numberOfElements
+  ) {
     const selector = setupMutationSelector(opt_numberOfElements);
 
     return {
@@ -74,7 +78,11 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
 
   it('should select multiple elements from a selector', () => {
     const numberOfMutations = 10;
-    const mutation = getAttributeMutation(undefined, undefined, numberOfMutations);
+    const mutation = getAttributeMutation(
+      undefined,
+      undefined,
+      numberOfMutations
+    );
     const mutationRecord = parseMutation(mutation, doc);
     expect(mutationRecord).to.be.ok;
     expect(mutationRecord.mutations.length).to.be.equal(numberOfMutations);
@@ -229,20 +237,23 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
       });
     });
 
-    it('should return a mutation recrord that, ' +
-      'has mutatations to change the attribute of a selector', () => {
-      const expectedStyle = 'color: #FFF';
-      const mutation = getAttributeMutation('style', expectedStyle);
-      const mutationRecord = parseMutation(mutation, doc);
+    it(
+      'should return a mutation recrord that, ' +
+        'has mutatations to change the attribute of a selector',
+      () => {
+        const expectedStyle = 'color: #FFF';
+        const mutation = getAttributeMutation('style', expectedStyle);
+        const mutationRecord = parseMutation(mutation, doc);
 
-      mutationRecord.mutations.forEach(mutationFunction => {
-        mutationFunction();
-      });
+        mutationRecord.mutations.forEach(mutationFunction => {
+          mutationFunction();
+        });
 
-      expect(
-        doc.querySelector(mutation['target']).getAttribute('style')
-      ).to.be.equal(expectedStyle);
-    });
+        expect(
+          doc.querySelector(mutation['target']).getAttribute('style')
+        ).to.be.equal(expectedStyle);
+      }
+    );
   });
 
   describe('characterData', () => {
@@ -262,19 +273,22 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
       });
     });
 
-    it('should return an mutation record that, ' +
-      'has mutations to change textContent of a selector', () => {
-      const expectedTextContent = 'Expected';
-      const mutation = getCharacterDataMutation(expectedTextContent);
-      const mutationRecord = parseMutation(mutation, doc);
+    it(
+      'should return an mutation record that, ' +
+        'has mutations to change textContent of a selector',
+      () => {
+        const expectedTextContent = 'Expected';
+        const mutation = getCharacterDataMutation(expectedTextContent);
+        const mutationRecord = parseMutation(mutation, doc);
 
-      mutationRecord.mutations.forEach(mutationFunction => {
-        mutationFunction();
-      });
+        mutationRecord.mutations.forEach(mutationFunction => {
+          mutationFunction();
+        });
 
-      expect(doc.querySelector(mutation['target']).textContent).to.be.equal(
-        expectedTextContent
-      );
-    });
+        expect(doc.querySelector(mutation['target']).textContent).to.be.equal(
+          expectedTextContent
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
relates to #20225
relates to #21705

This reworks the implementation to use `querySelectorAll` for the selector, instead of `querySelector`. Thus, a lot of the code now works around arrays, and passing in the specific selected element. Updated tests accordingly, as well as checking for the total number of mutations 😄 

# Example

<img width="627" alt="Screen Shot 2019-06-04 at 6 08 02 PM" src="https://user-images.githubusercontent.com/1448289/58895203-b6967780-86f3-11e9-9096-06bcc9253208.png">
