### PR TITLE
💅 Live story polishes

### DIFF
--- a/examples/amp-story/bookend.html
+++ b/examples/amp-story/bookend.html
@@ -62,9 +62,9 @@
           <h1>Advance to see the bookend!</h1>
         </amp-story-grid-layer>
       </amp-story-page>
-    </amp-story>
 
-    <amp-story-bookend src="./bookendv1.json" layout="nodisplay">
-    </amp-story-bookend>
+      <amp-story-bookend src="./bookendv1.json" layout="nodisplay">
+      </amp-story-bookend>
+    </amp-story>
   </body>
 </html>

--- a/examples/amp-story/live-story.html
+++ b/examples/amp-story/live-story.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story"
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+    <title>amp-story live story</title>
+    <meta name="viewport"
+          content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <link rel="canonical" href="index.html">
+    <style amp-custom>
+      amp-story-page {
+        background: black;
+        color: white;
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+
+  <body>
+    <amp-story id="story1" live-story
+        standalone
+        publisher="AMP Team"
+        title="Live Story"
+        publisher-logo-src="https://example.com/logo/1x1.png"
+        poster-portrait-src="https://example.com/my-story/poster/3x4.jpg"
+        poster-square-src="https://example.com/my-story/poster/1x1.jpg"
+        poster-landscape-src="https://example.com/my-story/poster/4x3.jpg">
+
+      <amp-story-page id="cover" data-sort-time="1552330790">
+        <amp-story-grid-layer template="vertical">
+          <p>Append a new page!</p>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- Uncomment the page below while looking at the story to see the real-time update! -->
+
+      <!-- <amp-story-page id="page1" data-sort-time="1552330791">
+        <amp-story-grid-layer template="vertical">
+          <p>This is a new update!</p>
+        </amp-story-grid-layer>
+      </amp-story-page> -->
+    </amp-story>
+  </body>
+
+</html>

--- a/examples/amp-story/live-story.html
+++ b/examples/amp-story/live-story.html
@@ -5,7 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
     <title>amp-story live story</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -156,10 +156,10 @@ export const StateProperty = {
 /** @private @const @enum {string} */
 export const Action = {
   ADD_TO_ACTIONS_WHITELIST: 'addToActionsWhitelist',
-  SET_PAGE_IDS: 'addToPageIds',
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
+  SET_PAGE_IDS: 'addToPageIds',
   TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_BOOKEND: 'toggleBookend',
@@ -218,10 +218,6 @@ const actions = (state, action, data) => {
       );
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.ACTIONS_WHITELIST]: newActionsWhitelist,
-      }));
-    case Action.SET_PAGE_IDS:
-      return /** @type {!State} */ (Object.assign({}, state, {
-        [StateProperty.PAGE_IDS]: data,
       }));
     // Triggers the amp-acess paywall.
     case Action.TOGGLE_ACCESS:
@@ -350,6 +346,10 @@ const actions = (state, action, data) => {
     case Action.SET_ADVANCEMENT_MODE:
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.ADVANCEMENT_MODE]: data,
+      }));
+    case Action.SET_PAGE_IDS:
+      return /** @type {!State} */ (Object.assign({}, state, {
+        [StateProperty.PAGE_IDS]: data,
       }));
     default:
       dev().error(TAG, 'Unknown action %s.', action);

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -220,9 +220,8 @@ const actions = (state, action, data) => {
         [StateProperty.ACTIONS_WHITELIST]: newActionsWhitelist,
       }));
     case Action.ADD_TO_PAGE_IDS:
-      const newPageIds = [].concat(state[StateProperty.PAGE_IDS], data);
       return /** @type {!State} */ (Object.assign({}, state, {
-        [StateProperty.PAGE_IDS]: newPageIds,
+        [StateProperty.PAGE_IDS]: data,
       }));
     // Triggers the amp-acess paywall.
     case Action.TOGGLE_ACCESS:

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -156,7 +156,7 @@ export const StateProperty = {
 /** @private @const @enum {string} */
 export const Action = {
   ADD_TO_ACTIONS_WHITELIST: 'addToActionsWhitelist',
-  ADD_TO_PAGE_IDS: 'addToPageIds',
+  SET_PAGE_IDS: 'addToPageIds',
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
@@ -219,7 +219,7 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.ACTIONS_WHITELIST]: newActionsWhitelist,
       }));
