### PR TITLE
Fix 3 viewports down bug

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1083,8 +1083,7 @@ export class AmpList extends AMP.BaseElement {
       .getClientRectAsync(dev().assertElement(endoOfListMarker))
       .then(positionRect => {
         const viewportHeight = this.viewport_.getHeight();
-        const viewportTop = this.viewport_.getScrollTop();
-        if (viewportTop + 3 * viewportHeight > positionRect.bottom) {
+        if (3 * viewportHeight > positionRect.bottom) {
           return this.loadMoreCallback_();
         }
       });

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -17,7 +17,6 @@
 import {AmpDocService} from '../../../../src/service/ampdoc-impl';
 import {AmpList} from '../amp-list';
 import {Services} from '../../../../src/services';
-import {isExperimentOn, toggleExperiment} from '../../../../src/experiments';
 import {
   measureElementStub,
   measureMutateElementStub,
@@ -58,14 +57,10 @@ describes.realWin(
       };
       sandbox.stub(Services, 'templatesFor').returns(templates);
       sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
-
-      toggleExperiment(win, 'amp-list-load-more', true);
     });
 
     describe('manual', () => {
       beforeEach(() => {
-        expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
-
         element = doc.createElement('amp-list');
         list = new AmpList(element);
 
@@ -151,8 +146,6 @@ describes.realWin(
 
     describe('loading states', () => {
       beforeEach(() => {
-        expect(isExperimentOn(win, 'amp-list-load-more')).to.be.true;
-
         element = doc.createElement('amp-list');
         list = new AmpList(element);
 

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -122,7 +122,7 @@
     layout="fixed-height"
     src="/list/infinite-scroll?items=10&left=50"
     [src]="data.url"
-    load-more="manual"
+    load-more="auto"
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">


### PR DESCRIPTION
The measurement from `positionRect.bottom` is actually (a call to `getClientBoundingRect`) measuring distance from viewport top already, not distance from the beginning of the page. There is no need to subtract the scrollTop distance in this case. 

- [ ] add tests