### PR TITLE
🏗 Print warning that `gulp test` will be deprecated soon

### DIFF
--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -647,13 +647,10 @@ async function runTests() {
   }
 }
 
-//TODO(estherkim): delete this file by the end of the week
+//TODO(estherkim): delete this file at some point
 function deprecateTaskWarning() {
-  log(
-    cyan(
-      '~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ *'
-    )
-  );
+  const pattern = '~ * ';
+  log(cyan(pattern.repeat(27)));
   log(red('Attention Please!'));
   log(
     cyan('gulp test [--unit | --integration]'),
@@ -675,11 +672,7 @@ function deprecateTaskWarning() {
     'All other flags remain the same and our documentation has been updated to reflect these changes.'
   );
   log('Thanks!', red('<3'), '@ampproject/wg-infra');
-  log(
-    cyan(
-      '~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ *'
-    )
-  );
+  log(cyan(pattern.repeat(27)));
 }
 
 async function test() {

--- a/build-system/tasks/runtime-test/index.js
+++ b/build-system/tasks/runtime-test/index.js
@@ -647,7 +647,44 @@ async function runTests() {
   }
 }
 
+//TODO(estherkim): delete this file by the end of the week
+function deprecateTaskWarning() {
+  log(
+    cyan(
+      '~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ *'
+    )
+  );
+  log(red('Attention Please!'));
+  log(
+    cyan('gulp test [--unit | --integration]'),
+    'has been renamed to new, separate tasks:',
+    cyan('gulp unit'),
+    'and',
+    cyan('gulp integration.')
+  );
+  log(
+    cyan('--local-changes'),
+    'has been changed to',
+    cyan('--local_changes'),
+    'and',
+    cyan('--saucelabs-lite'),
+    'has been renamed to',
+    cyan('--saucelabs')
+  );
+  log(
+    'All other flags remain the same and our documentation has been updated to reflect these changes.'
+  );
+  log('Thanks!', red('<3'), '@ampproject/wg-infra');
+  log(
+    cyan(
+      '~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ * ~ *'
+    )
+  );
+}
+
 async function test() {
+  deprecateTaskWarning();
+
   if (!argv.nobuild) {
     if (argv.unit || argv.a4a || argv['local-changes']) {
       await css();


### PR DESCRIPTION
To let developers know to use new tasks, print out a warning for several days before we delete this task.

![image](https://user-images.githubusercontent.com/44627152/59227285-f69da480-8ba2-11e9-99e9-f1b717dcfd00.png)


related to masterbug #22507