### PR TITLE
🚮 Stop caching visual diff node_modules on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,8 @@ jobs:
 cache:
   directories:
     - node_modules
+    - build-system/tasks/e2e/node_modules
+    - build-system/tasks/visual-diff/node_modules
     - sauce_connect
     - validator/node_modules
     - validator/nodejs/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,6 @@ jobs:
 cache:
   directories:
     - node_modules
-    - build-system/tasks/visual-diff/node_modules
     - sauce_connect
     - validator/node_modules
     - validator/nodejs/node_modules


### PR DESCRIPTION
Fixes this error seen on Travis visual diff jobs, similar to the e2e chromedriver error from earlier.

```
Error: Cannot find module 'puppeteer'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at installPercy_ (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/index.js:856:15)
    at visualDiff (/home/travis/build/ampproject/amphtml/build-system/tasks/visual-diff/index.js:767:3)
    at taskWrapper (/home/travis/build/ampproject/amphtml/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:402:14)
    at runBound (domain.js:415:12)
    at asyncRunner (/home/travis/build/ampproject/amphtml/node_modules/async-done/index.js:55:18)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```