### PR TITLE
📖  Documentation for requestOrigin

### DIFF
--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -291,6 +291,39 @@ In this example, all requests are valid.
 
 Some analytics providers have an already-provided configuration, which you use via the `type` attribute. If you are using an analytics provider, you may not need to include requests information. See your vendor documentation to find out if requests need to be configured, and how.
 
+##### Request Origin
+The top-level `requestOrigin` property accepts an absolute URL and defines the origin for requests. If `requestOrigin` is declared, the origin will be extracted from the value and it will be prepended to every outgoing request. `requestOrigin` will not be encoded and also accepts variables.
+
+```javascript
+"requestOrigin": "https://example.com",
+"requests": {
+  "base": "/analytics?a=${account}",
+  "pageview": {
+    "baseUrl": "${base}&type=pageview"
+  },
+  "event": {
+    "baseUrl": "${base}&type=event",
+  }
+}
+```
+
+In this example, outgoing requests will be `https://example.com/analytics?a=${account}&type=pageview` for `pageview` requests and `https://example.com/analytics?a=${account}&type=event` for `event` requests.
+
+Request objects can also have an `origin` property that will override this top-level `requestOrigin` property.
+
+```javascript
+"requestOrigin": "https://example.com",
+"requests": {
+  "pageview": {
+    "origin": 'https://newexample.com',
+    "baseUrl": "/analytics?type=pageview"
+  },
+}
+```
+
+In this example, the outgoing request will be `https://newexample.com/analytics?type=pageview` for the `pageview` request.
+
+
 ##### Batching configs
 To reduce the number of request pings, you can specify batching behaviors in the request configuration. Any [`extraUrlParams`](#extra-url-params) from `triggers` that use the same request are appended to the `baseUrl` of the request.
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -272,6 +272,7 @@ The `requests` configuration object specifies the URLs used to transmit data to 
 The properties for defining a request with an object are:
  - `baseUrl`: Defines the url of the request (required).
  - `reportWindow`: An optional property to specify the time (in seconds) to stop reporting requests. The trigger with `important: true` overrides the maximum report window constraint.
+ - [`origin`](#request-origin): An optional property to specify the origin for requests
 
 In this example, all requests are valid.
 
@@ -292,10 +293,10 @@ In this example, all requests are valid.
 Some analytics providers have an already-provided configuration, which you use via the `type` attribute. If you are using an analytics provider, you may not need to include requests information. See your vendor documentation to find out if requests need to be configured, and how.
 
 ##### Request Origin
-The top-level `requestOrigin` property accepts an absolute URL and defines the origin for requests. If `requestOrigin` is declared, the origin will be extracted from the value and it will be prepended to every outgoing request. `requestOrigin` will not be encoded and also accepts variables.
+The top-level `requestOrigin` property accepts an absolute URL and defines the origin for requests. If `requestOrigin` is declared, the origin will be extracted from the value and it will be prepended to `baseUrl`. `requestOrigin` accepts and supports variables substitution. Variables will **not** be encoded in `requestOrigin`.
 
 ```javascript
-"requestOrigin": "https://example.com",
+"requestOrigin": "${example}/ignore_query",
 "requests": {
   "base": "/analytics?a=${account}",
   "pageview": {
@@ -304,10 +305,13 @@ The top-level `requestOrigin` property accepts an absolute URL and defines the o
   "event": {
     "baseUrl": "${base}&type=event",
   }
+},
+"vars": {
+  "example": "https://example.com"
 }
 ```
 
-In this example, outgoing requests will be `https://example.com/analytics?a=${account}&type=pageview` for `pageview` requests and `https://example.com/analytics?a=${account}&type=event` for `event` requests.
+In this example, outgoing requests will be `https://example.com/analytics?a=${account}&type=pageview` for `pageview` requests and `https://example.com/analytics?a=${account}&type=event` for `event` requests. Notice that the `requestOrigin` value is not encoded and that only the origin is added to `baseUrl`.
 
 Request objects can also have an `origin` property that will override this top-level `requestOrigin` property.
 


### PR DESCRIPTION
Add documentation for the `requestOrigin` field in `amp-analyitcs` config. Implemented here https://github.com/ampproject/amphtml/pull/22454

cc @zhouyx 