### PR TITLE
Fix race and speed up amp-list/amp-bind interaction

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -689,6 +689,12 @@ let BindEvaluateBindingsResultDef;
  */
 let BindEvaluateExpressionResultDef;
 
+/**
+ * Options for Bind.rescan().
+ * @typedef {{apply: boolean|undefined, fast: boolean|undefined, timeout: number|undefined}}
+ */
+let BindRescanOptionsDef;
+
 /////////////////////////////
 ////// Web Anmomation externs
 /////////////////////////////

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -691,7 +691,7 @@ let BindEvaluateExpressionResultDef;
 
 /**
  * Options for Bind.rescan().
- * @typedef {{apply: boolean|undefined, fast: boolean|undefined, timeout: number|undefined}}
+ * @typedef {{apply: (boolean|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
  */
 let BindRescanOptionsDef;
 

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -691,7 +691,7 @@ let BindEvaluateExpressionResultDef;
 
 /**
  * Options for Bind.rescan().
- * @typedef {{apply: (boolean|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
+ * @typedef {{update: (boolean|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
  */
 let BindRescanOptionsDef;
 

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -11,6 +11,17 @@
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+  <style amp-custom>
+    amp-list {
+      font-family: monospace;
+      font-size: 11pt;
+    }
+    button {
+      font-family: monospace;
+      font-size: 9pt;
+      border: solid 1px black;
+    }
+  </style>
 </head>
 <body>
   <amp-state id="otherFoods">
@@ -27,12 +38,12 @@
     </script>
   </amp-state>
 
+  <h3>Remote src (URL)</h3>
   <button on="tap:AMP.setState({src:'/list/fruit-data/get'})">Show Fruit</button>
   <button on="tap:AMP.setState({src:'/list/vegetable-data/get'})">Show Vegetables</button>
   <button on="tap:AMP.setState({src: otherFoods})">Show Other Foods</button>
 
-  <hr>
-
+  <h3>Local src (JSON)</h3>
   <button on="tap:AMP.setState({
     src: [{
       name: 'pizza',
@@ -43,7 +54,7 @@
       quantity: 108,
       unitPrice: 6.50
     }]
-  })">Show Junk Food (local)</button>
+  })">Show Junk Food</button>
 
   <button on="tap:AMP.setState({
     src: [{
@@ -55,36 +66,53 @@
       quantity: 23,
       unitPrice: 0.78
     }]
-  })">Show Desserts (local)</button>
+  })">Show Desserts</button>
 
-  <button on="tap:AMP.setState({foo: foo+1})">Increment foo</button>
   <button on="tap:AMP.setState({src: (src || []).concat([{name: 'burger', quantity: 1, unitPrice: random()}])})">Add burger</button>
 
+  <h3>Other</h3>
+  <button on="tap:AMP.setState({foo: foo+1})">Increment foo</button>
+
+  <hr>
+
   <template id="my-template" type="amp-mustache">
