### PR TITLE
✨ Adding 'allow-popups' to the consent prompt UI iframe

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -356,13 +356,13 @@ export class ConsentUI {
    */
   createPromptIframeFromSrc_(promptUISrc) {
     const iframe = this.parent_.ownerDocument.createElement('iframe');
-    let sandbox = 'allow-scripts';
+    const sandbox = ['allow-scripts', 'allow-popups'];
     iframe.src = assertHttpsUrl(promptUISrc, this.parent_);
     const allowSameOrigin = this.allowSameOrigin_(iframe.src);
     if (allowSameOrigin) {
-      sandbox = 'allow-scripts allow-same-origin';
+      sandbox.push('allow-same-origin');
     }
-    iframe.setAttribute('sandbox', sandbox);
+    iframe.setAttribute('sandbox', sandbox.join(' '));
     const {classList} = iframe;
     classList.add(consentUiClasses.fill);
     // Append iframe lazily to save resources.


### PR DESCRIPTION
This PR adds the `allow-popups` rule to the consent prompt ui iframe.

This implements the feature requested in #22759

There doesn't appear to be any tests or an example related to this change that needed updating, correct me if I'm wrong.

/cc @zhouyx  @torch2424 