### PR TITLE
Update amp-bind docs for aria attributes.

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -371,7 +371,7 @@ A **binding** is a special attribute of the form `[property]` that links an elem
 
 When the **state** changes, expressions are re-evaluated and the bound elements' properties are updated with the new expression results.
 
-`amp-bind` supports data bindings on four types of element state:
+`amp-bind` supports data bindings on five types of element state:
 
 <table>
   <tr>
@@ -398,6 +398,11 @@ When the **state** changes, expressions are re-evaluated and the bound elements'
     <td>Size of <a href="https://www.ampproject.org/docs/reference/components">AMP elements</a></td>
     <td><code>[width]</code><br><code>[height]</code></td>
     <td>Changes the width and/or height of the AMP element.</td>
+  </tr>
+  <tr>
+    <td>Acessibility states and properties</td>
+    <td><code>[aria-hidden]</code><br><code>[aria-label]</code><br>etc.</td>
+    <td>Used for dynamically updating information available to assistive technologies like screen readers.</td>
   </tr>
   <tr>
     <td>Element-specific attributes</td>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -400,7 +400,7 @@ When the **state** changes, expressions are re-evaluated and the bound elements'
     <td>Changes the width and/or height of the AMP element.</td>
   </tr>
   <tr>
-    <td>Acessibility states and properties</td>
+    <td>Accessibility states and properties</td>
     <td><code>[aria-hidden]</code><br><code>[aria-label]</code><br>etc.</td>
     <td>Used for dynamically updating information available to assistive technologies like screen readers.</td>
   </tr>


### PR DESCRIPTION
Add a table entry to indicate that `aria-` attributes can be updated using `<amp-bind>`.
