### PR TITLE
Analytics trigger when opening/closing a tooltip

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -22,7 +22,11 @@ import {
   UIType,
   getStoreService,
 } from './amp-story-store-service';
-import {AdvancementMode} from './story-analytics';
+import {
+  AdvancementMode,
+  StoryEventType,
+  getAnalyticsService,
+} from './story-analytics';
 import {CSS} from '../../../build/amp-story-tooltip-1.0.css';
 import {EventType, dispatch} from './events';
 import {LocalizedStringId} from '../../../src/localized-strings';
@@ -320,6 +324,9 @@ export class AmpStoryEmbeddedComponent {
 
     /** @private {EmbeddedComponentState} */
     this.state_ = EmbeddedComponentState.HIDDEN;
+
+    /** @private {!./story-analytics.StoryAnalyticsService} */
+    this.analyticsService_ = getAnalyticsService(this.win_, this.storyEl_);
   }
 
   /**
@@ -526,6 +533,7 @@ export class AmpStoryEmbeddedComponent {
           this.focusedStateOverlay_.classList.toggle('i-amphtml-hidden', true);
         }
       );
+      this.analyticsService_.triggerEvent(StoryEventType.TOOLTIP_CLOSED);
       return;
     }
 
@@ -562,6 +570,8 @@ export class AmpStoryEmbeddedComponent {
         this.focusedStateOverlay_.classList.toggle('i-amphtml-hidden', false);
       }
     );
+
+    this.analyticsService_.triggerEvent(StoryEventType.TOOLTIP_OPENED);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -65,6 +65,7 @@ export const EXPANDABLE_COMPONENTS = {
     actionIcon: ActionIcon.EXPAND,
     localizedStringId: LocalizedStringId.AMP_STORY_TOOLTIP_EXPAND_TWEET,
     selector: 'amp-twitter',
+    dataIdAttribute: 'data-tweetid',
   },
 };
 
@@ -686,9 +687,16 @@ export class AmpStoryEmbeddedComponent {
     event.preventDefault();
     event.stopPropagation();
 
+    const embedConfig = this.getEmbedConfigFor_(
+      dev().assertElement(
+        this.triggeringTarget_,
+        `No tooltip triggering element found.`
+      )
+    );
+
     this.variableService_.onVariableUpdate(
       AnalyticsVariable.TOOLTIP_TRIGGER,
-      this.triggeringTarget_
+      this.triggeringTarget_.getAttribute(embedConfig.dataIdAttribute)
     );
 
     this.storeService_.dispatch(Action.TOGGLE_INTERACTIVE_COMPONENT, {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -29,7 +29,6 @@ import {
 } from './utils';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
-import {StoryEventType, getAnalyticsService} from './story-analytics';
 import {closest, isAmpElement} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {getState} from '../../../src/history';
@@ -595,10 +594,6 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
 
-<<<<<<< HEAD
     this.analyticsService_.triggerEvent(AnalyticsEvent.PAGE_ATTACHMENT_EXIT);
-=======
-    this.analyticsService_.triggerEvent(StoryEventType.PAGE_ATTACHMENT_EXIT);
->>>>>>> analytics for tooltip
   }
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -29,6 +29,7 @@ import {
 } from './utils';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
+import {StoryEventType, getAnalyticsService} from './story-analytics';
 import {closest, isAmpElement} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {getState} from '../../../src/history';
@@ -594,6 +595,10 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
 
+<<<<<<< HEAD
     this.analyticsService_.triggerEvent(AnalyticsEvent.PAGE_ATTACHMENT_EXIT);
+=======
+    this.analyticsService_.triggerEvent(StoryEventType.PAGE_ATTACHMENT_EXIT);
+>>>>>>> analytics for tooltip
   }
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -54,6 +54,7 @@ import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
 import {AmpStoryPageAttachment} from './amp-story-page-attachment';
 import {AmpStoryRenderService} from './amp-story-render-service';
+import {AnalyticsVariable, getVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
@@ -109,7 +110,6 @@ import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '../../../src/event-helper';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode} from '../../../src/mode';
-import {getVariableService} from './variable-service';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseQueryString} from '../../../src/url';
 import {registerServiceBuilder} from '../../../src/service';
@@ -627,7 +627,10 @@ export class AmpStory extends AMP.BaseElement {
       StateProperty.MUTED_STATE,
       isMuted => {
         this.onMutedStateUpdate_(isMuted);
-        this.variableService_.onMutedStateChange(isMuted);
+        this.variableService_.onVariableUpdate(
+          AnalyticsVariable.STORY_IS_MUTED,
+          isMuted
+        );
       },
       true /** callToInitialize */
     );
