### PR TITLE
🐛 Fix base path for `buildWebPushPublisherFile`

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -233,7 +233,7 @@ function buildWebPushPublisherFile(version, fileName, watch, options) {
   const minifiedName = fileName + '.js';
   return toPromise(
     gulp
-      .src(basePath + '/*.js', {base: '.'})
+      .src(basePath + '/*.js', {base: basePath})
       .pipe(file(builtName, js))
       .pipe(gulp.dest(tempBuildDir))
   )


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/22637#issuecomment-505197725
Fixes #22637