### PR TITLE
✨amp-experiment 1.0: Allowed all class changes

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -15,6 +15,10 @@
       background-color: yellow;
       height: 50px;
     }
+
+    .blue-class {
+      color: blue;
+    }
   </style>
 </head>
 <body>
@@ -50,6 +54,22 @@
                   "target": "h1",
                   "attributeName": "style",
                   "value": "background-color: #FF0000"
+                }
+              ]
+            }
+          }
+        },
+        "background-color-test": {
+          "consentNotificationId": "amp-user-notification",
+          "variants": {
+            "blue": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "class",
+                  "value": "blue-class"
                 }
               ]
             }

--- a/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
@@ -93,3 +93,22 @@ export class DefaultAllowedURLAttributeMutationEntry extends AllowedAttributeMut
     return true;
   }
 }
+
+/**
+ * Class for handling class type attribute
+ * mutations. E.g ['class']['*']
+ */
+export class DefaultClassAllowedAttributeMutationEntry extends AllowedAttributeMutationEntry {
+  /** @override */
+  validate(mutationRecord) {
+    const value = mutationRecord['value'];
+
+    // Don't allow the .i-amphtml class
+    // See `validator/validator-main.protoascii`
+    if (value.match(/(^|\\W)i-amphtml-/)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/allowed-attribute-mutation-entry.js
@@ -104,7 +104,8 @@ export class DefaultClassAllowedAttributeMutationEntry extends AllowedAttributeM
     const value = mutationRecord['value'];
 
     // Don't allow the .i-amphtml class
-    // See `validator/validator-main.protoascii`
+    // Should stay in sync with
+    // `validator/validator-main.protoascii`
     if (value.match(/(^|\\W)i-amphtml-/)) {
       return false;
     }

--- a/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
@@ -15,6 +15,7 @@
  */
 
 import {
+  AllowedAttributeMutationEntry,
   DefaultAllowedURLAttributeMutationEntry,
   DefaultStyleAllowedAttributeMutationEntry,
 } from './allowed-attribute-mutation-entry';
@@ -67,6 +68,9 @@ export function getAllowedAttributeMutationEntry(
 export const attributeMutationAllowList = {
   'style': {
     '*': new DefaultStyleAllowedAttributeMutationEntry(),
+  },
+  'class': {
+    '*': new AllowedAttributeMutationEntry(),
   },
   'src': {
     '*': new DefaultAllowedURLAttributeMutationEntry(),

--- a/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
+++ b/extensions/amp-experiment/1.0/attribute-allow-list/attribute-allow-list.js
@@ -15,8 +15,8 @@
  */
 
 import {
-  AllowedAttributeMutationEntry,
   DefaultAllowedURLAttributeMutationEntry,
+  DefaultClassAllowedAttributeMutationEntry,
   DefaultStyleAllowedAttributeMutationEntry,
 } from './allowed-attribute-mutation-entry';
 import {user, userAssert} from '../../../../src/log';
@@ -70,7 +70,7 @@ export const attributeMutationAllowList = {
     '*': new DefaultStyleAllowedAttributeMutationEntry(),
   },
   'class': {
-    '*': new AllowedAttributeMutationEntry(),
+    '*': new DefaultClassAllowedAttributeMutationEntry(),
   },
   'src': {
     '*': new DefaultAllowedURLAttributeMutationEntry(),

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -186,6 +186,12 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
       }
     });
 
+    it('should allow all class changes', () => {
+      const mutation = getAttributeMutation('class', 'any-class-is-fine');
+      const mutationOperation = parseMutation(mutation, doc);
+      expect(mutationOperation).to.be.ok;
+    });
+
     it('should error when unallowed style', () => {
       const mutation = getAttributeMutation('style', 'position: fixed');
       allowConsoleError(() => {

--- a/extensions/amp-experiment/1.0/test/test-mutation-parser.js
+++ b/extensions/amp-experiment/1.0/test/test-mutation-parser.js
@@ -186,10 +186,22 @@ describes.realWin('amp-experiment mutation-parser', {}, env => {
       }
     });
 
-    it('should allow all class changes', () => {
-      const mutation = getAttributeMutation('class', 'any-class-is-fine');
+    it('should allow class changes', () => {
+      const mutation = getAttributeMutation('class', 'this-class-is-fine');
       const mutationOperation = parseMutation(mutation, doc);
       expect(mutationOperation).to.be.ok;
+    });
+
+    it('should error when unallowed class changes', () => {
+      const mutation = getAttributeMutation(
+        'class',
+        'i-amphtml-this-class-is-bad'
+      );
+      allowConsoleError(() => {
+        expect(() => {
+          parseMutation(mutation, doc);
+        }).to.throw(/value/);
+      });
     });
 
     it('should error when unallowed style', () => {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -6227,6 +6227,8 @@ attr_lists: {
   attrs: { name: "accesskey" }
   attrs: {
     # attribute "class" for transformed is handled within the Validator engine.
+    # If this changes, please be sure to also update:
+    # amp-experiment 1.0 implementation.
     disabled_by: "transformed"
     name: "class"
     blacklisted_value_regex: "(^|\\W)i-amphtml-"


### PR DESCRIPTION
relates to #20225
relates to #21705

Pretty small change, but allows any class to be applied as an attribute mutation 😄 

# Example

<img width="625" alt="Screen Shot 2019-06-04 at 6 30 23 PM" src="https://user-images.githubusercontent.com/1448289/58896729-e5fab380-86f6-11e9-8629-40ad5864bc2b.png">
