### PR TITLE
🚮 Cleanup amp-date-picker feature flag

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,6 +1,5 @@
 {
   "allow-doc-opt-in": [
-    "amp-date-picker",
     "amp-img-auto-sizes",
     "amp-next-page",
     "disable-amp-story-desktop",
@@ -25,7 +24,6 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-consent-v2": 1,
-  "amp-date-picker": 1,
   "amp-force-prerender-visible-elements": 1,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,6 +1,5 @@
 {
   "allow-doc-opt-in": [
-    "amp-date-picker",
     "amp-img-auto-sizes",
     "amp-next-page",
     "disable-amp-story-desktop",
@@ -26,7 +25,6 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-auto-lightbox": 1,
   "amp-consent-v2": 1,
-  "amp-date-picker": 1,
   "amp-force-prerender-visible-elements": 1,
   "amp-ima-video": 1,
   "amp-img-auto-sizes": 1,

--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -5,7 +5,6 @@
   <title>AMP Date Picker Example</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta name="amp-experiments-opt-in" content="amp-date-picker">
   <style amp-custom>
   body {
     padding: 20px;

--- a/examples/travel-lb.amp.html
+++ b/examples/travel-lb.amp.html
@@ -5,7 +5,6 @@
   <title>Travel date picker example</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta name="amp-experiments-opt-in" content="amp-date-picker">
   <style amp-custom>
   amp-lightbox {
     background: rgba(0, 0, 0, .75);

--- a/examples/travel.amp.html
+++ b/examples/travel.amp.html
@@ -5,7 +5,6 @@
   <title>Travel date picker example</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta name="amp-experiments-opt-in" content="amp-date-picker">
   <style amp-custom>
   .DateRangePicker_picker {
     margin-top: -70px;


### PR DESCRIPTION
Cleans up the flag and some leftover doc-level optins from examples