### PR TITLE
🐛 AMP4Email: Deprecate amp-lightbox and amp-image-lightbox

### DIFF
--- a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
@@ -36,6 +36,8 @@ tags: {  # amp-image-lightbox
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
+  deprecation: "amp-image-lightbox cannot be properly positioned in email. This tag will no longer be useable in AMP4EMAIL in the future"
+  deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-image-lightbox>
   html_format: AMP

--- a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
@@ -36,7 +36,7 @@ tags: {  # amp-image-lightbox
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
-  deprecation: "amp-image-lightbox cannot be properly positioned in email. This tag will no longer be useable in AMP4EMAIL in the future"
+  deprecation: "amp-image-lightbox cannot be properly positioned in emails and will soon be invalid in AMP4EMAIL."
   deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-image-lightbox>

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -29,15 +29,27 @@ tags: {  # amp-lightbox
 }
 tags: {  # amp-lightbox
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL/AMP4ADS)"
+  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4ADS)"
   extension_spec: {
     name: "amp-lightbox"
     version: "0.1"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-lightbox
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-lightbox"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+  deprecation: "amp-lightbox cannot be properly positioned in email. This tag will no longer be useable in AMP4EMAIL in the future"
+  deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-lightbox>
   html_format: AMP

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -48,7 +48,7 @@ tags: {  # amp-lightbox
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
-  deprecation: "amp-lightbox cannot be properly positioned in email. This tag will no longer be useable in AMP4EMAIL in the future"
+  deprecation: "amp-lightbox cannot be properly positioned in emails and will soon be invalid in AMP4EMAIL."
   deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-lightbox>


### PR DESCRIPTION
Deprecate amp-lightbox and amp-image-lighbox in the AMP4EMAIL spec.
https://github.com/ampproject/amphtml/issues/23170

@choumx @fstanis 