### PR TITLE
✅ Improve Puppeteer support.

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -279,11 +279,7 @@ function describeEnv(factory) {
     }
 
     function createBrowserDescribe() {
-      const {browsers} = getConfig();
-
-      const allowedBrowsers = browsers
-        ? new Set(browsers.split(',').map(x => x.trim()))
-        : defaultBrowsers;
+      const allowedBrowsers = getAllowedBrowsers();
 
       spec.browsers
         .filter(x => allowedBrowsers.has(x))
@@ -292,6 +288,20 @@ function describeEnv(factory) {
             createVariantDescribe(browserName);
           });
         });
+    }
+
+    function getAllowedBrowsers() {
+      const {engine, browsers} = getConfig();
+
+      if (engine === 'puppeteer') {
+        return new Set(['chrome']);
+      }
+
+      const allowedBrowsers = browsers
+        ? new Set(browsers.split(',').map(x => x.trim()))
+        : defaultBrowsers;
+
+      return allowedBrowsers;
     }
 
     function createVariantDescribe(browserName) {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -35,6 +35,12 @@ const TEST_TIMEOUT = 20000;
 const SETUP_TIMEOUT = 30000;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const defaultBrowsers = new Set(['chrome', 'firefox']);
+/**
+ * TODO(cvializ): Firefox now experimentally supports puppeteer.
+ * When it's more mature we might want to support it.
+ * {@link https://github.com/GoogleChrome/puppeteer/blob/master/experimental/puppeteer-firefox/README.md}
+ */
+const PUPPETEER_BROWSERS = new Set(['chrome']);
 
 /**
  * @typedef {{
@@ -293,13 +299,20 @@ function describeEnv(factory) {
     function getAllowedBrowsers() {
       const {engine, browsers} = getConfig();
 
-      if (engine === 'puppeteer') {
-        return new Set(['chrome']);
-      }
-
       const allowedBrowsers = browsers
         ? new Set(browsers.split(',').map(x => x.trim()))
         : defaultBrowsers;
+
+      if (engine === 'puppeteer') {
+        const result = intersect(allowedBrowsers, PUPPETEER_BROWSERS);
+        if (result.size === 0) {
+          const browsersList = Array.from(allowedBrowsers).join(',');
+          throw new Error(
+            `browsers ${browsersList} not supported by Puppeteer`
+          );
+        }
+        return result;
+      }
 
       return allowedBrowsers;
     }
@@ -461,6 +474,17 @@ async function toggleExperiments(ampDriver, testUrl, experiments) {
   for (const experiment of experiments) {
     await ampDriver.toggleExperiment(experiment, true);
   }
+}
+
+/**
+ * Intersection of two sets
+ * @param {Set<T>} a
+ * @param {Set<T>} b
+ * @return {Set<T>}
+ * @template T
+ */
+function intersect(a, b) {
+  return new Set(Array.from(a).filter(aItem => b.has(aItem)));
 }
 
 module.exports = {

--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -356,7 +356,7 @@ class PuppeteerController {
    */
   getElementText(handle) {
     const element = handle.getElement();
-    const getter = element => ({value: element.innerText.trim()});
+    const getter = element => ({value: element./*OK*/ innerText.trim()});
     return new ControllerPromise(
       this.evaluateValue_(getter, element),
       this.getWaitFn_(getter, element)

--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -207,9 +207,7 @@ class PuppeteerController {
     const nodeListHandle = await frame.waitForFunction(
       (root, selector) => {
         const nodeList = root./*OK*/ querySelectorAll(selector);
-        return nodeList.length > 0
-          ? Array.prototype.slice.call(nodeList)
-          : null;
+        return nodeList.length > 0 ? Array.from(nodeList) : null;
       },
       {timeout: DEFAULT_WAIT_TIMEOUT},
       root,
@@ -400,7 +398,7 @@ class PuppeteerController {
     const getter = (element, property) => {
       let value = element[property];
       if (typeof value !== 'string' && typeof value.length === 'number') {
-        value = Array.prototype.slice.call(value);
+        value = Array.from(value);
       }
 
       return {value};

--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -60,7 +60,7 @@ const DEFAULT_WAIT_TIMEOUT = 10000;
  */
 async function waitFor(page, valueFn, args, condition, opt_mutate) {
   const handle = await evaluate(page, valueFn, ...args);
-  let value = await handle.jsonValue();
+  let value = await unboxHandle(handle);
   if (opt_mutate) {
     value = await opt_mutate(value);
   }
@@ -71,13 +71,24 @@ async function waitFor(page, valueFn, args, condition, opt_mutate) {
       {timeout: DEFAULT_WAIT_TIMEOUT},
       ...args
     );
-    const prop = await handle.jsonValue();
-    value = 'value' in prop ? prop.value : prop;
+    value = await unboxHandle(handle);
     if (opt_mutate) {
       value = await opt_mutate(value);
     }
   }
   return value;
+}
+
+/**
+ * Remove the jsonValue wrapper from a PuppeteerHandle and
+ * remove an outer object wrapper if present.
+ * @param {!PuppeteerHandle} handle
+ * @return {T}
+ * @template T
+ */
+async function unboxHandle(handle) {
+  const prop = await handle.jsonValue();
+  return 'value' in prop ? prop.value : prop;
 }
 
 /**

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -521,25 +521,6 @@ class SeleniumWebDriverController {
    * @return {!Promise}
    * @override
    */
-  async scroll(handle, opt_scrollToOptions) {
-    const webElement = handle.getElement();
-    const scrollTo = (element, opt_scrollToOptions) => {
-      element./*OK*/ scrollTo(opt_scrollToOptions);
-    };
-
-    return await this.driver.executeScript(
-      scrollTo,
-      webElement,
-      opt_scrollToOptions
-    );
-  }
-
-  /**
-   * @param {!ElementHandle<!WebElement>} handle
-   * @param {!ScrollToOptionsDef=} opt_scrollToOptions
-   * @return {!Promise}
-   * @override
-   */
   async scrollBy(handle, opt_scrollToOptions) {
     const webElement = handle.getElement();
     const scrollBy = (element, opt_scrollToOptions) => {

--- a/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
@@ -35,8 +35,8 @@ describes.endtoend(
     it('<amp-autocomplete> should render', async () => {
       const autocomplete = await controller.findElement('#autocomplete');
       await expect(
-        controller.getElementProperty(autocomplete, 'childElementCount')
-      ).to.equal(3);
+        controller.getElementProperty(autocomplete, 'children')
+      ).to.have.length(3);
 
       const input = await controller.findElement('#input');
       await expect(controller.getElementAttribute(input, 'type')).to.equal(
@@ -52,8 +52,8 @@ describes.endtoend(
         '.i-amphtml-autocomplete-results'
       );
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(3);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(3);
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
     });
@@ -63,8 +63,8 @@ describes.endtoend(
         '.i-amphtml-autocomplete-results'
       );
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(3);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(3);
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       const focusButton = await controller.findElement('#focusButton');
@@ -88,8 +88,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden')).to
         .be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(3);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(3);
 
       // New input narrows down suggested items.
       const input = await controller.findElement('#input');
@@ -97,8 +97,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden')).to
         .be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(2);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(2);
     });
 
     it('<amp-autocomplete> should select an item', async () => {
@@ -109,8 +109,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(3);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(3);
 
       // Displays all suggested items on focus.
       await controller.click(focusButton);
@@ -128,8 +128,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'childElementCount')
-      ).to.equal(1);
+        controller.getElementProperty(renderedResults, 'children')
+      ).to.have.length(1);
       const input = await controller.findElement('#input');
       await expect(controller.getElementProperty(input, 'value')).to.equal(
         'apple'

--- a/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
@@ -35,8 +35,8 @@ describes.endtoend(
     it('<amp-autocomplete> should render', async () => {
       const autocomplete = await controller.findElement('#autocomplete');
       await expect(
-        controller.getElementProperty(autocomplete, 'children')
-      ).to.have.length(3);
+        controller.getElementProperty(autocomplete, 'childElementCount')
+      ).to.equal(3);
 
       const input = await controller.findElement('#input');
       await expect(controller.getElementAttribute(input, 'type')).to.equal(
@@ -52,8 +52,8 @@ describes.endtoend(
         '.i-amphtml-autocomplete-results'
       );
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(3);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(3);
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
     });
@@ -63,8 +63,8 @@ describes.endtoend(
         '.i-amphtml-autocomplete-results'
       );
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(3);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(3);
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       const focusButton = await controller.findElement('#focusButton');
@@ -88,8 +88,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden')).to
         .be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(3);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(3);
 
       // New input narrows down suggested items.
       const input = await controller.findElement('#input');
@@ -97,8 +97,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden')).to
         .be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(2);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(2);
     });
 
     it('<amp-autocomplete> should select an item', async () => {
@@ -109,8 +109,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(3);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(3);
 
       // Displays all suggested items on focus.
       await controller.click(focusButton);
@@ -128,8 +128,8 @@ describes.endtoend(
       await expect(controller.getElementAttribute(renderedResults, 'hidden'))
         .not.to.be.null;
       await expect(
-        controller.getElementProperty(renderedResults, 'children')
-      ).to.have.length(1);
+        controller.getElementProperty(renderedResults, 'childElementCount')
+      ).to.equal(1);
       const input = await controller.findElement('#input');
       await expect(controller.getElementProperty(input, 'value')).to.equal(
         'apple'

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
@@ -24,7 +24,11 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/custom-arrows.amp.html',
-    experiments: ['amp-base-carousel', 'layers'],
+    experiments: [
+      'amp-base-carousel',
+      'layers',
+      'amp-lightbox-gallery-base-carousel',
+    ],
     browsers: ['chrome', 'firefox'],
     //TODO(spaharmi): fails on shadow demo
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -24,7 +24,11 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/basic.amp.html',
-    experiments: ['amp-base-carousel', 'layers'],
+    experiments: [
+      'amp-base-carousel',
+      'amp-lightbox-gallery-base-carousel',
+      'layers',
+    ],
     initialRect: {width: pageWidth, height: pageHeight},
     //TODO(spaharmi): fails on shadow demo
     environments: ['single', 'viewer-demo'],
@@ -73,7 +77,7 @@ describes.endtoend(
       const snappedScrollLeft = scrollLeft + slideWidth;
       const requestedScrollLeft = snappedScrollLeft + 1;
 
-      await controller.scroll(el, {left: requestedScrollLeft});
+      await controller.scrollTo(el, {left: requestedScrollLeft});
       // We should have snapped to the edge of the slide rather than the
       // requested scroll position.
       await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
@@ -93,7 +97,7 @@ describes.endtoend(
       const snappedScrollLeft = scrollLeft + slideWidth;
       const requestedScrollLeft = snappedScrollLeft + 1;
 
-      await controller.scroll(el, {left: requestedScrollLeft});
+      await controller.scrollTo(el, {left: requestedScrollLeft});
       // Wait for the scrolling to settle
       await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
       // The new scroll width/left should eventually be the same as before,
@@ -146,7 +150,7 @@ describes.endtoend(
         const restingScrollLeft = await prop(el, 'scrollLeft');
         const snappedScrollLeft = restingScrollLeft - slideWidth;
         const requestedScrollLeft = snappedScrollLeft - 1;
-        await controller.scroll(el, {left: requestedScrollLeft});
+        await controller.scrollTo(el, {left: requestedScrollLeft});
 
         await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
       });
@@ -163,14 +167,14 @@ describes.endtoend(
         const slideWidth = await prop(lastSlide, 'offsetWidth');
         const restingScrollLeft = await prop(el, 'scrollLeft');
         const lastSlideScrollPos = restingScrollLeft - slideWidth;
-        await controller.scroll(el, {left: lastSlideScrollPos});
+        await controller.scrollTo(el, {left: lastSlideScrollPos});
         await expect(prop(el, 'scrollLeft')).to.equal(lastSlideScrollPos);
         await expect(prop(el, 'scrollLeft')).to.equal(restingScrollLeft);
 
         // Go to the next slide by moving the slides width to the right.
         const snappedScrollLeft = restingScrollLeft + slideWidth;
         const requestedScrollLeft = snappedScrollLeft + 1;
-        await controller.scroll(el, {left: requestedScrollLeft});
+        await controller.scrollTo(el, {left: requestedScrollLeft});
 
         await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
       });

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -69,7 +69,7 @@ describes.endtoend(
       const snappedScrollLeft = scrollLeft + slideWidth;
       const requestedScrollLeft = snappedScrollLeft + 1;
 
-      await controller.scroll(el, {left: requestedScrollLeft});
+      await controller.scrollTo(el, {left: requestedScrollLeft});
       // We should have snapped to the edge of the slide rather than the
       // requested scroll position.
       await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -71,7 +71,7 @@ describes.endtoend(
       const el = await getScrollingElement(controller);
       const secondSlide = await getSlide(controller, 1);
 
-      await controller.scroll(el, {left: 333});
+      await controller.scrollTo(el, {left: 333});
       await expect(prop(el, 'scrollLeft')).to.equal(333);
       await controller.setWindowRect({
         width: 600,

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
@@ -78,7 +78,7 @@ describes.endtoend(
       const snappedScrollTop = scrollTop + slideHeight;
       const requestedScrollTop = snappedScrollTop + 1;
 
-      await controller.scroll(el, {top: requestedScrollTop});
+      await controller.scrollTo(el, {top: requestedScrollTop});
       // We should have snapped to the edge of the slide rather than the
       // requested scroll position.
       await expect(rect(firstSlide)).to.include({y: carouselTop - slideHeight});


### PR DESCRIPTION
It's not perfect and not as highly prioritized, but it should still be maintained unless we decided to delete the code from the repo. This PR is a pre-requisite for the request interception feature.

Main changes
- Changed `SeleniumTestController#scroll` to be `scrollTo` to match the `FunctionalTestController` API
- Only run the Chrome browser tests for Puppeteer runs.
- Fix `ControllerPromise` `waitFunction` in `PuppeteerController` for falsy expected values.

5 tests are still not passing with Puppeteer: 3 amp carousel, one amp-form, one amp-script. But this is better than before. I'd like to merge this PR before fixing to move incrementally.