### PR TITLE
Update form dirtiness on FORM_VALUE_CHANGE event

### DIFF
--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AmpEvents} from '../../../src/amp-events';
 import {createFormDataWrapper} from '../../../src/form-data-wrapper';
 import {dev} from '../../../src/log';
 import {isDisabled, isFieldDefault, isFieldEmpty} from '../../../src/form';
@@ -107,6 +108,13 @@ export class FormDirtiness {
   installEventHandlers_() {
     this.form_.addEventListener('input', this.onInput_.bind(this));
     this.form_.addEventListener('reset', this.onReset_.bind(this));
+
+    // `amp-bind` dispatches the custom event `FORM_VALUE_CHANGE` when it
+    // mutates the value of a form field (e.g. textarea, input, etc)
+    this.form_.addEventListener(
+      AmpEvents.FORM_VALUE_CHANGE,
+      this.onInput_.bind(this)
+    );
   }
 
   /**


### PR DESCRIPTION
`AmpEvents.FORM_VALUE_CHANGE` is dispatched when `amp-bind` changes a
form value (e.g. input field, dropdown menu selection, etc).

This updates `FormDirtiness` to listen to `amp-bind` changes, and
recalculate the overall dirtiness accordingly.

Part of #22534.

/cc @GoTcWang @cvializ 