### PR TITLE
Use experiment branch to gate fie-css-cleanup

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -108,13 +108,6 @@ export const ADX_ADY_EXP = {
   experiment: '21062593',
 };
 
-/** @const {!{branch: string, control: string, experiment: string}} */
-export const FIE_CSS_CLEANUP_EXP = {
-  branch: 'fie-css-cleanup',
-  control: '21064213',
-  experiment: '21064214',
-};
-
 /**
  * Returns the value of some navigation timing parameter.
  * Feature detection is used for safety on browsers that do not support the

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -28,7 +28,6 @@ import {
 } from '../../../ads/google/utils';
 import {
   ADX_ADY_EXP,
-  FIE_CSS_CLEANUP_EXP,
   QQID_HEADER,
   SANDBOX_HEADER,
   ValidAdContainerTypes,
@@ -47,6 +46,7 @@ import {
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
+import {FIE_CSS_CLEANUP_EXP} from '../../../src/service/extensions-impl';
 import {Navigation} from '../../../src/service/navigation';
 import {Services} from '../../../src/services';
 import {

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -46,7 +46,7 @@ import {
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
-import {FIE_CSS_CLEANUP_EXP} from '../../../src/service/extensions-impl';
+import {FIE_CSS_CLEANUP_EXP} from '../../../src/friendly-iframe-embed';
 import {Navigation} from '../../../src/service/navigation';
 import {Services} from '../../../src/services';
 import {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -24,7 +24,6 @@ import '../../amp-a4a/0.1/real-time-config-manager';
 import {
   ADX_ADY_EXP,
   AmpAnalyticsConfigDef,
-  FIE_CSS_CLEANUP_EXP,
   QQID_HEADER,
   SANDBOX_HEADER,
   ValidAdContainerTypes,
@@ -51,6 +50,7 @@ import {
 } from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
+import {FIE_CSS_CLEANUP_EXP} from '../../../src/service/extensions-impl';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Navigation} from '../../../src/service/navigation';
 import {RTC_VENDORS} from '../../amp-a4a/0.1/callout-vendors';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -50,7 +50,7 @@ import {
 } from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
-import {FIE_CSS_CLEANUP_EXP} from '../../../src/service/extensions-impl';
+import {FIE_CSS_CLEANUP_EXP} from '../../../src/friendly-iframe-embed';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Navigation} from '../../../src/service/navigation';
 import {RTC_VENDORS} from '../../amp-a4a/0.1/callout-vendors';

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -35,6 +35,7 @@ import {
   installServiceInEmbedIfEmbeddable,
   setParentWindow,
 } from './service';
+import {getExperimentBranch} from './experiments';
 import {getMode} from './mode';
 import {installAmpdocServices} from './service/core-services';
 import {install as installCustomElements} from './polyfills/custom-elements';
@@ -66,6 +67,15 @@ const EXCLUDE_INI_LOAD = [
   'AMP-PIXEL',
   'AMP-AD-EXIT',
 ];
+
+/**
+ * @const {{experiment: string, control: string, branch: string}}
+ */
+export const FIE_CSS_CLEANUP_EXP = {
+  branch: 'fie-css-cleanup',
+  control: '21064213',
+  experiment: '21064214',
+};
 
 /**
  * Parameters used to create the new "friendly iframe" embed.
@@ -704,7 +714,8 @@ export class FriendlyIframeEmbed {
     // Install runtime styles.
     installStylesForDoc(
       ampdoc,
-      isExperimentOn(topWin, 'fie-css-cleanup')
+      getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
+          FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,
       /* callback */ null,
