### PR TITLE
Linker: fix handling of fragments

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -127,7 +127,7 @@ export class LinkerManager {
         if (!element.href || event.type !== 'click') {
           return;
         }
-        element.href = this.applyLinkers_(element.href);
+        this.maybeWriteHref_(element);
       }, Priority.ANALYTICS_LINKER);
       navigation.registerNavigateToMutator(
         url => this.applyLinkers_(url),
@@ -138,6 +138,19 @@ export class LinkerManager {
     this.enableFormSupport_();
 
     return Promise.all(this.allLinkerPromises_);
+  }
+
+  /**
+   * Applys any matching linkers to the elements href. If no linkers exist,
+   * will not set href.
+   * @param {!Element} element
+   */
+  maybeWriteHref_(element) {
+    const {href} = element;
+    const maybeDecoratedUrl = this.applyLinkers_(href);
+    if (href !== maybeDecoratedUrl) {
+      element.href = maybeDecoratedUrl;
+    }
   }
 
   /**

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -631,6 +631,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     it('should not rewrite url if href is fragment', () => {
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
+        // Using a real anchor el here because of a.href getter will actually
+        // return the full url, not just the fragment.
         const a = doc.createElement('a');
         a.href = '#hello';
         a.hostname = 'amp.source.com';

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -628,6 +628,28 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       });
     });
 
+    it('should not rewrite url if href is fragment', () => {
+      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+      return lm.init().then(() => {
+        const a = doc.createElement('a');
+        a.href = '#hello';
+        a.hostname = 'amp.source.com';
+
+        const setterSpy = sandbox.spy();
+        const aProxy = new Proxy(a, {
+          get: (obj, prop) => {
+            return obj[prop];
+          },
+          set: setterSpy,
+        });
+
+        anchorClickHandlers.forEach(handler =>
+          handler(aProxy, {type: 'click'})
+        );
+        expect(setterSpy.notCalled).to.be.true;
+      });
+    });
+
     it('should not add linker if href is relative', () => {
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/ampproject/amphtml/pull/22361

We should not overwrite href if linker param is not added.

Fixes b/134696625