### PR TITLE
🐛 Don't overwrite existing babel plugins in unit test --coverage flag

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -222,8 +222,7 @@ class RuntimeTestConfig {
         'report-config': {lcovonly: {file: `lcov-${testType}.info`}},
       };
 
-      const newBabelifyConfig = Object.assign({}, this.babelifyConfig);
-      const instabulPlugin = [
+      const instanbulPlugin = [
         'istanbul',
         {
           exclude: [
@@ -236,15 +235,12 @@ class RuntimeTestConfig {
           ],
         },
       ];
+      // don't overwrite existing plugins
+      const plugins = [instanbulPlugin].concat(this.babelifyConfig.plugins);
 
-      // don't overwrite existing babel plugins
-      if ('plugins' in this.babelifyConfig) {
-        newBabelifyConfig['plugins'].push(instabulPlugin);
-      } else {
-        newBabelifyConfig['plugins'] = [instabulPlugin];
-      }
-
-      this.browserify.transform = [['babelify', newBabelifyConfig]];
+      this.browserify.transform = [
+        ['babelify', Object.assign({}, this.babelifyConfig, {plugins})],
+      ];
     }
   }
 }

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -222,7 +222,8 @@ class RuntimeTestConfig {
         'report-config': {lcovonly: {file: `lcov-${testType}.info`}},
       };
 
-      const plugin = [
+      const newBabelifyConfig = Object.assign({}, this.babelifyConfig);
+      const instabulPlugin = [
         'istanbul',
         {
           exclude: [
@@ -236,12 +237,14 @@ class RuntimeTestConfig {
         },
       ];
 
-      this.browserify.transform = [
-        [
-          'babelify',
-          Object.assign({}, this.babelifyConfig, {plugins: [plugin]}),
-        ],
-      ];
+      // don't overwrite existing babel plugins
+      if ('plugins' in this.babelifyConfig) {
+        newBabelifyConfig['plugins'].push(instabulPlugin);
+      } else {
+        newBabelifyConfig['plugins'] = [instabulPlugin];
+      }
+
+      this.browserify.transform = [['babelify', newBabelifyConfig]];
     }
   }
 }

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -100,11 +100,6 @@ import {NAVEGG_CONFIG} from './vendors/navegg';
 import {VPONANALYTICS_CONFIG} from './vendors/vponanalytics';
 import {WEBENGAGE_CONFIG} from './vendors/webengage';
 
-// eslint-disable-next-line no-undef
-if (ANALYTICS_VENDOR_SPLIT) {
-  // test
-}
-
 /**
  * @const {!JsonObject}
  */

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -100,6 +100,11 @@ import {NAVEGG_CONFIG} from './vendors/navegg';
 import {VPONANALYTICS_CONFIG} from './vendors/vponanalytics';
 import {WEBENGAGE_CONFIG} from './vendors/webengage';
 
+// eslint-disable-next-line no-undef
+if (ANALYTICS_VENDOR_SPLIT) {
+  // test
+}
+
 /**
  * @const {!JsonObject}
  */


### PR DESCRIPTION
Update to https://github.com/ampproject/amphtml/pull/23388

The control flow for the `--coverage` flag overwrites existing babel plugins, specifically the `minify-replace` plugin that is used to define experiment constants. This caused `--coverage` tests to fail.

This PR changes the `coverage` flow so that it doesn't overwrite existing babel plugins.