### PR TITLE
🏗 Enable package updates for E2E and visual diff tests

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -37,6 +37,7 @@ const TEST_RETRIES = 2;
 let webServerProcess_;
 
 function installPackages_() {
+  log('Running', cyan('yarn'), 'to install packages...');
   execOrDie('npx yarn --cwd build-system/tasks/e2e', {'stdio': 'ignore'});
 }
 
@@ -46,6 +47,7 @@ function buildRuntime_() {
 }
 
 function launchWebServer_() {
+  log('Launching webserver at', cyan(`http://${HOST}:${PORT}`) + '...');
   webServerProcess_ = execScriptAsync(
     `gulp serve --compiled --host ${HOST} --port ${PORT}`,
     {stdio: 'ignore'}
@@ -114,6 +116,7 @@ async function e2e() {
 
   // run tests
   if (!argv.watch) {
+    log('Running tests...');
     const mocha = createMocha_();
 
     // specify tests to run

--- a/build-system/tasks/e2e/package.json
+++ b/build-system/tasks/e2e/package.json
@@ -3,7 +3,7 @@
   "name": "gulp-e2e",
   "version": "0.1.0",
   "description": "Gulp e2e",
-  "dependencies": {
+  "devDependencies": {
     "@babel/register": "7.4.4",
     "babel-regenerator-runtime": "6.5.0",
     "chromedriver": "74.0.0",

--- a/build-system/tasks/visual-diff/package.json
+++ b/build-system/tasks/visual-diff/package.json
@@ -3,7 +3,7 @@
   "name": "gulp-visual-diff",
   "version": "0.1.0",
   "description": "Gulp visual diff",
-  "dependencies": {
+  "devDependencies": {
     "@percy/puppeteer": "0.4.0",
     "puppeteer": "1.9.0"
   }


### PR DESCRIPTION
There's a security vulnerability in one of our test deps that uses an outdated dependency version. It turns out this is because Renovate is configured to upgrade `devDependencies`, but leave `dependencies` alone (#23008). 

![image](https://user-images.githubusercontent.com/26553114/61554414-e3e08000-aa2a-11e9-93e8-82f00c642d65.png)

This PR moves all of the E2E and visual diff packages to `devDependencies` to enable automatic upgrades. It also adds some logging to the E2E tests (I found this useful while testing these changes.)

Soon, we should see version upgrade PRs for the packages used by our tests.