### PR TITLE
🐛 Enforce amp-ad type=custom has an HTTPS data-url

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -80,6 +80,12 @@ export class AmpAdCustom extends AMP.BaseElement {
       'custom ad slot should be alphanumeric: ' + this.slot_
     );
 
+    const urlService = Services.urlForDoc(this.element);
+    userAssert(
+      this.url_ && urlService.isSecure(this.url_),
+      'custom ad url must be an HTTPS URL'
+    );
+
     this.uiHandler = new AmpAdUIHandler(this);
   }
 
@@ -206,7 +212,7 @@ export class AmpAdCustom extends AMP.BaseElement {
   getFullUrl_() {
     // If this ad doesn't have a slot defined, just return the base URL
     if (this.slot_ === null) {
-      return /** @type {string} */ (this.url_);
+      return userAssert(this.url_);
     }
     if (ampCustomadFullUrls === null) {
       // The array of ad urls has not yet been built, do so now.

--- a/extensions/amp-ad/0.1/test/validator-amp-ad.html
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.html
@@ -42,6 +42,7 @@
   <!-- Valid -->
   <amp-ad width=300 height=250
       type="custom"
+      data-url="https://foobar.com"
       template="template-1">
   </amp-ad>
   <!-- Valid -->
@@ -66,5 +67,16 @@
   </amp-fx-flying-carpet>
   <!-- Invalid: amp-ad missing layout=fluid for fluid ad -->
   <amp-ad type=doubleclick width="100" height="fluid"></amp-ad>
+  <!-- Invalid: amp-ad type=custom missing data-url-->
+  <amp-ad width=300 height=250
+      type="custom"
+      template="template-1">
+  </amp-ad>
+  <!-- Invalid: amp-ad type=custom non-https data-url-->
+  <amp-ad width=300 height=250
+      type="custom"
+      data-url="http://foobar.com"
+      template="template-1">
+  </amp-ad>
 </body>
 </html>

--- a/extensions/amp-ad/0.1/test/validator-amp-ad.out
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.out
@@ -43,6 +43,7 @@ FAIL
 |    <!-- Valid -->
 |    <amp-ad width=300 height=250
 |        type="custom"
+|        data-url="https://foobar.com"
 |        template="template-1">
 |    </amp-ad>
 |    <!-- Valid -->
@@ -61,17 +62,32 @@ FAIL
 |    <amp-fx-flying-carpet height="300">
 |      <amp-ad data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:61:4 The tag 'amp-ad with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad) [AMP_TAG_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:62:4 The tag 'amp-ad with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad) [AMP_TAG_PROBLEM]
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad in an amp ad container with data-multi-size attr -->
 |    <amp-fx-flying-carpet height="300">
 |      <amp-embed data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:65:4 The tag 'amp-embed with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad) [AMP_TAG_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:66:4 The tag 'amp-embed with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad) [AMP_TAG_PROBLEM]
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad missing layout=fluid for fluid ad -->
 |    <amp-ad type=doubleclick width="100" height="fluid"></amp-ad>
 >>   ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:68:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://amp.dev/documentation/components/amp-ad) [AMP_LAYOUT_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:69:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://amp.dev/documentation/components/amp-ad) [AMP_LAYOUT_PROBLEM]
+|    <!-- Invalid: amp-ad type=custom missing data-url-->
+|    <amp-ad width=300 height=250
+>>   ^~~~~~~~~
+amp-ad/0.1/test/validator-amp-ad.html:71:2 The mandatory attribute 'data-url' is missing in tag 'amp-ad with type=custom'. (see https://github.com/ampproject/amphtml/blob/master/ads/custom.md) [AMP_TAG_PROBLEM]
+|        type="custom"
+|        template="template-1">
+|    </amp-ad>
+|    <!-- Invalid: amp-ad type=custom non-https data-url-->
+|    <amp-ad width=300 height=250
+>>   ^~~~~~~~~
+amp-ad/0.1/test/validator-amp-ad.html:76:2 Invalid URL protocol 'http:' for attribute 'data-url' in tag 'amp-ad with type=custom'. (see https://github.com/ampproject/amphtml/blob/master/ads/custom.md) [AMP_TAG_PROBLEM]
+|        type="custom"
+|        data-url="http://foobar.com"
+|        template="template-1">
+|    </amp-ad>
 |  </body>
 |  </html>

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -63,9 +63,49 @@ tags: {  # <amp-ad>
     blacklisted_value_regex: "__amp_source_origin"
   }
   attrs: { name: "template" }
-  attrs: { name: "type" mandatory: true }
+  attrs: {
+    name: "type"
+    mandatory: true
+    blacklisted_value_regex: "^("
+        "custom|"  # Handled separately below, has specific requirements
+        ")$"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: FLUID
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-ad type="custom">
+  html_format: AMP  # Ads are not allowed inside ads
+  tag_name: "AMP-AD"
+  spec_name: "amp-ad with type=custom"
+  requires_extension: "amp-ad"  # See note at top of file
+  also_requires_tag_warning: "amp-ad extension .js script"
+  # If modifying disallowed_ancestors, then please also edit
+  # extensions/amp-auto-ads/*/placement.js
+  disallowed_ancestor: "AMP-APP-BANNER"
+  attrs: {
+    name: "data-uri"
+    mandatory: true
+    value_url: {
+      protocol: "https"
+    }
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "custom"
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://github.com/ampproject/amphtml/blob/master/ads/custom.md"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -93,6 +93,7 @@ tags: {  # <amp-ad type="custom">
       protocol: "https"
     }
   }
+  attrs: { name: "template" }
   attrs: {
     name: "type"
     mandatory: true
@@ -220,7 +221,6 @@ tags: {  # <amp-embed>
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "template" }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad"

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -63,13 +63,7 @@ tags: {  # <amp-ad>
     blacklisted_value_regex: "__amp_source_origin"
   }
   attrs: { name: "template" }
-  attrs: {
-    name: "type"
-    mandatory: true
-    blacklisted_value_regex: "^("
-        "custom|"  # Handled separately below, has specific requirements
-        ")$"
-  }
+  attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad"
   amp_layout: {
@@ -93,7 +87,7 @@ tags: {  # <amp-ad type="custom">
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
   attrs: {
-    name: "data-uri"
+    name: "data-url"
     mandatory: true
     value_url: {
       protocol: "https"
@@ -103,6 +97,7 @@ tags: {  # <amp-ad type="custom">
     name: "type"
     mandatory: true
     value: "custom"
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "extended-amp-global"
   spec_url: "https://github.com/ampproject/amphtml/blob/master/ads/custom.md"


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/21314