### PR TITLE
🐛Fix global transform configs for `babelify`

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -72,8 +72,8 @@ module.exports = {
       [
         'babelify',
         {
-          // Transform "node_modules/", but ignore devDependencies (on Travis).
-          'global': isTravisBuild(),
+          // Transform "node_modules/", but ignore devDependencies.
+          'global': true,
           'ignore': devDependencies(),
           'sourceMapsAbsolute': true,
         },

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -27,6 +27,7 @@ const {
   startTestServer,
 } = require('./helpers');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../../ctrlcHandler');
+const {devDependencies} = require('../helpers');
 const {green, yellow, cyan, red} = require('ansi-colors');
 const {isTravisBuild} = require('../../travis');
 const {reportTestStarted} = require('.././report-test-status');
@@ -235,7 +236,17 @@ class RuntimeTestConfig {
         },
       ];
 
-      this.browserify.transform = [['babelify', {plugins: [plugin]}]];
+      this.browserify.transform = [
+        [
+          'babelify',
+          {
+            // Transform "node_modules/", but ignore devDependencies.
+            'global': true,
+            'ignore': devDependencies(),
+            'plugins': [plugin],
+          },
+        ],
+      ];
     }
   }
 }


### PR DESCRIPTION
#22927 added a global transform for packages listed in `dependencies` in `package.json`. However, it missed the code paths for code coverage and local test runs.

This PR fixes both issues.

Follow up to #22927
Closes #22949