### PR TITLE
🏗 Change `gulp lint` flag from `--local-changes` to `--local_changes`

### DIFF
--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -25,7 +25,7 @@
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-GULP_LINT_LOCAL="gulp lint --local-changes"
+GULP_LINT_LOCAL="gulp lint --local_changes"
 GULP_UNIT_LOCAL="gulp unit --local_changes --headless"
 
 echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "to skip them.)")

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -131,7 +131,7 @@ function runLinter(filePath, stream, options) {
               colors.yellow('NOTE 1:'),
               'You may be able to automatically fix some of these warnings ' +
                 '/ errors by running',
-              colors.cyan('gulp lint --local-changes --fix'),
+              colors.cyan('gulp lint --local_changes --fix'),
               'from your local branch.'
             );
             log(
@@ -219,7 +219,7 @@ function lint() {
     setFilesToLint(argv.files.split(','));
   } else if (
     !eslintRulesChanged() &&
-    (process.env.LOCAL_PR_CHECK || argv['local-changes'])
+    (process.env.LOCAL_PR_CHECK || argv.local_changes)
   ) {
     const jsFiles = jsFilesChanged();
     if (jsFiles.length == 0) {
@@ -241,6 +241,6 @@ lint.description = 'Validates against Google Closure Linter';
 lint.flags = {
   'watch': '  Watches for changes in files, validates against the linter',
   'fix': '  Fixes simple lint errors (spacing etc)',
-  'local-changes': '  Lints just the changes commited to the local branch',
+  'local_changes': '  Lints just the files changed in the local branch',
   'quiet': '  Suppress warnings from outputting',
 };

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -215,6 +215,17 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
+  // TODO(amp-infra): Remove this warning after a few weeks.
+  if (argv['local-changes']) {
+    log(
+      colors.yellow('WARNING:'),
+      'The',
+      colors.cyan('--local-changes'),
+      'flag has been renamed to',
+      colors.cyan('--local_changes')
+    );
+    return Promise.resolve();
+  }
   if (argv.files) {
     setFilesToLint(argv.files.split(','));
   } else if (

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -62,7 +62,7 @@ async function prCheck(cb) {
     return;
   }
 
-  runCheck('gulp lint --local-changes');
+  runCheck('gulp lint --local_changes');
   runCheck('gulp presubmit');
 
   if (buildTargets.has('AVA')) {

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -61,7 +61,7 @@ Command                                                                 | Descri
 `gulp lint --watch`                                                     | Watches for changes in files, and validates against the ESLint linter.
 `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.
 `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided. Can be used with `--fix`.
-`gulp lint --local-changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.
+`gulp lint --local_changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.
 `gulp build`                                                            | Builds the AMP library.
 `gulp build --extensions=amp-foo,amp-bar`                               | Builds the AMP library, with only the listed extensions.
 `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -354,7 +354,7 @@ For example, if you use [Visual Studio Code](https://code.visualstudio.com/), yo
 
 Alternatively, you can manually fix lint errors in your code by running:
 ```
-gulp lint --local-changes --fix
+gulp lint --local_changes --fix
 ```
 
 # Testing your changes


### PR DESCRIPTION
The convention for multi-word `gulp` flag names is to use an underscore instead of a dash.

This PR changes the `gulp lint` flag from `--local-changes` to `--local_changes`, and makes it consistent with the flag used for `gulp unit`. It also prints a warning when the old flag is used.