### PR TITLE
Replace deprecated method call `.createFile` with `.createOrUpdateFile` in bundle-size.js

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -121,7 +121,7 @@ function storeBundleSize() {
     })
     .catch(() => {
       return octokit.repos
-        .createFile(
+        .createOrUpdateFile(
           Object.assign(githubApiCallOptions, {
             message: `bundle-size: ${commitHash} (${bundleSize})`,
             content: Buffer.from(bundleSize).toString('base64'),


### PR DESCRIPTION
Fix #23278