### PR TITLE
Point people to Slack instead of buildcop when there's a test breakage

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -89,7 +89,7 @@ We also recommend scanning the [spec](../spec/). The non-element part should hel
 
 ## Builds and releases
 
-- The [AMP buildcop](buildcop.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass).  If you run into issues with builds that seem unrelated to your changes see if the issue is present on [Travis](https://travis-ci.org/ampproject/amphtml/builds) and let the buildcop know.
+- The [AMP buildcop](buildcop.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass).  If you run into issues with builds that seem unrelated to your changes see if the issue is present on [Travis](https://travis-ci.org/ampproject/amphtml/builds) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
 - Understanding the [AMP release process](release-schedule.md) is useful for understanding when a change in AMP will make it into production and what to do if things go wrong during the rollout of a change.
 
 ## [Code of conduct](../CODE_OF_CONDUCT.md)

--- a/contributing/buildcop.md
+++ b/contributing/buildcop.md
@@ -2,7 +2,9 @@
 
 The AMP buildcop is responsible for ensuring that the [master build](https://travis-ci.org/ampproject/amphtml/branches) remains green.  The AMP buildcop responsibility rotates between members of the community.
 
-If the build has been red for some time, please send a note to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack if the issue is not already reported.
+Make sure you are a member of the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack while you are buildcop.
+- If the build has been red for some time, please send a note to the #contributing channel if the issue is not already reported.
+- Pay attention for reports of issues with the build that the community may send to this channel.  (You may want to enable notifications for this channel while you are buildcop to make this easier.)
 
 ## Buildcop Tasks
 


### PR DESCRIPTION
We currently tell people to let the buildcop know when there is an issue with the tests, but don't have a way of contacting the buildcop.

Instead, let's point people to the #contributing channel on Slack, where the buildcop should be (and if not, someone who is in the channel would be able to let the buildcop know).

This change also more explicitly tells the buildcop to pay attention to the #contributing channel on Slack.

/cc @ampproject/wg-infra