### PR TITLE
♻️🐛 Refactors `getViewerInterceptResponse` and improves tests

### DIFF
--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -202,11 +202,11 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
 
   const viewer = Services.viewerForDoc(ampdocSingle);
   const whenFirstVisible = viewer.whenFirstVisible();
-  const isProxy = isProxyOrigin(input);
-  const canIntercept = viewer.hasCapability('xhrInterceptor');
-  const bypassInterceptorForLocalDev = init.bypassInterceptorForDev && getMode(win).localDev;
+  const urlIsProxy = isProxyOrigin(input);
+  const viewerCanIntercept = viewer.hasCapability('xhrInterceptor');
+  const interceptorDisabledForLocalDev = init.bypassInterceptorForDev && getMode(win).localDev;
 
-  if (isProxy || !canIntercept || bypassInterceptorForLocalDev) {
+  if (urlIsProxy || !viewerCanIntercept || interceptorDisabledForLocalDev) {
     return whenFirstVisible;
   }
   const htmlElement = ampdocSingle.getRootNode().documentElement;

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -199,13 +199,14 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   if (!ampdocSingle) {
     return Promise.resolve();
   }
+
   const viewer = Services.viewerForDoc(ampdocSingle);
   const whenFirstVisible = viewer.whenFirstVisible();
-  if (
-    isProxyOrigin(input) ||
-    !viewer.hasCapability('xhrInterceptor') ||
-    (init.bypassInterceptorForDev && getMode(win).localDev)
-  ) {
+  const isProxy = isProxyOrigin(input);
+  const canIntercept = viewer.hasCapability('xhrInterceptor');
+  const bypassInterceptorForLocalDev = init.bypassInterceptorForDev && getMode(win).localDev;
+
+  if (isProxy || !canIntercept || bypassInterceptorForLocalDev) {
     return whenFirstVisible;
   }
   const htmlElement = ampdocSingle.getRootNode().documentElement;

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -204,7 +204,8 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   const whenFirstVisible = viewer.whenFirstVisible();
   const urlIsProxy = isProxyOrigin(input);
   const viewerCanIntercept = viewer.hasCapability('xhrInterceptor');
-  const interceptorDisabledForLocalDev = init.bypassInterceptorForDev && getMode(win).localDev;
+  const interceptorDisabledForLocalDev =
+    init.bypassInterceptorForDev && getMode(win).localDev;
   if (urlIsProxy || !viewerCanIntercept || interceptorDisabledForLocalDev) {
     return whenFirstVisible;
   }

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -205,15 +205,16 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   const urlIsProxy = isProxyOrigin(input);
   const viewerCanIntercept = viewer.hasCapability('xhrInterceptor');
   const interceptorDisabledForLocalDev = init.bypassInterceptorForDev && getMode(win).localDev;
-
   if (urlIsProxy || !viewerCanIntercept || interceptorDisabledForLocalDev) {
     return whenFirstVisible;
   }
+
   const htmlElement = ampdocSingle.getRootNode().documentElement;
   const docOptedIn = htmlElement.hasAttribute('allow-xhr-interception');
   if (!docOptedIn) {
     return whenFirstVisible;
   }
+
   return whenFirstVisible
     .then(() => {
       return viewer.isTrustedViewer();

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -135,7 +135,16 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       );
     });
 
-    it('should be no-op if request is initialized to bypass', () => {
+    it('should wait for viewer visibility if viewer can NOT intercept', () => {
+      viewer.hasCapability = unusedParam => false;
+
+      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
+        // Expect no interception.
+        expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
+      });
+    });
+
+    it('should wait for viewer visibility if request is initialized to bypass', () => {
       // Given the bypass flag and localDev being true.
       init = {
         bypassInterceptorForDev: true,
@@ -148,7 +157,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       });
     });
 
-    it('should be no-op if amp doc does not support xhr interception', () => {
+    it('should wait for viewer visibility if amp doc does not support xhr interception', () => {
       doc.removeAttribute('allow-xhr-interception');
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
@@ -157,7 +166,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       });
     });
 
