### PR TITLE
Fix amp-sidebar scrolling on open/close in UIWebView

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -304,7 +304,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.scheduleLayout(children);
     this.scheduleResume(children);
     // As of iOS 12.2, focus() causes undesired scrolling in UIWebViews.
-    if (!Services.platformFor(this.win).isIos()) {
+    if (!this.isIosWebView_()) {
       tryFocus(this.element);
     }
     this.triggerEvent_(SidebarEvents.OPEN);
@@ -372,7 +372,7 @@ export class AmpSidebar extends AMP.BaseElement {
     }
     if (this.openerElement_ && sidebarIsActive && scrollDidNotChange) {
       // As of iOS 12.2, focus() causes undesired scrolling in UIWebViews.
-      if (!Services.platformFor(this.win).isIos()) {
+      if (!this.isIosWebView_()) {
         tryFocus(this.openerElement_);
       }
     }
@@ -470,6 +470,15 @@ export class AmpSidebar extends AMP.BaseElement {
   triggerEvent_(name) {
     const event = createCustomEvent(this.win, `${TAG}.${name}`, dict({}));
     this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isIosWebView_() {
+    return this.isIos_ &&
+        Services.viewerForDoc(this.element).isWebviewEmbedded();
   }
 }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -477,8 +477,9 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   isIosWebView_() {
-    return this.isIos_ &&
-        Services.viewerForDoc(this.element).isWebviewEmbedded();
+    // Don't use isWebviewEmbedded() because it assumes there's no parent
+    // iframe, but this is not necessarily true for all UIWebView embeds.
+    return this.isIos_ && Services.viewerForDoc(this.element).isEmbedded();
   }
 }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -303,7 +303,10 @@ export class AmpSidebar extends AMP.BaseElement {
     const children = this.getRealChildren();
     this.scheduleLayout(children);
     this.scheduleResume(children);
-    tryFocus(this.element);
+    // As of iOS 12.2, focus() causes undesired scrolling in UIWebViews.
+    if (!Services.platformFor(this.win).isIos()) {
+      tryFocus(this.element);
+    }
     this.triggerEvent_(SidebarEvents.OPEN);
   }
 
@@ -368,7 +371,10 @@ export class AmpSidebar extends AMP.BaseElement {
       this.historyId_ = -1;
     }
     if (this.openerElement_ && sidebarIsActive && scrollDidNotChange) {
-      tryFocus(this.openerElement_);
+      // As of iOS 12.2, focus() causes undesired scrolling in UIWebViews.
+      if (!Services.platformFor(this.win).isIos()) {
+        tryFocus(this.openerElement_);
+      }
     }
     return true;
   }


### PR DESCRIPTION
`HTMLElement.focus()` causes undesirable scrolling on UIWebView. There also doesn't seem to be a good way to target UIWebView specifically via user agent.

Tested on iPhone 7, Safari 12.1.3 and this doesn't appear to have any impact on a11y (VoiceOver focus).

`b/133327438`