### PR TITLE
🏗🐛 Silence `autoprefixer` deprecation warning by renaming `browsers` to `overrideBrowserslist`

### DIFF
--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -25,7 +25,7 @@ const postcssImport = require('postcss-import');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
 const cssprefixer = autoprefixer({
-  browsers: [
+  overrideBrowserslist: [
     'last 5 ChromeAndroid versions',
     'last 5 iOS versions',
     'last 3 FirefoxAndroid versions',


### PR DESCRIPTION
`autoprefixer` [added a warning](https://travis-ci.org/ampproject/amphtml/jobs/551960000#L323) for a potentially breaking change in its new version by renaming the `browsers` field. See #22652 and https://github.com/postcss/autoprefixer/issues/1226.

```
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.
  Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.
  If you really need to use option, rename it to overrideBrowserslist.
  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```

This PR renames `browsers` to `overrideBrowserslist` as recommended in the warning.
