### PR TITLE
Inabox: remove unnecessary dependency on storage services.

### DIFF
--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -93,10 +93,9 @@ startupChunk(self.document, function initial() {
     fullCss,
     () => {
       startupChunk(self.document, function services() {
-        // For security, storage and CLIENT_ID are not supported in inabox.
+        // For security, storage is not supported in inabox.
         // Fail early with console errors for any attempt of access.
         unsupportedService(ampdoc, 'storage');
-        unsupportedService(ampdoc, 'cid');
         // Core services.
         installRuntimeServices(self);
         fontStylesheetTimeout(self);

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -79,10 +79,7 @@ export function installRuntimeServices(global) {
 export function installAmpdocServices(ampdoc, opt_initParams, opt_inabox) {
   // Order is important!
   installUrlForDoc(ampdoc);
-  if (!opt_inabox) {
-    // For security, storage service is not supported in inabox.
-    installCidService(ampdoc);
-  }
+  installCidService(ampdoc);
   installDocumentInfoServiceForDoc(ampdoc);
   if (!opt_inabox) {
     // viewer & viewport were installed in amp-inabox.js

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -79,7 +79,10 @@ export function installRuntimeServices(global) {
 export function installAmpdocServices(ampdoc, opt_initParams, opt_inabox) {
   // Order is important!
   installUrlForDoc(ampdoc);
-  installCidService(ampdoc);
+  if (!opt_inabox) {
+    // For security, storage service is not supported in inabox.
+    installCidService(ampdoc);
+  }
   installDocumentInfoServiceForDoc(ampdoc);
   if (!opt_inabox) {
     // viewer & viewport were installed in amp-inabox.js
@@ -92,7 +95,10 @@ export function installAmpdocServices(ampdoc, opt_initParams, opt_inabox) {
   installUrlReplacementsServiceForDoc(ampdoc);
   installActionServiceForDoc(ampdoc);
   installStandardActionsForDoc(ampdoc);
-  installStorageServiceForDoc(ampdoc);
+  if (!opt_inabox) {
+    // For security, CLIENT_ID is not supported in inabox.
+    installStorageServiceForDoc(ampdoc);
+  }
   installGlobalNavigationHandlerForDoc(ampdoc);
   installGlobalSubmitListenerForDoc(ampdoc);
 }

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -93,7 +93,7 @@ export function installAmpdocServices(ampdoc, opt_initParams, opt_inabox) {
   installActionServiceForDoc(ampdoc);
   installStandardActionsForDoc(ampdoc);
   if (!opt_inabox) {
-    // For security, CLIENT_ID is not supported in inabox.
+    // For security, Storage is not supported in inabox.
     installStorageServiceForDoc(ampdoc);
   }
   installGlobalNavigationHandlerForDoc(ampdoc);


### PR DESCRIPTION
This reduces the size of amp4ads-v0.js from 273.5KB to 271KB
for #22867