### PR TITLE
✨ Add expiration time to experiments

### DIFF
--- a/build-system/build.conf.js
+++ b/build-system/build.conf.js
@@ -67,9 +67,8 @@ function getReplacePlugin() {
 
   // default each experiment flag constant to false
   Object.keys(experimentsConfig).forEach(experiment => {
-    const expirationStr =
-      experimentsConfig[experiment]['expirationTimestampMs'];
-    const expirationDate = new Date(parseInt(expirationStr, 10));
+    const expirationStr = experimentsConfig[experiment]['expirationDateUTC'];
+    const expirationDate = new Date(expirationStr);
     const expirationTimestampMs = expirationDate.getTime();
 
     // check experiment expiration times
@@ -77,7 +76,7 @@ function getReplacePlugin() {
       throw new Error(`Invalid expiration date for ${experiment}`);
     } else if (expirationTimestampMs < currentTimestampMs) {
       throw new Error(
-        `${experiment} has expired on ${expirationDate.toDateString()}. Please remove from experiments-config.json and cleanup relevant code.`
+        `${experiment} has expired on ${expirationDate.toUTCString()}. Please remove from experiments-config.json and cleanup relevant code.`
       );
     }
 

--- a/build-system/build.conf.js
+++ b/build-system/build.conf.js
@@ -63,7 +63,7 @@ function getReplacePlugin() {
     replacements.push(createReplacement(defineFlag, true));
   }
 
-  const currentTimestampMs = new Date().getTime();
+  const currentTimestampMs = Date.now();
 
   // default each experiment flag constant to false
   Object.keys(experimentsConfig).forEach(experiment => {

--- a/build-system/build.conf.js
+++ b/build-system/build.conf.js
@@ -63,8 +63,24 @@ function getReplacePlugin() {
     replacements.push(createReplacement(defineFlag, true));
   }
 
+  const currentTimestampMs = new Date().getTime();
+
   // default each experiment flag constant to false
   Object.keys(experimentsConfig).forEach(experiment => {
+    const expirationStr =
+      experimentsConfig[experiment]['expirationTimestampMs'];
+    const expirationDate = new Date(parseInt(expirationStr, 10));
+    const expirationTimestampMs = expirationDate.getTime();
+
+    // check experiment expiration times
+    if (experimentsConfig[experiment]['name'] && !expirationTimestampMs) {
+      throw new Error(`Invalid expiration date for ${experiment}`);
+    } else if (expirationTimestampMs < currentTimestampMs) {
+      throw new Error(
+        `${experiment} has expired on ${expirationDate.toDateString()}. Please remove from experiments-config.json and cleanup relevant code.`
+      );
+    }
+
     const experimentDefine =
       experimentsConfig[experiment]['defineExperimentConstant'];
 

--- a/build-system/global-configs/README.md
+++ b/build-system/global-configs/README.md
@@ -10,4 +10,5 @@ besides 1 or 0.
 - `name`: Experiment name
 - `command`: Command used to build the experiment
 - `issue`: The issue tracker URL for this experiment
+- `expirationTimestampMs`: The Unix timestamp in ms when this experiment expires
 - `defineExperimentConstant`: (Optional) The flag that is used to section out experiment code. This is passed into the `minify-replace` babel plugin and defaults to `false`. If an experiment relies on `minify-replace` to replace its experiment flag, this value must be defined.

--- a/build-system/global-configs/README.md
+++ b/build-system/global-configs/README.md
@@ -10,5 +10,5 @@ besides 1 or 0.
 - `name`: Experiment name
 - `command`: Command used to build the experiment
 - `issue`: The issue tracker URL for this experiment
-- `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC
+- `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC. If an experiment is expired, it will fail the build process. There is currently no realtime check for the expiration time.
 - `defineExperimentConstant`: (Optional) The flag that is used to section out experiment code. This is passed into the `minify-replace` babel plugin and defaults to `false`. If an experiment relies on `minify-replace` to replace its experiment flag, this value must be defined.

--- a/build-system/global-configs/README.md
+++ b/build-system/global-configs/README.md
@@ -10,5 +10,5 @@ besides 1 or 0.
 - `name`: Experiment name
 - `command`: Command used to build the experiment
 - `issue`: The issue tracker URL for this experiment
-- `expirationTimestampMs`: The Unix timestamp in ms when this experiment expires
+- `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC
 - `defineExperimentConstant`: (Optional) The flag that is used to section out experiment code. This is passed into the `minify-replace` babel plugin and defaults to `false`. If an experiment relies on `minify-replace` to replace its experiment flag, this value must be defined.

--- a/build-system/global-configs/README.md
+++ b/build-system/global-configs/README.md
@@ -10,5 +10,5 @@ besides 1 or 0.
 - `name`: Experiment name
 - `command`: Command used to build the experiment
 - `issue`: The issue tracker URL for this experiment
-- `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC. If an experiment is expired, it will fail the build process. There is currently no realtime check for the expiration time.
+- `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC. If an experiment is expired, it will fail the build process. This expiration date is only read during the build. As a result, the experiment will actually end on the following release date after the expiration.
 - `defineExperimentConstant`: (Optional) The flag that is used to section out experiment code. This is passed into the `minify-replace` babel plugin and defaults to `false`. If an experiment relies on `minify-replace` to replace its experiment flag, this value must be defined.

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -3,7 +3,7 @@
     "name": "ANALYTICS_VENDOR_SPLIT",
     "command": "gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
-    "expirationTimestampMs": "1565870400000",
+    "expirationDateUTC": "2019-08-08",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"
   },
   "experimentB": {},

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -3,6 +3,7 @@
     "name": "ANALYTICS_VENDOR_SPLIT",
     "command": "gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
+    "expirationTimestampMs": "1565870400000",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"
   },
   "experimentB": {},

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -885,7 +885,10 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.getTime\\(\\)': {
     message: 'Unless you do weird date math (whitelist), use Date.now().',
-    whitelist: ['extensions/amp-timeago/0.1/amp-timeago.js'],
+    whitelist: [
+      'extensions/amp-timeago/0.1/amp-timeago.js',
+      'build-system/build.conf.js',
+    ],
   },
   '\\.expandStringSync\\(': {
     message: requiresReviewPrivacy,


### PR DESCRIPTION
Add an expiration time (Unix timestamp in milliseconds) to experiments tracked in `experiments-config.json`. Build will throw an error if expiration timestamp is missing, or if expiration time has passed.

cc @zhouyx for review :)