### PR TITLE
♻️Move element dependent macros to `getMacros`

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -737,7 +737,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       .then(key =>
         Services.urlReplacementsForDoc(this.element).expandUrlAsync(
           key,
-          this.variableService_.getMacros()
+          this.variableService_.getMacros(this.element)
         )
       );
   }

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -389,7 +389,7 @@ export class AnalyticsConfig {
     const expansionPromises = [];
 
     const urlReplacements = Services.urlReplacementsForDoc(element);
-    const bindings = variableServiceForDoc(element).getMacros();
+    const bindings = variableServiceForDoc(element).getMacros(element);
 
     Object.keys(obj).forEach(key => {
       keys.push(key);

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -379,7 +379,7 @@ export class AnalyticsConfig {
   /**
    * Expands all key value pairs asynchronously and returns a promise that will
    * resolve with the expanded object.
-   * @param {!Element|!ShadowRoot} element
+   * @param {!Element} element
    * @param {!Object} obj
    * @return {!Promise<!Object>}
    */

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -57,7 +57,7 @@ export class CookieWriter {
     this.config_ = config;
 
     /** @const @private {!JsonObject} */
-    this.bindings_ = variableServiceForDoc(element).getMacros();
+    this.bindings_ = variableServiceForDoc(element).getMacros(element);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -19,7 +19,6 @@ import {Priority} from '../../../src/service/navigation';
 import {Services} from '../../../src/services';
 import {WindowInterface} from '../../../src/window-interface';
 import {addMissingParamsToUrl, addParamToUrl} from '../../../src/url';
-import {cookieReader} from './cookie-reader';
 import {createElementWithAttributes} from '../../../src/dom';
 import {createLinker} from './linker';
 import {dict} from '../../../src/utils/object';
@@ -219,12 +218,7 @@ export class LinkerManager {
    * @return {!Promise<string>} expanded template.
    */
   expandTemplateWithUrlParams_(template, expansionOptions) {
-    const bindings = this.variableService_.getMacros();
-
-    // TODO: (@zhouyx) Duplicate of binding in requests and linker.
-    // Move to varaible Servie once there's a way to detect FIE in that service
-    bindings['COOKIE'] = name =>
-      cookieReader(this.ampdoc_.win, this.element_, name);
+    const bindings = this.variableService_.getMacros(this.element);
 
     return this.variableService_
       .expandTemplate(template, expansionOptions)

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -218,7 +218,7 @@ export class LinkerManager {
    * @return {!Promise<string>} expanded template.
    */
   expandTemplateWithUrlParams_(template, expansionOptions) {
-    const bindings = this.variableService_.getMacros(this.element);
+    const bindings = this.variableService_.getMacros(this.element_);
 
     return this.variableService_
       .expandTemplate(template, expansionOptions)

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -118,6 +118,7 @@ export class LinkerManager {
           }
         });
         this.resolvedIds_[name] = expandedIds;
+        return expandedIds;
       });
     });
 
@@ -219,7 +220,6 @@ export class LinkerManager {
    */
   expandTemplateWithUrlParams_(template, expansionOptions) {
     const bindings = this.variableService_.getMacros(this.element_);
-
     return this.variableService_
       .expandTemplate(template, expansionOptions)
       .then(expanded => {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -15,14 +15,9 @@
  */
 
 import {BatchSegmentDef, defaultSerializer} from './transport-serializer';
-import {
-  ExpansionOptions,
-  getConsentStateStr,
-  variableServiceForDoc,
-} from './variables';
+import {ExpansionOptions, variableServiceForDoc} from './variables';
 import {SANDBOX_AVAILABLE_VARS} from './sandbox-vars-whitelist';
 import {Services} from '../../../src/services';
-import {cookieReader} from './cookie-reader';
 import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getResourceTiming} from './resource-timing';
@@ -131,16 +126,12 @@ export class RequestHandler {
 
     this.queueSize_++;
     this.lastTrigger_ = trigger;
-    const bindings = this.variableService_.getMacros();
+    const bindings = this.variableService_.getMacros(this.element_);
     bindings['RESOURCE_TIMING'] = getResourceTiming(
       this.ampdoc_,
       trigger['resourceTimingSpec'],
       this.startTime_
     );
-    // TODO: (@zhouyx) Move to variable service once that becomes
-    // a doc level services
-    bindings['CONSENT_STATE'] = getConsentStateStr(this.element_);
-    bindings['COOKIE'] = name => cookieReader(this.win, this.element_, name);
 
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -405,7 +405,7 @@ export function expandPostMessage(
   const variableService = variableServiceForDoc(ampdoc);
   const urlReplacementService = Services.urlReplacementsForDoc(element);
 
-  const bindings = variableService.getMacros();
+  const bindings = variableService.getMacros(element);
   expansionOption.freezeVar('extraUrlParams');
 
   const basePromise = variableService

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -226,6 +226,29 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
   });
 
+  it('should resolve element dependent vars and macros', () => {
+    win.document.cookie = 'foo=123';
+    const config = {
+      linkers: {
+        enabled: true,
+        proxyOnly: false,
+        testLinker1: {
+          ids: {
+            yum: '${myCookie}',
+          },
+        },
+      },
+      vars: {
+        'myCookie': 'COOKIE(foo)',
+      },
+    };
+
+    const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
+    return lm.init().then(expandedIds => {
+      expect(expandedIds[0]).to.eql({yum: '123'});
+    });
+  });
+
   it('should not add params where linker value is empty', () => {
     const config = {
       linkers: {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -423,6 +423,12 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         );
         return check('$MATCH(thisisatest, thisisatest, test)', 'thisisatest');
       });
+
+      it('"COOKIE" resolves cookie value', async () => {
+        doc.cookie = 'test=123';
+        await check('COOKIE(test)', '123');
+        doc.cookie = '';
+      });
     });
   });
 

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -205,7 +205,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     });
 
     function check(input, output, opt_bindings) {
-      const macros = Object.assign(variables.getMacros(), opt_bindings);
+      const macros = Object.assign(variables.getMacros(doc), opt_bindings);
       const expanded = urlReplacementService.expandUrlAsync(input, macros);
       return expect(expanded).to.eventually.equal(output);
     }

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -369,6 +369,36 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       );
     });
 
