### PR TITLE
🗑 Disable auto-lightbox on formats other than `amp/⚡`

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -31,7 +31,6 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {dev} from '../../../src/log';
-
 import {toArray} from '../../../src/types';
 import {tryParseJson} from '../../../src/json';
 

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -31,7 +31,7 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {dev} from '../../../src/log';
-import {getMode} from '../../../src/mode';
+
 import {toArray} from '../../../src/types';
 import {tryParseJson} from '../../../src/json';
 
@@ -339,30 +339,6 @@ function usesLightboxExplicitly(ampdoc) {
 }
 
 /**
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
- * @return {boolean}
- */
-function isProxyOriginOrLocalDev(ampdoc) {
-  // Allow `localDev` in lieu of proxy origin for manual testing, except in
-  // tests where we need to actually perform the check.
-  const {win} = ampdoc;
-  if (getMode(win).localDev && !getMode(win).test) {
-    return true;
-  }
-
-  // An attached node is required for proxy origin check. If no elements are
-  // present, short-circuit.
-  const {firstElementChild} = ampdoc.getBody();
-  if (!firstElementChild) {
-    return false;
-  }
-
-  // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
-  // See git.io/fhQ0a (#20359) for details.
-  return Services.urlForDoc(firstElementChild).isProxyOrigin(win.location);
-}
-
-/**
  * Determines whether auto-lightbox is enabled for a document.
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @return {boolean}
@@ -372,13 +348,10 @@ export function isEnabledForDoc(ampdoc) {
   if (usesLightboxExplicitly(ampdoc)) {
     return false;
   }
-  if (
-    !DocMetaAnnotations.hasValidOgType(ampdoc) &&
-    !DocMetaAnnotations.hasValidLdJsonType(ampdoc)
-  ) {
-    return false;
-  }
-  return isProxyOriginOrLocalDev(ampdoc);
+  return (
+    DocMetaAnnotations.hasValidOgType(ampdoc) ||
+    DocMetaAnnotations.hasValidLdJsonType(ampdoc)
+  );
 }
 
 /** @private {number} */

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -92,14 +92,6 @@ describes.realWin(
         }
       });
 
