### PR TITLE
🏗 Exempt `build-system/` from code coverage

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -228,9 +228,10 @@ class RuntimeTestConfig {
         {
           exclude: [
             'ads/**/*.js',
+            'build-system/**/*.js',
+            'extensions/**/test/**/*.js',
             'third_party/**/*.js',
             'test/**/*.js',
-            'extensions/**/test/**/*.js',
             'testing/**/*.js',
           ],
         },


### PR DESCRIPTION
#22931 added `build-system/tasks/e2e/controller-promise.js`, which is being [included](https://codecov.io/gh/ampproject/amphtml/tree/e6d62f2f3b41635c0aaa559b526ee01a41dc373a) in code coverage reports.

This PR removes `build-system/` from code coverage.