### PR TITLE
🏗🐛 Fix broken `runner.jar` tests by removing unused code

### DIFF
--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -2,15 +2,11 @@
 package org.ampproject;
 
 
-import java.util.Set;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerPass;
 import com.google.javascript.jscomp.CompilerTestCase;
-import com.google.javascript.rhino.IR;
-import com.google.javascript.rhino.Node;
 import org.junit.Test;
 
 
@@ -25,17 +21,8 @@ public class AmpPassTest extends CompilerTestCase {
       "devAssert$$module$src$log()"
       );
 
-  ImmutableMap<String, Node> assignmentReplacements = ImmutableMap.of(
-      "IS_MINIFIED",
-      IR.trueNode());
-
-  ImmutableMap<String, Node> prodAssignmentReplacements = ImmutableMap.of(
-      "IS_DEV",
-      IR.falseNode());
-
   @Override protected CompilerPass getProcessor(Compiler compiler) {
-    return new AmpPass(compiler, /* isProd */ true, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements, "123");
+    return new AmpPass(compiler, /* isProd */ true, suffixTypes, "123");
   }
 
   @Override protected int getNumRepetitions() {
@@ -316,22 +303,6 @@ public class AmpPassTest extends CompilerTestCase {
             "})()"));
   }
 
-  @Test public void testOptimizeGetModeFunction() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "const IS_DEV = true;",
-             "const IS_MINIFIED = false;",
-             "const IS_SOMETHING = true;",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "const IS_DEV = false;",
-             "const IS_MINIFIED = true;",
-             "const IS_SOMETHING = true;",
-            "})()"));
-  }
-
   @Test public void testRemoveAmpAddExtensionCallWithExplicitContext() throws Exception {
     test(
         LINE_JOINER.join(
@@ -366,17 +337,5 @@ public class AmpPassTest extends CompilerTestCase {
             "  console.log(a);",
             "})(self.AMP);",
             "console.log(a);"));
-  }
-
-  @Test public void testAmpVersionReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-            "var a = `test${internalRuntimeVersion$$module$src$internal_version()}ing`;",
-            "var b = 'test' + internalRuntimeVersion$$module$src$internal_version() + 'ing';",
-            "var c = internalRuntimeVersion$$module$src$internal_version();"),
-        LINE_JOINER.join(
-            "var a = `test${'123'}ing`;",
-            "var b = 'test' + '123' + 'ing';",
-            "var c = '123';"));
   }
 }

--- a/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
@@ -1,8 +1,5 @@
 package org.ampproject;
 
-
-import java.util.Set;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.rhino.IR;
@@ -19,17 +16,9 @@ import org.junit.Test;
 public class AmpPassTestEnvTest extends CompilerTestCase {
 
   ImmutableSet<String> suffixTypes = ImmutableSet.of();
-  ImmutableMap<String, Node> assignmentReplacements = ImmutableMap.of(
-      "IS_MINIFIED",
-      IR.trueNode());
-
-  ImmutableMap<String, Node> prodAssignmentReplacements = ImmutableMap.of(
-      "IS_DEV",
-      IR.falseNode());
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
-    return new AmpPass(compiler, /* isProd */ false, suffixTypes, assignmentReplacements,
-        prodAssignmentReplacements, "123");
+    return new AmpPass(compiler, /* isProd */ false, suffixTypes, "123");
   }
 
   @Override protected int getNumRepetitions() {
@@ -94,22 +83,6 @@ public class AmpPassTestEnvTest extends CompilerTestCase {
              "  if ($mode.getMode().minified) {",
              "    console.log('hello world');",
              "  }",
-            "})()"));
-  }
-
-  @Test public void testOptimizeGetModeFunction() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "const IS_DEV = true;",
-             "const IS_MINIFIED = false;",
-             "const IS_SOMETHING = true;",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "const IS_DEV = true;",
-             "const IS_MINIFIED = true;",
-             "const IS_SOMETHING = true;",
             "})()"));
   }
 }


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/pull/22839#pullrequestreview-262728210

Fixes these errors:
```
compile-tests:
    [mkdir] Created dir: /usr/local/google/home/rsimha/src/amphtml/build-system/runner/build/test
    [javac] Compiling 3 source files to /usr/local/google/home/rsimha/src/amphtml/build-system/runner/build/test
    [javac] Compiling 2 source files to /usr/local/google/home/rsimha/src/amphtml/build-system/runner/build/test
    [javac] /usr/local/google/home/rsimha/src/amphtml/build-system/runner/test/org/ampproject/AmpPassTest.java:37: error: constructor AmpPass in class AmpPass cannot be applied to given types;
    [javac]     return new AmpPass(compiler, /* isProd */ true, suffixTypes, assignmentReplacements,
    [javac]            ^
    [javac]   required: AbstractCompiler,boolean,ImmutableSet<String>,String
    [javac]   found: Compiler,boolean,ImmutableSet<String>,ImmutableMap<String,Node>,ImmutableMap<String,Node>,String
    [javac]   reason: actual and formal argument lists differ in length
    [javac] /usr/local/google/home/rsimha/src/amphtml/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java:31: error: constructor AmpPass in class AmpPass cannot be applied to given types;
    [javac]     return new AmpPass(compiler, /* isProd */ false, suffixTypes, assignmentReplacements,
    [javac]            ^
    [javac]   required: AbstractCompiler,boolean,ImmutableSet<String>,String
    [javac]   found: Compiler,boolean,ImmutableSet<String>,ImmutableMap<String,Node>,ImmutableMap<String,Node>,String
    [javac]   reason: actual and formal argument lists differ in length
    [javac] 2 errors

BUILD FAILED
/usr/local/google/home/rsimha/src/amphtml/build-system/runner/build.xml:112: Compile failed; see the compiler error output for details.
```