### PR TITLE
Fix a11y on amp-pinterest

### DIFF
--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {Util} from './util';
 import {assertAbsoluteHttpOrHttpsUrl, assertHttpsUrl} from '../../../src/url';
 import {openWindowDialog} from '../../../src/dom';
 import {toWin} from '../../../src/types';
-
 import {user, userAssert} from '../../../src/log';
 
 // Popup options
@@ -48,6 +48,15 @@ export class PinWidget {
     this.layout = '';
   }
 
+  /**
+   * Handle keypress if Enter or Space for accessibility.
+   * @param {Event} event
+   */
+  handleKeyDown(event) {
+    if (event.key == Keys.ENTER || event.key == Keys.SPACE) {
+      this.handleClick(event);
+    }
+  }
   /**
    * Override the default href click handling to log and open popup
    * @param {Event} event
@@ -150,6 +159,9 @@ export class PinWidget {
           '/repin/x/?amp=1&guid=' +
           Util.guid,
         'textContent': 'Save',
+        'role': 'button',
+        'aria-label': 'Repin this image: ' + this.alt,
+        'tabindex': '0',
       },
     });
     container.appendChild(repin);
@@ -188,6 +200,7 @@ export class PinWidget {
           'img': {
             'className': '-amp-pinterest-embed-pin-text-icon-attrib',
             'src': pin['attribution']['provider_icon_url'],
+            'alt': 'Pinterest image attribution icon',
           },
         })
       );
@@ -293,6 +306,8 @@ export class PinWidget {
 
     // listen for clicks
     structure.addEventListener('click', this.handleClick.bind(this));
+    // Handle Space and Enter while selected for a11y
+    structure.addEventListener('keydown', this.handleKeyDown.bind(this));
 
     // done
     return structure;

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -200,7 +200,7 @@ export class PinWidget {
           'img': {
             'className': '-amp-pinterest-embed-pin-text-icon-attrib',
             'src': pin['attribution']['provider_icon_url'],
-            'alt': 'from ' + ['attribution']['provider_name'],
+            'alt': 'from ' + pin['attribution']['provider_name'],
           },
         })
       );
@@ -307,7 +307,7 @@ export class PinWidget {
     // listen for clicks
     structure.addEventListener('click', this.handleClick.bind(this));
     // Handle Space and Enter while selected for a11y
-    structure.addEventListener('keydown', this.handleKeyDown.bind(this));
+    structure.addEventListener('keypress', this.handleKeyDown.bind(this));
 
     // done
     return structure;

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -200,7 +200,7 @@ export class PinWidget {
           'img': {
             'className': '-amp-pinterest-embed-pin-text-icon-attrib',
             'src': pin['attribution']['provider_icon_url'],
-            'alt': 'Pinterest image attribution icon',
+            'alt': 'from ' + ['attribution']['provider_name'],
           },
         })
       );

--- a/test/manual/amp-pinterest.amp.html
+++ b/test/manual/amp-pinterest.amp.html
@@ -1,14 +1,14 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Pinterest examples</title>
   <link rel="canonical" href="amps.html" >
-  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=5,minimal-ui">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script custom-element="amp-pinterest" src="../dist/v0/amp-pinterest-0.1.js" async></script>
+  <script custom-element="amp-pinterest" src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js" async></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="../dist/amp.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/19281. 

The more severe problem here is the untabbable and unclickable `Save` button that's a `<span>` in `pin-widget.js`. Addressed that by adding a `tabindex`, `aria-label`, and a `onKeyDown` handler that triggers the click handler if `SPACE` or `ENTER` while selected. 

Ran lighthouse a few times and added aria labels and such--we should probably do this more systematically with our components. 