### PR TITLE
🐛amp-brightcove: Redispatch loadedmetadata event

### DIFF
--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -220,6 +220,7 @@ class AmpBrightcove extends AMP.BaseElement {
         'ended': VideoEvents.ENDED,
         'ads-ad-started': VideoEvents.AD_START,
         'ads-ad-ended': VideoEvents.AD_END,
+        'loadedmetadata': VideoEvents.LOADEDMETADATA,
       })
     ) {
       return;

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -209,6 +209,11 @@ describes.realWin(
             return p;
           })
           .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.LOADEDMETADATA);
+            fakePostMessage(bc, {event: 'loadedmetadata', muted: false, playing: false});
+            return p;
+          })
+          .then(() => {
             const p = listenOncePromise(bc, VideoEvents.AD_START);
             fakePostMessage(bc, {
               event: 'ads-ad-started',

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -210,7 +210,11 @@ describes.realWin(
           })
           .then(() => {
             const p = listenOncePromise(bc, VideoEvents.LOADEDMETADATA);
-            fakePostMessage(bc, {event: 'loadedmetadata', muted: false, playing: false});
+            fakePostMessage(bc, {
+              event: 'loadedmetadata',
+              muted: false,
+              playing: false,
+            });
             return p;
           })
           .then(() => {


### PR DESCRIPTION
Redispatches the loadedmetadata event. This is needed for percentage analytics.
