### PR TITLE
correctly pingback multiple entitlements

### DIFF
--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
@@ -20,6 +20,7 @@ import {Services} from '../../../src/services';
 import {addParamToUrl, assertHttpsUrl} from '../../../src/url';
 import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {isArray} from '../../../src/types';
 
 /**
  * Implments the remotel local subscriptions platform which uses
@@ -80,6 +81,23 @@ export class LocalSubscriptionRemotePlatform extends LocalSubscriptionBasePlatfo
     return !!this.pingbackUrl_;
   }
 
+  /**
+   * Format data for pingback
+   * @param {./entitlement.Entitlement|Array<./entitlement.Entitlement>} entitlements
+   * @return {string}
+   * @private
+   */
+  stringifyPingbackData_(entitlements) {
+    if (isArray(entitlements)) {
+      const entitlementArray = [];
+      entitlements.forEach((ent) => {
+        entitlementArray.push(ent.jsonForPingback());
+      });
+      return JSON.stringify(entitlementArray);
+    }
+    return JSON.stringify(entitlements.jsonForPingback());
+  }
+
   /** @override */
   pingback(selectedEntitlement) {
     if (!this.isPingbackEnabled) {
@@ -102,7 +120,7 @@ export class LocalSubscriptionRemotePlatform extends LocalSubscriptionBasePlatfo
         headers: dict({
           'Content-Type': 'text/plain',
         }),
-        body: JSON.stringify(selectedEntitlement.jsonForPingback()),
+        body: this.stringifyPingbackData_(selectedEntitlement),
       });
     });
   }

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
@@ -90,7 +90,7 @@ export class LocalSubscriptionRemotePlatform extends LocalSubscriptionBasePlatfo
   stringifyPingbackData_(entitlements) {
     if (isArray(entitlements)) {
       const entitlementArray = [];
-      entitlements.forEach((ent) => {
+      entitlements.forEach(ent => {
         entitlementArray.push(ent.jsonForPingback());
       });
       return JSON.stringify(entitlementArray);

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -390,5 +390,19 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
         );
       });
     });
+    it('pingback should handle multiple entitlements ', () => {
+      const sendSignalStub = sandbox.stub(
+        localSubscriptionPlatform.xhr_,
+        'sendSignal'
+      );
+
+      return localSubscriptionPlatform.pingback([entitlement]).then(() => {
+        expect(sendSignalStub).to.be.calledOnce;
+        expect(sendSignalStub.getCall(0).args[0]).to.be.equal(pingbackUrl);
+        expect(sendSignalStub.getCall(0).args[1].body).to.equal(
+          JSON.stringify([entitlement.jsonForPingback()])
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes a bug where we were not correctly serializing multiple entitlements if `pingbackAllEntitlements` is set