### PR TITLE
🐛Fix form-validators with date picker on touch devices

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -892,7 +892,7 @@ export class AmpDatePicker extends AMP.BaseElement {
         this.mode_ == DatePickerMode.OVERLAY &&
         this.input_.isTouchDetected()
       ) {
-        setNonValidationReadonly(existingField, true);
+        setTouchNonValidationReadonly(existingField, true);
       }
       return existingField;
     }
@@ -991,11 +991,11 @@ export class AmpDatePicker extends AMP.BaseElement {
   }
 
   /**
-   * Suppress the mobile keyboard on focus.
-   * The `readonly` property on input elements prevents the mobile keyboard from
+   * Suppress the touch keyboard on focus.
+   * The `readonly` property on input elements prevents the touch keyboard from
    * appearing when the input receives focus.
    * However, `readonly` also prevents form validation from triggering.
-   * To suppress the mobile keyboard and also allow validation to occur, this
+   * To suppress the touch keyboard and also allow validation to occur, this
    * method adds `readonly` when focus occurs, and removes it on blur.
    * @param {!Event} e
    * @private
@@ -1007,7 +1007,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       return;
     }
 
-    if (!isNonValidationReadonly(target)) {
+    if (!isTouchNonValidationReadonly(target)) {
       return;
     }
 
@@ -1042,7 +1042,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       return;
     }
 
-    if (!isNonValidationReadonly(target)) {
+    if (!isTouchNonValidationReadonly(target)) {
       return;
     }
 
@@ -1998,11 +1998,11 @@ export class AmpDatePicker extends AMP.BaseElement {
 
 /**
  * Mark an element to receive the `readonly` property on focus.
- * That will prevent the mobile keyboard from appearing when it is not desired.
+ * That will prevent the touch keyboard from appearing when it is not desired.
  * @param {!Element} element
  * @param {boolean} toggle
  */
-function setNonValidationReadonly(element, toggle) {
+function setTouchNonValidationReadonly(element, toggle) {
   if (!toggle) {
     delete element.dataset[AMP_READONLY_DATA_ATTR];
     return;
@@ -2017,7 +2017,7 @@ function setNonValidationReadonly(element, toggle) {
  * @param {!Element} element
  * @return {boolean}
  */
-function isNonValidationReadonly(element) {
+function isTouchNonValidationReadonly(element) {
   return Boolean(element.dataset[AMP_READONLY_DATA_ATTR]);
 }
 

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -433,21 +433,46 @@ describes.realWin(
 
       describe('src attribute', () => {
         it('should set highlighted and blocked dates', () => {
-          const {element} = createDatePicker({
+          const {picker} = createDatePicker({
             src: 'http://localhost:9876/date-picker/src-data/get',
           });
 
-          const impl = element.implementation_;
-
-          sandbox.stub(impl, 'fetchSrc_').resolves({
+          sandbox.stub(picker, 'fetchSrc_').resolves({
             blocked: ['2018-01-03'],
             highlighted: ['2018-01-04'],
           });
 
-          return impl.setupSrcAttributes_().then(() => {
-            expect(impl.blocked_.contains('2018-01-03')).to.be.true;
-            expect(impl.highlighted_.contains('2018-01-04')).to.be.true;
+          return picker.setupSrcAttributes_().then(() => {
+            expect(picker.blocked_.contains('2018-01-03')).to.be.true;
+            expect(picker.highlighted_.contains('2018-01-04')).to.be.true;
           });
+        });
+      });
+
+      describe('touch keyboard suppression', () => {
+        it('should add and remove the readonly property on focus', () => {
+          const {element, picker} = createDatePicker({
+            'mode': 'overlay',
+            'input-selector': '#date',
+          });
+          const input = document.createElement('input');
+          input.id = 'date';
+          element.appendChild(input);
+          sandbox.stub(picker.input_, 'isTouchDetected').returns(true);
+
+          return picker
+            .buildCallback()
+            .then(() => {
+              expect(input).to.have.attribute('data-i-amphtml-readonly');
+              return picker.layoutCallback();
+            })
+            .then(() => {
+              const fakeEvent = {target: input};
+              picker.addTouchReadonly_(fakeEvent);
+              expect(input.readOnly).to.be.true;
+              picker.removeTouchReadonly_(fakeEvent);
+              expect(input.readOnly).to.be.false;
+            });
         });
       });
     });

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -450,7 +450,36 @@ describes.realWin(
       });
 
       describe('touch keyboard suppression', () => {
-        it('should add and remove the readonly property on focus', () => {
+        it(
+          'should add and remove the readonly property on focus' +
+            ' for touch devices',
+          () => {
+            const {element, picker} = createDatePicker({
+              'mode': 'overlay',
+              'input-selector': '#date',
+            });
+            const input = document.createElement('input');
+            input.id = 'date';
+            element.appendChild(input);
+            sandbox.stub(picker.input_, 'isTouchDetected').returns(true);
+
+            return picker
+              .buildCallback()
+              .then(() => {
+                expect(input).to.have.attribute('data-i-amphtml-readonly');
+                return picker.layoutCallback();
+              })
+              .then(() => {
+                const fakeEvent = {target: input};
+                picker.addTouchReadonly_(fakeEvent);
+                expect(input.readOnly).to.be.true;
+                picker.removeTouchReadonly_(fakeEvent);
+                expect(input.readOnly).to.be.false;
+              });
+          }
+        );
+
+        it('should not add and remove the readonly property on desktop', () => {
           const {element, picker} = createDatePicker({
             'mode': 'overlay',
             'input-selector': '#date',
@@ -458,18 +487,18 @@ describes.realWin(
           const input = document.createElement('input');
           input.id = 'date';
           element.appendChild(input);
-          sandbox.stub(picker.input_, 'isTouchDetected').returns(true);
+          sandbox.stub(picker.input_, 'isTouchDetected').returns(false);
 
           return picker
             .buildCallback()
             .then(() => {
-              expect(input).to.have.attribute('data-i-amphtml-readonly');
+              expect(input).to.not.have.attribute('data-i-amphtml-readonly');
               return picker.layoutCallback();
             })
             .then(() => {
               const fakeEvent = {target: input};
               picker.addTouchReadonly_(fakeEvent);
-              expect(input.readOnly).to.be.true;
+              expect(input.readOnly).to.be.false;
               picker.removeTouchReadonly_(fakeEvent);
               expect(input.readOnly).to.be.false;
             });


### PR DESCRIPTION
Fixes #22688

Instead of assigning `readonly` at load-time, assign it just before the mobile device focuses on the input element. This prevents the keyboard from appearing and allows validation to continue as normal.