### PR TITLE
Making sure the consent UI AMP element is upgraded before calling whenBuilt.

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -24,6 +24,7 @@ import {
   insertAfterOrAtStart,
   isAmpElement,
   removeElement,
+  whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {getConsentStateValue} from './consent-info';
 import {getData} from '../../../src/event-helper';
@@ -228,7 +229,13 @@ export class ConsentUI {
       // If the UI is an AMP Element, wait until it's built before showing it,
       // to avoid race conditions where the UI would be hidden by the runtime
       // at build time. (see #18841).
-      isAmpElement(this.ui_) ? this.ui_.whenBuilt().then(() => show()) : show();
+      if (isAmpElement(this.ui_)) {
+        whenUpgradedToCustomElement(this.ui_)
+          .then(() => this.ui_.whenBuilt())
+          .then(() => show());
+      } else {
+        show();
+      }
     }
 
     this.isVisible_ = true;


### PR DESCRIPTION
Making sure the consent UI AMP element is upgraded before calling `whenBuilt`.

This PR is actually a follow up on #18841, that waits for the consent UI to be built before showing it. Sometimes, the code would run even before the component is upgraded to an AMP custom element. The `whenBuilt` method would not exist, resulting in `this.h.whenBuilt is not a function` errors.