### PR TITLE
✨ Introduce new tick event `cls` (Cumulative Layout Shift).

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -110,6 +110,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     'build-system/dompurify.extern.js',
     'build-system/event-timing.extern.js',
     'build-system/layout-jank.extern.js',
+    'build-system/performance-observer.extern.js',
     'third_party/closure-compiler/externs/web_animations.js',
     'third_party/moment/moment.extern.js',
     'third_party/react-externs/externs.js',

--- a/build-system/performance-observer.extern.js
+++ b/build-system/performance-observer.extern.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for the PerformanceObserver API.
+ *
+ * Created from
+ * @see https://www.w3.org/TR/performance-timeline-2/#the-performanceobserver-interface
+ *
+ * @todo This should be removed when the definitions are released
+ * in closure-compiler.
+ *
+ * @externs
+ */
+
+/** @type {!Array} */ PerformanceObserver.supportedEntryTypes;

--- a/extensions/amp-viewer-integration/TICKEVENTS.md
+++ b/extensions/amp-viewer-integration/TICKEVENTS.md
@@ -38,3 +38,5 @@ As an example if we executed `perf.tick('label')` we assume we have a counterpar
 | First input delay, polyfill value | `fid-polyfill` | Millisecond delay in handling the first user input on the page, reported by [a polyfill](https://github.com/GoogleChromeLabs/first-input-delay) |
 | Layout Jank, first exit | `lj` | The aggregate jank score when the user leaves the page (navigation, tab switching, dismissing application) for the first time. See https://gist.github.com/skobes/2f296da1b0a88cc785a4bf10a42bca07 |
 | Layout Jank, second exit | `lj-2` | The aggregate jank score when the user leaves the page (navigation, tab switching, dismissing application) for the second time. |
+| Cumulative Layout Shift, first exit | `cls` | The aggregate layout shift score when the user leaves the page (navigation, tab switching, dismissing application) for the first time. See https://web.dev/layout-instability-api |
+| Cumulative Layout Shift, second exit | `cls-2` | The aggregate layout shift score when the user leaves the page (navigation, tab switching, dismissing application) for the second time. |

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -145,6 +145,7 @@ export class Performance {
      * @private {boolean}
      */
     this.supportsLayoutInstabilityAPI_ =
+      this.win.PerformanceObserver &&
       this.win.PerformanceObserver.supportedEntryTypes &&
       this.win.PerformanceObserver.supportedEntryTypes.includes('layoutShift');
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -117,6 +117,13 @@ export class Performance {
     this.jankScoresTicked_ = 0;
 
     /**
+     * How many times a layout shift metric has been ticked.
+     *
+     * @private {number}
+     */
+    this.shiftScoresTicked_ = 0;
+
+    /**
      * The sum of all layout jank fractions triggered on the page from the
      * Layout Jank API.
      *
@@ -124,8 +131,28 @@ export class Performance {
      */
     this.aggregateJankScore_ = 0;
 
+    /**
+     * The sum of all layout shift fractions triggered on the page from the
+     * Layout Instability API.
+     *
+     * @private {number}
+     */
+    this.aggregateShiftScore_ = 0;
+
+    /**
+     * Whether the user agent supports the Layout Instability API.
+     *
+     * @private {boolean}
+     */
+    this.supportsLayoutInstabilityAPI_ =
+      this.win.PerformanceObserver.supportedEntryTypes &&
+      this.win.PerformanceObserver.supportedEntryTypes.includes(
+        'layoutShift'
+      );
+
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
     this.boundTickLayoutJankScore_ = this.tickLayoutJankScore_.bind(this);
+    this.boundTickLayoutShiftScore_ = this.tickLayoutShiftScore_.bind(this);
     this.onViewerVisibilityChange_ = this.onViewerVisibilityChange_.bind(this);
 
     // Add RTV version as experiment ID, so we can slice the data by version.
@@ -185,6 +212,29 @@ export class Performance {
         this.win.addEventListener(
           BEFORE_UNLOAD_EVENT,
           this.boundTickLayoutJankScore_
+        );
+      }
+
+      this.viewer_.onVisibilityChanged(this.onViewerVisibilityChange_);
+    }
+
+      if (this.supportsLayoutInstabilityAPI_) {
+      // Register a handler to record the layout shift metric when the page
+      // enters the hidden lifecycle state.
+      this.win.addEventListener(
+        VISIBILITY_CHANGE_EVENT,
+        this.boundOnVisibilityChange_,
+        {capture: true}
+      );
+
+      // Safari does not reliably fire the `pagehide` or `visibilitychange`
+      // events when closing a tab, so we have to use `beforeunload`.
+      // See https://bugs.webkit.org/show_bug.cgi?id=151234
+      const platform = Services.platformFor(this.win);
+      if (platform.isSafari()) {
+        this.win.addEventListener(
+          BEFORE_UNLOAD_EVENT,
+          this.boundTickLayoutShiftScore_
         );
       }
 
@@ -252,6 +302,8 @@ export class Performance {
         recordedFirstInputDelay = true;
       } else if (entry.entryType === 'layoutJank') {
         this.aggregateJankScore_ += entry.fraction;
+      } else if (entry.entryType === 'layoutShift') {
+        this.aggregateShiftScore_ += entry.value;
       }
     };
 
@@ -278,6 +330,16 @@ export class Performance {
       // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
       this.win.performance.getEntriesByType('layoutJank').forEach(processEntry);
       entryTypesToObserve.push('layoutJank');
+    }
+
+    if (this.supportsLayoutInstabilityAPI_) {
+      // Programmatically read once as currently PerformanceObserver does not
+      // report past entries as of Chrome 61.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
+      this.win.performance
+        .getEntriesByType('layoutShift')
+        .forEach(processEntry);
+      entryTypesToObserve.push('layoutShift');
     }
 
     if (entryTypesToObserve.length === 0) {
@@ -320,7 +382,12 @@ export class Performance {
    */
   onVisibilityChange_() {
     if (this.win.document.visibilityState === 'hidden') {
-      this.tickLayoutJankScore_();
+      if (this.win.PerformanceLayoutJank) {
+        this.tickLayoutJankScore_();
+      }
+      if (this.supportsLayoutInstabilityAPI_) {
+        this.tickLayoutShiftScore_();
+      }
     }
   }
 
@@ -330,7 +397,12 @@ export class Performance {
    */
   onViewerVisibilityChange_() {
     if (this.viewer_.getVisibilityState() === VisibilityState.INACTIVE) {
-      this.tickLayoutJankScore_();
+      if (this.win.PerformanceLayoutJank) {
+        this.tickLayoutJankScore_();
+      }
+      if (this.supportsLayoutInstabilityAPI_) {
+        this.tickLayoutShiftScore_();
+      }
     }
   }
 
@@ -365,6 +437,41 @@ export class Performance {
       this.win.removeEventListener(
         BEFORE_UNLOAD_EVENT,
         this.boundTickLayoutJankScore_
+      );
+    }
+  }
+
+  /**
+   * Tick the layout shift score metric.
+   *
+   * A value of the metric is recorded in under two names, `cls` and `cls-2`,
+   * for the first two times the page transitions into a hidden lifecycle state
+   * (when the page is navigated a way from, the tab is backgrounded for
+   * another tab, or the user backgrounds the browser application).
+   *
+   * Since we can't reliably detect when a page session finally ends,
+   * recording the value for these first two events should provide a fair
+   * amount of visibility into this metric.
+   */
+  tickLayoutShiftScore_() {
+    if (this.shiftScoresTicked_ === 0) {
+      this.tickDelta('cls', this.aggregateShiftScore_);
+      this.flush();
+      this.shiftScoresTicked_ = 1;
+    } else if (this.shiftScoresTicked_ === 1) {
+      this.tickDelta('cls-2', this.aggregateShiftScore_);
+      this.flush();
+      this.shiftScoresTicked_ = 2;
+
+      // No more work to do, so clean up event listeners.
+      this.win.removeEventListener(
+        VISIBILITY_CHANGE_EVENT,
+        this.boundOnVisibilityChange_,
+        {capture: true}
+      );
+      this.win.removeEventListener(
+        BEFORE_UNLOAD_EVENT,
+        this.boundTickLayoutShiftScore_
       );
     }
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -146,9 +146,7 @@ export class Performance {
      */
     this.supportsLayoutInstabilityAPI_ =
       this.win.PerformanceObserver.supportedEntryTypes &&
-      this.win.PerformanceObserver.supportedEntryTypes.includes(
-        'layoutShift'
-      );
+      this.win.PerformanceObserver.supportedEntryTypes.includes('layoutShift');
 
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
     this.boundTickLayoutJankScore_ = this.tickLayoutJankScore_.bind(this);
@@ -218,7 +216,7 @@ export class Performance {
       this.viewer_.onVisibilityChanged(this.onViewerVisibilityChange_);
     }
 
-      if (this.supportsLayoutInstabilityAPI_) {
+    if (this.supportsLayoutInstabilityAPI_) {
       // Register a handler to record the layout shift metric when the page
       // enters the hidden lifecycle state.
       this.win.addEventListener(

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1262,9 +1262,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         return performanceObserver;
       });
 
-      fakeWin.PerformanceObserver.supportedEntryTypes = env.sandbox.stub();
-
-      fakeWin.PerformanceObserver.supportedEntryTypes.returns(['layoutShift']);
+      fakeWin.PerformanceObserver.supportedEntryTypes = ['layoutShift'];
 
       // Install services on fakeWin so some behaviors can be stubbed.
       installRuntimeServices(fakeWin);

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1216,4 +1216,204 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       });
     });
   });
+
+  describe('forwards cumulative layout shift metric', () => {
+    let fakeWin;
+    let windowEventListeners;
+    let performanceObserver;
+    let viewerVisibilityState;
+
+    beforeEach(() => {
+      // Fake window to fake `document.visibilityState` and the
+      // `PeformanceObserver` implementation.
+      fakeWin = {
+        Date: env.win.Date,
+        PerformanceObserver: env.sandbox.stub(),
+        addEventListener: env.sandbox.stub(),
+        removeEventListener: env.win.removeEventListener,
+        dispatchEvent: env.win.dispatchEvent,
+        document: {
+          addEventListener: env.sandbox.stub(),
+          hidden: false,
+          readyState: 'complete',
+          removeEventListener: env.sandbox.stub(),
+          visibilityState: 'visible',
+        },
+        location: env.win.location,
+        performance: {
+          getEntriesByType: env.sandbox.stub(),
+        },
+      };
+
+      // Fake window.addEventListener to fake `visibilitychange` and
+      // `beforeunload` events.
+      windowEventListeners = {};
+      fakeWin.addEventListener.callsFake((eventType, handler) => {
+        if (!windowEventListeners[eventType]) {
+          windowEventListeners[eventType] = [];
+        }
+        windowEventListeners[eventType].push(handler);
+      });
+
+      // Fake the PerformanceObserver implementation so we can send
+      // fake PerformanceEntry objects to listeners.
+      fakeWin.PerformanceObserver.callsFake(callback => {
+        performanceObserver = new PerformanceObserverImpl(callback);
+        return performanceObserver;
+      });
+
+      fakeWin.PerformanceObserver.supportedEntryTypes = env.sandbox.stub();
+
+      fakeWin.PerformanceObserver.supportedEntryTypes.returns(['layoutShift']);
+
+      // Install services on fakeWin so some behaviors can be stubbed.
+      installRuntimeServices(fakeWin);
+
+      const unresolvedPromise = new Promise(() => {});
+      const viewportSize = {width: 0, height: 0};
+      sandbox.stub(Services, 'viewerForDoc').returns({
+        isEmbedded: () => {},
+        hasBeenVisible: () => {},
+        onVisibilityChanged: () => {},
+        whenFirstVisible: () => unresolvedPromise,
+        whenMessagingReady: () => {},
+        getVisibilityState: () => viewerVisibilityState,
+      });
+      sandbox.stub(Services, 'resourcesForDoc').returns({
+        getResourcesInRect: () => unresolvedPromise,
+      });
+      sandbox.stub(Services, 'viewportForDoc').returns({
+        getSize: () => viewportSize,
+      });
+    });
+
+    function getPerformance() {
+      installPerformanceService(fakeWin);
+      return Services.performanceFor(fakeWin);
+    }
+
+    function toggleVisibility(win, on) {
+      win.document.visibilityState = on ? 'visible' : 'hidden';
+      fireEvent('visibilitychange');
+    }
+
+    function fireEvent(eventName) {
+      const event = new Event(eventName);
+      (windowEventListeners[eventName] || []).forEach(cb => cb(event));
+    }
+
+    it('for browsers that support the visibilitychange event', () => {
+      // Specify an Android Chrome user agent, which supports the
+      // visibilitychange event.
+      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+
+      // Document should be initially visible.
+      expect(fakeWin.document.visibilityState).to.equal('visible');
+
+      // Fake layoutShift that occured before the Performance service is started.
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutShift')
+        .returns([
+          {entryType: 'layoutShift', value: 0.25},
+          {entryType: 'layoutShift', value: 0.3},
+        ]);
+
+      const perf = getPerformance();
+      // visibilitychange/beforeunload listeners are now added.
+      perf.coreServicesAvailable();
+
+      // The document has become hidden, e.g. via the user switching tabs.
+      toggleVisibility(fakeWin, false);
+      expect(perf.events_.length).to.equal(1);
+      expect(perf.events_[0]).to.be.jsonEqual({
+        label: 'cls',
+        delta: 0.55,
+      });
+
+      // The user returns to the tab, and more layout shift occurs.
+      toggleVisibility(fakeWin, true);
+      const list = {
+        getEntries() {
+          return [
+            {entryType: 'layoutShift', value: 1},
+            {entryType: 'layoutShift', value: 0.0001},
+          ];
+        },
+      };
+      performanceObserver.triggerCallback(list);
+
+      toggleVisibility(fakeWin, false);
+      expect(perf.events_.length).to.equal(2);
+      expect(perf.events_[1]).to.be.jsonEqual({
+        label: 'cls-2',
+        delta: 1.5501,
+      });
+
+      // Any more layout shift shouldn't be reported.
+      toggleVisibility(fakeWin, true);
+      performanceObserver.triggerCallback(list);
+
+      toggleVisibility(fakeWin, false);
+      expect(perf.events_.length).to.equal(2);
+    });
+
+    it("for browsers that don't support the visibilitychange event", () => {
+      // Specify an iPhone Safari user agent, which does not support
+      // the visibilitychange event.
+      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(true);
+
+      // Document should be initially visible.
+      expect(fakeWin.document.visibilityState).to.equal('visible');
+
+      // Fake layoutShift that occured before the Performance service is started.
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutShift')
+        .returns([
+          {entryType: 'layoutShift', value: 0.25},
+          {entryType: 'layoutShift', value: 0.3},
+        ]);
+
+      const perf = getPerformance();
+      // visibilitychange/beforeunload listeners are now added.
+      perf.coreServicesAvailable();
+
+      // The document has become hidden, e.g. via the user switching tabs.
+      // Note: Don't fire visibilitychange (not supported in this case).
+      fakeWin.document.visibilityState = 'hidden';
+      fireEvent('beforeunload');
+
+      expect(perf.events_.length).to.equal(1);
+      expect(perf.events_[0]).to.be.jsonEqual({
+        label: 'cls',
+        delta: 0.55,
+      });
+    });
+
+    it('when the viewer visibility changes to inactive', () => {
+      // Specify an Android Chrome user agent.
+      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+
+      // Fake layoutShift that occured before the Performance service is started.
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutShift')
+        .returns([
+          {entryType: 'layoutShift', value: 0.25},
+          {entryType: 'layoutShift', value: 0.3},
+        ]);
+      const perf = getPerformance();
+      perf.coreServicesAvailable();
+      viewerVisibilityState = VisibilityState.INACTIVE;
+      perf.onViewerVisibilityChange_();
+
+      expect(perf.events_.length).to.equal(1);
+      expect(perf.events_[0]).to.be.jsonEqual({
+        label: 'cls',
+        delta: 0.55,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #23154

This introduces a bit of duplication with existing code for layout jank support. I've suggested we remove layout jank support in ~a month, see #23198. 