### PR TITLE
Remove amp-apester-media exp flag

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -23,7 +23,6 @@
   "ad-type-custom": 1,
   "amp-access-iframe": 1,
   "amp-ad-ff-adx-ady": 0.01,
-  "amp-apester-media": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-consent-v2": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -24,7 +24,6 @@
   "ad-type-custom": 1,
   "amp-access-iframe": 1,
   "amp-ad-ff-adx-ady": 0.01,
-  "amp-apester-media": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-consent-v2": 1,

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -143,12 +143,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4171',
   },
   {
-    id: 'amp-apester-media',
-    name: 'AMP extension for Apester media (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/3233',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/4291',
-  },
-  {
     id: 'cache-service-worker',
     name: 'AMP Cache Service Worker',
     spec: 'https://github.com/ampproject/amphtml/issues/1199',


### PR DESCRIPTION
The experiment was removed in https://github.com/ampproject/amphtml/commit/8a022533e1e3d2ce70609cb9058845e707751456#diff-b8f9686fbe618a8a1767815ebf2ae443

