### PR TITLE
🚀 Layers: Lazily remeasure child layouts

### DIFF
--- a/test/unit/test-layers.js
+++ b/test/unit/test-layers.js
@@ -147,9 +147,9 @@ describes.realWin('Layers', {amp: true}, env => {
             layout.forgetParentLayer();
             expect(layout.getParentLayer()).to.equal(rootLayout);
 
-            const spy = sinon.sandbox.spy(div, 'getBoundingClientRect');
-            rootLayout.dirtyMeasurements();
             rootLayout.remeasure();
+            const spy = sinon.sandbox.spy(layout, 'dirtyMeasurements');
+            rootLayout.dirtyMeasurements();
 
             expect(spy).to.have.callCount(1);
           });


### PR DESCRIPTION
This is attempt 2 to fix the quadratic remeasurements described in #22809.

This changes the layers code so that child layouts are remeasured as needed, not eagerly when the parent layer is remeasured. Still, causing any mutation inside a layer causes all layouts inside that layer to be invalidated. But since we no longer need to remeasure everything in that layer to get the measurements of a single layout, this leads to significantly less remeasures overall.