### PR TITLE
🏗 [pr-deploy-bot] Send http post to amp-pr-deploy-bot when dist finishes on Travis

### DIFF
--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -25,6 +25,7 @@
 const colors = require('ansi-colors');
 const {
   printChangeSummary,
+  processAndUploadDistOutput,
   startTimer,
   stopTimer,
   timedExecOrDie: timedExecOrDieBase,
@@ -66,7 +67,7 @@ function main() {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --fortesting');
       timedExecOrDie('gulp bundle-size --on_pr_build');
-      uploadDistOutput(FILENAME);
+      processAndUploadDistOutput(FILENAME);
     } else {
       timedExecOrDie('gulp bundle-size --on_skipped_build');
       console.log(

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -40,7 +40,7 @@ const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd, unusedFileName) =>
   timedExecOrDieBase(cmd, FILENAME);
 
-function main() {
+async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
   if (!runYarnChecks(FILENAME)) {
     stopTimer(FILENAME, FILENAME, startTime);
@@ -67,7 +67,7 @@ function main() {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --fortesting');
       timedExecOrDie('gulp bundle-size --on_pr_build');
-      processAndUploadDistOutput(FILENAME);
+      await processAndUploadDistOutput(FILENAME);
     } else {
       timedExecOrDie('gulp bundle-size --on_skipped_build');
       console.log(

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -195,7 +195,7 @@ function timedExecOrDie(cmd, fileName = 'utils.js') {
  * @param {string} outputDirs
  * @private
  */
-async function downloadOutput_(functionName, outputFileName, outputDirs) {
+function downloadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
   const buildOutputDownloadUrl = `${OUTPUT_STORAGE_LOCATION}/${outputFileName}`;
 
@@ -229,7 +229,7 @@ async function downloadOutput_(functionName, outputFileName, outputDirs) {
  * @param {string} outputDirs
  * @private
  */
-async function uploadOutput_(functionName, outputFileName, outputDirs) {
+function uploadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
 
   console.log(
@@ -296,7 +296,7 @@ function uploadBuildOutput(functionName) {
  * Zips and uploads the dist output to a remote storage location
  * @param {string} functionName
  */
-async function uploadDistOutput(functionName) {
+function uploadDistOutput(functionName) {
   uploadOutput_(functionName, DIST_OUTPUT_FILE, DIST_OUTPUT_DIRS);
 }
 

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -17,7 +17,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const request = require('request');
+const request = require('request-promise');
 const {gitCommitHash} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
 const {travisBuildNumber} = require('../travis');
@@ -55,14 +55,14 @@ async function replaceUrls(dir) {
   await Promise.all(promises);
 }
 
-function signalDistUploadComplete() {
+async function signalDistUploadComplete() {
   const sha = gitCommitHash();
   const travisBuild = travisBuildNumber();
   const url =
     'https://amp-pr-deploy-bot.appspot.com/probot/v0/pr-deploy/' +
     `travisbuilds/${travisBuild}/headshas/${sha}/0`;
 
-  request.post(url);
+  await request.post(url);
 }
 
 module.exports = {

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -18,8 +18,9 @@
 const fs = require('fs-extra');
 const path = require('path');
 const request = require('request');
-const {gitCommitHash, travisBuildNumber} = require('../git');
+const {gitCommitHash} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
+const {travisBuildNumber} = require('../travis');
 
 async function walk(dest) {
   const filelist = [];

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -17,6 +17,8 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const request = require('request');
+const {gitCommitHash, travisBuildNumber} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
 
 async function walk(dest) {
@@ -52,6 +54,17 @@ async function replaceUrls(dir) {
   await Promise.all(promises);
 }
 
+function signalDistUploadComplete() {
+  const sha = gitCommitHash();
+  const travisBuild = travisBuildNumber();
+  const url =
+    'https://amp-pr-deploy-bot.appspot.com/probot/v0/pr-deploy/' +
+    `travisbuilds/${travisBuild}/headshas/${sha}/0`;
+
+  request.post(url);
+}
+
 module.exports = {
   replaceUrls,
+  signalDistUploadComplete,
 };


### PR DESCRIPTION
This is so that the pr-deploy bot doesn't let someone deploy a PR branch before the bits are ready.