### PR TITLE
Dispatch a MUTATE event after amp-bind mutation

### DIFF
--- a/extensions/amp-bind/0.1/bind-events.js
+++ b/extensions/amp-bind/0.1/bind-events.js
@@ -20,6 +20,7 @@
  */
 export const BindEvents = {
   INITIALIZE: 'amp:bind:initialize',
+  MUTATE: 'amp:bind:mutate',
   RESCAN_TEMPLATE: 'amp:bind:rescan-template',
   SET_STATE: 'amp:bind:setState',
 };

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -26,12 +26,12 @@ import {
   iterateCursor,
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
+import {createCustomEvent, getDetail} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
 import {deepEquals, getValueForExpr, parseJson} from '../../../src/json';
 import {deepMerge, dict, map} from '../../../src/utils/object';
 import {dev, devAssert, user} from '../../../src/log';
 import {findIndex, remove} from '../../../src/utils/array';
-import {getDetail} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {installServiceInEmbedScope} from '../../../src/service';
 import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
@@ -1156,6 +1156,14 @@ export class Bind {
         // will schedule a pass after a short delay anyways.
         this.resources_./*OK*/ changeSize(element, height, width);
       }
+
+      const mutateEvent = createCustomEvent(
+        this.win_,
+        BindEvents.MUTATE,
+        /* detail */ null,
+        {bubbles: true}
+      );
+      element.dispatchEvent(mutateEvent);
 
       if (typeof element.mutatedAttributesCallback === 'function') {
         // Prevent an exception in the callback from interrupting execution,

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -512,6 +512,19 @@ describe
           });
         });
 
+        it('should dispatch a MUTATE event after applying the binding', () => {
+          const element = createElement(env, container, '[text]="foo"');
+          const spy = sandbox.spy(element, 'dispatchEvent');
+
+          return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
+            expect(spy).to.have.been.calledOnce;
+            expect(spy).calledWithMatch({
+              type: BindEvents.MUTATE,
+              bubbles: true,
+            });
+          });
+        });
+
         it('should support binding to string attributes', () => {
           const element = createElement(env, container, '[text]="1+1"');
           expect(element.textContent).to.equal('');


### PR DESCRIPTION
This creates a new custom event `BindEvents.MUTATE`. It is dispatched
whenever an `amp-bind` mutation happens.

The new event will be used to detect form field changes made by
`amp-bind`.

Part of #22534.

/cc @cvializ @choumx @GoTcWang thanks!