### PR TITLE
🏗🚮 Remove all single-pass sourcemaps (redux)

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -133,10 +133,12 @@ function declareExtensionVersionAlias(name, version, latestVersion, options) {
     'name': name,
     'file': name + '-' + latestVersion + '.js',
   };
-  extensionAliasFilePath[name + '-' + version + '.js.map'] = {
-    'name': name,
-    'file': name + '-' + latestVersion + '.js.map',
-  };
+  if (!argv.single_pass) {
+    extensionAliasFilePath[name + '-' + version + '.js.map'] = {
+      'name': name,
+      'file': name + '-' + latestVersion + '.js.map',
+    };
+  }
   if (options.hasCss) {
     extensionAliasFilePath[name + '-' + version + '.css'] = {
       'name': name,


### PR DESCRIPTION
This PR implements #23132 in a cleaner way.
