### PR TITLE
amp-ad doubleclick SRA - combine common key/values into single parameter

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -536,6 +536,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       psz = `${parentWidth}x-1`;
       msz = `${slotWidth}x-1`;
     }
+    if (!this.useSra) {
+      console.log(
+        'targeting',
+        serializeTargeting(
+          (this.jsonTargeting && this.jsonTargeting['targeting']) || null,
+          (this.jsonTargeting && this.jsonTargeting['categoryExclusions']) ||
+            null,
+          null
+        )
+      );
+    }
     return Object.assign(
       {
         'iu': this.element.getAttribute('data-slot'),
@@ -559,7 +570,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         'scp': serializeTargeting(
           (this.jsonTargeting && this.jsonTargeting['targeting']) || null,
           (this.jsonTargeting && this.jsonTargeting['categoryExclusions']) ||
-            null
+            null,
+          null
         ),
         'spsa': this.isSinglePageStoryAd
           ? `${pageLayoutBox.width}x${pageLayoutBox.height}`

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -536,17 +536,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       psz = `${parentWidth}x-1`;
       msz = `${slotWidth}x-1`;
     }
-    if (!this.useSra) {
-      console.log(
-        'targeting',
-        serializeTargeting(
-          (this.jsonTargeting && this.jsonTargeting['targeting']) || null,
-          (this.jsonTargeting && this.jsonTargeting['categoryExclusions']) ||
-            null,
-          null
-        )
-      );
-    }
     return Object.assign(
       {
         'iu': this.element.getAttribute('data-slot'),

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -439,6 +439,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should handle cancellation', () => {
+      expectAsyncConsoleError(/cancellation/i, 1);
       sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -208,6 +208,24 @@ describes.realWin('Doubleclick SRA', config, env => {
         'prev_scp': '|a=1&b=2|c=1&d=l%3Dd&excl_cat=a,b|',
       });
     });
+    it('should move common targeting into csp parameter', () => {
+      impls[0] = {jsonTargeting: {targeting: {a: 1, b: 2, c: 3, d: 4, e: 5}}};
+      impls[1] = {jsonTargeting: {targeting: {a: 1, b: 2, c: 3, d: 4}}};
+      impls[2] = {jsonTargeting: {targeting: {a: 2, b: 2, c: 4, d: 4}}};
+      impls[3] = {jsonTargeting: {targeting: {b: 2, d: 4}}};
+      expect(getTargetingAndExclusions(impls)).to.jsonEqual({
+        'csp': 'b=2&d=4',
+        'prev_scp': 'a=1&c=3&e=5|a=1&c=3|a=2&c=4|',
+      });
+    });
+    it('should not use csp parameter if slot has no targeting', () => {
+      impls[0] = {jsonTargeting: {targeting: {a: 1, b: 2}}};
+      impls[1] = {jsonTargeting: {}};
+      impls[2] = {jsonTargeting: {targeting: {a: 1, b: 2}}};
+      expect(getTargetingAndExclusions(impls)).to.jsonEqual({
+        'prev_scp': 'a=1&b=2||a=1&b=2',
+      });
+    });
     it('should determine experiment ids', () => {
       expect(getExperimentIds(impls)).to.be.null;
       impls[0] = {


### PR DESCRIPTION
For doubleclick SRA requests, combine key/values shared by all slots in the request into single parameter (csp) instead of duplicating causing url length increase.