### PR TITLE
Fix devAssert(0) console error.

### DIFF
--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -259,9 +259,9 @@ export class PaginationButtons {
         .signals()
         .whenSignal(CommonSignals.LOAD_END)
         .then(() => {
-          const currentPageIndex = /** @type {number} */ (devAssert(
+          const currentPageIndex = Number(
             this.storeService_.get(StateProperty.CURRENT_PAGE_INDEX)
-          ));
+          );
           this.onCurrentPageIndexUpdate_(currentPageIndex);
         });
     });


### PR DESCRIPTION
`CURRENT_PAGE_INDEX` is 0 when loading a story on the first page, triggering a console error on every non mobile story load.