### PR TITLE
New validation rule for A4A meta tags.

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad.html
@@ -33,6 +33,16 @@
     <!-- Specifies what type of landing page the user is direct to -->
     <meta name="amp-cta-landing-page-type" content="NONAMP">
 
+    <!-- Specifies where the attribution icon will be loaded from (optional). -->
+    <meta name="amp4ads-vars-attribution-icon" content="https://placekitten.com/30/30">
+    
+    <!-- Specifies where a click on attribution icon will land (optional). -->
+    <meta name="amp4ads-vars-attribution-url" content="https://example.com">
+    
+    <!-- Optional format for creatives to pass data to AMP runtime.  -->
+    <meta name="amp4ads-vars-foo" content="bar">
+
+
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <style amp-custom>
      amp-img {height: 100vh}

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad.out
@@ -34,6 +34,16 @@ PASS
 |      <!-- Specifies what type of landing page the user is direct to -->
 |      <meta name="amp-cta-landing-page-type" content="NONAMP">
 |
+|      <!-- Specifies where the attribution icon will be loaded from (optional). -->
+|      <meta name="amp4ads-vars-attribution-icon" content="https://placekitten.com/30/30">
+|      
+|      <!-- Specifies where a click on attribution icon will land (optional). -->
+|      <meta name="amp4ads-vars-attribution-url" content="https://example.com">
+|      
+|      <!-- Optional format for creatives to pass data to AMP runtime.  -->
+|      <meta name="amp4ads-vars-foo" content="bar">
+|
+|
 |      <style amp4ads-boilerplate>body{visibility:hidden}</style>
 |      <style amp-custom>
 |       amp-img {height: 100vh}

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.html
@@ -33,6 +33,14 @@
     <!-- Should fail due to invalid content choice. -->
     <meta name="amp-cta-landing-page-type" content="GAME">
 
+    <!-- Should fail due to no `content=`. -->
+    <meta name="amp4ads-vars-foo">
+
+    <!-- Should fail due unrecognized `name` -->
+    <meta name="amp4ads-vars" content="bar">
+    <meta name="amp4ads-vars-" content="bar">
+
+
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <style amp-custom>
      amp-img {height: 100vh}

--- a/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_story_ad_errors.out
@@ -40,6 +40,20 @@ amp4ads_feature_tests/amp_story_ad_errors.html:31:4 The mandatory attribute 'con
 >>     ^~~~~~~~~
 amp4ads_feature_tests/amp_story_ad_errors.html:34:4 The attribute 'content' in tag 'meta name=amp-cta-landing-page-type' is set to the invalid value 'GAME'. [DISALLOWED_HTML]
 |
+|      <!-- Should fail due to no `content=`. -->
+|      <meta name="amp4ads-vars-foo">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:37:4 The mandatory attribute 'content' is missing in tag 'meta name=amp4ads-vars-*'. [DISALLOWED_HTML]
+|
+|      <!-- Should fail due unrecognized `name` -->
+|      <meta name="amp4ads-vars" content="bar">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:40:4 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'amp4ads-vars'. [DISALLOWED_HTML]
+|      <meta name="amp4ads-vars-" content="bar">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_story_ad_errors.html:41:4 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'amp4ads-vars-'. [DISALLOWED_HTML]
+|
+|
 |      <style amp4ads-boilerplate>body{visibility:hidden}</style>
 |      <style amp-custom>
 |       amp-img {height: 100vh}

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -994,7 +994,7 @@ tags: {
   }
 }
 # AMP metadata, name=amp-vars-*
-# Allows advertises to pass information from creatives
+# Allows advertisers to pass information from creatives
 # to be included in amp-ad-metadata.
 tags: {
   html_format: AMP4ADS

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -993,15 +993,14 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
-# AMP metadata, name=amp-vars-*
+# AMP metadata, name=amp4ads-vars-*
 # Allows advertisers to pass information from creatives
 # to be included in amp-ad-metadata.
 tags: {
   html_format: AMP4ADS
   tag_name: "META"
-  spec_name: "meta name=amp-vars-*"
+  spec_name: "meta name=amp4ads-vars-*"
   mandatory_parent: "HEAD"
-  unique: true
   attrs: {
     name: "content"
     mandatory: true
@@ -1009,8 +1008,7 @@ tags: {
   attrs: {
     name: "name"
     mandatory: true
-    value_regex: "^amp-vars-.+"
-    dispatch_key: NAME_VALUE_DISPATCH
+    value_regex: "^amp4ads-vars-.+"
   }
 }
 # 4.2.6 The style

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1008,7 +1008,7 @@ tags: {
   attrs: {
     name: "name"
     mandatory: true
-    value_regex: "^amp4ads-vars-.+"
+    value_regex: "amp4ads-vars-.+"
   }
 }
 # 4.2.6 The style

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -993,6 +993,26 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
+# AMP metadata, name=amp-vars-*
+# Allows advertises to pass information from creatives
+# to be included in amp-ad-metadata.
+tags: {
+  html_format: AMP4ADS
+  tag_name: "META"
+  spec_name: "meta name=amp-vars-*"
+  mandatory_parent: "HEAD"
+  unique: true
+  attrs: {
+    name: "content"
+    mandatory: true
+  }
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_regex: "^amp-vars-.+"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
 # 4.2.6 The style
 # Text contents of the style tag will be validated seperately.
 tags: {  # Special custom 'author' spreadsheet for AMP


### PR DESCRIPTION
Introducing a new meta tag that advertisers can use to pass information to the amp runtime. These new meta tags will be read by the a4a transformer, and their data will be added to the created `<script type="application/json" amp-ad-metadata>` object.

format:
`<meta name="amp-vars-id" content="123">` 