### PR TITLE
✨ Add MATCH macro

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -405,7 +405,17 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       });
 
       it('handles negative index', () => {
+        expectAsyncConsoleError(
+          /Third argument in MATCH macro must be a number >= 0/
+        );
         return check('$MATCH(thisisatest, thisisatest, -1)', 'thisisatest');
+      });
+
+      it('handles NaN index', () => {
+        expectAsyncConsoleError(
+          /Third argument in MATCH macro must be a number >= 0/
+        );
+        return check('$MATCH(thisisatest, thisisatest, test)', 'thisisatest');
       });
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -362,6 +362,52 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         'a1b2c3&123'
       );
     });
+
+    describe('$MATCH', () => {
+      it('handles default index', () => {
+        return check('$MATCH(thisisatest, thisisatest)', 'thisisatest');
+      });
+
+      it('matches full match', () => {
+        return check('$MATCH(thisisatest, thisisatest, 0)', 'thisisatest');
+      });
+
+      it('matches partial match', () => {
+        return check('$MATCH(thisisatest, test, 0)', 'test');
+      });
+
+      it('matches 1st group match', () => {
+        return check('$MATCH(thisisatest, `thisisa(test)`, 1)', 'test');
+      });
+
+      it('matches 2nd group match', () => {
+        return check('$MATCH(thisisatest, `this(is)a(test)`, 2)', 'test');
+      });
+
+      it('does not match non-matching group', () => {
+        return check('$MATCH(thisisatest, `thisisa(?:test)`, 1)', '');
+      });
+
+      it('handles escaped regex chars', () => {
+        return check('$MATCH(1, \\d, 0)', '1');
+      });
+
+      it('handles no full match', () => {
+        return check('$MATCH(invalid, thisisatest, 0)', '');
+      });
+
+      it('handles no group match', () => {
+        return check('$MATCH(thisisatest, `thisisa(\\d+)?test`, 1)', '');
+      });
+
+      it('handles large index', () => {
+        return check('$MATCH(thisisatest, thisisatest, 100)', '');
+      });
+
+      it('handles negative index', () => {
+        return check('$MATCH(thisisatest, thisisatest, -1)', 'thisisatest');
+      });
+    });
   });
 
   describe('getNameArgs:', () => {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -145,23 +145,24 @@ function replaceMacro(string, matchPattern, opt_newSubStr) {
  * Applies the match function to the given string with the given regex
  * @param {string} string input to be replaced
  * @param {string} matchPattern string representation of regex pattern
- * @param {string=} opt_indexStr the matching group to return. Index of 0
- *                  indicates the full match. Defaults to 0
- * @return {string} returns the matching group given by opt_indexStr
+ * @param {string=} opt_matchingGroupIndexStr the matching group to return.
+ *                  Index of 0 indicates the full match. Defaults to 0
+ * @return {string} returns the matching group given by opt_matchingGroupIndexStr
  */
-function matchMacro(string, matchPattern, opt_indexStr) {
+function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
   if (!matchPattern) {
     user().warn(TAG, 'MATCH macro must have two or more arguments');
   }
 
   let index = 0;
-  if (opt_indexStr) {
-    index = parseInt(opt_indexStr, 10);
-  }
+  if (opt_matchingGroupIndexStr) {
+    index = parseInt(opt_matchingGroupIndexStr, 10);
 
-  // if given a non-number or negative number
-  if (!index || index < 0) {
-    index = 0;
+    // if given a non-number or negative number
+    if ((index != 0 && !index) || index < 0) {
+      user().error(TAG, 'Third argument in MATCH macro must be a number >= 0');
+      index = 0;
+    }
   }
 
   const regex = new RegExp(matchPattern);

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -142,6 +142,34 @@ function replaceMacro(string, matchPattern, opt_newSubStr) {
 }
 
 /**
+ * Applies the match function to the given string with the given regex
+ * @param {string} string input to be replaced
+ * @param {string} matchPattern string representation of regex pattern
+ * @param {string=} opt_indexStr the matching group to return. Index of 0
+ *                  indicates the full match. Defaults to 0
+ * @return {string} returns the matching group given by opt_indexStr
+ */
+function matchMacro(string, matchPattern, opt_indexStr) {
+  if (!matchPattern) {
+    user().warn(TAG, 'MATCH macro must have two or more arguments');
+  }
+
+  let index = 0;
+  if (opt_indexStr) {
+    index = parseInt(opt_indexStr, 10);
+  }
+
+  // if given a non-number or negative number
+  if (!index || index < 0) {
+    index = 0;
+  }
+
+  const regex = new RegExp(matchPattern);
+  const matches = string.match(regex);
+  return matches && matches[index] ? matches[index] : '';
+}
+
+/**
  * Provides support for processing of advanced variable syntax like nested
  * expansions macros etc.
  */
@@ -171,6 +199,7 @@ export class VariableService {
       stringToBool(value) ? thenValue : elseValue
     );
     this.register_('$REPLACE', replaceMacro);
+    this.register_('$MATCH', matchMacro);
     this.register_(
       '$EQUALS',
       (firstValue, secValue) => firstValue === secValue


### PR DESCRIPTION
Add a $MATCH macro. https://github.com/ampproject/amphtml/issues/23017

`$MATCH(str, regex, opt_index)`

Applies the [match function
](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) to the given `str` with the given `regex`.

Returns the matching group declared by `opt_index`, where `opt_index=0` indicates the full match. Defaults to 0. If there is no match for the given index, empty string is returned

E.g.
`$MATCH(test.123, test\.(\d+), 0)`     ->     `test.123`
`$MATCH(test.123, test\.(\d+), 1)`     ->     `123`
`$MATCH(test.test, test\.(\d+), 1)`     ->     ``

cc @zhouyx @zikas 