### PR TITLE
Change the background color of highlighted texts from orange to yellow.

### DIFF
--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -209,10 +209,9 @@ export class HighlightHandler {
 
     for (let i = 0; i < this.highlightedNodes_.length; i++) {
       const n = this.highlightedNodes_[i];
-      // The background color is same as Android Chrome text finding.
-      // https://cs.chromium.org/chromium/src/chrome/android/java/res/values/colors.xml?l=158&rcl=8b461e376e824c72fec1d6d91cd6633ba344dd55&q=ff9632
+      // The background color is same as Android Chrome text finding (yellow).
       setStyles(n, {
-        backgroundColor: '#ff9632',
+        backgroundColor: '#fcff00',
         color: '#000',
       });
     }

--- a/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
@@ -174,9 +174,9 @@ describes.realWin(
       });
 
       expect(root.innerHTML).to.equal(
-        '<div>text in <span style="background-color: rgb(255, 150, 50); ' +
+        '<div>text in <span style="background-color: rgb(252, 255, 0); ' +
           'color: rgb(0, 0, 0);">amp</span> doc</div><div>' +
-          '<span style="background-color: rgb(255, 150, 50); color: ' +
+          '<span style="background-color: rgb(252, 255, 0); color: ' +
           'rgb(0, 0, 0);">highlight</span>ed text</div>'
       );
 


### PR DESCRIPTION
Based on the discussion with UI designers, we decided to change the background color of highlighted texts into yellow to keep consistency with Chrome:

https://docs.google.com/document/d/1OzfBkwXkeALVHtcqrK7Wj_GN3Jk_rlhdOAElPH_jabI/edit#heading=h.6m0mi6jwv4v0