-    <strong>Product</strong>: {{name}}
-    <strong>Quantity:</strong>: {{quantity}}
-    <strong>Unit Price</strong>: ${{unitPrice}}
-    <strong>1+1:</strong>: <span [text]="1+1">?</span>
-    <strong>Foo</strong>: <span data-amp-bind-text="foo">?</span>
+    <strong>name</strong> {{name}}
+    <strong>#</strong> {{quantity}}
+    <strong>$</strong> {{unitPrice}}
+    <strong>1+1</strong>=<span [text]="1+1">?</span>
+    <strong>foo</strong>=<span data-amp-bind-text="foo">?</span>
   </template>
 
   <h3>Default</h3>
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="always"</h3>
-  <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
+  <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="refresh"</h3>
-  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
+  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="no"</h3>
-  <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
+  <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template" reset-on-refresh="always">
+    <div placeholder>(Placeholder)</div>
+  </amp-list>
+
+  <hr style="margin: 2400px 0">
+
+  <p>Due to viewport position, this amp-list will be laid out after amp-bind's initial DOM scan.</p>
+  <ol>
+    <li>Scroll down so that this amp-list enters viewport and is laid out.</li>
+    <li>Tap the "Increment foo" button.</li>
+  </ol>
+  <p>Expected: The amp-list's children should update their "Foo:" values.</p>
+  <h3>binding="refresh"</h3>
+  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 </body>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -412,7 +412,7 @@ export class Bind {
    * Removes bindings from `removedElements` and adds new bindings in
    * `addedElements`.
    *
-   * If `options.apply` is true, evaluates and applies changes to
+   * If `options.update` is true, evaluates and applies changes to
    * `addedElements` after adding new bindings.
    *
    * If `options.fast` is true, uses a faster scan method that requires
@@ -457,7 +457,7 @@ export class Bind {
       : this.slowScan_(addedElements, removedElements);
 
     return rescanPromise.then(() => {
-      if (options.apply) {
+      if (options.update) {
         return this.evaluate_().then(results =>
           this.applyElements_(results, addedElements)
         );

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -482,10 +482,13 @@ export class Bind {
       const children = el.querySelectorAll('[i-amphtml-binding]');
       Array.prototype.push.apply(elementsToScan, children);
     });
-    elementsToScan.forEach(el => {
-      const quota = this.maxNumberOfBindings_ - this.numberOfBindings();
-      this.scanElement_(el, quota, bindings);
-    });
+    const quota = this.maxNumberOfBindings_ - this.numberOfBindings();
+    for (let i = 0; i < elementsToScan.length; i++) {
+      const el = elementsToScan[i];
+      if (this.scanElement_(el, quota - bindings.length, bindings)) {
+        break;
+      }
+    }
 
     removePromise.then(removed => {
       dev().info(

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -473,7 +473,7 @@ export class Bind {
    */
   fastScan_(addedElements, removedElements) {
     /** @return {!Promise<number>} */
-    function add() {
+    const add = () => {
       if (this.numberOfBindings() > this.maxNumberOfBindings_) {
         this.emitMaxBindingsExceededError_();
         return Promise.resolve(0);
@@ -495,7 +495,7 @@ export class Bind {
       } else {
         return Promise.resolve(0);
       }
-    }
+    };
 
     return add().then(added => {
       // Don't return/chain this promise as an optimization.
@@ -541,7 +541,7 @@ export class Bind {
     return this.ww_('bind.init', [allowUrlProperties])
       .then(() => {
         return Promise.all([
-          this.addMacros_(),
+          this.addMacros_().then(() => this.addMacrosDeferred_.resolve()),
           this.addBindingsForNodes_([root]),
         ]);
       })
@@ -681,7 +681,6 @@ export class Bind {
             elements[i]
           );
         });
-        this.addMacrosDeferred_.resolve();
         return macros.length;
       });
     }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -472,6 +472,7 @@ export class Bind {
         this.emitMaxBindingsExceededError_();
         return Promise.resolve(0);
       }
+
       // Scan `addedElements` for bindings.
       const bindings = [];
       const elementsToScan = addedElements.slice();
@@ -690,6 +691,10 @@ export class Bind {
    * @private
    */
   addBindingsForNodes_(nodes) {
+    if (!nodes.length) {
+      return Promise.resolve(0);
+    }
+
     // For each node, scan it for bindings and store them.
     const scanPromises = nodes.map(node => {
       // Limit number of total bindings (unless in local manual testing).
@@ -760,6 +765,10 @@ export class Bind {
    * @private
    */
   removeBindingsForNodes_(nodes) {
+    if (!nodes.length) {
+      return Promise.resolve(0);
+    }
+
     // Eliminate bound elements that are descendants of `nodes`.
     remove(this.boundElements_, boundElement => {
       for (let i = 0; i < nodes.length; i++) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -842,12 +842,8 @@ export class Bind {
       }
       const element = dev().assertElement(node);
       const remainingQuota = limit - bindings.length;
-      // Ignore elements rendered by amp-mustache which have [i-amphtml-binding]
-      // attribute.
-      if (!element.hasAttribute('i-amphtml-binding')) {
-        if (this.scanElement_(element, remainingQuota, bindings)) {
-          limitExceeded = true;
-        }
+      if (this.scanElement_(element, remainingQuota, bindings)) {
+        limitExceeded = true;
       }
       return !walker.nextNode() || limitExceeded;
     };

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -472,9 +472,11 @@ export class Bind {
     // returned promise (worker message) as an optimization.
     const removePromise = this.removeBindingsForNodes_(removedElements);
 
-    // Scan `addedElements` for bindings.
+    // Scan `addedElements` and descendants for bindings.
     const bindings = [];
-    const elementsToScan = addedElements.slice();
+    const elementsToScan = addedElements.filter(el =>
+      el.hasAttribute('i-amphtml-binding')
+    );
     addedElements.forEach(el => {
       const children = el.querySelectorAll('[i-amphtml-binding]');
       Array.prototype.push.apply(elementsToScan, children);

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -115,11 +115,11 @@ function onBindReadyAndSetStateWithExpression(env, bind, expression, scope) {
  * @param {!Array<!Element>} removed
  * @return {!Promise}
  */
-function onBindReadyAndScanAndApply(env, bind, added, removed) {
+function onBindReadyAndRescan(env, bind, added, removed) {
   return bind
     .initializePromiseForTesting()
     .then(() => {
-      return bind.scanAndApply(added, removed);
+      return bind.rescan(added, removed, {apply: true, fast: true});
     })
     .then(() => {
       env.flushVsync();
@@ -1116,7 +1116,7 @@ describe
           });
         });
 
-        it('should scanAndApply()', function*() {
+        it('should rescan()', function*() {
           const foo = createElement(env, container, '[text]="foo"');
           yield onBindReadyAndSetState(env, bind, {foo: 'foo'});
           expect(foo.textContent).to.equal('foo');
@@ -1130,7 +1130,7 @@ describe
           );
           // Required marker attribute for elements with bindings.
           onePlusOne.setAttribute('i-amphtml-binding', '');
-          yield onBindReadyAndScanAndApply(
+          yield onBindReadyAndRescan(
             env,
             bind,
             /* added */ [onePlusOne],

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -113,13 +113,14 @@ function onBindReadyAndSetStateWithExpression(env, bind, expression, scope) {
  * @param {!Bind} bind
  * @param {!Array<!Element>} added
  * @param {!Array<!Element>} removed
+ * @param {!BindRescanOptions=} options
  * @return {!Promise}
  */
-function onBindReadyAndRescan(env, bind, added, removed) {
+function onBindReadyAndRescan(env, bind, added, removed, options) {
   return bind
     .initializePromiseForTesting()
     .then(() => {
-      return bind.rescan(added, removed, {apply: true, fast: true});
+      return bind.rescan(added, removed, options);
     })
     .then(() => {
       env.flushVsync();
@@ -1116,32 +1117,85 @@ describe
           });
         });
 
-        it('should rescan()', function*() {
-          const foo = createElement(env, container, '[text]="foo"');
-          yield onBindReadyAndSetState(env, bind, {foo: 'foo'});
-          expect(foo.textContent).to.equal('foo');
+        describe('rescan()', () => {
+          let toRemove;
+          let toAdd;
 
-          // The new `onePlusOne` element should be scanned and evaluated despite
-          // not being attached to the DOM.
-          const onePlusOne = createElement(
-            env,
-            /* container */ null,
-            '[text]="1+1"'
-          );
-          // Required marker attribute for elements with bindings.
-          onePlusOne.setAttribute('i-amphtml-binding', '');
-          yield onBindReadyAndRescan(
-            env,
-            bind,
-            /* added */ [onePlusOne],
-            /* removed */ [foo]
-          );
-          expect(onePlusOne.textContent).to.equal('2');
+          beforeEach(async () => {
+            toRemove = createElement(env, container, '[text]="foo"');
+            // New elements to rescan() don't need to be attached to DOM.
+            toAdd = createElement(env, /* container */ null, '[text]="1+1"');
+          });
 
-          // The binding for the `foo` element should have been removed, so
-          // performing AMP.setState({foo: ...}) should not change it.
-          yield onBindReadyAndSetState(env, bind, {foo: 'bar'});
-          expect(foo.textContent).to.not.equal('bar');
+          it('{update: true, fast: true}', async () => {
+            const options = {update: true, fast: true};
+
+            await onBindReadyAndSetState(env, bind, {foo: 'foo'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // [i-amphtml-binding] necessary in {fast: true}.
+            toAdd.setAttribute('i-amphtml-binding', '');
+
+            // `toAdd` should be scanned and updated.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('2');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar'});
+            // The `toRemove` element's bindings should have been removed.
+            expect(toRemove.textContent).to.not.equal('bar');
+          });
+
+          it('{update: true, fast: false}', async () => {
+            const options = {update: true, fast: false};
+
+            await onBindReadyAndSetState(env, bind, {foo: 'foo'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // `toAdd` should be scanned and updated.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('2');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar'});
+            // The `toRemove` element's bindings should have been removed.
+            expect(toRemove.textContent).to.not.equal('bar');
+          });
+
+          it('{update: false, fast: true}', async () => {
+            const options = {update: false, fast: true};
+
+            await onBindReadyAndSetState(env, bind, {foo: 'foo'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // [i-amphtml-binding] necessary in {fast: true}.
+            toAdd.setAttribute('i-amphtml-binding', '');
+
+            // `toAdd` should be scanned but not updated.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar'});
+            // Now that `toAdd` is scanned, it should be updated on setState().
+            expect(toAdd.textContent).to.equal('2');
+            // The `toRemove` element's bindings should have been removed.
+            expect(toRemove.textContent).to.not.equal('bar');
+          });
+
+          it('{update: false, fast: false}', async () => {
+            const options = {update: false, fast: false};
+
+            await onBindReadyAndSetState(env, bind, {foo: 'foo'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // `toAdd` should be scanned but not updated.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar'});
+            // Now that `toAdd` is scanned, it should be updated on setState().
+            expect(toAdd.textContent).to.equal('2');
+            // The `toRemove` element's bindings should have been removed.
+            expect(toRemove.textContent).to.not.equal('bar');
+          });
         });
 
         describe('AmpEvents.FORM_VALUE_CHANGE', () => {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -1876,10 +1876,10 @@ export class AmpDatePicker extends AMP.BaseElement {
   onMount() {
     if (this.mode_ == DatePickerMode.OVERLAY) {
       // REVIEW: this should be ok, since opening the overlay requires a
-      // user interaction, and this won't run until then
+      // user interaction, and this won't run until then.
       Services.bindForDocOrNull(this.element).then(bind => {
         if (bind) {
-          return bind.scanAndApply([this.element], [this.element]);
+          return bind.rescan([this.element], [this.element], {apply: true});
         }
       });
     } else {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -1879,7 +1879,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       // user interaction, and this won't run until then.
       Services.bindForDocOrNull(this.element).then(bind => {
         if (bind) {
-          return bind.rescan([this.element], [this.element], {apply: true});
+          return bind.rescan([this.element], [this.element], {'apply': true});
         }
       });
     } else {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -718,7 +718,7 @@ export class AmpList extends AMP.BaseElement {
       const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
       return bind
-        .rescan(elements, removedElements, {fast: true, apply})
+        .rescan(elements, removedElements, {'fast': true, 'apply': apply})
         .then(() => elements, () => elements);
     }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -424,7 +424,7 @@ export class AmpList extends AMP.BaseElement {
         // Clean up bindings in children before removing them from DOM.
         if (this.bind_) {
           const removed = toArray(this.container_.children);
-          this.bind_.rescan(/* added */ [], removed, {'apply': false});
+          this.bind_.rescan(/* added */ [], removed, {'fast': true, 'update': false});
         }
         removeChildren(dev().assertElement(this.container_));
       });
@@ -712,12 +712,13 @@ export class AmpList extends AMP.BaseElement {
 
     /**
      * @param {!../../../extensions/amp-bind/0.1/bind-impl.Bind} bind
+     * @return {!Promise<!Array<!Element>>}
      */
     const updateWith = bind => {
       const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
       return bind
-        .rescan(elements, removedElements, {'fast': true, 'apply': true})
+        .rescan(elements, removedElements, {'fast': true, 'update': true})
         .then(() => elements, () => elements);
     };
 
@@ -727,10 +728,10 @@ export class AmpList extends AMP.BaseElement {
       if (this.bind_ && this.bind_.signals().get('FIRST_MUTATE')) {
         return updateWith(this.bind_);
       } else {
-        // On first render, scan but don't apply.
+        // On initial render, do a non-blocking scan and don't update.
         Services.bindForDocOrNull(this.element).then(bind => {
           if (bind) {
-            bind.rescan(elements, [], {'fast': true, 'apply': false});
+            bind.rescan(elements, [], {'fast': true, 'update': false});
           }
         });
         return Promise.resolve(elements);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -424,7 +424,10 @@ export class AmpList extends AMP.BaseElement {
         // Clean up bindings in children before removing them from DOM.
         if (this.bind_) {
           const removed = toArray(this.container_.children);
-          this.bind_.rescan(/* added */ [], removed, {'fast': true, 'update': false});
+          this.bind_.rescan(/* added */ [], removed, {
+            'fast': true,
+            'update': false,
+          });
         }
         removeChildren(dev().assertElement(this.container_));
       });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -730,7 +730,9 @@ export class AmpList extends AMP.BaseElement {
       } else {
         // On first render, scan but don't apply.
         Services.bindForDocOrNull(this.element).then(bind => {
-          updateWith(bind, /* apply */ false);
+          if (bind) {
+            updateWith(bind, /* apply */ false);
+          }
         });
         return Promise.resolve(elements);
       }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -715,7 +715,9 @@ export class AmpList extends AMP.BaseElement {
 
     // Early out if elements contain no bindings.
     const hasBindings = elements.some(
-      el => !!el.querySelector('[i-amphtml-binding]')
+      el =>
+        el.hasAttribute('i-amphtml-binding') ||
+        !!el.querySelector('[i-amphtml-binding]')
     );
     if (!hasBindings) {
       return Promise.resolve(elements);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -712,15 +712,14 @@ export class AmpList extends AMP.BaseElement {
 
     /**
      * @param {!../../../extensions/amp-bind/0.1/bind-impl.Bind} bind
-     * @param {boolean=} apply
      */
-    function updateWith(bind, apply = true) {
+    const updateWith = bind => {
       const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
       return bind
-        .rescan(elements, removedElements, {'fast': true, 'apply': apply})
+        .rescan(elements, removedElements, {'fast': true, 'apply': true})
         .then(() => elements, () => elements);
-    }
+    };
 
     // "refresh": Do _not_ block on retrieval of the Bind service before the
     // first mutation (AMP.setState).
@@ -731,7 +730,7 @@ export class AmpList extends AMP.BaseElement {
         // On first render, scan but don't apply.
         Services.bindForDocOrNull(this.element).then(bind => {
           if (bind) {
-            updateWith(bind, /* apply */ false);
+            bind.rescan(elements, [], {'fast': true, 'apply': false});
           }
         });
         return Promise.resolve(elements);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -580,8 +580,6 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   scheduleRender_(data, opt_append, opt_payload) {
-    dev().info(TAG, 'schedule:', this.element, data);
-
     const deferred = new Deferred();
     const {promise, resolve: resolver, reject: rejecter} = deferred;
 
@@ -615,7 +613,6 @@ export class AmpList extends AMP.BaseElement {
     const current = this.renderItems_;
 
     devAssert(current && current.data, 'Nothing to render.');
-    dev().info(TAG, 'pass:', this.element, current);
     const scheduleNextPass = () => {
       // If there's a new `renderItems_`, schedule it for render.
       if (this.renderItems_ !== current) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -930,22 +930,29 @@ describes.repeated(
               element.setAttribute('binding', 'refresh');
             });
 
-            it('should not call rescan() before FIRST_MUTATE', function*() {
+            it('should rescan() with {update: false} before FIRST_MUTATE', async () => {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
-              yield list.layoutCallback();
-              expect(bind.rescan).to.not.have.been.called;
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(output, [], {
+                update: false,
+                fast: true,
+              });
             });
 
-            it('should call rescan() after FIRST_MUTATE', function*() {
+            it('should rescan() with {update: true} after FIRST_MUTATE', async () => {
               bind.signals = () => {
                 return {get: name => name === 'FIRST_MUTATE'};
               };
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
-              yield list.layoutCallback();
+              await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
-              expect(bind.rescan).calledWithExactly(output, [list.container_]);
+              expect(bind.rescan).calledWithExactly(output, [list.container_], {
+                update: true,
+                fast: true,
+              });
             });
           });
 
@@ -954,10 +961,10 @@ describes.repeated(
               element.setAttribute('binding', 'no');
             });
 
-            it('should not call rescan()', function*() {
+            it('should not rescan()', async () => {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
-              yield list.layoutCallback();
+              await list.layoutCallback();
               expect(bind.rescan).to.not.have.been.called;
             });
           });

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -698,7 +698,7 @@ describes.repeated(
 
           beforeEach(() => {
             bind = {
-              scanAndApply: sandbox.stub().returns(Promise.resolve()),
+              rescan: sandbox.stub().returns(Promise.resolve()),
               signals: () => {
                 return {get: unusedName => false};
               },
@@ -824,8 +824,8 @@ describes.repeated(
                 'src': 'https://new.com/list.json',
               });
 
-              expect(bind.scanAndApply).to.be.calledTwice;
-              expect(bind.scanAndApply).to.be.calledWith([], sinon.match.array);
+              expect(bind.rescan).to.be.calledTwice;
+              expect(bind.rescan).to.be.calledWith([], sinon.match.array);
             });
           });
 
@@ -904,11 +904,11 @@ describes.repeated(
           });
 
           describe('no `binding` attribute', () => {
-            it('should call scanAndApply()', function*() {
+            it('should call rescan()', function*() {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               yield list.layoutCallback();
-              expect(bind.scanAndApply).to.have.been.calledOnce;
+              expect(bind.rescan).to.have.been.calledOnce;
             });
           });
 
@@ -917,11 +917,11 @@ describes.repeated(
               element.setAttribute('binding', 'always');
             });
 
-            it('should call scanAndApply()', function*() {
+            it('should call rescan()', function*() {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               yield list.layoutCallback();
-              expect(bind.scanAndApply).to.have.been.calledOnce;
+              expect(bind.rescan).to.have.been.calledOnce;
             });
           });
 
@@ -930,24 +930,22 @@ describes.repeated(
               element.setAttribute('binding', 'refresh');
             });
 
-            it('should not call scanAndApply() before FIRST_MUTATE', function*() {
+            it('should not call rescan() before FIRST_MUTATE', function*() {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               yield list.layoutCallback();
-              expect(bind.scanAndApply).to.not.have.been.called;
+              expect(bind.rescan).to.not.have.been.called;
             });
 
-            it('should call scanAndApply() after FIRST_MUTATE', function*() {
+            it('should call rescan() after FIRST_MUTATE', function*() {
               bind.signals = () => {
                 return {get: name => name === 'FIRST_MUTATE'};
               };
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               yield list.layoutCallback();
-              expect(bind.scanAndApply).to.have.been.calledOnce;
-              expect(bind.scanAndApply).calledWithExactly(output, [
-                list.container_,
-              ]);
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(output, [list.container_]);
             });
           });
 
@@ -956,11 +954,11 @@ describes.repeated(
               element.setAttribute('binding', 'no');
             });
 
-            it('should not call scanAndApply()', function*() {
+            it('should not call rescan()', function*() {
               const output = [doc.createElement('div')];
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               yield list.layoutCallback();
-              expect(bind.scanAndApply).to.not.have.been.called;
+              expect(bind.rescan).to.not.have.been.called;
             });
           });
         }); // with amp-bind

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -904,11 +904,24 @@ describes.repeated(
           });
 
           describe('no `binding` attribute', () => {
-            it('should call rescan()', function*() {
-              const output = [doc.createElement('div')];
-              expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
-              yield list.layoutCallback();
+            it('should rescan()', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {update: true, fast: true}
+              );
+            });
+
+            it('should not rescan() if new children have no bindings', async () => {
+              const child = doc.createElement('div');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.not.be.called;
             });
           });
 
@@ -917,11 +930,17 @@ describes.repeated(
               element.setAttribute('binding', 'always');
             });
 
-            it('should call rescan()', function*() {
-              const output = [doc.createElement('div')];
-              expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
-              yield list.layoutCallback();
+            it('should rescan()', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {update: true, fast: true}
+              );
             });
           });
 
@@ -931,11 +950,12 @@ describes.repeated(
             });
 
             it('should rescan() with {update: false} before FIRST_MUTATE', async () => {
-              const output = [doc.createElement('div')];
-              expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
               await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
-              expect(bind.rescan).calledWithExactly(output, [], {
+              expect(bind.rescan).calledWithExactly([child], [], {
                 update: false,
                 fast: true,
               });
@@ -945,14 +965,19 @@ describes.repeated(
               bind.signals = () => {
                 return {get: name => name === 'FIRST_MUTATE'};
               };
-              const output = [doc.createElement('div')];
-              expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
               await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
-              expect(bind.rescan).calledWithExactly(output, [list.container_], {
-                update: true,
-                fast: true,
-              });
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {
+                  update: true,
+                  fast: true,
+                }
+              );
             });
           });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -824,7 +824,7 @@ describes.repeated(
                 'src': 'https://new.com/list.json',
               });
 
-              expect(bind.rescan).to.be.calledTwice;
+              expect(bind.rescan).to.be.calledOnce;
               expect(bind.rescan).to.be.calledWith([], sinon.match.array);
             });
           });


### PR DESCRIPTION
Fixes #22341, partial for #21901.

- Bug: Fix race condition between `amp-list[binding=refresh]` and amp-bind's initial DOM scan.
- Optimization: Skip `Bind.rescan` in amp-list if new children have no binding marker attributes (`[i-amphtml-binding]`).
- Optimization: Significantly speed up initial render for amp-list[binding=always] by changing `Bind.rescan` to only wait for a small part of Bind's initialization.
- Bug: Refactor `Bind.rescan` to fix/support amp-date-picker's usage.