### PR TITLE
Use css.js for autoplay styles

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -53,7 +53,7 @@ const cssEntryPoints = [
   {
     path: 'video-autoplay.css',
     outJs: 'video-autoplay.css.js',
-    outCss: 'video-autoplay.css',
+    outCss: 'video-autoplay-out.css',
   },
 ];
 

--- a/src/service/video/install-autoplay-styles.js
+++ b/src/service/video/install-autoplay-styles.js
@@ -16,7 +16,7 @@
 
 import {installStylesForDoc} from '../../style-installer';
 // Source for this constant is css/video-autoplay.css
-import {cssText} from '../../../build/video-autoplay.css.js';
+import {cssText} from '../../../build/video-autoplay.css';
 
 /**
  * @param  {!../ampdoc-impl.AmpDoc} ampdoc

--- a/src/service/video/install-autoplay-styles.js
+++ b/src/service/video/install-autoplay-styles.js
@@ -16,7 +16,7 @@
 
 import {installStylesForDoc} from '../../style-installer';
 // Source for this constant is css/video-autoplay.css
-import {cssText} from '../../../build/video-autoplay.css';
+import {cssText} from '../../../build/video-autoplay.css.js';
 
 /**
  * @param  {!../ampdoc-impl.AmpDoc} ampdoc


### PR DESCRIPTION
A change introduced in PR #22377 was causing errors when I ran `gulp` since it attempts to parse a CSS file as JS. The code no longer produces the error when the `.css.js` file is used instead.

<img width="733" alt="Screen Shot 2019-06-05 at 16 58 29" src="https://user-images.githubusercontent.com/2363700/58990113-39cad280-87b3-11e9-99b1-8dd68d1e29c5.png">
