### PR TITLE
🏗 Force exact versions during `yarn add`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--add.exact true


### PR DESCRIPTION
This PR makes it so that `yarn add` installs an exact version to `package.json` by default

See https://yarnpkg.com/lang/en/docs/yarnrc/#toc-cli-arguments