### PR TITLE
Inabox: remove unnecessary dependency on maybeTrackImpression

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -210,7 +210,8 @@ app.get('/a4a/:bid', (req, res) => {
             "img": "\${htmlAttr(amp-img,src)}",
             "navTiming": "\${navTiming(requestStart,requestStart)}",
             "navType": "\${navType}",
-            "navRedirectCount": "\${navRedirectCount}"
+            "navRedirectCount": "\${navRedirectCount}",
+            "sourceUrl": "\${sourceUrl}"
           }
         }
       }

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -45,7 +45,6 @@ import {
 import {installViewerServiceForDoc} from '../service/viewer-impl';
 import {internalRuntimeVersion} from '../internal-version';
 import {isExperimentOn} from '../experiments';
-import {maybeTrackImpression} from '../impression';
 import {maybeValidate} from '../validator-integration';
 import {startupChunk} from '../chunk';
 import {stubElementsForDoc} from '../service/custom-element-registry';
@@ -103,7 +102,6 @@ startupChunk(self.document, function initial() {
         installAmpdocServices(ampdoc, undefined, true);
         // We need the core services (viewer/resources) to start instrumenting
         perf.coreServicesAvailable();
-        maybeTrackImpression(self);
         registerIniLoadListener(ampdoc);
       });
       startupChunk(self.document, function builtins() {

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -24,6 +24,7 @@ import {Services} from '../services';
 import {adopt} from '../runtime';
 import {cssText as ampDocCss} from '../../build/ampdoc.css';
 import {cssText as ampSharedCss} from '../../build/ampshared.css';
+import {doNotTrackImpression} from '../impression';
 import {fontStylesheetTimeout} from '../font-stylesheet-timeout';
 import {getA4AId, registerIniLoadListener} from './utils';
 import {getMode} from '../mode';
@@ -45,7 +46,6 @@ import {
 import {installViewerServiceForDoc} from '../service/viewer-impl';
 import {internalRuntimeVersion} from '../internal-version';
 import {isExperimentOn} from '../experiments';
-import {doNotTrackImpression} from '../impression';
 import {maybeValidate} from '../validator-integration';
 import {startupChunk} from '../chunk';
 import {stubElementsForDoc} from '../service/custom-element-registry';

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -45,6 +45,7 @@ import {
 import {installViewerServiceForDoc} from '../service/viewer-impl';
 import {internalRuntimeVersion} from '../internal-version';
 import {isExperimentOn} from '../experiments';
+import {doNotTrackImpression} from '../impression';
 import {maybeValidate} from '../validator-integration';
 import {startupChunk} from '../chunk';
 import {stubElementsForDoc} from '../service/custom-element-registry';
@@ -102,6 +103,7 @@ startupChunk(self.document, function initial() {
         installAmpdocServices(ampdoc, undefined, true);
         // We need the core services (viewer/resources) to start instrumenting
         perf.coreServicesAvailable();
+        doNotTrackImpression();
         registerIniLoadListener(ampdoc);
       });
       startupChunk(self.document, function builtins() {

--- a/test/integration/test-amp-inabox.js
+++ b/test/integration/test-amp-inabox.js
@@ -89,6 +89,7 @@ describe
         expect(req.url).to.match(/^\/bar\?/);
         const queries = parseQueryString(req.url.substr('/bar'.length));
         expect(queries['cid']).to.equal('');
+        expect(queries['sourceUrl']).be.ok;
       });
       return Promise.all([imgPromise, pixelPromise, analyticsPromise]);
     }


### PR DESCRIPTION
`maybeTrackImpression` was introduced for Ads landing page (ALP), which does not apply to AMPHTML ads.

This will reduce amp4ads-v0.js size from 275K to 273K.
for #22867