### PR TITLE
Remove debugging fetch from amp-analytics.

### DIFF
--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -474,7 +474,6 @@ export class AmpdocAnalyticsRoot extends AnalyticsRoot {
   createVisibilityManager() {
     if (this.hostVisibilityService_) {
       // If there is hostAPI (hostAPI never exist with the FIE case)
-      fetch('http://localhost:8000/visiblityManagerForMAPP');
       return new VisibilityManagerForMApp(
         this.ampdoc,
         this.hostVisibilityService_


### PR DESCRIPTION
This line is throwing some superfluous errors when we're testing AMP on mobile apps. I'm assuming it's not actually needed.