### PR TITLE
Remove unnecessary type cast in macro resolvers

### DIFF
--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -89,15 +89,14 @@ export class ExpansionOptions {
 }
 
 /**
- * @param {*} value
+ * @param {string} value
  * @param {string} s
  * @param {string=} opt_l
  * @return {string}
  */
 function substrMacro(value, s, opt_l) {
   const start = Number(s);
-  const str = value.toString();
-  let {length} = str;
+  let {length} = value;
   userAssert(
     isFiniteNumber(start),
     'Start index ' + start + 'in substr macro should be a number'
@@ -110,7 +109,7 @@ function substrMacro(value, s, opt_l) {
     );
   }
 
-  return str.substr(start, length);
+  return value.substr(start, length);
 }
 
 /**
@@ -120,7 +119,7 @@ function substrMacro(value, s, opt_l) {
  */
 function defaultMacro(value, defaultValue) {
   if (!value || !value.length) {
-    return user().assertString(defaultValue);
+    return defaultValue;
   }
   return value;
 }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -278,10 +278,10 @@ export class GlobalVariableSource extends VariableSource {
         if (!clientIds) {
           return null;
         }
-        return clientIds[dev().assertString(scope)];
+        return clientIds[scope];
       },
       (scope, opt_userNotificationId, opt_cookieName) => {
-        user().assertString(
+        userAssert(
           scope,
           'The first argument to CLIENT_ID, the fallback' +
             /*OK*/ ' Cookie name, is required'
@@ -308,7 +308,7 @@ export class GlobalVariableSource extends VariableSource {
           .then(cid => {
             return cid.get(
               {
-                scope: dev().assertString(scope),
+                /** @type {string} */ scope,
                 createCookieIfNotPresent: true,
                 cookieName: opt_cookieName,
               },
@@ -773,7 +773,7 @@ export class GlobalVariableSource extends VariableSource {
 
   /**
    * Return the QUERY_PARAM from the current location href
-   * @param {*} param
+   * @param {string} param
    * @param {string} defaultValue
    * @return {string}
    * @private
@@ -788,13 +788,12 @@ export class GlobalVariableSource extends VariableSource {
       removeAmpJsParamsFromUrl(this.ampdoc.win.location.href)
     );
     const params = parseQueryString(url.search);
-    const key = user().assertString(param);
     const {replaceParams} = this.getDocInfo_();
-    if (typeof params[key] !== 'undefined') {
-      return params[key];
+    if (typeof params[param] !== 'undefined') {
+      return params[param];
     }
-    if (replaceParams && typeof replaceParams[key] !== 'undefined') {
-      return /** @type {string} */ (replaceParams[key]);
+    if (replaceParams && typeof replaceParams[param] !== 'undefined') {
+      return /** @type {string} */ (replaceParams[param]);
     }
     return defaultValue;
   }

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -20,10 +20,10 @@ import {loadPromise} from '../event-helper';
 /** @typedef {string|number|boolean|undefined|null} */
 export let ResolverReturnDef;
 
-/** @typedef {function(...*):ResolverReturnDef} */
+/** @typedef {function(...string):ResolverReturnDef} */
 export let SyncResolverDef;
 
-/** @typedef {function(...*):!Promise<ResolverReturnDef>} */
+/** @typedef {function(...string):!Promise<ResolverReturnDef>} */
 export let AsyncResolverDef;
 
 /** @typedef {{sync: SyncResolverDef, async: AsyncResolverDef}} */


### PR DESCRIPTION
This is to follow up #22423 

After the fix in #22508. All macro input arguments are guaranteed to be string. Removed unnecessary string check. 