### PR TITLE
Linker: change default behavior to decorate all subdomains (if can be found)

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -22,9 +22,9 @@ import {addMissingParamsToUrl, addParamToUrl} from '../../../src/url';
 import {createElementWithAttributes} from '../../../src/dom';
 import {createLinker} from './linker';
 import {dict} from '../../../src/utils/object';
+import {getHighestAvailableDomain} from '../../../src/cookies';
 import {isObject} from '../../../src/types';
 import {user} from '../../../src/log';
-import {getHighestAvailableDomain} from '../../../src/cookies';
 
 /** @const {string} */
 const TAG = 'amp-analytics/linker-manager';
@@ -88,8 +88,7 @@ export class LinkerManager {
       return;
     }
 
-    this.highestAvailableDomain_ =
-        getHighestAvailableDomain(this.ampdoc_.win);
+    this.highestAvailableDomain_ = getHighestAvailableDomain(this.ampdoc_.win);
 
     this.config_ = this.processConfig_(
       /** @type {!JsonObject} */ (this.config_)
@@ -325,26 +324,30 @@ export class LinkerManager {
 
     const {sourceUrl, canonicalUrl} = Services.documentInfoForDoc(this.ampdoc_);
     const canonicalOrigin = this.urlService_.parse(canonicalUrl).hostname;
-    const isFriendlyCanonicalOrigin =
-        areFriendlyDomains(canonicalOrigin, hostname);
+    const isFriendlyCanonicalOrigin = areFriendlyDomains(
+      canonicalOrigin,
+      hostname
+    );
     // Default to all subdomains matching (if there's one) plus canonicalOrigin
 
     if (this.highestAvailableDomain_) {
-      const wildCardMatching = '*.' + this.highestAvailableDomain_;
       const destinationDomain = [
         this.highestAvailableDomain_,
         '*' + this.highestAvailableDomain_,
       ];
-      return this.destinationDomainsMatch_(destinationDomain, hostname) ||
-          isFriendlyCanonicalOrigin;
+      return (
+        this.destinationDomainsMatch_(destinationDomain, hostname) ||
+        isFriendlyCanonicalOrigin
+      );
     }
 
     // In the case where highestAvailableDomain cannot be found.
     // (proxyOrigin, no <meta name='amp-cookie-scope'> found)
     // default to friendly domain matching.
     const sourceOrigin = this.urlService_.parse(sourceUrl).hostname;
-    return areFriendlyDomains(sourceOrigin, hostname) ||
-        isFriendlyCanonicalOrigin
+    return (
+      areFriendlyDomains(sourceOrigin, hostname) || isFriendlyCanonicalOrigin
+    );
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -24,6 +24,7 @@ import {createLinker} from './linker';
 import {dict} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';
 import {user} from '../../../src/log';
+import {getHighestAvailableDomain} from '../../../src/cookies';
 
 /** @const {string} */
 const TAG = 'amp-analytics/linker-manager';
@@ -71,6 +72,9 @@ export class LinkerManager {
 
     /** @const @private {!./variables.VariableService} */
     this.variableService_ = variableServiceForDoc(this.ampdoc_);
+
+    /** @private {?string} */
+    this.highestAvailableDomain_ = null;
   }
 
   /**
@@ -83,6 +87,9 @@ export class LinkerManager {
     if (!isObject(this.config_)) {
       return;
     }
+
+    this.highestAvailableDomain_ =
+        getHighestAvailableDomain(this.ampdoc_.win);
 
     this.config_ = this.processConfig_(
       /** @type {!JsonObject} */ (this.config_)
@@ -302,23 +309,13 @@ export class LinkerManager {
       return false;
     }
 
-    // If domains are given we check for exact match or wildcard match.
+    // If destinationDomain is specified specifically, respect it.
     if (domains) {
-      for (let i = 0; i < domains.length; i++) {
-        const domain = domains[i];
-        // Exact match.
-        if (domain === hostname) {
-          return true;
-        }
-        // Allow wildcard subdomain matching.
-        if (domain.indexOf('*') !== -1 && isWildCardMatch(hostname, domain)) {
-          return true;
-        }
-      }
-      return false;
+      return this.destinationDomainsMatch_(domains, hostname);
     }
 
-    // If no domains given, default to friendly domain matching.
+    // Fallback to default behavior
+
     // Don't append linker for exact domain match, relative urls, or
     // fragments.
     const winHostname = WindowInterface.getHostname(this.ampdoc_.win);
@@ -327,12 +324,48 @@ export class LinkerManager {
     }
 
     const {sourceUrl, canonicalUrl} = Services.documentInfoForDoc(this.ampdoc_);
-    const sourceOrigin = this.urlService_.parse(sourceUrl).hostname;
     const canonicalOrigin = this.urlService_.parse(canonicalUrl).hostname;
-    return (
-      areFriendlyDomains(sourceOrigin, hostname) ||
-      areFriendlyDomains(canonicalOrigin, hostname)
-    );
+    const isFriendlyCanonicalOrigin =
+        areFriendlyDomains(canonicalOrigin, hostname);
+    // Default to all subdomains matching (if there's one) plus canonicalOrigin
+
+    if (this.highestAvailableDomain_) {
+      const wildCardMatching = '*.' + this.highestAvailableDomain_;
+      const destinationDomain = [
+        this.highestAvailableDomain_,
+        '*' + this.highestAvailableDomain_,
+      ];
+      return this.destinationDomainsMatch_(destinationDomain, hostname) ||
+          isFriendlyCanonicalOrigin;
+    }
+
+    // In the case where highestAvailableDomain cannot be found.
+    // (proxyOrigin, no <meta name='amp-cookie-scope'> found)
+    // default to friendly domain matching.
+    const sourceOrigin = this.urlService_.parse(sourceUrl).hostname;
+    return areFriendlyDomains(sourceOrigin, hostname) ||
+        isFriendlyCanonicalOrigin
+  }
+
+  /**
+   * Helper method to find out if hostname match the destinationDomain array.
+   * @param {Array<string>} domains
+   * @param {string} hostname
+   * @return {boolean}
+   */
+  destinationDomainsMatch_(domains, hostname) {
+    for (let i = 0; i < domains.length; i++) {
+      const domain = domains[i];
+      // Exact match.
+      if (domain === hostname) {
+        return true;
+      }
+      // Allow wildcard subdomain matching.
+      if (domain.indexOf('*') !== -1 && isWildCardMatch(hostname, domain)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -28,6 +28,7 @@ import {
 import {installVariableServiceForTesting} from '../variables';
 import {mockWindowInterface} from '../../../../testing/test-helper';
 import {toggleExperiment} from '../../../../src/experiments';
+import * as Cookies from '../../../../src/cookies';
 
 describes.realWin('Linker Manager', {amp: true}, env => {
   let sandbox;
@@ -275,165 +276,201 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
   });
 
-  it('should respect destinationDomains config', () => {
-    const config = {
-      linkers: {
-        enabled: true,
-        testLinker1: {
-          ids: {
-            id: '111',
+  describe('destination domains match', () => {
+    it('should respect destinationDomains config', () => {
+
+      const config = {
+        linkers: {
+          enabled: true,
+          testLinker1: {
+            ids: {
+              id: '111',
+            },
+          },
+          testLinker2: {
+            ids: {
+              id: '222',
+            },
+            destinationDomains: ['foo.com', 'bar.com'],
           },
         },
-        testLinker2: {
-          ids: {
-            id: '222',
+      };
+
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        // testLinker1 should apply to both canonical and source
+        // testLinker2 should not
+        const canonicalDomainUrl = clickAnchor('https://www.canonical.com/path');
+        expect(canonicalDomainUrl).to.contain('testLinker1=');
+        expect(canonicalDomainUrl).to.not.contain('testLinker2=');
+
+        const sourceDomainUrl = clickAnchor('https://www.source.com/path');
+        expect(sourceDomainUrl).to.contain('testLinker1=');
+        expect(sourceDomainUrl).to.not.contain('testLinker2=');
+
+        // testLinker2 should apply to both foo and bar
+        // testLinker1 should not
+        const fooUrl = clickAnchor('https://foo.com/path');
+        expect(fooUrl).to.not.contain('testLinker1=');
+        expect(fooUrl).to.contain('testLinker2=');
+
+        const barDomainUrl = clickAnchor('https://bar.com/path');
+        expect(barDomainUrl).to.not.contain('testLinker1=');
+        expect(barDomainUrl).to.contain('testLinker2=');
+      });
+    });
+
+    it('should respect default destinationDomains config', () => {
+      const config = {
+        linkers: {
+          enabled: true,
+          destinationDomains: ['foo.com'],
+          testLinker1: {
+            ids: {
+              id: '111',
+            },
           },
-          destinationDomains: ['foo.com', 'bar.com'],
+          testLinker2: {
+            ids: {
+              id: '222',
+            },
+            destinationDomains: ['bar.com'],
+          },
         },
-      },
-    };
+      };
 
-    const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
-    return lm.init().then(() => {
-      // testLinker1 should apply to both canonical and source
-      // testLinker2 should not
-      const canonicalDomainUrl = clickAnchor('https://www.canonical.com/path');
-      expect(canonicalDomainUrl).to.contain('testLinker1=');
-      expect(canonicalDomainUrl).to.not.contain('testLinker2=');
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        const fooDomainUrl = clickAnchor('https://foo.com/path');
+        const barDomainUrl = clickAnchor('https://bar.com/path');
 
-      const sourceDomainUrl = clickAnchor('https://www.source.com/path');
-      expect(sourceDomainUrl).to.contain('testLinker1=');
-      expect(sourceDomainUrl).to.not.contain('testLinker2=');
+        expect(fooDomainUrl).to.contain('testLinker1=');
+        expect(fooDomainUrl).to.not.contain('testLinker2=');
+        expect(barDomainUrl).to.contain('testLinker2=');
+        expect(barDomainUrl).to.not.contain('testLinker1=');
+      });
+    });
 
-      // testLinker2 should apply to both foo and bar
-      // testLinker1 should not
-      const fooUrl = clickAnchor('https://foo.com/path');
-      expect(fooUrl).to.not.contain('testLinker1=');
-      expect(fooUrl).to.contain('testLinker2=');
+    it('should accept wildcard domains', () => {
+      const config = {
+        linkers: {
+          enabled: true,
+          destinationDomains: ['*.foo.com'],
+          testLinker1: {
+            ids: {
+              id: '111',
+            },
+          },
+          testLinker2: {
+            ids: {
+              id: '222',
+            },
+            destinationDomains: ['*.bar.com*'],
+          },
+          testLinker3: {
+            ids: {
+              id: '333',
+            },
+            destinationDomains: ['*.baz.co*'],
+          },
+        },
+      };
 
-      const barDomainUrl = clickAnchor('https://bar.com/path');
-      expect(barDomainUrl).to.not.contain('testLinker1=');
-      expect(barDomainUrl).to.contain('testLinker2=');
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        const subdomain = clickAnchor('https://amp.foo.com/path');
+        expect(subdomain).to.contain('testLinker1=');
+        expect(subdomain).to.not.contain('testLinker2=');
+        expect(subdomain).to.not.contain('testLinker3=');
+
+        const noDot = clickAnchor('https://foo.com/path');
+        expect(noDot).to.not.contain('testLinker1=');
+        expect(noDot).to.not.contain('testLinker2=');
+        expect(noDot).to.not.contain('testLinker3=');
+
+        const thirdLevel = clickAnchor('https://a.b.foo.com/path');
+        expect(thirdLevel).to.contain('testLinker1=');
+        expect(thirdLevel).to.not.contain('testLinker2=');
+        expect(thirdLevel).to.not.contain('testLinker3=');
+
+        const multiTLDDomainEnabled = clickAnchor('https://foo.bar.com.uk/path');
+        expect(multiTLDDomainEnabled).to.contain('testLinker2=');
+        expect(multiTLDDomainEnabled).to.not.contain('testLinker1=');
+        expect(multiTLDDomainEnabled).to.not.contain('testLinker3=');
+
+        const multiTLDDomainDisabled = clickAnchor('https://amp.foo.com.uk/path');
+        expect(multiTLDDomainDisabled).to.not.contain('testLinker1=');
+        expect(multiTLDDomainDisabled).to.not.contain('testLinker2=');
+        expect(multiTLDDomainDisabled).to.not.contain('testLinker3=');
+
+        const co = clickAnchor('https://www.baz.com/path');
+        expect(co).to.contain('testLinker3=');
+        expect(co).not.to.contain('testLinker1=');
+        expect(co).not.to.contain('testLinker2=');
+      });
+    });
+
+    it('should match all subdomain and w/o destinationDomains', () => {
+      sandbox.stub(Cookies, 'getHighestAvailableDomain').returns('test.com');
+      const config = {
+        linkers: {
+          enabled: true,
+          testLinker1: {
+            ids: {
+              id: '111',
+            },
+          },
+        },
+      };
+
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        const url1 = clickAnchor('https://www.source.com/path');
+        const url2 = clickAnchor('https://foo.test.com');
+        const url3 = clickAnchor('https://test.com');
+        const url4 = clickAnchor('https://canonical.com/path');
+        const url5 = clickAnchor('https://amp.www.canonical.com/path');
+        const url6 = clickAnchor('https://amp.google.com/path');
+
+        expect(url1).to.not.contain('testLinker1=');
+        expect(url2).to.contain('testLinker1=');
+        expect(url3).to.contain('testLinker1=');
+        expect(url4).to.contain('testLinker1=');
+        expect(url5).to.contain('testLinker1=');
+        expect(url6).to.not.contain('testLinker1=');
+      });
+    });
+
+    it('should match friendly domain as fallback', () => {
+      sandbox.stub(Cookies, 'getHighestAvailableDomain').returns(null);
+      const config = {
+        linkers: {
+          enabled: true,
+          testLinker1: {
+            ids: {
+              id: '111',
+            },
+          },
+        },
+      };
+
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        const url1 = clickAnchor('https://www.source.com/path');
+        const url2 = clickAnchor('https://amp.www.source.com/path');
+        const url3 = clickAnchor('https://canonical.com/path');
+        const url4 = clickAnchor('https://amp.www.canonical.com/path');
+        const url5 = clickAnchor('https://amp.google.com/path');
+
+        expect(url1).to.contain('testLinker1=');
+        expect(url2).to.contain('testLinker1=');
+        expect(url3).to.contain('testLinker1=');
+        expect(url4).to.contain('testLinker1=');
+        expect(url5).to.not.contain('testLinker1=');
+      });
     });
   });
 
-  it('should respect default destinationDomains config', () => {
-    const config = {
-      linkers: {
-        enabled: true,
-        destinationDomains: ['foo.com'],
-        testLinker1: {
-          ids: {
-            id: '111',
-          },
-        },
-        testLinker2: {
-          ids: {
-            id: '222',
-          },
-          destinationDomains: ['bar.com'],
-        },
-      },
-    };
-
-    const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
-    return lm.init().then(() => {
-      const fooDomainUrl = clickAnchor('https://foo.com/path');
-      const barDomainUrl = clickAnchor('https://bar.com/path');
-
-      expect(fooDomainUrl).to.contain('testLinker1=');
-      expect(fooDomainUrl).to.not.contain('testLinker2=');
-      expect(barDomainUrl).to.contain('testLinker2=');
-      expect(barDomainUrl).to.not.contain('testLinker1=');
-    });
-  });
-
-  it('should accept wildcard domains', () => {
-    const config = {
-      linkers: {
-        enabled: true,
-        destinationDomains: ['*.foo.com'],
-        testLinker1: {
-          ids: {
-            id: '111',
-          },
-        },
-        testLinker2: {
-          ids: {
-            id: '222',
-          },
-          destinationDomains: ['*.bar.com*'],
-        },
-        testLinker3: {
-          ids: {
-            id: '333',
-          },
-          destinationDomains: ['*.baz.co*'],
-        },
-      },
-    };
-
-    const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
-    return lm.init().then(() => {
-      const subdomain = clickAnchor('https://amp.foo.com/path');
-      expect(subdomain).to.contain('testLinker1=');
-      expect(subdomain).to.not.contain('testLinker2=');
-      expect(subdomain).to.not.contain('testLinker3=');
-
-      const noDot = clickAnchor('https://foo.com/path');
-      expect(noDot).to.not.contain('testLinker1=');
-      expect(noDot).to.not.contain('testLinker2=');
-      expect(noDot).to.not.contain('testLinker3=');
-
-      const thirdLevel = clickAnchor('https://a.b.foo.com/path');
-      expect(thirdLevel).to.contain('testLinker1=');
-      expect(thirdLevel).to.not.contain('testLinker2=');
-      expect(thirdLevel).to.not.contain('testLinker3=');
-
-      const multiTLDDomainEnabled = clickAnchor('https://foo.bar.com.uk/path');
-      expect(multiTLDDomainEnabled).to.contain('testLinker2=');
-      expect(multiTLDDomainEnabled).to.not.contain('testLinker1=');
-      expect(multiTLDDomainEnabled).to.not.contain('testLinker3=');
-
-      const multiTLDDomainDisabled = clickAnchor('https://amp.foo.com.uk/path');
-      expect(multiTLDDomainDisabled).to.not.contain('testLinker1=');
-      expect(multiTLDDomainDisabled).to.not.contain('testLinker2=');
-      expect(multiTLDDomainDisabled).to.not.contain('testLinker3=');
-
-      const co = clickAnchor('https://www.baz.com/path');
-      expect(co).to.contain('testLinker3=');
-      expect(co).not.to.contain('testLinker1=');
-      expect(co).not.to.contain('testLinker2=');
-    });
-  });
-
-  it('should match friendly domain if destinationDomains unspecified', () => {
-    const config = {
-      linkers: {
-        enabled: true,
-        testLinker1: {
-          ids: {
-            id: '111',
-          },
-        },
-      },
-    };
-
-    const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
-    return lm.init().then(() => {
-      const url1 = clickAnchor('https://www.source.com/path');
-      const url2 = clickAnchor('https://amp.www.source.com/path');
-      const url3 = clickAnchor('https://canonical.com/path');
-      const url4 = clickAnchor('https://amp.www.canonical.com/path');
-      const url5 = clickAnchor('https://amp.google.com/path');
-
-      expect(url1).to.contain('testLinker1=');
-      expect(url2).to.contain('testLinker1=');
-      expect(url3).to.contain('testLinker1=');
-      expect(url4).to.contain('testLinker1=');
-      expect(url5).to.not.contain('testLinker1=');
-    });
-  });
 
   it('should respect proxyOnly config', () => {
     windowInterface.getLocation.returns({

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Cookies from '../../../../src/cookies';
 import {
   LinkerManager,
   areFriendlyDomains,
@@ -28,7 +29,6 @@ import {
 import {installVariableServiceForTesting} from '../variables';
 import {mockWindowInterface} from '../../../../testing/test-helper';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as Cookies from '../../../../src/cookies';
 
 describes.realWin('Linker Manager', {amp: true}, env => {
   let sandbox;
@@ -278,7 +278,6 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   describe('destination domains match', () => {
     it('should respect destinationDomains config', () => {
-
       const config = {
         linkers: {
           enabled: true,
@@ -300,7 +299,9 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return lm.init().then(() => {
         // testLinker1 should apply to both canonical and source
         // testLinker2 should not
-        const canonicalDomainUrl = clickAnchor('https://www.canonical.com/path');
+        const canonicalDomainUrl = clickAnchor(
+          'https://www.canonical.com/path'
+        );
         expect(canonicalDomainUrl).to.contain('testLinker1=');
         expect(canonicalDomainUrl).to.not.contain('testLinker2=');
 
@@ -393,12 +394,16 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         expect(thirdLevel).to.not.contain('testLinker2=');
         expect(thirdLevel).to.not.contain('testLinker3=');
 
-        const multiTLDDomainEnabled = clickAnchor('https://foo.bar.com.uk/path');
+        const multiTLDDomainEnabled = clickAnchor(
+          'https://foo.bar.com.uk/path'
+        );
         expect(multiTLDDomainEnabled).to.contain('testLinker2=');
         expect(multiTLDDomainEnabled).to.not.contain('testLinker1=');
         expect(multiTLDDomainEnabled).to.not.contain('testLinker3=');
 
-        const multiTLDDomainDisabled = clickAnchor('https://amp.foo.com.uk/path');
+        const multiTLDDomainDisabled = clickAnchor(
+          'https://amp.foo.com.uk/path'
+        );
         expect(multiTLDDomainDisabled).to.not.contain('testLinker1=');
         expect(multiTLDDomainDisabled).to.not.contain('testLinker2=');
         expect(multiTLDDomainDisabled).to.not.contain('testLinker3=');
@@ -470,7 +475,6 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       });
     });
   });
-
 
   it('should respect proxyOnly config', () => {
     windowInterface.getLocation.returns({


### PR DESCRIPTION
Order:
1. respect `destinationDomains`
2. if `destinationDomains` can't be found. etld+1 can be found: Decorate all subdomain + friendly domain to canonical url
3. if `destinationDomains` can't be found. etld+1 can't be found (proxy origin w/o meta tag): Decorate all friendly domains (canonical + source)
