### PR TITLE
:sparkles:add loadscript option for RevContent ad

### DIFF
--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {validateData, writeScript, loadScript} from '../3p/3p';
+import {loadScript, validateData, writeScript} from '../3p/3p';
 
 /**
  * @param {!Window} global
@@ -51,6 +51,6 @@ export function revcontent(global, data) {
   if (data.loadscript) {
     loadScript(window, endpoint);
   } else {
-    writeScript(window, endpoint); 
+    writeScript(window, endpoint);
   }
 }

--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {validateData, writeScript} from '../3p/3p';
+import {validateData, writeScript, loadScript} from '../3p/3p';
 
 /**
  * @param {!Window} global
@@ -25,6 +25,7 @@ export function revcontent(global, data) {
     'https://labs-cdn.revcontent.com/build/amphtml/revcontent.amp.min.js';
   const required = ['id', 'width', 'height', 'wrapper'];
   const optional = [
+    'loadscript',
     'api',
     'key',
     'ssl',
@@ -47,5 +48,9 @@ export function revcontent(global, data) {
 
   validateData(data, required, optional);
   global.data = data;
-  writeScript(window, endpoint);
+  if (data.loadscript) {
+    loadScript(window, endpoint);
+  } else {
+    writeScript(window, endpoint); 
+  }
 }

--- a/ads/revcontent.md
+++ b/ads/revcontent.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## Example
 
 ```html
-<amp-ad width="400" height="260" layout="responsive" 
+<amp-ad width="400" height="260" layout="responsive"
       type="revcontent"
       heights="(max-width: 320px) 933px,
       (max-width: 360px) 1087px,
@@ -51,6 +51,7 @@ Supported parameters:
 - `data-endpoint`
 - `data-ssl`
 - `data-testing`
+- `data-loadscript`
 
 ## Auto-sizing of Ads
 


### PR DESCRIPTION
For certain implementations `writeScript` is not a good option. `loadScript` will allow the recontent amp script to be added after the page is rendered. This should probably be the default but to maintain backward compatibility it will be enabled by passing the `loadscript` data attribute