### PR TITLE
Revert "Disable prerendering mode for SwG"

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -252,9 +252,7 @@ export class GoogleSubscriptionsPlatform {
      * for the page to be visible to avoid leaking that the
      * page was prerendered
      */
-    // TODO(#23102): restore safe prerendering mode. Instead of `false`,
-    // return `this.isGoogleViewer_`.
-    return false;
+    return this.isGoogleViewer_;
   }
 
   /** @override */

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -447,9 +447,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should allow prerender if in a google viewer', () => {
     viewer.params_['viewerUrl'] = 'https://www.google.com/other';
     platform = new GoogleSubscriptionsPlatform(ampdoc, {}, serviceAdapter);
-    // TODO(#23102): restore safe prerendering mode. This will be `true` once
-    // it's restored.
-    expect(platform.isPrerenderSafe()).to.be.false;
+    expect(platform.isPrerenderSafe()).to.be.true;
   });
 
   it('should attach button given to decorateUI', () => {


### PR DESCRIPTION
Reverts ampproject/amphtml#23103 fixes #23102 now that #23101 fix is merged.