### PR TITLE
🐛 AMP4Email: Blacklist amp-lightbox and amp-image-lightbox 

### DIFF
--- a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
@@ -26,20 +26,8 @@ tags: {  # amp-image-lightbox
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # amp-image-lightbox
-  html_format: AMP4EMAIL
-  tag_name: "SCRIPT"
-  spec_name: "SCRIPT[custom-element=amp-image-lightbox] (AMP4EMAIL)"
-  extension_spec: {
-    name: "amp-image-lightbox"
-    version: "0.1"
-    version: "latest"
-  }
-  attr_lists: "common-extension-attrs"
-}
 tags: {  # <amp-image-lightbox>
   html_format: AMP
-  html_format: AMP4EMAIL
   tag_name: "AMP-IMAGE-LIGHTBOX"
   requires_extension: "amp-image-lightbox"
   # Support dimensions / sizes / etc. like an amp-lightbox.

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS-IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the license.
+# limitations under the license. stuff
 #
 
 tags: {  # amp-lightbox

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS-IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the license. stuff
+# limitations under the license.
 #
 
 tags: {  # amp-lightbox

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -29,7 +29,6 @@ tags: {  # amp-lightbox
 }
 tags: {  # amp-lightbox
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   tag_name: "SCRIPT"
   spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL/AMP4ADS)"
   extension_spec: {
@@ -41,7 +40,6 @@ tags: {  # amp-lightbox
 }
 tags: {  # <amp-lightbox>
   html_format: AMP
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "AMP-LIGHTBOX"
   requires_extension: "amp-lightbox"


### PR DESCRIPTION
Remove amp-lightbox and amp-image-lighbox from the AMP4EMAIL spec.
Fixes https://github.com/ampproject/amphtml/issues/23170

@choumx 