### PR TITLE
🐛Remove logic for old amp-twitter default loader

### DIFF
--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -119,26 +119,12 @@ class AmpTwitter extends AMP.BaseElement {
    * @private
    */
   updateForSuccessState_(height) {
-    let placeholderHeight;
-    this.measureMutateElement(
-      () => {
-        if (!this.userPlaceholder_) {
-          // Use an explicit height so that the placeholder does not move when\
-          // the container resizes.
-          placeholderHeight = this.element./*OK*/ getBoundingClientRect()
-            .height;
-        }
-      },
-      () => {
-        if (this.userPlaceholder_) {
-          this.togglePlaceholder(false);
-        }
-        this./*OK*/ changeHeight(height);
-        if (placeholderHeight) {
-          setStyle(this.getPlaceholder(), 'height', placeholderHeight, 'px');
-        }
+    this.mutateElement(() => {
+      if (this.userPlaceholder_) {
+        this.togglePlaceholder(false);
       }
-    );
+      this./*OK*/ changeHeight(height);
+    });
   }
 
   /**

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -19,7 +19,6 @@ import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
-import {setStyle} from '../../../src/style';
 
 class AmpTwitter extends AMP.BaseElement {
   /** @param {!AmpElement} element */


### PR DESCRIPTION
The logic for sizing the placeholder, when a user placeholder is not present is no longer needed.

Fixes #22990
