### PR TITLE
🏗 Enable `e2e`, `integration`, and `visual-diff` tests to be run using the `canary` AMP config

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -87,22 +87,10 @@ function transferSrcsToTempDir() {
 }
 
 /**
- * Entry point for the `gulp dist` task
+ * Dist Build
  * @return {!Promise}
  */
 async function dist() {
-  await performDist();
-}
-
-/**
- * Used by the `gulp dist` task and by other test tasks that compile the runtime
- * as a pre-requisite step
- * @param {?Object} extraArgs
- */
-async function performDist(extraArgs = {}) {
-  Object.keys(extraArgs).forEach(key => {
-    argv[key] = extraArgs[key];
-  });
   maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';
@@ -446,7 +434,6 @@ function preBuildLoginDoneVersion(version) {
 
 module.exports = {
   dist,
-  performDist,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -91,7 +91,7 @@ function transferSrcsToTempDir() {
  * @return {!Promise}
  */
 async function dist() {
-  return performDist();
+  await performDist();
 }
 
 /**

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -57,7 +57,7 @@ const {isTravisBuild} = require('../travis');
 const {maybeUpdatePackages} = require('./update-packages');
 
 const {green, cyan} = colors;
-let argv = require('minimist')(process.argv.slice(2));
+const argv = require('minimist')(process.argv.slice(2));
 
 const babel = require('@babel/core');
 const deglob = require('globs-to-files');
@@ -87,17 +87,22 @@ function transferSrcsToTempDir() {
 }
 
 /**
- * Dist Build
- * @param {Object|Function} args
+ * Entry point for the `gulp dist` task
  * @return {!Promise}
  */
-async function dist(args) {
-  // The default 'dist' task passes in a callback of type Function. The testing
-  // tasks ('e2e', 'integration', and 'visual-diff') pass in args via an Object.
-  if (typeof args == 'object') {
-    argv = args;
-  }
+async function dist() {
+  return performDist();
+}
 
+/**
+ * Used by the `gulp dist` task and by other test tasks that compile the runtime
+ * as a pre-requisite step
+ * @param {?Object} extraArgs
+ */
+async function performDist(extraArgs = {}) {
+  Object.keys(extraArgs).forEach(key => {
+    argv[key] = extraArgs[key];
+  });
   maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';
@@ -441,6 +446,7 @@ function preBuildLoginDoneVersion(version) {
 
 module.exports = {
   dist,
+  performDist,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -57,7 +57,7 @@ const {isTravisBuild} = require('../travis');
 const {maybeUpdatePackages} = require('./update-packages');
 
 const {green, cyan} = colors;
-const argv = require('minimist')(process.argv.slice(2));
+let argv = require('minimist')(process.argv.slice(2));
 
 const babel = require('@babel/core');
 const deglob = require('globs-to-files');
@@ -88,9 +88,16 @@ function transferSrcsToTempDir() {
 
 /**
  * Dist Build
+ * @param {Object|Function} args
  * @return {!Promise}
  */
-async function dist() {
+async function dist(args) {
+  // The default 'dist' task passes in a callback of type Function. The testing
+  // tasks ('e2e', 'integration', and 'visual-diff') pass in args via an Object.
+  if (typeof args == 'object') {
+    argv = args;
+  }
+
   maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,10 +23,8 @@ const glob = require('glob');
 const log = require('fancy-log');
 const Mocha = require('mocha');
 const tryConnect = require('try-net-connect');
-const {clean} = require('../clean');
 const {cyan} = require('ansi-colors');
 const {execOrDie, execScriptAsync} = require('../../exec');
-const {performDist} = require('../dist');
 const {reportTestStarted} = require('../report-test-status');
 const {watch} = require('gulp');
 
@@ -42,9 +40,9 @@ function installPackages_() {
   execOrDie('npx yarn --cwd build-system/tasks/e2e', {'stdio': 'ignore'});
 }
 
-async function buildRuntime_() {
-  await clean();
-  await performDist({fortesting: true});
+function buildRuntime_() {
+  execOrDie('gulp clean');
+  execOrDie(`gulp dist --fortesting --config ${argv.config}`);
 }
 
 function launchWebServer_() {
@@ -108,7 +106,7 @@ async function e2e() {
 
   // build runtime
   if (!argv.nobuild) {
-    await buildRuntime_();
+    buildRuntime_();
   }
 
   // start up web server
@@ -169,7 +167,8 @@ e2e.flags = {
   'browsers':
     '  Run only the specified browser tests. Options are ' +
     '`chrome`, `firefox`.',
-  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  'config':
+    '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -108,7 +108,7 @@ async function e2e() {
 
   // build runtime
   if (!argv.nobuild) {
-    buildRuntime_();
+    await buildRuntime_();
   }
 
   // start up web server

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,7 +23,9 @@ const glob = require('glob');
 const log = require('fancy-log');
 const Mocha = require('mocha');
 const tryConnect = require('try-net-connect');
+const {clean} = require('../clean');
 const {cyan} = require('ansi-colors');
+const {dist} = require('../dist');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {reportTestStarted} = require('../report-test-status');
 const {watch} = require('gulp');
@@ -40,9 +42,10 @@ function installPackages_() {
   execOrDie('npx yarn --cwd build-system/tasks/e2e', {'stdio': 'ignore'});
 }
 
-function buildRuntime_() {
-  execOrDie('gulp clean');
-  execOrDie('gulp dist --fortesting');
+async function buildRuntime_() {
+  argv.fortesting = true;
+  await clean();
+  await dist(argv);
 }
 
 function launchWebServer_() {
@@ -167,6 +170,7 @@ e2e.flags = {
   'browsers':
     '  Run only the specified browser tests. Options are ' +
     '`chrome`, `firefox`.',
+  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -25,8 +25,8 @@ const Mocha = require('mocha');
 const tryConnect = require('try-net-connect');
 const {clean} = require('../clean');
 const {cyan} = require('ansi-colors');
-const {dist} = require('../dist');
 const {execOrDie, execScriptAsync} = require('../../exec');
+const {performDist} = require('../dist');
 const {reportTestStarted} = require('../report-test-status');
 const {watch} = require('gulp');
 
@@ -43,9 +43,8 @@ function installPackages_() {
 }
 
 async function buildRuntime_() {
-  argv.fortesting = true;
   await clean();
-  await dist(argv);
+  await performDist({fortesting: true});
 }
 
 function launchWebServer_() {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -46,7 +46,7 @@ const argv = require('minimist')(process.argv.slice(2));
  * Tasks that should print the `--nobuild` help text.
  * @private @const {!Set<string>}
  */
-const NOBUILD_HELP_TASKS = new Set(['test', 'visual-diff']);
+const NOBUILD_HELP_TASKS = new Set(['e2e', 'integration', 'visual-diff']);
 
 const MODULE_SEPARATOR = ';';
 const EXTENSION_BUNDLE_MAP = {

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -25,7 +25,7 @@ const {
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
 const {clean} = require('./clean');
-const {dist} = require('./dist');
+const {performDist} = require('./dist');
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -37,10 +37,8 @@ class Runner extends RuntimeTestRunner {
     if (argv.nobuild) {
       return;
     }
-    argv.fortesting = true;
-    argv.compiled = true;
     await clean();
-    await dist(argv);
+    await performDist({compiled: true, fortesting: true});
   }
 }
 

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -24,8 +24,7 @@ const {
   RuntimeTestRunner,
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
-const {clean} = require('./clean');
-const {performDist} = require('./dist');
+const {execOrDie} = require('../exec');
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -37,8 +36,8 @@ class Runner extends RuntimeTestRunner {
     if (argv.nobuild) {
       return;
     }
-    await clean();
-    await performDist({compiled: true, fortesting: true});
+    execOrDie('gulp clean');
+    execOrDie(`gulp dist --fortesting --config ${argv.config}`);
   }
 }
 
@@ -67,7 +66,8 @@ integration.flags = {
   'chrome_flags': '  Uses the given flags to launch Chrome',
   'compiled':
     '  Changes integration tests to use production JS binaries for execution',
-  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  'config':
+    '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'coverage': '  Run tests in code coverage mode',
   'firefox': '  Runs tests on Firefox',
   'files': '  Runs tests for specific files',

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -40,7 +40,7 @@ class Runner extends RuntimeTestRunner {
     argv.fortesting = true;
     argv.compiled = true;
     await clean();
-    await dist();
+    await dist(argv);
   }
 }
 
@@ -69,6 +69,7 @@ integration.flags = {
   'chrome_flags': '  Uses the given flags to launch Chrome',
   'compiled':
     '  Changes integration tests to use production JS binaries for execution',
+  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   'coverage': '  Run tests in code coverage mode',
   'firefox': '  Runs tests on Firefox',
   'files': '  Runs tests for specific files',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -623,7 +623,9 @@ const forbiddenTerms = {
     whitelist: [
       'build-system/amp.extern.js',
       'build-system/app.js',
+      'build-system/tasks/e2e/index.js',
       'build-system/tasks/firebase.js',
+      'build-system/tasks/integration.js',
       'build-system/tasks/prepend-global/index.js',
       'build-system/tasks/prepend-global/test.js',
       'build-system/tasks/visual-diff/index.js',

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -116,7 +116,6 @@ function maybePrintArgvMessages() {
     verbose: 'Enabling verbose mode. Expect lots of output!',
     testnames: 'Listing the names of all tests being run.',
     files: 'Running tests in the file(s): ' + cyan(argv.files),
-    compiled: 'Running tests against minified code.',
     grep:
       'Only running tests that match the pattern "' + cyan(argv.grep) + '".',
     coverage: 'Running tests in code coverage mode.',
@@ -160,7 +159,9 @@ function maybePrintArgvMessages() {
       green('to run tests in a headless Chrome window.')
     );
   }
-  if (!argv.compiled) {
+  if (argv.compiled || !argv.nobuild) {
+    log(green('Running tests against minified code.'));
+  } else {
     log(green('Running tests against unminified code.'));
   }
   Object.keys(argv).forEach(arg => {

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -260,7 +260,11 @@ class RuntimeTestRunner {
   async setup() {
     // TODO(alanorozco): Come up with a more elegant check?
     global.AMP_TESTING = true;
-    process.env.SERVE_MODE = argv.compiled ? 'compiled' : 'default';
+
+    // Run tests against compiled code when explicitly specified via --compiled,
+    // or when the minified runtime is automatically built.
+    process.env.SERVE_MODE =
+      argv.compiled || !argv.nobuild ? 'compiled' : 'default';
 
     await this.maybeBuild();
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -37,6 +37,8 @@ const {
   gitTravisMasterBaseline,
   shortSha,
 } = require('../../git');
+const {clean} = require('../clean');
+const {dist} = require('../dist');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
@@ -840,8 +842,9 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       );
     }
   } else {
-    execOrDie('gulp clean');
-    execOrDie('gulp dist --fortesting');
+    argv.fortesting = true;
+    await clean();
+    await dist(argv);
   }
 }
 
@@ -885,6 +888,7 @@ visualDiff.flags = {
   'master': '  Includes a blank snapshot (baseline for skipped builds)',
   'empty': '  Creates a dummy Percy build with only a blank snapshot',
   'chrome_debug': '  Prints debug info from Chrome',
+  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   'webserver_debug': '  Prints debug info from the local gulp webserver',
   'debug': '  Prints all the above debug info',
   'grep': '  Runs tests that match the pattern',

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -38,10 +38,10 @@ const {
   shortSha,
 } = require('../../git');
 const {clean} = require('../clean');
-const {dist} = require('../dist');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
+const {performDist} = require('../dist');
 
 // optional dependencies for local development (outside of visual diff tests)
 let puppeteer;
@@ -842,9 +842,8 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       );
     }
   } else {
-    argv.fortesting = true;
     await clean();
-    await dist(argv);
+    await performDist({fortesting: true});
   }
 }
 

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -37,11 +37,9 @@ const {
   gitTravisMasterBaseline,
   shortSha,
 } = require('../../git');
-const {clean} = require('../clean');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
-const {performDist} = require('../dist');
 
 // optional dependencies for local development (outside of visual diff tests)
 let puppeteer;
@@ -765,7 +763,7 @@ async function createEmptyBuild() {
  * Runs the AMP visual diff tests.
  */
 async function visualDiff() {
-  await ensureOrBuildAmpRuntimeInTestMode_();
+  ensureOrBuildAmpRuntimeInTestMode_();
   installPercy_();
   setupCleanup_();
   maybeOverridePercyEnvironmentVariables();
@@ -842,8 +840,8 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       );
     }
   } else {
-    await clean();
-    await performDist({fortesting: true});
+    execOrDie('gulp clean');
+    execOrDie(`gulp dist --fortesting --config ${argv.config}`);
   }
 }
 
@@ -887,7 +885,8 @@ visualDiff.flags = {
   'master': '  Includes a blank snapshot (baseline for skipped builds)',
   'empty': '  Creates a dummy Percy build with only a blank snapshot',
   'chrome_debug': '  Prints debug info from Chrome',
-  'config': '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  'config':
+    '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'webserver_debug': '  Prints debug info from the local gulp webserver',
   'debug': '  Prints all the above debug info',
   'grep': '  Runs tests that match the pattern',

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -765,7 +765,7 @@ async function createEmptyBuild() {
  * Runs the AMP visual diff tests.
  */
 async function visualDiff() {
-  ensureOrBuildAmpRuntimeInTestMode_();
+  await ensureOrBuildAmpRuntimeInTestMode_();
   installPercy_();
   setupCleanup_();
   maybeOverridePercyEnvironmentVariables();

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -80,7 +80,8 @@ Command                                                                 | Descri
 `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.
 `gulp unit`                                                             | Runs the unit tests in Chrome (doesn't require the AMP library to be built).
 `gulp unit --local_changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.
-`gulp integration`                                                      | Runs the integration tests in Chrome (requires the AMP library to be built).
+`gulp integration`                                                      | Runs the integration tests in Chrome after building the runtime with the `prod` version of `AMP_CONFIG`.
+`gulp integration --config=<config>`                                    | Same as above, but `config` can be `prod` or `canary`. (Defaults to `prod`.)
 `gulp [unit\|integration] --verbose`                                    | Runs tests in Chrome with logging enabled.
 `gulp [unit\|integration] --nobuild`                                    | Runs tests without re-build.
 `gulp [unit\|integration] --coverage`                                   | Runs code coverage tests. After running, the report will be available at test/coverage/index.html
@@ -103,7 +104,8 @@ Command                                                                 | Descri
 `gulp validator`                                                        | Builds and tests the AMP validator. Run automatically upon push.
 `gulp ava`                                                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava).
 `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed.
-`gulp visual-diff`                                                      | Runs all visual diff tests on a headless instance of local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
+`gulp visual-diff`                                                      | Runs all visual diff tests on a headless instance of local Chrome after building the runtime with the `prod` version of `AMP_CONFIG`. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
+`gulp visual-diff --config=<config>`                                    | Same as above, but `config` can be `prod` or `canary`. (Defaults to `prod`.)
 `gulp visual-diff --nobuild`                                            | Same as above, but without re-build.
 `gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.
 `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
@@ -111,7 +113,8 @@ Command                                                                 | Descri
 `gulp firebase --file path/to/file`                                     | Same as above, but copies over the file specified as `firebase/index.html`.
 `gulp firebase --min`                                                   | Same as `gulp firebase`, but uses minified files of the form `/dist/v0/amp-component-name.js` instead of unminified files of the form `/dist/v0/amp-component-name.max.js`.
 `gulp firebase --nobuild`                                               | Same as `gulp firebase`, but skips the `gulp build` step.
-`gulp e2e`                                                              | Runs all end-to-end tests on Chrome.
+`gulp e2e`                                                              | Runs all end-to-end tests on Chrome after building the runtime with the `prod` version of `AMP_CONFIG`..
+`gulp e2e --config=<config>`                                            | Same as above, but `config` can be `prod` or `canary`. (Defaults to `prod`.)
 `gulp e2e --files=<test-files-path-glob>`                               | Runs end-to-end tests from the specified files on the latest Chrome browser.
 `gulp e2e --nobuild`                                                    | Runs all end-to-end tests without building the runtime.
 `gulp e2e --testnames`                                                  | Lists the name of each test being run, and prints a summary at the end.


### PR DESCRIPTION
This PR enables the running of the `e2e`, `integration`, and `visual-diff` tests against the `canary` config.

**To run against the `prod` config (default):**
```
gulp e2e [...]
gulp integration [...]
gulp visual-diff [...]
```

**To run against the `canary` config:**
```
gulp e2e --config canary [...]
gulp integration --config canary [...]
gulp visual-diff --config canary [...]
```

**To run against whichever config type was previously built:**
```
gulp e2e --nobuild [...]
gulp integration --nobuild [...]
gulp visual-diff --nobuild [...]
```

