### PR TITLE
Vertical rendering mode triggers all publishers custom CSS animations with no delay.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -24,6 +24,12 @@ amp-story[standalone][i-amphtml-vertical] {
   contain: initial !important;
 }
 
+/* Overrides publishers custom CSS animations, if any. */
+[i-amphtml-vertical] * {
+  transition-delay: 0s !important;
+  transition-duration: 0s !important;
+}
+
 [i-amphtml-vertical] amp-story-page {
   position: relative !important;
   /* iPhone 6/7/8 ratio. */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1843,6 +1843,16 @@ export class AmpStory extends AMP.BaseElement {
             this.element.appendChild(pageAttachments[i]);
           }
         });
+
+        this.signals()
+          .whenSignal(CommonSignals.LOAD_END)
+          .then(() => {
+            this.vsync_.mutate(() => {
+              this.pages_.forEach(page =>
+                page.element.setAttribute('active', '')
+              );
+            });
+          });
         break;
     }
   }


### PR DESCRIPTION
Vertical rendering mode triggers all publishers custom CSS animations with no delay.

Context: some publishers might rely on the `[active]` attribute to trigger their CSS animations.
This PR adds an `[active]` attribute to all pages, and sets both the transition delay and duration to 0s, so pages are displayed in their final state.

Fixes #23070