### PR TITLE
♻️ Create enums for Actions and ActionResults

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import {
+  Action,
+  ActionStatus,
+  SubscriptionAnalyticsEvents,
+} from '../../amp-subscriptions/0.1/analytics';
 import {CSS} from '../../../build/amp-subscriptions-google-0.1.css';
 import {
   ConfiguredRuntime,
@@ -27,7 +32,6 @@ import {
 } from '../../amp-subscriptions/0.1/entitlement';
 import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
-import {SubscriptionAnalyticsEvents} from '../../amp-subscriptions/0.1/analytics';
 import {SubscriptionsScoreFactor} from '../../amp-subscriptions/0.1/score-factors.js';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {parseUrlDeprecated} from '../../../src/url';
@@ -99,8 +103,8 @@ export class GoogleSubscriptionsPlatform {
       this.onLinkComplete_();
       this.subscriptionAnalytics_.actionEvent(
         this.getServiceId(),
-        'link',
-        'success'
+        Action.LINK,
+        ActionStatus.SUCCESS
       );
       // TODO(dvoytenko): deprecate separate "link" events.
       this.subscriptionAnalytics_.serviceEvent(
@@ -110,15 +114,15 @@ export class GoogleSubscriptionsPlatform {
     });
     this.runtime_.setOnFlowStarted(e => {
       if (
-        e.flow == 'subscribe' ||
-        e.flow == 'contribute' ||
-        e.flow == 'showContributionOptions' ||
-        e.flow == 'showOffers'
+        e.flow == Action.SUBSCRIBE ||
+        e.flow == Action.CONTRIBUTE ||
+        e.flow == Action.SHOW_CONTRIBUTION_OPTIONS ||
+        e.flow == Action.SHOW_OFFERS
       ) {
         this.subscriptionAnalytics_.actionEvent(
           this.getServiceId(),
           e.flow,
-          'started'
+          ActionStatus.STARTED
         );
       }
     });
@@ -127,8 +131,8 @@ export class GoogleSubscriptionsPlatform {
         this.onLinkComplete_();
         this.subscriptionAnalytics_.actionEvent(
           this.getServiceId(),
-          'link',
-          'rejected'
+          Action.LINK,
+          ActionStatus.REJECTED
         );
         // TODO(dvoytenko): deprecate separate "link" events.
         this.subscriptionAnalytics_.serviceEvent(
@@ -136,15 +140,15 @@ export class GoogleSubscriptionsPlatform {
           this.getServiceId()
         );
       } else if (
-        e.flow == 'subscribe' ||
-        e.flow == 'contribute' ||
-        e.flow == 'showContributionOptions' ||
-        e.flow == 'showOffers'
+        e.flow == Action.SUBSCRIBE ||
+        e.flow == Action.CONTRIBUTE ||
+        e.flow == Action.SHOW_CONTRIBUTION_OPTIONS ||
+        e.flow == Action.SHOW_OFFERS
       ) {
         this.subscriptionAnalytics_.actionEvent(
           this.getServiceId(),
           e.flow,
-          'rejected'
+          ActionStatus.REJECTED
         );
       }
     });
@@ -153,12 +157,12 @@ export class GoogleSubscriptionsPlatform {
     });
     this.runtime_.setOnSubscribeResponse(promise => {
       promise.then(response => {
-        this.onSubscribeResponse_(response, 'subscribe');
+        this.onSubscribeResponse_(response, Action.SUBSCRIBE);
       });
     });
     this.runtime_.setOnContributionResponse(promise => {
       promise.then(response => {
-        this.onSubscribeResponse_(response, 'contribute');
+        this.onSubscribeResponse_(response, Action.CONTRIBUTE);
       });
     });
 
