### PR TITLE
🐛Remove text nodes from amp-story on build

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -446,7 +446,7 @@ export class AmpStory extends AMP.BaseElement {
     const textNodes = Array.from(this.element.childNodes).filter(
       node => node.nodeType === Node.TEXT_NODE
     );
-    textNodes.forEach((node) => {
+    textNodes.forEach(node => {
       this.element.removeChild(node);
     });
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -442,6 +442,14 @@ export class AmpStory extends AMP.BaseElement {
     // hover. (See 17654)
     this.element.removeAttribute('title');
 
+    // Remove text nodes which would be shown outside of the amp-story
+    const textNodes = Array.from(this.element.childNodes).filter(
+      node => node.nodeType === Node.TEXT_NODE
+    );
+    textNodes.forEach((node) => {
+      this.element.removeChild(node);
+    });
+
     if (isExperimentOn(this.win, 'amp-story-branching')) {
       this.registerAction('goToPage', invocation => {
         const {args} = invocation;

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -183,6 +183,18 @@ describes.realWin(
       });
     });
 
+    it('should remove text child nodes when built', () => {
+      createPages(story.element, 1, ['cover']);
+      const textToRemove = 'this should be removed';
+      const textNode = win.document.createTextNode(textToRemove);
+      story.element.appendChild(textNode);
+      story.buildCallback();
+      return story.layoutCallback().then(() => {
+        console.log(story.element.childNodes);
+        expect(story.element.innerText).to.not.have.string(textToRemove);
+      });
+    });
+
     it('should preload the bookend if navigating to the last page', () => {
       createPages(story.element, 1, ['cover']);
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -190,7 +190,6 @@ describes.realWin(
       story.element.appendChild(textNode);
       story.buildCallback();
       return story.layoutCallback().then(() => {
-        console.log(story.element.childNodes);
         expect(story.element.innerText).to.not.have.string(textToRemove);
       });
     });


### PR DESCRIPTION
Fixes 21346

Previously, text children of amp-story would appear outside of the story page. This removes text children when amp-story component is built.

/cc @newmuis @gmajoulet 