### PR TITLE
✨ Updates SWG to use prerenderSafe fetch param

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -459,7 +459,11 @@ const forbiddenTerms = {
   },
   'prerenderSafe': {
     message: requiresReviewPrivacy,
-    whitelist: ['build-system/amp.extern.js', 'src/utils/xhr-utils.js'],
+    whitelist: [
+      'build-system/amp.extern.js',
+      'extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js',
+      'src/utils/xhr-utils.js',
+    ],
   },
   'eval\\(': {
     message: shouldNeverBeUsed,

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -252,9 +252,7 @@ export class GoogleSubscriptionsPlatform {
      * for the page to be visible to avoid leaking that the
      * page was prerendered
      */
-    // TODO(#23102): restore safe prerendering mode. Instead of `false`,
-    // return `this.isGoogleViewer_`.
-    return false;
+    return this.isGoogleViewer_;
   }
 
   /** @override */

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -456,6 +456,7 @@ class AmpFetcher {
     return this.xhr_
       .fetchJson(url, {
         credentials: 'include',
+        prerenderSafe: true,
       })
       .then(response => response.json());
   }

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -450,9 +450,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should allow prerender if in a google viewer', () => {
     viewer.params_['viewerUrl'] = 'https://www.google.com/other';
     platform = new GoogleSubscriptionsPlatform(ampdoc, {}, serviceAdapter);
-    // TODO(#23102): restore safe prerendering mode. This will be `true` once
-    // it's restored.
-    expect(platform.isPrerenderSafe()).to.be.false;
+    expect(platform.isPrerenderSafe()).to.be.true;
   });
 
   it('should attach button given to decorateUI', () => {

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -146,7 +146,10 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should proxy fetch via AMP fetcher', () => {
     const fetchStub = sandbox.stub(xhr, 'fetchJson').callsFake((url, init) => {
       expect(url).to.match(/publication\/example.org/);
-      expect(init).to.deep.equal({credentials: 'include'});
+      expect(init).to.deep.equal({
+        credentials: 'include',
+        prerenderSafe: true,
+      });
       return Promise.resolve({
         json: () => {
           return Promise.resolve({entitlements: entitlementResponse});


### PR DESCRIPTION
Updates SWG to use the new `prerenderSafe` param when fetching entitlements. This will allow the entitlements fetch to be sent before the view is active, but only for viewers on Google domains.

Fixes #23102.