### PR TITLE
Cleanup `amp-autocomplete` experiment.

### DIFF
--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -38,11 +38,6 @@
       text-decoration: underline;
     }
   </style>
-  <script>
-      (self.AMP=self.AMP||[]).push((AMP) => {
-        AMP.toggleExperiment('amp-autocomplete', true);
-      });
-  </script>
 </head>
 <body>
     <h1>Autocomplete</h1>

--- a/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
+++ b/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
@@ -14,11 +14,6 @@
         font: 8pt 'Courier New', Courier, monospace;
       }
   </style>
-  <script>
-      (self.AMP=self.AMP||[]).push((AMP) => {
-        AMP.toggleExperiment('amp-autocomplete', true);
-      });
-  </script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -30,12 +30,10 @@ import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {hasOwn, map, ownProperty} from '../../../src/utils/object';
 import {includes, startsWith} from '../../../src/string';
 import {isEnumValue} from '../../../src/types';
-import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {toggle} from '../../../src/style';
 import fuzzysearch from '../../../third_party/fuzzysearch/index';
 
-const EXPERIMENT = 'amp-autocomplete';
 const TAG = 'amp-autocomplete';
 
 /**
@@ -168,11 +166,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    userAssert(
-      isExperimentOn(this.win, 'amp-autocomplete'),
-      `Experiment ${EXPERIMENT} is not turned on.`
-    );
-
     this.action_ = Services.actionServiceForDoc(this.element);
     this.viewport_ = Services.viewportForDoc(this.element);
 

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-autocomplete';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(
   'amp-autocomplete init',
@@ -30,7 +29,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      toggleExperiment(win, 'amp-autocomplete', true);
     });
 
     function setupAutocomplete(
@@ -83,7 +81,7 @@ describes.realWin(
       return ampAutocomplete.build().then(() => ampAutocomplete);
     }
 
-    it('should layout with experiment on', () => {
+    it('should layout', () => {
       let impl, filterAndRenderSpy, clearAllSpy, filterSpy, renderSpy;
       return getAutocomplete({
         'filter': 'substring',
@@ -110,7 +108,7 @@ describes.realWin(
         });
     });
 
-    it('should render with experiment on', () => {
+    it('should render', () => {
       let impl, filterAndRenderSpy, clearAllSpy, filterSpy, renderSpy;
       return getAutocomplete({
         'filter': 'substring',
@@ -171,15 +169,6 @@ describes.realWin(
         'max-entries': '10',
       }).then(ampAutocomplete => {
         expect(ampAutocomplete.implementation_.maxEntries_).to.equal(10);
-      });
-    });
-
-    it('should not render with experiment off', () => {
-      toggleExperiment(win, 'amp-autocomplete', false);
-      return allowConsoleError(() => {
-        return expect(getAutocomplete({})).to.be.rejectedWith(
-          'Experiment amp-autocomplete is not turned on.'
-        );
       });
     });
 

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -16,7 +16,6 @@
 
 import '../amp-autocomplete';
 import {Keys} from '../../../../src/utils/key-codes';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(
   'amp-autocomplete unit tests',
@@ -31,7 +30,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      toggleExperiment(win, 'amp-autocomplete', true);
 
       const form = doc.createElement('form');
       const ampAutocomplete = doc.createElement('amp-autocomplete');

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -69,7 +69,7 @@ Example:
 
 <table>
   <tr>
-    <td width="40%"><strong>filter [required]</strong></td>
+    <td width="40%"><strong>filter (required)</strong></td>
     <td>The filtering mechanism applied to source data to produce filtered results for user input. In all cases the filtered results will be displayed in array order of data retrieved. If filtering is being done (<code>filter != none</code>), it is done client side. The following are supported values:
     <ul>
       <li><strong>substring</strong>: if the user input is a substring of an item, then the item is suggested</li>
@@ -81,40 +81,48 @@ Example:
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>filter-expr [optional]</strong></td>
+    <td width="40%"><strong>src (optional)</strong></td>
+    <td>The URL of the remote endpoint that returns the JSON that will be filtered and rendered within this <code>amp-autocomplete</code>. This must be a CORS HTTP service and the URL's protocol must be HTTPS. The endpoint must implement the requirements specified in the <a href="https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests?referrer=ampproject.org">CORS Requests in AMP</a> spec.
+
+    The src attribute may be omitted if the <code>[src]</code> attribute exists.
+
+    If fetching the data at the src URL fails, the <amp-autocomplete> triggers a fallback.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>filter-expr (optional)</strong></td>
     <td>Required if <code>filter==custom</code></td>
   </tr>
   <tr>
-    <td width="40%"><strong>filter-value [optional]</strong></td>
+    <td width="40%"><strong>filter-value (optional)</strong></td>
     <td>If data is an array of JsonObjects, the filter-value is the property name that will be accessed for client side filtering. This attribute is unnecessary if filter is none. Defaults to "value".</td>
   </tr>
   <tr>
-    <td width="40%"><strong>min-characters [optional]</strong></td>
+    <td width="40%"><strong>min-characters (optional)</strong></td>
     <td>
       The min character length of a user input to provide results, default 1
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>max-entries [optional]</strong></td>
+    <td width="40%"><strong>max-entries (optional)</strong></td>
     <td>
       The max specified number of items to suggest at once based on a user input, displays all if unspecified
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>suggest-first [optional]</strong></td>
+    <td width="40%"><strong>suggest-first (optional)</strong></td>
     <td>
       Suggest the first entry in the list of results by marking it active; only possible if <code>filter==prefix</code> (does nothing otherwise)
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>submit-on-enter [optional]</strong></td>
+    <td width="40%"><strong>submit-on-enter (optional)</strong></td>
     <td>
       The enter key is primarily used for selecting suggestions in autocomplete, so it shouldn’t also submit the form unless the developer explicitly sets it to do so (for search fields/one field forms, et cetera).
       The user flow is as follows: If <code>submit-on-enter</code> is <code>true</code>, pressing <code>Enter</code> will select any currently active item and engage in default behavior, including submitting the form if applicable. If <code>submit-on-enter</code> is <code>false</code>, pressing <code>Enter</code> <em>while suggestions are displaying</em> will select any currently active item only and prevent any other default behavior. If suggestions are not displaying, autocomplete allows default behavior. <strong>Defaults to false.</strong>
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>highlight-user-entry [optional]</strong></td>
+    <td width="40%"><strong>highlight-user-entry (optional)</strong></td>
     <td>If present, exposes the <code>autocomplete-partial</code> class on the substring within the suggested item that resulted in its match with the user input. This can be used to stylize the corresponding match to stand out to the user. <strong>Defaults to false.</strong>
     </td>
   </tr>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -33,7 +33,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-     <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+     <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -33,7 +33,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-     <td>Stable</td>
+     <td>Launched</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -4,7 +4,6 @@ formats:
  - websites
 teaser:
   text: Suggests completed results corresponding to the user input as they type into the input field.
-experimental: true
 ---
 <!--
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.
@@ -23,8 +22,6 @@ limitations under the License.
 -->
 
 # `amp-autocomplete`
-
-**This feature is experimental and activated by the `amp-autocomplete` experiment.**
 
 <table>
   <tr>

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -404,14 +404,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/20517',
   },
   {
-    id: 'amp-autocomplete',
-    name:
-      'AMP Autocomplete provides a set of suggestions to' +
-      ' complete a user query in an input field.',
-    spec: 'https://github.com/ampproject/amphtml/issues/9785',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/21021',
-  },
-  {
     id: 'inabox-viewport-friendly',
     name:
       'Inabox viewport measures the host window directly if ' +


### PR DESCRIPTION
Resolves #21021

- Remove experiment tags from `amp-autocomplete` component, tests, and examples
- Update availability and associated documentation
- Removes `amp-autocomplete` from `experiments.js`