### PR TITLE
Inabox: remove unnecessary dependencies on various viewport bindings

### DIFF
--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -100,7 +100,7 @@ startupChunk(self.document, function initial() {
         // runtime tries to install the normal one.
         installViewerServiceForDoc(ampdoc);
         installInaboxViewportService(ampdoc);
-        installAmpdocServices(ampdoc);
+        installAmpdocServices(ampdoc, undefined, true);
         // We need the core services (viewer/resources) to start instrumenting
         perf.coreServicesAvailable();
         maybeTrackImpression(self);

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -73,15 +73,19 @@ export function installRuntimeServices(global) {
  * Install ampdoc-level services.
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  * @param {!Object<string, string>=} opt_initParams
+ * @param {boolean=} opt_inabox
  * @restricted
  */
-export function installAmpdocServices(ampdoc, opt_initParams) {
+export function installAmpdocServices(ampdoc, opt_initParams, opt_inabox) {
   // Order is important!
   installUrlForDoc(ampdoc);
   installCidService(ampdoc);
   installDocumentInfoServiceForDoc(ampdoc);
-  installViewerServiceForDoc(ampdoc, opt_initParams);
-  installViewportServiceForDoc(ampdoc);
+  if (!opt_inabox) {
+    // viewer & viewport were installed in amp-inabox.js
+    installViewerServiceForDoc(ampdoc, opt_initParams);
+    installViewportServiceForDoc(ampdoc);
+  }
   installHiddenObserverForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc);


### PR DESCRIPTION
This will reduce amp4ads-v0.js size from 285K to 275k by excluding all the unused iOS viewport bindings code from inabox runtime.

for #22867