### PR TITLE
🐛Fix `data-slide-id` not being preserved when lightboxing a carousel.

### DIFF
--- a/examples/article-with-lightbox-2.0-gallery.amp.html
+++ b/examples/article-with-lightbox-2.0-gallery.amp.html
@@ -346,8 +346,7 @@
         "requests": {
           "open": "https://foo.com/open",
           "thumb": "https://foo.com/thumb",
-          "slide": "https://foo.com/slide",
-          "gallerySlide": "https://foo.com/gallerySlide",
+          "slide": "https://foo.com/slide?to=${toSlide}&from=${fromSlide}",
           "controlToggle": "https://foo.com/controlToggle",
           "descExpand": "https://foo.com/descExpand"
         },
@@ -363,17 +362,14 @@
           "trackAmpCarouselChange": {
             "selector": "main",
             "on": "amp-carousel-change",
-            "request": "slide",
-            "extraUrlParams": {
-              "id": "${toSlide}"
-            }
+            "request": "slide"
           },
           "trackAmpCarouselChangeInLightbox": {
             "selector": "amp-lightbox-gallery",
             "on": "amp-carousel-change",
-            "request": "gallerySlide",
+            "request": "slide",
             "extraUrlParams": {
-              "id": "${toSlide}"
+              "gallery": "true"
             }
           },
           "trackControlsToggled": {
@@ -456,12 +452,14 @@
           </p>
           <h3>Other Modern Architectures</h3>
           <amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
+            <!-- Uses a data-slide-id for the analytics event instead of the index. -->
             <amp-img data-slide-id="first" src="https://picsum.photos/1600/900?image=898" layout="responsive" width="1600" height="900" aria-describedby="desc1">
               <div id="desc1" class="lightbox-only-description">
                 <p>Short - Sed pharetra semper fringilla. Nulla fringilla, neque eget</p>
               </div>
             </amp-img>
 
+            <!-- Uses a data-slide-id for the analytics event instead of the index. -->
             <amp-img data-slide-id="second" src="https://picsum.photos/1600/900?image=864" layout="responsive" width="1600" height="900" aria-describedby="desc2">
               <div id="desc2" class="lightbox-only-description">
                 <p> Medium - Sed pharetra semper fringilla. Nulla fringilla, neque eget varius suscipit, mi turpis congue odio,
@@ -471,6 +469,7 @@
               </div>
             </amp-img>
 
+            <!-- Uses a data-slide-id for the analytics event instead of the index. -->
             <amp-img data-slide-id="third" src="https://picsum.photos/1600/900?image=870" layout="responsive" width="1600" height="900" aria-describedby="desc3">
               <div id="desc3" class="lightbox-only-description">
                 <p> Long - Sed pharetra semper fringilla. Nulla fringilla, neque eget varius suscipit, mi turpis congue odio,
@@ -484,14 +483,17 @@
               </div>
             </amp-img>
 
-            <amp-img data-slide-id="fourth" src="https://picsum.photos/1600/400?image=857" layout="responsive" width="1600" height="400"
+            <!-- No data-slide-id, will use the index of analytics. -->
+            <amp-img src="https://picsum.photos/1600/400?image=857" layout="responsive" width="1600" height="400"
               alt="Wide image">
             </amp-img>
 
-            <amp-img data-slide-id="fifth" src="https://picsum.photos/400/1600?image=682" layout="responsive" width="400" height="1600" alt="Tall image">
+            <!-- No data-slide-id, will use the index of analytics. -->
+            <amp-img src="https://picsum.photos/400/1600?image=682" layout="responsive" width="400" height="1600" alt="Tall image">
             </amp-img>
 
-            <amp-img data-slide-id="sixth" id="cover" src="https://picsum.photos/900/1600?image=629" layout="responsive" width="900" height="1600" alt="Tall image with fit:cover">
+             <!-- No data-slide-id, will use the index of analytics. -->
+            <amp-img id="cover" src="https://picsum.photos/900/1600?image=629" layout="responsive" width="900" height="1600" alt="Tall image with fit:cover">
             </amp-img>
           </amp-carousel>
 

--- a/examples/article-with-lightbox-2.0-gallery.amp.html
+++ b/examples/article-with-lightbox-2.0-gallery.amp.html
@@ -347,6 +347,7 @@
           "open": "https://foo.com/open",
           "thumb": "https://foo.com/thumb",
           "slide": "https://foo.com/slide",
+          "gallerySlide": "https://foo.com/gallerySlide",
           "controlToggle": "https://foo.com/controlToggle",
           "descExpand": "https://foo.com/descExpand"
         },
@@ -359,9 +360,21 @@
             "on": "thumbnailsViewToggled",
             "request": "thumb"
           },
