### PR TITLE
🏗 Disable `renovate` for all dependencies in package.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,24 +9,9 @@
   },
   "statusCheckVerify": true,
   "commitMessagePrefix": "📦",
-  "ignoreDeps": [
-    "babel-polyfill",
-    "document-register-element",
-    "moment-with-locales",
-    "moment",
-    "preact-compat",
-    "preact",
-    "promise-pjs",
-    "prop-types",
-    "react-addons-shallow-compare",
-    "react-dates",
-    "react-dom",
-    "react-externs",
-    "react-with-direction",
-    "react",
-    "web-activities",
-    "web-animations-js"
-  ],
+  "dependencies": {
+    "enabled": false
+  },
   "includePaths": [
     "package.json",
     "build-system/tasks/e2e/package.json"


### PR DESCRIPTION
This PR prevents potentially risky auto-updates to packages that are shipped with the runtime.