### PR TITLE
🐛Fix bottom of slides being clipped.

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.css
+++ b/extensions/amp-base-carousel/0.1/carousel.css
@@ -37,19 +37,28 @@
   align-items: center;
 
   scroll-behavior: smooth;
-  /* Hide scrollbar */
-  box-sizing: content-box !important;
   -webkit-overflow-scrolling: touch !important;
+  
+  /*
+   * Hide scrollbars, with three different methods:
+   *
+   * 1. scrollbar-width
+   *  - Note: this is actually scrollbar *thickness* and applies to horizontal
+   *    scrollbars as well
+   * 2. ::-webkit-scrollbar
+   * 3. Using padding to push scrollbar outside of the overflow
+   *
+   * The last method has side-effect of having the bottom of the slides being
+   * cut-off, since the height (or width) of the scrollbar is included when
+   * calculating the 100% height (or width) of the slide.
+   */
+  scrollbar-width: none; /* Firefox */
+  box-sizing: content-box !important;
 
   --visible-count: 1;
 }
 
-/**
- * Make sure the scrollbar does not take up space on desktop, which will cause
- * the bottom of the slides to be cutoff. Padding + overflow is used to hide
- * the scrollbars for all browsers.
- * TODO(sparhami) Find a solution for the clipping on all browsers.
- */
+/* Chrome, Safari */
 .i-amphtml-carousel-scroll::-webkit-scrollbar {
   display: none;
 }

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -105,26 +105,26 @@ amp-carousel .amp-carousel-button.amp-disabled {
   top: 0;
   width: 100% !important;
   scroll-snap-type: x mandatory !important;
-  /**
-   * Hide the scrollbar by tucking it under some padding
-   * which gets cut off as it overflows the parent.
-   * The exact size of the padding does not matter as long as it is
-   * larger than the height of the scrollbar. 20px is large enough to cover
-   * both desktop and mobile scrolbar sizes in different browsers.
-   * This relies on content box-sizing, although that's the default
-   * we still ensure it does not get overwritten.
+  /*
+   * Hide scrollbars, with three different methods:
+   *
+   * 1. scrollbar-width
+   *  - Note: this is actually scrollbar *thickness* and applies to horizontal
+   *    scrollbars as well
+   * 2. ::-webkit-scrollbar
+   * 3. Using padding to push scrollbar outside of the overflow
+   *
+   * The last method has side-effect of having the bottom of the slides being
+   * cut-off, since the height (or width) of the scrollbar is included when
+   * calculating the 100% height (or width) of the slide.
    */
+  scrollbar-width: none; /* Firefox */
   padding-bottom: 20px !important;
   box-sizing: content-box !important;
   -webkit-overflow-scrolling: touch !important;
 }
 
-/**
- * Make sure the scrollbar does not take up space on desktop, which will cause
- * the bottom of the slides to be cutoff. Padding + overflow is used to hide
- * the scrollbars for all browsers.
- * TODO(sparhami) Find a solution for the clipping on all browsers.
- */
+/* Chrome, Safari */
 .i-amphtml-slides-container::-webkit-scrollbar {
   display: none !important;
 }


### PR DESCRIPTION
Fixes the clipping in Firefox for `<amp-carousel>` and `<amp-base-carousel>`. This was already fixed for Safari/Chrome (#20513).
There does not appear to be a solution for Edge/IE.

Fixes #18352