### PR TITLE
Remove dynamic-live-list attribute

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-live-story.html
+++ b/examples/visual-tests/amp-story/amp-story-live-story.html
@@ -26,7 +26,7 @@
         poster-portrait-src="/examples/visual-tests/picsum.photos/image981_900x1600.jpg"
         poster-landscape-src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg"
         poster-square-src="/examples/visual-tests/picsum.photos/image981_1600x1600.jpg"
-        id="story1" dynamic-live-list="story-list">
+        id="story1" live-story>
 
       <amp-story-page id="cover" data-sort-time="1552330790">
         <amp-story-grid-layer template="vertical">

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -231,12 +231,16 @@ export class LiveListManager {
   /**
    * Updates the appropriate `amp-live-list` with its updates from the server.
    *
-   * @param {!Element} liveList
+   * @param {!Element} liveList Live list or custom element that built it.
    * @return {number}
    */
   updateLiveList_(liveList) {
-    // amp-live-list elements can be appended dynamically by another
-    // component using the dynamic-list suffix.
+    // amp-live-list elements can be appended dynamically in the client by
+    // another component using the `other-component-id` + `dynamic-list` suffix
+    // as the ID of the amp-live-list.
+    // The fact that we know how this ID is built allows us to find the
+    // amp-live-list element in the server document. See live-story-manager.js
+    // for an example.
     const dynamicId = liveList.id + 'dynamic-list';
     const id =
       dynamicId in this.liveLists_ ? dynamicId : liveList.getAttribute('id');

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -236,10 +236,10 @@ export class LiveListManager {
    */
   updateLiveList_(liveList) {
     // amp-live-list elements can be appended dynamically by another
-    // component using the [dynamic-live-list] attribute.
-    const id = liveList.hasAttribute('dynamic-live-list')
-      ? liveList.getAttribute('dynamic-live-list')
-      : liveList.getAttribute('id');
+    // component using the dynamic-list suffix.
+    const dynamicId = liveList.id + 'dynamic-list';
+    const id =
+      dynamicId in this.liveLists_ ? dynamicId : liveList.getAttribute('id');
     userAssert(id, 'amp-live-list must have an id.');
     userAssert(
       id in this.liveLists_,

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -236,12 +236,13 @@ export class LiveListManager {
    */
   updateLiveList_(liveList) {
     // amp-live-list elements can be appended dynamically in the client by
-    // another component using the `other-component-id` + `dynamic-list` suffix
-    // as the ID of the amp-live-list.
+    // another component using the `i-amphtml-` + `other-component-id` +
+    // `-dynamic-list` combination as the ID of the amp-live-list.
+    //
     // The fact that we know how this ID is built allows us to find the
     // amp-live-list element in the server document. See live-story-manager.js
     // for an example.
-    const dynamicId = liveList.id + 'dynamic-list';
+    const dynamicId = 'i-amphtml-' + liveList.id + '-dynamic-list';
     const id =
       dynamicId in this.liveLists_ ? dynamicId : liveList.getAttribute('id');
     userAssert(id, 'amp-live-list must have an id.');

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -190,7 +190,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
           'disable-pagination': '',
           'auto-insert': '',
         },
-        'myList1dynamic-list'
+        'i-amphtml-custom-slot-dynamic-list'
       );
       clientLiveList.element[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = customSlot.id;
       clientLiveList.buildCallback();

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -173,7 +173,6 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     () => {
       const customSlot = document.createElement('div');
       customSlot.setAttribute('id', 'custom-slot');
-      customSlot.setAttribute('dynamic-live-list', 'custom-list');
 
       const fromServer = doc.createElement('div');
       fromServer.appendChild(customSlot);
@@ -191,7 +190,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
           'disable-pagination': '',
           'auto-insert': '',
         },
-        'custom-list'
+        'myList1dynamic-list'
       );
       clientLiveList.element[AMP_LIVE_LIST_CUSTOM_SLOT_ID] = customSlot.id;
       clientLiveList.buildCallback();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1004,7 +1004,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeLiveStory_() {
-    if (this.element.hasAttribute('dynamic-live-list')) {
+    if (this.element.hasAttribute('live-story')) {
       this.liveStoryManager_ = new LiveStoryManager(this);
       this.liveStoryManager_.build();
 

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -50,7 +50,7 @@ export class LiveStoryManager {
       this.ampStory_.win.document,
       'amp-live-list',
       dict({
-        'id': this.storyEl_.id + 'dynamic-list',
+        'id': 'i-amphtml-' + this.storyEl_.id + '-dynamic-list',
         'data-poll-interval':
           this.storyEl_.getAttribute('data-poll-interval') || 15000,
         'sort': 'ascending',

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -46,16 +46,11 @@ export class LiveStoryManager {
    * configuration and appends it to the DOM.
    */
   build() {
-    const listId = userAssert(
-      this.storyEl_.getAttribute('dynamic-live-list'),
-      'amp-story element must contain the dynamic-live-list attribute to ' +
-        'use the live story functionality.'
-    );
     const liveListEl = createElementWithAttributes(
       this.ampStory_.win.document,
       'amp-live-list',
       dict({
-        'id': listId,
+        'id': this.storyEl_.id + 'dynamic-list',
         'data-poll-interval':
           this.storyEl_.getAttribute('data-poll-interval') || 15000,
         'sort': 'ascending',

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -70,7 +70,9 @@ describes.realWin('LiveStoryManager', {amp: true}, env => {
     liveStoryManager.build();
     const liveListEl = ampStory.element.querySelector('amp-live-list');
 
-    expect(liveListEl.id).to.equal(ampStory.element.id + 'dynamic-list');
+    expect(liveListEl.id).to.equal(
+      'i-amphtml-' + ampStory.element.id + '-dynamic-list'
+    );
   });
 
   it('should throw if no story id is set', () => {

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -53,7 +53,7 @@ describes.realWin('LiveStoryManager', {amp: true}, env => {
     storyEl = win.document.createElement('amp-story');
     addAttributesToElement(storyEl, {
       'id': 'testStory',
-      'dynamic-live-list': 'storyLiveList',
+      'live-story': '',
     });
     ampStory = new AmpStory(storyEl);
     liveStoryManager = new LiveStoryManager(ampStory);
@@ -66,24 +66,11 @@ describes.realWin('LiveStoryManager', {amp: true}, env => {
     expect(liveListEl).to.exist;
   });
 
-  it('live-list id should correspond to attribute dynamic-live-list', () => {
+  it('live-list id should equal story id + dymanic-list combo', () => {
     liveStoryManager.build();
-    const storyAttr = ampStory.element.getAttribute('dynamic-live-list');
-
     const liveListEl = ampStory.element.querySelector('amp-live-list');
-    expect(storyAttr).to.equal(liveListEl.id);
-  });
 
-  it('should throw if no dynamic-live-list attr is set', () => {
-    ampStory.element.removeAttribute('dynamic-live-list');
-
-    allowConsoleError(() => {
-      expect(() => {
-        liveStoryManager.build();
-      }).to.throw(
-        /amp-story element must contain the dynamic-live-list attribute to use the live story functionality/
-      );
-    });
+    expect(liveListEl.id).to.equal(ampStory.element.id + 'dynamic-list');
   });
 
   it('should throw if no story id is set', () => {


### PR DESCRIPTION
In an effort to make the "live story" functionality as easy to use for publishers as possible, we are removing the need to include a value in the `dynamic-live-list` attribute. 

Previously this value was used so that, when updating the live list with the server updates, the code reading the document from the server knew how to find the amp-live-list element. Since this value was present in both client and server documents, it gave us the information we needed to find the updates in the server document.

With this PR we follow a different approach -- from using something _we have_ to something _we know_. It uses a reserved hash (id + 'dynamic-list') to make the match and find the live list in the DOM. This way, when looking at the server document, we know how to find this element without needing an explicit value. 

Partial for #21714