### PR TITLE
🏗🚮 Clean up custom code in `runner.jar` that has been replaced by babel transforms

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -15,8 +15,6 @@
  */
 package org.ampproject;
 
-
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilerOptions;
@@ -24,11 +22,8 @@ import com.google.javascript.jscomp.CustomPassExecutionTime;
 import com.google.javascript.jscomp.FlagUsageException;
 import com.google.javascript.jscomp.PropertyRenamingPolicy;
 import com.google.javascript.jscomp.VariableRenamingPolicy;
-import com.google.javascript.rhino.IR;
-import com.google.javascript.rhino.Node;
 
 import java.io.IOException;
-import java.util.Set;
 
 
 /**
@@ -44,8 +39,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
   private boolean pseudo_names = false;
 
   private boolean is_production_env = true;
-
-  private String amp_version = "";
 
   /**
    * List of string suffixes to eliminate from the AST.
@@ -72,7 +65,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     }
     CompilerOptions options = super.createOptions();
     options.setCollapsePropertiesLevel(CompilerOptions.PropertyCollapseLevel.ALL);
-    AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes, amp_version);
+    AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
     options.setDevirtualizePrototypeMethods(true);
     options.setExtractPrototypeMemberDeclarations(true);
@@ -111,7 +104,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
   public static void main(String[] args) {
     AmpCommandLineRunner runner = new AmpCommandLineRunner(args);
 
-    // Scan for TYPECHECK_ONLY string which we pass in as a --define
     for (String arg : args) {
       if (arg.contains("TYPECHECK_ONLY=true")) {
         runner.typecheck_only = true;
@@ -119,8 +111,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.is_production_env = false;
       } else if (arg.contains("PSEUDO_NAMES=true")) {
         runner.pseudo_names = true;
-      } else if (arg.contains("VERSION=")) {
-        runner.amp_version = arg.substring(arg.lastIndexOf("=") + 1);
       }
     }
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -1,8 +1,6 @@
 
 package org.ampproject;
 
-
-
 import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerPass;
@@ -22,7 +20,7 @@ public class AmpPassTest extends CompilerTestCase {
       );
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
-    return new AmpPass(compiler, /* isProd */ true, suffixTypes, "123");
+    return new AmpPass(compiler, /* isProd */ true, suffixTypes);
   }
 
   @Override protected int getNumRepetitions() {
@@ -162,110 +160,6 @@ public class AmpPassTest extends CompilerTestCase {
             "})()"));
   }
 
-  @Test public void testGetModeLocalDevPropertyReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { localDev: true } }",
-             "var $mode = { getMode: getMode };",
-             "  if ($mode.getMode().localDev) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { localDev: true }; }",
-             "var $mode = { getMode: getMode };",
-             "  if (false) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"));
-  }
-
-  @Test public void testGetModeTestPropertyReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { test: true } }",
-             "var $mode = { getMode: getMode };",
-             "  if ($mode.getMode().test) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { test: true }; }",
-             "var $mode = { getMode: getMode };",
-             "  if (false) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"));
-  }
-
-  @Test public void testGetModeMinifiedPropertyReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { minified: false } }",
-             "var $mode = { getMode: getMode };",
-             "  if ($mode.getMode().minified) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { minified: false }; }",
-             "var $mode = { getMode: getMode };",
-             "  if (true) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"));
-  }
-
-  @Test public void testGetModeWinTestPropertyReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { test: true } }",
-             "var win = {};",
-             "var $mode = { getMode: getMode };",
-             "  if ($mode.getMode(win).test) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { test: true }; }",
-             "var win = {};",
-             "var $mode = { getMode: getMode };",
-             "  if (false) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"));
-  }
-
-  @Test public void testGetModeWinMinifiedPropertyReplacement() throws Exception {
-    test(
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { minified: false } }",
-             "var win = {};",
-             "var $mode = { getMode: getMode };",
-             "  if ($mode.getMode(win).minified) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"),
-        LINE_JOINER.join(
-             "(function() {",
-             "function getMode() { return { minified: false }; }",
-             "var win = {};",
-             "var $mode = { getMode: getMode };",
-             "  if (true) {",
-             "    console.log('hello world');",
-             "  }",
-            "})()"));
-  }
-
   @Test public void testGetModePreserve() throws Exception {
     test(
         LINE_JOINER.join(
@@ -301,41 +195,5 @@ public class AmpPassTest extends CompilerTestCase {
              "    console.log('hello world');",
              "  }",
             "})()"));
-  }
-
-  @Test public void testRemoveAmpAddExtensionCallWithExplicitContext() throws Exception {
-    test(
-        LINE_JOINER.join(
-            "var a = 'hello';",
-            "self.AMP.extension('hello', '0.1', function(AMP) {",
-            "  var a = 'world';",
-            "  console.log(a);",
-            "});",
-            "console.log(a);"),
-        LINE_JOINER.join(
-            "var a = 'hello';",
-            "(function(AMP) {",
-            "  var a = 'world';",
-            "  console.log(a);",
-            "})(self.AMP);",
-            "console.log(a);"));
-  }
-
-  @Test public void testRemoveAmpAddExtensionCallWithNoContext() throws Exception {
-    test(
-        LINE_JOINER.join(
-            "var a = 'hello';",
-            "AMP.extension('hello', '0.1', function(AMP) {",
-            "  var a = 'world';",
-            "  console.log(a);",
-            "});",
-            "console.log(a);"),
-        LINE_JOINER.join(
-            "var a = 'hello';",
-            "(function(AMP) {",
-            "  var a = 'world';",
-            "  console.log(a);",
-            "})(self.AMP);",
-            "console.log(a);"));
   }
 }

--- a/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTestEnvTest.java
@@ -1,9 +1,6 @@
 package org.ampproject;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.javascript.rhino.IR;
-import com.google.javascript.rhino.Node;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerPass;
 import com.google.javascript.jscomp.CompilerTestCase;
@@ -18,7 +15,7 @@ public class AmpPassTestEnvTest extends CompilerTestCase {
   ImmutableSet<String> suffixTypes = ImmutableSet.of();
 
   @Override protected CompilerPass getProcessor(Compiler compiler) {
-    return new AmpPass(compiler, /* isProd */ false, suffixTypes, "123");
+    return new AmpPass(compiler, /* isProd */ false, suffixTypes);
   }
 
   @Override protected int getNumRepetitions() {


### PR DESCRIPTION
In #22839, several `babel` transformations were added to the multi pass build as a pre-requisite step to running closure compiler. With this, we no longer need most of the custom passes in `AmpPass.java`.

This PR cleans up all unnecessary code in `runner.jar`.

**Coming up:** Fix the removal of `assert` functions via `babel`, and remove `AmpPass.java` altogether.

Follow up to #22839 
Partial fix for #17120 and #22452