@@ -185,8 +189,8 @@ export class GoogleSubscriptionsPlatform {
       this.runtime_.linkAccount();
       this.subscriptionAnalytics_.actionEvent(
         this.getServiceId(),
-        'link',
-        'started'
+        Action.LINK,
+        ActionStatus.STARTED
       );
       // TODO(dvoytenko): deprecate separate "link" events.
       this.subscriptionAnalytics_.serviceEvent(
@@ -207,7 +211,7 @@ export class GoogleSubscriptionsPlatform {
   /** @private */
   onNativeSubscribeRequest_() {
     this.maybeComplete_(
-      this.serviceAdapter_.delegateActionToLocal('subscribe')
+      this.serviceAdapter_.delegateActionToLocal(Action.SUBSCRIBE)
     );
   }
 
@@ -235,7 +239,7 @@ export class GoogleSubscriptionsPlatform {
     this.subscriptionAnalytics_.actionEvent(
       this.getServiceId(),
       eventType,
-      'success'
+      ActionStatus.SUCCESS
     );
   }
 
@@ -379,21 +383,21 @@ export class GoogleSubscriptionsPlatform {
      * subscribe flows elsewhere since they are invoked after
      * offer selection.
      */
-    if (action == 'subscribe') {
+    if (action == Action.SUBSCRIBE) {
       this.runtime_.showOffers({
         list: 'amp',
         isClosable: true,
       });
       return Promise.resolve(true);
     }
-    if (action == 'contribute') {
+    if (action == Action.CONTRIBUTE) {
       this.runtime_.showContributionOptions({
         list: 'amp',
         isClosable: true,
       });
       return Promise.resolve(true);
     }
-    if (action == 'login') {
+    if (action == Action.LOGIN) {
       this.runtime_.linkAccount();
       return Promise.resolve(true);
     }
@@ -405,7 +409,7 @@ export class GoogleSubscriptionsPlatform {
     const opts = options ? options : {};
 
     switch (action) {
-      case 'subscribe':
+      case Action.SUBSCRIBE:
         element.textContent = '';
         this.runtime_.attachButton(element, options, () => {});
         break;
@@ -415,7 +419,7 @@ export class GoogleSubscriptionsPlatform {
         opts.theme = 'light';
         opts.lang = userAssert(
           element.getAttribute('subscriptions-lang'),
-          'subscribe-smartbutton must have a language attrbiute'
+          'subscribe-smartbutton must have a language attribute'
         );
         this.runtime_.attachSmartButton(element, opts, () => {});
         break;
@@ -424,7 +428,7 @@ export class GoogleSubscriptionsPlatform {
         opts.theme = 'dark';
         opts.lang = userAssert(
           element.getAttribute('subscriptions-lang'),
-          'subscribe-smartbutton must have a language attrbiute'
+          'subscribe-smartbutton must have a language attribute'
         );
         this.runtime_.attachSmartButton(element, opts, () => {});
         break;

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -15,6 +15,11 @@
  */
 
 import {
+  Action,
+  ActionStatus,
+  SubscriptionAnalytics,
+} from '../../../amp-subscriptions/0.1/analytics';
+import {
   ConfiguredRuntime,
   Entitlements,
   SubscribeResponse,
@@ -27,7 +32,6 @@ import {GoogleSubscriptionsPlatform} from '../amp-subscriptions-google';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../../../amp-subscriptions/0.1/service-adapter';
 import {Services} from '../../../../src/services';
-import {SubscriptionAnalytics} from '../../../amp-subscriptions/0.1/analytics';
 import {SubscriptionsScoreFactor} from '../../../amp-subscriptions/0.1/score-factors';
 
 const PLATFORM_ID = 'subscribe.google.com';
@@ -269,7 +273,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should delegate login when linking not requested', () => {
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('login')
+      .withExactArgs(Action.LOGIN)
       .returns(Promise.resolve(false))
       .once();
     callback(callbacks.loginRequest)({linkRequested: false});
@@ -280,7 +284,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     platform.isGoogleViewer_ = false;
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('login')
+      .withExactArgs(Action.LOGIN)
       .returns(Promise.resolve(false))
       .once();
     callback(callbacks.loginRequest)({linkRequested: true});
@@ -295,7 +299,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should reauthorize on complete linking', () => {
     analyticsMock
       .expects('actionEvent')
-      .withExactArgs(PLATFORM_ID, 'link', 'success')
+      .withExactArgs(PLATFORM_ID, Action.LINK, ActionStatus.SUCCESS)
       .once();
     serviceAdapterMock.expects('resetPlatforms').once();
     callback(callbacks.linkComplete)();
@@ -304,7 +308,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should reauthorize on canceled linking', () => {
     analyticsMock
       .expects('actionEvent')
-      .withExactArgs(PLATFORM_ID, 'link', 'rejected')
+      .withExactArgs(PLATFORM_ID, Action.LINK, ActionStatus.REJECTED)
       .once();
     serviceAdapterMock.expects('resetPlatforms').once();
     callback(callbacks.flowCanceled)({flow: 'linkAccount'});
@@ -313,23 +317,23 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should log subscribe start', () => {
     analyticsMock
       .expects('actionEvent')
-      .withExactArgs(PLATFORM_ID, 'subscribe', 'started')
+      .withExactArgs(PLATFORM_ID, Action.SUBSCRIBE, ActionStatus.STARTED)
       .once();
-    callback(callbacks.flowStarted)({flow: 'subscribe'});
+    callback(callbacks.flowStarted)({flow: Action.SUBSCRIBE});
   });
 
   it('should log subscribe cancel', () => {
     analyticsMock
       .expects('actionEvent')
-      .withExactArgs(PLATFORM_ID, 'subscribe', 'rejected')
+      .withExactArgs(PLATFORM_ID, Action.SUBSCRIBE, ActionStatus.REJECTED)
       .once();
-    callback(callbacks.flowCanceled)({flow: 'subscribe'});
+    callback(callbacks.flowCanceled)({flow: Action.SUBSCRIBE});
   });
 
   it('should reauthorize on complete subscribe', () => {
     analyticsMock
       .expects('actionEvent')
-      .withExactArgs(PLATFORM_ID, 'subscribe', 'success')
+      .withExactArgs(PLATFORM_ID, Action.SUBSCRIBE, ActionStatus.SUCCESS)
       .once();
     const promise = Promise.resolve();
     const response = new SubscribeResponse(
@@ -353,7 +357,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should delegate native subscribe request', () => {
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('subscribe')
+      .withExactArgs(Action.SUBSCRIBE)
       .returns(Promise.resolve(false))
       .once();
     callback(callbacks.subscribeRequest)();
@@ -363,7 +367,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     const loginResult = Promise.resolve(true);
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('login')
+      .withExactArgs(Action.LOGIN)
       .returns(loginResult)
       .once();
     callback(callbacks.loginRequest)({linkRequested: false});
@@ -376,7 +380,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     const loginResult = Promise.resolve(false);
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('login')
+      .withExactArgs(Action.LOGIN)
       .returns(loginResult)
       .once();
     callback(callbacks.loginRequest)({linkRequested: false});
@@ -389,7 +393,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     const loginResult = Promise.resolve(true);
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs('subscribe')
+      .withExactArgs(ActionStatus.SUBSCRIBE)
       .returns(loginResult)
       .once();
     callback(callbacks.subscribeRequest)();
@@ -498,19 +502,19 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should show offers if subscribe action is delegated', () => {
     const executeStub = platform.runtime_.showOffers;
-    platform.executeAction('subscribe');
+    platform.executeAction(Action.SUBSCRIBE);
     expect(executeStub).to.be.calledWith({list: 'amp', isClosable: true});
   });
 
   it('should show contributions if contribute action is delegated', () => {
     const executeStub = platform.runtime_.showContributionOptions;
-    platform.executeAction('contribute');
+    platform.executeAction(Action.CONTRIBUTE);
     expect(executeStub).to.be.calledWith({list: 'amp', isClosable: true});
   });
 
   it('should link accounts if login action is delegated', () => {
     const executeStub = platform.runtime_.linkAccount;
-    platform.executeAction('login');
+    platform.executeAction(Action.LOGIN);
     expect(executeStub).to.be.calledWith();
   });
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -393,7 +393,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     const loginResult = Promise.resolve(true);
     serviceAdapterMock
       .expects('delegateActionToLocal')
-      .withExactArgs(ActionStatus.SUBSCRIBE)
+      .withExactArgs(Action.SUBSCRIBE)
       .returns(loginResult)
       .once();
     callback(callbacks.subscribeRequest)();

--- a/extensions/amp-subscriptions/0.1/actions.js
+++ b/extensions/amp-subscriptions/0.1/actions.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionStatus} from './analytics';
 import {assertHttpsUrl, parseQueryString} from '../../../src/url';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
@@ -116,7 +117,7 @@ export class Actions {
 
     dev().fine(TAG, 'Start action: ', url, action);
 
-    this.analytics_.actionEvent(LOCAL, action, 'started');
+    this.analytics_.actionEvent(LOCAL, action, ActionStatus.STARTED);
     const dialogPromise = this.openPopup_(url);
     const actionPromise = dialogPromise
       .then(result => {
@@ -126,15 +127,15 @@ export class Actions {
         const s = query['success'];
         const success = s == 'true' || s == 'yes' || s == '1';
         if (success) {
-          this.analytics_.actionEvent(LOCAL, action, 'success');
+          this.analytics_.actionEvent(LOCAL, action, ActionStatus.SUCCESS);
         } else {
-          this.analytics_.actionEvent(LOCAL, action, 'rejected');
+          this.analytics_.actionEvent(LOCAL, action, ActionStatus.REJECTED);
         }
         return success || !s;
       })
       .catch(reason => {
         dev().fine(TAG, 'Action failed: ', action, reason);
-        this.analytics_.actionEvent(LOCAL, action, 'failed');
+        this.analytics_.actionEvent(LOCAL, action, ActionStatus.FAILED);
         if (this.actionPromise_ == actionPromise) {
           this.actionPromise_ = null;
         }

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -44,6 +44,23 @@ export const SubscriptionAnalyticsEvents = {
   LINK_CANCELED: 'subscriptions-link-canceled',
 };
 
+export const Action = {
+  LOGIN: 'login',
+  LOGOUT: 'logout',
+  LINK: 'link',
+  SUBSCRIBE: 'subscribe',
+  CONTRIBUTE: 'contribute',
+  SHOW_CONTRIBUTION_OPTIONS: 'showContributionOptions',
+  SHOW_OFFERS: 'showOffers',
+};
+
+export const ActionStatus = {
+  STARTED: 'started',
+  REJECTED: 'rejected',
+  FAILED: 'failed',
+  SUCCESS: 'success',
+}
+
 export class SubscriptionAnalytics {
   /**
    * Creates an instance of SubscriptionAnalytics.

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -44,6 +44,7 @@ export const SubscriptionAnalyticsEvents = {
   LINK_CANCELED: 'subscriptions-link-canceled',
 };
 
+/** @enum {string} */
 export const Action = {
   LOGIN: 'login',
   LOGOUT: 'logout',
@@ -54,12 +55,13 @@ export const Action = {
   SHOW_OFFERS: 'showOffers',
 };
 
+/** @enum {string} */
 export const ActionStatus = {
   STARTED: 'started',
   REJECTED: 'rejected',
   FAILED: 'failed',
   SUCCESS: 'success',
-}
+};
 
 export class SubscriptionAnalytics {
   /**

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Action} from './analytics';
 import {Actions} from './actions';
 import {LocalSubscriptionPlatformRenderer} from './local-subscription-platform-renderer';
 import {UrlBuilder} from './url-builder';
@@ -93,11 +94,11 @@ export class LocalSubscriptionBasePlatform {
    */
   validateActionMap(actionMap) {
     userAssert(
-      actionMap['login'],
+      actionMap[Action.LOGIN],
       'Action "login" is not present in action map'
     );
     userAssert(
-      actionMap['subscribe'],
+      actionMap[Action.SUBSCRIBE],
       'Action "subscribe" is not present in action map'
     );
     return actionMap;
@@ -129,7 +130,7 @@ export class LocalSubscriptionBasePlatform {
       if (serviceAttr == 'local') {
         this.executeAction(action);
       } else if ((serviceAttr || 'auto') == 'auto') {
-        if (action == 'login') {
+        if (action == Action.LOGIN) {
           // The "login" action is somewhat special b/c viewers can
           // enhance this action, e.g. to provide save/link feature.
           const platform = this.serviceAdapter_.selectPlatformForLogin();

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import {Action, SubscriptionAnalytics} from '../analytics';
 import {Actions} from '../actions';
-import {SubscriptionAnalytics} from '../analytics';
 import {UrlBuilder} from '../url-builder';
 import {WebLoginDialog} from '../../../amp-access/0.1/login-dialog';
 
@@ -45,8 +45,9 @@ describes.realWin('Actions', {amp: true}, env => {
     analyticsMock = sandbox.mock(analytics);
     buildSpy = sandbox.spy(Actions.prototype, 'build');
     actions = new Actions(ampdoc, urlBuilder, analytics, {
-      'login': 'https://example.org/login?rid=READER_ID',
-      'subscribe': 'https://example.org/subscribe?rid=READER_ID&a=AUTHDATA(a)',
+      [Action.LOGIN]: 'https://example.org/login?rid=READER_ID',
+      [Action.SUBSCRIBE]:
+        'https://example.org/subscribe?rid=READER_ID&a=AUTHDATA(a)',
     });
     openResolver = null;
     openStub = sandbox.stub(WebLoginDialog.prototype, 'open').callsFake(() => {
@@ -68,10 +69,10 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions.build().then(() => {
       const builtActions = actions.builtActionUrlMap_;
       expect(Object.keys(builtActions)).to.have.length(2);
-      expect(builtActions['login']).to.equal(
+      expect(builtActions[Action.LOGIN]).to.equal(
         'https://example.org/login?rid=RD'
       );
-      expect(builtActions['subscribe']).to.equal(
+      expect(builtActions[Action.SUBSCRIBE]).to.equal(
         'https://example.org/subscribe?rid=RD&a=A'
       );
     });
@@ -89,7 +90,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver('#success=yes');
         return promise;
@@ -103,7 +104,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver('#success=true');
         return promise;
@@ -117,7 +118,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver('#success=1');
         return promise;
@@ -139,7 +140,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver('#success=no');
         return promise;
@@ -153,7 +154,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver('');
         return promise;
@@ -165,13 +166,13 @@ describes.realWin('Actions', {amp: true}, env => {
 
   it('should block re-execution of actions for some time', () => {
     return actions.build().then(() => {
-      const promise = actions.execute('login');
+      const promise = actions.execute(Action.LOGIN);
       expect(openStub).to.be.calledOnce;
       // Repeated call is blocked.
-      expect(actions.execute('login')).to.equal(promise);
+      expect(actions.execute(Action.LOGIN)).to.equal(promise);
       // After timeout, the call is allowed.
       clock.tick(1001);
-      expect(actions.execute('login')).to.not.equal(promise);
+      expect(actions.execute(Action.LOGIN)).to.not.equal(promise);
     });
   });
 
@@ -187,7 +188,7 @@ describes.realWin('Actions', {amp: true}, env => {
     return actions
       .build()
       .then(() => {
-        const promise = actions.execute('login');
+        const promise = actions.execute(Action.LOGIN);
         expect(openStub).to.be.calledOnce;
         openResolver(Promise.reject(new Error('broken')));
         return promise;
@@ -216,7 +217,7 @@ describes.realWin('Actions', {amp: true}, env => {
   it('should fail before build is complete', () => {
     allowConsoleError(() => {
       expect(() => {
-        actions.execute('login');
+        actions.execute(Action.LOGIN);
       }).to.throw(/Action URL is not ready/);
     });
   });

--- a/extensions/amp-subscriptions/0.1/test/test-analytics.js
+++ b/extensions/amp-subscriptions/0.1/test/test-analytics.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {SubscriptionAnalytics} from '../analytics';
+import {ActionStatus, SubscriptionAnalytics} from '../analytics';
 
 describes.realWin('SubscriptionAnalytics', {amp: true}, env => {
   let analytics;
@@ -39,7 +39,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, env => {
 
   it('should trigger an action event', () => {
     const stub = sandbox.stub(analytics, 'event');
-    analytics.actionEvent('service1', 'action1', 'success');
+    analytics.actionEvent('service1', 'action1', ActionStatus.SUCCESS);
     expect(stub).to.be.calledOnce.calledWith(
       'subscriptions-action-action1-success',
       {'serviceId': 'service1'}

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {Action} from '../analytics';
 import {Dialog} from '../dialog';
 import {Entitlement} from '../entitlement';

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import {Action} from '../analytics';
 import {Dialog} from '../dialog';
 import {Entitlement} from '../entitlement';
 import {LocalSubscriptionPlatformRenderer} from '../local-subscription-platform-renderer';
@@ -66,14 +68,14 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
     beforeEach(() => {
       actions1 = createElementWithAttributes(doc, 'div', {
         id: 'actions1',
-        'subscriptions-action': 'login',
+        'subscriptions-action': Action.LOGIN,
         'subscriptions-display': 'loggedIn',
       });
       actions2 = createElementWithAttributes(doc, 'div', {
         id: 'actions2',
         'subscriptions-section': 'actions',
         'subscriptions-display': 'subscribed',
-        'subscriptions-action': 'login',
+        'subscriptions-action': Action.LOGIN,
         'subscriptions-service': 'service',
         'subscriptions-decorate': '',
       });

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import {Action, SubscriptionAnalytics} from '../analytics';
 import {Dialog} from '../dialog';
 import {Entitlement} from '../entitlement';
 import {LocalSubscriptionIframePlatform} from '../local-subscription-platform-iframe';
 import {Messenger} from '../../../amp-access/0.1/iframe-api/messenger';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../service-adapter';
-import {SubscriptionAnalytics} from '../analytics';
 import {UrlBuilder} from '../url-builder';
 import {localSubscriptionPlatformFactory} from '../local-subscription-platform';
 
@@ -30,8 +30,8 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
   let serviceAdapter;
 
   const actionMap = {
-    'subscribe': 'https://lipsum.com/subscribe',
-    'login': 'https://lipsum.com/login',
+    [Action.SUBSCRIBE]: 'https://lipsum.com/subscribe',
+    [Action.LOGIN]: 'https://lipsum.com/login',
   };
 
   const configiframeSrc = 'https://lipsum.com/iframe?rid=READER_ID';

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import {Action, SubscriptionAnalytics} from '../analytics';
 import {Dialog} from '../dialog';
 import {Entitlement, GrantReason} from '../entitlement';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../service-adapter';
-import {SubscriptionAnalytics} from '../analytics';
 import {localSubscriptionPlatformFactory} from '../local-subscription-platform';
 
 describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
@@ -28,8 +28,8 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   let getEncryptedDocumentKeyStub;
 
   const actionMap = {
-    'subscribe': 'https://lipsum.com/subscribe',
-    'login': 'https://lipsum.com/login',
+    [Action.SUBSCRIBE]: 'https://lipsum.com/subscribe',
+    [Action.LOGIN]: 'https://lipsum.com/login',
   };
   const service = 'sample-service';
   const source = 'sample-source';
@@ -183,19 +183,19 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     let actionMap;
     beforeEach(() => {
       actionMap = {
-        'subscribe': 'https://lipsum.com/subscribe',
-        'login': 'https://lipsum.com/login',
+        [Action.SUBSCRIBE]: 'https://lipsum.com/subscribe',
+        [Action.LOGIN]: 'https://lipsum.com/login',
         'other': 'https://lipsum.com/other',
       };
     });
 
     it('should check that login action is present', () => {
-      delete actionMap['login'];
+      delete actionMap[Action.LOGIN];
       expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw;
     });
 
     it('should check that subscribe action is present', () => {
-      delete actionMap['subscribe'];
+      delete actionMap[Action.SUBSCRIBE];
       expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw;
     });
 
@@ -217,7 +217,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     let element;
     beforeEach(() => {
       element = document.createElement('div');
-      element.setAttribute('subscriptions-action', 'subscribe');
+      element.setAttribute('subscriptions-action', Action.SUBSCRIBE);
       element.setAttribute('subscriptions-service', 'local');
     });
 
@@ -268,7 +268,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       'should delegate service selection to scoreBasedLogin if no service ' +
         'name is specified for login',
       () => {
-        element.setAttribute('subscriptions-action', 'login');
+        element.setAttribute('subscriptions-action', Action.LOGIN);
         element.removeAttribute('subscriptions-service');
         const platform = {};
         const serviceId = 'serviceId';
@@ -285,7 +285,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
         );
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
-        expect(delegateStub).to.be.calledWith('login', serviceId);
+        expect(delegateStub).to.be.calledWith(Action.LOGIN, serviceId);
       }
     );
 
@@ -293,7 +293,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       'should delegate service selection to scoreBasedLogin ' +
         'service specified is auto for login',
       () => {
-        element.setAttribute('subscriptions-action', 'login');
+        element.setAttribute('subscriptions-action', Action.LOGIN);
         element.setAttribute('subscriptions-service', 'auto');
         const loginStub = sandbox
           .stub(
@@ -310,12 +310,12 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
         platform.getServiceId = sandbox.stub().callsFake(() => serviceId);
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
-        expect(delegateStub).to.be.calledWith('login', serviceId);
+        expect(delegateStub).to.be.calledWith(Action.LOGIN, serviceId);
       }
     );
 
     it('should NOT delegate for scoreBasedLogin for non-login action', () => {
-      element.setAttribute('subscriptions-action', 'subscribe');
+      element.setAttribute('subscriptions-action', Action.SUBSCRIBE);
       element.setAttribute('subscriptions-service', 'auto');
       const loginStub = sandbox.stub(
         localSubscriptionPlatform.serviceAdapter_,
@@ -335,7 +335,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       localSubscriptionPlatform.handleClick_(element);
       expect(loginStub).to.not.be.called;
       expect(delegateStub).to.not.be.called;
-      expect(executeStub).to.be.calledOnce.calledWith('subscribe');
+      expect(executeStub).to.be.calledOnce.calledWith(Action.SUBSCRIBE);
     });
   });
 

--- a/extensions/amp-subscriptions/0.1/test/test-renderer.js
+++ b/extensions/amp-subscriptions/0.1/test/test-renderer.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Action} from '../analytics';
 import {CSS} from '../../../../build/amp-subscriptions-0.1.css';
 import {Renderer} from '../renderer';
 import {Services} from '../../../../src/services';
@@ -145,15 +146,15 @@ describes.realWin(
 
       actionLogin = createElementWithAttributes(doc, 'div', {
         id: 'actionLogin',
-        'subscriptions-action': 'login',
+        'subscriptions-action': Action.LOGIN,
       });
       actionLogout = createElementWithAttributes(doc, 'div', {
         id: 'actionLogout',
-        'subscriptions-action': 'logout',
+        'subscriptions-action': Action.LOGOUT,
       });
       actionSubscribe = createElementWithAttributes(doc, 'div', {
         id: 'actionSubscribe',
-        'subscriptions-action': 'subscribe',
+        'subscriptions-action': Action.SUBSCRIBE,
       });
 
       doc.body.appendChild(unrelated);

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import {Action, SubscriptionAnalytics} from '../analytics';
 import {Dialog} from '../dialog';
 import {Entitlement, GrantReason} from '../entitlement';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../service-adapter';
 import {Services} from '../../../../src/services';
-import {SubscriptionAnalytics} from '../analytics';
 import {ViewerSubscriptionPlatform} from '../viewer-subscription-platform';
 import {getWinOrigin} from '../../../../src/url';
 
@@ -44,8 +44,8 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
   const authUrl = 'https://subscribe.google.com/subscription/2/entitlements';
   const pingbackUrl = 'https://lipsum.com/login/pingback';
   const actionMap = {
-    'subscribe': 'https://lipsum.com/subscribe',
-    'login': 'https://lipsum.com/login',
+    [Action.SUBSCRIBE]: 'https://lipsum.com/subscribe',
+    [Action.LOGIN]: 'https://lipsum.com/login',
   };
   const serviceConfig = {
     'serviceId': 'local',


### PR DESCRIPTION
This replaces the use of strings with enums for action commands and logging within amp-subscriptions and amp-subscriptions-google.  It is required for a future project which will enhance event management within the subscriptions frameworks.