### PR TITLE
🐛Smoother amp-youtube video looping

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -223,6 +223,9 @@ class AmpYoutube extends AMP.BaseElement {
       params['playsinline'] = '1';
     }
 
+    // Fixes issue with the Youtube AS3 player that requires
+    // `data-param-playlist` to be set whenever the `data-param-loop` is set
+    // See https://developers.google.com/youtube/player_parameters#loop
     if ('loop' in params && params['loop'] == '1' && !('playlist' in params)) {
       params['playlist'] = dev().assertString(this.videoid_);
     }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -223,6 +223,10 @@ class AmpYoutube extends AMP.BaseElement {
       params['playsinline'] = '1';
     }
 
+    if ('loop' in params && params['loop'] == '1' && !('playlist' in params)) {
+      params['playlist'] = dev().assertString(this.videoid_);
+    }
+
     src = addParamsToUrl(src, params);
     return (this.videoIframeSrc_ = src);
   }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -283,7 +283,7 @@ class AmpYoutube extends AMP.BaseElement {
       this.unlistenLooping_ = listen(
         this.element,
         VideoEvents.ENDED,
-        this.play.bind(this)
+        unusedEvent => this.play(false /** unusedIsAutoplay */)
       );
     }
 

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -276,7 +276,7 @@ class AmpYoutube extends AMP.BaseElement {
       this.unlistenLooping_ = listen(
         this.element,
         VideoEvents.ENDED,
-        this.play.bind(this)
+        () => this.play(false /* unusedIsAutoplay */)
       );
     }
 

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -81,6 +81,12 @@ class AmpYoutube extends AMP.BaseElement {
     /** @private {?boolean}  */
     this.muted_ = false;
 
+    /** @private {?boolean}  */
+    this.isLoop_ = false;
+
+    /** @private {?boolean}  */
+    this.isPlaylist_ = false;
+
     /** @private {?Element} */
     this.iframe_ = null;
 
@@ -236,11 +242,12 @@ class AmpYoutube extends AMP.BaseElement {
 
     // In the case of a playlist, looping is delegated to the Youtube player
     // instead of AMP manually looping the video through the Youtube API
-    const hasLoop =
+    this.isLoop_ =
       element.hasAttribute('loop') ||
       ('loop' in params && params['loop'] == '1');
-    if (hasLoop) {
-      if ('playlist' in params) {
+    this.isPlaylist_ = 'playlist' in params;
+    if (this.isLoop_) {
+      if (this.isPlaylist_) {
         // Use native looping for playlists
         params['loop'] = '1';
       } else if ('loop' in params) {
@@ -274,12 +281,7 @@ class AmpYoutube extends AMP.BaseElement {
       this.handleYoutubeMessage_.bind(this)
     );
 
-    const params = getDataParamsFromAttributes(this.element);
-    const hasLoop =
-      this.element.hasAttribute('loop') ||
-      ('loop' in params && params['loop'] == '1');
-    const isPlaylist = 'playlist' in params;
-    if (hasLoop && !isPlaylist) {
+    if (this.isLoop_ && !this.isPlaylist_) {
       this.unlistenLooping_ = listen(
         this.element,
         VideoEvents.ENDED,

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -107,12 +107,16 @@ describes.realWin(
         return getYt({
           'data-videoid': datasource,
           'autoplay': '1',
+          'loop': '',
+          'data-param-loop': '1',
           'data-param-my-param': 'hello world',
         }).then(yt => {
           const iframe = yt.querySelector('iframe');
           expect(iframe.src).to.contain('myParam=hello%20world');
           // data-param-autoplay is black listed in favor of just autoplay
           expect(iframe.src).to.not.contain('autoplay=1');
+          // data-param-loop is black listed in favor of just loop for single videos
+          expect(iframe.src).to.not.contain('loop=1');
           // playsinline should default to 1 if not provided.
           expect(iframe.src).to.contain('playsinline=1');
         });
@@ -138,6 +142,28 @@ describes.realWin(
           expect(iframe.src).to.contain('playsinline=1');
           // annotation policy should default to 3 if not specified.
           expect(iframe.src).to.contain('iv_load_policy=3');
+        });
+      });
+
+      it('should keep data-param-loop in the iframe src for playlists', () => {
+        return getYt({
+          'data-videoid': datasource,
+          'data-param-playlist': datasource,
+          'data-param-loop': '1',
+        }).then(yt => {
+          const iframe = yt.querySelector('iframe');
+          expect(iframe.src).to.contain('loop=1');
+        });
+      });
+
+      it('should pass data-param-loop to the iframe src for playlists when using loop', () => {
+        return getYt({
+          'data-videoid': datasource,
+          'data-param-playlist': datasource,
+          'loop': '',
+        }).then(yt => {
+          const iframe = yt.querySelector('iframe');
+          expect(iframe.src).to.contain('loop=1');
         });
       });
 

--- a/extensions/amp-youtube/0.1/test/validator-amp-youtube.html
+++ b/extensions/amp-youtube/0.1/test/validator-amp-youtube.html
@@ -40,6 +40,10 @@
   <amp-youtube width="480" height="270"
     data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q">
   </amp-youtube>
+  <!-- Valid: with loop attribute -->
+  <amp-youtube width="480" height="270"
+               data-videoid="dQw4w9WgXcQ" loop>
+  </amp-youtube>
 
   <!-- Invalid: data-videoid and data-live-channelid both missing. -->
   <amp-youtube width="480" height="270"></amp-youtube>

--- a/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
+++ b/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
@@ -41,26 +41,30 @@ FAIL
 |    <amp-youtube width="480" height="270"
 |      data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q">
 |    </amp-youtube>
+|    <!-- Valid: with loop attribute -->
+|    <amp-youtube width="480" height="270"
+|                 data-videoid="dQw4w9WgXcQ" loop>
+|    </amp-youtube>
 |
 |    <!-- Invalid: data-videoid and data-live-channelid both missing. -->
 |    <amp-youtube width="480" height="270"></amp-youtube>
 >>   ^~~~~~~~~
-amp-youtube/0.1/test/validator-amp-youtube.html:45:2 The tag 'amp-youtube' is missing a mandatory attribute - pick one of ['data-live-channelid', 'data-videoid']. (see https://amp.dev/documentation/components/amp-youtube) [AMP_TAG_PROBLEM]
+amp-youtube/0.1/test/validator-amp-youtube.html:49:2 The tag 'amp-youtube' is missing a mandatory attribute - pick one of ['data-live-channelid', 'data-videoid']. (see https://amp.dev/documentation/components/amp-youtube) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: dimensions are missing. -->
 |    <amp-youtube data-videoid="dQw4w9WgXcQ">
 >>   ^~~~~~~~~
-amp-youtube/0.1/test/validator-amp-youtube.html:47:2 Incomplete layout attributes specified for tag 'amp-youtube'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-youtube) [AMP_LAYOUT_PROBLEM]
+amp-youtube/0.1/test/validator-amp-youtube.html:51:2 Incomplete layout attributes specified for tag 'amp-youtube'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-youtube) [AMP_LAYOUT_PROBLEM]
 |    </amp-youtube>
 |    <!-- Invalid: the attr value must be a video id -->
 |    <amp-youtube width="480" height="270"
 >>   ^~~~~~~~~
-amp-youtube/0.1/test/validator-amp-youtube.html:50:2 The attribute 'data-videoid' in tag 'amp-youtube' is set to the invalid value 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'. (see https://amp.dev/documentation/components/amp-youtube) [DISALLOWED_HTML]
+amp-youtube/0.1/test/validator-amp-youtube.html:54:2 The attribute 'data-videoid' in tag 'amp-youtube' is set to the invalid value 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'. (see https://amp.dev/documentation/components/amp-youtube) [DISALLOWED_HTML]
 |                 data-videoid="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
 |    </amp-youtube>
 |    <!-- Invalid: cannot have both data-videoid and data-live-channelid -->
 |    <amp-youtube width="480" height="270"
 >>   ^~~~~~~~~
-amp-youtube/0.1/test/validator-amp-youtube.html:54:2 Mutually exclusive attributes encountered in tag 'amp-youtube' - pick one of ['data-live-channelid', 'data-videoid']. (see https://amp.dev/documentation/components/amp-youtube) [AMP_TAG_PROBLEM]
+amp-youtube/0.1/test/validator-amp-youtube.html:58:2 Mutually exclusive attributes encountered in tag 'amp-youtube' - pick one of ['data-live-channelid', 'data-videoid']. (see https://amp.dev/documentation/components/amp-youtube) [AMP_TAG_PROBLEM]
 |      data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q"
 |      data-videoid="dQw4w9WgXcQ">
 |    </amp-youtube>
@@ -68,7 +72,7 @@ amp-youtube/0.1/test/validator-amp-youtube.html:54:2 Mutually exclusive attribut
 |    <!-- Invalid: `dock` without `amp-video-docking` extension -->
 |    <amp-youtube width="480" height="270" data-videoid="dQw4w9WgXcQ" dock>
 >>   ^~~~~~~~~
-amp-youtube/0.1/test/validator-amp-youtube.html:60:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-youtube/0.1/test/validator-amp-youtube.html:64:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </amp-youtube>
 |  </body>
 |  </html>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -112,7 +112,7 @@ With the responsive layout, the width and height from the example should yield c
   <li>`data-param-controls=1` becomes `&controls=1`</li>
 </ul>
 <p>See <a href="https://developers.google.com/youtube/player_parameters">YouTube Embedded Player Parameters</a> for more parameter options for YouTube.</p>
-<p>Note: Use the <code>autoplay</code> attribute instead of <code>data-param-autoplay</code> and the <code>loop</code> attribute instead of <code>data-param-loop</code>.</p>
+<p>Note: Use the <code>autoplay</code> attribute instead of <code>data-param-autoplay</code> and the <code>loop</code> attribute instead of <code>data-param-loop</code> since both the autoplay and looping behaviors are handled internally by AMP instead of the Youtube player.</p>
 </td>
   </tr>
   <tr>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -73,19 +73,27 @@ With the responsive layout, the width and height from the example should yield c
 <table>
   <tr>
     <td width="40%"><strong>autoplay</strong></td>
-    <td>If this attribute is present, and the browser supports autoplay:</p>
-<ul>
-  <li>the video is automatically muted before autoplay starts
-  </li>
-  <li>when the video is scrolled out of view, the video is paused
-  </li>
-  <li>when the video is scrolled into view, the video resumes playback
-  </li>
-  <li>when the user taps the video, the video is unmuted
-  </li>
-  <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
-  </li>
-</ul></td>
+    <td>
+      <p>If this attribute is present, and the browser supports autoplay:</p>
+      <ul>
+        <li>the video is automatically muted before autoplay starts
+        </li>
+        <li>when the video is scrolled out of view, the video is paused
+        </li>
+        <li>when the video is scrolled into view, the video resumes playback
+        </li>
+        <li>when the user taps the video, the video is unmuted
+        </li>
+        <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+        </li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>loop</strong></td>
+    <td>
+      <p>If this attribute is present, the video or playlist will play again (from the beginning) once it ends.</p>
+    </td>
   </tr>
   <tr>
     <td width="40%"><strong>data-videoid</strong></td>
@@ -98,12 +106,13 @@ With the responsive layout, the width and height from the example should yield c
   </tr>
   <tr>
     <td width="40%"><strong>data-param-&#42;</strong></td>
-    <td><p>All <code>data-param-*</code> attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.</p>
+    <td><p>All <code>data-param-*</code> attributes (with the exception of <code>data-param-autoplay</code> and <code>data-param-loop</code>) will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.</p>
 <p>Keys and values will be URI encoded. Keys will be camel cased.</p>
 <ul>
   <li>`data-param-controls=1` becomes `&controls=1`</li>
 </ul>
 <p>See <a href="https://developers.google.com/youtube/player_parameters">YouTube Embedded Player Parameters</a> for more parameter options for YouTube.</p>
+<p>Note: Use the <code>autoplay</code> attribute instead of <code>data-param-autoplay</code> and the <code>loop</code> attribute instead of <code>data-param-loop</code>.</p>
 </td>
   </tr>
   <tr>

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -35,6 +35,7 @@ tags: {  # <amp-youtube>
   tag_name: "AMP-YOUTUBE"
   requires_extension: "amp-youtube"
   attrs: { name: "autoplay" }
+  attrs: { name: "loop" }
   attrs: {
     name: "credentials"
     value_casei: "include"


### PR DESCRIPTION
See discussion in #22855 for context
Closes #22855 

### Changes
- Handles looping internally through javascript instead of the Youtube player for standalone videos (fixes both transition issues during looping as well as removes the need to add `data-param-playlist` whenever `data-param-loop` is specified), and delegates looping to the Youtube player for playlists

### Breaking changes
- `data-param-loop` is no longer supported on `amp-youtube` and is replaced by the `loop` parameter

Screencast demonstrating the issue (credits @westonruter ) https://youtu.be/8PZGJf3dtwM