### PR TITLE
comment out bad configuration temporarily

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -223,15 +223,15 @@ module.exports = {
       },
       SAUCE_TIMEOUT_CONFIG
     ),
-    SL_Safari_12: Object.assign(
-      {
-        base: 'SauceLabs',
-        browserName: 'safari',
-        platform: 'macOS 10.13',
-        version: '12.0',
-      },
-      SAUCE_TIMEOUT_CONFIG
-    ),
+    //SL_Safari_12: Object.assign(
+      //{
+        //base: 'SauceLabs',
+        //browserName: 'safari',
+        //platform: 'macOS 10.13',
+        //version: '12.0',
+      //},
+      //SAUCE_TIMEOUT_CONFIG
+    //),
     SL_Safari_11: Object.assign(
       {
         base: 'SauceLabs',


### PR DESCRIPTION
temporarily disabling this due to error:

```
[launcher.sauce]: Can not start safari 12.0 (macOS 10.13)
  [init({"version":"12.0","platform":"macOS 10.13","tags":[],"name":"AMP HTML on Sauce","tunnel-identifier":"59261.8","record-video":false,"record-screenshots":false,"device-orientation":null,"disable-popup-handler":true,"build":"59261","public":null,"commandTimeout":600,"idleTimeout":300,"maxDuration":600,"customData":{},"base":"SauceLabs","browserName":"safari"})] The environment you requested was unavailable.
  Misconfigured -- Unsupported OS/browser/version/device combo: OS: 'Mac 10.13', Browser: 'safari', Version: '12.0.', Device: 'unspecified'
04 06 2019 12:58:27.614:ERROR [karma-server]: { Error: [init({"version":"12.0","platform":"macOS 10.13","tags":[],"name":"AMP HTML on Sauce","tunnel-identifier":"59261.8","record-video":false,"record-screenshots":false,"device-orientation":null,"disable-popup-handler":true,"build":"59261","public":null,"commandTimeout":600,"idleTimeout":300,"maxDuration":600,"customData":{},"base":"SauceLabs","browserName":"safari"})] The environment you requested was unavailable.
    at /home/travis/build/ampproject/amphtml/node_modules/wd/lib/webdriver.js:138:15
    at Request._callback (/home/travis/build/ampproject/amphtml/node_modules/wd/lib/http-utils.js:89:7)
    at Request.self.callback (/home/travis/build/ampproject/amphtml/node_modules/request/request.js:185:22)
    at Request.emit (events.js:198:13)
    at Request.EventEmitter.emit (domain.js:466:23)
    at Request.<anonymous> (/home/travis/build/ampproject/amphtml/node_modules/request/request.js:1161:10)
    at Request.emit (events.js:198:13)
    at Request.EventEmitter.emit (domain.js:466:23)
    at IncomingMessage.<anonymous> (/home/travis/build/ampproject/amphtml/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:286:20)
    at IncomingMessage.emit (events.js:203:15)
    at IncomingMessage.EventEmitter.emit (domain.js:466:23)
    at endReadableNT (_stream_readable.js:1129:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  data:
   'Misconfigured -- Unsupported OS/browser/version/device combo: OS: \'Mac 10.13\', Browser: \'safari\', Version: \'12.0.\', Device: \'unspecified\'' }


```