### PR TITLE
Fix rotation overlay font size.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
@@ -17,10 +17,11 @@
 .i-amphtml-story-no-rotation-overlay {
   position: absolute !important;
   z-index: 200000!important; /** unsupported-browser-overlay - 1 */
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 20px !important;
   font-weight: 700 !important;
-  line-height: 1.5;
-  padding: 32px;
+  line-height: 1.5 !important;
+  padding: 32px !important;
   background-color: #000 !important;
   color: #fff!important;
   top:0 !important;


### PR DESCRIPTION
Fix rotation overlay font size that was made really small as a side effect of the responsive font sizing. The font size was ~9px.