@@ -652,7 +655,10 @@ export class AmpStory extends AMP.BaseElement {
     );
 
     this.storeService_.subscribe(StateProperty.ADVANCEMENT_MODE, mode => {
-      this.variableService_.onAdvancementModeStateChange(mode);
+      this.variableService_.onVariableUpdate(
+        AnalyticsVariable.STORY_ADVANCEMENT_MODE,
+        mode
+      );
     });
 
     this.element.addEventListener(EventType.SWITCH_PAGE, e => {

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -28,6 +28,8 @@ export const AnalyticsEvent = {
   PAGE_VISIBLE: 'story-page-visible',
   STORY_MUTED: 'story-audio-muted',
   STORY_UNMUTED: 'story-audio-unmuted',
+  TOOLTIP_CLOSED: 'story-tooltip-closed',
+  TOOLTIP_OPENED: 'story-tooltip-opened',
 };
 
 /** @enum {string} */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -28,8 +28,8 @@ export const AnalyticsEvent = {
   PAGE_VISIBLE: 'story-page-visible',
   STORY_MUTED: 'story-audio-muted',
   STORY_UNMUTED: 'story-audio-unmuted',
-  TOOLTIP_CLOSED: 'story-tooltip-closed',
-  TOOLTIP_OPENED: 'story-tooltip-opened',
+  TOOLTIP_ENTER: 'story-tooltip-enter',
+  TOOLTIP_EXIT: 'story-tooltip-exit',
 };
 
 /** @enum {string} */

--- a/extensions/amp-story/1.0/test/test-variable-service.js
+++ b/extensions/amp-story/1.0/test/test-variable-service.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {AdvancementMode} from '../story-analytics';
-import {AmpStoryVariableService} from '../variable-service';
+import {AmpStoryVariableService, AnalyticsVariable} from '../variable-service';
 import {StateChangeType} from '../navigation-state';
 
 describes.fakeWin('amp-story variable service', {}, () => {
@@ -39,7 +39,8 @@ describes.fakeWin('amp-story variable service', {}, () => {
   });
 
   it('should update storyAdvancementMode on change', () => {
-    variableService.onAdvancementModeStateChange(
+    variableService.onVariableUpdate(
+      AnalyticsVariable.STORY_ADVANCEMENT_MODE,
       AdvancementMode.MANUAL_ADVANCE
     );
 

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -24,7 +24,7 @@ import {registerServiceBuilder} from '../../../src/service';
 export let StoryVariableDef;
 
 /** @enum {string} */
-const Variable = {
+export const AnalyticsVariable = {
   STORY_PAGE_ID: 'storyPageId',
   STORY_PAGE_INDEX: 'storyPageIndex',
   STORY_PAGE_COUNT: 'storyPageCount',
@@ -32,6 +32,7 @@ const Variable = {
   STORY_PROGRESS: 'storyProgress',
   STORY_PREVIOUS_PAGE_ID: 'storyPreviousPageId',
   STORY_ADVANCEMENT_MODE: 'storyAdvancementMode',
+  TOOLTIP_TRIGGER: 'tooltipTrigger',
 };
 
 /**
@@ -63,13 +64,14 @@ export class AmpStoryVariableService {
   constructor() {
     /** @private {!StoryVariableDef} */
     this.variables_ = dict({
-      [Variable.STORY_PAGE_INDEX]: null,
-      [Variable.STORY_PAGE_ID]: null,
-      [Variable.STORY_PAGE_COUNT]: null,
-      [Variable.STORY_PROGRESS]: null,
-      [Variable.STORY_IS_MUTED]: null,
-      [Variable.STORY_PREVIOUS_PAGE_ID]: null,
-      [Variable.STORY_ADVANCEMENT_MODE]: null,
+      [AnalyticsVariable.STORY_PAGE_INDEX]: null,
+      [AnalyticsVariable.STORY_PAGE_ID]: null,
+      [AnalyticsVariable.STORY_PAGE_COUNT]: null,
+      [AnalyticsVariable.STORY_PROGRESS]: null,
+      [AnalyticsVariable.STORY_IS_MUTED]: null,
+      [AnalyticsVariable.STORY_PREVIOUS_PAGE_ID]: null,
+      [AnalyticsVariable.STORY_ADVANCEMENT_MODE]: null,
+      [AnalyticsVariable.TOOLTIP_TRIGGER]: null,
     });
   }
 
@@ -86,27 +88,24 @@ export class AmpStoryVariableService {
           totalPages,
           previousPageId,
         } = stateChangeEvent.value;
-        this.variables_[Variable.STORY_PAGE_INDEX] = pageIndex;
-        this.variables_[Variable.STORY_PAGE_ID] = pageId;
-        this.variables_[Variable.STORY_PROGRESS] = storyProgress;
-        this.variables_[Variable.STORY_PAGE_COUNT] = totalPages;
-        this.variables_[Variable.STORY_PREVIOUS_PAGE_ID] = previousPageId;
+        this.variables_[AnalyticsVariable.STORY_PAGE_INDEX] = pageIndex;
+        this.variables_[AnalyticsVariable.STORY_PAGE_ID] = pageId;
+        this.variables_[AnalyticsVariable.STORY_PROGRESS] = storyProgress;
+        this.variables_[AnalyticsVariable.STORY_PAGE_COUNT] = totalPages;
+        this.variables_[
+          AnalyticsVariable.STORY_PREVIOUS_PAGE_ID
+        ] = previousPageId;
         break;
     }
   }
 
   /**
-   * @param {boolean} isMuted
+   * Updates a variable with a new value
+   * @param {string} name
+   * @param {*} update
    */
-  onMutedStateChange(isMuted) {
-    this.variables_[Variable.STORY_IS_MUTED] = isMuted;
-  }
-
-  /**
-   * @param {string} advancementMode
-   */
-  onAdvancementModeStateChange(advancementMode) {
-    this.variables_[Variable.STORY_ADVANCEMENT_MODE] = advancementMode;
+  onVariableUpdate(name, update) {
+    this.variables_[name] = update;
   }
 
   /**


### PR DESCRIPTION
* Adds analytics trigger when opening/closing a tooltip.
* Adds variable to know what element/link triggered the tooltip.
* Also introduces `AmpStoryVariableService#onVariableUpdate` method so we don't have to add a new method per variable type.

Partial for #12191