+    it('"COOKIE" resolves cookie value', async () => {
+      doc.cookie = 'test=123';
+      await check('COOKIE(test)', '123');
+      doc.cookie = '';
+    });
+
+    it('COOKIE resolves to empty string in FIE', async () => {
+      doc.cookie = 'test=123';
+      const fakeFie = doc.createElement('div');
+      fakeFie.classList.add('i-amphtml-fie');
+      doc.body.appendChild(fakeFie);
+      fakeFie.appendChild(analyticsElement);
+      await check('COOKIE(test)', '');
+      doc.cookie = '';
+    });
+
+    it('COOKIE resolves to empty string when inabox', async () => {
+      doc.cookie = 'test=123';
+      env.win.AMP_MODE.runtime = 'inabox';
+      await check('COOKIE(test)', '');
+      doc.cookie = '';
+    });
+
+    it('COOKIE resolves to empty string on cache', async () => {
+      win.location = 'https://www-example-com.cdn.ampproject.org';
+      doc.cookie = 'test=123';
+      await check('COOKIE(test)', '');
+      doc.cookie = '';
+    });
+
     describe('$MATCH', () => {
       it('handles default index', () => {
         return check('$MATCH(thisisatest, thisisatest)', 'thisisatest');
@@ -423,14 +453,38 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
         );
         return check('$MATCH(thisisatest, thisisatest, test)', 'thisisatest');
       });
-
-      it('"COOKIE" resolves cookie value', async () => {
-        doc.cookie = 'test=123';
-        await check('COOKIE(test)', '123');
-        doc.cookie = '';
-      });
     });
   });
+
+  // describes.realWin(
+  //   'FIE testing',
+  //   {
+  //     amp: {ampdoc: 'fie'},
+  //   },
+  //   env => {
+  //     let win;
+  //     let doc;
+  //     let variables;
+
+  //     beforeEach(() => {
+  //       win = env.win;
+  //       doc = win.doc;
+  //       installLinkerReaderService(win);
+  //       variables = new VariableService(env.ampdoc);
+  //     });
+
+  //     it('does not resolve cookie when inabox', async () => {
+  //       win.AMP_MODE.runtime = 'inabox';
+  //       win.location =
+  //         'https://beta-washingtonpost-com.cdn.ampproject.org/v/s/' +
+  //         'beta.washingtonpost.com/politics/2019/07/29/' +
+  //         'bidens-electability-numbers-are-up-therefore-so-are-his-poll-numbers/';
+  //       doc.cookie = 'test=123';
+  //       await check('COOKIE(test)', '123');
+  //       doc.cookie = '';
+  //     });
+  //   }
+  // );
 
   describe('getNameArgs:', () => {
     function check(input, name, argList) {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -456,36 +456,6 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     });
   });
 
