### PR TITLE
Play and finish all animations in story vertical rendering mode. 

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-vertical-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-vertical-rendering.html
@@ -51,8 +51,8 @@
           <amp-img layout="fill" src="./img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical" class="bottom blue-bottom-gradient">
-          <p animate-in="fly-in-right" animate-in-duration="3s">
-            <span data-text-background-color="#00A3DB">Relentlessly pursues moth annoy owner until he gives you food say meow repeatedly until belly rubs, feels good drool that box?</span>
+          <p>
+            <span data-text-background-color="#00A3DB" animate-in="fly-in-right" animate-in-duration="3s">Relentlessly pursues moth annoy owner until he gives you food say meow repeatedly until belly rubs, feels good drool that box?</span>
           </p>
         </amp-story-grid-layer>
         <amp-story-page-attachment data-title="Lorem ipsum" layout="nodisplay">
@@ -69,8 +69,8 @@
           <amp-img layout="fill" src="./img/cat2.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="center">
-          <p animate-in="fly-in-right" animate-in-duration="3s">
-            <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
+          <p>
+            <span animate-in="fly-in-right" animate-in-duration="3s" data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
         </amp-story-grid-layer>
       </amp-story-page>

--- a/examples/visual-tests/amp-story/amp-story-vertical-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-vertical-rendering.html
@@ -51,7 +51,7 @@
           <amp-img layout="fill" src="./img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical" class="bottom blue-bottom-gradient">
-          <p>
+          <p animate-in="fly-in-right" animate-in-duration="3s">
             <span data-text-background-color="#00A3DB">Relentlessly pursues moth annoy owner until he gives you food say meow repeatedly until belly rubs, feels good drool that box?</span>
           </p>
         </amp-story-grid-layer>
@@ -69,7 +69,7 @@
           <amp-img layout="fill" src="./img/cat2.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="center">
-          <p>
+          <p animate-in="fly-in-right" animate-in-duration="3s">
             <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
         </amp-story-grid-layer>

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -307,8 +307,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     );
     this.setDescendantCssTextStyles_();
     this.storeService_.subscribe(
-        StateProperty.UI_STATE,
-        uiState => this.onUIStateUpdate_(uiState), true /* callToInitialize */);
+      StateProperty.UI_STATE,
+      uiState => this.onUIStateUpdate_(uiState),
+      true /* callToInitialize */
+    );
   }
 
   /**
@@ -469,11 +471,12 @@ export class AmpStoryPage extends AMP.BaseElement {
   onUIStateUpdate_(uiState) {
     // On vertical rendering, render all the animations with their final state.
     if (uiState === UIType.VERTICAL && this.animationManager_) {
-      this.signals().whenSignal(CommonSignals.LOAD_END)
-          .then(() => this.maybeApplyFirstAnimationFrame())
-          .then(() => {
-            this.animationManager_.finishAll();
-          });
+      this.signals()
+        .whenSignal(CommonSignals.LOAD_END)
+        .then(() => this.maybeApplyFirstAnimationFrame())
+        .then(() => {
+          this.animationManager_.finishAll();
+        });
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -306,6 +306,9 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.emitProgress_(progress)
     );
     this.setDescendantCssTextStyles_();
+    this.storeService_.subscribe(
+        StateProperty.UI_STATE,
+        uiState => this.onUIStateUpdate_(uiState), true /* callToInitialize */);
   }
 
   /**
@@ -456,6 +459,22 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   onResize_() {
     this.findAndPrepareEmbeddedComponents_(true /* forceResize */);
+  }
+
+  /**
+   * Reacts to UI state updates.
+   * @param {!UIType} uiState
+   * @private
+   */
+  onUIStateUpdate_(uiState) {
+    // On vertical rendering, render all the animations with their final state.
+    if (uiState === UIType.VERTICAL && this.animationManager_) {
+      this.signals().whenSignal(CommonSignals.LOAD_END)
+          .then(() => this.maybeApplyFirstAnimationFrame())
+          .then(() => {
+            this.animationManager_.finishAll();
+          });
+    }
   }
 
   /** @return {!Promise} */

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -300,7 +300,9 @@ class AnimationRunner {
    * @private
    */
   finishWhenReady_(runner) {
-    if (runner.getPlayState() == WebAnimationPlayState.RUNNING) {
+    if (this.runner_) {
+      // Init or no-op if the runner was already running.
+      runner.start();
       runner.finish();
     }
   }


### PR DESCRIPTION
Any story content supposed to animate in when a page becomes active is hidden by default, and ignored by some search engine indexing tools.

This PR plays all the animations with no duration on render, and shows the pages in their active state.

If this PR works, the visual diff test should be a no-op. :))

Fixes #23070