### PR TITLE
Story min-height fallback during prerendering.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -126,6 +126,11 @@ amp-story[standalone] {
   min-width: initial !important;
 }
 
+amp-story[standalone].amp-notbuilt {
+  /* Ensures amp-story has a height and is prerendered. */
+  min-height: 1px !important;
+}
+
 amp-story[standalone]:-webkit-full-screen {
   height: 100vh !important;
   max-height: none !important;


### PR DESCRIPTION
To be prerendered, an element has to either:
- Be in the first 20 elements discovered
- Be positioned in a predefined layout area AND have a non zero height (!!!!)

`amp-story` is `height: 100%;` which means the height has to be propagated from its ancestors chain. The chain starts as soon as `amp-story.buildCallback()` sets a class on `<html>`. When the document is visible, `amp-story` will build even if it has no height. However, during prerendering, we need to make sure it has a height of at least 1px in order to build.

There's already a `min-height: 1px;` rule in `ampdoc.css`, but apparently if the `amp-story.css` loads before the runtime tries to build `<amp-story>`, it would be overriden by the expected styles we want when the document is visible.
This fix should be a safe prerendering only fallback, with no side-effect when the document is visible.