### PR TITLE
🏗 Gulp test refactor clean up

### DIFF
--- a/build-system/tasks/a4a.js
+++ b/build-system/tasks/a4a.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const testConfig = require('../config');
 const {
   maybePrintArgvMessages,
   refreshKarmaWdCache,
@@ -27,17 +26,6 @@ const {
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
 const {css} = require('./css');
-
-class Config extends RuntimeTestConfig {
-  constructor(testType) {
-    super(testType);
-  }
-
-  /** @override */
-  getFiles() {
-    return testConfig.chaiAsPromised.concat(testConfig.a4aTestPaths);
-  }
-}
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -62,7 +50,7 @@ async function a4a() {
   maybePrintArgvMessages();
   refreshKarmaWdCache();
 
-  const config = new Config('a4a');
+  const config = new RuntimeTestConfig('a4a');
   const runner = new Runner(config);
 
   await runner.setup();
@@ -72,4 +60,21 @@ async function a4a() {
 
 module.exports = {
   a4a,
+};
+
+a4a.description = 'Runs a4a tests';
+a4a.flags = {
+  'chrome_canary': '  Runs tests on Chrome Canary',
+  'chrome_flags': '  Uses the given flags to launch Chrome',
+  'firefox': '  Runs tests on Firefox',
+  'files': '  Runs tests for specific files',
+  'grep': '  Runs tests that match the pattern',
+  'headless': '  Run tests in a headless Chrome window',
+  'ie': '  Runs tests on IE',
+  'nobuild': '  Skips build step',
+  'nohelp': '  Silence help messages that are printed prior to test run',
+  'safari': '  Runs tests on Safari',
+  'testnames': '  Lists the name of each test being run',
+  'verbose': '  With logging enabled',
+  'watch': '  Watches for changes in files, runs corresponding test(s)',
 };

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -16,7 +16,6 @@
 'using strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const testConfig = require('../config');
 const {
   maybePrintArgvMessages,
   refreshKarmaWdCache,
@@ -28,23 +27,6 @@ const {
 } = require('./runtime-test/runtime-test-base');
 const {clean} = require('./clean');
 const {dist} = require('./dist');
-
-class Config extends RuntimeTestConfig {
-  constructor(testType) {
-    super(testType);
-  }
-
-  /** @override */
-  getFiles() {
-    const files = testConfig.commonIntegrationTestPaths;
-
-    if (argv.files) {
-      return files.concat(argv.files);
-    }
-
-    return files.concat(testConfig.integrationTestPaths);
-  }
-}
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -71,7 +53,7 @@ async function integration() {
   maybePrintArgvMessages();
   refreshKarmaWdCache();
 
-  const config = new Config('integration');
+  const config = new RuntimeTestConfig('integration');
   const runner = new Runner(config);
 
   await runner.setup();
@@ -84,5 +66,22 @@ module.exports = {
 };
 
 integration.description = 'Runs integration tests';
-//TODO(estherkim): fill this out
-integration.flags = {};
+integration.flags = {
+  'chrome_canary': '  Runs tests on Chrome Canary',
+  'chrome_flags': '  Uses the given flags to launch Chrome',
+  'compiled':
+    '  Changes integration tests to use production JS binaries for execution',
+  'coverage': '  Run tests in code coverage mode',
+  'firefox': '  Runs tests on Firefox',
+  'files': '  Runs tests for specific files',
+  'grep': '  Runs tests that match the pattern',
+  'headless': '  Run tests in a headless Chrome window',
+  'ie': '  Runs tests on IE',
+  'nobuild': '  Skips build step',
+  'nohelp': '  Silence help messages that are printed prior to test run',
+  'safari': '  Runs tests on Safari',
+  'saucelabs': '  Runs tests on saucelabs (requires setup)',
+  'testnames': '  Lists the name of each test being run',
+  'verbose': '  With logging enabled',
+  'watch': '  Watches for changes in files, runs corresponding test(s)',
+};

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
+const testConfig = require('../../config');
 
 const {gitDiffNameOnlyMaster} = require('../../git');
 const {green, cyan} = require('ansi-colors');
@@ -126,7 +127,9 @@ function getJsFilesFor(cssFile, cssJsFileMap) {
   return jsFiles;
 }
 
-function getUnitTestsToRun(unitTestPaths) {
+function getUnitTestsToRun() {
+  log(green('INFO:'), 'Determining which unit tests to run...');
+
   if (isLargeRefactor()) {
     log(
       green('INFO:'),
@@ -136,7 +139,7 @@ function getUnitTestsToRun(unitTestPaths) {
     return;
   }
 
-  const tests = unitTestsToRun(unitTestPaths);
+  const tests = unitTestsToRun();
   if (tests.length == 0) {
     log(
       green('INFO:'),
@@ -161,7 +164,7 @@ function getUnitTestsToRun(unitTestPaths) {
  * @param {!Array<string>} unitTestPaths
  * @return {!Array<string>}
  */
-function unitTestsToRun(unitTestPaths) {
+function unitTestsToRun(unitTestPaths = testConfig.unitTestPaths) {
   const cssJsFileMap = extractCssJsFileMap();
   const filesChanged = gitDiffNameOnlyMaster();
   const testsToRun = [];
@@ -208,7 +211,6 @@ function unitTestsToRun(unitTestPaths) {
   });
 
   if (srcFiles.length > 0) {
-    log(green('INFO:'), 'Determining which unit tests to run...');
     const moreTestsToRun = getTestsFor(srcFiles);
     moreTestsToRun.forEach(test => {
       if (!testsToRun.includes(test)) {

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -106,7 +106,7 @@ function refreshKarmaWdCache() {
  * Prints help messages for args if tests are being run for local development.
  */
 function maybePrintArgvMessages() {
-  if (argv.nohelp) {
+  if (argv.nohelp || isTravisBuild()) {
     return;
   }
 
@@ -115,7 +115,8 @@ function maybePrintArgvMessages() {
     firefox: 'Running tests on Firefox.',
     ie: 'Running tests on IE.',
     edge: 'Running tests on Edge.',
-    'chrome_canary': 'Running tests on Chrome Canary.',
+    // eslint-disable-next-line
+    chrome_canary: 'Running tests on Chrome Canary.',
     saucelabs: 'Running tests on Sauce Labs browsers.',
     nobuild: 'Skipping build.',
     watch:
@@ -124,11 +125,6 @@ function maybePrintArgvMessages() {
     verbose: 'Enabling verbose mode. Expect lots of output!',
     testnames: 'Listing the names of all tests being run.',
     files: 'Running tests in the file(s): ' + cyan(argv.files),
-    integration:
-      'Running only the integration tests. Prerequisite: ' +
-      cyan('gulp dist --fortesting'),
-    unit: 'Running only the unit tests. Prerequisite: ' + cyan('gulp css'),
-    a4a: 'Running only A4A tests.',
     compiled: 'Running tests against minified code.',
     grep:
       'Only running tests that match the pattern "' + cyan(argv.grep) + '".',
@@ -147,42 +143,41 @@ function maybePrintArgvMessages() {
       cyan(chromeFlags)
     );
   }
-  if (!isTravisBuild()) {
-    log(
-      green('Run'),
-      cyan('gulp help'),
-      green('to see a list of all test flags.')
-    );
-    log(green('⤷ Use'), cyan('--nohelp'), green('to silence these messages.'));
+
+  log(
+    green('Run'),
+    cyan('gulp help'),
+    green('to see a list of all test flags.')
+  );
+  log(green('⤷ Use'), cyan('--nohelp'), green('to silence these messages.'));
+  log(
+    green('⤷ Use'),
+    cyan('--local_changes'),
+    green('to run unit tests from files commited to the local branch.')
+  );
+  if (!argv.testnames && !argv.files && !argv.local_changes) {
     log(
       green('⤷ Use'),
-      cyan('--local_changes'),
-      green('to run unit tests from files commited to the local branch.')
+      cyan('--testnames'),
+      green('to see the names of all tests being run.')
     );
-    if (!argv.testnames && !argv.files && !argv.local_changes) {
-      log(
-        green('⤷ Use'),
-        cyan('--testnames'),
-        green('to see the names of all tests being run.')
-      );
-    }
-    if (!argv.headless) {
-      log(
-        green('⤷ Use'),
-        cyan('--headless'),
-        green('to run tests in a headless Chrome window.')
-      );
-    }
-    if (!argv.compiled) {
-      log(green('Running tests against unminified code.'));
-    }
-    Object.keys(argv).forEach(arg => {
-      const message = argvMessages[arg];
-      if (message) {
-        log(yellow(`--${arg}:`), green(message));
-      }
-    });
   }
+  if (!argv.headless) {
+    log(
+      green('⤷ Use'),
+      cyan('--headless'),
+      green('to run tests in a headless Chrome window.')
+    );
+  }
+  if (!argv.compiled) {
+    log(green('Running tests against unminified code.'));
+  }
+  Object.keys(argv).forEach(arg => {
+    const message = argvMessages[arg];
+    if (message) {
+      log(yellow(`--${arg}:`), green(message));
+    }
+  });
 }
 
 function maybePrintCoverageMessage() {

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -19,6 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const babelify = require('babelify');
 const karmaConfig = require('../karma.conf');
 const log = require('fancy-log');
+const testConfig = require('../../config');
 const {
   createKarmaServer,
   getAdTypes,
@@ -29,15 +30,152 @@ const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
 const {green, yellow, cyan, red} = require('ansi-colors');
 const {isTravisBuild} = require('../../travis');
 const {reportTestStarted} = require('.././report-test-status');
+const {unitTestsToRun} = require('./helpers-unit');
+
+/**
+ * Updates the browsers based off of the test type
+ * being run (unit, integration, a4a) and test settings.
+ * Keeps the default spec as is if no matching settings are found.
+ * @param {!RuntimeTestConfig} config
+ */
+function updateBrowsers(config) {
+  if (argv.saucelabs) {
+    if (config.testType == 'unit') {
+      Object.assign(config, {browsers: ['SL_Safari_12', 'SL_Firefox']});
+      return;
+    }
+
+    if (config.testType == 'integration') {
+      Object.assign(config, {
+        browsers: [
+          'SL_Chrome',
+          'SL_Firefox',
+          'SL_Edge_17',
+          'SL_Safari_12',
+          'SL_IE_11',
+          // TODO(amp-infra): Evaluate and add more platforms here.
+          //'SL_Chrome_Android_7',
+          //'SL_iOS_11',
+          //'SL_iOS_12',
+          'SL_Chrome_Beta',
+          'SL_Firefox_Beta',
+        ],
+      });
+      return;
+    }
+
+    throw new Error(
+      'The --saucelabs flag is valid only for `gulp unit` and `gulp integration`.'
+    );
+  }
+
+  const chromeFlags = [];
+  if (argv.chrome_flags) {
+    argv.chrome_flags.split(',').forEach(flag => {
+      chromeFlags.push('--'.concat(flag));
+    });
+  }
+
+  const options = new Map();
+  options
+    .set('chrome_canary', {browsers: ['ChromeCanary']})
+    .set('chrome_flags', {
+      browsers: ['Chrome_flags'],
+      customLaunchers: {
+        // eslint-disable-next-line
+        Chrome_flags: {
+          base: 'Chrome',
+          flags: chromeFlags,
+        },
+      },
+    })
+    .set('edge', {browsers: ['Edge']})
+    .set('firefox', {browsers: ['Firefox']})
+    .set('headless', {browsers: ['Chrome_no_extensions_headless']})
+    .set('ie', {
+      browsers: ['IE'],
+      customLaunchers: {
+        IeNoAddOns: {
+          base: 'IE',
+          flags: ['-extoff'],
+        },
+      },
+    })
+    .set('safari', {browsers: ['Safari']});
+
+  for (const [key, value] of options) {
+    if (argv.hasOwnProperty(key)) {
+      Object.assign(config, value);
+      return;
+    }
+  }
+}
+
+/**
+ * Get the appropriate files based off of the test type
+ * being run (unit, integration, a4a) and test settings.
+ * @param {string} testType
+ * @return {!Array<string>}
+ */
+function getFiles(testType) {
+  let files;
+
+  switch (testType) {
+    case 'unit':
+      files = testConfig.commonUnitTestPaths.concat(testConfig.chaiAsPromised);
+      if (argv.files) {
+        return files.concat(argv.files);
+      }
+      if (argv.saucelabs) {
+        return files.concat(testConfig.unitTestOnSaucePaths);
+      }
+      if (argv.local_changes) {
+        return files.concat(unitTestsToRun(testConfig.unitTestPaths));
+      }
+      return files.concat(testConfig.unitTestPaths);
+
+    case 'integration':
+      files = testConfig.commonIntegrationTestPaths;
+      if (argv.files) {
+        return files.concat(argv.files);
+      }
+      return files.concat(testConfig.integrationTestPaths);
+
+    case 'a4a':
+      return testConfig.chaiAsPromised.concat(testConfig.a4aTestPaths);
+
+    default:
+      throw new Error(`Test type ${testType} was not recognized`);
+  }
+}
+
+/**
+ * Adds reporters to the default karma spec per test settings.
+ * Overrides default reporters for verbose settings.
+ * @param {!RuntimeTestConfig} config
+ */
+function updateReporters(config) {
+  if (argv.testnames || argv.local_changes || argv.files) {
+    config.reporters = ['mocha'];
+  }
+
+  if (argv.coverage) {
+    config.reporters.push('coverage-istanbul');
+  }
+
+  if (argv.saucelabs) {
+    config.reporters.push('saucelabs');
+  }
+}
 
 class RuntimeTestConfig {
   constructor(testType) {
     this.testType = testType;
 
     Object.assign(this, karmaConfig);
-    this.browsers = this.getBrowsersObject().browsers;
-    this.files = this.getFiles();
-    this.reporters = this.getReporters();
+    updateBrowsers(this);
+    updateReporters(this);
+    this.files = getFiles(this.testType);
     this.singleRun = !argv.watch && !argv.w;
     this.client.mocha.grep = !!argv.grep;
     this.client.verboseLogging = !!argv.verbose || !!argv.v;
@@ -96,100 +234,6 @@ class RuntimeTestConfig {
 
       this.browserify.transform = [['babelify', {plugins: [plugin]}]];
     }
-  }
-
-  getBrowsersObject() {
-    if (argv.saucelabs) {
-      if (this.testType == 'unit') {
-        return {browsers: ['SL_Safari_12', 'SL_Firefox']};
-      }
-
-      if (this.testType == 'integration') {
-        return {
-          browsers: [
-            'SL_Chrome',
-            'SL_Firefox',
-            'SL_Edge_17',
-            'SL_Safari_12',
-            'SL_IE_11',
-            // TODO(amp-infra): Evaluate and add more platforms here.
-            //'SL_Chrome_Android_7',
-            //'SL_iOS_11',
-            //'SL_iOS_12',
-            'SL_Chrome_Beta',
-            'SL_Firefox_Beta',
-          ],
-        };
-      }
-
-      throw new Error(
-        'The --saucelabs flag is valid only for `gulp unit` and `gulp integration`.'
-      );
-    }
-
-    const chromeFlags = [];
-    if (argv.chrome_flags) {
-      argv.chrome_flags.split(',').forEach(flag => {
-        chromeFlags.push('--'.concat(flag));
-      });
-    }
-
-    const options = new Map();
-    options
-      .set('chrome_canary', {browsers: ['ChromeCanary']})
-      .set('chrome_flags', {
-        browsers: ['Chrome_flags'],
-        customLaunchers: {
-          // eslint-disable-next-line
-          Chrome_flags: {
-            base: 'Chrome',
-            flags: chromeFlags,
-          },
-        },
-      })
-      .set('edge', {browsers: ['Edge']})
-      .set('firefox', {browsers: ['Firefox']})
-      .set('headless', {browsers: ['Chrome_no_extensions_headless']})
-      .set('ie', {
-        browsers: ['IE'],
-        customLaunchers: {
-          IeNoAddOns: {
-            base: 'IE',
-            flags: ['-extoff'],
-          },
-        },
-      })
-      .set('safari', {browsers: ['Safari']});
-
-    for (const [key, value] of options) {
-      if (argv.hasOwnProperty(key)) {
-        return value;
-      }
-    }
-
-    return {browsers: this.browsers};
-  }
-
-  getFiles() {
-    throw new Error('Karma files config must be overridden');
-  }
-
-  getReporters() {
-    let {reporters} = this;
-
-    if (argv.testnames || argv.local_changes || argv.files) {
-      reporters = ['mocha'];
-    }
-
-    if (argv.coverage) {
-      reporters.push('coverage-istanbul');
-    }
-
-    if (argv.saucelabs) {
-      reporters.push('saucelabs');
-    }
-
-    return reporters;
   }
 }
 

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -155,7 +155,10 @@ function getFiles(testType) {
  * @param {!RuntimeTestConfig} config
  */
 function updateReporters(config) {
-  if (argv.testnames || argv.local_changes || argv.files) {
+  if (
+    (argv.testnames || argv.local_changes || argv.files) &&
+    !isTravisBuild()
+  ) {
     config.reporters = ['mocha'];
   }
 

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -16,7 +16,6 @@
 'using strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const testConfig = require('../config');
 const {
   maybePrintArgvMessages,
   refreshKarmaWdCache,
@@ -28,33 +27,6 @@ const {
 } = require('./runtime-test/runtime-test-base');
 const {css} = require('./css');
 const {getUnitTestsToRun} = require('./runtime-test/helpers-unit');
-
-class Config extends RuntimeTestConfig {
-  constructor(testType) {
-    super(testType);
-  }
-
-  /** @override */
-  getFiles() {
-    const files = testConfig.commonUnitTestPaths.concat(
-      testConfig.chaiAsPromised
-    );
-
-    if (argv.files) {
-      return files.concat(argv.files);
-    }
-
-    if (argv.saucelabs) {
-      return files.concat(testConfig.unitTestOnSaucePaths);
-    }
-
-    if (argv.local_changes) {
-      return files.concat(getUnitTestsToRun(testConfig.unitTestPaths));
-    }
-
-    return files.concat(testConfig.unitTestPaths);
-  }
-}
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -72,17 +44,18 @@ class Runner extends RuntimeTestRunner {
 }
 
 async function unit() {
-  if (
-    shouldNotRun() ||
-    (argv.local_changes && !getUnitTestsToRun(testConfig.unitTestPaths))
-  ) {
+  if (shouldNotRun()) {
     return;
   }
 
   maybePrintArgvMessages();
   refreshKarmaWdCache();
 
-  const config = new Config('unit');
+  if (argv.local_changes && !getUnitTestsToRun()) {
+    return;
+  }
+
+  const config = new RuntimeTestConfig('unit');
   const runner = new Runner(config);
 
   await runner.setup();
@@ -95,22 +68,22 @@ module.exports = {
 };
 
 unit.description = 'Runs unit tests';
-//TODO(estherkim): fill this out
 unit.flags = {
-  'local_changes': '',
-  'saucelabs': '',
-  'chrome_canary': '',
-  'chrome_flags': '',
-  'coverage': '',
-  'firefox': '',
-  'files': '',
-  'grep': '',
-  'headless': '',
-  'ie': '',
-  'nobuild': '',
-  'nohelp': '',
-  'safari': '',
-  'testnames': '',
-  'verbose': '',
-  'watch': '',
+  'chrome_canary': '  Runs tests on Chrome Canary',
+  'chrome_flags': '  Uses the given flags to launch Chrome',
+  'coverage': '  Run tests in code coverage mode',
+  'firefox': '  Runs tests on Firefox',
+  'files': '  Runs tests for specific files',
+  'grep': '  Runs tests that match the pattern',
+  'headless': '  Run tests in a headless Chrome window',
+  'ie': '  Runs tests on IE',
+  'local_changes':
+    '  Run unit tests directly affected by the files changed in the local branch',
+  'nobuild': '  Skips build step',
+  'nohelp': '  Silence help messages that are printed prior to test run',
+  'safari': '  Runs tests on Safari',
+  'saucelabs': '  Runs tests on saucelabs (requires setup)',
+  'testnames': '  Lists the name of each test being run',
+  'verbose': '  With logging enabled',
+  'watch': '  Watches for changes in files, runs corresponding test(s)',
 };


### PR DESCRIPTION
Gulp test refactor clean up
- moves config methods outside class
- fixes bug for `gulp unit --local_changes` that logged things twice
- updates Travis reporter for `gulp unit --local_changes` that printed test names instead of dots
- fills out gulp task information for `unit`, `integration`, and `a4a`

Follow up to https://github.com/ampproject/amphtml/pull/22717

