### PR TITLE
amp-script: Allow removal of attributes

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -278,6 +278,21 @@ class AmpScriptService {
 }
 
 /**
+ * sandbox="allow-forms" enables tags in HTMLFormElement.elements.
+ * @const {!Array<string>}
+ */
+const FORM_ELEMENTS = [
+  'form',
+  'button',
+  'fieldset',
+  'input',
+  'object',
+  'output',
+  'select',
+  'textarea',
+];
+
+/**
  * A DOMPurify wrapper that implements the worker-dom.Sanitizer interface.
  * @visibleForTesting
  */
@@ -287,10 +302,10 @@ export class SanitizerImpl {
    * @param {!Array<string>} sandboxTokens
    */
   constructor(win, sandboxTokens) {
-    /** @private {!DomPurifyDef} */
+    /** @private @const {!DomPurifyDef} */
     this.purifier_ = createPurifier(win.document, dict({'IN_PLACE': true}));
 
-    /** @private {!Object<string, boolean>} */
+    /** @private @const {!Object<string, boolean>} */
     this.allowedTags_ = getAllowedTags();
 
     // TODO(choumx): Support opt-in for variable substitutions.
@@ -299,20 +314,10 @@ export class SanitizerImpl {
     this.allowedTags_['amp-layout'] = true;
     this.allowedTags_['amp-pixel'] = false;
 
-    // "allow-forms" enables tags in HTMLFormElement.elements.
-    const allowForms = sandboxTokens.includes('allow-forms');
-    const formElements = [
-      'form',
-      'button',
-      'fieldset',
-      'input',
-      'object',
-      'output',
-      'select',
-      'textarea',
-    ];
-    formElements.forEach(fe => {
-      this.allowedTags_[fe] = allowForms;
+    /** @private @const {boolean} */
+    this.allowForms_ = sandboxTokens.includes('allow-forms');
+    FORM_ELEMENTS.forEach(fe => {
+      this.allowedTags_[fe] = this.allowForms_;
     });
   }
 
@@ -329,7 +334,9 @@ export class SanitizerImpl {
     const tag = node.nodeName.toLowerCase();
     const clean = this.allowedTags_[tag];
     if (!clean) {
-      user().warn(TAG, 'Sanitized node:', node);
+      if (this.warnIfFormsAreDisallowed_(tag)) {
+        user().warn(TAG, 'Sanitized node:', node);
+      }
     }
     return clean;
   }
@@ -366,7 +373,25 @@ export class SanitizerImpl {
         return true;
       }
     }
-    user().warn(TAG, 'Sanitized [%s]="%s":', attribute, value, node);
+    if (!this.warnIfFormsAreDisallowed_(tag)) {
+      user().warn(TAG, 'Sanitized [%s]="%s":', attribute, value, node);
+    }
+    return false;
+  }
+
+  /**
+   * @param {string} tag
+   * @return {boolean}
+   */
+  warnIfFormsAreDisallowed_(tag) {
+    if (!this.allowForms_ && FORM_ELEMENTS.includes(tag)) {
+      user().warn(
+        TAG,
+        'Form elements (%s) are not allowed without sandbox="allow-forms".',
+        tag
+      );
+      return true;
+    }
     return false;
   }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -334,7 +334,7 @@ export class SanitizerImpl {
     const tag = node.nodeName.toLowerCase();
     const clean = this.allowedTags_[tag];
     if (!clean) {
-      if (this.warnIfFormsAreDisallowed_(tag)) {
+      if (!this.warnIfFormsAreDisallowed_(tag)) {
         user().warn(TAG, 'Sanitized node:', node);
       }
     }

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -390,16 +390,21 @@ export function validateAttributeChange(purifier, node, attr, value) {
   if (whitelist) {
     const {attribute, values} = whitelist;
     if (attribute === attr) {
-      if (value == null || !values.includes(value)) {
+      if (value === null || !values.includes(value)) {
         return false;
       }
     }
   }
   // a[target] is required and only certain values are allowed.
   if (tag === 'a' && attr === 'target') {
-    if (value == null || !WHITELISTED_TARGETS.includes(value)) {
+    if (value === null || !WHITELISTED_TARGETS.includes(value)) {
       return false;
     }
+  }
+  // By now, the attribute is safe to remove.  DOMPurify.isValidAttribute()
+  // expects non-null values.
+  if (value === null) {
+    return true;
   }
   // Don't allow binding attributes for now.
   if (bindingTypeForAttr(attr) !== BindingType.NONE) {
@@ -414,12 +419,10 @@ export function validateAttributeChange(purifier, node, attr, value) {
     // TODO(choumx): This opts out of DOMPurify's attribute _value_ sanitization
     // for the above, which assumes that the attributes don't have security
     // implications beyond URLs etc. that are covered by isValidAttr().
-    // This is OK for now, but we should instead somehow modify ALLOWED_ATTR
-    // to preserve value sanitization.
-    const whitelisted = WHITELISTED_ATTRS.includes(attr);
+    // This is OK but we ought to contribute new hooks and remove this.
     const attrsByTags = WHITELISTED_ATTRS_BY_TAGS[tag];
     const whitelistedForTag = attrsByTags && attrsByTags.includes(attr);
-    if (!whitelisted && !whitelistedForTag && !startsWith(tag, 'amp-')) {
+    if (!whitelistedForTag && !startsWith(tag, 'amp-')) {
       return false;
     }
   }

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -390,20 +390,20 @@ export function validateAttributeChange(purifier, node, attr, value) {
   if (whitelist) {
     const {attribute, values} = whitelist;
     if (attribute === attr) {
-      if (value === null || !values.includes(value)) {
+      if (value == null || !values.includes(value)) {
         return false;
       }
     }
   }
   // a[target] is required and only certain values are allowed.
   if (tag === 'a' && attr === 'target') {
-    if (value === null || !WHITELISTED_TARGETS.includes(value)) {
+    if (value == null || !WHITELISTED_TARGETS.includes(value)) {
       return false;
     }
   }
   // By now, the attribute is safe to remove.  DOMPurify.isValidAttribute()
   // expects non-null values.
-  if (value === null) {
+  if (value == null) {
     return true;
   }
   // Don't allow binding attributes for now.

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -721,13 +721,6 @@ describe('validateAttributeChange', () => {
     expect(vac('p', 'data-amp-bind-text', 'foo')).to.be.false;
   });
 
-  it('should allow whitelisted attributes', () => {
-    purifier.isValidAttribute = () => false;
-
-    expect(vac('p', 'heights', '(min-width:500px) 200px, 80%')).to.be.true;
-    expect(vac('button', 'on', 'tap:AMP.print')).to.be.true;
-  });
-
   it('should allow whitelisted-by-tag attributes', () => {
     purifier.isValidAttribute = () => false;
 


### PR DESCRIPTION
Partial for #23156.

- Allow removal of attributes early since `DOMPurify.isValidAttribute` expects non-null values.
- Add warning for sanitized form elements without `[sandbox=allow-forms]`.
- Remove special-case for `WHITELISTED_ATTRS` in `validateAttributeChange()` since I didn't realize those are already covered by the DOMPurify config.