### PR TITLE
Various optimizations to AMP inabox friendly iframe position observer.

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -86,7 +86,7 @@ export class InaboxMessagingHost {
     /** @private {!Object<string,!AdFrameDef>} */
     this.iframeMap_ = Object.create(null);
 
-    /** @private {!PositionObserver} */
+    /** @private {!./position-observer.PositionObserver} */
     this.positionObserver_ = getPublicPositionObserver(win);
 
     /** @private {!NamedObservable} */

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -24,7 +24,7 @@ import {canInspectWindow} from '../../src/iframe-helper';
 import {dev, devAssert} from '../../src/log';
 import {dict} from '../../src/utils/object';
 import {getData} from '../../src/event-helper';
-import {getPublicPositionObserver} from './position-observer';
+import {getPositionObserver} from './position-observer';
 
 /** @const */
 const TAG = 'InaboxMessagingHost';
@@ -87,7 +87,7 @@ export class InaboxMessagingHost {
     this.iframeMap_ = Object.create(null);
 
     /** @private {!./position-observer.PositionObserver} */
-    this.positionObserver_ = getPublicPositionObserver(win);
+    this.positionObserver_ = getPositionObserver(win);
 
     /** @private {!NamedObservable} */
     this.msgObservable_ = new NamedObservable();

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -20,11 +20,11 @@ import {
   deserializeMessage,
   serializeMessage,
 } from '../../src/3p-frame-messaging';
-import {PositionObserver} from './position-observer';
 import {canInspectWindow} from '../../src/iframe-helper';
 import {dev, devAssert} from '../../src/log';
 import {dict} from '../../src/utils/object';
 import {getData} from '../../src/event-helper';
+import {getPublicPositionObserver} from './position-observer';
 
 /** @const */
 const TAG = 'InaboxMessagingHost';
@@ -87,7 +87,7 @@ export class InaboxMessagingHost {
     this.iframeMap_ = Object.create(null);
 
     /** @private {!PositionObserver} */
-    this.positionObserver_ = new PositionObserver(win);
+    this.positionObserver_ = getPublicPositionObserver(win);
 
     /** @private {!NamedObservable} */
     this.msgObservable_ = new NamedObservable();

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -179,3 +179,14 @@ function getScrollingElement(win) {
 function isWebKit(ua) {
   return /WebKit/i.test(ua) && !/Edge/i.test(ua);
 }
+
+/**
+ * @param {!Window} win
+ * @return {!PositionObserver}
+ */
+export function getPublicPositionObserver(win) {
+  const AMP_INABOX_POSITION_OBSERVER = 'ampInaboxPositionObserver';
+  win[AMP_INABOX_POSITION_OBSERVER] =
+    win[AMP_INABOX_POSITION_OBSERVER] || new PositionObserver(win);
+  return win[AMP_INABOX_POSITION_OBSERVER];
+}

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -34,6 +34,9 @@ let PositionEntryDef;
 /** @const */
 const MIN_EVENT_INTERVAL_IN_MS = 100;
 
+/** @const */
+const AMP_INABOX_POSITION_OBSERVER = 'ampInaboxPositionObserver';
+
 export class PositionObserver {
   /**
    * @param {!Window} win
@@ -185,8 +188,7 @@ function isWebKit(ua) {
  * @param {!Window} win
  * @return {!PositionObserver}
  */
-export function getPublicPositionObserver(win) {
-  const AMP_INABOX_POSITION_OBSERVER = 'ampInaboxPositionObserver';
+export function getPositionObserver(win) {
   win[AMP_INABOX_POSITION_OBSERVER] =
     win[AMP_INABOX_POSITION_OBSERVER] || new PositionObserver(win);
   return win[AMP_INABOX_POSITION_OBSERVER];

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -95,9 +95,9 @@ export class PositionObserver {
    */
   getPositionEntry_(element) {
     return {
-      viewportRect: /** @type {!LayoutRectDef} */ (this.viewportRect_),
+      'viewportRect': /** @type {!LayoutRectDef} */ (this.viewportRect_),
       // relative position to viewport
-      targetRect: this.getTargetRect(element),
+      'targetRect': this.getTargetRect(element),
     };
   }
 

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -181,6 +181,7 @@ function isWebKit(ua) {
 }
 
 /**
+ * Use an existing position observer within the window, if any.
  * @param {!Window} win
  * @return {!PositionObserver}
  */

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -835,3 +835,8 @@ var WebAnimationSelectorDef;
  * }}
  */
 var WebAnimationSubtargetDef;
+
+var ampInaboxPositionObserver;
+ampInaboxPositionObserver.observe;
+ampInaboxPositionObserver.getTargetRect;
+ampInaboxPositionObserver.getViewportRect;

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -203,7 +203,7 @@ export class ViewportBindingInabox {
         /** @type {!HTMLIFrameElement|!HTMLElement} */
         (this.win.frameElement || this.getScrollingElement()),
         data => {
-          this.updateLayoutRects_(data.viewportRect, data.targetRect);
+          this.updateLayoutRects_(data['viewportRect'], data['targetRect']);
         }
       );
     });

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -203,7 +203,7 @@ export class ViewportBindingInabox {
         /** @type {!HTMLIFrameElement|!HTMLElement} */
         (this.win.frameElement || this.getScrollingElement()),
         data => {
-          this.updateLayoutRects_(data['viewportRect'], data['targetRect']);
+          this.updateLayoutRects_(data.viewportRect, data.targetRect);
         }
       );
     });

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -21,7 +21,7 @@ import {Viewport} from '../service/viewport/viewport-impl';
 import {ViewportBindingDef} from '../service/viewport/viewport-binding-def';
 import {canInspectWindow} from '../iframe-helper';
 import {dev, devAssert} from '../log';
-import {getPublicPositionObserver} from '../../ads/inabox/position-observer';
+import {getPositionObserver} from '../../ads/inabox/position-observer';
 import {iframeMessagingClientFor} from './inabox-iframe-messaging-client';
 import {isExperimentOn} from '../experiments';
 import {layoutRectLtwh, moveLayoutRect} from '../layout-rect';
@@ -198,7 +198,7 @@ export class ViewportBindingInabox {
     return Services.resourcesPromiseForDoc(
       this.win.document.documentElement
     ).then(() => {
-      this.topWindowPositionObserver_ = getPublicPositionObserver(this.win.top);
+      this.topWindowPositionObserver_ = getPositionObserver(this.win.top);
       this.unobserveFunction_ = this.topWindowPositionObserver_.observe(
         /** @type {!HTMLIFrameElement|!HTMLElement} */
         (this.win.frameElement || this.getScrollingElement()),

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -200,6 +200,9 @@ export class ViewportBindingInabox {
     ).then(() => {
       this.topWindowPositionObserver_ = getPositionObserver(this.win.top);
       this.unobserveFunction_ = this.topWindowPositionObserver_.observe(
+        // If the window is the top window (not sitting in an iframe) then
+        // frameElement doesn't exist. In that case we observe the scrolling
+        // element.
         /** @type {!HTMLIFrameElement|!HTMLElement} */
         (this.win.frameElement || this.getScrollingElement()),
         data => {

--- a/test/unit/inabox/test-position-observer.js
+++ b/test/unit/inabox/test-position-observer.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {PositionObserver} from '../../../ads/inabox/position-observer';
+import {
+  PositionObserver,
+  getPublicPositionObserver,
+} from '../../../ads/inabox/position-observer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 
 describes.realWin('inabox-host:position-observer', {}, env => {
@@ -105,5 +108,13 @@ describes.realWin('inabox-host:position-observer', {}, env => {
     expect(observer.getTargetRect(element)).to.deep.equal(
       layoutRectLtwh(14, 18, 30, 40)
     );
+  });
+
+  it('should get existing observer', () => {
+    const observer1 = getPublicPositionObserver(win);
+    const observer2 = getPublicPositionObserver(win);
+    const observer3 = new PositionObserver(win);
+    expect(observer1).to.equal(observer2);
+    expect(observer2).to.not.equal(observer3);
   });
 });

--- a/test/unit/inabox/test-position-observer.js
+++ b/test/unit/inabox/test-position-observer.js
@@ -16,7 +16,7 @@
 
 import {
   PositionObserver,
-  getPublicPositionObserver,
+  getPositionObserver,
 } from '../../../ads/inabox/position-observer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 
@@ -111,8 +111,8 @@ describes.realWin('inabox-host:position-observer', {}, env => {
   });
 
   it('should get existing observer', () => {
-    const observer1 = getPublicPositionObserver(win);
-    const observer2 = getPublicPositionObserver(win);
+    const observer1 = getPositionObserver(win);
+    const observer2 = getPositionObserver(win);
     const observer3 = new PositionObserver(win);
     expect(observer1).to.equal(observer2);
     expect(observer2).to.not.equal(observer3);


### PR DESCRIPTION
1. If `window.frameElement` is not available (e.g. because the ad IS the top window) use `getScrollingElement()`. This is mostly relevant for mobile apps.

2. Both the host script and the amp4ads runtime within friendly iframes will now share one position observer (sitting at the host window) instead of using a separate one for each. This prevents multiple scroll listeners, which can reduce performance.

3. Fix single pass build, which was actually broken before because of minification - the position observer would send back the minified `data` object while the inabox runtime would still try to read the unminified name (`data['viewportRect']`). The object will now be unminified in all cases.