### PR TITLE
📖 Update testing documentation

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -339,7 +339,7 @@ Please verify your ad is fully functioning, for example, by clicking on an ad. W
 Please make sure your changes pass the tests:
 
 ```
-gulp test --watch --nobuild --files=test/unit/{test-ads-config.js,test-integration.js}
+gulp unit --watch --nobuild --files=test/unit/{test-ads-config.js,test-integration.js}
 
 ```
 

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -104,7 +104,7 @@ async function prCheck(cb) {
       runCheck('gulp clean');
       runCheck('gulp dist --fortesting');
     }
-    runCheck('gulp test --nobuild --compiled --integration --headless');
+    runCheck('gulp integration --nobuild --compiled --headless');
   }
 
   if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR')) {

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -79,22 +79,21 @@ Command                                                                 | Descri
 `gulp pr-check`                                                         | Runs all the Travis CI checks locally.
 `gulp pr-check --nobuild`                                               | Runs all the Travis CI checks locally, but skips the `gulp build` step.
 `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.
-`gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).
-`gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.
-`gulp test --local-changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.
-`gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).
-`gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.
-`gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.
-`gulp test [--unit\|--integration] --nobuild`                           | Runs tests without re-build.
-`gulp test [--unit\|--integration] --coverage`                          | Runs code coverage tests. After running, the report will be available at test/coverage/index.html
-`gulp test [--unit\|--integration] --watch`                             | Watches for changes in files, runs corresponding test(s) in Chrome.
-`gulp test [--unit\|--integration] --watch --verbose`                   | Same as `watch`, with logging enabled.
-`gulp test [--integration] --saucelabs`                                 | Runs integration tests on saucelabs (requires [setup](#testing-on-sauce-labs)).
-`gulp test [--unit] --saucelabs_lite`                                   | Runs unit tests on a subset of saucelabs browsers (requires [setup](#testing-on-sauce-labs)).
-`gulp test [--unit\|--integration] --safari`                            | Runs tests in Safari.
-`gulp test [--unit\|--integration] --firefox`                           | Runs tests in Firefox.
-`gulp test [--unit\|--integration] --files=<test-files-path-glob>`      | Runs specific test files.
-`gulp test [--unit\|--integration] --testnames`                         | Lists the name of each test being run, and prints a summary at the end.
+`gulp unit`                                                             | Runs the unit tests in Chrome (doesn't require the AMP library to be built).
+`gulp unit --local_changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.
+`gulp integration`                                                      | Runs the integration tests in Chrome (requires the AMP library to be built).
+`gulp [unit|integration] --verbose`                                    | Runs tests in Chrome with logging enabled.
+`gulp [unit|integration] --nobuild`                                    | Runs tests without re-build.
+`gulp [unit|integration] --coverage`                                   | Runs code coverage tests. After running, the report will be available at test/coverage/index.html
+`gulp [unit|integration] --watch`                                      | Watches for changes in files, runs corresponding test(s) in Chrome.
+`gulp [unit|integration] --watch --verbose`                            | Same as `watch`, with logging enabled.
+`gulp [unit|integration] --saucelabs`                                  | Runs tests on saucelabs browsers (requires [setup](#testing-on-sauce-labs)).
+`gulp [unit|integration] --safari`                                     | Runs tests in Safari.
+`gulp [unit|integration] --firefox`                                    | Runs tests in Firefox.
+`gulp [unit|integration] --edge`                                       | Runs tests in Edge.
+`gulp [unit|integration] --ie`                                         | Runs tests in Internet Explorer.
+`gulp [unit|integration] --files=<test-files-path-glob>`               | Runs specific test files.
+`gulp [unit|integration] --testnames`                                  | Lists the name of each test being run, and prints a summary at the end.
 `gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/. Serve unminified AMP by default.
 `gulp serve --quiet`                                                    | Same as `serve`, with logging silenced.
 `gulp serve --port 9000`                                                | Same as `serve`, but uses a port number other than the default of 8000.
@@ -208,7 +207,7 @@ For testing documents on arbitrary URLs with your current local version of the A
 
 ## Testing on Sauce Labs
 
-We use [Sauce Labs](https://saucelabs.com) to perform cross-browser testing (thanks Sauce Labs!). In general local testing (i.e. gulp test) and the automatic test run on [Travis](https://travis-ci.org/ampproject/amphtml/pull_requests) that happens when you send a pull request are sufficient, but if you want to run your tests across multiple environments/browsers before sending your PR we recommend using Sauce Labs as well.
+We use [Sauce Labs](https://saucelabs.com) to perform cross-browser testing (thanks Sauce Labs!). In general local testing (i.e. gulp [unit|integration]) and the automatic test run on [Travis](https://travis-ci.org/ampproject/amphtml/pull_requests) that happens when you send a pull request are sufficient, but if you want to run your tests across multiple environments/browsers before sending your PR we recommend using Sauce Labs as well.
 
 To run the tests on Sauce Labs:
 
@@ -228,13 +227,13 @@ To run the tests on Sauce Labs:
    sc
 
    # after seeing the "Sauce Connect is up" msg, run the tests
-   gulp test --saucelabs
+   gulp [unit|integration] --saucelabs
    ```
 * It may take a few minutes for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard.
 
 ## Visual Diff Tests
 
-In addition to building the AMP runtime and running `gulp test`, the automatic test run on Travis includes a set of visual diff tests to make sure a new commit to `master` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
+In addition to building the AMP runtime and running `gulp [unit|integration]`, the automatic test run on Travis includes a set of visual diff tests to make sure a new commit to `master` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
 
 The technology stack used is:
 

--- a/contributing/buildcop.md
+++ b/contributing/buildcop.md
@@ -27,4 +27,4 @@ If the build has been red for some time, please send a note to the [#contributin
         *   If there are diffs that look like flakes, click “Approve” on the Percy build to unblock the PR (and ping @danielrozenberg as an FYI).
     4.  Approve and merge the PR.
 3.  Report and triage any failing tests on *beta* browsers:
-    1.  Check recent [master builds](https://travis-ci.org/ampproject/amphtml/branches) on Travis, even the green ones. Look for the `gulp test ... --saucelabs` task in the logs and check for any failing tests under the *beta* test batch(es). Create issues for those tests.
+    1.  Check recent [master builds](https://travis-ci.org/ampproject/amphtml/branches) on Travis, even the green ones. Look for the `gulp [unit|integration] ... --saucelabs` task in the logs and check for any failing tests under the *beta* test batch(es). Create issues for those tests.

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -784,7 +784,7 @@ For faster testing during development, consider using --files argument
 to only run your extensions' tests.
 
 ```shell
-$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
+$ gulp unit --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
 ```
 
 ## Type checking

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -371,7 +371,7 @@ To run the tests that are affected by the changes on your feature branch:
 gulp unit --local_changes
 ```
 
-By default, all tests are run on Chrome. Pass `--firefox`, `--safari`, `--edge`, or `--ie` to run tests on other browsers.
+By default, all tests are run on Chrome. Pass one of the following flags to run tests on a different browser: `--firefox`, `--safari`, `--edge`, `--ie`.
 
 If you need help with fixing failing tests, please ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 
@@ -400,6 +400,12 @@ To run tests in a single file, use `gulp unit --files=<path>`:
 
 ```
 gulp unit --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
+```
+
+To run tests in multiple files, use `gulp unit --files=<path-1> --files=<path-2>`:
+
+```
+gulp unit --files=extensions/amp-story/1.0/test/test-amp-story-embedded-component.js --files=extensions/amp-story/1.0/test/test-amp-story-hint.js
 ```
 
 Testing tips:

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -368,10 +368,10 @@ Note: You can automatically run critical checks before `git push` by enabling ou
 To run the tests that are affected by the changes on your feature branch:
 
 ```
-gulp test --local-changes
+gulp unit --local_changes
 ```
 
-By default, all tests are run on Chrome. Pass `--firefox` or `--safari` to run tests in Firefox and Safari, respectively.
+By default, all tests are run on Chrome. Pass `--firefox`, `--safari`, `--edge`, or `--ie` to run tests on other browsers.
 
 If you need help with fixing failing tests, please ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 
@@ -396,16 +396,16 @@ The `amphtml` testing framework uses the [Mocha](https://mochajs.org/), [Chai](h
 
 Existing components will usually have existing tests that you can follow as an example. For example, the [amp-video](../extensions/amp-video/amp-video.md) component has tests in [test/test-amp-video.js](../extensions/amp-video/0.1/test/test-amp-video.js).
 
-To run tests in a single file, use `gulp test --files=<path>`:
+To run tests in a single file, use `gulp unit --files=<path>`:
 
 ```
-gulp test --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
+gulp unit --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
 ```
 
 Testing tips:
 
 - Use Mocha's [`.only()`](https://mochajs.org/#exclusive-tests) feature to exclusively run certain test-cases or suites.
-- Add `--watch` to your `gulp test` command to automatically re-run tests on code changes.
+- Add `--watch` to your `gulp unit` command to automatically re-run tests on code changes.
 
 For more help, see [How to get help](#how-to-get-help).
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -103,7 +103,7 @@ git checkout -b <branch name> master
 * Run integration tests, but skip building after having done so previously: `gulp integration --nobuild`
 * Run the tests in a specified set of files: `gulp [unit|integration] --files=<test-files-path-glob>`
 * Add the `--watch` flag to `gulp [unit|integration]` to automatically re-run the tests when a file changes
-* To run only a certain set of Mocha tests, change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp [unit|integration] --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
+* To run only a certain set of Mocha tests, change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp [unit|integration] --watch` to automatically rerun your test when files are changed (but make sure to run all the tests before sending your change for review)
 
 ## Create commits to contain your changes
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -98,12 +98,12 @@ git checkout -b <branch name> master
 
 ## Test AMP
 
-* Run the unit tests: `gulp test --unit` (doesn't build the runtime)
-* Run the integration tests: `gulp test --integration` (builds the runtime)
-* Run tests, but skip building after having done so previously: `gulp test [--unit|--integration] --nobuild`
-* Run the tests in a specified set of files: `gulp test [--unit|--integration] --files=<test-files-path-glob>`
-* Add the `--watch` flag to any `gulp test` command to automatically re-run the tests when a file changes
-* To run only a certain set of Mocha tests, change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
+* Run the unit tests: `gulp unit` (doesn't build the runtime)
+* Run the integration tests: `gulp integration` (builds the runtime)
+* Run integration tests, but skip building after having done so previously: `gulp integration --nobuild`
+* Run the tests in a specified set of files: `gulp [unit|integration] --files=<test-files-path-glob>`
+* Add the `--watch` flag to `gulp [unit|integration]` to automatically re-run the tests when a file changes
+* To run only a certain set of Mocha tests, change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp [unit|integration] --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
 
 ## Create commits to contain your changes
 

--- a/contributing/good-first-issues-template.md
+++ b/contributing/good-first-issues-template.md
@@ -40,7 +40,7 @@ Step-by-step instructions for the contributor to follow as they work through the
 - [ ] [Create a Git branch](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch) for making your changes.
 - [ ] [Sign the Contributor License Agreement](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributor-license-agreement) before creating a Pull Request.  (If you are contributing code on behalf of a corporation start this process as early as possible.)
 <!--
-Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run `gulp test --unt` or `gulp test --integration` to see it fails, change a file and then run test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
+Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run `gulp unit` or `gulp integration` to see it fails, change a file and then run test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
 -->
 - [ ] [Commit your changes](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#edit-files-and-commit-them) frequently.
 - [ ] [Push your changes to GitHub](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#push-your-changes-to-your-github-fork).


### PR DESCRIPTION
Switches out `gulp test` with `gulp unit` or `gulp integration` in documentation + minor clean ups.

related to masterbug #22507