### PR TITLE
🐛 Don't update progress variable when ad is shown

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -49,6 +49,7 @@ import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
 import {AmpStoryPageAttachment} from './amp-story-page-attachment';
 import {AmpStoryRenderService} from './amp-story-render-service';
+import {AnalyticsVariable, getVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
@@ -105,7 +106,6 @@ import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '../../../src/event-helper';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode} from '../../../src/mode';
-import {AnalyticsVariable, getVariableService} from './variable-service';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseQueryString} from '../../../src/url';
 import {registerServiceBuilder} from '../../../src/service';
@@ -659,7 +659,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.storeService_.subscribe(StateProperty.ADVANCEMENT_MODE, mode => {
       this.variableService_.onVariableUpdate(
-        AnalyticsVariable.STORY_IS_MUTED,
+        AnalyticsVariable.STORY_ADVANCEMENT_MODE,
         mode
       );
     });

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1413,14 +1413,16 @@ export class AmpStory extends AMP.BaseElement {
           }
         }
 
-        this.storeService_.dispatch(Action.CHANGE_PAGE, {
-          id: targetPageId,
-          index: pageIndex,
-        });
-
+        let storePageIndex;
         if (targetPage.isAd()) {
           this.storeService_.dispatch(Action.TOGGLE_AD, true);
           setAttributeInMutate(this, Attributes.AD_SHOWING);
+
+          // Keep current page index when an ad is shown. Otherwise it messes
+          // up with the progress variable in the VariableService.
+          storePageIndex = this.storeService_.get(
+            StateProperty.CURRENT_PAGE_INDEX
+          );
         } else {
           this.storeService_.dispatch(Action.TOGGLE_AD, false);
           removeAttributeInMutate(this, Attributes.AD_SHOWING);
@@ -1436,7 +1438,13 @@ export class AmpStory extends AMP.BaseElement {
               this.advancement_.getProgress()
             );
           }
+          storePageIndex = pageIndex;
         }
+
+        this.storeService_.dispatch(Action.CHANGE_PAGE, {
+          id: targetPageId,
+          index: storePageIndex,
+        });
 
         // If first navigation.
         if (!oldPage) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -105,7 +105,7 @@ import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '../../../src/event-helper';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode} from '../../../src/mode';
-import {getVariableService} from './variable-service';
+import {AnalyticsVariable, getVariableService} from './variable-service';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseQueryString} from '../../../src/url';
 import {registerServiceBuilder} from '../../../src/service';
@@ -628,7 +628,10 @@ export class AmpStory extends AMP.BaseElement {
       StateProperty.MUTED_STATE,
       isMuted => {
         this.onMutedStateUpdate_(isMuted);
-        this.variableService_.onMutedStateChange(isMuted);
+        this.variableService_.onVariableUpdate(
+          AnalyticsVariable.STORY_IS_MUTED,
+          isMuted
+        );
       },
       true /** callToInitialize */
     );
