### PR TITLE
♻️ ESLint Rules: Allow ExportSpecifier

### DIFF
--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -35,11 +35,6 @@ module.exports = function(context) {
               });
             });
         }
-      } else if (node.specifiers) {
-        context.report({
-          node,
-          message: 'Side-effect linting not implemented',
-        });
       }
     },
   };


### PR DESCRIPTION
- Allows ExportSpecifier

Example:
```js
export {x, y};
```