@@ -763,7 +774,8 @@ export class FriendlyIframeEmbed {
     // Install runtime styles.
     installStylesLegacy(
       childWin.document,
-      isExperimentOn(topWin, 'fie-css-cleanup')
+      getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
+          FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,
       /* callback */ null,

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -35,7 +35,7 @@ import {
   installServiceInEmbedIfEmbeddable,
   setParentWindow,
 } from './service';
-import {getExperimentBranch} from './experiments';
+import {getExperimentBranch, isExperimentOn} from './experiments';
 import {getMode} from './mode';
 import {installAmpdocServices} from './service/core-services';
 import {install as installCustomElements} from './polyfills/custom-elements';
@@ -45,7 +45,7 @@ import {installCustomElements as installRegisterElement} from 'document-register
 import {installStylesForDoc, installStylesLegacy} from './style-installer';
 import {installTimerInEmbedWindow} from './service/timer-impl';
 import {isDocumentReady} from './document-ready';
-import {isExperimentOn} from './experiments';
+
 import {layoutRectLtwh, moveLayoutRect} from './layout-rect';
 import {loadPromise} from './event-helper';
 import {
@@ -715,7 +715,7 @@ export class FriendlyIframeEmbed {
     installStylesForDoc(
       ampdoc,
       getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
-          FIE_CSS_CLEANUP_EXP.experiment
+        FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,
       /* callback */ null,
@@ -775,7 +775,7 @@ export class FriendlyIframeEmbed {
     installStylesLegacy(
       childWin.document,
       getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
-          FIE_CSS_CLEANUP_EXP.experiment
+        FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,
       /* callback */ null,

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -113,7 +113,6 @@ let ExtensionHolderDef;
  */
 const FIE_CSS_CLEANUP_EXP = {
   branch: 'fie-css-cleanup',
-  control: '21064213',
   experiment: '21064214',
 };
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -19,7 +19,6 @@ import {
   ExperimentInfo, // eslint-disable-line no-unused-vars
   getExperimentBranch,
   isExperimentOn,
-  randomlySelectUnsetExperiments,
 } from '../experiments';
 import {Services} from '../services';
 import {
@@ -458,8 +457,8 @@ export class Extensions {
 
     // Install necessary polyfills.
     installPolyfillsInChildWindow(parentWin, childWin);
+
     // Install runtime styles.
-    this.maybeSelectFieCssExperiment(this.win);
     installStylesForDoc(
       ampdoc,
       isExperimentOn(this.win, 'fie-css-cleanup') &&
@@ -520,7 +519,6 @@ export class Extensions {
     installPolyfillsInChildWindow(parentWin, childWin);
 
     // Install runtime styles.
-    this.maybeSelectFieCssExperiment(this.win);
     installStylesLegacy(
       childWin.document,
       isExperimentOn(this.win, 'fie-css-cleanup') &&
@@ -597,19 +595,6 @@ export class Extensions {
       promises.push(promise);
     });
     return Promise.all(promises);
-  }
-
-  /**
-   * Select the experiment branch for fie-css-cleanup if necessary.
-   * @param {!Window} win
-   */
-  maybeSelectFieCssExperiment(win) {
-    const experimentInfoMap = /** @type {!Object<string, !ExperimentInfo>} */ ({});
-    experimentInfoMap['fie-css-cleanup'] = {
-      isTrafficEligible: () => true,
-      branches: [FIE_CSS_CLEANUP_EXP.control, FIE_CSS_CLEANUP_EXP.experiment],
-    };
-    randomlySelectUnsetExperiments(win, experimentInfoMap);
   }
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -15,19 +15,33 @@
  */
 
 import {Deferred} from '../utils/promise';
+import {
+  ExperimentInfo, // eslint-disable-line no-unused-vars
+  getExperimentBranch,
+  isExperimentOn,
+  randomlySelectUnsetExperiments,
+} from '../experiments';
 import {Services} from '../services';
 import {
   calculateExtensionScriptUrl,
   parseExtensionUrl,
 } from './extension-location';
 import {dev, devAssert, rethrowAsync} from '../log';
-import {getMode} from '../mode';
-import {installStylesForDoc} from '../style-installer';
 import {
-  getExperimentBranch,
-  isExperimentOn,
-  randomlySelectUnsetExperiments,
-} from '../experiments';
+  getAmpdoc,
+  installServiceInEmbedIfEmbeddable,
+  registerServiceBuilder,
+  registerServiceBuilderForDoc,
+  setParentWindow,
+} from '../service';
+import {getMode} from '../mode';
+import {installAmpdocServices} from './core-services';
+import {install as installCustomElements} from '../polyfills/custom-elements';
+import {install as installDOMTokenListToggle} from '../polyfills/domtokenlist-toggle';
+import {install as installDocContains} from '../polyfills/document-contains';
+import {installCustomElements as installRegisterElement} from 'document-register-element/build/document-register-element.patched';
+import {installStylesForDoc, installStylesLegacy} from '../style-installer';
+import {installTimerInEmbedWindow} from './timer-impl';
 import {map} from '../utils/object';
 import {registerServiceBuilder, registerServiceBuilderForDoc} from '../service';
 import {startsWith} from '../string';

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -461,7 +461,7 @@ export class Extensions {
     installStylesForDoc(
       ampdoc,
       isExperimentOn(this.win, 'fie-css-cleanup') &&
-        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.experiment) ===
+        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
           FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,
@@ -521,7 +521,7 @@ export class Extensions {
     installStylesLegacy(
       childWin.document,
       isExperimentOn(this.win, 'fie-css-cleanup') &&
-        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.experiment) ===
+        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
           FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
         : ampDocCss + ampSharedCss,

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -15,30 +15,14 @@
  */
 
 import {Deferred} from '../utils/promise';
-import {
-  getExperimentBranch,
-} from '../experiments';
 import {Services} from '../services';
 import {
   calculateExtensionScriptUrl,
   parseExtensionUrl,
 } from './extension-location';
 import {dev, devAssert, rethrowAsync} from '../log';
-import {
-  getAmpdoc,
-  installServiceInEmbedIfEmbeddable,
-  registerServiceBuilder,
-  registerServiceBuilderForDoc,
-  setParentWindow,
-} from '../service';
 import {getMode} from '../mode';
-import {installAmpdocServices} from './core-services';
-import {install as installCustomElements} from '../polyfills/custom-elements';
-import {install as installDOMTokenListToggle} from '../polyfills/domtokenlist-toggle';
-import {install as installDocContains} from '../polyfills/document-contains';
-import {installCustomElements as installRegisterElement} from 'document-register-element/build/document-register-element.patched';
-import {installStylesForDoc, installStylesLegacy} from '../style-installer';
-import {installTimerInEmbedWindow} from './timer-impl';
+import {installStylesForDoc} from '../style-installer';
 import {map} from '../utils/object';
 import {registerServiceBuilder, registerServiceBuilderForDoc} from '../service';
 import {startsWith} from '../string';
@@ -105,15 +89,6 @@ let ExtensionDef;
  * @private
  */
 let ExtensionHolderDef;
-
-/**
- * @const {{experiment: string, control: string, branch: string}}
- */
-export const FIE_CSS_CLEANUP_EXP = {
-  branch: 'fie-css-cleanup',
-  control: '21064213',
-  experiment: '21064214',
-};
 
 /**
  * @param {string} extensionId
@@ -435,162 +410,6 @@ export class Extensions {
         }
       });
     });
-  }
-
-  /**
-   * Install extensions in the child window (friendly iframe). The pre-install
-   * callback, if specified, is executed after polyfills have been configured
-   * but before the first extension is installed.
-   * @param {!./ampdoc-impl.AmpDocFie} ampdoc
-   * @param {!Array<string>} extensionIds
-   * @param {function(!Window, ?./ampdoc-impl.AmpDoc=)=} opt_preinstallCallback
-   * @return {!Promise}
-   * @restricted
-   */
-  installExtensionsInFie(ampdoc, extensionIds, opt_preinstallCallback) {
-    const childWin = ampdoc.win;
-    const topWin = this.win;
-    const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
-    setParentWindow(childWin, parentWin);
-
-    // Install necessary polyfills.
-    installPolyfillsInChildWindow(parentWin, childWin);
-
-    // Install runtime styles.
-    installStylesForDoc(
-      ampdoc,
-        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
-          FIE_CSS_CLEANUP_EXP.experiment
-        ? ampSharedCss
-        : ampDocCss + ampSharedCss,
-      /* callback */ null,
-      /* opt_isRuntimeCss */ true,
-      /* opt_ext */ 'amp-runtime'
-    );
-
-    // Run pre-install callback.
-    if (opt_preinstallCallback) {
-      opt_preinstallCallback(ampdoc.win, ampdoc);
-    }
-
-    // Install embeddable standard services.
-    installStandardServicesInEmbeddedDoc(ampdoc);
-
-    // Install built-ins and legacy elements.
-    copyBuiltinElementsToChildWindow(topWin, childWin);
-    stubLegacyElements(childWin);
-
-    return Promise.all(
-      extensionIds.map(extensionId => {
-        // This will extend automatic upgrade of custom elements from top
-        // window to the child window.
-        if (!LEGACY_ELEMENTS.includes(extensionId)) {
-          stubElementIfNotKnown(childWin, extensionId);
-        }
-        return this.installExtensionInDoc_(ampdoc, extensionId);
-      })
-    );
-  }
-
-  /**
-   * Install extensions in the child window (friendly iframe). The pre-install
-   * callback, if specified, is executed after polyfills have been configured
-   * but before the first extension is installed.
-   * @param {!Window} childWin
-   * @param {!Array<string>} extensionIds
-   * @param {function(!Window, ?./ampdoc-impl.AmpDoc=)=} opt_preinstallCallback
-   * @return {!Promise}
-   * @restricted
-   */
-  installExtensionsInChildWindow(
-    childWin,
-    extensionIds,
-    opt_preinstallCallback
-  ) {
-    // TODO(#22733): remove this method when ampdoc-fie is launched.
-    const topWin = this.win;
-    const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
-    setParentWindow(childWin, parentWin);
-
-    // Install necessary polyfills.
-    installPolyfillsInChildWindow(parentWin, childWin);
-
-    // Install runtime styles.
-    installStylesLegacy(
-      childWin.document,
-        getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
-          FIE_CSS_CLEANUP_EXP.experiment
-        ? ampSharedCss
-        : ampDocCss + ampSharedCss,
-      /* callback */ null,
-      /* opt_isRuntimeCss */ true,
-      /* opt_ext */ 'amp-runtime'
-    );
-
-    // Run pre-install callback.
-    if (opt_preinstallCallback) {
-      opt_preinstallCallback(childWin);
-    }
-
-    // Install embeddable standard services.
-    installStandardServicesInEmbed(childWin);
-
-    // Install built-ins and legacy elements.
-    copyBuiltinElementsToChildWindow(topWin, childWin);
-    stubLegacyElements(childWin);
-
-    const promises = [];
-    extensionIds.forEach(extensionId => {
-      // This will extend automatic upgrade of custom elements from top
-      // window to the child window.
-      if (!LEGACY_ELEMENTS.includes(extensionId)) {
-        stubElementIfNotKnown(childWin, extensionId);
-      }
-
-      // Install CSS.
-      const promise = this.preloadExtension(extensionId).then(extension => {
-        // Adopt embeddable extension services.
-        extension.services.forEach(service => {
-          installServiceInEmbedIfEmbeddable(childWin, service.serviceClass);
-        });
-
-        // Adopt the custom elements.
-        let elementPromises = null;
-        for (const elementName in extension.elements) {
-          const elementDef = extension.elements[elementName];
-          const elementPromise = new Promise(resolve => {
-            if (elementDef.css) {
-              installStylesLegacy(
-                childWin.document,
-                elementDef.css,
-                /* completeCallback */ resolve,
-                /* isRuntime */ false,
-                extensionId
-              );
-            } else {
-              resolve();
-            }
-          }).then(() => {
-            upgradeOrRegisterElement(
-              childWin,
-              elementName,
-              elementDef.implementationClass
-            );
-          });
-          if (elementPromises) {
-            elementPromises.push(elementPromise);
-          } else {
-            elementPromises = [elementPromise];
-          }
-        }
-        if (elementPromises) {
-          return Promise.all(elementPromises).then(() => extension);
-        }
-        return extension;
-      });
-      promises.push(promise);
-    });
-    return Promise.all(promises);
   }
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -16,7 +16,7 @@
 
 import {Deferred} from '../utils/promise';
 import {
-  isExperimentOn,
+  getExperimentBranch,
 } from '../experiments';
 import {Services} from '../services';
 import {
@@ -109,8 +109,9 @@ let ExtensionHolderDef;
 /**
  * @const {{experiment: string, control: string, branch: string}}
  */
-const FIE_CSS_CLEANUP_EXP = {
+export const FIE_CSS_CLEANUP_EXP = {
   branch: 'fie-css-cleanup',
+  control: '21064213',
   experiment: '21064214',
 };
 
@@ -458,7 +459,6 @@ export class Extensions {
     // Install runtime styles.
     installStylesForDoc(
       ampdoc,
-      isExperimentOn(this.win, 'fie-css-cleanup') &&
         getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
           FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss
@@ -518,7 +518,6 @@ export class Extensions {
     // Install runtime styles.
     installStylesLegacy(
       childWin.document,
-      isExperimentOn(this.win, 'fie-css-cleanup') &&
         getExperimentBranch(this.win, FIE_CSS_CLEANUP_EXP.branch) ===
           FIE_CSS_CLEANUP_EXP.experiment
         ? ampSharedCss

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -16,8 +16,6 @@
 
 import {Deferred} from '../utils/promise';
 import {
-  ExperimentInfo, // eslint-disable-line no-unused-vars
-  getExperimentBranch,
   isExperimentOn,
 } from '../experiments';
 import {Services} from '../services';


### PR DESCRIPTION
Rather than using the experiment as gate, this PR changes to use the experiment branch to match what ads uses to send the experiment IDs to the server.