### PR TITLE
🏗  Replace hack to prevent inlining of cssText with a `@noinline` annotation

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -52,14 +52,6 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
    * delivery), this could go away there.
    */
   @Override public boolean isExported(String name, boolean local) {
-    // Bad hack, but we should really not try to inline CSS as these strings can
-    // be very long.
-    // See https://github.com/ampproject/amphtml/issues/10118
-    // cssText is defined in build-system/tasks/css.js#writeCss
-    if (name.startsWith("cssText$$module$build$")) {
-      return true;
-    }
-
     if (local) {
       return false;
     }

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -86,10 +86,13 @@ function compileCss(watch, opt_compileAll) {
    */
   function writeCss(css, jsFilename, cssFilename, append) {
     return toPromise(
-      // cssText is hardcoded in AmpCodingConvention.java
-      file(jsFilename, 'export const cssText = ' + JSON.stringify(css), {
-        src: true,
-      })
+      file(
+        jsFilename,
+        '/** @noinline */ export const cssText = ' + JSON.stringify(css),
+        {
+          src: true,
+        }
+      )
         .pipe(gulp.dest('build'))
         .on('end', function() {
           mkdirSync('build');


### PR DESCRIPTION
#10121 added a hack to `AmpCodingConvention.java` to prevent the inlining of CSS. This is no longer required because closure supports the `@noinline` annotation. (See https://github.com/google/closure-compiler/issues/2751 and https://github.com/google/closure-compiler/commit/5698304a8e8832805a67a720396540d53cb4a88b)

This PR replaces the hack with a `@noinline` annotation wherever `cssText` is defined.

Follow up to #23363
Partial fix for #17120 and #22452