### PR TITLE
🐛 Catch invalid json responses in amp-addthis

### DIFF
--- a/extensions/amp-addthis/0.1/addthis-utils/pixel.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pixel.js
@@ -201,13 +201,16 @@ export const callPixelEndpoint = event => {
       credentials: 'include',
     })
     .then(res => res.json())
-    .then(json => {
-      const {pixels = []} = json;
-      if (pixels.length > 0) {
-        dropPixelGroups(pixels, {
-          sid: eventData['sid'],
-          ampDoc,
-        });
-      }
-    });
+    .then(
+      json => {
+        const {pixels = []} = json;
+        if (pixels.length > 0) {
+          dropPixelGroups(pixels, {
+            sid: eventData['sid'],
+            ampDoc,
+          });
+        }
+      },
+      () => {}
+    );
 };


### PR DESCRIPTION
It appears (from our error logs) that the JSON requests occasionally return invalid JSON. Maybe something to do with ad blocking?

Fixes https://github.com/ampproject/amphtml/issues/19253.

/cc @taojing10 @dmvjs @pjcunnin @matthinegardner