### PR TITLE
🐛 Fix async completion bug in `gulp ava`

### DIFF
--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -22,7 +22,7 @@ const {isTravisBuild} = require('../travis');
 /**
  * Runs ava tests.
  */
-function ava() {
+async function ava() {
   return gulp
     .src([
       require.resolve('./csvify-size/test.js'),


### PR DESCRIPTION
Fixes [this](https://travis-ci.org/ampproject/amphtml/jobs/556521119#L347) async completion bug introduced by #23188. Unfortunately, PR job didn't test it because the `ava` tests are run only when the tests or code are changed.