-  // describes.realWin(
-  //   'FIE testing',
-  //   {
-  //     amp: {ampdoc: 'fie'},
-  //   },
-  //   env => {
-  //     let win;
-  //     let doc;
-  //     let variables;
-
-  //     beforeEach(() => {
-  //       win = env.win;
-  //       doc = win.doc;
-  //       installLinkerReaderService(win);
-  //       variables = new VariableService(env.ampdoc);
-  //     });
-
-  //     it('does not resolve cookie when inabox', async () => {
-  //       win.AMP_MODE.runtime = 'inabox';
-  //       win.location =
-  //         'https://beta-washingtonpost-com.cdn.ampproject.org/v/s/' +
-  //         'beta.washingtonpost.com/politics/2019/07/29/' +
-  //         'bidens-electability-numbers-are-up-therefore-so-are-his-poll-numbers/';
-  //       doc.cookie = 'test=123';
-  //       await check('COOKIE(test)', '123');
-  //       doc.cookie = '';
-  //     });
-  //   }
-  // );
-
   describe('getNameArgs:', () => {
     function check(input, name, argList) {
       it('can parse ' + name, () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -192,6 +192,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     let win;
     let urlReplacementService;
     let sandbox;
+    let analyticsElement;
 
     beforeEach(() => {
       sandbox = env.sandbox;
@@ -202,10 +203,15 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       variables = variableServiceForDoc(doc);
       const {documentElement} = win.document;
       urlReplacementService = Services.urlReplacementsForDoc(documentElement);
+      analyticsElement = doc.createElement('amp-analytics');
+      doc.body.appendChild(analyticsElement);
     });
 
     function check(input, output, opt_bindings) {
-      const macros = Object.assign(variables.getMacros(doc), opt_bindings);
+      const macros = Object.assign(
+        variables.getMacros(analyticsElement),
+        opt_bindings
+      );
       const expanded = urlReplacementService.expandUrlAsync(input, macros);
       return expect(expanded).to.eventually.equal(output);
     }

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -214,13 +214,10 @@ export class VariableService {
   }
 
   /**
-   * @param {Element=} element
+   * @param {!Element} element
    * @return {!JsonObject} contains all registered macros
    */
   getMacros(element) {
-    if (!element) {
-      return this.macros_;
-    }
     const elementMacros = {
       'COOKIE': name =>
         cookieReader(this.ampdoc_.win, dev().assertElement(element), name),

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -225,7 +225,8 @@ export class VariableService {
       'COOKIE': name => cookieReader(this.ampdoc_.win, element, name),
       'CONSENT_STATE': getConsentStateStr(element),
     };
-    return Object.assign({}, this.macros_, elementMacros);
+    const merged = Object.assign({}, this.macros_, elementMacros);
+    return /** @type {JsonObject} */ (merged);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -17,7 +17,7 @@
 import {Services} from '../../../src/services';
 import {base64UrlEncodeFromString} from '../../../src/utils/base64';
 import {cookieReader} from './cookie-reader';
-import {devAssert, user, userAssert} from '../../../src/log';
+import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getConsentPolicyState} from '../../../src/consent';
 import {
@@ -223,7 +223,7 @@ export class VariableService {
     }
     const elementMacros = {
       'COOKIE': name =>
-        cookieReader(this.ampdoc_.win, /** @type {!Element} */ (element), name),
+        cookieReader(this.ampdoc_.win, dev().assertElement(element), name),
       'CONSENT_STATE': getConsentStateStr(element),
     };
     const merged = Object.assign({}, this.macros_, elementMacros);

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -16,6 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {base64UrlEncodeFromString} from '../../../src/utils/base64';
+import {cookieReader} from './cookie-reader';
 import {devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getConsentPolicyState} from '../../../src/consent';
@@ -213,10 +214,18 @@ export class VariableService {
   }
 
   /**
+   * @param {Element=} element
    * @return {!JsonObject} contains all registered macros
    */
-  getMacros() {
-    return this.macros_;
+  getMacros(element) {
+    if (!element) {
+      return this.macros_;
+    }
+    const elementMacros = {
+      'COOKIE': name => cookieReader(this.ampdoc_.win, element, name),
+      'CONSENT_STATE': getConsentStateStr(element),
+    };
+    return Object.assign({}, this.macros_, elementMacros);
   }
 
   /**
@@ -377,7 +386,7 @@ export function getNameArgsForTesting(key) {
  * @param {!Element} element
  * @return {!Promise<?string>}
  */
-export function getConsentStateStr(element) {
+function getConsentStateStr(element) {
   return getConsentPolicyState(element).then(consent => {
     if (!consent) {
       return null;

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -222,11 +222,12 @@ export class VariableService {
       return this.macros_;
     }
     const elementMacros = {
-      'COOKIE': name => cookieReader(this.ampdoc_.win, element, name),
+      'COOKIE': name =>
+        cookieReader(this.ampdoc_.win, /** @type {!Element} */ (element), name),
       'CONSENT_STATE': getConsentStateStr(element),
     };
     const merged = Object.assign({}, this.macros_, elementMacros);
-    return /** @type {JsonObject} */ (merged);
+    return /** @type {!JsonObject} */ (merged);
   }
 
   /**


### PR DESCRIPTION
Removes some code duplication and a race? where different macros would be available depending on when getMacros would be called (this may still exist for resource timing which was not moved).

@zhouyx please let me know if there is anything I am missing in this PR. Seems like there is already pretty good test coverage.

