### PR TITLE
✨ Add Yieldlab to RTC callout vendors

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -128,6 +128,11 @@ export const RTC_VENDORS = {
     disableKeyAppend: true,
     macros: ['PLACEMENT_ID', '_DIVIDER_'],
   },
+  yieldlab: {
+    url: 'https://ad.yieldlab.net/yp/ADSLOT_ID?content=amp&t=amp%3D1',
+    macros: ['ADSLOT_ID'],
+    disableKeyAppend: true,
+  },
 };
 
 // DO NOT MODIFY: Setup for tests

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -133,6 +133,7 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 *   Rubicon
 *   Salesforce
 *   Yieldbot
+*   Yieldlab
 
 ### RTC Callout Request Specification
 

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -32,6 +32,7 @@ To use RTC, you must meet the following requirements:
 *   Rubicon
 *   Salesforce
 *   Yieldbot
+*   Yieldlab
 
 ### Overview
 


### PR DESCRIPTION
Add Yieldlab (https://www.yieldlab.com) to RTC callout vendors.
