### PR TITLE
🐛Enable tap event on the first child of an amp-accordion

### DIFF
--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -36,9 +36,11 @@
     <nav>
       <ul>
         <li>
+            <p id="foo">text</p>
+            <button type="button" on="tap:foo.toggleVisibility">Toggle text</button>
           <amp-accordion id="ac1" animate>
             <section id="item1" on="expand:ac2.collapse(section='item2')">
-              <h1>Item 1 (Expanding it closes Item 2)</h1>
+              <h1 on="tap:foo.toggleVisibility">Item 1 (Expanding it closes Item 2), Toggle text</h1>
               <div>
                 <p>1A</p>
                 <p>1B</p>

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -17,7 +17,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {Animation} from '../../../src/animation';
 import {CSS} from '../../../build/amp-accordion-0.1.css';
-import {Keys} from '../../../src/utils/key-codes';
+import {KeyCodes, Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
@@ -520,7 +520,9 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   onHeaderPicked_(event) {
-    event.preventDefault();
+    if (event.keyCode === KeyCodes.SPACE) {
+      event.preventDefault();
+    }
     const header = dev().assertElement(event.currentTarget);
     const section = dev().assertElement(header.parentElement);
     this.toggle_(section);

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-accordion';
-import {Keys} from '../../../../src/utils/key-codes';
+import {KeyCodes, Keys} from '../../../../src/utils/key-codes';
 import {computedStyle} from '../../../../src/style';
 import {poll} from '../../../../testing/iframe';
 import {tryFocus} from '../../../../src/dom';
@@ -419,7 +419,7 @@ describes.realWin(
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'true'
         );
-        expect(clickEvent.preventDefault.called).to.be.true;
+        expect(clickEvent.preventDefault.called).not.to.be.true;
       });
     });
 
@@ -439,7 +439,7 @@ describes.realWin(
         ampAccordion.implementation_.onHeaderPicked_(clickEvent);
         expect(header.parentNode.hasAttribute('expanded')).to.be.true;
         expect(header.getAttribute('aria-expanded')).to.equal('true');
-        expect(clickEvent.preventDefault).to.have.been.called;
+        expect(clickEvent.preventDefault).not.to.have.been.called;
       });
     });
 
@@ -462,7 +462,7 @@ describes.realWin(
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
           'false'
         );
-        expect(clickEvent.preventDefault).to.have.been.called;
+        expect(clickEvent.preventDefault).not.to.have.been.called;
       });
     });
 
@@ -491,6 +491,7 @@ describes.realWin(
           );
           const keyDownEvent = {
             key: Keys.SPACE,
+            keyCode: KeyCodes.SPACE,
             target: headerElements[0],
             currentTarget: headerElements[0],
             preventDefault: sandbox.spy(),
@@ -568,7 +569,7 @@ describes.realWin(
           expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
             'false'
           );
-          expect(keyDownEvent.preventDefault.called).to.be.true;
+          expect(keyDownEvent.preventDefault.called).not.to.be.true;
         });
       }
     );


### PR DESCRIPTION
Fixes #22381 

- Only call `event.preventDefault` on `Space` keyboard event so as to prevent any scrolling behavior while enabling other `click` events to trigger the `tap` AMP event. This change means `Space` still cannot trigger the `tap` event.
- Add example to manually test the fix and update tests.