### PR TITLE
Add live-story-disabled attribute to support disabled live stories

### DIFF
--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -253,7 +253,10 @@ export class LiveListManager {
     );
 
     const inClientDomLiveList = this.liveLists_[id];
-    inClientDomLiveList.toggle(!liveList.hasAttribute('disabled'));
+    inClientDomLiveList.toggle(
+      !liveList.hasAttribute('disabled') &&
+        !liveList.hasAttribute('live-story-disabled')
+    );
 
     if (inClientDomLiveList.isEnabled()) {
       return inClientDomLiveList.update(liveList);

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -255,6 +255,8 @@ export class LiveListManager {
     const inClientDomLiveList = this.liveLists_[id];
     inClientDomLiveList.toggle(
       !liveList.hasAttribute('disabled') &&
+        // When the live list is an amp-story, we use an amp-story specific
+        // attribute so publishers can disable the live story functionality.
         !liveList.hasAttribute('live-story-disabled')
     );
 


### PR DESCRIPTION
Support a `live-story-disabled` attribute in the `live-list-manager.js` so that when a live story is disabled we stop polling for new updates.

Partial for #21714 #22841