### PR TITLE
Rendering page attachments at the bottom of the document in vertical rendering.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -119,9 +119,6 @@ const TAG = 'amp-story-page';
 /** @private @const {string} */
 const ADVERTISEMENT_ATTR_NAME = 'ad';
 
-/** @private @const {string} */
-const HAS_ATTACHMENT_ATTR_NAME = 'i-amphtml-has-attachment';
-
 /** @private @const {number} */
 const REWIND_TIMEOUT_MS = 350;
 
@@ -308,7 +305,6 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.emitProgress_(progress)
     );
     this.setDescendantCssTextStyles_();
-    this.setHasAttachmentAttribute_();
   }
 
   /**
@@ -944,15 +940,6 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (distance > 0 && distance <= 2) {
       this.findAndPrepareEmbeddedComponents_();
       this.preloadAllMedia_();
-    }
-  }
-
-  /**
-   * @private
-   */
-  setHasAttachmentAttribute_() {
-    if (this.element.querySelector('amp-story-page-attachment')) {
-      this.element.setAttribute(HAS_ATTACHMENT_ATTR_NAME, '');
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -50,7 +50,7 @@ export const UIType = {
   MOBILE: 0,
   DESKTOP_PANELS: 1, // Default desktop UI.
   DESKTOP_FULLBLEED: 2, // Desktop UI if landscape mode is enabled.
-  SCROLL: 3, // Vertical scrolling versions, for search engine bots indexing.
+  VERTICAL: 3, // Vertical scrolling versions, for search engine bots indexing.
 };
 
 /**
@@ -323,6 +323,13 @@ const actions = (state, action, data) => {
         [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: !!data,
       }));
     case Action.TOGGLE_UI:
+      if (
+        state[StateProperty.UI_STATE] === UIType.VERTICAL &&
+        data !== UIType.VERTICAL
+      ) {
+        dev().error(TAG, 'Cannot switch away from UIType.VERTICAL');
+        return state;
+      }
       return /** @type {!State} */ (Object.assign({}, state, {
         // Keep DESKTOP_STATE for compatiblity with v0.1.
         [StateProperty.DESKTOP_STATE]: data === UIType.DESKTOP_PANELS,

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-amp-story[standalone][scroll] {
-  overflow-y: auto !important;
+amp-story[standalone][vertical] {
   height: auto !important;
   contain: initial !important;
 }
 
-[scroll] amp-story-page {
+[vertical] amp-story-page {
   position: relative !important;
   /* iPhone 6/7/8 ratio. */
   height: 178vw !important;
@@ -29,18 +28,20 @@ amp-story[standalone][scroll] {
 }
 
 /* Increase CSS specifity. */
-amp-story[scroll].i-amphtml-element amp-story-page.i-amphtml-element {
+amp-story[vertical].i-amphtml-element amp-story-page.i-amphtml-element {
   transform: none !important;
 }
 
-[scroll] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content {
+[vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content {
   opacity: 1 !important;
 }
 
-[scroll] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content > * {
+[vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content > * {
   display: block !important;
 }
 
-[scroll] amp-story-page[i-amphtml-has-attachment] {
-  margin-bottom: 178vw !important;
+[vertical] amp-story-page-attachment {
+  position: relative !important;
+  height: 178vw !important;
+  transform: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-amp-story[standalone][vertical] {
+/**
+ * Vertical scrolling rendering, so the pages are visible to search engine
+ * indexing tools, and not stacked on top of each other.
+ */
+
+amp-story[standalone][i-amphtml-vertical] {
   height: auto !important;
   contain: initial !important;
 }
 
-[vertical] amp-story-page {
+[i-amphtml-vertical] amp-story-page {
   position: relative !important;
   /* iPhone 6/7/8 ratio. */
   height: 178vw !important;
@@ -28,19 +33,19 @@ amp-story[standalone][vertical] {
 }
 
 /* Increase CSS specifity. */
-amp-story[vertical].i-amphtml-element amp-story-page.i-amphtml-element {
+amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element {
   transform: none !important;
 }
 
-[vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content {
+[i-amphtml-vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content {
   opacity: 1 !important;
 }
 
-[vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content > * {
+[i-amphtml-vertical] .i-amphtml-story-page-attachment-container[hidden] .i-amphtml-story-page-attachment-content > * {
   display: block !important;
 }
 
-[vertical] amp-story-page-attachment {
+[i-amphtml-vertical] amp-story-page-attachment {
   position: relative !important;
   height: 178vw !important;
   transform: none !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -17,9 +17,9 @@
 @import './amp-story-access.css';
 @import './amp-story-desktop-panels.css';
 @import './amp-story-page-attachment.css';
-@import './amp-story-scroll.css';
 @import './amp-story-templates.css';
 @import './amp-story-user-overridable.css';
+@import './amp-story-vertical.css';
 @import './pagination-buttons.css';
 
 /** Common */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1781,8 +1781,6 @@ export class AmpStory extends AMP.BaseElement {
       case UIType.MOBILE:
         this.vsync_.mutate(() => {
           this.element.removeAttribute('desktop');
-          this.element.removeAttribute('scroll');
-          resetStyles(this.win.document.body, ['height']);
           this.element.classList.remove('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
@@ -1792,8 +1790,6 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
-          this.element.removeAttribute('scroll');
-          resetStyles(this.win.document.body, ['height']);
           this.element.classList.add('i-amphtml-story-desktop-panels');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
@@ -1812,19 +1808,27 @@ export class AmpStory extends AMP.BaseElement {
         this.buildPaginationButtons_();
         this.vsync_.mutate(() => {
           this.element.setAttribute('desktop', '');
-          this.element.removeAttribute('scroll');
-          resetStyles(this.win.document.body, ['height']);
           this.element.classList.add('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
         });
         break;
-      case UIType.SCROLL:
+      // Because of the DOM mutations, switching from this mode to another is
+      // not allowed, and prevented within the store service.
+      case UIType.VERTICAL:
+        const pageAttachments = scopedQuerySelectorAll(
+          this.element,
+          'amp-story-page amp-story-page-attachment'
+        );
+
         this.vsync_.mutate(() => {
-          this.element.setAttribute('scroll', '');
+          this.element.setAttribute('vertical', '');
           setImportantStyles(this.win.document.body, {height: 'auto'});
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
+          for (let i = 0; i < pageAttachments.length; i++) {
+            this.element.appendChild(pageAttachments[i]);
+          }
         });
         break;
     }
@@ -1837,7 +1841,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   getUIType_() {
     if (this.platform_.isBot()) {
-      return UIType.SCROLL;
+      return UIType.VERTICAL;
     }
 
     if (

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1821,7 +1821,7 @@ export class AmpStory extends AMP.BaseElement {
         );
 
         this.vsync_.mutate(() => {
-          this.element.setAttribute('vertical', '');
+          this.element.setAttribute('i-amphtml-vertical', '');
           setImportantStyles(this.win.document.body, {height: 'auto'});
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');


### PR DESCRIPTION
- Rendering page attachments at the bottom of the document in vertical rendering
- Rename `UIType.SCROLL` into `UIType.VERTICAL`
- Preventing from switching from `UIType.VERTICAL` to any other `UIType`. All the other UITypes can be switched from one to the other, but allowing to do so with this mode would introduce a lot of unnecessary complexity. This PR adds an error message if someone tries to do so, so we don't end up in a broken state. 