### PR TITLE
Allow width expansion for parent/full-width creatives

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1206,8 +1206,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @private
    */
   handleResize_(width, height) {
-    const pWidth = parseInt(this.element.getAttribute('width'), 10);
-    const pHeight = parseInt(this.element.getAttribute('height'), 10);
+    const pWidth = Number(this.element.getAttribute('width'));
+    const pHeight = Number(this.element.getAttribute('height'));
     const isFluidRequestAndFixedResponse = !!(
       this.isFluidRequest_ &&
       width &&

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1211,26 +1211,24 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /**
    * Attempts to resize the ad, if the returned size is smaller than the primary
    * dimensions.
-   * @param {number} width
-   * @param {number} height
+   * @param {number} newWidth
+   * @param {number} newHeight
    * @private
    */
-  handleResize_(width, height) {
+  handleResize_(newWidth, newHeight) {
     const isFluidRequestAndFixedResponse = !!(
       this.isFluidRequest_ &&
-      width &&
-      height
+      newWidth &&
+      newHeight
     );
-    const declaredSize = this.getDeclaredSlotSize_();
-    const pWidth = declaredSize.width;
-    const pHeight = declaredSize.height;
-    const returnedSizeDifferent = width != pWidth || height != pHeight;
-    const heightNotIncreased = height <= pHeight;
+    const {width, height} = this.getDeclaredSlotSize_();
+    const returnedSizeDifferent = newWidth != width || newHeight != height;
+    const heightNotIncreased = newHeight <= height;
     if (
       isFluidRequestAndFixedResponse ||
       (returnedSizeDifferent && heightNotIncreased)
     ) {
-      this.attemptChangeSize(height, width).catch(() => {});
+      this.attemptChangeSize(newHeight, newWidth).catch(() => {});
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1219,16 +1219,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       isFluidRequestAndFixedResponse ||
       (returnedSizeDifferent && heightNotIncreased)
     ) {
-      if (height == pHeight) {
-        // If we're only changing the width, then we call changeSize which
-        // should allow us to resize the element even if it's in the viewport.
-        this.mutateElement(() => {
-          this.element.getResources()
-              ./*OK*/changeSize(this.element, height, width);
-        });
-      } else {
-        this.attemptChangeSize(height, width).catch(() => {});
-      }
+      this.attemptChangeSize(height, width).catch(() => {});
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1222,7 +1222,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       if (height == pHeight) {
         // If we're only changing the width, then we call changeSize which
         // should allow us to resize the element even if it's in the viewport.
-        this.element.getResources().changeSize(this.element, height, width);
+        this.mutateElement(() => {
+          this.element.getResources()
+              ./*OK*/changeSize(this.element, height, width);
+        });
       } else {
         this.attemptChangeSize(height, width).catch(() => {});
       }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1209,12 +1209,18 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const pWidth = this.element.getAttribute('width');
     const pHeight = this.element.getAttribute('height');
     const isFluidRequestAndFixedResponse =
-        this.isFluidRequest_ && width && height;
+        !!(this.isFluidRequest_ && width && height);
     const returnedSizeDifferent = width != pWidth || height != pHeight;
     const heightNotIncreased = height <= pHeight
     if (isFluidRequestAndFixedResponse ||
         returnedSizeDifferent && heightNotIncreased) {
-      this.attemptChangeSize(height, width).catch(() => {});
+      if (height == pHeight) {
+        // If we're only changing the width, then we call changeSize which
+        // should allow us to resize the element even if it's in the viewport.
+        this.element.getResources().changeSize(this.element, height, width);
+      } else {
+        this.attemptChangeSize(height, width).catch(() => {});
+      }
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1206,8 +1206,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @private
    */
   handleResize_(width, height) {
-    const pWidth = this.element.getAttribute('width');
-    const pHeight = this.element.getAttribute('height');
+    const pWidth = parseInt(this.element.getAttribute('width'), 10);
+    const pHeight = parseInt(this.element.getAttribute('height'), 10);
     const isFluidRequestAndFixedResponse = !!(
       this.isFluidRequest_ &&
       width &&

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1216,13 +1216,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @private
    */
   handleResize_(width, height) {
-    const pWidth = Number(this.element.getAttribute('width'));
-    const pHeight = Number(this.element.getAttribute('height'));
     const isFluidRequestAndFixedResponse = !!(
       this.isFluidRequest_ &&
       width &&
       height
     );
+    const declaredSize = this.getDeclaredSlotSize_();
+    const pWidth = declaredSize.width;
+    const pHeight = declaredSize.height;
     const returnedSizeDifferent = width != pWidth || height != pHeight;
     const heightNotIncreased = height <= pHeight;
     if (

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1208,14 +1208,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   handleResize_(width, height) {
     const pWidth = this.element.getAttribute('width');
     const pHeight = this.element.getAttribute('height');
-    // We want to resize only if neither returned dimension is larger than its
-    // primary counterpart, and if at least one of the returned dimensions
-    // differ from its primary counterpart.
-    if (
-      (this.isFluidRequest_ && width && height) ||
-      ((width != pWidth || height != pHeight) &&
-        (width <= pWidth && height <= pHeight))
-    ) {
+    const isFluidRequestAndFixedResponse =
+        this.isFluidRequest_ && width && height;
+    const returnedSizeDifferent = width != pWidth || height != pHeight;
+    const heightNotIncreased = height <= pHeight
+    if (isFluidRequestAndFixedResponse ||
+        returnedSizeDifferent && heightNotIncreased) {
       this.attemptChangeSize(height, width).catch(() => {});
     }
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -154,10 +154,10 @@ let TroubleshootDataDef;
 /** @private {?JsonObject} */
 let windowLocationQueryParameters;
 
-/**
- * @typedef
- * {({width: number, height: number}|../../../src/layout-rect.LayoutRectDef)}
- */
+/** @typedef {{width: number, height: number}} */
+let SizeDef;
+
+/** @typedef {(SizeDef|../../../src/layout-rect.LayoutRectDef)} */
 let LayoutRectOrDimsDef;
 
 /** @final */
@@ -877,15 +877,25 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * Returns the width and height of the slot as defined by the width and height
    * attributes, or the dimensions as computed by
    * getIntersectionElementLayoutBox.
-   * @return {{width: number, height: number}|../../../src/layout-rect.LayoutRectDef}
+   * @return {!LayoutRectOrDimsDef}
    */
   getSlotSize() {
-    const width = Number(this.element.getAttribute('width'));
-    const height = Number(this.element.getAttribute('height'));
+    const {width, height} = this.getDeclaredSlotSize_();
     return width && height
       ? {width, height}
       : // width/height could be 'auto' in which case we fallback to measured.
         this.getIntersectionElementLayoutBox();
+  }
+
+  /**
+   * Returns the width and height, as defined by the slot element's width and
+   * height attributes.
+   * @return {!SizeDef}
+   */
+  getDeclaredSlotSize_() {
+    const width = Number(this.element.getAttribute('width'));
+    const height = Number(this.element.getAttribute('height'));
+    return {width, height};
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1208,12 +1208,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   handleResize_(width, height) {
     const pWidth = this.element.getAttribute('width');
     const pHeight = this.element.getAttribute('height');
-    const isFluidRequestAndFixedResponse =
-        !!(this.isFluidRequest_ && width && height);
+    const isFluidRequestAndFixedResponse = !!(
+      this.isFluidRequest_ &&
+      width &&
+      height
+    );
     const returnedSizeDifferent = width != pWidth || height != pHeight;
-    const heightNotIncreased = height <= pHeight
-    if (isFluidRequestAndFixedResponse ||
-        returnedSizeDifferent && heightNotIncreased) {
+    const heightNotIncreased = height <= pHeight;
+    if (
+      isFluidRequestAndFixedResponse ||
+      (returnedSizeDifferent && heightNotIncreased)
+    ) {
       if (height == pHeight) {
         // If we're only changing the width, then we call changeSize which
         // should allow us to resize the element even if it's in the viewport.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1087,11 +1087,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         impl.element.style.width = `${width}px`;
         return Promise.resolve();
       });
-      sandbox.stub(impl.element.getResources(), 'changeSize').callsFake(
-          (element, height, width) => {
-            element.style.height = `${height}px`;
-            element.style.width = `${width}px`;
-          });
+      sandbox
+        .stub(impl.element.getResources(), 'changeSize')
+        .callsFake((element, height, width) => {
+          element.style.height = `${height}px`;
+          element.style.width = `${width}px`;
+        });
       sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
         return {
           customElementExtensions: [],

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1083,10 +1083,15 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         };
       });
       sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
-        impl.element.setAttribute('height', height);
-        impl.element.setAttribute('width', width);
+        impl.element.style.height = `${height}px`;
+        impl.element.style.width = `${width}px`;
         return Promise.resolve();
       });
+      sandbox.stub(impl.element.getResources(), 'changeSize').callsFake(
+          (element, height, width) => {
+            element.style.height = `${height}px`;
+            element.style.width = `${width}px`;
+          });
       sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
         return {
           customElementExtensions: [],
@@ -1210,20 +1215,20 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('should attempt resize for fluid request + fixed response case', () => {
       impl.isFluidRequest_ = true;
       impl.handleResize_(350, 300);
-      expect(impl.element.getAttribute('width')).to.equal('350');
-      expect(impl.element.getAttribute('height')).to.equal('300');
+      expect(impl.element.getAttribute('style')).to.match(/width: 350/);
+      expect(impl.element.getAttribute('style')).to.match(/height: 300/);
     });
 
     it('should attempt resize for larger width response', () => {
       impl.handleResize_(350, 50);
-      expect(impl.element.getAttribute('width')).to.equal('350');
-      expect(impl.element.getAttribute('height')).to.equal('50');
+      expect(impl.element.getAttribute('style')).to.match(/width: 350/);
+      expect(impl.element.getAttribute('style')).to.match(/height: 50/);
     });
 
     it('should not attempt resize for larger height response', () => {
       impl.handleResize_(350, 300);
-      expect(impl.element.getAttribute('width')).to.equal('200');
-      expect(impl.element.getAttribute('height')).to.equal('50');
+      expect(impl.element.getAttribute('style')).to.match(/width: 200/);
+      expect(impl.element.getAttribute('style')).to.match(/height: 50/);
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1206,6 +1206,25 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         expect(impl.adUrl_.length).to.be.ok;
       });
     });
+
+    it('should attempt resize for fluid request + fixed response case', () => {
+      impl.isFluidRequest_ = true;
+      impl.handleResize_(350, 300);
+      expect(impl.element.getAttribute('width')).to.equal('350');
+      expect(impl.element.getAttribute('height')).to.equal('300');
+    });
+
+    it('should attempt resize for larger width response', () => {
+      impl.handleResize_(350, 50);
+      expect(impl.element.getAttribute('width')).to.equal('350');
+      expect(impl.element.getAttribute('height')).to.equal('50');
+    });
+
+    it('should not attempt resize for larger height response', () => {
+      impl.handleResize_(350, 300);
+      expect(impl.element.getAttribute('width')).to.equal('200');
+      expect(impl.element.getAttribute('height')).to.equal('50');
+    });
   });
 
   describe('Troubleshoot for AMP pages', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1087,12 +1087,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         impl.element.style.width = `${width}px`;
         return Promise.resolve();
       });
-      sandbox
-        .stub(impl.element.getResources(), 'changeSize')
-        .callsFake((element, height, width) => {
-          element.style.height = `${height}px`;
-          element.style.width = `${width}px`;
-        });
       sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
         return {
           customElementExtensions: [],


### PR DESCRIPTION
Allow width expansion to occur if the returned width is larger than the initial width.

Previously, for multi-size, we disallowed this behavior. However, as we introduce parent/full-width flexible ads, this behavior must be allowed.

Originally from PR #22593. That PR was abandoned due to git accidentally pulling in a bunch of unrelated changes.