### PR TITLE
Rename reported test status from `local_changes` to `local-changes`

### DIFF
--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -34,7 +34,7 @@ const IS_SINGLE_PASS = !!argv.single_pass;
 
 const TEST_TYPE_SUBTYPES = new Map([
   ['integration', ['local', 'single-pass', 'saucelabs']],
-  ['unit', ['local', 'local_changes', 'saucelabs']],
+  ['unit', ['local', 'local-changes', 'saucelabs']],
   ['e2e', ['local']],
 ]);
 const TEST_TYPE_BUILD_TARGETS = new Map([

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -58,7 +58,7 @@ function inferTestType() {
   }
 
   if (IS_LOCAL_CHANGES) {
-    return `${type}/local_changes`;
+    return `${type}/local-changes`;
   }
 
   if (IS_SAUCELABS) {


### PR DESCRIPTION
This PR is a nit, because this:
![image](https://user-images.githubusercontent.com/1839738/59202506-a0147400-8b6a-11e9-8e49-d8053aa6c99e.png)

Looks better than this:
![image](https://user-images.githubusercontent.com/1839738/59202448-7c512e00-8b6a-11e9-8bb7-99900e27a225.png)

(especially because we still have the `single-pass` line, not `single_pass` 😬)