-          "trackSlideChange": {
-            "on": "slideChange",
-            "request": "slide"
+          "trackAmpCarouselChange": {
+            "selector": "main",
+            "on": "amp-carousel-change",
+            "request": "slide",
+            "extraUrlParams": {
+              "id": "${toSlide}"
+            }
+          },
+          "trackAmpCarouselChangeInLightbox": {
+            "selector": "amp-lightbox-gallery",
+            "on": "amp-carousel-change",
+            "request": "gallerySlide",
+            "extraUrlParams": {
+              "id": "${toSlide}"
+            }
           },
           "trackControlsToggled": {
             "on": "controlsToggled",
@@ -443,13 +456,13 @@
           </p>
           <h3>Other Modern Architectures</h3>
           <amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
-            <amp-img src="https://picsum.photos/1600/900?image=898" layout="responsive" width="1600" height="900" aria-describedby="desc1">
+            <amp-img data-slide-id="first" src="https://picsum.photos/1600/900?image=898" layout="responsive" width="1600" height="900" aria-describedby="desc1">
               <div id="desc1" class="lightbox-only-description">
                 <p>Short - Sed pharetra semper fringilla. Nulla fringilla, neque eget</p>
               </div>
             </amp-img>
 
-            <amp-img src="https://picsum.photos/1600/900?image=864" layout="responsive" width="1600" height="900" aria-describedby="desc2">
+            <amp-img data-slide-id="second" src="https://picsum.photos/1600/900?image=864" layout="responsive" width="1600" height="900" aria-describedby="desc2">
               <div id="desc2" class="lightbox-only-description">
                 <p> Medium - Sed pharetra semper fringilla. Nulla fringilla, neque eget varius suscipit, mi turpis congue odio,
                   quis dignissim nisi nulla at erat. Duis non nibh vel erat vehicula hendrerit eget vel velit. Donec congue
@@ -458,7 +471,7 @@
               </div>
             </amp-img>
 
-            <amp-img src="https://picsum.photos/1600/900?image=870" layout="responsive" width="1600" height="900" aria-describedby="desc3">
+            <amp-img data-slide-id="third" src="https://picsum.photos/1600/900?image=870" layout="responsive" width="1600" height="900" aria-describedby="desc3">
               <div id="desc3" class="lightbox-only-description">
                 <p> Long - Sed pharetra semper fringilla. Nulla fringilla, neque eget varius suscipit, mi turpis congue odio,
                   quis dignissim nisi nulla at erat. Duis non nibh vel erat vehicula hendrerit eget vel velit. Donec congue
@@ -471,14 +484,14 @@
               </div>
             </amp-img>
 
-            <amp-img src="https://picsum.photos/1600/400?image=857" layout="responsive" width="1600" height="400"
+            <amp-img data-slide-id="fourth" src="https://picsum.photos/1600/400?image=857" layout="responsive" width="1600" height="400"
               alt="Wide image">
             </amp-img>
 
-            <amp-img src="https://picsum.photos/400/1600?image=682" layout="responsive" width="400" height="1600" alt="Tall image">
+            <amp-img data-slide-id="fifth" src="https://picsum.photos/400/1600?image=682" layout="responsive" width="400" height="1600" alt="Tall image">
             </amp-img>
 
-            <amp-img id="cover" src="https://picsum.photos/900/1600?image=629" layout="responsive" width="900" height="1600" alt="Tall image with fit:cover">
+            <amp-img data-slide-id="sixth" id="cover" src="https://picsum.photos/900/1600?image=629" layout="responsive" width="900" height="1600" alt="Tall image with fit:cover">
             </amp-img>
           </amp-carousel>
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -312,6 +312,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         const container = this.doc_.createElement('div');
         const imageViewer = htmlFor(this.doc_)`
           <amp-image-viewer layout="fill"></amp-image-viewer>`;
+        // Copy any data attributes from the cloneNode to the new slide
+        // container. For example. when cloning carousel slides, we want to
+        // carry over data-slide-id.
+        for (const name in clonedNode.dataset) {
+          container.dataset[name] = clonedNode.dataset[name];
+        }
         clonedNode.removeAttribute('class');
         imageViewer.appendChild(clonedNode);
         container.appendChild(imageViewer);


### PR DESCRIPTION
- Copy over all `data-` attributes when carousel slides are wrapped for
pan-zoom within `<amp-lightbox-gallery>`.
- Fixes/improvements for `article-with-lightbox-2.0-gallery` example:
  * Fix incorrect analytics config for carousel slide changes, was using the wrong event name so analytics was not firing.
  * Add from/to slide as url params.
  * Add URL param for the slide changes in the lightbox as an example of
  how to distinguish the two sources of slide changes.
  * Add data-slide-id for some of the slides in the second carousel as
  an example.

Fixes #22883
