### PR TITLE
:bug: Send layout jank metrics more proactively.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -15,6 +15,7 @@
  */
 
 import {Services} from '../services';
+import {VisibilityState} from '../visibility-state';
 import {dev} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
@@ -125,6 +126,7 @@ export class Performance {
 
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
     this.boundTickLayoutJankScore_ = this.tickLayoutJankScore_.bind(this);
+    this.onViewerVisibilityChange_ = this.onViewerVisibilityChange_.bind(this);
 
     // Add RTV version as experiment ID, so we can slice the data by version.
     this.addEnabledExperiment('rtv-' + getMode(this.win).rtvVersion);
@@ -185,6 +187,8 @@ export class Performance {
           this.boundTickLayoutJankScore_
         );
       }
+
+      this.viewer_.onVisibilityChanged(this.onViewerVisibilityChange_);
     }
 
     // We don't check `isPerformanceTrackingOn` here since there are some
@@ -316,6 +320,16 @@ export class Performance {
    */
   onVisibilityChange_() {
     if (this.win.document.visibilityState === 'hidden') {
+      this.tickLayoutJankScore_();
+    }
+  }
+
+  /**
+   * When the viewer visibility state of the document changes to inactive,
+   * send the layout jank score.
+   */
+  onViewerVisibilityChange_() {
+    if (this.viewer_.getVisibilityState() === VisibilityState.INACTIVE) {
       this.tickLayoutJankScore_();
     }
   }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -16,6 +16,7 @@
 
 import * as lolex from 'lolex';
 import {Services} from '../../src/services';
+import {VisibilityState} from '../../src/visibility-state';
 import {getMode} from '../../src/mode';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import {installRuntimeServices} from '../../src/runtime';
@@ -1024,6 +1025,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     let fakeWin;
     let windowEventListeners;
     let performanceObserver;
+    let viewerVisibilityState;
 
     beforeEach(() => {
       // Fake window to fake `document.visibilityState`.
@@ -1075,6 +1077,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         onVisibilityChanged: () => {},
         whenFirstVisible: () => unresolvedPromise,
         whenMessagingReady: () => {},
+        getVisibilityState: () => viewerVisibilityState,
       });
       sandbox.stub(Services, 'resourcesForDoc').returns({
         getResourcesInRect: () => unresolvedPromise,
@@ -1180,6 +1183,31 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       // Note: Don't fire visibilitychange (not supported in this case).
       fakeWin.document.visibilityState = 'hidden';
       fireEvent('beforeunload');
+
+      expect(perf.events_.length).to.equal(1);
+      expect(perf.events_[0]).to.be.jsonEqual({
+        label: 'lj',
+        delta: 0.55,
+      });
+    });
+
+    it('forwards layout jank metric on viewer visibility change to inactive', () => {
+      // Specify an Android Chrome user agent.
+      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+
+      // Fake layoutJank that occured before the Performance service is started.
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutJank')
+        .returns([
+          {entryType: 'layoutJank', fraction: 0.25},
+          {entryType: 'layoutJank', fraction: 0.3},
+        ]);
+      const perf = getPerformance();
+      perf.coreServicesAvailable();
+      viewerVisibilityState = VisibilityState.INACTIVE;
+      perf.onViewerVisibilityChange_();
 
       expect(perf.events_.length).to.equal(1);
       expect(perf.events_[0]).to.be.jsonEqual({


### PR DESCRIPTION
This metric is now sent when the viewer visibility state changes to inactive, rather than just on document end of lifecycle.

Fixes #22781