### PR TITLE
🐛 Make sure `rrule` code is included in `amp-date-picker`

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -232,6 +232,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       'third_party/inputmask/**/*.js',
       'node_modules/dompurify/dist/purify.es.js',
       'node_modules/promise-pjs/promise.js',
+      'node_modules/rrule/**/*.js',
       'node_modules/set-dom/src/**/*.js',
       'node_modules/web-animations-js/web-animations.install.js',
       'node_modules/web-activities/activity-ports.js',

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -25,7 +25,7 @@ const postcssImport = require('postcss-import');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
 const cssprefixer = autoprefixer({
-  browsers: [
+  overrideBrowserslist: [
     'last 5 ChromeAndroid versions',
     'last 5 iOS versions',
     'last 3 FirefoxAndroid versions',

--- a/extensions/amp-date-picker/0.1/dates-list.js
+++ b/extensions/amp-date-picker/0.1/dates-list.js
@@ -146,7 +146,7 @@ export class DatesList {
  * Date.prototype.getUTC* methods must be used to create a new date object.
  * {@link https://github.com/jakubroztocil/rrule#important-use-utc-dates}
  * @param {!Date} rruleDate
- * @return {!DateType}
+ * @return {!Date}
  */
 function normalizeRruleReturn(rruleDate) {
   const year = rruleDate.getUTCFullYear();

--- a/extensions/amp-date-picker/0.1/dates-list.js
+++ b/extensions/amp-date-picker/0.1/dates-list.js
@@ -15,7 +15,7 @@
  */
 
 import {requireExternal} from '../../../src/module';
-import {rrulestr} from 'rrule';
+import {rrulestr} from 'rrule/dist/esm/src/index.js';
 
 /** @enum {string} */
 const DateType = {
@@ -139,7 +139,6 @@ export class DatesList {
  * Tries to parse a string into an RRULE object.
  * @param {string} str A string which represents a repeating date RRULE spec.
  * @return {?JsonObject}
- * @suppress {missingProperties} // Remove after https://github.com/google/closure-compiler/issues/3041 is fixed
  */
 function tryParseRrulestr(str) {
   try {

--- a/extensions/amp-date-picker/0.1/test/test-dates-list.js
+++ b/extensions/amp-date-picker/0.1/test/test-dates-list.js
@@ -21,7 +21,8 @@ import {requireExternal} from '../../../../src/module';
 describes.sandboxed('DatesList', {}, () => {
   const moment = requireExternal('moment');
 
-  it('should accept date strings and RRULE strings', () => {
+  // TODO(cvializ): This test fails with the latest version of rrule. Fix it.
+  it.skip('should accept date strings and RRULE strings', () => {
     const containedDate = '09/04/1998';
     const notContainedDate = '09/03/1998';
     const containedRrule =

--- a/extensions/amp-date-picker/0.1/test/test-dates-list.js
+++ b/extensions/amp-date-picker/0.1/test/test-dates-list.js
@@ -21,12 +21,12 @@ import {requireExternal} from '../../../../src/module';
 describes.sandboxed('DatesList', {}, () => {
   const moment = requireExternal('moment');
 
-  // TODO(cvializ): This test fails with the latest version of rrule. Fix it.
-  it.skip('should accept date strings and RRULE strings', () => {
+  it('should accept date strings and RRULE strings', function() {
+    this.timeout(3000);
     const containedDate = '09/04/1998';
     const notContainedDate = '09/03/1998';
     const containedRrule =
-      'FREQ=WEEKLY;DTSTART=20180101T000000Z;WKST=SU;BYDAY=TU,SA';
+      'FREQ=WEEKLY;COUNT=10;DTSTART=20180101T000000Z;WKST=SU;BYDAY=TU,SA';
     const matchesRrule = '01/02/2018';
     const datesList = new DatesList([containedDate, containedRrule]);
 
@@ -67,7 +67,7 @@ describes.sandboxed('DatesList', {}, () => {
     const dateBefore = '01/01/1998';
     // const notContainedDate = '09/03/1998';
     const containedRrule =
-      'FREQ=WEEKLY;DTSTART=20180101T000000Z;WKST=SU;BYDAY=TU,SA';
+      'FREQ=WEEKLY;COUNT=10;DTSTART=20180101T000000Z;WKST=SU;BYDAY=TU,SA';
     // const matchesRrule = '01/02/2018';
     const datesList = new DatesList([containedDate, containedRrule]);
 


### PR DESCRIPTION
In #22946, we switched `rrule` from a copy in `third_party` to an installed module. However, we neglected to add an entry for the module in the directories included in the runtime.

This PR fixes things so that the `rrule` code is included in `dist/v0/amp-date-picker-0.1.js`.

~It will likely have to be cherry-picked to canary before next week's prod push.~ **Edit:** None of the currently released versions are affected by this issue. This fix will make it into the next canary and prod releases. 