-    it('should be no-op if URL is known as a proxy URL', () => {
+    it('should wait for viewer visibility if URL is known as a proxy URL', () => {
       input = 'https://cdn.ampproject.org';
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -148,7 +148,9 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       init = {
         bypassInterceptorForDev: true,
       };
-      win.AMP_MODE = {localDev: true};
+      win.AMP_MODE = {
+        localDev: true,
+      };
 
       await getViewerInterceptResponse(win, ampDocSingle, input, init);
 
@@ -175,7 +177,9 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
     });
 
     it('should send xhr request to viewer', async () => {
-      init = {body: {}};
+      init = {
+        body: {},
+      };
       input = 'https://www.shouldsendxhrrequesttoviewer.org';
 
       await getViewerInterceptResponse(win, ampDocSingle, input, init);

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -130,12 +130,13 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
         () => {
+          // Expect no-op.
           expect(viewerForDoc).to.not.have.been.called;
         }
       );
     });
 
-    it('should wait for viewer visibility if viewer can NOT intercept', () => {
+    it('should not intercept if viewer can not intercept', () => {
       viewer.hasCapability = unusedParam => false;
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
@@ -144,7 +145,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       });
     });
 
-    it('should wait for viewer visibility if request is initialized to bypass', () => {
+    it('should not intercept if request is initialized to bypass for local development', () => {
       // Given the bypass flag and localDev being true.
       init = {
         bypassInterceptorForDev: true,
@@ -157,7 +158,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       });
     });
 
-    it('should wait for viewer visibility if amp doc does not support xhr interception', () => {
+    it('should not intercept if amp doc does not support xhr interception', () => {
       doc.removeAttribute('allow-xhr-interception');
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
@@ -166,7 +167,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       });
     });
 
-    it('should wait for viewer visibility if URL is known as a proxy URL', () => {
+    it('should not intercept if URL is known as a proxy URL', () => {
       input = 'https://cdn.ampproject.org';
 
       return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -125,85 +125,73 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       };
     });
 
-    it('should be no-op if amp doc is absent', () => {
+    it('should be no-op if amp doc is absent', async () => {
       ampDocSingle = null;
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          // Expect no-op.
-          expect(viewerForDoc).to.not.have.been.called;
-        }
-      );
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      // Expect no-op.
+      expect(viewerForDoc).to.not.have.been.called;
     });
 
-    it('should not intercept if viewer can not intercept', () => {
+    it('should not intercept if viewer can not intercept', async () => {
       viewer.hasCapability = unusedParam => false;
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          // Expect no interception.
-          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-        }
-      );
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      // Expect no interception.
+      expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
     });
 
-    it('should not intercept if request is initialized to bypass for local development', () => {
+    it('should not intercept if request is initialized to bypass for local development', async () => {
       // Given the bypass flag and localDev being true.
       init = {
         bypassInterceptorForDev: true,
       };
       win.AMP_MODE = {localDev: true};
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          // Expect no interception.
-          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-        }
-      );
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      // Expect no interception.
+      expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
     });
 
-    it('should not intercept if amp doc does not support xhr interception', () => {
+    it('should not intercept if amp doc does not support xhr interception', async () => {
       doc.removeAttribute('allow-xhr-interception');
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          // Expect no interception.
-          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-        }
-      );
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      // Expect no interception.
+      expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
     });
 
-    it('should not intercept if URL is known as a proxy URL', () => {
+    it('should not intercept if URL is known as a proxy URL', async () => {
       input = 'https://cdn.ampproject.org';
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          // Expect no interception.
-          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-        }
-      );
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      // Expect no interception.
+      expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
     });
 
-    it('should send xhr request to viewer', () => {
+    it('should send xhr request to viewer', async () => {
       init = {body: {}};
       input = 'https://www.shouldsendxhrrequesttoviewer.org';
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
-        () => {
-          const msgPayload = dict({
-            'originalRequest': {
-              'input': 'https://www.shouldsendxhrrequesttoviewer.org',
-              'init': {
-                'body': {},
-              },
-            },
-          });
-          expect(viewer.sendMessageAwaitResponse).to.have.been.calledOnce;
-          expect(viewer.sendMessageAwaitResponse).to.have.been.calledWith(
-            'xhr',
-            msgPayload
-          );
-        }
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      const msgPayload = dict({
+        'originalRequest': {
+          'input': 'https://www.shouldsendxhrrequesttoviewer.org',
+          'init': {
+            'body': {},
+          },
+        },
+      });
+      expect(viewer.sendMessageAwaitResponse).to.have.been.calledOnce;
+      expect(viewer.sendMessageAwaitResponse).to.have.been.calledWith(
+        'xhr',
+        msgPayload
       );
     });
   });

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -139,10 +139,12 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
     it('should not intercept if viewer can not intercept', () => {
       viewer.hasCapability = unusedParam => false;
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
-        // Expect no interception.
-        expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-      });
+      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
+        () => {
+          // Expect no interception.
+          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
+        }
+      );
     });
 
     it('should not intercept if request is initialized to bypass for local development', () => {
@@ -152,28 +154,34 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       };
       win.AMP_MODE = {localDev: true};
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
-        // Expect no interception.
-        expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-      });
+      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
+        () => {
+          // Expect no interception.
+          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
+        }
+      );
     });
 
     it('should not intercept if amp doc does not support xhr interception', () => {
       doc.removeAttribute('allow-xhr-interception');
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
-        // Expect no interception.
-        expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-      });
+      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
+        () => {
+          // Expect no interception.
+          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
+        }
+      );
     });
 
     it('should not intercept if URL is known as a proxy URL', () => {
       input = 'https://cdn.ampproject.org';
 
-      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(() => {
-        // Expect no interception.
-        expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
-      });
+      return getViewerInterceptResponse(win, ampDocSingle, input, init).then(
+        () => {
+          // Expect no interception.
+          expect(viewer.sendMessageAwaitResponse).to.not.have.been.called;
+        }
+      );
     });
 
     it('should send xhr request to viewer', () => {


### PR DESCRIPTION
### Implementation
- Adds descriptively named variables for readability.

### Tests
- Fixes issue where test variables were leaking across tests.
- Fixes issue with `hasCapability` stub (used in several tests) returning `false` by default. So other means of preventing interception weren't being tested in isolation.
- Fixes issues with `'initialized to bypass'` test. An extra line (`ampDocSingle = null`) at the top of the test was causing `getViewerInterceptResponse` to no-op, before checking for the bypass flag and dev environment (which wasn't being mocked).
- Adds new `'proxy URL'` test.
- Adds new `'viewer can not intercept'` test.
- Updates tests to use async/await for readability.
- Updated a few beginnings of test titles from `'should be no-op...'` to `'should not intercept...'`. This helps clarify which tests expect an immediately resolved promise ('no-op') from `getViewerInterceptResponse`, versus a promise that resolves once the view becomes visible ('should not intercept').