### PR TITLE
🏗🐛 Don't cancel `watch` if an edit causes a compilation error (redux)

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -356,22 +356,28 @@ function buildExtension(
   if (options.compileOnlyCss && !hasCss) {
     return Promise.resolve();
   }
+  const path = 'extensions/' + name + '/' + version;
+
   // Use a separate watcher for extensions to copy / inline CSS and compile JS
   // instead of relying on the watcher used by compileUnminifiedJs, which only
   // recompiles JS.
-  const path = 'extensions/' + name + '/' + version;
-  const optionsCopy = Object.create(options);
   if (options.watch) {
-    optionsCopy.watch = false;
+    options.watch = false;
     watch(path + '/*', function() {
-      buildExtension(name, version, latestVersion, hasCss, optionsCopy);
+      buildExtension(
+        name,
+        version,
+        latestVersion,
+        hasCss,
+        Object.assign({}, options, {continueOnError: true})
+      );
     });
   }
   const promises = [];
   if (hasCss) {
     mkdirSync('build');
     mkdirSync('build/css');
-    const buildCssPromise = buildExtensionCss(path, name, version, optionsCopy);
+    const buildCssPromise = buildExtensionCss(path, name, version, options);
     if (options.compileOnlyCss) {
       return buildCssPromise;
     }
@@ -388,7 +394,7 @@ function buildExtension(
     if (argv.single_pass) {
       return Promise.resolve();
     } else {
-      return buildExtensionJs(path, name, version, latestVersion, optionsCopy);
+      return buildExtensionJs(path, name, version, latestVersion, options);
     }
   });
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -365,21 +365,20 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
 /**
  * Handles a browserify bundling error
  * @param {Error} err
- * @param {boolean} failOnError
- * @param {string} srcFilename
- * @param {string} startTime
+ * @param {boolean} continueOnError
+ * @param {string} destFilename
  */
-function handleBundleError(err, failOnError, srcFilename, startTime) {
+function handleBundleError(err, continueOnError, destFilename) {
   let message = err;
   if (err.stack) {
     // Drop the node_modules call stack, which begins with '    at'.
     message = err.stack.replace(/    at[^]*/, '').trim();
   }
   console.error(red(message));
-  if (failOnError) {
-    process.exit(1);
+  if (continueOnError) {
+    log('Error while compiling', cyan(destFilename));
   } else {
-    endBuildStep('Error while compiling', srcFilename, startTime);
+    process.exit(1);
   }
 }
 
@@ -448,21 +447,21 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
 
   if (options.watch) {
     bundler = watchify(bundler);
-    bundler.on('update', () => performBundle(/* failOnError */ false));
+    bundler.on('update', () => performBundle(/* continueOnError */ true));
   }
 
   /**
-   * @param {boolean} failOnError
+   * @param {boolean} continueOnError
    * @return {Promise}
    */
-  function performBundle(failOnError) {
+  function performBundle(continueOnError) {
     let startTime;
     return toPromise(
       bundler
         .bundle()
         .once('readable', () => (startTime = Date.now()))
         .on('error', err =>
-          handleBundleError(err, failOnError, srcFilename, startTime)
+          handleBundleError(err, continueOnError, destFilename)
         )
         .pipe(source(srcFilename))
         .pipe(buffer())
@@ -497,7 +496,7 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       });
   }
 
-  return performBundle(/* failOnError */ true);
+  return performBundle(options.continueOnError);
 }
 
 /**


### PR DESCRIPTION
This PR cleans up the old logic used to determine when to stop compilation and when to continue it during `watch` by adding a new field to `options` called `continueOnError`. This was necessary because extensions use an additional `watch` mechanism since they need to respond to changes to `.js` and `.css` files.

Addresses https://github.com/ampproject/amphtml/pull/13312#issuecomment-501037941

Follow up to #13312
Follow up to #22659