### PR TITLE
Allowing the position attribute on amp-story-grid-layer.

### DIFF
--- a/extensions/amp-story/1.0/test/validator-amp-story-templates.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-templates.html
@@ -1,0 +1,50 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the AMP Story grid layer templates.
+-->
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+    <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
+    <title>Landscape story</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="canonical" href="index.html">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+
+  <body>
+    <amp-story
+        standalone
+        publisher="The AMP team"
+        publisher-logo-src="./img/AMP-Brand-White-Icon.svg"
+        poster-portrait-src="./img/overview.jpg"
+        title="Landscape story"
+        supports-landscape>
+      <amp-story-page id="cover">
+        <amp-story-grid-layer template="fill" position="landscape-half-left">
+          <amp-img layout="fill" src="./img/example.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical" position="landscape-half-right">
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet massa felis. Integer consequat accumsan velit, in condimentum quam sodales eu. Aliquam ac elit malesuada, iaculis massa egestas, malesuada dui. Suspendisse molestie ultricies mauris, vel tincidunt libero dignissim vel. Vivamus lacinia elit sit amet risus sagittis, sit amet imperdiet leo congue. Quisque finibus at est non commodo. Pellentesque ullamcorper feugiat metus sed ultrices. Vestibulum iaculis egestas ultricies.</p>
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-templates.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-templates.out
@@ -1,0 +1,51 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the AMP Story grid layer templates.
+|  -->
+|  <!doctype html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|      <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+|      <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+|      <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+|      <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
+|      <title>Landscape story</title>
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link rel="canonical" href="index.html">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    </head>
+|
+|    <body>
+|      <amp-story
+|          standalone
+|          publisher="The AMP team"
+|          publisher-logo-src="./img/AMP-Brand-White-Icon.svg"
+|          poster-portrait-src="./img/overview.jpg"
+|          title="Landscape story"
+|          supports-landscape>
+|        <amp-story-page id="cover">
+|          <amp-story-grid-layer template="fill" position="landscape-half-left">
+|            <amp-img layout="fill" src="./img/example.jpg"></amp-img>
+|          </amp-story-grid-layer>
+|          <amp-story-grid-layer template="vertical" position="landscape-half-right">
+|            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet massa felis. Integer consequat accumsan velit, in condimentum quam sodales eu. Aliquam ac elit malesuada, iaculis massa egestas, malesuada dui. Suspendisse molestie ultricies mauris, vel tincidunt libero dignissim vel. Vivamus lacinia elit sit amet risus sagittis, sit amet imperdiet leo congue. Quisque finibus at est non commodo. Pellentesque ullamcorper feugiat metus sed ultrices. Vestibulum iaculis egestas ultricies.</p>
+|          </amp-story-grid-layer>
+|        </amp-story-page>
+|      </amp-story>
+|    </body>
+|  </html>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -146,6 +146,11 @@ tags: {  # <amp-story-grid-layer>
     value: "thirds"
     value: "vertical"
   }
+  attrs: {
+    name: "position"
+    value: "landscape-half-left"
+    value: "landscape-half-right"
+  }
   descendant_tag_list: "amp-story-grid-layer-allowed-descendants"
   reference_points: {
     tag_spec_name: "AMP-STORY-GRID-LAYER default"


### PR DESCRIPTION
Allowing the `position` attribute on `amp-story-grid-layer` so publishers can use [this feature](https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/1.0/amp-story-templates.css#L17-L37).

![image](https://user-images.githubusercontent.com/1492044/60457026-f70ce680-9c08-11e9-9ed6-9a4e43f72930.png)
