### PR TITLE
Loading amp-video poster on layout and not build.

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -55,7 +55,6 @@ const ATTRS_TO_PROPAGATE_ON_BUILD = [
   'controls',
   'crossorigin',
   'disableremoteplayback',
-  'poster',
   'controlsList',
 ];
 
@@ -64,7 +63,7 @@ const ATTRS_TO_PROPAGATE_ON_BUILD = [
  *       video manager since amp-video implements the VideoInterface.
  * @private {!Array<string>}
  */
-const ATTRS_TO_PROPAGATE_ON_LAYOUT = ['loop', 'preload'];
+const ATTRS_TO_PROPAGATE_ON_LAYOUT = ['loop', 'poster', 'preload'];
 
 /** @private {!Array<string>} */
 const ATTRS_TO_PROPAGATE = ATTRS_TO_PROPAGATE_ON_BUILD.concat(
@@ -209,10 +208,7 @@ class AmpVideo extends AMP.BaseElement {
     this.applyFillContent(this.video_, true);
     propagateObjectFitStyles(this.element, this.video_);
 
-    this.createPosterForAndroidBug_();
     element.appendChild(this.video_);
-
-    this.onPosterLoaded_(() => this.hideBlurryPlaceholder_());
 
     // Gather metadata
     const artist = element.getAttribute('artist');
@@ -307,6 +303,9 @@ class AmpVideo extends AMP.BaseElement {
       dev().assertElement(this.video_),
       /* opt_removeMissingAttrs */ true
     );
+
+    this.createPosterForAndroidBug_();
+    this.onPosterLoaded_(() => this.hideBlurryPlaceholder_());
 
     this.propagateCachedSources_();
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -265,7 +265,6 @@ describes.realWin(
         function(element) {
           // Should set appropriate attributes in buildCallback
           const video = element.querySelector('video');
-          expect(video.getAttribute('poster')).to.equal('img.png');
           expect(video.getAttribute('controls')).to.exist;
           expect(video.getAttribute('playsinline')).to.exist;
           expect(video.getAttribute('webkit-playsinline')).to.exist;
@@ -282,7 +281,7 @@ describes.realWin(
       });
     });
 
-    it('should not set src or preload in build', () => {
+    it('should not set poster, src, or preload in build', () => {
       return getVideo(
         {
           src: 'video.mp4',
@@ -295,6 +294,7 @@ describes.realWin(
         function(element) {
           const video = element.querySelector('video');
           expect(video.getAttribute('preload')).to.equal('none');
+          expect(video.hasAttribute('poster')).to.be.false;
           expect(video.hasAttribute('src')).to.be.false;
         }
       ).then(v => {
@@ -302,6 +302,7 @@ describes.realWin(
         const video = v.querySelector('video');
         expect(video.tagName).to.equal('VIDEO');
         expect(video.getAttribute('preload')).to.equal('auto');
+        expect(video.getAttribute('poster')).to.equal('img.png');
       });
     });
 
@@ -317,7 +318,7 @@ describes.realWin(
         function(element) {
           const video = element.querySelector('video');
           expect(video.getAttribute('preload')).to.equal('none');
-          expect(video.getAttribute('poster')).to.equal('img.png');
+          expect(video.hasAttribute('poster')).to.be.false;
           expect(video.hasAttribute('src')).to.be.false;
         }
       ).then(v => {
@@ -386,7 +387,7 @@ describes.realWin(
         function(element) {
           const video = element.querySelector('video');
           expect(video.getAttribute('preload')).to.equal('none');
-          expect(video.getAttribute('poster')).to.equal('img.png');
+          expect(video.hasAttribute('poster')).to.be.false;
           expect(video.hasAttribute('src')).to.be.false;
         }
       ).then(v => {


### PR DESCRIPTION
This is actually a feature request with some code to show that we're willing to do the work :)
I have no context on the decisions that led to this implementation that seems to be unique across AMP, feel free to point out anything I'm missing.

Runtime controls when elements lifecycle callbacks such as `buildCallback` and `layoutCallback` are called. As per the [documentation](https://github.com/ampproject/amphtml/blob/master/contributing/building-an-amp-extension.md#buildcallback), `buildCallback` should not load resources, since they would load no matter where the element is on the page.

Most extensions use the `createPlaceholderCallback` to insert an `amp-img`, that will only get loaded on `layoutCallback`. However, since amp-video sets its poster placeholder by setting a `poster` attribute on the video element, its loading is not controlled by the AMP runtime, but it starts loading as soon as the attribute is set.
The proposal here would be to move the `poster` attribute propagation from the `buildCallback` to the `layoutCallback`, so it behaves like other extensions, and only load when needed.

This would fix the issue where posters from videos load even if the video is very far away from the viewport, which is very problematic for stories.
This change should not affect the prerendering case, since amp-video would get both its build and layout callbacks called if they're in the prerendering viewport, just like `amp-img` and other extensions.

Am I missing anything? Does this fix need any more work for use cases I forgot?