### PR TITLE
Improve all adp modules coverage to above 80%

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -38,7 +38,7 @@ import {createDateRangePicker} from './date-range-picker';
 import {createDeferred} from './react-utils';
 import {createSingleDatePicker} from './single-date-picker';
 import {dashToCamelCase} from '../../../src/string';
-import {dev, user, userAssert} from '../../../src/log';
+import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {once} from '../../../src/utils/function';
@@ -543,7 +543,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       this.setupTemplates_();
     }
 
-    Promise.resolve(p).then(() => this.setState_(newState));
+    return Promise.resolve(p).then(() => this.setState_(newState));
   }
 
   /** @override */
@@ -674,10 +674,10 @@ export class AmpDatePicker extends AMP.BaseElement {
       return;
     }
 
-    if (!this.stateMachine_) {
-      return;
-    }
-
+    devAssert(
+      this.stateMachine_,
+      'transitonTo called before state machine is initialized'
+    );
     this.stateMachine_.setState(state);
   }
 

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker-bind.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker-bind.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../../../../third_party/react-dates/bundle';
+import * as lolex from 'lolex';
+import {AmpDatePicker} from '../amp-date-picker';
+import {createElementWithAttributes} from '../../../../src/dom.js';
+
+describes.realWin(
+  'amp-date-picker',
+  {
+    amp: {
+      runtimeOn: false,
+      extensions: ['amp-date-picker'],
+    },
+  },
+  env => {
+    let clock;
+    let document;
+
+    const DEFAULT_ATTRS = {
+      layout: 'fixed-height',
+      height: '360',
+    };
+
+    /**
+     * @param {!JsonObject<string, string>=} opt_attrs
+     * @param {!Element=} opt_parent
+     * @return {{
+     *   element: !Element,
+     *   picker: !AmpDatePicker,
+     *   buildCallback: function():!Promise,
+     *   layoutCallback: function():!Promise
+     * }}
+     */
+    function createDatePicker(opt_attrs = {}, opt_parent = document.body) {
+      const attrs = Object.assign({}, DEFAULT_ATTRS, opt_attrs);
+      let input = null;
+      let endInput = null;
+      if (attrs['mode'] === 'overlay') {
+        input = document.createElement('input');
+        input.id = 'date';
+
+        if (attrs['type'] === 'range') {
+          endInput = document.createElement('input');
+          endInput.id = 'endDate';
+          attrs['start-input-selector'] = '#date';
+          attrs['end-input-selector'] = '#endDate';
+        } else {
+          attrs['input-selector'] = '#date';
+        }
+      }
+      const element = createElementWithAttributes(
+        document,
+        'amp-date-picker',
+        attrs
+      );
+
+      if (input) {
+        element.appendChild(input);
+      }
+      if (endInput) {
+        element.appendChild(endInput);
+      }
+      opt_parent.appendChild(element);
+      const picker = new AmpDatePicker(element);
+
+      return {
+        element,
+        input,
+        endInput,
+        picker,
+        async buildCallback() {
+          await picker.buildCallback();
+        },
+        async layoutCallback() {
+          await picker.buildCallback();
+          await picker.layoutCallback();
+        },
+      };
+    }
+
+    beforeEach(() => {
+      document = env.win.document;
+      clock = lolex.install({
+        // Use the global window and not env.win. There is no way to inject the
+        // env.win into moment right now.
+        target: window,
+        now: new Date('2018-01-01T08:00:00Z'),
+      });
+    });
+
+    afterEach(() => {
+      clock.uninstall();
+    });
+
+    describe('bind', () => {
+      it('should forward mutations to the date picker state', async () => {
+        const {picker, layoutCallback} = createDatePicker({
+          src: 'https://localhost:8000/examples/date-picker.json',
+        });
+        sandbox.stub(picker, 'fetchSrc_').resolves();
+        const setStateSpy = sandbox.spy(picker, 'setState_');
+        await layoutCallback();
+
+        await picker.mutatedAttributesCallback({
+          'min': '2019-01-01',
+          'max': '2019-12-31',
+          'src': 'https://localhost:8000/examples/date-picker-other.json',
+        });
+
+        expect(setStateSpy.getCall(0).args[0]).to.deep.equal({
+          'max': '2019-12-31',
+          'min': '2019-01-01',
+        });
+      });
+    });
+  }
+);

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -449,6 +449,100 @@ describes.realWin(
         });
       });
 
