### PR TITLE
Dispatch VALUE_CHANGE on `amp-bind` value changes

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1151,7 +1151,12 @@ export class Bind {
         }
 
         if (isPropertyAFormValue(element.tagName, property)) {
-          dispatchAmpFormValueChangeEvent(this.localWin_, element);
+          const dispatchAt =
+            element.tagName === 'OPTION' ? element.closest('SELECT') : element;
+
+          if (dispatchAt) {
+            dispatchAmpFormValueChangeEvent(this.localWin_, dispatchAt);
+          }
         }
       });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -56,6 +56,13 @@ const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
  */
 const MAX_MERGE_DEPTH = 10;
 
+/** @const {!Object<string, !Array<string>>} */
+const FORM_VALUE_PROPERTIES = {
+  'INPUT': ['checked', 'value'],
+  'OPTION': ['selected'],
+  'TEXTAREA': ['text'],
+};
+
 /**
  * A bound property, e.g. [property]="expression".
  * `previousResult` is the result of this expression during the last evaluation.
@@ -1185,7 +1192,8 @@ export class Bind {
    * @param {string} property
    */
   dispatchFormValueChangeEventIfNecessary_(element, property) {
-    if (!isPropertyAFormValue(element.tagName, property)) {
+    const props = FORM_VALUE_PROPERTIES[element.tagName];
+    if (!props || !props.includes(property)) {
       return;
     }
 
@@ -1676,25 +1684,5 @@ export class Bind {
       }
       this.localWin_.dispatchEvent(event);
     }
-  }
-}
-
-/**
- * Returns whether the element's property represents the value of a form field.
- * @param {string} tagName
- * @param {string} property
- * @return {boolean}
- */
-function isPropertyAFormValue(tagName, property) {
-  switch (property) {
-    case 'checked':
-    case 'value':
-      return tagName === 'INPUT';
-    case 'selected':
-      return tagName === 'OPTION';
-    case 'text':
-      return tagName === 'TEXTAREA';
-    default:
-      return false;
   }
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1151,7 +1151,7 @@ export class Bind {
         }
 
         if (isPropertyAFormValue(element.tagName, property)) {
-          dispatchAmpValueChangeEvent(this.localWin_, element);
+          dispatchAmpFormValueChangeEvent(this.localWin_, element);
         }
       });
 
@@ -1673,14 +1673,14 @@ function isPropertyAFormValue(tagName, property) {
 }
 
 /**
- * Dispatches an `AmpEvents.VALUE_CHANGE` event at the given element.
+ * Dispatches an `AmpEvents.FORM_VALUE_CHANGE` event at the given element.
  * @param {!Window} win
  * @param {!Element} element
  */
-function dispatchAmpValueChangeEvent(win, element) {
+function dispatchAmpFormValueChangeEvent(win, element) {
   const ampValueChangeEvent = createCustomEvent(
     win,
-    AmpEvents.VALUE_CHANGE,
+    AmpEvents.FORM_VALUE_CHANGE,
     /* detail */ null,
     {bubbles: true}
   );

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -56,11 +56,18 @@ const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
  */
 const MAX_MERGE_DEPTH = 10;
 
-/** @const {!Object<string, !Array<string>>} */
+/** @const {!Object<string, !Object<string, boolean>>} */
 const FORM_VALUE_PROPERTIES = {
-  'INPUT': ['checked', 'value'],
-  'OPTION': ['selected'],
-  'TEXTAREA': ['text'],
+  'INPUT': {
+    'checked': true,
+    'value': true,
+  },
+  'OPTION': {
+    'selected': true,
+  },
+  'TEXTAREA': {
+    'text': true,
+  },
 };
 
 /**
@@ -1192,8 +1199,8 @@ export class Bind {
    * @param {string} property
    */
   dispatchFormValueChangeEventIfNecessary_(element, property) {
-    const props = FORM_VALUE_PROPERTIES[element.tagName];
-    if (!props || !props.includes(property)) {
+    const isPropertyAFormValue = FORM_VALUE_PROPERTIES[element.tagName];
+    if (!isPropertyAFormValue || !isPropertyAFormValue[property]) {
       return;
     }
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1139,8 +1139,8 @@ describe
           expect(foo.textContent).to.not.equal('bar');
         });
 
-        describe('AmpEvents.VALUE_CHANGE dispatches', () => {
-          it('should dispatch on <input [value]> changes', () => {
+        describe('AmpEvents.VALUE_CHANGE', () => {
+          it('should dispatch VALUE_CHANGE on <input [value]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1158,7 +1158,7 @@ describe
             });
           });
 
-          it('should dispatch on <input [checked]> changes', () => {
+          it('should dispatch VALUE_CHANGE on <input [checked]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1178,7 +1178,7 @@ describe
             );
           });
 
-          it('should dispatch on <option [selected]> changes', () => {
+          it('should dispatch VALUE_CHANGE on <option [selected]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1198,7 +1198,7 @@ describe
             );
           });
 
-          it('should dispatch on <textarea [text]> changes', () => {
+          it('should dispatch VALUE_CHANGE on <textarea [text]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1216,7 +1216,7 @@ describe
             });
           });
 
-          it('should NOT dispatch on other attributes', () => {
+          it('should NOT dispatch VALUE_CHANGE on other attributes changes', () => {
             const element = createElement(
               env,
               container,
@@ -1230,7 +1230,7 @@ describe
             });
           });
 
-          it('should NOT dispatch on other elements', () => {
+          it('should NOT dispatch VALUE_CHANGE on other element changes', () => {
             const element = createElement(env, container, '[text]="foo"', 'p');
             const spy = sandbox.spy(element, 'dispatchEvent');
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -141,6 +141,11 @@ function waitForEvent(env, name) {
   });
 }
 
+const FORM_VALUE_CHANGE_EVENT_ARGUMENTS = {
+  type: AmpEvents.FORM_VALUE_CHANGE,
+  bubbles: true,
+};
+
 describe
   .configure()
   .ifChrome()
@@ -1151,10 +1156,7 @@ describe
 
             return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
               expect(spy).to.have.been.calledOnce;
-              expect(spy).calledWithMatch({
-                type: AmpEvents.FORM_VALUE_CHANGE,
-                bubbles: true,
-              });
+              expect(spy).calledWithMatch(FORM_VALUE_CHANGE_EVENT_ARGUMENTS);
             });
           });
 
@@ -1170,10 +1172,7 @@ describe
             return onBindReadyAndSetState(env, bind, {foo: 'checked'}).then(
               () => {
                 expect(spy).to.have.been.calledOnce;
-                expect(spy).calledWithMatch({
-                  type: AmpEvents.FORM_VALUE_CHANGE,
-                  bubbles: true,
-                });
+                expect(spy).calledWithMatch(FORM_VALUE_CHANGE_EVENT_ARGUMENTS);
               }
             );
           });

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1178,14 +1178,16 @@ describe
             );
           });
 
