### PR TITLE
Viewer messaging to select the next/previous document.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -374,7 +374,11 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.state_ = state;
         break;
       case PageState.PAUSED:
-        this.advancement_.stop(true /** canResume */);
+        // canResume keeps the time advancement timer if set to true, and resets
+        // it when set to false. If the bookend if open, reset the timer. If
+        // user is long pressing, don't reset it.
+        const canResume = !this.storeService_.get(StateProperty.BOOKEND_STATE);
+        this.advancement_.stop(canResume);
         this.pauseAllMedia_(false /** rewindToBeginning */);
         if (this.animationManager_) {
           this.animationManager_.pauseAll();
@@ -1077,20 +1081,20 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Navigates to the previous page in the story.
    */
   previous() {
-    const targetPageId = this.getPreviousPageId();
+    const pageId = this.getPreviousPageId();
 
-    if (targetPageId === null) {
+    if (pageId === null) {
       dispatch(
         this.win,
         this.element,
-        EventType.SHOW_NO_PREVIOUS_PAGE_HELP,
+        EventType.NO_PREVIOUS_PAGE,
         /* payload */ undefined,
         {bubbles: true}
       );
       return;
     }
 
-    this.switchTo_(targetPageId, NavigationDirection.PREVIOUS);
+    this.switchTo_(pageId, NavigationDirection.PREVIOUS);
   }
 
   /**
@@ -1102,6 +1106,13 @@ export class AmpStoryPage extends AMP.BaseElement {
     const pageId = this.getNextPageId(isAutomaticAdvance);
 
     if (!pageId) {
+      dispatch(
+        this.win,
+        this.element,
+        EventType.NO_NEXT_PAGE,
+        /* payload */ undefined,
+        {bubbles: true}
+      );
       return;
     }
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -165,6 +165,7 @@ export const Action = {
   TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_BOOKEND: 'toggleBookend',
+  TOGGLE_CAN_SHOW_BOOKEND: 'toggleCanShowBookend',
   TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
   TOGGLE_INTERACTIVE_COMPONENT: 'toggleInteractiveComponent',
@@ -249,6 +250,10 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.BOOKEND_STATE]: !!data,
         [StateProperty.PAUSED_STATE]: !!data,
+      }));
+    case Action.TOGGLE_CAN_SHOW_BOOKEND:
+      return /** @type {!State} */ (Object.assign({}, state, {
+        [StateProperty.CAN_SHOW_BOOKEND]: !!data,
       }));
     case Action.TOGGLE_INTERACTIVE_COMPONENT:
       data = /** @type {InteractiveComponentDef} */ (data);

--- a/extensions/amp-story/1.0/events.js
+++ b/extensions/amp-story/1.0/events.js
@@ -43,8 +43,11 @@ export const EventType = {
   // warnings or errors).
   DEV_LOG_ENTRIES_AVAILABLE: 'ampstory:devlogentriesavailable',
 
-  // Triggered when user clicks on left 25% of the first page
-  SHOW_NO_PREVIOUS_PAGE_HELP: 'ampstory:shownopreviouspagehelp',
+  // Triggered when user clicks on end 75% of the last page
+  NO_NEXT_PAGE: 'ampstory:nonextpage',
+
+  // Triggered when user clicks on start 25% of the first page
+  NO_PREVIOUS_PAGE: 'ampstory:nopreviouspage',
 
   // Triggered when a story has loaded at least its initial set of pages.
   STORY_LOADED: 'ampstory:load',


### PR DESCRIPTION
The Story runtime decides to either show the bookend, or send a message to the viewer depending the the `#cap=swipe` attribute.
When displayed in the context of a viewer that has multiple documents, the story runtime doesn't show the bookend but asks the viewer to navigate to the next story.

This PR enables messaging to tap to a next or previous story and browse a feed of stories from a viewer.

- Renames `SHOW_NO_PREVIOUS_PAGE_HELP` event into `NO_PREVIOUS_PAGE`
- Introduces a new `NO_NEXT_PAGE` event. We should eventually move away from these events but it'd be a pretty large refactoring, and we were happy with their performance last time we checked.
- Sends a message to the viewer when tapping back on the first page, or next on the last page, if in a viewer with multiple stories
- Triggers the bookend on auto-advance on the last page, if not in a viewer with multiple stories

Fixes #22661, #15601