### PR TITLE
Add a promo to README for AMPCS2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovateapp.com/)
 [![Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
+> **The [AMP Contributor Summit 2019](https://amp.dev/events/amp-cs-2019) will be in NYC October 8-10.** This technical summit is an opportunity for the AMP open source community to meet face-to-face to discuss the latest in AMP and where AMP is going.  It consists of a mix of different formats, including talks, breakout sessions and many opportunities for informal conversations.  **[Apply to attend the summit](https://events.withgoogle.com/ampcs2019/registrations/new/) by July 22, 2019!**
+
 [AMP](https://amp.dev) is a web component framework for easily creating user-first websites, stories, ads, emails and more.
 
 AMP is an open source project, and we'd love your help making it better!


### PR DESCRIPTION
This adds a promo for the AMP Contributor Summit 2019 to our main repo's README.md.

/cc @ampproject/wg-outreach 