@@ -655,7 +658,10 @@ export class AmpStory extends AMP.BaseElement {
     );
 
     this.storeService_.subscribe(StateProperty.ADVANCEMENT_MODE, mode => {
-      this.variableService_.onAdvancementModeStateChange(mode);
+      this.variableService_.onVariableUpdate(
+        AnalyticsVariable.STORY_IS_MUTED,
+        mode
+      );
     });
 
     this.element.addEventListener(EventType.SWITCH_PAGE, e => {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1413,7 +1413,7 @@ export class AmpStory extends AMP.BaseElement {
           }
         }
 
-        let storePageIndex;
+        let storePageIndex = pageIndex;
         if (targetPage.isAd()) {
           this.storeService_.dispatch(Action.TOGGLE_AD, true);
           setAttributeInMutate(this, Attributes.AD_SHOWING);
@@ -1438,7 +1438,6 @@ export class AmpStory extends AMP.BaseElement {
               this.advancement_.getProgress()
             );
           }
-          storePageIndex = pageIndex;
         }
 
         this.storeService_.dispatch(Action.CHANGE_PAGE, {

--- a/extensions/amp-story/1.0/test/test-variable-service.js
+++ b/extensions/amp-story/1.0/test/test-variable-service.js
@@ -16,7 +16,7 @@
 
 import {Action, getStoreService} from '../amp-story-store-service';
 import {AdvancementMode} from '../story-analytics';
-import {getVariableService} from '../variable-service';
+import {AnalyticsVariable, getVariableService} from '../variable-service';
 
 describes.fakeWin('amp-story variable service', {}, env => {
   let variableService;
@@ -39,7 +39,8 @@ describes.fakeWin('amp-story variable service', {}, env => {
   });
 
   it('should update storyAdvancementMode on change', () => {
-    variableService.onAdvancementModeStateChange(
+    variableService.onVariableUpdate(
+      AnalyticsVariable.STORY_ADVANCEMENT_MODE,
       AdvancementMode.MANUAL_ADVANCE
     );
 

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -24,7 +24,7 @@ import {registerServiceBuilder} from '../../../src/service';
 export let StoryVariableDef;
 
 /** @enum {string} */
-export const Variable = {
+export const AnalyticsVariable = {
   STORY_PAGE_ID: 'storyPageId',
   STORY_PAGE_INDEX: 'storyPageIndex',
   STORY_PAGE_COUNT: 'storyPageCount',
@@ -64,13 +64,13 @@ export class AmpStoryVariableService {
   constructor(win) {
     /** @private {!StoryVariableDef} */
     this.variables_ = dict({
-      [Variable.STORY_PAGE_INDEX]: null,
-      [Variable.STORY_PAGE_ID]: null,
-      [Variable.STORY_PAGE_COUNT]: null,
-      [Variable.STORY_PROGRESS]: null,
-      [Variable.STORY_IS_MUTED]: null,
-      [Variable.STORY_PREVIOUS_PAGE_ID]: null,
-      [Variable.STORY_ADVANCEMENT_MODE]: null,
+      [AnalyticsVariable.STORY_PAGE_INDEX]: null,
+      [AnalyticsVariable.STORY_PAGE_ID]: null,
+      [AnalyticsVariable.STORY_PAGE_COUNT]: null,
+      [AnalyticsVariable.STORY_PROGRESS]: null,
+      [AnalyticsVariable.STORY_IS_MUTED]: null,
+      [AnalyticsVariable.STORY_PREVIOUS_PAGE_ID]: null,
+      [AnalyticsVariable.STORY_ADVANCEMENT_MODE]: null,
     });
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
@@ -82,7 +82,7 @@ export class AmpStoryVariableService {
   /** @private */
   initializeListeners_() {
     this.storeService_.subscribe(StateProperty.PAGE_IDS, pageIds => {
-      this.variables_[Variable.STORY_PAGE_COUNT] = pageIds.length;
+      this.variables_[AnalyticsVariable.STORY_PAGE_COUNT] = pageIds.length;
     });
 
     this.storeService_.subscribe(
@@ -92,21 +92,22 @@ export class AmpStoryVariableService {
           return;
         }
 
-        this.variables_[Variable.STORY_PREVIOUS_PAGE_ID] = this.variables_[
-          Variable.STORY_PAGE_ID
-        ];
+        this.variables_[
+          AnalyticsVariable.STORY_PREVIOUS_PAGE_ID
+        ] = this.variables_[AnalyticsVariable.STORY_PAGE_ID];
 
-        this.variables_[Variable.STORY_PAGE_ID] = pageId;
+        this.variables_[AnalyticsVariable.STORY_PAGE_ID] = pageId;
 
         const pageIndex = /** @type {number} */ (this.storeService_.get(
           StateProperty.CURRENT_PAGE_INDEX
         ));
-        this.variables_[Variable.STORY_PAGE_INDEX] = pageIndex;
+        this.variables_[AnalyticsVariable.STORY_PAGE_INDEX] = pageIndex;
 
         const numberOfPages = this.storeService_.get(StateProperty.PAGE_IDS)
           .length;
         if (numberOfPages > 0) {
-          this.variables_[Variable.STORY_PROGRESS] = pageIndex / numberOfPages;
+          this.variables_[AnalyticsVariable.STORY_PROGRESS] =
+            pageIndex / numberOfPages;
         }
       },
       true /* callToInitialize */
@@ -114,17 +115,12 @@ export class AmpStoryVariableService {
   }
 
   /**
-   * @param {boolean} isMuted
+   * Updates a variable with a new value
+   * @param {string} name
+   * @param {*} update
    */
-  onMutedStateChange(isMuted) {
-    this.variables_[Variable.STORY_IS_MUTED] = isMuted;
-  }
-
-  /**
-   * @param {string} advancementMode
-   */
-  onAdvancementModeStateChange(advancementMode) {
-    this.variables_[Variable.STORY_ADVANCEMENT_MODE] = advancementMode;
+  onVariableUpdate(name, update) {
+    this.variables_[name] = update;
   }
 
   /**


### PR DESCRIPTION
When an ad is displayed, the progress variable is set to 1 because the ad is at the end of the DOM tree, after the amp-story-pages. And since `progress = pageIndex / totalPages`, the variable is set to 1, even if the ad is shown in the middle of the story.

This PR makes it so that the progress is unchanged whenever an ad is shown.

Also in this PR:
* Consolidate `onMutedStateChange` & `onAdvancementModeStateChange` methods from variable-service