### PR TITLE
Story desktop GPU memory optimization so videos play smoothly.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -89,7 +89,6 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
   transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
   opacity: 0.05 !important;
   transform-origin: left !important;
-  border-radius: 0 !important;
 }
 
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page.i-amphtml-element {
@@ -185,8 +184,4 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
   max-width: calc(3/5 * 75vh) !important;
   min-width: 320px !important;
   min-height: 533px !important;
-}
-
-.i-amphtml-story-desktop-panels > amp-story-page {
-  box-shadow: 0 50px 200px rgba(0, 0, 0, 0.7) !important
 }

--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -89,6 +89,8 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
   transform: scale(0.9) translateX(calc(250% + 192px)) translateY(0%) !important;
   opacity: 0.05 !important;
   transform-origin: left !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page.i-amphtml-element {


### PR DESCRIPTION
The GPU memory used by our desktop three panels experience was so high that on some computers, the hardware-accelerated video decoding was stuttering, resulting on videos not playing.
(Hardware accelerated video decoding uses GPU, not CPU, which is why videos were playing smoothly when we were disabling it).

This fix gets all videos to play as smooth as expected in this desktop three panels layout, but as a nice side effect gets the overall experience much much faster.
Removing this `box-shadow` has no visible effect, since we removed the background images.

One line fix but really interesting performance improvements:

| Device  | Max GPU memory / Min FPS before | Max GPU memory / Min FPS after | Improvement |
| :-------------: | :-------------: | :-------------: | :-------------: |
| Dell workstation (linux)  | ~73mb / 41 FPS | 13mb / 56 FPS | 5.6x less GPU memory used |
| MacBook pro 2017 13i  | ~280mb / 17 FPS | ~60mb / 42 FPS | 4.7x less GPU memory used |

Fixes #23184