### PR TITLE
Add facebook social share without appid

### DIFF
--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -66,9 +66,13 @@
       <amp-social-share type="facebook"
                         data-param-text="Hello world"
                         data-param-href="https://example.com/?ref=URL"
-                        data-param-app_id="145634995501895"
                         aria-label="Share to Facebook">
       </amp-social-share>
+      <amp-social-share type="facebook-url"
+                        data-param-u="https://www.google.com"
+                        aria-label="Share to Facebook">
+      </amp-social-share>
+
       <amp-social-share type="twitter"
                         aria-label="Share to Twitter">
       </amp-social-share>

--- a/extensions/amp-social-share/0.1/amp-social-share-config.js
+++ b/extensions/amp-social-share/0.1/amp-social-share-config.js
@@ -42,6 +42,12 @@ const BUILTINS = dict({
       'href': 'CANONICAL_URL',
     },
   },
+  'facebook-url': {
+    'shareEndpoint': 'https://www.facebook.com/sharer.php',
+    'defaultParams': {
+      'u': 'CANONICAL_URL',
+    },
+  },
   'pinterest': {
     'shareEndpoint': 'https://www.pinterest.com/pin/create/button/',
     'defaultParams': {

--- a/extensions/amp-social-share/0.1/amp-social-share.css
+++ b/extensions/amp-social-share/0.1/amp-social-share.css
@@ -41,6 +41,11 @@ amp-social-share {
   background-color: #32529f;
 }
 
+/* Facebook Styling */
+.amp-social-share-facebook-url {
+  background-color: #32529f;
+}
+
 /* Pinterest Styling */
 .amp-social-share-pinterest {
   background-color: #e60023;

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -138,6 +138,15 @@ The `amp-social-share` component provides [some pre-configured providers](0.1/am
     </td>
   </tr>
   <tr>
+    <td>Facebook (URL Sharing)</td>
+    <td><code>facebook-url</code></td>
+    <td>
+      <ul>
+       <li><code>data-param-u</code>: <strong>required</strong>, defaults to: current url. This parameter should be the url to be sent to Facebook for sharing.</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
     <td>LinkedIn</td>
     <td><code>linkedin</code></td>
     <td>

--- a/third_party/optimized-svg-icons/amp-social-share-svgs.css
+++ b/third_party/optimized-svg-icons/amp-social-share-svgs.css
@@ -4,7 +4,7 @@
  * See https://github.com/ampproject/amphtml/issues/4277 for more details.
  */
 
-.amp-social-share-facebook {
+.amp-social-share-facebook, .amp-social-share-facebook-url {
   background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22%23ffffff%22%20d%3D%22M211.9%20197.4h-36.7v59.9h36.7V433.1h70.5V256.5h49.2l5.2-59.1h-54.4c0%200%200-22.1%200-33.7%200-13.9%202.8-19.5%2016.3-19.5%2010.9%200%2038.2%200%2038.2%200V82.9c0%200-40.2%200-48.8%200%20-52.5%200-76.1%2023.1-76.1%2067.3C211.9%20188.8%20211.9%20197.4%20211.9%20197.4z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E');
 }
 


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/22041. A relatively straightforward addition of a new share endpoint for facebook sharing. Maybe we can bikeshed a bit on the naming? 