-    case Action.ADD_TO_PAGE_IDS:
+    case Action.SET_PAGE_IDS:
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.PAGE_IDS]: data,
       }));

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1030,8 +1030,13 @@ export class AmpStory extends AMP.BaseElement {
       this.element.addEventListener(AmpEvents.DOM_UPDATE, () => {
         this.liveStoryManager_.update();
         this.initializePages_().then(() => {
-          this.setDesktopPositionAttributes_(this.activePage_);
           this.preloadPagesByDistance_();
+          if (
+            this.storeService_.get(StateProperty.UI_STATE) ===
+            UIType.DESKTOP_PANELS
+          ) {
+            this.setDesktopPositionAttributes_(this.activePage_);
+          }
         });
       });
     }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -897,7 +897,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     // TODO(#19768): Avoid passing a private function here.
-    this.paginationButtons_ = PaginationButtons.create(this.win, () =>
+    this.paginationButtons_ = PaginationButtons.create(this, () =>
       this.hasBookend_()
     );
 

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -15,9 +15,10 @@
  */
 
 import {Action, getStoreService} from './amp-story-store-service';
+import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {userAssert} from '../../../src/log';
 
 /**
  * Property used for storing id of custom slot. This custom slot can be used to
@@ -29,10 +30,14 @@ const AMP_LIVE_LIST_CUSTOM_SLOT_ID = 'AMP_LIVE_LIST_CUSTOM_SLOT_ID';
 export class LiveStoryManager {
   /**
    * @param {!./amp-story.AmpStory} ampStory
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
-  constructor(ampStory) {
+  constructor(ampStory, ampdoc) {
     /** @private @const {!./amp-story.AmpStory} */
     this.ampStory_ = ampStory;
+
+    /** @private @const {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = ampdoc;
 
     /** @private @const {!Element} */
     this.storyEl_ = ampStory.element;
@@ -64,37 +69,28 @@ export class LiveStoryManager {
       'amp-story must contain id to use the live story functionality'
     );
 
+    Services.extensionsFor(this.ampdoc_.win).installExtensionForDoc(
+      this.ampdoc_,
+      'amp-live-list'
+    );
+
     this.storyEl_.insertBefore(liveListEl, this.storyEl_.firstElementChild);
   }
 
   /**
    * Updates the client amp-story with the changes from the server document.
-   *
-   * @param {?EventTarget} updatedStoryEl
-   * @param {!NodeList<!Element>} currentPages
    */
