### PR TITLE
🐛Fix `Ad` badge in non-chrome browsers.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
@@ -14,6 +14,28 @@
  * limitations under the License.
  */
 
+.i-amphtml-ad-overlay-container {
+  height: 24px !important;
+  left: 0 !important;
+  padding: 14px 0 0 !important;
+  pointer-events: none !important;
+  position: absolute !important;
+  top: 0 !important;
+  z-index: 100001 !important;
+}
+
+.i-amphtml-ad-overlay-container[dir=rtl] {
+  left: auto !important;
+  right: 0 !important;
+}
+
+.i-amphtml-ad-overlay-container[desktop-panels] {
+  /* On desktop a story page has a with of 45vh. */
+  left: calc(50vw - 22.5vh) !important;
+  /* And a height of 75 vh. */
+  top: 12.5vh !important;
+}
+
 .i-amphtml-story-ad-attribution {
   color: #FFFFFF !important;
   font-size: 18px !important;
@@ -26,17 +48,17 @@
   visibility: hidden !important;
 }
 
-:host-context([dir=rtl]) .i-amphtml-story-ad-attribution {
+[dir=rtl] .i-amphtml-story-ad-attribution {
   margin-left: 0px !important;
   margin-right: 16px !important;
 }
 
-:host-context([ad-showing][desktop]:not([supports-landscape])) .i-amphtml-story-ad-attribution {
+[ad-showing][desktop-panels] .i-amphtml-story-ad-attribution {
   /* Have to wait for page to slide in. */
   transition: opacity 0.1s linear 0.3s;
 }
 
-:host-context([ad-showing]) .i-amphtml-story-ad-attribution {
+[ad-showing] .i-amphtml-story-ad-attribution {
   visibility: visible !important;
   opacity: 1 !important;
 }

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -61,34 +61,6 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   }
 }
 
-.i-amphtml-ad-overlay-container {
-  height: 24px !important;
-  left: 0 !important;
-  padding: 14px 0 0 !important;
-  pointer-events: none !important;
-  position: absolute !important;
-  top: 0 !important;
-  z-index: 100001 !important;
-}
-
-[dir=rtl] .i-amphtml-ad-overlay-container {
-  left: auto !important;
-  right: 0 !important;
-}
-
-[desktop]:not([supports-landscape]) .i-amphtml-ad-overlay-container {
-  /* On desktop a story page has a with of 45vh. */
-  left: calc(50vw - 22.5vh) !important;
-  /* And a height of 75 vh. */
-  top: 12.5vh !important;
-}
-
-[dir=rtl] [desktop] .i-amphtml-ad-overlay-container {
-  left: auto !important;
-  /* On desktop a story page has a with of 45vh. */
-  right: calc(50vw - 22.5vh) !important;
-}
-
 .i-amphtml-glass-pane {
   height: 100% !important;
   width: 100% !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -328,7 +328,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     }
 
     // TODO(ccordry): Move all this to use store service. We would like to
-    // eventually depricate navigationState.
+    // eventually deprecate navigationState.
     this.navigationState_ = this.ampStory_.getNavigationState();
     this.navigationState_.observe(this.handleStateChange_.bind(this));
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -84,10 +84,11 @@ const TIMEOUT_LIMIT = 10000; // 10 seconds
 /** @const */
 const GLASS_PANE_CLASS = 'i-amphtml-glass-pane';
 
-/** @private @enum {string} */
-const Attributes = {
+/** @enum {string} */
+export const Attributes = {
   AD_SHOWING: 'ad-showing',
   DESKTOP_PANELS: 'desktop-panels',
+  DIR: 'dir',
   IFRAME_BODY_VISIBLE: 'amp-story-visible',
   LOADING: 'i-amphtml-loading',
   NEXT_PAGE_NO_AD: 'next-page-no-ad',
@@ -241,6 +242,9 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.pendingAdView_ = false;
+
+    /** @private {?Element} */
+    this.adBadgeContainer_ = null;
 
     /**
      * Version of the story store service depends on which version of amp-story
@@ -396,8 +400,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   onRtlStateUpdate_(rtlState) {
     this.mutateElement(() => {
       rtlState
-        ? this.adBadgeContainer_.setAttribute('dir', 'rtl')
-        : this.adBadgeContainer_.removeAttribute('rtl');
+        ? this.adBadgeContainer_.setAttribute(Attributes.DIR, 'rtl')
+        : this.adBadgeContainer_.removeAttribute(Attributes.DIR);
     });
   }
 
@@ -418,6 +422,14 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         root.setAttribute(DESKTOP_PANELS, '');
       }
     });
+  }
+
+  /**
+   * @visibleForTesting
+   * @return {Element}
+   */
+  getAdBadgeRoot() {
+    return this.adBadgeContainer_;
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -462,7 +462,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     badge.className = 'i-amphtml-story-ad-attribution';
     badge.textContent = 'Ad';
 
-    this.adBadgeContainer_.append(badge);
+    this.adBadgeContainer_.appendChild(badge);
     createShadowRootWithStyle(root, this.adBadgeContainer_, attributionCSS);
     this.ampStory_.element.appendChild(root);
   }

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -26,7 +26,10 @@ import {
   StateChangeEventDef,
   StateChangeType,
 } from '../../amp-story/1.0/navigation-state';
-import {StateProperty} from '../../amp-story/1.0/amp-story-store-service';
+import {
+  StateProperty,
+  UIType,
+} from '../../amp-story/1.0/amp-story-store-service';
 import {CSS as attributionCSS} from '../../../build/amp-story-auto-ads-attribution-0.1.css';
 import {createElementWithAttributes, isJsonScriptTag} from '../../../src/dom';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
@@ -81,14 +84,14 @@ const TIMEOUT_LIMIT = 10000; // 10 seconds
 /** @const */
 const GLASS_PANE_CLASS = 'i-amphtml-glass-pane';
 
-/** @const */
-const LOADING_ATTR = 'i-amphtml-loading';
-
-/** @const {string} */
-const NEXT_PAGE_NO_AD = 'next-page-no-ad';
-
-/** @const {string} */
-const IFRAME_BODY_VISIBLE_ATTR = 'amp-story-visible';
+/** @private @enum {string} */
+const Attributes = {
+  AD_SHOWING: 'ad-showing',
+  DESKTOP_PANELS: 'desktop-panels',
+  IFRAME_BODY_VISIBLE: 'amp-story-visible',
+  LOADING: 'i-amphtml-loading',
+  NEXT_PAGE_NO_AD: 'next-page-no-ad',
+};
 
 /** @const */
 const DATA_ATTR = {
@@ -320,6 +323,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       return Promise.resolve();
     }
 
+    // TODO(ccordry): Move all this to use store service. We would like to
+    // eventually depricate navigationState.
     this.navigationState_ = this.ampStory_.getNavigationState();
     this.navigationState_.observe(this.handleStateChange_.bind(this));
 
@@ -328,6 +333,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       .whenSignal(CommonSignals.INI_LOAD)
       .then(() => {
         this.createAdOverlay_();
+        this.initializeListeners_();
         this.readConfig_();
         this.schedulePage_();
       });
@@ -341,6 +347,77 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   isAutomaticAdInsertionAllowed_() {
     return !!this.storeService_.get(StateProperty.CAN_INSERT_AUTOMATIC_AD);
+  }
+
+  /**
+   * Subscribes to all relevant state changes from the containing story.
+   * @private
+   */
+  initializeListeners_() {
+    this.storeService_.subscribe(StateProperty.AD_STATE, isAd => {
+      this.onAdStateUpdate_(isAd);
+    });
+
+    this.storeService_.subscribe(
+      StateProperty.RTL_STATE,
+      rtlState => {
+        this.onRtlStateUpdate_(rtlState);
+      },
+      true /** callToInitialize */
+    );
+
+    this.storeService_.subscribe(
+      StateProperty.UI_STATE,
+      uiState => {
+        this.onUIStateUpdate_(uiState);
+      },
+      true /** callToInitialize */
+    );
+  }
+
+  /**
+   * Reacts to the ad state updates and passes the information along as
+   * attributes to the shadowed ad badge.
+   * @param {boolean} isAd
+   */
+  onAdStateUpdate_(isAd) {
+    this.mutateElement(() => {
+      isAd
+        ? this.adBadgeContainer_.setAttribute(Attributes.AD_SHOWING, '')
+        : this.adBadgeContainer_.removeAttribute(Attributes.AD_SHOWING);
+    });
+  }
+
+  /**
+   * Reacts to the rtl state updates and passes the information along as
+   * attributes to the shadowed ad badge.
+   * @param {boolean} rtlState
+   */
+  onRtlStateUpdate_(rtlState) {
+    this.mutateElement(() => {
+      rtlState
+        ? this.adBadgeContainer_.setAttribute('dir', 'rtl')
+        : this.adBadgeContainer_.removeAttribute('rtl');
+    });
+  }
+
+  /**
+   * Reacts to UI state updates and passes the information along as
+   * attributes to the shadowed ad badge.
+   * @param {!UIType} uiState
+   * @private
+   */
+  onUIStateUpdate_(uiState) {
+    this.mutateElement(() => {
+      const {DESKTOP_PANELS} = Attributes;
+      const root = this.adBadgeContainer_;
+
+      root.removeAttribute(DESKTOP_PANELS);
+
+      if (uiState === UIType.DESKTOP_PANELS) {
+        root.setAttribute(DESKTOP_PANELS, '');
+      }
+    });
   }
 
   /**
@@ -364,15 +441,18 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   createAdOverlay_() {
-    const container = this.win.document.createElement('aside');
-    container.className = 'i-amphtml-ad-overlay-container';
+    const root = this.win.document.createElement('div');
 
-    const span = this.win.document.createElement('p');
-    span.className = 'i-amphtml-story-ad-attribution';
-    span.textContent = 'Ad';
+    this.adBadgeContainer_ = this.win.document.createElement('aside');
+    this.adBadgeContainer_.className = 'i-amphtml-ad-overlay-container';
 
-    createShadowRootWithStyle(container, span, attributionCSS);
-    this.ampStory_.element.appendChild(container);
+    const badge = this.win.document.createElement('p');
+    badge.className = 'i-amphtml-story-ad-attribution';
+    badge.textContent = 'Ad';
+
+    this.adBadgeContainer_.append(badge);
+    createShadowRootWithStyle(root, this.adBadgeContainer_, attributionCSS);
+    this.ampStory_.element.appendChild(root);
   }
 
   /**
@@ -453,7 +533,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         // remove loading attribute once loaded so that desktop CSS will position
         // offscren with all other pages
         const currentPageEl = this.adPageEls_[this.adPageEls_.length - 1];
-        currentPageEl.removeAttribute(LOADING_ATTR);
+        currentPageEl.removeAttribute(Attributes.LOADING);
 
         this.analyticsEventWithCurrentAd_(Events.AD_LOADED, {
           [Vars.AD_LOADED]: Date.now(),
@@ -584,6 +664,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @return {boolean}
    */
   createCtaLayer_(adPageElement, ctaText, ctaUrl) {
+    // TODO(ccordry): Move button to shadow root.
     const a = this.win.document.createElement('a');
     a.className = 'i-amphtml-story-ad-link';
     a.setAttribute('target', '_blank');
@@ -718,7 +799,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       friendlyIframeEmbed.contentDocument || friendlyIframeEmbed.win.document;
     const {body} = frameDoc;
     this.mutateElement(() => {
-      body.setAttribute(IFRAME_BODY_VISIBLE_ATTR, '');
+      body.setAttribute(Attributes.IFRAME_BODY_VISIBLE, '');
       this.visibleAdBody_ = body;
     });
   }
@@ -729,7 +810,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   removeVisibleAttribute_() {
     this.mutateElement(() => {
       if (this.visibleAdBody_) {
-        this.visibleAdBody_.removeAttribute(IFRAME_BODY_VISIBLE_ATTR);
+        this.visibleAdBody_.removeAttribute(Attributes.IFRAME_BODY_VISIBLE);
         this.visibleAdBody_ = null;
       }
     });
@@ -867,7 +948,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   nextPageNoAd_(page) {
-    return page.element.hasAttribute(NEXT_PAGE_NO_AD);
+    return page.element.hasAttribute(Attributes.NEXT_PAGE_NO_AD);
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -14,11 +14,31 @@
  * limitations under the License.
  */
 import * as analytics from '../../../../src/analytics';
-import {AmpStoryAutoAds} from '../amp-story-auto-ads';
+import {
+  Action,
+  UIType,
+  getStoreService,
+} from '../../../amp-story/1.0/amp-story-store-service';
+import {AmpStory} from '../../../amp-story/1.0/amp-story';
+import {AmpStoryAutoAds, Attributes} from '../amp-story-auto-ads';
+import {CommonSignals} from '../../../../src/common-signals';
 import {Services} from '../../../../src/services';
 import {macroTask} from '../../../../testing/yield';
 
 const NOOP = () => {};
+
+function addStoryAutoAdsConfig(document, autoAdsEl) {
+  const config = {
+    'ad-attributes': {
+      type: 'doubleclick',
+      'data-slot': '/30497360/a4a/fake_ad_unit',
+    },
+  };
+  const child = document.createElement('script');
+  child.setAttribute('type', 'application/json');
+  child.innerText = JSON.stringify(config);
+  autoAdsEl.append(child);
+}
 
 describes.realWin(
   'amp-story-auto-ads',
@@ -32,6 +52,7 @@ describes.realWin(
     let adElement;
     let storyElement;
     let autoAds;
+    let story;
 
     beforeEach(() => {
       win = env.win;
@@ -41,11 +62,12 @@ describes.realWin(
       storyElement = win.document.createElement('amp-story');
       win.document.body.appendChild(storyElement);
       storyElement.appendChild(adElement);
+      story = new AmpStory(storyElement);
       autoAds = new AmpStoryAutoAds(adElement);
       autoAds.config_ = {
         'ad-attributes': {
           type: 'doubleclick',
-          'data-slot': '/30497360/samfrank_native_v2_a4a',
+          'data-slot': '/30497360/a4a/fake_ad_unit',
         },
       };
     });
@@ -99,6 +121,52 @@ describes.realWin(
           /* pageId */ 'non-ad-page'
         );
         expect(removeVisibleStub.calledOnce).to.be.true;
+      });
+    });
+
+    describe('ad badge', () => {
+      let storeService;
+
+      beforeEach(async () => {
+        // Force sync mutateElement.
+        sandbox.stub(autoAds, 'mutateElement').callsArg(0);
+        addStoryAutoAdsConfig(win.document, adElement);
+        storeService = getStoreService(win);
+        await story.buildCallback();
+        // Fire these events so that story ads thinks the parent story is ready.
+        story.signals().signal(CommonSignals.BUILT);
+        story.signals().signal(CommonSignals.INI_LOAD);
+        await autoAds.buildCallback();
+        await autoAds.layoutCallback();
+      });
+
+      it('should propigate the ad-showing attribute', async () => {
+        expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(
+          Attributes.AD_SHOWING
+        );
+        storeService.dispatch(Action.TOGGLE_AD, true);
+        expect(autoAds.getAdBadgeRoot()).to.have.attribute(
+          Attributes.AD_SHOWING
+        );
+      });
+
+      it('should propigate the desktop-panels attribute', async () => {
+        expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(
+          Attributes.DESKTOP_PANELS
+        );
+        storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
+        expect(autoAds.getAdBadgeRoot()).to.have.attribute(
+          Attributes.DESKTOP_PANELS
+        );
+      });
+
+      it('should propigate the dir=rtl attribute', async () => {
+        expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(Attributes.DIR);
+        storeService.dispatch(Action.TOGGLE_RTL, true);
+        expect(autoAds.getAdBadgeRoot()).to.have.attribute(
+          Attributes.DIR,
+          'rtl'
+        );
       });
     });
 

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -27,14 +27,14 @@ import {macroTask} from '../../../../testing/yield';
 
 const NOOP = () => {};
 
-function addStoryAutoAdsConfig(document, autoAdsEl) {
+function addStoryAutoAdsConfig(doc, autoAdsEl) {
   const config = {
     'ad-attributes': {
       type: 'doubleclick',
       'data-slot': '/30497360/a4a/fake_ad_unit',
     },
   };
-  const child = document.createElement('script');
+  const child = doc.createElement('script');
   child.setAttribute('type', 'application/json');
   child.innerText = JSON.stringify(config);
   autoAdsEl.append(child);
@@ -140,7 +140,7 @@ describes.realWin(
         await autoAds.layoutCallback();
       });
 
-      it('should propigate the ad-showing attribute', async () => {
+      it('should propigate the ad-showing attribute', () => {
         expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(
           Attributes.AD_SHOWING
         );
@@ -150,7 +150,7 @@ describes.realWin(
         );
       });
 
-      it('should propigate the desktop-panels attribute', async () => {
+      it('should propigate the desktop-panels attribute', () => {
         expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(
           Attributes.DESKTOP_PANELS
         );
@@ -160,7 +160,7 @@ describes.realWin(
         );
       });
 
-      it('should propigate the dir=rtl attribute', async () => {
+      it('should propigate the dir=rtl attribute', () => {
         expect(autoAds.getAdBadgeRoot()).not.to.have.attribute(Attributes.DIR);
         storeService.dispatch(Action.TOGGLE_RTL, true);
         expect(autoAds.getAdBadgeRoot()).to.have.attribute(


### PR DESCRIPTION
Moves the ad badge container to the same shadow root as the ad badge.

Changes logic to to propagate all meaningful attributes to the shadow root (using js), instead of relying on not-well-supported  `:host-context` CSS selector. 

Closes #22592 