-          it('should dispatch FORM_VALUE_CHANGE on <option [selected]> changes', () => {
-            const element = createElement(
-              env,
-              container,
-              '[selected]="foo"',
-              'option'
-            );
-            const spy = sandbox.spy(element, 'dispatchEvent');
+          it('should dispatch FORM_VALUE_CHANGE at parent <select> on <option [selected]> changes', () => {
+            const select = env.win.document.createElement('select');
+            select.innerHTML = `
+              <optgroup>
+                <option [selected]="foo"></option>
+              </optgroup>
+            `;
+            container.appendChild(select);
+
+            const spy = sandbox.spy(select, 'dispatchEvent');
 
             return onBindReadyAndSetState(env, bind, {foo: 'selected'}).then(
               () => {

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1138,6 +1138,109 @@ describe
           yield onBindReadyAndSetState(env, bind, {foo: 'bar'});
           expect(foo.textContent).to.not.equal('bar');
         });
+
+        describe('AmpEvents.VALUE_CHANGE dispatches', () => {
+          it('should dispatch on <input [value]> changes', () => {
+            const element = createElement(
+              env,
+              container,
+              '[value]="foo"',
+              'input'
+            );
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
+              expect(spy).to.have.been.calledOnce;
+              expect(spy).calledWithMatch({
+                type: AmpEvents.VALUE_CHANGE,
+                bubbles: true,
+              });
+            });
+          });
+
+          it('should dispatch on <input [checked]> changes', () => {
+            const element = createElement(
+              env,
+              container,
+              '[checked]="foo"',
+              'input'
+            );
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'checked'}).then(
+              () => {
+                expect(spy).to.have.been.calledOnce;
+                expect(spy).calledWithMatch({
+                  type: AmpEvents.VALUE_CHANGE,
+                  bubbles: true,
+                });
+              }
+            );
+          });
+
+          it('should dispatch on <option [selected]> changes', () => {
+            const element = createElement(
+              env,
+              container,
+              '[selected]="foo"',
+              'option'
+            );
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'selected'}).then(
+              () => {
+                expect(spy).to.have.been.calledOnce;
+                expect(spy).calledWithMatch({
+                  type: AmpEvents.VALUE_CHANGE,
+                  bubbles: true,
+                });
+              }
+            );
+          });
+
+          it('should dispatch on <textarea [text]> changes', () => {
+            const element = createElement(
+              env,
+              container,
+              '[text]="foo"',
+              'textarea'
+            );
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
+              expect(spy).to.have.been.calledOnce;
+              expect(spy).calledWithMatch({
+                type: AmpEvents.VALUE_CHANGE,
+                bubbles: true,
+              });
+            });
+          });
+
+          it('should NOT dispatch on other attributes', () => {
+            const element = createElement(
+              env,
+              container,
+              '[name]="foo"',
+              'input'
+            );
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'name'}).then(() => {
+              expect(spy).to.not.have.been.called;
+            });
+          });
+
+          it('should NOT dispatch on other elements', () => {
+            const element = createElement(env, container, '[text]="foo"', 'p');
+            const spy = sandbox.spy(element, 'dispatchEvent');
+
+            return onBindReadyAndSetState(env, bind, {foo: 'selected'}).then(
+              () => {
+                expect(spy).to.not.have.been.called;
+              }
+            );
+          });
+        });
       }
     ); // in single ampdoc
   });

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1139,8 +1139,8 @@ describe
           expect(foo.textContent).to.not.equal('bar');
         });
 
