### PR TITLE
Support element-scope services

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -42,6 +42,7 @@ import {hasOwn} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
+  registerServiceBuilderForElement,
 } from '../service';
 import {internalRuntimeVersion} from '../internal-version';
 import {tryResolve} from '../utils/promise';
@@ -1321,6 +1322,16 @@ export function extractClientIdFromGaCookie(gaCookie) {
 export function installUrlReplacementsServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(ampdoc, 'url-replace', function(doc) {
     return new UrlReplacements(doc, new GlobalVariableSource(doc));
+  });
+}
+
+/**
+ * @param {!Element} element
+ * @param {!VariableSource} varSource
+ */
+export function installUrlReplacementsServiceForElement(element, varSource) {
+  registerServiceBuilderForElement(element, 'url-replace', function(doc) {
+    return new UrlReplacements(doc, varSource);
   });
 }
 

--- a/src/services.js
+++ b/src/services.js
@@ -636,7 +636,8 @@ export class Services {
   static urlReplacementsForDoc(element) {
     return /** @type {!./service/url-replacements-impl.UrlReplacements} */ (getExistingServiceForDocInEmbedScope(
       element,
-      'url-replace'
+      'url-replace',
+      /* opt_searchElementPath */ true
     ));
   }
 

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -233,6 +233,7 @@ describe('service', () => {
     let ampdoc;
     let ampdocMock;
     let node;
+    let doc;
     let count;
     let factory;
 
@@ -260,7 +261,12 @@ describe('service', () => {
       registerServiceBuilder(windowApi, 'ampdoc', function() {
         return ampdocServiceApi;
       });
-      node = {nodeType: 1, ownerDocument: {defaultView: windowApi}};
+      doc = {};
+      node = {
+        nodeType: 1,
+        ownerDocument: {defaultView: windowApi},
+        parentElement: doc,
+      };
       resetServiceForTesting(windowApi, 'a');
       resetServiceForTesting(windowApi, 'b');
       resetServiceForTesting(windowApi, 'c');
@@ -509,7 +515,11 @@ describe('service', () => {
           frameElement: {ownerDocument: {defaultView: windowApi}},
         };
         childWin.document.defaultView = childWin;
-        childWinNode = {nodeType: 1, ownerDocument: childWin.document};
+        childWinNode = {
+          nodeType: 1,
+          ownerDocument: {defaultView: childWin},
+          parentElement: node,
+        };
         setParentWindow(childWin, windowApi);
 
         // A grandchild.
@@ -521,6 +531,7 @@ describe('service', () => {
           nodeType: 1,
           ownerDocument: grandchildWin.document,
           frameElement: {ownerDocument: {defaultView: childWin}},
+          parentElement: childWinNode,
         };
         setParentWindow(grandchildWin, childWin);
 


### PR DESCRIPTION
Allow AMP elements to override services for its descendants. Also:

- Begins decoupling of "service holder" from "AmpDoc" or window.
- Audited for collision of `holder.services` in AmpElement and found none.

### Alternatives

- Modifying `UrlReplacements` directly, but it doesn't work since `expand...()` APIs don't have element context.
- Making `amp-script` an `AmpDoc`, but it seems too heavyweight.

### Use case

The specific use case is to have stricter URL replacements for amp-script's children. E.g. require whitelisting of variables used in the DOM subtree:

```html
<!-- CLIENT_ID is only allowed for URLs to foo.com domain. -->
<amp-script allow-variables="CLIENT_ID foo.com; HTML_ATTR bar.com;">
</amp-script>
```