### PR TITLE
🐛 Firefox mobile progress bar glitch fix

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -107,10 +107,6 @@
   margin: 0 2px!important;
   overflow: hidden!important;
   width: 100% !important;
-
-  /* An empty mask image works around Safari not clipping rounded corners.
-   * https://stackoverflow.com/questions/5736503/how-to-make-css3-rounded-corners-hide-overflow-in-chrome-opera/10296258#10296258 */
-  -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC) !important;
 }
 
 .i-amphtml-story-page-progress-value {
@@ -120,12 +116,10 @@
   width: 100% !important;
   transform: translateZ(0) scaleX(0) !important; /* 0-width by default */
   transform-origin: left !important;
-  -moz-transform-origin: 0% !important; /* Fixes glitchy progress bar in firefox mobile. */
 }
 
 [dir=rtl] .i-amphtml-story-page-progress-value {
   transform-origin: right !important;
-  -moz-transform-origin: 100% !important; /* Fixes glitchy progress bar in firefox mobile. */
 }
 
 .i-amphtml-first-page-active[info] .i-amphtml-message-container {

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -120,10 +120,12 @@
   width: 100% !important;
   transform: translateZ(0) scaleX(0) !important; /* 0-width by default */
   transform-origin: left !important;
+  -moz-transform-origin: 0% !important; /* Fixes glitchy progress bar in firefox mobile. */
 }
 
 [dir=rtl] .i-amphtml-story-page-progress-value {
   transform-origin: right !important;
+  -moz-transform-origin: 100% !important; /* Fixes glitchy progress bar in firefox mobile. */
 }
 
 .i-amphtml-first-page-active[info] .i-amphtml-message-container {


### PR DESCRIPTION
Fixes #21898

Having this `-webkit-mask-image` property was causing glitches in Firefox mobile. 

Not sure why we had it in the first place but I tested it on both an Android with Firefox and on iOS with Chrome/Safari and it seems to work fine without it.

Demo: https://stamp-animation.firebaseapp.com