### PR TITLE
🏗 Create gulp a4a and refactor unit/integration/a4a

### DIFF
--- a/build-system/tasks/a4a.js
+++ b/build-system/tasks/a4a.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'using strict';
+'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
 const testConfig = require('../config');
@@ -27,7 +27,6 @@ const {
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
 const {css} = require('./css');
-const {getUnitTestsToRun} = require('./runtime-test/helpers-unit');
 
 class Config extends RuntimeTestConfig {
   constructor(testType) {
@@ -36,23 +35,7 @@ class Config extends RuntimeTestConfig {
 
   /** @override */
   getFiles() {
-    const files = testConfig.commonUnitTestPaths.concat(
-      testConfig.chaiAsPromised
-    );
-
-    if (argv.files) {
-      return files.concat(argv.files);
-    }
-
-    if (argv.saucelabs) {
-      return files.concat(testConfig.unitTestOnSaucePaths);
-    }
-
-    if (argv.local_changes) {
-      return files.concat(getUnitTestsToRun(testConfig.unitTestPaths));
-    }
-
-    return files.concat(testConfig.unitTestPaths);
+    return testConfig.chaiAsPromised.concat(testConfig.a4aTestPaths);
   }
 }
 
@@ -61,7 +44,7 @@ class Runner extends RuntimeTestRunner {
     super(config);
   }
 
-  /** @ override */
+  /** @override */
   async maybeBuild() {
     if (argv.nobuild) {
       return;
@@ -71,18 +54,15 @@ class Runner extends RuntimeTestRunner {
   }
 }
 
-async function unit() {
-  if (
-    shouldNotRun() ||
-    (argv.local_changes && !getUnitTestsToRun(testConfig.unitTestPaths))
-  ) {
+async function a4a() {
+  if (shouldNotRun()) {
     return;
   }
 
   maybePrintArgvMessages();
   refreshKarmaWdCache();
 
-  const config = new Config('unit');
+  const config = new Config('a4a');
   const runner = new Runner(config);
 
   await runner.setup();
@@ -91,26 +71,5 @@ async function unit() {
 }
 
 module.exports = {
-  unit,
-};
-
-unit.description = 'Runs unit tests';
-//TODO(estherkim): fill this out
-unit.flags = {
-  'local_changes': '',
-  'saucelabs': '',
-  'chrome_canary': '',
-  'chrome_flags': '',
-  'coverage': '',
-  'firefox': '',
-  'files': '',
-  'grep': '',
-  'headless': '',
-  'ie': '',
-  'nobuild': '',
-  'nohelp': '',
-  'safari': '',
-  'testnames': '',
-  'verbose': '',
-  'watch': '',
+  a4a,
 };

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -16,162 +16,50 @@
 'using strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const babelify = require('babelify');
-const defaultConfig = require('./karma.conf');
-const log = require('fancy-log');
 const testConfig = require('../config');
 const {
-  createKarmaServer,
-  getAdTypes,
-  getBrowserConfig,
   maybePrintArgvMessages,
-  maybeSetCoverageConfig,
   refreshKarmaWdCache,
-  runTestInBatches,
-  startTestServer,
+  shouldNotRun,
 } = require('./runtime-test/helpers');
+const {
+  RuntimeTestRunner,
+  RuntimeTestConfig,
+} = require('./runtime-test/runtime-test-base');
 const {clean} = require('./clean');
-const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
 const {dist} = require('./dist');
-const {green, yellow, cyan, red} = require('ansi-colors');
-const {isTravisBuild} = require('../travis');
-const {reportTestStarted} = require('./report-test-status');
 
-function shouldNotRun() {
-  if (argv.saucelabs) {
-    if (!process.env.SAUCE_USERNAME) {
-      throw new Error('Missing SAUCE_USERNAME Env variable');
+class Config extends RuntimeTestConfig {
+  constructor(testType) {
+    super(testType);
+  }
+
+  /** @override */
+  getFiles() {
+    const files = testConfig.commonIntegrationTestPaths;
+
+    if (argv.files) {
+      return files.concat(argv.files);
     }
-    if (!process.env.SAUCE_ACCESS_KEY) {
-      throw new Error('Missing SAUCE_ACCESS_KEY Env variable');
+
+    return files.concat(testConfig.integrationTestPaths);
+  }
+}
+
+class Runner extends RuntimeTestRunner {
+  constructor(config) {
+    super(config);
+  }
+
+  /** @override */
+  async maybeBuild() {
+    if (argv.nobuild) {
+      return;
     }
-  }
-
-  return false;
-}
-
-async function maybeBuild() {
-  if (argv.nobuild) {
-    return;
-  }
-  argv.fortesting = true;
-  argv.compiled = true;
-  await clean();
-  await dist();
-}
-
-function setConfigOverrides(config) {
-  config.singleRun = !argv.watch && !argv.w;
-  config.client.mocha.grep = !!argv.grep;
-  config.client.verboseLogging = !!argv.verbose || !!argv.v;
-  config.client.captureConsole = !!argv.verbose || !!argv.v || !!argv.files;
-
-  config.browserify.configure = function(bundle) {
-    bundle.on('prebundle', function() {
-      log(green('Transforming tests with'), cyan('browserify') + green('...'));
-    });
-    bundle.on('transform', function(tr) {
-      if (tr instanceof babelify) {
-        tr.once('babelify', function() {
-          process.stdout.write('.');
-        });
-      }
-    });
-  };
-
-  // c.client is available in test browser via window.parent.karma.config
-  config.client.amp = {
-    useCompiledJs: !!argv.compiled,
-    saucelabs: !!argv.saucelabs,
-    singlePass: !!argv.single_pass,
-    adTypes: getAdTypes(),
-    mochaTimeout: defaultConfig.client.mocha.timeout,
-    propertiesObfuscated: !!argv.single_pass,
-    testServerPort: defaultConfig.client.testServerPort,
-    testOnIe:
-      config.browsers.includes('IE') || config.browsers.includes('SL_IE_11'),
-  };
-}
-
-function getFileConfig() {
-  const files = testConfig.commonIntegrationTestPaths;
-
-  if (argv.files) {
-    return {'files': files.concat(argv.files)};
-  }
-
-  return {'files': files.concat(testConfig.integrationTestPaths)};
-}
-
-function getReporterConfig() {
-  let {reporters} = defaultConfig;
-
-  if ((!isTravisBuild() && argv.testnames) || (argv.files && !argv.saucelabs)) {
-    reporters = ['mocha'];
-  }
-
-  if (argv.coverage) {
-    reporters.push('coverage-istanbul');
-  }
-
-  if (argv.saucelabs) {
-    reporters.push('saucelabs');
-  }
-
-  return {'reporters': reporters};
-}
-
-function getTestConfig() {
-  const browsers = getBrowserConfig();
-  const files = getFileConfig();
-  const reporters = getReporterConfig();
-  const config = Object.assign({}, defaultConfig, browsers, files, reporters);
-
-  maybeSetCoverageConfig(config, 'lcov-integration.info');
-  setConfigOverrides(config);
-
-  return config;
-}
-
-function runIntegrationTests(config) {
-  reportTestStarted();
-
-  if (argv.saucelabs) {
-    return runTestInBatches(config);
-  }
-
-  return createKarmaServer(config);
-}
-
-function setup(config) {
-  // Avoid Karma startup errors
-  refreshKarmaWdCache();
-
-  const testServer = startTestServer(config.client.testServerPort);
-  const handlerProcess = createCtrlcHandler('gulp integration');
-
-  return new Map()
-    .set('handlerProcess', handlerProcess)
-    .set('testServer', testServer);
-}
-
-function teardown(env) {
-  const exitCode = env.get('exitCode');
-
-  // Exit tests
-  // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
-  if (isTravisBuild()) {
-    setTimeout(() => {
-      process.exit(exitCode);
-    }, 5000);
-  }
-
-  env.get('testServer').emit('kill');
-  exitCtrlcHandler(env.get('handlerProcess'));
-
-  if (exitCode != 0) {
-    log(red('ERROR:'), yellow(`Karma test failed with exit code ${exitCode}`));
-    process.exitCode = exitCode;
+    argv.fortesting = true;
+    argv.compiled = true;
+    await clean();
+    await dist();
   }
 }
 
@@ -180,20 +68,15 @@ async function integration() {
     return;
   }
 
-  // TODO(alanorozco): Come up with a more elegant check?
-  global.AMP_TESTING = true;
-  process.env.SERVE_MODE = argv.compiled ? 'compiled' : 'default';
-
-  maybeBuild();
   maybePrintArgvMessages();
+  refreshKarmaWdCache();
 
-  const config = getTestConfig();
-  const env = setup(config);
+  const config = new Config('integration');
+  const runner = new Runner(config);
 
-  const exitCode = await runIntegrationTests(config);
-
-  env.set('exitCode', exitCode);
-  teardown(env);
+  await runner.setup();
+  await runner.run();
+  await runner.teardown();
 }
 
 module.exports = {

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -336,7 +336,7 @@ async function runTestInBatches(config) {
  * @param {!Array{string}} browsers list of SauceLabs browsers as
  *     customLaunchers IDs. *
  * @param {Object} config karma config
- * @param {!Function} runCompleteFn a function to execute on the
+ * @param {function()} runCompleteFn a function to execute on the
  *     `run_complete` event. It should take two arguments, (browser, results),
  *     and return nothing.
  * @return {number} processExitCode
@@ -380,7 +380,7 @@ async function runTestInBatchesWithBrowsers(
 /**
  * Creates and starts karma server
  * @param {!Object} configBatch
- * @param {!Function} runCompleteFn a function to execute on the
+ * @param {function()} runCompleteFn a function to execute on the
  *     `run_complete` event. It should take two arguments, (browser, results),
  *     and return nothing.
  * @return {!Promise<number>}

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -394,7 +394,6 @@ async function createKarmaServer(
     resolver = resolverIn;
   });
 
-  console.log(configBatch.browsers);
   const karmaServer = new Server(configBatch, exitCode => {
     maybePrintCoverageMessage();
     resolver(exitCode);

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -224,10 +224,9 @@ class RuntimeTestRunner {
 
     if (argv.saucelabs) {
       this.exitCode = await runTestInBatches(this.config);
-      return;
+    } else {
+      this.exitCode = await createKarmaServer(this.config);
     }
-
-    this.exitCode = await createKarmaServer(this.config);
   }
 
   async teardown() {

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const babelify = require('babelify');
+const karmaConfig = require('../karma.conf');
+const log = require('fancy-log');
+const {
+  createKarmaServer,
+  getAdTypes,
+  runTestInBatches,
+  startTestServer,
+} = require('./helpers');
+const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
+const {green, yellow, cyan, red} = require('ansi-colors');
+const {isTravisBuild} = require('../../travis');
+const {reportTestStarted} = require('.././report-test-status');
+
+class RuntimeTestConfig {
+  constructor(testType) {
+    this.testType = testType;
+
+    Object.assign(this, karmaConfig);
+    this.singleRun = !argv.watch && !argv.w;
+    this.client.mocha.grep = !!argv.grep;
+    this.client.verboseLogging = !!argv.verbose || !!argv.v;
+    this.client.captureConsole = !!argv.verbose || !!argv.v || !!argv.files;
+    this.browserify.configure = function(bundle) {
+      bundle.on('prebundle', function() {
+        log(
+          green('Transforming tests with'),
+          cyan('browserify') + green('...')
+        );
+      });
+      bundle.on('transform', function(tr) {
+        if (tr instanceof babelify) {
+          tr.once('babelify', function() {
+            process.stdout.write('.');
+          });
+        }
+      });
+    };
+
+    // c.client is available in test browser via window.parent.karma.config
+    this.client.amp = {
+      useCompiledJs: !!argv.compiled,
+      saucelabs: !!argv.saucelabs,
+      singlePass: !!argv.single_pass,
+      adTypes: getAdTypes(),
+      mochaTimeout: this.client.mocha.timeout,
+      propertiesObfuscated: !!argv.single_pass,
+      testServerPort: this.client.testServerPort,
+      testOnIe:
+        this.browsers.includes('IE') || this.browsers.includes('SL_IE_11'),
+    };
+
+    if (argv.coverage && this.testType != 'a4a') {
+      this.plugins.push('karma-coverage-istanbul-reporter');
+      this.coverageIstanbulReporter = {
+        dir: 'test/coverage',
+        reports: isTravisBuild()
+          ? ['lcovonly']
+          : ['html', 'text', 'text-summary'],
+        'report-config': {lcovonly: {file: `lcov-${testType}.info`}},
+      };
+
+      const plugin = [
+        'istanbul',
+        {
+          exclude: [
+            'ads/**/*.js',
+            'third_party/**/*.js',
+            'test/**/*.js',
+            'extensions/**/test/**/*.js',
+            'testing/**/*.js',
+          ],
+        },
+      ];
+
+      this.browserify.transform = [['babelify', {plugins: [plugin]}]];
+    }
+
+    this.browsers = this.getBrowsersObject().browsers;
+    this.files = this.getFiles();
+    this.reporters = this.getReporters();
+  }
+
+  getBrowsersObject() {
+    if (argv.saucelabs) {
+      if (this.testType == 'unit') {
+        return {browsers: ['SL_Safari_12', 'SL_Firefox']};
+      }
+
+      if (this.testType == 'integration') {
+        return {
+          browsers: [
+            'SL_Chrome',
+            'SL_Firefox',
+            'SL_Edge_17',
+            'SL_Safari_12',
+            'SL_IE_11',
+            // TODO(amp-infra): Evaluate and add more platforms here.
+            //'SL_Chrome_Android_7',
+            //'SL_iOS_11',
+            //'SL_iOS_12',
+            'SL_Chrome_Beta',
+            'SL_Firefox_Beta',
+          ],
+        };
+      }
+
+      throw new Error(
+        'The --saucelabs flag is valid only for `gulp unit` and `gulp integration`.'
+      );
+    }
+
+    const chromeFlags = [];
+    if (argv.chrome_flags) {
+      argv.chrome_flags.split(',').forEach(flag => {
+        chromeFlags.push('--'.concat(flag));
+      });
+    }
+
+    const options = new Map();
+    options
+      .set('chrome_canary', {browsers: ['ChromeCanary']})
+      .set('chrome_flags', {
+        browsers: ['Chrome_flags'],
+        customLaunchers: {
+          // eslint-disable-next-line
+          Chrome_flags: {
+            base: 'Chrome',
+            flags: chromeFlags,
+          },
+        },
+      })
+      .set('edge', {browsers: ['Edge']})
+      .set('firefox', {browsers: ['Firefox']})
+      .set('headless', {browsers: ['Chrome_no_extensions_headless']})
+      .set('ie', {
+        browsers: ['IE'],
+        customLaunchers: {
+          IeNoAddOns: {
+            base: 'IE',
+            flags: ['-extoff'],
+          },
+        },
+      })
+      .set('safari', {browsers: ['Safari']});
+
+    for (const key of Array.from(options.keys())) {
+      if (argv[key]) {
+        return options.get(key);
+      }
+    }
+
+    return {browsers: this.browsers};
+  }
+
+  getFiles() {
+    throw new Error('Karma files config must be overridden');
+  }
+
+  getReporters() {
+    let {reporters} = this;
+
+    if (argv.testnames || argv.local_changes || argv.files) {
+      reporters = ['mocha'];
+    }
+
+    if (argv.coverage) {
+      reporters.push('coverage-istanbul');
+    }
+
+    if (argv.saucelabs) {
+      reporters.push('saucelabs');
+    }
+
+    return reporters;
+  }
+}
+
+class RuntimeTestRunner {
+  constructor(config) {
+    this.config = config;
+    this.env = null;
+    this.exitCode = 0;
+  }
+
+  async maybeBuild() {
+    throw new Error('maybeBuild method must be overridden');
+  }
+
+  async setup() {
+    // TODO(alanorozco): Come up with a more elegant check?
+    global.AMP_TESTING = true;
+    process.env.SERVE_MODE = argv.compiled ? 'compiled' : 'default';
+
+    await this.maybeBuild();
+
+    const testServer = startTestServer(this.config.client.testServerPort);
+    const handlerProcess = createCtrlcHandler(`gulp ${this.config.testType}`);
+
+    this.env = new Map()
+      .set('handlerProcess', handlerProcess)
+      .set('testServer', testServer);
+  }
+
+  async run() {
+    reportTestStarted();
+
+    if (argv.saucelabs) {
+      this.exitCode = await runTestInBatches(this.config);
+      return;
+    }
+
+    this.exitCode = await createKarmaServer(this.config);
+  }
+
+  async teardown() {
+    this.env.get('testServer').emit('kill');
+    exitCtrlcHandler(this.env.get('handlerProcess'));
+
+    if (this.exitCode != 0) {
+      log(
+        red('ERROR:'),
+        yellow(`Karma test failed with exit code ${this.exitCode}`)
+      );
+      process.exitCode = this.exitCode;
+    }
+  }
+}
+
+module.exports = {
+  RuntimeTestRunner,
+  RuntimeTestConfig,
+};

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -161,9 +161,9 @@ class RuntimeTestConfig {
       })
       .set('safari', {browsers: ['Safari']});
 
-    for (const key of Array.from(options.keys())) {
-      if (argv[key]) {
-        return options.get(key);
+    for (const [key, value] of options) {
+      if (argv.hasOwnProperty(key)) {
+        return value;
       }
     }
 

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -35,6 +35,9 @@ class RuntimeTestConfig {
     this.testType = testType;
 
     Object.assign(this, karmaConfig);
+    this.browsers = this.getBrowsersObject().browsers;
+    this.files = this.getFiles();
+    this.reporters = this.getReporters();
     this.singleRun = !argv.watch && !argv.w;
     this.client.mocha.grep = !!argv.grep;
     this.client.verboseLogging = !!argv.verbose || !!argv.v;
@@ -93,10 +96,6 @@ class RuntimeTestConfig {
 
       this.browserify.transform = [['babelify', {plugins: [plugin]}]];
     }
-
-    this.browsers = this.getBrowsersObject().browsers;
-    this.files = this.getFiles();
-    this.reporters = this.getReporters();
   }
 
   getBrowsersObject() {

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -61,7 +61,7 @@ class Runner extends RuntimeTestRunner {
     super(config);
   }
 
-  /** @ override */
+  /** @override */
   async maybeBuild() {
     if (argv.nobuild) {
       return;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ const {
 const {
   processGithubIssues,
 } = require('./build-system/tasks/process-github-issues');
+const {a4a} = require('./build-system/tasks/a4a');
 const {ava} = require('./build-system/tasks/ava');
 const {babelPluginTests} = require('./build-system/tasks/babel-plugin-tests');
 const {build, defaultTask, watch} = require('./build-system/tasks/build');
@@ -65,6 +66,7 @@ const {validator, validatorWebui} = require('./build-system/tasks/validator');
 const {visualDiff} = require('./build-system/tasks/visual-diff');
 
 // Keep this list alphabetized.
+gulp.task('a4a', a4a);
 gulp.task('ava', ava);
 gulp.task('babel-plugin-tests', babelPluginTests);
 gulp.task('build', build);


### PR DESCRIPTION
Changes in this PR
- Creates `gulp a4a`
- Moves shared code into new `RuntimeTestRunner` and `RuntimeTestConfig` classes that unit, integration, and a4a tests use

Next steps
1. Documentation
2. Delete `runtime-test/index.js` and announce changes to team

related to masterbug #22507