### PR TITLE
🐛Remove srcset on relayout if needed

### DIFF
--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -85,7 +85,7 @@ export class AmpAnim extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const img = dev().assertElement(this.img_);
-    this.propagateAttributes(LAYOUT_ATTRIBUTES, img);
+    this.propagateAttributes(LAYOUT_ATTRIBUTES, img, true);
     guaranteeSrcForSrcsetUnsupportedBrowsers(img);
     return this.loadPromise(img);
   }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -85,7 +85,13 @@ export class AmpAnim extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const img = dev().assertElement(this.img_);
-    this.propagateAttributes(LAYOUT_ATTRIBUTES, img, true);
+    // Remove missing attributes to remove the placeholder srcset if none is
+    // specified on the element.
+    this.propagateAttributes(
+      LAYOUT_ATTRIBUTES,
+      img,
+      /* opt_removeMissingAttrs */ true
+    );
     guaranteeSrcForSrcsetUnsupportedBrowsers(img);
     return this.loadPromise(img);
   }

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -79,9 +79,32 @@ describes.realWin(
 
       impl.unlayoutCallback();
       expect(img.getAttribute('src')).to.equal(SRC_PLACEHOLDER);
+      expect(img.getAttribute('srcset')).to.equal(SRC_PLACEHOLDER);
 
       impl.layoutCallback();
       expect(img.getAttribute('src')).to.equal('test.jpg');
+      expect(img.getAttribute('srcset')).to.equal(EXAMPLE_SRCSET);
+    });
+
+    it('should clear srcset if missing on relayout', () => {
+      const el = env.win.document.createElement('amp-anim');
+      el.setAttribute('src', 'test.jpg');
+      el.setAttribute('width', 100);
+      el.setAttribute('height', 100);
+
+      const impl = new AmpAnim(el);
+      impl.buildCallback();
+      impl.layoutCallback();
+      const img = el.querySelector('img');
+      expect(img.getAttribute('src')).to.equal('test.jpg');
+
+      impl.unlayoutCallback();
+      expect(img.getAttribute('src')).to.equal(SRC_PLACEHOLDER);
+      expect(img.getAttribute('srcset')).to.equal(SRC_PLACEHOLDER);
+
+      impl.layoutCallback();
+      expect(img.getAttribute('src')).to.equal('test.jpg');
+      expect(img.getAttribute('srcset')).to.equal(null);
     });
 
     it('should propagate the object-fit attribute', () => {


### PR DESCRIPTION
Pass opt_removeMissingAttrs to remove the srcset attribute if it is not specified on the amp-anim element. This clears the placeholder value set in `unlayoutCallback`.

Fixes #22864