+      describe('changing dates', () => {
+        it('should set the date in a single date picker', async () => {
+          const {element, picker, layoutCallback} = createDatePicker();
+          await layoutCallback();
+
+          picker.onDateChange(moment('2018-01-03'));
+
+          expect(element.getAttribute('date')).to.equal('2018-01-03');
+        });
+
+        it('should set date range in a date range picker', async () => {
+          const {element, picker, layoutCallback} = createDatePicker({
+            'blocked': '2018-01-06',
+          });
+          await layoutCallback();
+
+          picker.onDatesChange({
+            'startDate': moment('2018-01-03'),
+            'endDate': moment('2018-01-05'),
+          });
+
+          expect(element.getAttribute('start-date')).to.equal('2018-01-03');
+          expect(element.getAttribute('end-date')).to.equal('2018-01-05');
+        });
+      });
+
+      describe('iterateDataRange', () => {
+        it('should not iterate for an end date before start date ', () => {
+          const {picker} = createDatePicker();
+          const spy = sandbox.spy();
+
+          picker.iterateDateRange_(
+            moment('2018-01-03'),
+            moment('2018-01-01'),
+            spy
+          );
+
+          expect(spy).to.not.have.been.called;
+        });
+
+        it('should handle both dates being the same', () => {
+          const {picker} = createDatePicker();
+          const spy = sandbox.spy();
+
+          picker.iterateDateRange_(
+            moment('2018-01-01'),
+            moment('2018-01-01'),
+            spy
+          );
+
+          expect(spy).to.have.been.calledOnce;
+          const date = spy.getCall(0).args[0];
+          expect(date.isSame('2018-01-01')).to.be.true;
+        });
+
+        it('should handle a null end date as both dates being the same', () => {
+          const {picker} = createDatePicker();
+          const spy = sandbox.spy();
+
+          picker.iterateDateRange_(moment('2018-01-01'), null, spy);
+
+          expect(spy).to.have.been.calledOnce;
+          const date = spy.getCall(0).args[0];
+          expect(date.isSame('2018-01-01')).to.be.true;
+        });
+
+        it('should handle both dates being different', () => {
+          const {picker} = createDatePicker();
+          const spy = sandbox.spy();
+
+          picker.iterateDateRange_(
+            moment('2018-01-01'),
+            moment('2018-01-07'),
+            spy
+          );
+
+          expect(spy.callCount).to.equal(7);
+          let date = spy.getCall(0).args[0];
+          expect(date.isSame('2018-01-01')).to.be.true;
+          date = spy.getCall(1).args[0];
+          expect(date.isSame('2018-01-02')).to.be.true;
+          date = spy.getCall(2).args[0];
+          expect(date.isSame('2018-01-03')).to.be.true;
+          date = spy.getCall(3).args[0];
+          expect(date.isSame('2018-01-04')).to.be.true;
+          date = spy.getCall(4).args[0];
+          expect(date.isSame('2018-01-05')).to.be.true;
+          date = spy.getCall(5).args[0];
+          expect(date.isSame('2018-01-06')).to.be.true;
+          date = spy.getCall(6).args[0];
+          expect(date.isSame('2018-01-07')).to.be.true;
+        });
+      });
+
       describe('touch keyboard suppression', () => {
         it(
           'should add and remove the readonly property on focus' +

--- a/extensions/amp-date-picker/0.1/test/test-wrapper-maximum-nights.js
+++ b/extensions/amp-date-picker/0.1/test/test-wrapper-maximum-nights.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../../../../third_party/react-dates/bundle';
+import * as lolex from 'lolex';
+import {requireExternal} from '../../../../src/module';
+import {wrap as withMaximumNights} from '../wrappers/maximum-nights';
+
+describes.sandboxed('amp-date-picker', {}, () => {
+  const moment = requireExternal('moment');
+  let clock;
+
+  function FakeDatePicker() {
+    return 'amp-date-picker';
+  }
+
+  beforeEach(() => {
+    clock = lolex.install({
+      // Use the global window and not env.win. There is no way to inject the
+      // env.win into moment right now.
+      target: window,
+      now: new Date('2018-01-01T08:00:00Z'),
+    });
+  });
+
+  afterEach(() => {
+    clock.uninstall();
+  });
+
+  describe('wrapper maximum-nights', () => {
+    it('should pass through if maximum nights is not set', async () => {
+      const {getIsOutsideRange} = withMaximumNights(FakeDatePicker);
+      const props = {
+        isOutsideRange: () => false,
+        startDate: null,
+        endDate: null,
+        focusedInput: 'startDate',
+        maximumNights: null,
+      };
+
+      const isOutsideRange = getIsOutsideRange(props);
+      expect(isOutsideRange(moment('2018-01-01'))).to.be.false;
+    });
+
+    it('should match end dates beyond the maximum-night props', async () => {
+      const {getIsOutsideRange} = withMaximumNights(FakeDatePicker);
+      const props = {
+        isOutsideRange: () => false,
+        startDate: moment('2018-01-01'),
+        endDate: null,
+        focusedInput: 'endDate',
+        maximumNights: 7,
+      };
+
+      const isOutsideRange = getIsOutsideRange(props);
+      expect(isOutsideRange(moment('2018-01-09'))).to.be.true;
+    });
+
+    it('should match start dates beyond the maximum-night props', async () => {
+      const {getIsOutsideRange} = withMaximumNights(FakeDatePicker);
+      const props = {
+        isOutsideRange: () => false,
+        startDate: null,
+        endDate: moment('2018-01-09'),
+        focusedInput: 'startDate',
+        maximumNights: 7,
+      };
+
+      const isOutsideRange = getIsOutsideRange(props);
+      expect(isOutsideRange(moment('2018-01-01'))).to.be.true;
+    });
+
+    it('should combine with the outer isOutsideRange prop', async () => {
+      const {getIsOutsideRange} = withMaximumNights(FakeDatePicker);
+      const props = {
+        isOutsideRange: date => moment('2018-01-04').isSame(date),
+        startDate: moment('2018-01-01'),
+        endDate: null,
+        focusedInput: 'startDate',
+        maximumNights: 7,
+      };
+
+      const isOutsideRange = getIsOutsideRange(props);
+      expect(isOutsideRange(moment('2018-01-04'))).to.be.true;
+    });
+  });
+});

--- a/extensions/amp-date-picker/0.1/wrappers/maximum-nights.js
+++ b/extensions/amp-date-picker/0.1/wrappers/maximum-nights.js
@@ -63,6 +63,8 @@ export function wrap(WrappedComponent) {
       return React.createElement(WrappedComponent, props);
     }
   }
+  /** @private @const visible for testing */
+  MaximumNights.getIsOutsideRange = getIsOutsideRange;
 
   /**
    * Creates a function that will restrict the user from selecting a range


### PR DESCRIPTION
With this PR, every file in `amp-date-picker` should have test coverage above 80%. Some of these tests are also regression tests for previous bugs.