### PR TITLE
Fix IE11 syntax error with attributeFilter without attributes

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -157,6 +157,7 @@ class AmpAccordion extends AMP.BaseElement {
         this.toggleExpandMutations_(mutations);
       });
       expandObserver.observe(section, {
+        attributes: true,
         attributeFilter: ['data-expand'],
       });
 


### PR DESCRIPTION
Fixes #23254 

IE11 and Edge emit a syntax error when `attributesFilter` is used without `attributes: true` in the observe configuration object.

For example: https://stackoverflow.com/questions/50593385/mutationobserver-syntax-error-on-ie-11