-    function mockIsProxyOrigin(isProxyOrigin) {
-      env.sandbox.stub(Services, 'urlForDoc').returns({
-        isProxyOrigin() {
-          return isProxyOrigin;
-        },
-      });
-    }
-
     function spyInstallExtensionsForDoc() {
       const installExtensionForDoc = env.sandbox.spy();
 
@@ -440,7 +432,6 @@ describes.realWin(
       it('does not load extension if no candidates found', async () => {
         const installExtensionForDoc = spyInstallExtensionsForDoc();
 
-        mockIsProxyOrigin(true);
         mockCandidates([]);
 
         await waitForAllScannedToBeResolved();
@@ -452,7 +443,6 @@ describes.realWin(
       it('loads extension if >= 1 candidates meet criteria', async () => {
         const installExtensionForDoc = spyInstallExtensionsForDoc();
 
-        mockIsProxyOrigin(true);
         mockCandidates([
           mockLoadedSignal(
             html`
@@ -483,7 +473,6 @@ describes.realWin(
         ]);
 
         mockAllCriteriaMet(false);
-        mockIsProxyOrigin(true);
 
         await waitForAllScannedToBeResolved();
 
@@ -518,7 +507,6 @@ describes.realWin(
         allCriteriaMet.withArgs(matchEquals(c)).returns(true);
 
         mockCandidates([a, b, c]);
-        mockIsProxyOrigin(true);
 
         await waitForAllScannedToBeResolved();
 
@@ -540,7 +528,6 @@ describes.realWin(
         );
 
         mockAllCriteriaMet(true);
-        mockIsProxyOrigin(true);
 
         await waitForAllScannedToBeResolved();
 
@@ -592,7 +579,6 @@ describes.realWin(
       };
 
       it('rejects documents without any type annotation', () => {
-        mockIsProxyOrigin(true);
         expectIsEnabled(false);
       });
 
@@ -674,7 +660,6 @@ describes.realWin(
 
       describe('by LD+JSON @type', () => {
         it('rejects doc with invalid LD+JSON @type', () => {
-          mockIsProxyOrigin(true);
           mockLdJsonSchemaTypes('hamberder');
           expectIsEnabled(false);
         });
@@ -682,9 +667,8 @@ describes.realWin(
         ldJsonSchemaTypes.forEach(type => {
           const typeSubObj = `{..."@type": "${type}"}`;
 
-          it(`accepts docs with ${typeSubObj} schema and proxy origin`, () => {
+          it(`accepts docs with ${typeSubObj} schema`, () => {
             mockLdJsonSchemaTypes(type);
-            mockIsProxyOrigin(true);
             expectIsEnabled(true);
           });
 
@@ -703,13 +687,6 @@ describes.realWin(
             doc.body.appendChild(lightboxable);
 
             mockLdJsonSchemaTypes(type);
-            mockIsProxyOrigin(true);
-            expectIsEnabled(false);
-          });
-
-          it(`rejects docs with ${typeSubObj} schema, non-proxy origin`, () => {
-            mockLdJsonSchemaTypes(type);
-            mockIsProxyOrigin(false);
             expectIsEnabled(false);
           });
         });
@@ -717,7 +694,6 @@ describes.realWin(
 
       describe('by og:type', () => {
         it('rejects doc with invalid <meta property="og:type">', () => {
-          mockIsProxyOrigin(true);
           mockOgType('cinnamonroll');
           expectIsEnabled(false);
         });
@@ -725,9 +701,8 @@ describes.realWin(
         ogTypes.forEach(type => {
           const ogTypeMeta = `<meta property="og:type" content="${type}">`;
 
-          it(`accepts docs with ${ogTypeMeta} and proxy origin`, () => {
+          it(`accepts docs with ${ogTypeMeta}`, () => {
             mockOgType(type);
-            mockIsProxyOrigin(true);
             expectIsEnabled(true);
           });
 
@@ -746,13 +721,6 @@ describes.realWin(
             doc.body.appendChild(lightboxable);
 
             mockOgType(type);
-            mockIsProxyOrigin(true);
-            expectIsEnabled(false);
-          });
-
-          it(`rejects docs with ${ogTypeMeta} for non-proxy origin`, () => {
-            mockOgType(type);
-            mockIsProxyOrigin(false);
             expectIsEnabled(false);
           });
         });

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -17,6 +17,7 @@
 import {ChunkPriority, chunk} from './chunk';
 import {Services} from './services';
 import {dev} from './log';
+import {isAmp4Email} from './format';
 
 /** @const @enum {string} */
 export const AutoLightboxEvents = {
@@ -29,10 +30,14 @@ export const AutoLightboxEvents = {
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installAutoLightboxExtension(ampdoc) {
+  const {win} = ampdoc;
+  if (isAmp4Email(win.document)) {
+    return;
+  }
   chunk(
     ampdoc,
     () => {
-      Services.extensionsFor(ampdoc.win).installExtensionForDoc(
+      Services.extensionsFor(win).installExtensionForDoc(
         ampdoc,
         'amp-auto-lightbox'
       );

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -41,14 +41,18 @@ function isProxyOriginOrLocalDev(ampdoc) {
 
   // An attached node is required for proxy origin check. If no elements are
   // present, short-circuit.
-  const {firstElementChild} = ampdoc.getBody();
-  if (!firstElementChild) {
+  if (!ampdoc.isSingleDoc()) {
+    return false;
+  }
+
+  const {documentElement} = ampdoc.getRoot();
+  if (!documentElement) {
     return false;
   }
 
   // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
   // See git.io/fhQ0a (#20359) for details.
-  return Services.urlForDoc(firstElementChild).isProxyOrigin(win.location);
+  return Services.urlForDoc(documentElement).isProxyOrigin(win.location);
 }
 
 /**

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -45,7 +45,7 @@ function isProxyOriginOrLocalDev(ampdoc) {
     return false;
   }
 
-  const {documentElement} = ampdoc.getRoot();
+  const {documentElement} = ampdoc.getRootNode();
   if (!documentElement) {
     return false;
   }

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -31,6 +31,10 @@ export const AutoLightboxEvents = {
  */
 export function installAutoLightboxExtension(ampdoc) {
   const {win} = ampdoc;
+  // Only enabled on proxy origins for which the document is tagged as
+  // <html amp> or <html ⚡>
+  // The auto-lightbox extension does a proxy origin check, so this just
+  // short-circuits loading the extension.
   if (!isAmphtml(win.document)) {
     return;
   }

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -28,7 +28,7 @@ export const AutoLightboxEvents = {
 };
 
 /**
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @return {boolean}
  */
 function isProxyOriginOrLocalDev(ampdoc) {

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -17,7 +17,7 @@
 import {ChunkPriority, chunk} from './chunk';
 import {Services} from './services';
 import {dev} from './log';
-import {isAmp4Email} from './format';
+import {isAmphtml} from './format';
 
 /** @const @enum {string} */
 export const AutoLightboxEvents = {
@@ -31,7 +31,7 @@ export const AutoLightboxEvents = {
  */
 export function installAutoLightboxExtension(ampdoc) {
   const {win} = ampdoc;
-  if (isAmp4Email(win.document)) {
+  if (!isAmphtml(win.document)) {
     return;
   }
   chunk(

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -17,6 +17,7 @@
 import {ChunkPriority, chunk} from './chunk';
 import {Services} from './services';
 import {dev} from './log';
+import {getMode} from './mode';
 import {isAmphtml} from './format';
 
 /** @const @enum {string} */
@@ -27,15 +28,37 @@ export const AutoLightboxEvents = {
 };
 
 /**
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {boolean}
+ */
+function isProxyOriginOrLocalDev(ampdoc) {
+  // Allow `localDev` in lieu of proxy origin for manual testing, except in
+  // tests where we need to actually perform the check.
+  const {win} = ampdoc;
+  if (getMode(win).localDev && !getMode(win).test) {
+    return true;
+  }
+
+  // An attached node is required for proxy origin check. If no elements are
+  // present, short-circuit.
+  const {firstElementChild} = ampdoc.getBody();
+  if (!firstElementChild) {
+    return false;
+  }
+
+  // TODO(alanorozco): Additionally check for transformed, webpackaged flag.
+  // See git.io/fhQ0a (#20359) for details.
+  return Services.urlForDoc(firstElementChild).isProxyOrigin(win.location);
+}
+
+/**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installAutoLightboxExtension(ampdoc) {
   const {win} = ampdoc;
   // Only enabled on proxy origins for which the document is tagged as
-  // <html amp> or <html ⚡>
-  // The auto-lightbox extension does a proxy origin check, so this just
-  // short-circuits loading the extension.
-  if (!isAmphtml(win.document)) {
+  // <html amp> or <html ⚡>.
+  if (!isAmphtml(win.document) || !isProxyOriginOrLocalDev(ampdoc)) {
     return;
   }
   chunk(

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Checks that the document is of an AMP format type.
+ * @param {!Array<string>} formats
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+function isAmpFormatType(formats, doc) {
+  const html = doc.documentElement;
+  const isFormatType = formats.some(format => html.hasAttribute(format));
+  return isFormatType;
+}
+
+/**
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isAmp4Email(doc) {
+  return isAmpFormatType(['⚡4email', 'amp4email'], doc);
+}

--- a/src/format.js
+++ b/src/format.js
@@ -33,3 +33,11 @@ function isAmpFormatType(formats, doc) {
 export function isAmp4Email(doc) {
   return isAmpFormatType(['⚡4email', 'amp4email'], doc);
 }
+
+/**
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isStdAmp(doc) {
+  return isAmpFormatType(['⚡', 'amp'], doc);
+}

--- a/src/format.js
+++ b/src/format.js
@@ -38,6 +38,6 @@ export function isAmp4Email(doc) {
  * @param {!Document} doc
  * @return {boolean}
  */
-export function isStdAmp(doc) {
+export function isAmphtml(doc) {
   return isAmpFormatType(['⚡', 'amp'], doc);
 }

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -23,6 +23,7 @@ import {
   WHITELISTED_TARGETS,
   isValidAttr,
 } from './sanitation';
+import {isAmp4Email} from './format';
 import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -23,7 +23,6 @@ import {
   WHITELISTED_TARGETS,
   isValidAttr,
 } from './sanitation';
-import {isAmp4Email} from './format';
 import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';

--- a/src/sanitation.js
+++ b/src/sanitation.js
@@ -15,6 +15,7 @@
  */
 
 import {dict} from './utils/object';
+import {isAmp4Email} from './format';
 import {isUrlAttribute} from './url-rewrite';
 import {startsWith} from './string';
 
@@ -270,24 +271,4 @@ export function isValidAttr(
   }
 
   return true;
-}
-
-/**
- * Checks that the document is of an AMP format type.
- * @param {!Array<string>} formats
- * @param {!Document} doc
- * @return {boolean}
- */
-function isAmpFormatType(formats, doc) {
-  const html = doc.documentElement;
-  const isFormatType = formats.some(format => html.hasAttribute(format));
-  return isFormatType;
-}
-
-/**
- * @param {!Document} doc
- * @return {boolean}
- */
-export function isAmp4Email(doc) {
-  return isAmpFormatType(['⚡4email', 'amp4email'], doc);
 }


### PR DESCRIPTION
`amp-lightbox-gallery` is not allowed on `amp4email`, which makes the loading of this extension unnecessary and could lead to bugs.

b/136742391 for internal tracking.