### PR TITLE
🐛 Animation improvements

### DIFF
--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -114,7 +114,7 @@ class AnimationRunner {
     /** @private @const */
     this.keyframes_ = this.filterKeyframes_(animationDef.preset.keyframes);
 
-    /** @private @const */
+    /** @private */
     this.delay_ = animationDef.delay || this.presetDef_.delay || 0;
 
     /** @private @const */
@@ -273,7 +273,10 @@ class AnimationRunner {
       promise = promise.then(() => {
         return new Promise(resolve => {
           this.delayStartTime_ = Date.now();
-          this.delayId_ = this.timer_.delay(resolve, this.delay_);
+          this.delayId_ = /** @type {number} */ (this.timer_.delay(
+            resolve,
+            this.delay_
+          ));
         }).then(() => {
           this.delayId_ = null;
           this.delayElapsedTime_ = null;

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -79,22 +79,11 @@ class AnimationRunner {
    *    !../../amp-animation/0.1/web-animations.Builder
    * >} webAnimationBuilderPromise
    * @param {!../../../src/service/vsync-impl.Vsync} vsync
-   * @param {!../../../src/service/timer-impl.Timer} timer
    * @param {!AnimationSequence} sequence
    */
-  constructor(
-    page,
-    animationDef,
-    webAnimationBuilderPromise,
-    vsync,
-    timer,
-    sequence
-  ) {
+  constructor(page, animationDef, webAnimationBuilderPromise, vsync, sequence) {
     /** @private @const */
     this.page_ = page;
-
-    /** @private @const */
-    this.timer_ = timer;
 
     /** @private @const */
     this.vsync_ = vsync;
@@ -114,7 +103,7 @@ class AnimationRunner {
     /** @private @const */
     this.keyframes_ = this.filterKeyframes_(animationDef.preset.keyframes);
 
-    /** @private */
+    /** @private @const */
     this.delay_ = animationDef.delay || this.presetDef_.delay || 0;
 
     /** @private @const */
@@ -141,15 +130,6 @@ class AnimationRunner {
 
     /** @private {?../../amp-animation/0.1/runners/animation-runner.AnimationRunner} */
     this.runner_ = null;
-
-    /** @private {?number} */
-    this.delayId_ = null;
-
-    /** @private {?number} */
-    this.delayStartTime_ = null;
-
-    /** @private {?number} */
-    this.delayElapsedTime_ = null;
 
     /** @private {?PlaybackActivity} */
     this.scheduledActivity_ = null;
@@ -213,6 +193,7 @@ class AnimationRunner {
     return this.keyframes_.then(keyframes => ({
       keyframes,
       target: this.target_,
+      delay: `${this.delay_}ms`,
       duration: `${this.duration_}ms`,
       easing: this.easing_,
       fill: 'forwards',
@@ -242,7 +223,6 @@ class AnimationRunner {
       return;
     }
 
-    this.delay_ = this.animationDef_.delay || this.presetDef_.delay || 0;
     this.playback_(PlaybackActivity.START, this.getStartWaitPromise_());
   }
 
@@ -257,31 +237,6 @@ class AnimationRunner {
       const startAfterId = /** @type {string} */ (this.animationDef_
         .startAfterId);
       promise = promise.then(() => this.sequence_.waitFor(startAfterId));
-    }
-
-    return promise.then(() => this.getDelayWaitPromise_());
-  }
-
-  /**
-   * @return {!Promise}
-   * @private
-   */
-  getDelayWaitPromise_() {
-    let promise = Promise.resolve();
-
-    if (this.delay_) {
-      promise = promise.then(() => {
-        return new Promise(resolve => {
-          this.delayStartTime_ = Date.now();
-          this.delayId_ = /** @type {number} */ (this.timer_.delay(
-            resolve,
-            this.delay_
-          ));
-        }).then(() => {
-          this.delayId_ = null;
-          this.delayElapsedTime_ = null;
-        });
-      });
     }
 
     return promise;
@@ -314,22 +269,12 @@ class AnimationRunner {
 
   /** Pauses the animation. */
   pause() {
-    // Animation waiting for a sequenced animation.
-    if (this.scheduledActivity_ !== null && !this.delayId_) {
+    // Animation hasn't started yet since it's waiting for a sequenced
+    // animation.
+    if (this.scheduledActivity_ !== null) {
       return;
     }
 
-    // Check if animation is still waiting for a delay animation.
-    if (this.delayId_) {
-      // Delete the waiting promise that the animation is waiting for to keep it
-      // from starting.
-      this.timer_.cancel(this.delayId_);
-      this.delayId_ = null;
-
-      // Set delay elapsed time passed before pausing.
-      this.delayElapsedTime_ = Date.now() - this.delayStartTime_;
-      return;
-    }
     if (this.runner_) {
       devAssert(this.runner_).pause();
     }
@@ -337,16 +282,12 @@ class AnimationRunner {
 
   /** Resumes the animation. */
   resume() {
-    // Animation waiting for a sequenced animation.
-    if (this.scheduledActivity_ !== null && !this.delayElapsedTime_) {
+    // Animation hasn't started yet since it's waiting for a sequenced
+    // animation.
+    if (this.scheduledActivity_ !== null) {
       return;
     }
-    if (this.delayElapsedTime_) {
-      // Restart promise with the remaining delay time before it was paused.
-      this.delay_ = this.delay_ - this.delayElapsedTime_;
-      this.playback_(PlaybackActivity.START, this.getDelayWaitPromise_());
-      return;
-    }
+
     if (this.runner_) {
       devAssert(this.runner_).resume();
     }
@@ -368,9 +309,7 @@ class AnimationRunner {
   cancel() {
     this.scheduledActivity_ = null;
     this.scheduledWait_ = null;
-    this.timer_.cancel(this.delayId_);
-    this.delayId_ = null;
-    this.delayElapsedTime_ = null;
+
     if (this.runner_) {
       devAssert(this.runner_).cancel();
     }
@@ -489,9 +428,6 @@ export class AnimationManager {
     this.vsync_ = Services.vsyncFor(this.ampdoc_.win);
 
     /** @private @const */
-    this.timer_ = Services.timerFor(this.ampdoc_.win);
-
-    /** @private @const */
     this.builderPromise_ = this.createAnimationBuilderPromise_();
 
     /** @private {?Array<!Promise<!AnimationRunner>>} */
@@ -594,7 +530,6 @@ export class AnimationManager {
       animationDef,
       devAssert(this.builderPromise_),
       this.vsync_,
-      this.timer_,
       this.sequence_
     );
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -271,7 +271,7 @@ class AnimationRunner {
   pause() {
     // Animation hasn't started yet since it's waiting for a sequenced
     // animation.
-    if (this.scheduledActivity_ !== null) {
+    if (this.scheduledWait_ !== null) {
       return;
     }
 
@@ -284,7 +284,7 @@ class AnimationRunner {
   resume() {
     // Animation hasn't started yet since it's waiting for a sequenced
     // animation.
-    if (this.scheduledActivity_ !== null) {
+    if (this.scheduledWait_ !== null) {
       return;
     }
 


### PR DESCRIPTION
This PR introduces a number of fixes for animation bugs that we've had for a while related to hold-to-pause.

1: Console errors were showing up due to animations that hadn't started yet. This was due to the fact that we weren't checking if the animation was still waiting for another animation or had a delay.

2: When an animation with a delay was paused, it ignored the pausing and continued to animate. Fixes #23224

3: When an animation with a delay hadn't started yet, and the user navigated to another page and then came back, the delay wasn't being restarted, so it would appear right away on page landing.


To address these, I separated the `getStartWaitPromise_ ` and a new `getDelayWaitPromise_` that is only in charge of the delay. Each delay will get a `delayId_` and a `delayStartTime_`. With these, we are able to cancel and restart the `delay` for the corresponding animation.

EDIT: the above paragraph's approach wasn't necessary. We only needed to include the delay in the animation keyframe definition (see latest commit).

![ezgif-1-f74baaa078c3](https://user-images.githubusercontent.com/5449100/61228527-7237c780-a6f4-11e9-837e-c00f6c87280c.gif)


