### PR TITLE
🐛 Update execOrDie to handle a null status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,6 @@ jobs:
 cache:
   directories:
     - node_modules
-    - build-system/tasks/e2e/node_modules
     - build-system/tasks/visual-diff/node_modules
     - sauce_connect
     - validator/node_modules

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -66,7 +66,7 @@ function execScriptAsync(script, options) {
  */
 function execOrDie(cmd, options) {
   const p = exec(cmd, options);
-  if (p.status != 0) {
+  if (p.status && p.status != 0) {
     process.exit(p.status);
   }
 }


### PR DESCRIPTION
Also temporarily removes e2e node_modules in Travis cache.

Closes https://github.com/ampproject/amphtml/issues/23004