### PR TITLE
Do not add nameless submit buttons to form data

### DIFF
--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -157,7 +157,7 @@ class NativeFormDataWrapper {
     }
 
     const button = getSubmitButtonUsed(opt_form);
-    if (button) {
+    if (button && button.name) {
       this.append(button.name, button.value);
     }
   }

--- a/test/unit/test-form-data-wrapper.js
+++ b/test/unit/test-form-data-wrapper.js
@@ -381,6 +381,30 @@ describes.realWin('FormDataWrapper', {}, env => {
             ]);
           }
         );
+
+        it('excludes the submit input if it has no name attribute', () => {
+          const form = env.win.document.createElement('form');
+
+          const input = env.win.document.createElement('input');
+          input.type = 'text';
+          input.name = 'foo1';
+          input.value = 'bar';
+
+          const submit = env.win.document.createElement('input');
+          submit.type = 'submit';
+          // no name attribute
+          submit.value = 'baz';
+
+          form.appendChild(input);
+          form.appendChild(submit);
+          env.win.document.body.appendChild(form);
+
+          submit.focus();
+          const formData = createFormDataWrapper(env.win, form);
+          expect(fromIterator(formData.entries())).to.have.deep.members([
+            ['foo1', 'bar'],
+          ]);
+        });
       });
     });
 


### PR DESCRIPTION
Fixes #23270

It looks like we check for this in `getFormAsObject` but neglected to in `NativeFormDataWrapper#maybeIncludeSubmitButton`. Added a regression test.