### PR TITLE
Update adsense example AMPHTML doc to make example snippet responsive and update supported tags

### DIFF
--- a/ads/google/adsense.md
+++ b/ads/google/adsense.md
@@ -19,11 +19,14 @@ limitations under the License.
 ## Example
 
 ```html
-<amp-ad width=300 height=250
+<amp-ad width="100vw" height=320
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912">
- </amp-ad>
+      data-ad-slot="7046626912"
+      data-auto-format="rspv"
+      data-full-width>
+    <div overflow></div>
+</amp-ad>
 ```
 
 ## Configuration
@@ -32,9 +35,16 @@ For semantics of configuration, please see [ad network documentation](https://su
 
 Supported parameters:
 
+- data-ad-channel
 - data-ad-client
 - data-ad-slot
 - data-ad-host
 - data-adtest
+- data-auto-format
+- data-full-width
 - data-tag-origin
 - data-language
+- data-matched-content-ui-type
+- data-matched-content-rows-num
+- data-matched-content-columns-num
+- data-npa-on-unknown-consent


### PR DESCRIPTION
Update adsense example AMPHTML doc to make example snippet responsive and update supported tags.

Responsive is the preferred format for using the AdSense tag.