### PR TITLE
🚀 FetchInitDef prerenderSafe param

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -34,6 +34,7 @@
  *   headers: (!JsonObject|undefined),
  *   method: (string|undefined),
  *   ampCors: (boolean|undefined),
+ *   prerenderSafe: (boolean|undefined)
  *   bypassInterceptorForDev: (boolean|undefined)
  * }}
  */

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -34,7 +34,7 @@
  *   headers: (!JsonObject|undefined),
  *   method: (string|undefined),
  *   ampCors: (boolean|undefined),
- *   prerenderSafe: (boolean|undefined)
+ *   prerenderSafe: (boolean|undefined),
  *   bypassInterceptorForDev: (boolean|undefined)
  * }}
  */

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -457,7 +457,13 @@ const forbiddenTerms = {
       'extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js',
     ],
   },
-  'prerenderSafe': requiresReviewPrivacy,
+  'prerenderSafe': {
+    message: requiresReviewPrivacy,
+    whitelist: [
+      'build-system/amp.extern.js',
+      'src/utils/xhr-utils.js',
+    ],
+  },
   'eval\\(': {
     message: shouldNeverBeUsed,
     whitelist: ['extension/amp-bind/0.1/test/test-bind-expr.js'],

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -457,6 +457,7 @@ const forbiddenTerms = {
       'extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js',
     ],
   },
+  'prerenderSafe': requiresReviewPrivacy,
   'eval\\(': {
     message: shouldNeverBeUsed,
     whitelist: ['extension/amp-bind/0.1/test/test-bind-expr.js'],

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -459,10 +459,7 @@ const forbiddenTerms = {
   },
   'prerenderSafe': {
     message: requiresReviewPrivacy,
-    whitelist: [
-      'build-system/amp.extern.js',
-      'src/utils/xhr-utils.js',
-    ],
+    whitelist: ['build-system/amp.extern.js', 'src/utils/xhr-utils.js'],
   },
   'eval\\(': {
     message: shouldNeverBeUsed,

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -201,25 +201,25 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   }
 
   const viewer = Services.viewerForDoc(ampdocSingle);
-  const whenFirstVisible = viewer.whenFirstVisible();
+  const whenUnblocked = init.prerenderSafe
+    ? Promise.resolve()
+    : viewer.whenFirstVisible();
   const urlIsProxy = isProxyOrigin(input);
   const viewerCanIntercept = viewer.hasCapability('xhrInterceptor');
   const interceptorDisabledForLocalDev =
     init.bypassInterceptorForDev && getMode(win).localDev;
   if (urlIsProxy || !viewerCanIntercept || interceptorDisabledForLocalDev) {
-    return whenFirstVisible;
+    return whenUnblocked;
   }
 
   const htmlElement = ampdocSingle.getRootNode().documentElement;
   const docOptedIn = htmlElement.hasAttribute('allow-xhr-interception');
   if (!docOptedIn) {
-    return whenFirstVisible;
+    return whenUnblocked;
   }
 
-  return whenFirstVisible
-    .then(() => {
-      return viewer.isTrustedViewer();
-    })
+  return whenUnblocked
+    .then(() => viewer.isTrustedViewer())
     .then(viewerTrusted => {
       if (
         !(

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -112,7 +112,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
         hasCapability: unusedParam => true,
         isTrustedViewer: () => Promise.resolve(true),
         sendMessageAwaitResponse: sandbox.stub().returns(Promise.resolve({})),
-        whenFirstVisible: () => Promise.resolve(),
+        whenFirstVisible: sandbox.stub().returns(Promise.resolve()),
       };
       viewerForDoc = sandbox.stub(Services, 'viewerForDoc').returns(viewer);
       win = {
@@ -192,11 +192,26 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
           },
         },
       });
-      expect(viewer.sendMessageAwaitResponse).to.have.been.calledOnce;
-      expect(viewer.sendMessageAwaitResponse).to.have.been.calledWith(
+      expect(viewer.sendMessageAwaitResponse).to.have.been.calledOnceWith(
         'xhr',
         msgPayload
       );
+    });
+
+    it('should wait for visibility', async () => {
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      expect(viewer.whenFirstVisible).to.have.been.calledOnce;
+    });
+
+    it('should not wait for visibility if prerenderSafe', async () => {
+      init = {
+        prerenderSafe: true,
+      };
+
+      await getViewerInterceptResponse(win, ampDocSingle, input, init);
+
+      expect(viewer.whenFirstVisible).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
Adds prerenderSafe param to FetchInitDef. This param marks a request as safe to send before the viewer is visible.

Fixes #23101.