### PR TITLE
🐛 Set value of url parameter for fast fetch

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -384,7 +384,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.getRafmtParam_(),
       'pfx': pfx ? '1' : '0',
-      'aanf': this.element.getAttribute('data-no-fill'),
+      'aanf':
+        this.element.parentNode &&
+        this.element.parentNode.hasAttribute('no-fill')
+          ? this.element.parentNode.getAttribute('no-fill')
+          : null,
       // Matched content specific fields.
       'crui': this.element.getAttribute('data-matched-content-ui-type'),
       'cr_row': this.element.getAttribute('data-matched-content-rows-num'),

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -384,6 +384,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.getRafmtParam_(),
       'pfx': pfx ? '1' : '0',
+      'aanf': this.element.getAttribute('data-no-fill'),
       // Matched content specific fields.
       'crui': this.element.getAttribute('data-matched-content-ui-type'),
       'cr_row': this.element.getAttribute('data-matched-content-rows-num'),

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -525,6 +525,18 @@ describes.realWin(
         });
       });
 
+      it('should contain aanf if sticky ad', () => {
+        const ampStickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
+          'layout': 'nodisplay',
+        });
+        element.setAttribute('data-no-fill', 'true');
+        ampStickyAd.appendChild(element);
+        doc.body.appendChild(ampStickyAd);
+        return impl.getAdUrl().then(adUrl => {
+          expect(adUrl).to.contain('aanf=true');
+        });
+      });
+
       it('formats client properly', () => {
         element.setAttribute('data-ad-client', 'SoMeClient');
         return impl.getAdUrl().then(url => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -525,16 +525,16 @@ describes.realWin(
         });
       });
 
-      it('should contain aanf if sticky ad', () => {
+      it('should contain aanf if sticky ad has no fill attribue', () => {
         const ampStickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
           'layout': 'nodisplay',
+          'no-fill': 'true',
         });
-        element.setAttribute('data-no-fill', 'true');
         ampStickyAd.appendChild(element);
         doc.body.appendChild(ampStickyAd);
-        return impl.getAdUrl().then(adUrl => {
-          expect(adUrl).to.contain('aanf=true');
-        });
+        return expect(impl.getAdUrl()).to.eventually.match(
+          /(\?|&)aanf=true(&|$)/
+        );
       });
 
       it('formats client properly', () => {

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -115,6 +115,7 @@ export class AnchorAdStrategy {
       dict({
         'width': String(viewportWidth),
         'height': '100',
+        'data-no-fill': String(noFill),
       })
     ));
     const doc = this.ampdoc.win.document;
@@ -124,7 +125,6 @@ export class AnchorAdStrategy {
       'amp-sticky-ad',
       dict({
         'layout': 'nodisplay',
-        'data-no-fill': String(noFill),
       })
     );
     stickyAd.appendChild(ampAd);

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -115,7 +115,6 @@ export class AnchorAdStrategy {
       dict({
         'width': String(viewportWidth),
         'height': '100',
-        'data-no-fill': String(noFill),
       })
     ));
     const doc = this.ampdoc.win.document;
@@ -125,6 +124,7 @@ export class AnchorAdStrategy {
       'amp-sticky-ad',
       dict({
         'layout': 'nodisplay',
+        'no-fill': String(noFill),
       })
     );
     stickyAd.appendChild(ampAd);

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -163,8 +163,8 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
-              expect(stickyAd.getAttribute('data-no-fill')).to.equal('false');
+              const ampAd = stickyAd.firstChild;
+              expect(ampAd.getAttribute('data-no-fill')).to.equal('false');
               resolve();
             }
           );
@@ -194,8 +194,8 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
-              expect(stickyAd.getAttribute('data-no-fill')).to.equal('true');
+              const ampAd = stickyAd.firstChild;
+              expect(ampAd.getAttribute('data-no-fill')).to.equal('true');
               resolve();
             }
           );
@@ -226,8 +226,8 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
-              expect(stickyAd.getAttribute('data-no-fill')).to.equal('false');
+              const ampAd = stickyAd.firstChild;
+              expect(ampAd.getAttribute('data-no-fill')).to.equal('false');
               resolve();
             }
           );

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -142,7 +142,7 @@ describes.realWin(
         return Promise.all([strategyPromise, expectPromise]);
       });
 
-      it('should set data-no-fill to false if opted in for anchor ads', () => {
+      it('should set no-fill to false if opted in for anchor ads', () => {
         configObj['optInStatus'].push(2);
 
         const anchorAdStrategy = new AnchorAdStrategy(
@@ -163,8 +163,7 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              const ampAd = stickyAd.firstChild;
-              expect(ampAd.getAttribute('data-no-fill')).to.equal('false');
+              expect(stickyAd.getAttribute('no-fill')).to.equal('false');
               resolve();
             }
           );
@@ -173,7 +172,7 @@ describes.realWin(
         return Promise.all([strategyPromise, expectPromise]);
       });
 
-      it('should set data-no-fill to true if opted in only for no fill anchor ads', () => {
+      it('should set no-fill to true if opted in only for no fill anchor ads', () => {
         configObj['optInStatus'].push(4);
 
         const anchorAdStrategy = new AnchorAdStrategy(
@@ -194,8 +193,7 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              const ampAd = stickyAd.firstChild;
-              expect(ampAd.getAttribute('data-no-fill')).to.equal('true');
+              expect(stickyAd.getAttribute('no-fill')).to.equal('true');
               resolve();
             }
           );
@@ -204,7 +202,7 @@ describes.realWin(
         return Promise.all([strategyPromise, expectPromise]);
       });
 
-      it('should set data-no-fill to false if opted in for both filled anchor ads and no fill anchor ads', () => {
+      it('should set no-fill to false if opted in for both filled anchor ads and no fill anchor ads', () => {
         configObj['optInStatus'].push(2);
         configObj['optInStatus'].push(4);
 
@@ -226,8 +224,7 @@ describes.realWin(
             },
             () => {
               const stickyAd = env.win.document.body.firstChild;
-              const ampAd = stickyAd.firstChild;
-              expect(ampAd.getAttribute('data-no-fill')).to.equal('false');
+              expect(stickyAd.getAttribute('no-fill')).to.equal('false');
               resolve();
             }
           );


### PR DESCRIPTION
Setting value of the 'aanf' url parameter with the actual value of the data attribute of the ad element. Also this PR sets the data attribute on actual ad element instead of sticky ad element.