### PR TITLE
🏗 [pr-deploy-bot] Add html files to dist package that Travis uploads 

### DIFF
--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -43,7 +43,7 @@ const DIST_OUTPUT_FILE = isTravisBuild()
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
 const DIST_OUTPUT_DIRS =
-  'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP examples/ test/manual/';
+  'build/ dist/ dist.3p/ dist.tools/ EXTENSIONS_CSS_MAP examples/ test/manual/';
 
 const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
 const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -32,6 +32,7 @@ const {
   travisPullRequestSha,
 } = require('../travis');
 const {execOrDie, exec} = require('../exec');
+const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
 const BUILD_OUTPUT_FILE = isTravisBuild()
   ? `amp_build_${travisBuildNumber()}.zip`
@@ -39,7 +40,9 @@ const BUILD_OUTPUT_FILE = isTravisBuild()
 const DIST_OUTPUT_FILE = isTravisBuild()
   ? `amp_dist_${travisBuildNumber()}.zip`
   : '';
-const OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
+
+const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
+const DIST_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP examples/ test/manual/';
 const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
 const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';
 const OUTPUT_STORAGE_PROJECT_ID = 'amp-travis-build-storage';
@@ -184,9 +187,10 @@ function timedExecOrDie(cmd, fileName = 'utils.js') {
  * Download output helper
  * @param {string} functionName
  * @param {string} outputFileName
+ * @param {string} outputDirs
  * @private
  */
-async function downloadOutput_(functionName, outputFileName) {
+async function downloadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
   const buildOutputDownloadUrl = `${OUTPUT_STORAGE_LOCATION}/${outputFileName}`;
 
@@ -209,7 +213,7 @@ async function downloadOutput_(functionName, outputFileName) {
 
   console.log(fileLogPrefix, 'Verifying extracted files...');
   exec('echo travis_fold:start:verify_unzip_results && echo');
-  execOrDie(`ls -laR ${OUTPUT_DIRS}`);
+  execOrDie(`ls -laR ${outputDirs}`);
   exec('echo travis_fold:end:verify_unzip_results');
 }
 
@@ -217,20 +221,21 @@ async function downloadOutput_(functionName, outputFileName) {
  * Upload output helper
  * @param {string} functionName
  * @param {string} outputFileName
+ * @param {string} outputDirs
  * @private
  */
-async function uploadOutput_(functionName, outputFileName) {
+async function uploadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
 
   console.log(
     `\n${fileLogPrefix} Compressing ` +
-      colors.cyan(OUTPUT_DIRS.split(' ').join(', ')) +
+      colors.cyan(outputDirs.split(' ').join(', ')) +
       ' into ' +
       colors.cyan(outputFileName) +
       '...'
   );
   exec('echo travis_fold:start:zip_results && echo');
-  execOrDie(`zip -r ${outputFileName} ${OUTPUT_DIRS}`);
+  execOrDie(`zip -r ${outputFileName} ${outputDirs}`);
   exec('echo travis_fold:end:zip_results');
 
   console.log(
@@ -263,7 +268,7 @@ function authenticateWithStorageLocation_() {
  * @param {string} functionName
  */
 function downloadBuildOutput(functionName) {
-  downloadOutput_(functionName, BUILD_OUTPUT_FILE);
+  downloadOutput_(functionName, BUILD_OUTPUT_FILE, BUILD_OUTPUT_DIRS);
 }
 
 /**
@@ -271,7 +276,7 @@ function downloadBuildOutput(functionName) {
  * @param {string} functionName
  */
 function downloadDistOutput(functionName) {
-  downloadOutput_(functionName, DIST_OUTPUT_FILE);
+  downloadOutput_(functionName, DIST_OUTPUT_FILE, DIST_OUTPUT_DIRS);
 }
 
 /**
@@ -279,15 +284,17 @@ function downloadDistOutput(functionName) {
  * @param {string} functionName
  */
 function uploadBuildOutput(functionName) {
-  uploadOutput_(functionName, BUILD_OUTPUT_FILE);
+  uploadOutput_(functionName, BUILD_OUTPUT_FILE, BUILD_OUTPUT_DIRS);
 }
 
 /**
  * Zips and uploads the dist output to a remote storage location
  * @param {string} functionName
  */
-function uploadDistOutput(functionName) {
-  uploadOutput_(functionName, DIST_OUTPUT_FILE);
+async function uploadDistOutput(functionName) {
+  await replaceUrls('test/manual');
+  await replaceUrls('examples');
+  uploadOutput_(functionName, DIST_OUTPUT_FILE, DIST_OUTPUT_DIRS);
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -42,7 +42,9 @@ const DIST_OUTPUT_FILE = isTravisBuild()
   : '';
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
-const DIST_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP examples/ test/manual/';
+const DIST_OUTPUT_DIRS =
+  'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP examples/ test/manual/';
+
 const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
 const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';
 const OUTPUT_STORAGE_PROJECT_ID = 'amp-travis-build-storage';

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -38,8 +38,8 @@ async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
 
   const inabox = false;
-  const storyV1 = true;  
-  let result = replaceUrlsAppUtil('compiled', data, '', inabox, storyV1);
+  const storyV1 = true;
+  const result = replaceUrlsAppUtil('compiled', data, '', inabox, storyV1);
 
   await fs.writeFile(filePath, result, 'utf8');
 }
@@ -54,4 +54,4 @@ async function replaceUrls(dir) {
 
 module.exports = {
   replaceUrls,
-}
+};

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
+
+async function walk(dest) {
+  const filelist = [];
+  const files = await fs.readdir(dest);
+
+  for (let i = 0; i < files.length; i++) {
+    const file = `${dest}/${files[i]}`;
+
+    fs.statSync(file).isDirectory()
+      ? Array.prototype.push.apply(filelist, await walk(file))
+      : filelist.push(file);
+  }
+
+  return filelist;
+}
+
+async function replace(filePath) {
+  const data = await fs.readFile(filePath, 'utf8');
+
+  const inabox = false;
+  const storyV1 = true;  
+  let result = replaceUrlsAppUtil('compiled', data, '', inabox, storyV1);
+
+  await fs.writeFile(filePath, result, 'utf8');
+}
+
+async function replaceUrls(dir) {
+  const files = await walk(dir);
+  const promises = files
+    .filter(fileName => path.extname(fileName) == '.html')
+    .map(file => replace(file));
+  await Promise.all(promises);
+}
+
+module.exports = {
+  replaceUrls,
+}


### PR DESCRIPTION
Adds HTML files from `examples` and `test/manual` to the dist package that Travis uploads
Replaces the URLs with the minified versions that live in the same dir (not cdn)

This is so that the pr-deploy-bot can grab all the stuff necessary to create a test site for a PR branch when you ask it to.

