### PR TITLE
🐛 Cleanup detached layers periodically

### DIFF
--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -150,6 +150,12 @@ export class LayoutLayers {
       })
     );
 
+    /**
+     * Cleanup any detached layouts at most every second.
+     * @private @const {!function()}
+     */
+    this.throttledCleanup_ = throttle(win, () => this.cleanup_(), 1000);
+
     // Declare scrollingElement as the one true scrolling layer.
     const root = this.declareLayer_(
       scrollingElement,
@@ -162,12 +168,6 @@ export class LayoutLayers {
      * @private {!LayoutElement}
      */
     this.activeLayer_ = root;
-
-    /**
-     * Cleanup any detached layouts at most every second.
-     * @private @const {!function()}
-     */
-    this.throttledCleanup_ = throttle(win, () => this.cleanup_(), 1000);
   }
 
   /** @override */

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -425,7 +425,6 @@ export class LayoutLayers {
     if (this.onScroll_) {
       this.onScroll_(/* layer.getElements() */);
     }
-
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -18,11 +18,12 @@ import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev, devAssert} from '../log';
 import {getMode} from '../mode';
+import {isConnectedNode, rootNodeFor} from '../dom';
 import {isInFie} from '../friendly-iframe-embed';
 import {listen} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
-import {rootNodeFor} from '../dom';
+import {throttle} from '../utils/rate-limit.js';
 
 const LAYOUT_PROP = '__AMP_LAYOUT';
 
@@ -161,6 +162,12 @@ export class LayoutLayers {
      * @private {!LayoutElement}
      */
     this.activeLayer_ = root;
+
+    /**
+     * Cleanup any detached layouts at most every second.
+     * @private @const {!function()}
+     */
+    this.throttledCleanup_ = throttle(win, () => this.cleanup_(), 1000);
   }
 
   /** @override */
@@ -181,6 +188,7 @@ export class LayoutLayers {
    * @return {!LayoutElement}
    */
   add(element) {
+    this.throttledCleanup_();
     let layout = LayoutElement.forOptional(element);
     // Elements may already have a layout (common for calls to get size or
     // position from Resources).
@@ -202,12 +210,10 @@ export class LayoutLayers {
    * This also "dirties" the layout, so if's being reparented it will lazily
    * update appropriately.
    *
-   * TODO(jridgewell): This won't catch detach events from native DOM
-   * elements...
-   *
    * @param {!Element} element
    */
   remove(element) {
+    this.throttledCleanup_();
     const layout = LayoutElement.forOptional(element);
     if (!layout) {
       return;
@@ -219,7 +225,7 @@ export class LayoutLayers {
       layouts.splice(index, 1);
     }
 
-    const parent = layout.getParentLayer();
+    const parent = layout.parentLayer_;
     if (parent) {
       parent.remove(layout);
     } else {
@@ -248,6 +254,7 @@ export class LayoutLayers {
    * @return {!PositionDef}
    */
   getScrolledPosition(element, opt_ancestor) {
+    this.throttledCleanup_();
     const layout = this.add(element);
     const pos = layout.getScrolledPosition(opt_ancestor);
     return positionLt(Math.round(pos.left), Math.round(pos.top));
@@ -264,6 +271,7 @@ export class LayoutLayers {
    * @return {!PositionDef}
    */
   getOffsetPosition(element, opt_ancestor) {
+    this.throttledCleanup_();
     const layout = this.add(element);
     const pos = layout.getOffsetPosition(opt_ancestor);
     return positionLt(Math.round(pos.left), Math.round(pos.top));
@@ -276,6 +284,7 @@ export class LayoutLayers {
    * @return {!SizeDef}
    */
   getSize(element) {
+    this.throttledCleanup_();
     const layout = this.add(element);
     const size = layout.getSize();
     return sizeWh(Math.round(size.width), Math.round(size.height));
@@ -294,6 +303,7 @@ export class LayoutLayers {
    * @param {boolean=} opt_force
    */
   remeasure(element, opt_force) {
+    this.throttledCleanup_();
     const layout = this.add(element);
     const from = layout.getParentLayer() || layout;
     if (opt_force) {
@@ -309,6 +319,7 @@ export class LayoutLayers {
    * @param {!Element} element
    */
   declareLayer(element) {
+    this.throttledCleanup_();
     this.declareLayer_(element, false, false);
   }
 
@@ -318,11 +329,15 @@ export class LayoutLayers {
    * @param {!Element} node
    */
   dirty(node) {
+    this.throttledCleanup_();
     // Find a parent layer, or fall back to the root scrolling layer in cases
     // where the node is the scrolling layer (which doesn't have a parent).
-    const layer =
-      LayoutElement.getParentLayer(node) ||
-      LayoutElement.for(this.scrollingElement_);
+    let layer;
+    if (node === this.scrollingElement_) {
+      layer = LayoutElement.for(this.scrollingElement_);
+    } else {
+      layer = LayoutElement.getParentLayer(node) || this.add(node);
+    }
     layer.dirtyMeasurements();
   }
 
@@ -347,6 +362,7 @@ export class LayoutLayers {
    * @private
    */
   onResize_() {
+    this.throttledCleanup_();
     const layouts = this.layouts_;
     for (let i = 0; i < layouts.length; i++) {
       const layout = layouts[i];
@@ -409,6 +425,7 @@ export class LayoutLayers {
     if (this.onScroll_) {
       this.onScroll_(/* layer.getElements() */);
     }
+
   }
 
   /**
@@ -417,6 +434,7 @@ export class LayoutLayers {
    * @param {function()} handler
    */
   onScroll(handler) {
+    this.throttledCleanup_();
     this.onScroll_ = handler;
   }
 
@@ -426,6 +444,7 @@ export class LayoutLayers {
    * @return {!LayoutElement}
    */
   getActiveLayer() {
+    this.throttledCleanup_();
     return this.activeLayer_;
   }
 
@@ -443,8 +462,22 @@ export class LayoutLayers {
    * @template T
    */
   iterateAncestry(element, iterator, state) {
+    this.throttledCleanup_();
     const layout = this.add(element);
     return layout.iterateAncestry(iterator, state);
+  }
+
+  /**
+   * Checks every layout to see if any have been detached from the DOM tree.
+   * @private
+   */
+  cleanup_() {
+    const removed = remove(this.layouts_, layout => {
+      return !layout.isConnected();
+    });
+    for (let i = 0; i < removed.length; i++) {
+      removed[i].undeclareLayer();
+    }
   }
 }
 
@@ -833,11 +866,13 @@ export class LayoutElement {
     }
 
     this.isLayer_ = false;
-    // Handle if this was a fixed position layer (and therefore had null parent
-    // layer).
-    const parent =
-      this.getParentLayer() || LayoutElement.getParentLayer(element, true);
-    this.transfer_(/** @type {!LayoutElement} */ (devAssert(parent)));
+    const children = this.children_;
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      child.forgetParentLayer();
+      child.dirtyMeasurements();
+    }
+    children.length = 0;
   }
 
   /**
@@ -1262,6 +1297,14 @@ export class LayoutElement {
       position.left - this.getScrollLeft(),
       position.top - this.getScrollTop()
     );
+  }
+
+  /**
+   * Whether the layout's element is currently connected to the DOM tree.
+   * @return {boolean}
+   */
+  isConnected() {
+    return isConnectedNode(this.element_);
   }
 }
 


### PR DESCRIPTION
This handles cleanup of layouts that have been removed from the DOM tree but are still stuck in the Layers tree. Custom elements didn't really have a problem, since they would eventually invoke `detachedCallback` which would notify layers. But native elements (which can also be added to the layers tree) don't have a similar callback without using a `MutationObserver`.

I chose to avoid a MO here because it would just be calling the `throttledCleanup` itself. Instead, we attempt cleanup whenever someone interacts with Layers. Because we're throttling, it shouldn't hurt performance that much.

Fixes https://github.com/ampproject/amphtml/issues/23433.