### PR TITLE
Pass correct event target from the bookend to the AMP linker

### DIFF
--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AMP_CUSTOM_LINKER_TARGET} from '../../../../src/service/navigation';
 import {
   Action,
   StateProperty,
@@ -500,6 +501,10 @@ export class AmpStoryBookend extends AMP.BaseElement {
       this.close_();
       return;
     }
+
+    // Pass custom target so that linker can see it, otherwise it would see
+    // the entire shadow DOM tree and not know what target to choose.
+    event[AMP_CUSTOM_LINKER_TARGET] = target;
 
     if (target.hasAttribute('on')) {
       const actionService = Services.actionServiceForDoc(this.element);

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {AMP_CUSTOM_LINKER_TARGET} from '../../../../src/service/navigation';
 import {
   Action,
   StateProperty,
@@ -62,6 +61,12 @@ const BOOKEND_VERSION_KEY = 'bookendVersion';
  * @private @const {string}
  */
 const DEPRECATED_BOOKEND_VERSION_KEY = 'bookend-version';
+
+/**
+ * Key used for retargeting event target originating from shadow DOM.
+ * @const {string}
+ */
+const AMP_CUSTOM_LINKER_TARGET = '__AMP_CUSTOM_LINKER_TARGET__';
 
 /**
  * @param {string} hidden

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -43,8 +43,11 @@ const VALID_TARGETS = ['_top', '_blank'];
 /** @private @const {string} */
 const ORIG_HREF_ATTRIBUTE = 'data-a4a-orig-href';
 
-/** @const {string} */
-export const AMP_CUSTOM_LINKER_TARGET = '__AMP_CUSTOM_LINKER_TARGET__';
+/**
+ * Key used for retargeting event target originating from shadow DOM.
+ * @const {string}
+ */
+const AMP_CUSTOM_LINKER_TARGET = '__AMP_CUSTOM_LINKER_TARGET__';
 
 /**
  * @enum {number} Priority reserved for extensions in anchor mutations.

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -43,6 +43,9 @@ const VALID_TARGETS = ['_top', '_blank'];
 /** @private @const {string} */
 const ORIG_HREF_ATTRIBUTE = 'data-a4a-orig-href';
 
+/** @const {string} */
+export const AMP_CUSTOM_LINKER_TARGET = '__AMP_CUSTOM_LINKER_TARGET__';
+
 /**
  * @enum {number} Priority reserved for extensions in anchor mutations.
  * The higher the priority, the sooner it's invoked.
@@ -343,7 +346,9 @@ export class Navigation {
     if (e.defaultPrevented) {
       return;
     }
-    const element = dev().assertElement(e.target);
+    const element = dev().assertElement(
+      e[AMP_CUSTOM_LINKER_TARGET] || e.target
+    );
     const target = closestAncestorElementBySelector(element, 'A');
     if (!target || !target.href) {
       return;

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -118,6 +118,8 @@ describes.sandboxed('Navigation', {}, () => {
 
       describe('discovery', () => {
         it('should select a direct link', () => {
+          // TODO(alabiaga): throughout the file -- invoke the handler via the
+          // document used to get the navigation service. e.g document.click().
           handler.handle_(event);
           expect(handleNavSpy).to.be.calledOnce;
           expect(handleNavSpy).to.be.calledWith(event, anchor);

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -100,11 +100,12 @@ describes.sandboxed('Navigation', {}, () => {
         doc.body.appendChild(customAnchor);
 
         const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-        sandbox
-          .stub(Services, 'urlReplacementsForDoc')
-          .withArgs(anchor)
-          .withArgs(customAnchor)
-          .returns(urlReplacements);
+        const urlReplacementStub = sandbox.stub(
+          Services,
+          'urlReplacementsForDoc'
+        );
+        urlReplacementStub.withArgs(anchor).returns(urlReplacements);
+        urlReplacementStub.withArgs(customAnchor).returns(urlReplacements);
 
         elementWithId = doc.createElement('div');
         elementWithId.id = 'test';
@@ -125,14 +126,12 @@ describes.sandboxed('Navigation', {}, () => {
         });
 
         it('should select a custom linker target', () => {
-          const handleClickSpy = sandbox.spy(handler, 'handleClick_');
-
           event.target = null;
           event['__AMP_CUSTOM_LINKER_TARGET__'] = customAnchor;
           handler.handle_(event);
 
-          expect(handleClickSpy).to.be.calledOnce;
-          expect(handleClickSpy).to.be.calledWith(customAnchor, event);
+          expect(handleNavSpy).to.be.calledOnce;
+          expect(handleNavSpy).to.be.calledWith(event, customAnchor);
         });
 
         it('should NOT handle custom protocol when not iframed', () => {

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -57,6 +57,7 @@ describes.sandboxed('Navigation', {}, () => {
       let anchor;
       let elementWithId;
       let anchorWithName;
+      let customAnchor;
 
       beforeEach(() => {
         win = env.win;
@@ -94,10 +95,15 @@ describes.sandboxed('Navigation', {}, () => {
         doc.body.appendChild(anchor);
         event.target = anchor;
 
+        customAnchor = doc.createElement('a');
+        customAnchor.href = 'https://www.google.com/custom';
+        doc.body.appendChild(customAnchor);
+
         const urlReplacements = Services.urlReplacementsForDoc(documentElement);
         sandbox
           .stub(Services, 'urlReplacementsForDoc')
           .withArgs(anchor)
+          .withArgs(customAnchor)
           .returns(urlReplacements);
 
         elementWithId = doc.createElement('div');
@@ -116,6 +122,17 @@ describes.sandboxed('Navigation', {}, () => {
           expect(handleNavSpy).to.be.calledWith(event, anchor);
           expect(handleCustomProtocolSpy).to.be.calledOnce;
           expect(handleCustomProtocolSpy).to.be.calledWith(event, anchor);
+        });
+
+        it.only('should select a custom linker target', () => {
+          const handleClickSpy = sandbox.spy(handler, 'handleClick_');
+
+          event.target = null;
+          event['__AMP_CUSTOM_LINKER_TARGET__'] = customAnchor;
+          handler.handle_(event);
+
+          expect(handleClickSpy).to.be.calledOnce;
+          expect(handleClickSpy).to.be.calledWith(customAnchor, event);
         });
 
         it('should NOT handle custom protocol when not iframed', () => {

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -124,7 +124,7 @@ describes.sandboxed('Navigation', {}, () => {
           expect(handleCustomProtocolSpy).to.be.calledWith(event, anchor);
         });
 
-        it.only('should select a custom linker target', () => {
+        it('should select a custom linker target', () => {
           const handleClickSpy = sandbox.spy(handler, 'handleClick_');
 
           event.target = null;


### PR DESCRIPTION
fixes #23260

When clicking a link from the bookend, the URL wasn't being decorated with the `_gl` parameter because the bookend is inside a shadow DOM. 

This is because whenever the `handle_` method in `navigation.js` received the event, the `target` would correspond to the entire shadow DOM root, instead of the actual clicked target.

This PR allows custom AMP targets to be forwarded on the event by using a custom property, then `navigation.js` can check if this property exists, and use that instead of the default `target` that comes in the event.

![ezgif-1-de302fb497d8](https://user-images.githubusercontent.com/5449100/61077984-8e362300-a3ed-11e9-96e4-5a869baba964.gif)
