### PR TITLE
🏗 Clean up build cache on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,14 @@ jobs:
       name: "Remote (Sauce Labs) Tests"
       script:
         - unbuffer node build-system/pr-check/remote-tests.js
+      after_script:
+        - ps -ef
     - stage: test
       name: "End to End Tests"
       script:
         - unbuffer node build-system/pr-check/e2e-tests.js
+      after_script:
+        - ps -ef
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,6 @@ jobs:
       name: "Remote (Sauce Labs) Tests"
       script:
         - unbuffer node build-system/pr-check/remote-tests.js
-      after_script:
-        - build-system/sauce_connect/stop_sauce_connect.sh
     - stage: test
       name: "End to End Tests"
       script:
@@ -87,9 +85,7 @@ cache:
     - node_modules
     - build-system/tasks/e2e/node_modules
     - build-system/tasks/visual-diff/node_modules
-    - sauce_connect
     - validator/node_modules
     - validator/nodejs/node_modules
     - validator/webui/node_modules
-    - $HOME/.cache/pip
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/remote-tests.js
       after_script:
+        - build-system/sauce_connect/stop_sauce_connect.sh
         - ps -ef
     - stage: test
       name: "End to End Tests"
@@ -89,6 +90,7 @@ cache:
     - node_modules
     - build-system/tasks/e2e/node_modules
     - build-system/tasks/visual-diff/node_modules
+    - sauce_connect
     - validator/node_modules
     - validator/nodejs/node_modules
     - validator/webui/node_modules


### PR DESCRIPTION
Removes `$HOME/.cache/pip` from the cache because it changes every build, which means uploading new files for every Travis job. `pip` should already be supported on Xenial VMs but if not, we should install it in a `before_install` script instead of keeping in the cache.

Removes `stop_sauce_connect.sh` because it's a duplicate.

Also removes `sauce_connect` from the cache - unclear what that is?

Adds `ps -ef` as `after_script`s on the remote test and e2e jobs, because they have a tendency to hang and I'd like to see what processes are still running after the tests are complete.