### PR TITLE
🏗 Add pretty_print option to compiled output

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -363,6 +363,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       jscomp_off: ['unknownDefines'],
       define,
       hide_warnings_for: hideWarningsFor,
+      formatting: argv.pretty_print ? 'PRETTY_PRINT' : '',
     };
 
     // For now do type check separately

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -363,8 +363,10 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       jscomp_off: ['unknownDefines'],
       define,
       hide_warnings_for: hideWarningsFor,
-      formatting: argv.pretty_print ? 'PRETTY_PRINT' : '',
     };
+    if (argv.pretty_print) {
+      compilerOptions.formatting = 'PRETTY_PRINT';
+    }
 
     // For now do type check separately
     if (options.typeCheckOnly) {

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -138,6 +138,7 @@ exports.getFlags = function(config) {
       'globalThis',
     ],
     hide_warnings_for: config.hideWarningsFor,
+    formatting: argv.pretty_print ? 'PRETTY_PRINT' : '',
   };
 
   // Turn object into deterministically sorted array.

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -138,8 +138,10 @@ exports.getFlags = function(config) {
       'globalThis',
     ],
     hide_warnings_for: config.hideWarningsFor,
-    formatting: argv.pretty_print ? 'PRETTY_PRINT' : '',
   };
+  if (argv.pretty_print) {
+    flags.formatting = 'PRETTY_PRINT';
+  }
 
   // Turn object into deterministically sorted array.
   const flagsArray = [];

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -384,6 +384,9 @@ dist.flags = {
   pseudo_names:
     '  Compiles with readable names. ' +
     'Great for profiling and debugging production code.',
+  pretty_print:
+    '  Outputs compiled code with whitespace. ' +
+    'Great for debugging production code.',
   fortesting: '  Compiles production binaries for local testing',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   single_pass: "Compile AMP's primary JS bundles in a single invocation",


### PR DESCRIPTION
This prints the minified closure builds without whitespace, making debugging issues with compiled code less of a nuisance.