-        describe('AmpEvents.VALUE_CHANGE', () => {
-          it('should dispatch VALUE_CHANGE on <input [value]> changes', () => {
+        describe('AmpEvents.FORM_VALUE_CHANGE', () => {
+          it('should dispatch FORM_VALUE_CHANGE on <input [value]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1152,13 +1152,13 @@ describe
             return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
               expect(spy).to.have.been.calledOnce;
               expect(spy).calledWithMatch({
-                type: AmpEvents.VALUE_CHANGE,
+                type: AmpEvents.FORM_VALUE_CHANGE,
                 bubbles: true,
               });
             });
           });
 
-          it('should dispatch VALUE_CHANGE on <input [checked]> changes', () => {
+          it('should dispatch FORM_VALUE_CHANGE on <input [checked]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1171,14 +1171,14 @@ describe
               () => {
                 expect(spy).to.have.been.calledOnce;
                 expect(spy).calledWithMatch({
-                  type: AmpEvents.VALUE_CHANGE,
+                  type: AmpEvents.FORM_VALUE_CHANGE,
                   bubbles: true,
                 });
               }
             );
           });
 
-          it('should dispatch VALUE_CHANGE on <option [selected]> changes', () => {
+          it('should dispatch FORM_VALUE_CHANGE on <option [selected]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1191,14 +1191,14 @@ describe
               () => {
                 expect(spy).to.have.been.calledOnce;
                 expect(spy).calledWithMatch({
-                  type: AmpEvents.VALUE_CHANGE,
+                  type: AmpEvents.FORM_VALUE_CHANGE,
                   bubbles: true,
                 });
               }
             );
           });
 
-          it('should dispatch VALUE_CHANGE on <textarea [text]> changes', () => {
+          it('should dispatch FORM_VALUE_CHANGE on <textarea [text]> changes', () => {
             const element = createElement(
               env,
               container,
@@ -1210,13 +1210,13 @@ describe
             return onBindReadyAndSetState(env, bind, {foo: 'bar'}).then(() => {
               expect(spy).to.have.been.calledOnce;
               expect(spy).calledWithMatch({
-                type: AmpEvents.VALUE_CHANGE,
+                type: AmpEvents.FORM_VALUE_CHANGE,
                 bubbles: true,
               });
             });
           });
 
-          it('should NOT dispatch VALUE_CHANGE on other attributes changes', () => {
+          it('should NOT dispatch FORM_VALUE_CHANGE on other attributes changes', () => {
             const element = createElement(
               env,
               container,
@@ -1230,7 +1230,7 @@ describe
             });
           });
 
-          it('should NOT dispatch VALUE_CHANGE on other element changes', () => {
+          it('should NOT dispatch FORM_VALUE_CHANGE on other element changes', () => {
             const element = createElement(env, container, '[text]="foo"', 'p');
             const spy = sandbox.spy(element, 'dispatchEvent');
 

--- a/src/amp-events.js
+++ b/src/amp-events.js
@@ -21,7 +21,7 @@
 export const AmpEvents = {
   BUILT: 'amp:built',
   DOM_UPDATE: 'amp:dom-update',
-  VALUE_CHANGE: 'amp:value-change',
+  FORM_VALUE_CHANGE: 'amp:form-value-change',
   VISIBILITY_CHANGE: 'amp:visibilitychange', // https://github.com/ampproject/amphtml/blob/master/ads/README.md#page-visibility
   // The following codes are only used for testing.
   // TODO(choumx): Move these to a separate enum so they can be DCE'd.

--- a/src/amp-events.js
+++ b/src/amp-events.js
@@ -21,6 +21,7 @@
 export const AmpEvents = {
   BUILT: 'amp:built',
   DOM_UPDATE: 'amp:dom-update',
+  VALUE_CHANGE: 'amp:value-change',
   VISIBILITY_CHANGE: 'amp:visibilitychange', // https://github.com/ampproject/amphtml/blob/master/ads/README.md#page-visibility
   // The following codes are only used for testing.
   // TODO(choumx): Move these to a separate enum so they can be DCE'd.


### PR DESCRIPTION
This introduces a new `AmpEvents.VALUE_CHANGE` event. It is dispatched
when `amp-bind` mutates form input values, specifically:
`<input [value]>`, `<textarea [text]>`, `<input [checked]>`, and
`<option [selected]>`.

A custom event is chosen over a mutation observer, because binding
`[text]` on `textarea` does not change the DOM (and it's expected), thus
a mutation observer won't pick up the change. The same applies to
`input` elements, when we eventually have two separate bindings for
`[value]` and `[defaultValue]`.

Part of #22534.

/cc @GoTcWang @choumx thanks!