### PR TITLE
fix type narrowing problem so that we can remove casts

### DIFF
--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -72,9 +72,7 @@ export class AmpExperiment extends AMP.BaseElement {
         '<script type="application/json"> child.'
     );
 
-    return /** @type {!JsonObject} */ (devAssert(
-      parseJson(children[0].textContent)
-    ));
+    return devAssert(parseJson(children[0].textContent));
   }
 
   /**

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -156,9 +156,7 @@ export class AmpExperiment extends AMP.BaseElement {
         '<script type="application/json"> child.'
     );
 
-    return /** @type {!JsonObject} */ (devAssert(
-      parseJson(children[0].textContent)
-    ));
+    return devAssert(parseJson(children[0].textContent));
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -294,9 +294,7 @@ export class ShareWidget {
    * @private
    */
   getAmpDoc_() {
-    return /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */ (devAssert(
-      this.ampdoc_
-    ));
+    return devAssert(this.ampdoc_);
   }
 
   /** @private */

--- a/src/log.js
+++ b/src/log.js
@@ -311,12 +311,24 @@ export class Log {
    *   elements in an array. When e.g. passed to console.error this yields
    *   native displays of things like HTML elements.
    *
+   * NOTE: for an explanation of the tempate R implementation see
+   * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+   *
    * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
    *     not evaluate to true.
    * @param {string=} opt_message The assertion message
    * @param {...*} var_args Arguments substituted into %s in the message.
-   * @return {T} The value of shouldBeTrueish.
+   * @return {R} The value of shouldBeTrueish.
+   * @throws {!Error} When `value` is `null` or `undefined`.
    * @template T
+   * @template R :=
+   *     mapunion(T, (V) =>
+   *         cond(eq(V, 'null'),
+   *             none(),
+   *             cond(eq(V, 'undefined'),
+   *                 none(),
+   *                 V)))
+   *  =:
    * @closurePrimitive {asserts.matchesReturn}
    */
   assert(shouldBeTrueish, opt_message, var_args) {
@@ -720,6 +732,9 @@ export function isFromEmbed(win, opt_element) {
  *   elements in an array. When e.g. passed to console.error this yields
  *   native displays of things like HTML elements.
  *
+ * NOTE: for an explanation of the tempate R implementation see
+ * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+ *
  * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
  *     not evaluate to true.
  * @param {string=} opt_message The assertion message
@@ -732,8 +747,17 @@ export function isFromEmbed(win, opt_element) {
  * @param {*=} opt_7 Optional argument
  * @param {*=} opt_8 Optional argument
  * @param {*=} opt_9 Optional argument
- * @return {T} The value of shouldBeTrueish.
+ * @return {R} The value of shouldBeTrueish.
  * @template T
+ * @template R :=
+ *     mapunion(T, (V) =>
+ *         cond(eq(V, 'null'),
+ *             none(),
+ *             cond(eq(V, 'undefined'),
+ *                 none(),
+ *                 V)))
+ *  =:
+ * @throws {!Error} When `value` is `null` or `undefined`.
  * @closurePrimitive {asserts.matchesReturn}
  */
 export function devAssert(
@@ -779,6 +803,9 @@ export function devAssert(
  *   elements in an array. When e.g. passed to console.error this yields
  *   native displays of things like HTML elements.
  *
+ * NOTE: for an explanation of the tempate R implementation see
+ * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+ *
  * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
  *     not evaluate to true.
  * @param {string=} opt_message The assertion message
@@ -791,8 +818,17 @@ export function devAssert(
  * @param {*=} opt_7 Optional argument
  * @param {*=} opt_8 Optional argument
  * @param {*=} opt_9 Optional argument
- * @return {T} The value of shouldBeTrueish.
+ * @return {R} The value of shouldBeTrueish.
  * @template T
+ * @template R :=
+ *     mapunion(T, (V) =>
+ *         cond(eq(V, 'null'),
+ *             none(),
+ *             cond(eq(V, 'undefined'),
+ *                 none(),
+ *                 V)))
+ *  =:
+ * @throws {!Error} When `value` is `null` or `undefined`.
  * @closurePrimitive {asserts.matchesReturn}
  */
 export function userAssert(

--- a/src/log.js
+++ b/src/log.js
@@ -312,7 +312,7 @@ export class Log {
    *   native displays of things like HTML elements.
    *
    * NOTE: for an explanation of the tempate R implementation see
-   * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+   * https://github.com/google/closure-library/blob/08858804/closure/goog/asserts/asserts.js#L192-L213
    *
    * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
    *     not evaluate to true.
@@ -733,7 +733,7 @@ export function isFromEmbed(win, opt_element) {
  *   native displays of things like HTML elements.
  *
  * NOTE: for an explanation of the tempate R implementation see
- * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+ * https://github.com/google/closure-library/blob/08858804/closure/goog/asserts/asserts.js#L192-L213
  *
  * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
  *     not evaluate to true.
@@ -804,7 +804,7 @@ export function devAssert(
  *   native displays of things like HTML elements.
  *
  * NOTE: for an explanation of the tempate R implementation see
- * https://github.com/google/closure-library/blob/master/closure/goog/asserts/asserts.js#L192-L213
+ * https://github.com/google/closure-library/blob/08858804/closure/goog/asserts/asserts.js#L192-L213
  *
  * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
  *     not evaluate to true.


### PR DESCRIPTION
previously we always had to cast the return type to the assert functions/methods to get the correct return type (because it would always return a union type of `type|null`. adding the `@template R` annotation here fixes the type narrowing problem since it reduces the type to just the passed in type.