### PR TITLE
🐛Fixes an issue with looping videos and the Youtube AS3 player

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -223,6 +223,9 @@ class AmpYoutube extends AMP.BaseElement {
       params['playsinline'] = '1';
     }
 
+    // Fixes issue with the Youtube AS3 player that requires
+    // `data-param-playlist` to be set whenever the `data-param-loop` is set
+    // See https://developers.google.com/youtube/player_parameters#loop
     if ('loop' in params && params['loop'] == '1' && !('playlist' in params)) {
       params['playlist'] = dev().assertString(this.videoid_);
     }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -223,6 +223,10 @@ class AmpYoutube extends AMP.BaseElement {
       params['playsinline'] = '1';
     }
 
+    if ('loop' in params && params['loop'] == '1' && !('playlist' in params)) {
+      params['playlist'] = dev().assertString(this.videoid_);
+    }
+
     src = addParamsToUrl(src, params);
     return (this.videoIframeSrc_ = src);
   }


### PR DESCRIPTION
Closes #22855 

Not sure if this is necessary since it can be solved on the developer-side by making sure the `data-param-playlist` is set whenever `data-param-loop` is used but doesn't hurt to add.

See discussion on #22855 for context.

### Changes
- Makes sure the `data-param-playlist` is set to the video's ID whenever the `data-param-loop` is set to '1' which solves an issue where the video doesn't loop on the Youtube AS3 player (no problem with the HTML5 player)