### PR TITLE
🐛 remove a p-tag that was too much and crashed the table at amp-brid-player

### DIFF
--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -61,7 +61,7 @@ Example:
 <table>
   <tr>
     <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay:</p>
+    <td>If this attribute is present, and the browser supports autoplay:
 <ul>
   <li>the video is automatically muted before autoplay starts</li>
   <li>when the video is scrolled out of view, the video is paused</li>


### PR DESCRIPTION
There has been a <p>-tag that crashed the table on the amp-brid-player component site. I removed it, which has repaired the table.
@nainar 