### PR TITLE
🐛 FixedLayer: Do not track children of already tracked elements

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -327,12 +327,15 @@ export class FixedLayer {
    * @return {!Promise}
    */
   addElement(element, opt_forceTransfer) {
-    this.setupElement_(
+    const added = this.setupElement_(
       element,
       /* selector */ '*',
       /* position */ 'fixed',
       opt_forceTransfer
     );
+    if (!added) {
+      return Promise.resolve();
+    }
     this.sortInDomOrder_();
 
     // If this is the first element, we need to start the mutation observer.
@@ -651,6 +654,7 @@ export class FixedLayer {
    *    be forcibly transferred to the transfer layer.
    * @param {boolean=} opt_lightboxMode If true, then descendants of lightboxes
    *    are allowed to be set up. Default is false.
+   * @return {boolean}
    * @private
    */
   setupElement_(
@@ -666,16 +670,34 @@ export class FixedLayer {
     // Ignore lightboxes because FixedLayer can interfere with their
     // opening/closing animations (#19149).
     if (isLightbox(element)) {
-      return;
+      return false;
     }
     const isLightboxDescendant = closest(element, isLightbox);
     if (!opt_lightboxMode && isLightboxDescendant) {
-      return;
+      return false;
+    }
+
+    const elements = this.elements_;
+    let removals = [];
+    for (let i = 0; i < elements.length; i++) {
+      const el = elements[i];
+      if (el === element) {
+        break;
+      }
+      if (el.contains(element)) {
+        return false;
+      }
+      if (element.contains(el)) {
+        removals.push(el);
+      }
+    }
+    for (let i = 0; i < removals.length; i++) {
+      this.removeElement(removals[i]);
     }
 
     let fe = null;
-    for (let i = 0; i < this.elements_.length; i++) {
-      const el = this.elements_[i];
+    for (let i = 0; i < elements.length; i++) {
+      const el = elements[i];
       if (el.element == element && el.position == position) {
         fe = el;
         break;
@@ -705,10 +727,11 @@ export class FixedLayer {
         stickyNow: false,
         lightboxed: !!isLightboxDescendant,
       };
-      this.elements_.push(fe);
+      elements.push(fe);
     }
 
     fe.forceTransfer = isFixed ? opt_forceTransfer : false;
+    return true;
   }
 
   /**

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -678,15 +678,21 @@ export class FixedLayer {
     }
 
     const elements = this.elements_;
-    let removals = [];
+
+    // Avoid ancestor-descendant relationships in tracked elements to prevent
+    // "double top-offset" (#22860).
+    const removals = [];
     for (let i = 0; i < elements.length; i++) {
       const el = elements[i];
       if (el === element) {
         break;
       }
+      // Early exit if element is a child of an already-tracked element...
       if (el.contains(element)) {
         return false;
       }
+      // Remove the already-tracked element if it is a child of the new
+      // element...
       if (element.contains(el)) {
         removals.push(el);
       }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -683,7 +683,7 @@ export class FixedLayer {
     // "double top-offset" (#22860).
     const removals = [];
     for (let i = 0; i < elements.length; i++) {
-      const el = elements[i];
+      const el = elements[i].element;
       if (el === element) {
         break;
       }

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -324,6 +324,16 @@ describes.sandboxed('FixedLayer', {}, () => {
         }
         return Node.DOCUMENT_POSITION_PRECEDING;
       },
+      contains(elem) {
+        let el = elem;
+        while (el) {
+          if (el === this) {
+            return true;
+          }
+          el = el.parentElement;
+        }
+        return false;
+      },
       hasAttribute(name) {
         for (let i = 0; i < this.attributes.length; i++) {
           if (this.attributes[i].name === name) {

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -1210,6 +1210,36 @@ describes.sandboxed('FixedLayer', {}, () => {
             });
         });
       });
+
+      it('should ignore descendants of already-tracked elements', () => {
+        const updateStub = sandbox.stub(fixedLayer, 'update');
+        expect(fixedLayer.elements_).to.have.length(5);
+
+        element1.appendChild(element6);
+
+        // Add.
+        fixedLayer.addElement(element6);
+        expect(updateStub).not.to.have.been.called;
+        expect(fixedLayer.elements_).to.have.length(5);
+      });
+
+      it('should replace descendants of tracked elements', () => {
+        const updateStub = sandbox.stub(fixedLayer, 'update');
+        expect(fixedLayer.elements_).to.have.length(5);
+
+        element6.appendChild(element1);
+
+        // Add.
+        fixedLayer.addElement(element6);
+        expect(updateStub).to.be.calledOnce;
+        expect(fixedLayer.elements_).to.have.length(5);
+
+        const fe = fixedLayer.elements_[4];
+        expect(fe.id).to.equal('F5');
+        expect(fe.element).to.equal(element6);
+        expect(fe.selectors).to.deep.equal(['*']);
+        expect(fe.forceTransfer).to.be.undefined;
+      });
     });
 
   describe('with-transfer', () => {


### PR DESCRIPTION
This prevents double-offsetting of elements that are nested inside another fixed/sticky-positioned element.

Fixes #22860
Fixes #22881