### PR TITLE
Add e2e tests for amp-sidebar. Fix bug in ShadowDOM.

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -401,7 +401,9 @@ export class AmpSidebar extends AMP.BaseElement {
       mask.addEventListener('click', () => {
         this.close_();
       });
-      this.element.ownerDocument.body.appendChild(mask);
+      this.getAmpDoc()
+        .getBody()
+        .appendChild(mask);
       mask.addEventListener('touchmove', e => {
         e.preventDefault();
       });

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
@@ -47,14 +47,15 @@ describes.endtoend(
       await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
         .false;
 
-      await expect(
-        controller.getElementProperty(sidebar, 'clientWidth')
-      ).to.be.greaterThan(0);
+      await expect(controller.getElementRect(sidebar)).to.include({
+        width: 300,
+        left: 0,
+      });
 
       const backingImage = await controller.findElement('#image img');
       await expect(
         controller.getElementProperty(backingImage, 'clientWidth')
-      ).to.be.greaterThan(0);
+      ).to.equal(300);
     });
 
     it('should close the sidebar on button click', async () => {
@@ -65,9 +66,14 @@ describes.endtoend(
       await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
         .false;
 
+      // Wait for the button to become visible
+      await expect(controller.getElementRect(sidebar)).to.include({
+        width: 300,
+        right: 300,
+      });
+
       const close = await controller.findElement('#close');
       await controller.click(close);
-
       await expect(controller.getElementProperty(sidebar, 'hidden')).to.be.true;
     });
 

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller';
+
+describes.endtoend(
+  'amp-sidebar',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-sidebar/amp-sidebar.html',
+  },
+  async env => {
+    let controller;
+
+    beforeEach(() => {
+      controller = env.controller;
+    });
+
+    it('should render correctly', async () => {
+      const sidebar = await controller.findElement('#sidebar');
+
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be.true;
+      const image = await controller.findElement('#image');
+      await expect(
+        controller.getElementProperty(image, 'clientWidth')
+      ).to.equal(0);
+    });
+
+    it('should open the sidebar', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const sidebar = await controller.findElement('#sidebar');
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
+        .false;
+
+      await expect(
+        controller.getElementProperty(sidebar, 'clientWidth')
+      ).to.be.greaterThan(0);
+
+      const backingImage = await controller.findElement('#image img');
+      await expect(
+        controller.getElementProperty(backingImage, 'clientWidth')
+      ).to.be.greaterThan(0);
+    });
+
+    it('should close the sidebar on button click', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const sidebar = await controller.findElement('#sidebar');
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
+        .false;
+
+      const close = await controller.findElement('#close');
+      await controller.click(close);
+
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be.true;
+    });
+
+    it('should close the sidebar on esc', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const sidebar = await controller.findElement('#sidebar');
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
+        .false;
+
+      await controller.type(null, Key.Escape);
+
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be.true;
+    });
+
+    it('should close the sidebar on click outside', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const sidebar = await controller.findElement('#sidebar');
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be
+        .false;
+
+      const mask = await controller.findElement('.i-amphtml-sidebar-mask');
+      await controller.click(mask);
+
+      await expect(controller.getElementProperty(sidebar, 'hidden')).to.be.true;
+    });
+  }
+);

--- a/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
+++ b/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>amp-sidebar</title>
+    <link rel="canonical" href="//example.com" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+</head>
+
+<body>
+  <amp-sidebar
+    id="sidebar"
+    layout="nodisplay"
+    side="right">
+    <p>This is the amp-sidebar demo</p>
+    <amp-img
+        id="image"
+        src="/examples/img/sample.jpg"
+        layout="responsive"
+        width="13" height="10"
+    ></amp-img>
+    <button id="close" on="tap: sidebar.close">Close sidebar</button>
+  </amp-sidebar>
+
+  <button id="open" on="tap:sidebar.open">
+    Open Sidebar
+  </button>
+</body>
+</html>

--- a/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
+++ b/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
@@ -8,13 +8,18 @@
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+    <style amp-custom>
+    amp-sidebar {
+      width: 300px;
+    }
+    </style>
 </head>
 
 <body>
   <amp-sidebar
     id="sidebar"
     layout="nodisplay"
-    side="right">
+    side="left">
     <p>This is the amp-sidebar demo</p>
     <amp-img
         id="image"


### PR DESCRIPTION
Closes #6757 

In ShadowDOM the sidebar mask was getting appended to the outer doc, not the body of the shadow document, so its styles and behavior weren't getting applied. This uses the ampdoc API method to get a reference to the correct body and fixes the bug.