### PR TITLE
📖Fix invalid and unnecessary code block quotes in docs

### DIFF
--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -56,8 +56,8 @@ Allows rendering of <a href="https://github.com/janl/mustache.js/">Mustache.js</
 Mustache is a logic-less template syntax. See [Mustache.js docs](https://github.com/janl/mustache.js/) for more details. Some of the core Mustache tags are:
 
 - `{{variable}}`: A variable tag. It outputs the the HTML-escaped value of a variable.
-- `{{#section}}``{{/section}}`: A section tag. It can test the existence of a variable and iterate over it if it's an array.
-- `{{^section}}``{{/section}}`: An inverted tag. It can test the non-existence of a variable.
+- `{{#section}} {{/section}}`: A section tag. It can test the existence of a variable and iterate over it if it's an array.
+- `{{^section}} {{/section}}`: An inverted tag. It can test the non-existence of a variable.
 - `{{{unescaped}}}`: Unescaped HTML. It's restricted in the markup it may output (see "Restrictions" below).
 
 ## Usage


### PR DESCRIPTION
The amp-mustache documentation contains unnecessary code block quotes that normally will be rendered, but should not.
As seen on github the quotes after the `{{#section}}` block are shown:
https://github.com/ampproject/amphtml/blob/master/extensions/amp-mustache/amp-mustache.md#syntax
On amp.dev the quotes are currently not shown, but this will change as we are about to change the preprocessing of the imported markdown files from amphtml.
So please apply this PR to remove the unnecessary quotes.