### PR TITLE
📖 Convert ampbyexample iframes to inline preview

### DIFF
--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -57,16 +57,16 @@ Learn more about layouts in the [AMP HTML Layout System](https://github.com/ampp
 #### Example: Displaying a responsive image
 In the following example, we display an image that responds to the size of the viewport by setting `layout=responsive`.  The image stretches and shrinks according to the aspect ratio specified by the `width` and `height`.
 
-<div>
-<amp-iframe height="193"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampimg.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true"]
+```html
+<amp-img alt="A view of the sea"
+  src="{{server_for_email}}/static/inline-examples/images/sea.jpg"
+  width="900"
+  height="675"
+  layout="responsive">
+</amp-img>
+```
+[/example]
 
 {% call callout('Read on', type='read') %}
 Learn about responsive AMP pages in the [Create Responsive AMP Pages](https://www.ampproject.org/docs/guides/responsive/responsive_design.html) guide.
@@ -77,16 +77,20 @@ If the resource requested by the `amp-img` component fails to load, the space wi
 #### Example: Specifying a fallback image
 In the following example, if the browser doesn't support WebP, the fallback JPG image displays:
 
-<div>
-<amp-iframe height="271"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampimg.fallback.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true"]
+```html
+<amp-img alt="Mountains"
+  width="550"
+  height="368"
+  src="{{server_for_email}}/static/inline-examples/images/mountains.webp">
+  <amp-img alt="Mountains"
+    fallback
+    width="550"
+    height="368"
+    src="{{server_for_email}}/static/inline-examples/images/mountains.jpg"></amp-img>
+</amp-img>
+```
+[/example]
 
 A placeholder background color or other visual can be set using CSS selector and style on the element itself.
 
@@ -180,16 +184,16 @@ For responsive images, the `width` and `height` do not need to match the exact w
 
 For example, instead of specifying `width="900"` and `height="675"`, you can just specify `width="1.33"` and `height="1"`.
 
-<div>
-<amp-iframe height="193"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampimg.aspectratio.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true"]
+```html
+<amp-img alt="A view of the sea"
+  src="{{server_for_email}}/static/inline-examples/images/sea.jpg"
+  width="1.33"
+  height="1"
+  layout="responsive">
+</amp-img>
+```
+[/example]
 
 #### Setting multiple source files for different screen resolutions
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -58,17 +58,26 @@ The `amp-accordion` component allows you to display collapsible and expandable c
 
 In this example, we display three sections, where the third section is expanded on page load.  Also, we opted out of preserving the collapsed/expanded state by setting `disable-session-states`.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="395"
-    layout="fixed-height"
-    sandbox="allow-scripts allow-forms allow-same-origin"
-    resizable
-    src="https://ampproject-b5f4c.firebaseapp.com/examples/ampaccordion.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-accordion"]
+```html
+<amp-accordion{% if not format=='email'%} disable-session-states{% endif %}>
+  <section>
+    <h2>Section 1</h2>
+    <p>Content in section 1.</p>
+  </section>
+  <section>
+    <h2>Section 2</h2>
+    <div>Content in section 2.</div>
+  </section>
+  <section expanded>
+    <h2>Section 3</h2>
+    <amp-img src="{{server_for_email}}/static/inline-examples/images/squirrel.jpg"
+      width="320"
+      height="256"></amp-img>
+  </section>
+</amp-accordion>
+```
+[/example]
 
 {% call callout('Tip', type='success') %}
 To see more demos of the `amp-accordion`, visit [AMP By Example](https://ampbyexample.com/components/amp-accordion/).

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -61,17 +61,38 @@ network’s JS inside that iframe sandbox.
 The `<amp-ad>` requires width and height values to be specified according to the [rule](https://www.ampproject.org/docs/design/amp-html-layout#(tl;dr)-summary-of-layout-requirements-&-behaviors) of its layout type. It requires a `type` argument that select what ad network is displayed. All `data-*` attributes on the tag are automatically passed as arguments to the code that eventually renders the ad. What `data-` attributes are required for a given type of network depends and must be documented with the ad network.
 
 #### Example: Displaying a few ads
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="522"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampad.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+
+[example preview="inline" playground="true" imports="amp-ad"]
+```html
+<amp-ad type="a9"
+  data-amzn_assoc_ad_mode="auto"
+  data-divid="amzn-assoc-ad-fe746097-f142-4f8d-8dfb-45ec747632e5"
+  data-recomtype="async"
+  data-adinstanceid="fe746097-f142-4f8d-8dfb-45ec747632e5"
+    width="300"
+    height="250"
+    data-aax_size="300x250"
+    data-aax_pubname="test123"
+    data-aax_src="302">
+  </amp-ad>
+  <amp-ad width="300"
+    height="250"
+    type="industrybrains"
+    data-width="300"
+    data-height="250"
+    data-cid="19626-3798936394">
+  </amp-ad>
+  <amp-embed type="taboola"
+    width="400"
+    height="300"
+    layout="responsive"
+    data-publisher="amp-demo"
+    data-mode="thumbnails-a"
+    data-placement="Ads Example"
+    data-article="auto">
+  </amp-embed>
+```
+[/example]
 
 ## Attributes
 <table>

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -57,17 +57,22 @@ The carousel consists of an arbitrary number of items, as well as optional navig
 
 The carousel advances between items if the user swipes, uses arrow keys, or clicks an optional navigation arrow.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-  <amp-iframe height="313"
-              layout="fixed-height"
-              sandbox="allow-scripts allow-forms allow-same-origin"
-              resizable
-              src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.basic.embed.html">
-    <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-    <div placeholder></div>
-  </amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-carousel"]
+```html
+<amp-carousel width="450"
+  height="300">
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+    width="450"
+    height="300"></amp-img>
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image2.jpg"
+    width="450"
+    height="300"></amp-img>
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image3.jpg"
+    width="450"
+    height="300"></amp-img>
+</amp-carousel>
+```
+[/example]
 
 
 ### Advancing to a specific slide
@@ -76,17 +81,51 @@ Setting a method for the `on` attribute on an element to `tap:carousel-id.goToSl
 
 In the following example, we have a carousel of three images with preview buttons below the carousel. When a user clicks one of the buttons, the corresponding carousel item displays.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="878"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.advance-slide.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-carousel"]
+```html
+<amp-carousel id="carousel-with-preview"
+    width="450"
+    height="300"
+    layout="responsive"
+    type="slides">
+    <amp-img src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+      width="450"
+      height="300"
+      layout="responsive"
+      alt="apples"></amp-img>
+    <amp-img src="{{server_for_email}}/static/inline-examples/images/image2.jpg"
+      width="450"
+      height="300"
+      layout="responsive"
+      alt="lemons"></amp-img>
+    <amp-img src="{{server_for_email}}/static/inline-examples/images/image3.jpg"
+      width="450"
+      height="300"
+      layout="responsive"
+      alt="blueberries"></amp-img>
+  </amp-carousel>
+  <div class="carousel-preview">
+    <button on="tap:carousel-with-preview.goToSlide(index=0)">
+      <amp-img src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+        width="60"
+        height="40"
+        alt="apples"></amp-img>
+    </button>
+    <button on="tap:carousel-with-preview.goToSlide(index=1)">
+      <amp-img src="{{server_for_email}}/static/inline-examples/images/image2.jpg"
+        width="60"
+        height="40"
+        alt="lemons"></amp-img>
+    </button>
+    <button on="tap:carousel-with-preview.goToSlide(index=2)">
+      <amp-img src="{{server_for_email}}/static/inline-examples/images/image3.jpg"
+        width="60"
+        height="40"
+        alt="blueberries"></amp-img>
+    </button>
+  </div>
+```
+[/example]
 
 ## Attributes
 <table>
@@ -144,13 +183,30 @@ The visibility of arrows can also be controlled via styling, and a media query c
     <td width="40%"><strong>loop (optional)</strong></td>
     <td><p>Allows the user to advance past the first item or the final item. There must be at least 3 slides for looping to occur. The <code>loop</code> attribute is only applicable to carousels with <code>type=slides</code>.</p>
 <p><em>Example: Displays a slides carousel with controls, looping, and delayed autoplay</em></p>
-<!--embedded example - displays in ampproject.org -->
-<div>
-  <amp-iframe height="446" layout="fixed-height" sandbox="allow-scripts allow-forms allow-same-origin" resizable src="https://ampproject-b5f4c.firebaseapp.com/examples/ampcarousel.controls.embed.html">
-    <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-    <div placeholder></div>
-  </amp-iframe>
-</div></td>
+
+[example preview="inline" playground="true" imports="amp-carousel"]
+```html
+<amp-carousel type="slides"
+  width="450"
+  height="300"
+  controls
+  loop
+  {% if not format=='email'%}  autoplay
+  delay="3000"{% endif %}
+  data-next-button-aria-label="Go to next slide"
+  data-previous-button-aria-label="Go to previous slide">
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+    width="450"
+    height="300"></amp-img>
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image2.jpg"
+    width="450"
+    height="300"></amp-img>
+  <amp-img src="{{server_for_email}}/static/inline-examples/images/image3.jpg"
+    width="450"
+    height="300"></amp-img>
+</amp-carousel>
+```
+[/example]</td>
   </tr>
   <tr>
     <td width="40%"><strong>common attributes</strong></td>

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -53,34 +53,34 @@ The `amp-fit-text` component allows you to manage the size and fit of text withi
 
 In the following example, the `<amp-fit-text>` element is nested within a 300x300 blue `div` block (class `fixedblock`). For the `<amp-fit-text>` element, we specified a `responsive` layout.  As a result, the text scales responsively per the aspect ratio provided by the width and height (200x200) of the `<amp-fit-text>` element, but the text does not exceed the size of its parent.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="207"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.base.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
+[example preview="inline" playground="true" imports="amp-fit-text"]
+```html
+<div class="fixedblock">
+  <amp-fit-text width="200"
+    height="200"
+    layout="responsive">
+    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+  </amp-fit-text>
 </div>
+```
+[/example]
 
 ##### Example: Text scales to fit area using a maximum font size
 
 The following example is similar to the one above, but in this example we specify a `max-font-size` of `22`, so the text is smaller but still fits the space:
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-  <amp-iframe height="226"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.max-font.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-
+[example preview="inline" playground="true" imports="amp-fit-text"]
+```html
+<div class="fixedblock">
+  <amp-fit-text width="200"
+    height="200"
+    layout="responsive"
+    max-font-size="22">
+    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+  </amp-fit-text>
 </div>
+```
+[/example]
 
 ### Overflowing content
 
@@ -91,17 +91,18 @@ If the content of the `amp-fit-text` overflows the available space, even with a
 
 In the following example, we specified a `min-font-size` of `40`, which causes the content to exceed the size of its fixed block parent, so the text is truncated to fit the container.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="226"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.min-font.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
+[example preview="inline" playground="true" imports="amp-fit-text"]
+```html
+<div class="fixedblock">
+  <amp-fit-text width="200"
+    height="200"
+    layout="responsive"
+    min-font-size="40">
+    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+  </amp-fit-text>
 </div>
+```
+[/example]
 
 
 ## Attributes

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -59,17 +59,42 @@ Before creating a `<form>`, you must include the required script for the `<amp-f
 
 Here's an example of a basic form:
 
-<!-- embedded sample that is rendered on ampproject.org -->
-<div>
-  <amp-iframe height="671"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampform.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-  </amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-form" template="amp-mustache"]
+```html
+<form method="post"
+    action-xhr="https://example.com/subscribe"{% if not format=='email'%}  
+    target="_top"{% endif %}>
+    <fieldset>
+      <label>
+        <span>Name:</span>
+        <input type="text"
+          name="name"
+          required>
+      </label>
+      <br>
+      <label>
+        <span>Email:</span>
+        <input type="email"
+          name="email"
+          required>
+      </label>
+      <br>
+      <input type="submit"
+        value="Subscribe">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        Subscription successful!
+      </template>
+    </div>
+    <div submit-error>
+      <template type="amp-mustache">
+        Subscription failed!
+      </template>
+    </div>
+  </form>
+```
+[/example]
 
 ## Attributes
 
@@ -176,17 +201,29 @@ AMP exposes `change` and `input-debounced` events on child `<input>` elements. T
 
 For example, a common use case is to submit a form on input change (selecting a radio button to answer a poll, choosing a language from a `select` input to translate a page, etc.).
 
-<!-- embedded sample that is rendered on ampproject.org -->
-<div>
-<amp-iframe height="450"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampform.inputevent.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-form"]
+```html
+<form id="myform"
+    method="post"
+    action-xhr="https://example.com/myform"{% if not format=='email'%}  
+    target="_blank"{% endif %}>
+    <fieldset>
+      <label>
+        <input name="answer1"
+          value="Value 1"
+          type="radio"
+          on="change:myform.submit">Value 1
+      </label>
+      <label>
+        <input name="answer1"
+          value="Value 2"
+          type="radio"
+          on="change:myform.submit">Value 2
+      </label>
+    </fieldset>
+  </form>
+```
+[/example]
 
 See the [full example here](../../examples/forms.amp.html).
 
@@ -421,17 +458,46 @@ To specify custom validation on your form:
 
 Here's an example:
 
-<!-- embedded sample that is rendered on ampproject.org -->
-<div>
-<amp-iframe height="748"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampform.customval.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-form"]
+```html
+<form method="post"
+    action-xhr="https://example.com/subscribe"
+    custom-validation-reporting="show-all-on-submit"{% if not format=='email'%}  
+    target="_blank"{% endif %}>
+    <fieldset>
+      <label>
+        <span>Name:</span>
+        <input type="text"
+          name="name"
+          id="name5"
+          required
+          pattern="\w+\s\w+">
+        <span visible-when-invalid="valueMissing"
+          validation-for="name5"></span>
+        <span visible-when-invalid="patternMismatch"
+          validation-for="name5">
+          Please enter your first and last name separated by a space (e.g. Jane Miller)
+        </span>
+      </label>
+      <br>
+      <label>
+        <span>Email:</span>
+        <input type="email"
+          name="email"
+          id="email5"
+          required>
+        <span visible-when-invalid="valueMissing"
+          validation-for="email5"></span>
+        <span visible-when-invalid="typeMismatch"
+          validation-for="email5"></span>
+      </label>
+      <br>
+      <input type="submit"
+        value="Subscribe">
+    </fieldset>
+  </form>
+```
+[/example]
 
 For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 
@@ -467,8 +533,8 @@ Here's an example:
 <form
   method="post"
   action-xhr="/form/verify-json/post"
-  verify-xhr="/form/verify-json/post"
-  target="_blank"
+  verify-xhr="/form/verify-json/post"{% if not format=='email'%}  
+  target="_blank"{% endif %}
 >
     <fieldset>
         <label>

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -62,17 +62,20 @@ For more details on templates, see [AMP HTML Templates](../../spec/amp-html-temp
 
 In the following example, we retrieve JSON data that contains URLs and titles, and render the content in a nested [amp-mustache template](https://www.ampproject.org/docs/reference/components/amp-mustache).
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="259"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/amplist.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-list" template="amp-mustache"]
+```html
+<amp-list width="auto"
+  height="100"
+  layout="fixed-height"
+  src="{{server_for_email}}/static/inline-examples/data/amp-list-urls.json">
+  <template type="amp-mustache">{% raw %}
+    <div class="url-entry">
+      <a href="{{url}}">{{title}}</a>
+    </div>
+  {% endraw %}</template>
+</amp-list>
+```
+[/example]
 
 Here is the JSON file that we used:
 
@@ -130,17 +133,27 @@ Optionally, the `<amp-list>` element can contain an element with an `overflow` a
 
 In the following example, we display a list of images and titles. Because the `<amp-list>` content requires more space than available, the AMP Runtime displays the overflow element.
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="213"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/amplist.overflow.embed.html?active-tab=preview&preview-height=213">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-list" template="amp-mustache"]
+```html
+<amp-list width="auto"
+  height="140"
+  layout="fixed-height"
+  src="{{server_for_email}}/static/inline-examples/data/amp-list-data.json">
+  <template type="amp-mustache">{% raw %}
+    <div class="image-entry">
+      <amp-img src="{{imageUrl}}"
+        width="100"
+        height="75"></amp-img>
+      <span class="image-title">{{title}}</span>
+    </div>
+  {% endraw %}</template>
+  <div overflow
+    class="list-overflow">
+    See more
+  </div>
+</amp-list>
+```
+[/example]
 
 Here's the CSS for the `overflow`:
 

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -48,17 +48,15 @@ The `amp-twitter` component allows you to embed a Tweet or Moment for the specif
 
 Here's an example of a basic embedded Tweet:
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="164"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/amptwitter.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-twitter" imports="amp-twitter"]
+```html
+<amp-twitter width="375"
+  height="472"
+  layout="responsive"
+  data-tweetid="885634330868850689">
+</amp-twitter>
+```
+[/example]
 
 ## Appearance
 
@@ -71,30 +69,44 @@ An element marked with a `placeholder` attribute displays while the content for 
 Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/responsive/placeholders) guide to learn more about how placeholders and fallbacks interact for the `amp-twitter` component.
 
 *Example: Specifying a placeholder*
-<!--embedded example - displays in ampproject.org -->
-<div>
-  <amp-iframe height="278"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/amptwitter.placeholder.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+
+[example preview="inline" playground="true" imports="amp-twitter" imports="amp-twitter"]
+```html
+<amp-twitter width="375"
+  height="472"
+  layout="responsive"
+  data-tweetid="638793490521001985">
+  <blockquote placeholder>
+    <p>I only needed to change some CSS.
+      <a href="http://t.co/LvjLbjgY9F">pic.twitter.com/LvjLbjgY9F</a>
+    </p>&mdash; Malte Ubl (@cramforce)
+    <a href="https://twitter.com/cramforce/status/638793490521001985">September 1, 2015</a>
+  </blockquote>
+</amp-twitter>
+```
+[/example]
 
 *Example: Specifying a placeholder and a fallback*
 
-<div>
-  <amp-iframe height="354"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/amptwitter.placeholder-and-fallback.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-</div>
+[example preview="inline" playground="true" imports="amp-twitter" imports="amp-twitter"]
+```html
+<amp-twitter width="390"
+  height="330"
+  layout="responsive"
+  data-tweetid="855178606556856320">
+  <blockquote placeholder>
+    <p>What are 5 common misconceptions people often have about AMP? Find out on today&#39;s installment of Amplify:
+      <a href="https://t.co/kaSvV8SQtI">https://t.co/kaSvV8SQtI</a>
+      <a href="https://t.co/Cu9VYOmiKV">pic.twitter.com/Cu9VYOmiKV</a>
+    </p>&mdash; AMP Project (@AMPhtml)
+    <a href="https://twitter.com/AMPhtml/status/855178606556856320">April 20, 2017</a>
+  </blockquote>
+  <div fallback>
+    An error occurred while retrieving the Tweet. It might have been deleted.
+  </div>
+</amp-twitter>
+```
+[/example]
 
 ## Attributes
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -59,18 +59,23 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
 
 #### Example
 
-<!--embedded example - displays in ampproject.org -->
-<div>
-<amp-iframe height="293"
-            layout="fixed-height"
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            resizable
-            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampvideo.basic.embed.html">
-  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
-  <div placeholder></div>
-</amp-iframe>
-
-</div>
+[example preview="inline" playground="true" imports="amp-video"]
+```html
+<amp-video {% if format=='stories'%}autoplay {% endif %}controls
+  width="640"
+  height="360"
+  layout="responsive"
+  poster="{{server_for_email}}/static/inline-examples/images/kitten-playing.png">
+  <source src="{{server_for_email}}/static/inline-examples/videos/kitten-playing.webm"
+    type="video/webm" />
+  <source src="{{server_for_email}}/static/inline-examples/videos/kitten-playing.mp4"
+    type="video/mp4" />
+  <div fallback>
+    <p>This browser does not support the video element.</p>
+  </div>
+</amp-video>
+```
+[/example]
 
 ## Analytics
 


### PR DESCRIPTION
Ampbyexample code and preview iframes are replaced with inline example code
Resolves https://github.com/ampproject/docs/issues/2053

For the documentation directly in the 'docs' project this was already done.
An example how this looks like can be seen here:
https://amp-dev-staging.appspot.com/documentation/guides-and-tutorials/develop/media_iframes_3p/?format=websites
