### PR TITLE
🏗 Print `TRAVIS_COMMIT_RANGE` during PR builds

### DIFF
--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -29,7 +29,7 @@ const {
 const {
   isTravisBuild,
   travisBuildNumber,
-  travisCommitSha,
+  travisCommitRange,
   travisPullRequestSha,
 } = require('../travis');
 const {execOrDie, exec} = require('../exec');
@@ -66,8 +66,8 @@ function printChangeSummary(fileName) {
         `commit ${colors.cyan(shortSha(gitTravisMasterBaseline()))}`
     );
     console.log(
-      `${fileLogPrefix} ${colors.cyan('TRAVIS_COMMIT')} is currently at ` +
-        `commit ${colors.cyan(shortSha(travisCommitSha()))}`
+      `${fileLogPrefix} ${colors.cyan('TRAVIS_COMMIT_RANGE')} is ` +
+        `${colors.cyan(travisCommitRange())}`
     );
     commitSha = travisPullRequestSha();
   } else {

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -29,6 +29,7 @@ const {
 const {
   isTravisBuild,
   travisBuildNumber,
+  travisCommitSha,
   travisPullRequestSha,
 } = require('../travis');
 const {execOrDie, exec} = require('../exec');
@@ -63,6 +64,10 @@ function printChangeSummary(fileName) {
     console.log(
       `${fileLogPrefix} ${colors.cyan('origin/master')} is currently at ` +
         `commit ${colors.cyan(shortSha(gitTravisMasterBaseline()))}`
+    );
+    console.log(
+      `${fileLogPrefix} ${colors.cyan('TRAVIS_COMMIT')} is currently at ` +
+        `commit ${colors.cyan(shortSha(travisCommitSha()))}`
     );
     commitSha = travisPullRequestSha();
   } else {

--- a/build-system/travis.js
+++ b/build-system/travis.js
@@ -138,11 +138,27 @@ function travisCommitSha() {
   return process.env.TRAVIS_COMMIT;
 }
 
+/**
+ * Returns the range of commits being tested by the ongoing Travis build.
+ * @return {string}
+ */
+function travisCommitRange() {
+  if (!isTravisBuild()) {
+    log(
+      red('ERROR:'),
+      'This is not a Travis build. Cannot get',
+      cyan('process.env.TRAVIS_COMMIT_RANGE') + '.'
+    );
+  }
+  return process.env.TRAVIS_COMMIT_RANGE;
+}
+
 module.exports = {
   isTravisBuild,
   isTravisPullRequestBuild,
   isTravisPushBuild,
   travisBuildNumber,
+  travisCommitRange,
   travisCommitSha,
   travisJobNumber,
   travisPullRequestBranch,


### PR DESCRIPTION
It turns out that we are incorrectly using `origin/master` (a moving target) to determine which files have been changed by a PR ~when we should be using `$TRAVIS_COMMIT` (fixed for all stages of a build)~.

This PR merely prints the value of ~`$TRAVIS_COMMIT`~ `$TRAVIS_COMMIT_RANGE` next to the value of `origin/master` during PR builds.

Once I verify that it is indeed consistent across build stages even when `origin/master` moves forward, I'll send out a follow up PR to switch our build target logic to use `$TRAVIS_COMMIT_RANGE`.

**Reference:** https://travis-ci.community/t/origin-master-moving-forward-between-build-stages/4189
**Edit:** Modified to use `TRAVIS_COMMIT_RANGE` instead of `TRAVIS_COMMIT`

Partial fix for #21527
