### PR TITLE
🚀Move `non-blocking` font media to `print`

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -89,9 +89,6 @@ function maybeTimeoutFonts(win) {
       // To avoid blocking the render, we assign a non-matching media
       // attribute first…
       const media = link.media || 'all';
-      // Move from generic 'non-matching' media to 'print', avoiding
-      // issue where Chromium based browsers will avoid downloading
-      // these media assets aggressively. (https://bugs.chromium.org/p/chromium/issues/detail?id=977573)
       link.media = 'print';
       // And then switch it back to the original after the stylesheet
       // loaded.

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -89,7 +89,10 @@ function maybeTimeoutFonts(win) {
       // To avoid blocking the render, we assign a non-matching media
       // attribute first…
       const media = link.media || 'all';
-      link.media = 'not-matching';
+      // Move from generic 'non-matching' media to 'print', avoiding
+      // issue where Chromium based browsers will avoid downloading
+      // these media assets aggressively. (https://bugs.chromium.org/p/chromium/issues/detail?id=977573)
+      link.media = 'print';
       // And then switch it back to the original after the stylesheet
       // loaded.
       link.onload = () => {

--- a/test/unit/test-font-stylesheet-timeout.js
+++ b/test/unit/test-font-stylesheet-timeout.js
@@ -102,7 +102,7 @@ describes.realWin(
           const after = win.document.querySelector('link[rel="stylesheet"]');
           expect(after).to.equal(link);
           expect(after.href).to.equal(link.href);
-          expect(after.media).to.equal('not-matching');
+          expect(after.media).to.equal('print');
           after.href = immediatelyLoadingHref('/* make-it-load */');
           return new Promise(resolve => {
             after.addEventListener('load', () => {

--- a/test/unit/test-font-stylesheet-timeout.js
+++ b/test/unit/test-font-stylesheet-timeout.js
@@ -102,7 +102,7 @@ describes.realWin(
           const after = win.document.querySelector('link[rel="stylesheet"]');
           expect(after).to.equal(link);
           expect(after.href).to.equal(link.href);
-          expect(after.media).to.equal('print');
+          expect(after.media).to.equal("print");
           after.href = immediatelyLoadingHref('/* make-it-load */');
           return new Promise(resolve => {
             after.addEventListener('load', () => {

--- a/test/unit/test-font-stylesheet-timeout.js
+++ b/test/unit/test-font-stylesheet-timeout.js
@@ -102,7 +102,7 @@ describes.realWin(
           const after = win.document.querySelector('link[rel="stylesheet"]');
           expect(after).to.equal(link);
           expect(after.href).to.equal(link.href);
-          expect(after.media).to.equal("print");
+          expect(after.media).to.equal('print');
           after.href = immediatelyLoadingHref('/* make-it-load */');
           return new Promise(resolve => {
             after.addEventListener('load', () => {


### PR DESCRIPTION
Fixes #22984. Chromium based browsers are changing the loading semantics of resources for media queries they know will never be supported. As a result, the font loading semantics of AMP are likely to break.

This PR moves AMP font loading timeout to use `print` instead of `not-blocking`.