### PR TITLE
🐛 Do not toggle loading to same state

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1706,6 +1706,10 @@ function createBaseCustomElementClass(win) {
         // Loading has already been canceled. Ignore.
         return;
       }
+      if (state === this.loadingState_ && !opt_options) {
+        // Loading state is the same.
+        return;
+      }
       this.loadingState_ = state;
       if (!state && !this.loadingContainer_) {
         return;


### PR DESCRIPTION
This should break an infinite loop when an element has to wait for layout (eg, owned by another element) but is in viewport. Showing the loading indicator causes a mutate, which has to be measured, which causes another mutate (because the `toggleLoading` happens as a step in `onLayoutMeasure`).

Fixes #22525.