### PR TITLE
amp-truncate-text: support custom actions.

### DIFF
--- a/extensions/amp-truncate-text/0.1/amp-truncate-text-shadow.css
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text-shadow.css
@@ -27,7 +27,7 @@
   position: static;
 }
 
-:host(:not([i-amphtml-truncate-expanded])) .collapse-slot {
+:host(:not([i-amphtml-truncate-expanded])) .expanded-slot {
   display: none;
 }
 
@@ -44,7 +44,7 @@
   white-space: nowrap !important;
 }
 
-:host(:not([i-amphtml-truncate-overflow])) .expand-slot {
+:host(:not([i-amphtml-truncate-overflow])) .collapsed-slot {
   display: none;
 }
 

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.css
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.css
@@ -27,7 +27,7 @@ amp-truncate-text[i-amphtml-truncate-expanded] .i-amphtml-truncate-content {
   position: static !important;
 }
 
-amp-truncate-text:not([i-amphtml-truncate-expanded]) .i-amphtml-truncate-collapse-slot {
+amp-truncate-text:not([i-amphtml-truncate-expanded]) .i-amphtml-truncate-expanded-slot {
   display: none !important;
 }
 
@@ -44,7 +44,7 @@ amp-truncate-text:not([i-amphtml-truncate-expanded]) .i-amphtml-truncate-collaps
   white-space: nowrap !important;
 }
 
-.i-amphtml-truncate-content:not([i-amphtml-truncate-overflow]) .i-amphtml-truncate-expand-slot {
+.i-amphtml-truncate-content:not([i-amphtml-truncate-overflow]) .i-amphtml-truncate-collapsed-slot {
   display: none !important;
 }
 

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -63,13 +63,13 @@ export class AmpTruncateText extends AMP.BaseElement {
     this.content_ = null;
 
     /** @private {?Element} */
-    this.persistentSlot_ = null;
-
-    /** @private {?Element} */
     this.collapsedSlot_ = null;
 
     /** @private {?Element} */
     this.expandedSlot_ = null;
+
+    /** @private {?Element} */
+    this.persistentSlot_ = null;
 
     /** @private {boolean} */
     this.useShadow_ = false;
@@ -115,34 +115,35 @@ export class AmpTruncateText extends AMP.BaseElement {
     this.content_ = html`
       <div class="i-amphtml-truncate-content">
         <span class="i-amphtml-default-slot"></span>
+        <span class="i-amphtml-truncate-collapsed-slot" name="collapsed"></span>
+        <span class="i-amphtml-truncate-expanded-slot" name="expanded"></span>
         <span
           class="i-amphtml-truncate-persistent-slot"
           name="persistent"
         ></span>
-        <span class="i-amphtml-truncate-collapsed-slot" name="collapsed"></span>
-        <span class="i-amphtml-truncate-expanded-slot" name="expanded"></span>
       </div>
     `;
 
     const defaultSlot = this.content_.querySelector('.i-amphtml-default-slot');
-    this.persistentSlot_ = this.content_.querySelector(
-      '.i-amphtml-truncate-persistent-slot'
-    );
+
     this.collapsedSlot_ = this.content_.querySelector(
       '.i-amphtml-truncate-collapsed-slot'
     );
     this.expandedSlot_ = this.content_.querySelector(
       '.i-amphtml-truncate-expanded-slot'
     );
+    this.persistentSlot_ = this.content_.querySelector(
+      '.i-amphtml-truncate-persistent-slot'
+    );
 
-    iterateCursor(this.element.querySelectorAll('[slot="persistent"]'), el => {
-      this.persistentSlot_.appendChild(el);
-    });
     iterateCursor(this.element.querySelectorAll('[slot="collapsed"]'), el => {
       this.collapsedSlot_.appendChild(el);
     });
     iterateCursor(this.element.querySelectorAll('[slot="expanded"]'), el => {
       this.expandedSlot_.appendChild(el);
+    });
+    iterateCursor(this.element.querySelectorAll('[slot="persistent"]'), el => {
+      this.persistentSlot_.appendChild(el);
     });
     this.getRealChildNodes().forEach(node => {
       defaultSlot.appendChild(node);
@@ -162,17 +163,17 @@ export class AmpTruncateText extends AMP.BaseElement {
       html`
         <div class="content">
           <slot></slot>
-          <slot class="persistent-slot" name="persistent"></slot>
           <slot class="collapsed-slot" name="collapsed"></slot>
           <slot class="expanded-slot" name="expanded"></slot>
+          <slot class="persistent-slot" name="persistent"></slot>
         </div>
       `
     );
 
     this.content_ = null;
-    this.persistentSlot_ = sr.querySelector('.persistent-slot');
     this.collapsedSlot_ = sr.querySelector('.collapsed-slot');
     this.expandedSlot_ = sr.querySelector('.expanded-slot');
+    this.persistentSlot_ = sr.querySelector('.persistent-slot');
   }
 
   /** @override */

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-truncate-text-0.1.css';
+import {Services} from '../../../src/services';
 import {CSS as ShadowCSS} from '../../../build/amp-truncate-text-shadow-0.1.css';
+import {
+  closestAncestorElementBySelector,
+  iterateCursor,
+} from '../../../src/dom';
 import {createShadowRoot} from './shadow-utils';
 import {dev, userAssert} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
-import {iterateCursor} from '../../../src/dom';
+import {toArray} from '../../../src/types';
 import {truncateText} from './truncate-text';
 
 /**
@@ -40,6 +46,15 @@ import {truncateText} from './truncate-text';
  *       one time thing
  */
 export class AmpTruncateText extends AMP.BaseElement {
+  /**
+   * Sets up the actions supported by this element.
+   * @private
+   */
+  setupActions_() {
+    this.registerAction('expand', () => this.expand_(), ActionTrust.HIGH);
+    this.registerAction('collapse', () => this.collapse_(), ActionTrust.HIGH);
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -48,10 +63,13 @@ export class AmpTruncateText extends AMP.BaseElement {
     this.content_ = null;
 
     /** @private {?Element} */
-    this.expandSlot_ = null;
+    this.persistentSlot_ = null;
 
     /** @private {?Element} */
-    this.collapseSlot_ = null;
+    this.collapsedSlot_ = null;
+
+    /** @private {?Element} */
+    this.expandedSlot_ = null;
 
     /** @private {boolean} */
     this.useShadow_ = false;
@@ -80,8 +98,13 @@ export class AmpTruncateText extends AMP.BaseElement {
       this.build_();
     }
 
-    this.expandSlot_.addEventListener('click', () => this.expand_());
-    this.collapseSlot_.addEventListener('click', () => this.collapse_());
+    this.setupActions_();
+    this.collapsedSlot_.addEventListener('click', event => {
+      this.maybeExpand_(event);
+    });
+    this.expandedSlot_.addEventListener('click', event => {
+      this.maybeCollapse_(event);
+    });
   }
 
   /**
@@ -92,24 +115,34 @@ export class AmpTruncateText extends AMP.BaseElement {
     this.content_ = html`
       <div class="i-amphtml-truncate-content">
         <span class="i-amphtml-default-slot"></span>
-        <span class="i-amphtml-truncate-expand-slot" name="expand"></span>
-        <span class="i-amphtml-truncate-collapse-slot" name="collapse"></span>
+        <span
+          class="i-amphtml-truncate-persistent-slot"
+          name="persistent"
+        ></span>
+        <span class="i-amphtml-truncate-collapsed-slot" name="collapsed"></span>
+        <span class="i-amphtml-truncate-expanded-slot" name="expanded"></span>
       </div>
     `;
 
     const defaultSlot = this.content_.querySelector('.i-amphtml-default-slot');
-    this.expandSlot_ = this.content_.querySelector(
-      '.i-amphtml-truncate-expand-slot'
+    this.persistentSlot_ = this.content_.querySelector(
+      '.i-amphtml-truncate-persistent-slot'
     );
-    this.collapseSlot_ = this.content_.querySelector(
-      '.i-amphtml-truncate-collapse-slot'
+    this.collapsedSlot_ = this.content_.querySelector(
+      '.i-amphtml-truncate-collapsed-slot'
+    );
+    this.expandedSlot_ = this.content_.querySelector(
+      '.i-amphtml-truncate-expanded-slot'
     );
 
-    iterateCursor(this.element.querySelectorAll('[slot="expand"]'), el => {
-      this.expandSlot_.appendChild(el);
+    iterateCursor(this.element.querySelectorAll('[slot="persistent"]'), el => {
+      this.persistentSlot_.appendChild(el);
     });
-    iterateCursor(this.element.querySelectorAll('[slot="collapse"]'), el => {
-      this.collapseSlot_.appendChild(el);
+    iterateCursor(this.element.querySelectorAll('[slot="collapsed"]'), el => {
+      this.collapsedSlot_.appendChild(el);
+    });
+    iterateCursor(this.element.querySelectorAll('[slot="expanded"]'), el => {
+      this.expandedSlot_.appendChild(el);
     });
     this.getRealChildNodes().forEach(node => {
       defaultSlot.appendChild(node);
@@ -129,15 +162,17 @@ export class AmpTruncateText extends AMP.BaseElement {
       html`
         <div class="content">
           <slot></slot>
-          <slot class="expand-slot" name="expand"></slot>
-          <slot class="collapse-slot" name="collapse"></slot>
+          <slot class="persistent-slot" name="persistent"></slot>
+          <slot class="collapsed-slot" name="collapsed"></slot>
+          <slot class="expanded-slot" name="expanded"></slot>
         </div>
       `
     );
 
     this.content_ = null;
-    this.expandSlot_ = sr.querySelector('.expand-slot');
-    this.collapseSlot_ = sr.querySelector('.collapse-slot');
+    this.persistentSlot_ = sr.querySelector('.persistent-slot');
+    this.collapsedSlot_ = sr.querySelector('.collapsed-slot');
+    this.expandedSlot_ = sr.querySelector('.expanded-slot');
   }
 
   /** @override */
@@ -168,6 +203,23 @@ export class AmpTruncateText extends AMP.BaseElement {
   }
 
   /**
+   * @return {!Array<!Element>} The elements to show when overflowing.
+   */
+  getElementsForOverflow_() {
+    if (this.useShadow_) {
+      return toArray(
+        this.element.querySelectorAll('[slot="persistent"], [slot="collapsed"]')
+      );
+    }
+
+    return toArray(
+      this.element.querySelectorAll(
+        '.i-amphtml-truncate-persistent-slot, .i-amphtml-truncate-collapsed-slot'
+      )
+    );
+  }
+
+  /**
    * Truncates the content of the element.
    * @private
    */
@@ -175,17 +227,61 @@ export class AmpTruncateText extends AMP.BaseElement {
     const container = dev().assertElement(
       this.useShadow_ ? this.element : this.content_
     );
-    const overflowElement = this.useShadow_
-      ? this.element.querySelector('[slot="expand"]')
-      : this.element.querySelector('.i-amphtml-truncate-expand-slot');
+    const overflowElements = this.getElementsForOverflow_();
 
     truncateText({
       container,
-      overflowElement,
+      overflowElements,
     });
     // Take the records to clear them out. This prevents mutations from
     // the truncation from invoking the observer's callback.
     this.mutationObserver_.takeRecords();
+  }
+
+  /**
+   * Expands the component, unless the event came from an element that is
+   * actionable.
+   * @param {!Event} event
+   */
+  maybeExpand_(event) {
+    this.maybeToggle_(event, true);
+  }
+
+  /**
+   * Collapses the component, unless the event came from an element that is
+   * actionable.
+   * @param {!Event} event
+   */
+  maybeCollapse_(event) {
+    this.maybeToggle_(event, false);
+  }
+
+  /**
+   * Expand/collapses the component unless the element already has an
+   * associated action or will navigate.
+   * @param {!Event} event
+   * @param {boolean} expand Whether to expand or collapse.
+   */
+  maybeToggle_(event, expand) {
+    const target = dev().assertElement(event.target);
+    const actionService = Services.actionServiceForDoc(this.element);
+
+    // If we have a tap action on any ancestor, then skip expansion.
+    if (actionService.hasAction(target, 'tap')) {
+      return;
+    }
+
+    // If we have an ancestor anchor (either for the slotted element, or
+    // wrapping the whole amp-truncate-text). skip expansion.
+    if (closestAncestorElementBySelector(target, 'a[href]')) {
+      return;
+    }
+
+    if (expand) {
+      this.expand_();
+    } else {
+      this.collapse_();
+    }
   }
 
   /**

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -204,9 +204,9 @@ export class AmpTruncateText extends AMP.BaseElement {
   }
 
   /**
-   * @return {!Array<!Element>} The elements to show when overflowing.
+   * @return {!Array<!Node>} The nodes to show when overflowing.
    */
-  getElementsForOverflow_() {
+  getNodesForOverflow_() {
     if (this.useShadow_) {
       return toArray(
         this.element.querySelectorAll('[slot="persistent"], [slot="collapsed"]')
@@ -228,11 +228,11 @@ export class AmpTruncateText extends AMP.BaseElement {
     const container = dev().assertElement(
       this.useShadow_ ? this.element : this.content_
     );
-    const overflowElements = this.getElementsForOverflow_();
+    const overflowNodes = this.getNodesForOverflow_();
 
     truncateText({
       container,
-      overflowElements,
+      overflowNodes,
     });
     // Take the records to clear them out. This prevents mutations from
     // the truncation from invoking the observer's callback.

--- a/extensions/amp-truncate-text/0.1/test/validator-amp-truncate-text.html
+++ b/extensions/amp-truncate-text/0.1/test/validator-amp-truncate-text.html
@@ -31,18 +31,18 @@
 
   <amp-truncate-text layout="fixed" width="150" height="80" overflow-style="right">
     Hello world
-    <div slot="expand">Expand</div>
+    <div slot="collapsed">Expand</div>
   </amp-truncate-text>
 
   <amp-truncate-text layout="responsive" width="150" height="80">
     Hello world
-    <div slot="expand">Expand</div>
-  </amp-truncate-text>
+    <div slot="collapsed">Expand</div>
+  </amp-truncate-collapsed>
 
   <!-- Invalid overflow-style -->
   <amp-truncate-text layout="fixed" width="150" height="80" overflow-style="left">
     Hello world
-    <div slot="expand">Expand</div>
+    <div slot="collapsed">Expand</div>
   </amp-truncate-text>
 </body>
 </html>

--- a/extensions/amp-truncate-text/0.1/test/validator-amp-truncate-text.out
+++ b/extensions/amp-truncate-text/0.1/test/validator-amp-truncate-text.out
@@ -32,20 +32,20 @@ FAIL
 |
 |    <amp-truncate-text layout="fixed" width="150" height="80" overflow-style="right">
 |      Hello world
-|      <div slot="expand">Expand</div>
+|      <div slot="collapsed">Expand</div>
 |    </amp-truncate-text>
 |
 |    <amp-truncate-text layout="responsive" width="150" height="80">
 |      Hello world
-|      <div slot="expand">Expand</div>
-|    </amp-truncate-text>
+|      <div slot="collapsed">Expand</div>
+|    </amp-truncate-collapsed>
 |
 |    <!-- Invalid overflow-style -->
 |    <amp-truncate-text layout="fixed" width="150" height="80" overflow-style="left">
 >>   ^~~~~~~~~
 amp-truncate-text/0.1/test/validator-amp-truncate-text.html:43:2 The attribute 'overflow-style' in tag 'amp-truncate-text' is set to the invalid value 'left'. (see https://amp.dev/documentation/components/amp-truncate-text) [DISALLOWED_HTML]
 |      Hello world
-|      <div slot="expand">Expand</div>
+|      <div slot="collapsed">Expand</div>
 |    </amp-truncate-text>
 |  </body>
 |  </html>

--- a/extensions/amp-truncate-text/0.1/truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/truncate-text.js
@@ -172,10 +172,10 @@ function getOverflowY(element) {
  *
  * @param {{
  *   container: !Element,
- *   overflowElements: !Array<!Element>,
+ *   overflowNodes: !Array<!Node>,
  * }} config
  */
-export function truncateText({container, overflowElements} = {}) {
+export function truncateText({container, overflowNodes} = {}) {
   clearTruncated(container);
 
   // If everything fits while the overflow button is hidden, we are done.
@@ -189,7 +189,7 @@ export function truncateText({container, overflowElements} = {}) {
   // Set the container as truncateed, so we show the overflow element and we can
   // truncate taking the size into account.
   setTruncated(container);
-  runTruncation(container, containerRect, overflowElements);
+  runTruncation(container, containerRect, overflowNodes);
 }
 
 /**
@@ -214,12 +214,12 @@ function getAllNodes(root, filter, nodes = []) {
  * truncation and truncating it.
  * @param {!Element} container The Element to do truncation for.
  * @param {!ClientRect} containerRect The rect for `container`.
- * @param {!Array<!Element>} overflowElements Any elements that should be
- *    be showing when there is overflow.
+ * @param {!Array<!Node>} overflowNodes Any nodes that should be showing
+ *    when there is overflow.
  */
-function runTruncation(container, containerRect, overflowElements) {
+function runTruncation(container, containerRect, overflowNodes) {
   const nodes = getAllNodes(container, node => {
-    return !overflowElements.includes(node);
+    return !overflowNodes.includes(node);
   });
 
   // Work backwards, truncating nodes from the end until we find one that can

--- a/extensions/amp-truncate-text/0.1/truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/truncate-text.js
@@ -172,10 +172,10 @@ function getOverflowY(element) {
  *
  * @param {{
  *   container: !Element,
- *   overflowElement: ?Element,
+ *   overflowElements: !Array<!Element>,
  * }} config
  */
-export function truncateText({container, overflowElement} = {}) {
+export function truncateText({container, overflowElements} = {}) {
   clearTruncated(container);
 
   // If everything fits while the overflow button is hidden, we are done.
@@ -189,7 +189,7 @@ export function truncateText({container, overflowElement} = {}) {
   // Set the container as truncateed, so we show the overflow element and we can
   // truncate taking the size into account.
   setTruncated(container);
-  runTruncation(container, containerRect, overflowElement);
+  runTruncation(container, containerRect, overflowElements);
 }
 
 /**
@@ -214,12 +214,12 @@ function getAllNodes(root, filter, nodes = []) {
  * truncation and truncating it.
  * @param {!Element} container The Element to do truncation for.
  * @param {!ClientRect} containerRect The rect for `container`.
- * @param {?Element} overflowElement An Element that shows when overflowing,
- *    or null if none is specified.
+ * @param {!Array<!Element>} overflowElements Any elements that should be
+ *    be showing when there is overflow.
  */
-function runTruncation(container, containerRect, overflowElement) {
+function runTruncation(container, containerRect, overflowElements) {
   const nodes = getAllNodes(container, node => {
-    return node != overflowElement;
+    return !overflowElements.includes(node);
   });
 
   // Work backwards, truncating nodes from the end until we find one that can

--- a/extensions/amp-truncate-text/amp-truncate-text.md
+++ b/extensions/amp-truncate-text/amp-truncate-text.md
@@ -52,14 +52,18 @@ Truncates text with an ellipsis, optionally showing an overflow element when the
 
 <table>
   <tr>
-    <td width="40%"><strong>slot="expand"</strong></td>
-    <td>An optional element show when the element has truncateed text. Clicking
+    <td width="40%"><strong>slot="collapsed"</strong></td>
+    <td>An optional element show when the element has truncated text. Clicking
     this will expand the element. This must be a direct child of <code>amp-truncate-text</code>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>slot="collapse"</strong></td>
+    <td width="40%"><strong>slot="expanded"</strong></td>
     <td>An optional element show when the element was expanded. Clicking
     this will collapse the element to the same size before expansion. This must be a direct child of <code>amp-truncate-text</code>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>slot="persistent"</strong></td>
+    <td>An optional element than is always shown, regardless of whether or not the text is truncated. This must be a direct child of <code>amp-truncate-text</code>.</td>
   </tr>
 </table>
 
@@ -70,6 +74,36 @@ Truncates text with an ellipsis, optionally showing an overflow element when the
   Some text that may get truncated.
   <button slot="expand">See more</button>
   <button slot="collapse">See less</button>
+</amp-truncate-text>
+```
+
+## Using a Custom Action
+
+If you do not want to expand in place, you can use `slot="persistent"` to perform a custom acton, such as navigating to another page with additional information. This can be useful when there is more content than would make sense to expand inline.
+
+```html
+<amp-truncate-text layout="fixed-height" height="3em">
+  Some text that may get truncated.
+  <a href="some/url" slot="persistent">See more</a>
+</amp-truncate-text>
+```
+
+You can also customize the action for an element with `slot="collapsed"` by using either an anchor tag or a tap action. Note that this will not show up if the text fits. For example:
+
+```html
+<amp-truncate-text layout="fixed-height" height="3em">
+  Some text that may get truncated.
+  <a href="some/url" slot="collapsed">See more</a>
+</amp-truncate-text>
+```
+
+By default, clicking within an element that has `slot="expanded"` will collapse the content. Like for `slot="collapsed"`, using an anchor tag or a tap action will allow you to override the behavior to do something else, like link to another page.
+
+```html
+<amp-truncate-text layout="fixed-height" height="3em">
+  Some text that may get truncated.
+  <button slot="collapsed">See more</button>
+  <a href="some/url" slot="expanded">See even more</a>
 </amp-truncate-text>
 ```
 

--- a/test/manual/amp-truncate-text/always-show-expand.amp.html
+++ b/test/manual/amp-truncate-text/always-show-expand.amp.html
@@ -2,11 +2,19 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>amp-truncate-text responsive size</title>
+  <title>amp-truncate-text always show expand</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
+    .text {
+      font-size: 1em;
+      line-height: 1.25;
+      height: 2.5em;
+      width: 300px;
+      overflow: hidden;
+    }
+
     .overflow-button {
       color: #1b61e0;
     }
@@ -18,9 +26,6 @@
       padding-bottom: 0;
       border: none;
       background-color: transparent;
-    }
-
-    .right-aligned {
       float: right;
     }
   </style>
@@ -28,14 +33,28 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <h1>Responsive size</h1>
+  <h1>Always show the expand button</h1>
 
-  <amp-truncate-text layout="responsive" width="5" height="1">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
-    luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
-    Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
-    Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="collapsed" class="overflow-button compact right-aligned">See more</button>
+  <amp-truncate-text class="text" layout="container">
+    Should always have a see more button, even without truncation.
+    <span on="tap:foo.scrollTo(pos = 'top')" slot="persistent" class="overflow-button compact"> See more</a>
   </amp-truncate-text>
+
+  <amp-truncate-text class="text" layout="container" always-show-expand>
+    Should always have a see more button, even without truncation. This one should be truncated.
+    <span on="tap:foo.scrollTo(pos = 'top')" slot="persistent" class="overflow-button compact"> See more</a>
+  </amp-truncate-text>
+
+  <div style="height: 100vh"></div>
+
+  <section>
+    <h1 id="foo">
+      Some more details.
+    </h1>
+    <p>
+      Some placeholder text.
+    </p>
+  </section>
+
 </body>
 </html>

--- a/test/manual/amp-truncate-text/even-more.amp.html
+++ b/test/manual/amp-truncate-text/even-more.amp.html
@@ -2,11 +2,19 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>amp-truncate-text responsive size</title>
+  <title>amp-truncate-text always show expand</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
+    .text {
+      font-size: 1em;
+      line-height: 1.25;
+      height: 2.5em;
+      width: 300px;
+      overflow: hidden;
+    }
+
     .overflow-button {
       color: #1b61e0;
     }
@@ -18,9 +26,6 @@
       padding-bottom: 0;
       border: none;
       background-color: transparent;
-    }
-
-    .right-aligned {
       float: right;
     }
   </style>
@@ -28,14 +33,25 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <h1>Responsive size</h1>
+  <h1>Always show the expand button</h1>
 
-  <amp-truncate-text layout="responsive" width="5" height="1">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
-    luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
-    Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
-    Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="collapsed" class="overflow-button compact right-aligned">See more</button>
+  <amp-truncate-text class="text" layout="container">
+    This is some text that should be truncated, but the "whole" content may not be available without another request. So the "Even more" button when expanded can be used.
+    <button slot="collapsed" class="overflow-button compact">See more</button>
+    <span on="tap:foo.scrollTo(pos = 'top')" slot="expanded" class="overflow-button compact"> Even more</a>
   </amp-truncate-text>
+
+
+  <div style="height: 100vh"></div>
+
+  <section>
+    <h1 id="foo">
+      Some more details.
+    </h1>
+    <p>
+      Some placeholder text.
+    </p>
+  </section>
+
 </body>
 </html>

--- a/test/manual/amp-truncate-text/expand-collapse.amp.html
+++ b/test/manual/amp-truncate-text/expand-collapse.amp.html
@@ -37,8 +37,8 @@
 
   <amp-truncate-text class="text" layout="container">
     Some text <a href="#">with a long link that should ellipsize and show</a> a see more span afterwards.
-    <button slot="expand" class="overflow-button compact"> See more</button>
-    <button slot="collapse" class="overflow-button compact"> See less</button>
+    <button slot="collapsed" class="overflow-button compact"> See more</button>
+    <button slot="expanded" class="overflow-button compact"> See less</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/full-width-button.amp.html
+++ b/test/manual/amp-truncate-text/full-width-button.amp.html
@@ -44,7 +44,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button compact full-width">See more</button>
+    <button slot="collapsed" class="overflow-button compact full-width">See more</button>
   </amp-truncate-text>
 
   <amp-truncate-text layout="container" class="text">
@@ -52,7 +52,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button compact full-width">See more</button>
+    <button slot="collapsed" class="overflow-button compact full-width">See more</button>
   </amp-truncate-text>
 
   <amp-truncate-text layout="container" class="text">
@@ -60,7 +60,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button compact full-width">See more</button>
+    <button slot="collapsed" class="overflow-button compact full-width">See more</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/inline-block-compact.amp.html
+++ b/test/manual/amp-truncate-text/inline-block-compact.amp.html
@@ -40,7 +40,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button compact">See more</button>
+    <button slot="collapsed" class="overflow-button compact">See more</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/inline-block-large.amp.html
+++ b/test/manual/amp-truncate-text/inline-block-large.amp.html
@@ -38,7 +38,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button large">See more</button>
+    <button slot="collapsed" class="overflow-button large">See more</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/inline-button.amp.html
+++ b/test/manual/amp-truncate-text/inline-button.amp.html
@@ -41,7 +41,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="inline-button right-aligned"> See more</button>
+    <button slot="collapsed" class="inline-button right-aligned"> See more</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/link-before-truncation.amp.html
+++ b/test/manual/amp-truncate-text/link-before-truncation.amp.html
@@ -28,7 +28,7 @@
 
   <amp-truncate-text layout="container" class="text">
     Some text <a href="#">with a link</a> that should ellipsize and show a see more span afterwards.
-    <span slot="expand" class="see-more"> See more</span>
+    <span slot="collapsed" class="see-more"> See more</span>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/link-truncated.amp.html
+++ b/test/manual/amp-truncate-text/link-truncated.amp.html
@@ -28,7 +28,7 @@
 
   <amp-truncate-text layout="container" class="text">
     Some text <a href="#">with a long link that should ellipsize and show</a> a see more span afterwards.
-    <span slot="expand" class="see-more"> See more</span>
+    <span slot="collapsed" class="see-more"> See more</span>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/persistent-and-collapsed.amp.html
+++ b/test/manual/amp-truncate-text/persistent-and-collapsed.amp.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-truncate-text persistent and collapsed</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    .square {
+      width: 200px;
+      height: 200px;
+      background-color: #39f;
+    }
+
+    .text {
+      font-size: 1em;
+      line-height: 1.25;
+      height: 3.75em;
+      width: 300px;
+      overflow: hidden;
+    }
+
+    .overflow-button {
+      color: #1b61e0;
+    }
+
+    .overflow-button.compact {
+      font-size: inherit;
+      font-family: inherit;
+      padding-top: 0;
+      padding-bottom: 0;
+      border: none;
+      background-color: transparent;
+      float: right;
+    }
+
+    .credit {
+      clear: both;
+    }
+  </style>
+  <script async custom-element="amp-truncate-text" src="https://cdn.ampproject.org/v0/amp-truncate-text-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Persistent and collapsed</h1>
+
+  <figure>
+    <div class="square"></div>
+    <figcaption>
+      <amp-truncate-text class="text" layout="container">
+        The persistent slotted content should always show even when this gets truncated. The rest of this text is just to force truncation so the collapsed element shows.
+        <button class="overflow-button compact" slot="collapsed">See more</button>
+        <div class="credit" slot="persistent"> By Foobius Barius</div>
+      </amp-truncate-text>
+    </figcaption>
+  </figure>
+
+</body>
+</html>

--- a/test/manual/amp-truncate-text/persistent.amp.html
+++ b/test/manual/amp-truncate-text/persistent.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>amp-truncate-text always show expand</title>
+  <title>amp-truncate-text persistent button</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -33,7 +33,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <h1>Always show the expand button</h1>
+  <h1>Persistent button</h1>
 
   <amp-truncate-text class="text" layout="container">
     Should always have a see more button, even without truncation.

--- a/test/manual/amp-truncate-text/right-aligned-compact.amp.html
+++ b/test/manual/amp-truncate-text/right-aligned-compact.amp.html
@@ -44,7 +44,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button compact right-aligned">See more</button>
+    <button slot="collapsed" class="overflow-button compact right-aligned">See more</button>
   </amp-truncate-text>
 </body>
 </html>

--- a/test/manual/amp-truncate-text/right-aligned-large.amp.html
+++ b/test/manual/amp-truncate-text/right-aligned-large.amp.html
@@ -42,7 +42,7 @@
     luctus nunc ut elit cursus, et imperdiet diam vehicula. Duis et nisi sed urna blandit bibendum et sit amet erat.
     Suspendisse potenti. Curabitur consequat volutpat arcu nec elementum. Etiam a turpis ac libero varius condimentum.
     Maecenas sollicitudin felis aliquam tortor vulputate, ac posuere velit semper.
-    <button slot="expand" class="overflow-button large right-aligned">See more</button>
+    <button slot="collapsed" class="overflow-button large right-aligned">See more</button>
   </amp-truncate-text>
 </body>
 </html>


### PR DESCRIPTION
- Rename "expand" slot into "collapsed", since it may be used to do something
other than expand.
- Rename "collapse" slot into "expanded", since it may be used to do something
other than collapse.
- Support custom tap actions as well as anchor tags, which will override
the default expand/collapse behavior of the "collapsed" and "expanded"
slots.
- Add a "persistent" slot that is always present. This is useful when
you have something like a short description (which may be truncated,
depending on available space), but you want to link to another page
regardless of truncation.