### PR TITLE
Update amp-twitter validation for moments and timelines

### DIFF
--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
@@ -81,7 +81,7 @@
       layout="responsive">
   </amp-twitter>
 
-  <h2>Non-number momentid</h2>  
+  <h2>Non-number momentid</h2>
   <amp-twitter width=486 height=1312
       layout="responsive"
       data-momentid="https://twitter.com/i/moments/1009149991452135424">
@@ -94,11 +94,50 @@
       data-cards="hidden">
   </amp-twitter>
 
-  <h2>Using limit with tweetid</h2>  
+  <h2>Using limit</h2>
+  <h3>with tweetid</h3>
   <amp-twitter width=486 height=1312
       layout="responsive"
       data-tweetid="585110598171631616"
       data-limit="42">
   </amp-twitter>
+  <h3>with moment</h3>
+  <amp-twitter width=886 height=256
+      layout="responsive"
+      data-momentid="650667182356082688"
+      data-limit="3">
+  </amp-twitter>
+
+  <h2>Timelines</h2>
+  <h3>with data-theme</h3>
+  <amp-twitter width="1" height="5"
+    layout="responsive"
+    data-timeline-source-type="profile"
+    data-timeline-user-id="143531181"
+    data-theme="dark">
+  </amp-twitter>
+
+  <h3>with data-link-color</h3>
+  <amp-twitter width="1" height="5"
+    layout="responsive"
+    data-timeline-source-type="profile"
+    data-timeline-user-id="143531181"
+    data-link-color="#55acee">
+  </amp-twitter>
+
+  <h2>Moments</h2>
+  <h3>with data-theme</h3>
+  <amp-twitter width=886 height=256
+    layout="responsive"
+    data-momentid="650667182356082688"
+    data-theme="dark">
+  </amp-twitter>
+  <h3>with data-link-color</h3>
+  <amp-twitter width=886 height=256
+    layout="responsive"
+    data-momentid="650667182356082688"
+    data-link-color="#55acee">
+  </amp-twitter>
+
 </body>
 </html>

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
@@ -84,7 +84,7 @@ amp-twitter/0.1/test/validator-amp-twitter.html:80:2 The tag 'amp-twitter' is mi
 |        layout="responsive">
 |    </amp-twitter>
 |
-|    <h2>Non-number momentid</h2>  
+|    <h2>Non-number momentid</h2>
 |    <amp-twitter width=486 height=1312
 >>   ^~~~~~~~~
 amp-twitter/0.1/test/validator-amp-twitter.html:85:2 The attribute 'data-momentid' in tag 'amp-twitter' is set to the invalid value 'https://twitter.com/i/moments/1009149991452135424'. (see https://amp.dev/documentation/components/amp-twitter) [DISALLOWED_HTML]
@@ -101,13 +101,52 @@ amp-twitter/0.1/test/validator-amp-twitter.html:91:2 The attribute 'data-tweetid
 |        data-cards="hidden">
 |    </amp-twitter>
 |
-|    <h2>Using limit with tweetid</h2>  
+|    <h2>Using limit</h2>
+|    <h3>with tweetid</h3>
 |    <amp-twitter width=486 height=1312
 >>   ^~~~~~~~~
-amp-twitter/0.1/test/validator-amp-twitter.html:98:2 The attribute 'data-momentid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-limit'. (see https://amp.dev/documentation/components/amp-twitter) [DISALLOWED_HTML]
+amp-twitter/0.1/test/validator-amp-twitter.html:99:2 The attribute 'data-momentid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-limit'. (see https://amp.dev/documentation/components/amp-twitter) [DISALLOWED_HTML]
 |        layout="responsive"
 |        data-tweetid="585110598171631616"
 |        data-limit="42">
 |    </amp-twitter>
+|    <h3>with moment</h3>
+|    <amp-twitter width=886 height=256
+|        layout="responsive"
+|        data-momentid="650667182356082688"
+|        data-limit="3">
+|    </amp-twitter>
+|
+|    <h2>Timelines</h2>
+|    <h3>with data-theme</h3>
+|    <amp-twitter width="1" height="5"
+|      layout="responsive"
+|      data-timeline-source-type="profile"
+|      data-timeline-user-id="143531181"
+|      data-theme="dark">
+|    </amp-twitter>
+|
+|    <h3>with data-link-color</h3>
+|    <amp-twitter width="1" height="5"
+|      layout="responsive"
+|      data-timeline-source-type="profile"
+|      data-timeline-user-id="143531181"
+|      data-link-color="#55acee">
+|    </amp-twitter>
+|
+|    <h2>Moments</h2>
+|    <h3>with data-theme</h3>
+|    <amp-twitter width=886 height=256
+|      layout="responsive"
+|      data-momentid="650667182356082688"
+|      data-theme="dark">
+|    </amp-twitter>
+|    <h3>with data-link-color</h3>
+|    <amp-twitter width=886 height=256
+|      layout="responsive"
+|      data-momentid="650667182356082688"
+|      data-link-color="#55acee">
+|    </amp-twitter>
+|
 |  </body>
 |  </html>

--- a/extensions/amp-twitter/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/validator-amp-twitter.protoascii
@@ -49,21 +49,9 @@ tags: {  # <amp-twitter>
     }
   }
   attrs: {
-    name: "data-link-color"
-    trigger: {
-      also_requires_attr: "data-tweetid"
-    }
-  }
-  attrs: {
     name: "data-momentid"
     mandatory_oneof: "['data-momentid', 'data-timeline-source-type', 'data-tweetid']"
     value_regex: "\\d+"
-  }
-  attrs: {
-    name: "data-theme"
-    trigger: {
-      also_requires_attr: "data-tweetid"
-    }
   }
   attrs: {
     name: "data-timeline-id"

--- a/test/manual/amp-twitter.amp.html
+++ b/test/manual/amp-twitter.amp.html
@@ -23,11 +23,30 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <h1>Tweet with super wide aspect ratio</h1>
+  <h1>Tweets</h1>
+  <h2>Tweet with super wide aspect ratio</h2>
   <amp-twitter width=886 height=256
       layout="responsive"
       data-tweetID="585110598171631616"
       data-cards="hidden">
+  </amp-twitter>
+
+  <h2>Twitter timeline</h2>
+  <amp-twitter width="1"
+             height="5"
+             layout="responsive"
+             data-timeline-source-type="profile"
+             data-timeline-user-id="15534471"
+             data-link-color="#55acee"
+             data-tweet-limit="3"
+             data-chrome="noheader, nofooter, noscrollbar">
+  </amp-twitter>
+
+  <h2>Twitter Moment</h2>
+  <amp-twitter width=886 height=256
+      layout="responsive"
+      data-momentid="650667182356082688"
+      data-limit="3">
   </amp-twitter>
 </body>
 </html>


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/20340. 

The attributes `theme` and `link-color` are applicable to Tweets, Moments and Timelines. Since we already validate that one of `data-momentid`, `data-timeline-source-type`, or `data-tweetid` must be present, there is no need to additionally validate these since we pass on all `data-` attributes. 
