### PR TITLE
🏗 Silence / fix known warnings that appear when `gulp check-types` detects an error

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -299,6 +299,7 @@ window.vg;
  * @type {function(*)}
  */
 let ReactRender = function() {};
+let RRule;
 /**
  * @param {Date} unusedDt
  * @param {boolean} unusedInc

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -352,14 +352,14 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       source_map_location_mapping: '|' + sourceMapBase,
       warning_level: options.verboseLogging ? 'VERBOSE' : 'DEFAULT',
       jscomp_error: [],
-      // moduleLoad: Demote "module not found" errors to ignore missing files
-      //     in type declarations in the swg.js bundle.
       // accessControls: Demote "Access to private variable" errors to allow
       //     AMP code to access variables in other files.
-      jscomp_warning: ['moduleLoad', 'accessControls'],
-      // Turn off warning for "Unknown @define" since we use define to pass
-      // args such as FORTESTING to our runner.
-      jscomp_off: ['unknownDefines'],
+      jscomp_warning: ['accessControls'],
+      // moduleLoad: Demote "module not found" type check errors until
+      //     https://github.com/google/closure-compiler/issues/3041 is fixed.
+      // unknownDefines: Demote warning for "Unknown @define" since we use
+      //     define to pass args such as FORTESTING to our runner.
+      jscomp_off: ['moduleLoad', 'unknownDefines'],
       define,
       hide_warnings_for: hideWarningsFor,
     };


### PR DESCRIPTION
When `gulp check-types` detects a real error, it's accompanied by hundreds of warnings due to known issues in the code. This PR fixes / silences those warnings so that only the errors that need to be acted on are displayed on the screen.