### PR TITLE
🖍 AMP FIE CSS cleanup Doubleclick/Adsense experiment

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -108,6 +108,13 @@ export const ADX_ADY_EXP = {
   experiment: '21062593',
 };
 
+/** @const {!{branch: string, control: string, experiment: string}} */
+export const FIE_CSS_CLEANUP_EXP = {
+  branch: 'fie-css-cleanup',
+  control: '21064213',
+  experiment: '21064214',
+};
+
 /**
  * Returns the value of some navigation timing parameter.
  * Feature detection is used for safety on browsers that do not support the

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -28,6 +28,7 @@ import {
 } from '../../../ads/google/utils';
 import {
   ADX_ADY_EXP,
+  FIE_CSS_CLEANUP_EXP,
   QQID_HEADER,
   SANDBOX_HEADER,
   ValidAdContainerTypes,
@@ -291,6 +292,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       [[ADX_ADY_EXP.branch]]: {
         isTrafficEligible: () => true,
         branches: [[ADX_ADY_EXP.control], [ADX_ADY_EXP.experiment]],
+      },
+      [[FIE_CSS_CLEANUP_EXP.branch]]: {
+        isTrafficEligible: () => true,
+        branches: [
+          [FIE_CSS_CLEANUP_EXP.control],
+          [FIE_CSS_CLEANUP_EXP.experiment],
+        ],
       },
     });
     const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -24,6 +24,7 @@ import '../../amp-a4a/0.1/real-time-config-manager';
 import {
   ADX_ADY_EXP,
   AmpAnalyticsConfigDef,
+  FIE_CSS_CLEANUP_EXP,
   QQID_HEADER,
   SANDBOX_HEADER,
   ValidAdContainerTypes,
@@ -393,6 +394,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       [[ADX_ADY_EXP.branch]]: {
         isTrafficEligible: () => true,
         branches: [[ADX_ADY_EXP.control], [ADX_ADY_EXP.experiment]],
+      },
+      [[FIE_CSS_CLEANUP_EXP.branch]]: {
+        isTrafficEligible: () => true,
+        branches: [
+          [FIE_CSS_CLEANUP_EXP.control],
+          [FIE_CSS_CLEANUP_EXP.experiment],
+        ],
       },
     });
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoMap);


### PR DESCRIPTION
Send experiment ID to Doubleclick/Adsense to validate FIE CSS reduction changes for https://github.com/ampproject/amphtml/issues/22418

See https://github.com/ampproject/amphtml/pull/22631/files for changes validated.