-  update(updatedStoryEl, currentPages) {
-    const newPageEls = devAssert(
-      updatedStoryEl,
-      'No updated story EventTarget was found.'
-    ).querySelectorAll('amp-story-page.amp-live-list-item-new');
-
-    let lastPageEl = currentPages[currentPages.length - 1];
-
-    const pageImplPromises = Array.prototype.map.call(newPageEls, pageEl =>
-      pageEl.getImpl()
-    );
-
-    Promise.all(pageImplPromises).then(pages => {
-      pages.forEach(page => {
-        // New amp-story-pages are always appended last.
-        this.storyEl_.insertBefore(page.element, lastPageEl.nextElementSibling);
-        this.ampStory_.addPage(page);
-        this.ampStory_.insertPage(lastPageEl.id, page.element.id);
-        this.storeService_.dispatch(Action.ADD_TO_PAGE_IDS, [page.element.id]);
-        lastPageEl = page.element;
-      });
-      this.storeService_.dispatch(Action.ADD_NEW_PAGE_ID, lastPageEl.id);
+  update() {
+    const storyPages = this.storyEl_.querySelectorAll('amp-story-page');
+    const newPages = Array.prototype.filter.call(storyPages, page => {
+      return page.classList.contains('amp-live-list-item-new');
     });
+
+    const lastNewPageEl = newPages[newPages.length - 1];
+    const pageIds = Array.prototype.map.call(storyPages, el => el.id);
+
+    this.storeService_.dispatch(Action.ADD_TO_PAGE_IDS, pageIds);
+    this.storeService_.dispatch(Action.ADD_NEW_PAGE_ID, lastNewPageEl.id);
+    return this.ampStory_.initializePages();
   }
 }

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -15,6 +15,7 @@
  */
 
 import {Action, getStoreService} from './amp-story-store-service';
+import {CommonSignals} from '../../../src/common-signals';
 import {EventType} from './events';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes, lastChildElement} from '../../../src/dom';
@@ -69,14 +70,16 @@ export class LiveStoryManager {
       'amp-story must contain id to use the live story functionality'
     );
 
-    this.ampStory_.element.addEventListener(EventType.STORY_LOADED, () => {
-      Services.extensionsFor(this.ampdoc_.win).installExtensionForDoc(
-        this.ampdoc_,
-        'amp-live-list'
-      );
-    });
-
-    this.storyEl_.insertBefore(liveListEl, this.storyEl_.firstElementChild);
+    this.ampStory_.element
+      .signals()
+      .whenSignal(CommonSignals.LOAD_END)
+      .then(() => {
+        Services.extensionsFor(this.ampdoc_.win).installExtensionForDoc(
+          this.ampdoc_,
+          'amp-live-list'
+        );
+        this.storyEl_.insertBefore(liveListEl, this.storyEl_.firstElementChild);
+      });
   }
 
   /**

--- a/extensions/amp-story/1.0/live-story-manager.js
+++ b/extensions/amp-story/1.0/live-story-manager.js
@@ -16,7 +16,6 @@
 
 import {Action, getStoreService} from './amp-story-store-service';
 import {CommonSignals} from '../../../src/common-signals';
-import {EventType} from './events';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes, lastChildElement} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -246,6 +246,13 @@ export class PaginationButtons {
       }
     );
 
+    this.storeService_.subscribe(StateProperty.PAGE_IDS, () => {
+      const currentPageIndex = this.storeService_.get(
+        StateProperty.CURRENT_PAGE_INDEX
+      );
+      this.onCurrentPageIndexUpdate_(currentPageIndex);
+    });
+
     this.storeService_.subscribe(
       StateProperty.SYSTEM_UI_IS_VISIBLE_STATE,
       isVisible => {

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -19,6 +19,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AdvancementMode} from './story-analytics';
+import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
 import {devAssert} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
@@ -166,10 +167,14 @@ class PaginationButton {
 /** Pagination buttons layer. */
 export class PaginationButtons {
   /**
-   * @param {!Window} win
+   * @param {!./amp-story.AmpStory} ampStory
    * @param {function():Promise<boolean>} hasBookend
    */
-  constructor(win, hasBookend) {
+  constructor(ampStory, hasBookend) {
+    /** @private @const {!./amp-story.AmpStory} */
+    this.ampStory_ = ampStory;
+
+    const {win} = this.ampStory_;
     const doc = win.document;
     this.storeService_ = getStoreService(win);
 
@@ -205,12 +210,12 @@ export class PaginationButtons {
   }
 
   /**
-   * @param {!Window} win
+   * @param {!./amp-story.AmpStory} ampStory
    * @param {function():Promise<boolean>} hasBookend
    * @return {!PaginationButtons}
    */
-  static create(win, hasBookend) {
-    return new PaginationButtons(win, hasBookend);
+  static create(ampStory, hasBookend) {
+    return new PaginationButtons(ampStory, hasBookend);
   }
 
   /** @param {!Element} element */
@@ -247,16 +252,18 @@ export class PaginationButtons {
     );
 
     this.storeService_.subscribe(StateProperty.PAGE_IDS, () => {
-      // Make sure the story is laid out before updating.
-      this.forwardButton_.element.addEventListener(
-        EventType.STORY_LOADED,
-        () => {
+      // Since onCurrentPageIndexUpdate_ uses this.hasBookend_, and the bookend
+      // isn't initialized until after the story is laid out, we wait for the
+      // story to be laid out before calling this function.
+      this.ampStory_.element
+        .signals()
+        .whenSignal(CommonSignals.LOAD_END)
+        .then(() => {
           const currentPageIndex = this.storeService_.get(
             StateProperty.CURRENT_PAGE_INDEX
           );
           this.onCurrentPageIndexUpdate_(currentPageIndex);
-        }
-      );
+        });
     });
 
     this.storeService_.subscribe(

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -259,9 +259,9 @@ export class PaginationButtons {
         .signals()
         .whenSignal(CommonSignals.LOAD_END)
         .then(() => {
-          const currentPageIndex = this.storeService_.get(
-            StateProperty.CURRENT_PAGE_INDEX
-          );
+          const currentPageIndex = /** @type {number} */ (devAssert(
+            this.storeService_.get(StateProperty.CURRENT_PAGE_INDEX)
+          ));
           this.onCurrentPageIndexUpdate_(currentPageIndex);
         });
     });

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -247,10 +247,16 @@ export class PaginationButtons {
     );
 
     this.storeService_.subscribe(StateProperty.PAGE_IDS, () => {
-      const currentPageIndex = this.storeService_.get(
-        StateProperty.CURRENT_PAGE_INDEX
+      // Make sure the story is laid out before updating.
+      this.forwardButton_.element.addEventListener(
+        EventType.STORY_LOADED,
+        () => {
+          const currentPageIndex = this.storeService_.get(
+            StateProperty.CURRENT_PAGE_INDEX
+          );
+          this.onCurrentPageIndexUpdate_(currentPageIndex);
+        }
       );
-      this.onCurrentPageIndexUpdate_(currentPageIndex);
     });
 
     this.storeService_.subscribe(

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -140,7 +140,7 @@ export class ProgressBar {
    * Clears the progress bar.
    */
   clear_() {
-    removeChildren(this.root_);
+    removeChildren(devAssert(this.root_));
     this.segmentIdMap_ = map();
     this.segmentCount_ = 0;
   }

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -19,8 +19,8 @@ import {StateProperty, getStoreService} from './amp-story-store-service';
 import {dev, devAssert} from '../../../src/log';
 import {escapeCssSelectorNth} from '../../../src/css';
 import {hasOwn, map} from '../../../src/utils/object';
+import {removeChildren, scopedQuerySelector} from '../../../src/dom';
 import {scale, setImportantStyles} from '../../../src/style';
-import {scopedQuerySelector} from '../../../src/dom';
 
 /**
  * Transition used to show the progress of a media. Has to be linear so the
@@ -111,7 +111,7 @@ export class ProgressBar {
           this.updateProgress(
             this.activeSegmentId_,
             this.activeSegmentProgress_,
-            true /** opt_updateAllSegments */
+            true /** updateAllSegments */
           );
         }
       },
@@ -140,8 +140,8 @@ export class ProgressBar {
    * Clears the progress bar.
    */
   clear_() {
+    removeChildren(this.root_);
     this.segmentIdMap_ = map();
-    this.root_.textContent = '';
     this.segmentCount_ = 0;
   }
 
@@ -184,9 +184,9 @@ export class ProgressBar {
    * @param {string} segmentId the id of the segment whos progress to change.
    * @param {number} progress A number from 0.0 to 1.0, representing the
    *     progress of the current segment.
-   * @param {boolean} opt_updateAllSegments Updates all of the segments.
+   * @param {boolean} updateAllSegments Updates all of the segments.
    */
-  updateProgress(segmentId, progress, opt_updateAllSegments) {
+  updateProgress(segmentId, progress, updateAllSegments = false) {
     this.assertVaildSegmentId_(segmentId);
     const segmentIndex = this.segmentIdMap_[segmentId];
 
@@ -194,7 +194,7 @@ export class ProgressBar {
 
     // If updating progress for a new segment, update all the other progress
     // bar segments.
-    if (this.activeSegmentIndex_ !== segmentIndex || opt_updateAllSegments) {
+    if (this.activeSegmentIndex_ !== segmentIndex || updateAllSegments) {
       this.updateSegments_(
         segmentIndex,
         progress,

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -69,6 +69,9 @@ export class ProgressBar {
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win_);
+
+    /** @private {string} */
+    this.activeSegmentId_ = '';
   }
 
   /**
@@ -88,24 +91,34 @@ export class ProgressBar {
       return this.getRoot();
     }
 
-    this.isBuilt_ = true;
-
     this.root_ = this.win_.document.createElement('ol');
     this.root_.classList.add('i-amphtml-story-progress-bar');
 
     this.storeService_.subscribe(
       StateProperty.PAGE_IDS,
       pageIds => {
-        // Assumes the new page is the last page.
+        if (this.isBuilt_) {
+          this.clear_();
+        }
+
         pageIds.forEach(id => {
           if (!(id in this.segmentIdMap_)) {
             this.addSegment_(id);
           }
         });
+
+        if (this.isBuilt_) {
+          this.updateProgress(
+            this.activeSegmentId_,
+            this.activeSegmentProgress_,
+            true /** opt_updateAllSegments */
+          );
+        }
       },
       true /** callToInitialize */
     );
 
+    this.isBuilt_ = true;
     return this.getRoot();
   }
 
@@ -121,6 +134,15 @@ export class ProgressBar {
     segmentProgressValue.classList.add('i-amphtml-story-page-progress-value');
     segmentProgressBar.appendChild(segmentProgressValue);
     this.root_.appendChild(segmentProgressBar);
+  }
+
+  /**
+   * Clears the progress bar.
+   */
+  clear_() {
+    this.segmentIdMap_ = map();
+    this.root_.textContent = '';
+    this.segmentCount_ = 0;
   }
 
   /**
@@ -159,11 +181,12 @@ export class ProgressBar {
   /**
    * Updates a segment with its corresponding progress.
    *
-   * @param {string} segmentId the id of the segment whos progress to change
+   * @param {string} segmentId the id of the segment whos progress to change.
    * @param {number} progress A number from 0.0 to 1.0, representing the
    *     progress of the current segment.
+   * @param {boolean} opt_updateAllSegments Updates all of the segments.
    */
-  updateProgress(segmentId, progress) {
+  updateProgress(segmentId, progress, opt_updateAllSegments) {
     this.assertVaildSegmentId_(segmentId);
     const segmentIndex = this.segmentIdMap_[segmentId];
 
@@ -171,7 +194,7 @@ export class ProgressBar {
 
     // If updating progress for a new segment, update all the other progress
     // bar segments.
-    if (this.activeSegmentIndex_ !== segmentIndex) {
+    if (this.activeSegmentIndex_ !== segmentIndex || opt_updateAllSegments) {
       this.updateSegments_(
         segmentIndex,
         progress,
@@ -182,6 +205,7 @@ export class ProgressBar {
 
     this.activeSegmentProgress_ = progress;
     this.activeSegmentIndex_ = segmentIndex;
+    this.activeSegmentId_ = segmentId;
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -14,134 +14,140 @@
  * limitations under the License.
  */
 
+import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
+import {CommonSignals} from '../../../../src/common-signals';
 import {LiveStoryManager} from '../live-story-manager';
 import {Services} from '../../../../src/services';
 import {addAttributesToElement} from '../../../../src/dom';
 
-describes.realWin('LiveStoryManager', {amp: true}, env => {
-  let win;
-  let liveStoryManager;
-  let ampStory;
-  let storyEl;
+describes.realWin(
+  'LiveStoryManager',
+  {
+    amp: {
+      runtimeOn: true,
+      extensions: ['amp-story:1.0'],
+    },
+  },
+  env => {
+    let win;
+    let liveStoryManager;
+    let ampStory;
+    let storyEl;
 
-  /**
-   * @param {!Element} container
-   * @param {number} count
-   * @param {Array<string>=} opt_ids
-   * @return {!Array<!Element>}
-   */
-  function createPages(container, count, opt_ids) {
-    return Array(count)
-      .fill(undefined)
-      .map((unused, i) => {
-        const page = win.document.createElement('amp-story-page');
-        page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
-        const storyPage = new AmpStoryPage(page);
-        page.getImpl = () => Promise.resolve(storyPage);
-        sandbox.stub(storyPage, 'mutateElement').callsFake(fn => fn());
-        container.appendChild(page);
-        return page;
+    /**
+     * @param {!Element} container
+     * @param {number} count
+     * @param {Array<string>=} opt_ids
+     * @return {!Array<!Element>}
+     */
+    function createPages(container, count, opt_ids) {
+      return Array(count)
+        .fill(undefined)
+        .map((unused, i) => {
+          const page = win.document.createElement('amp-story-page');
+          page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
+          const storyPage = new AmpStoryPage(page);
+          page.getImpl = () => Promise.resolve(storyPage);
+          sandbox.stub(storyPage, 'mutateElement').callsFake(fn => fn());
+          container.appendChild(page);
+          return page;
+        });
+    }
+
+    beforeEach(() => {
+      win = env.win;
+      const viewer = Services.viewerForDoc(env.ampdoc);
+      sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+      sandbox.stub(win.history, 'replaceState');
+
+      storyEl = win.document.createElement('amp-story');
+      win.document.body.appendChild(storyEl);
+      addAttributesToElement(storyEl, {
+        'id': 'testStory',
+        'live-story': '',
       });
+
+      AmpStory.isBrowserSupported = () => true;
+
+      return storyEl.getImpl().then(impl => {
+        ampStory = impl;
+      });
+    });
+
+    afterEach(() => {
+      storyEl.remove();
+    });
+
+    it('should build a dynamic live-list', () => {
+      createPages(ampStory.element, 2, ['cover', 'page-1']);
+      liveStoryManager = new LiveStoryManager(ampStory);
+      liveStoryManager.build();
+
+      return ampStory
+        .layoutCallback()
+        .then(() => ampStory.element.signals().signal(CommonSignals.LOAD_END))
+        .then(() => {
+          const liveListEl = ampStory.element.querySelector('amp-live-list');
+          expect(liveListEl).to.exist;
+        });
+    });
+
+    it('live-list id should equal story id + dymanic-list combo', () => {
+      createPages(ampStory.element, 2, ['cover', 'page-1']);
+      liveStoryManager = new LiveStoryManager(ampStory);
+      liveStoryManager.build();
+
+      return ampStory
+        .layoutCallback()
+        .then(() => ampStory.element.signals().signal(CommonSignals.LOAD_END))
+        .then(() => {
+          const liveListEl = ampStory.element.querySelector('amp-live-list');
+          expect(liveListEl.id).to.equal(
+            'i-amphtml-' + ampStory.element.id + '-dynamic-list'
+          );
+        });
+    });
+
+    it('should throw if no story id is set', () => {
+      createPages(ampStory.element, 2, ['cover', 'page-1']);
+      liveStoryManager = new LiveStoryManager(ampStory);
+      ampStory.element.removeAttribute('id');
+
+      allowConsoleError(() => {
+        expect(() => {
+          liveStoryManager.build();
+        }).to.throw(
+          /amp-story must contain id to use the live story functionality/
+        );
+      });
+    });
+
+    it('should append new page from server to client in update', () => {
+      createPages(ampStory.element, 2, ['cover', 'page-1']);
+      expect(ampStory.element.children.length).to.equal(2);
+      liveStoryManager = new LiveStoryManager(ampStory);
+      liveStoryManager.build();
+
+      return ampStory
+        .layoutCallback()
+        .then(() => ampStory.element.signals().signal(CommonSignals.LOAD_END))
+        .then(() => {
+          const dispatchSpy = sandbox.spy(ampStory.storeService_, 'dispatch');
+
+          const newPage = win.document.createElement('amp-story-page');
+          // This would normally get added by AmpLiveList.
+          newPage.classList.add('amp-live-list-item-new');
+          newPage.id = 'newPage';
+          ampStory.element.appendChild(newPage);
+          liveStoryManager.update();
+          expect(dispatchSpy).to.have.been.calledWith(Action.SET_PAGE_IDS, [
+            'cover',
+            'page-1',
+            'newPage',
+          ]);
+        });
+    });
   }
-
-  beforeEach(() => {
-    win = env.win;
-    const viewer = Services.viewerForDoc(env.ampdoc);
-    sandbox.stub(Services, 'viewerForDoc').returns(viewer);
-    storyEl = win.document.createElement('amp-story');
-    addAttributesToElement(storyEl, {
-      'id': 'testStory',
-      'live-story': '',
-    });
-    ampStory = new AmpStory(storyEl);
-    liveStoryManager = new LiveStoryManager(ampStory);
-  });
-
-  it('should build a dynamic live-list', () => {
-    liveStoryManager.build();
-
-    const liveListEl = ampStory.element.querySelector('amp-live-list');
-    expect(liveListEl).to.exist;
-  });
-
-  it('live-list id should equal story id + dymanic-list combo', () => {
-    liveStoryManager.build();
-    const liveListEl = ampStory.element.querySelector('amp-live-list');
-
-    expect(liveListEl.id).to.equal(
-      'i-amphtml-' + ampStory.element.id + '-dynamic-list'
-    );
-  });
-
-  it('should throw if no story id is set', () => {
-    ampStory.element.removeAttribute('id');
-
-    allowConsoleError(() => {
-      expect(() => {
-        liveStoryManager.build();
-      }).to.throw(
-        /amp-story must contain id to use the live story functionality/
-      );
-    });
-  });
-
-  it('should append new page from server to client in update', () => {
-    const currentPages = createPages(ampStory.element, 2, ['cover', 'page-1']);
-    const pagesImplPromises = Array.prototype.map.call(currentPages, pageEl =>
-      pageEl.getImpl()
-    );
-    Promise.all(pagesImplPromises).then(pages => {
-      ampStory.pages_ = pages;
-    });
-    expect(ampStory.element.children.length).to.equal(2);
-
-    const fromServerStoryEl = win.document.createElement('amp-story');
-    const fromServerStory = new AmpStory(fromServerStoryEl);
-    const fromServerPages = createPages(fromServerStory.element, 3, [
-      'cover',
-      'page-1',
-      'page-2',
-    ]);
-    const fromServerLastPage = fromServerPages[fromServerPages.length - 1];
-    // This would normally get added by AmpLiveList.
-    fromServerLastPage.classList.add('amp-live-list-item-new');
-
-    liveStoryManager.build();
-    liveStoryManager.update(fromServerStory.element, currentPages);
-
-    expect(ampStory.element.children.length).to.equal(3);
-  });
-
-  it('should append new page at the end', () => {
-    const currentPages = createPages(ampStory.element, 2, ['cover', 'page-1']);
-    const pagesImplPromises = Array.prototype.map.call(currentPages, pageEl =>
-      pageEl.getImpl()
-    );
-    Promise.all(pagesImplPromises).then(pages => {
-      ampStory.pages_ = pages;
-    });
-    expect(ampStory.element.children.length).to.equal(2);
-
-    const fromServerStoryEl = win.document.createElement('amp-story');
-    const fromServerStory = new AmpStory(fromServerStoryEl);
-    const fromServerPages = createPages(fromServerStory.element, 3, [
-      'cover',
-      'page-2',
-      'page-1',
-    ]);
-    const fromServerNewPage = fromServerPages[fromServerPages.length - 1];
-    // This would normally get added by AmpLiveList.
-    fromServerNewPage.classList.add('amp-live-list-item-new');
-
-    liveStoryManager.build();
-    liveStoryManager.update(fromServerStory.element, currentPages);
-
-    const fromClientLastPage = ampStory.element.querySelector(
-      'amp-story-page:last-of-type'
-    );
-
-    expect(fromClientLastPage.id).to.equal(fromServerNewPage.id);
-  });
-});
+);


### PR DESCRIPTION
Part of  #21714

* Installs amp-live-list extension automatically.
* Updates pagination buttons in 3-panels view. Closes #22770.
* Updates distance attributes on new pages.
* Supports adding a new page in the middle of a story & updates progress bar accordingly.
* Stops trying to append the new pages on the LiveStoryManger and leaves that to the amp-live-list.
* Adds an example live story.