### PR TITLE
🏗 Increase parallelism for single pass unless `--pseudo_names` is used

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -37,11 +37,10 @@ const {VERSION: internalRuntimeVersion} = require('../internal-version');
 const isProdBuild = !!argv.type;
 const queue = [];
 let inProgress = 0;
-// TODO(erwinm/rsima, #23238): Theres a weird race condition where when we use
-// `pseudo_names` we get "Error parsing json encoded files". turning the closure
-// invocations to 1 seems to fix the issue.
-const MAX_PARALLEL_CLOSURE_INVOCATIONS =
-  argv.single_pass || argv.pseudo_names ? 1 : 4;
+
+// `--pseudo_names` slows down closure compilation and results in a race.
+// See https://github.com/google/closure-compiler-npm/issues/9
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = argv.pseudo_names ? 1 : 4;
 
 /**
  * Prefixes the the tmp directory if we need to shadow files that have been

--- a/build-system/pr-check/single-pass-tests.js
+++ b/build-system/pr-check/single-pass-tests.js
@@ -41,7 +41,7 @@ function main() {
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
-    timedExecOrDie('gulp dist --fortesting --single_pass --pseudo_names');
+    timedExecOrDie('gulp dist --fortesting --single_pass');
     timedExecOrDie(
       'gulp integration --nobuild --compiled --single_pass --headless'
     );
@@ -54,7 +54,7 @@ function main() {
       buildTargets.has('INTEGRATION_TEST')
     ) {
       timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp dist --fortesting --single_pass --pseudo_names');
+      timedExecOrDie('gulp dist --fortesting --single_pass');
       timedExecOrDie(
         'gulp integration --nobuild --compiled --single_pass --headless'
       );


### PR DESCRIPTION
This PR stops using `--pseudo_names` for `gulp dist` on Travis. It also increases the parallelism for single pass compile when the flag isn't being used.

Closes #23238