### PR TITLE
Add no-duplicate-name-typedefs eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "amphtml-internal/no-array-destructuring": 2,
     "amphtml-internal/no-deep-destructuring": 2,
     "amphtml-internal/no-duplicate-import": 2,
+    "amphtml-internal/no-duplicate-name-typedef": 2,
     "amphtml-internal/no-es2015-number-props": 2,
     "amphtml-internal/no-export-side-effect": 2,
     "amphtml-internal/no-for-of-statement": 2,

--- a/build-system/eslint-rules/no-duplicate-name-typedef.js
+++ b/build-system/eslint-rules/no-duplicate-name-typedef.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Global cache of typedefName: typedefLocation.
+const typedefs = new Map();
+
+module.exports = function(context) {
+  return {
+    VariableDeclaration(node) {
+      if (!node.leadingComments) {
+        return;
+      }
+
+      const typedefComment = node.leadingComments.find(comment => {
+        return comment.type === 'Block' && /@typedef/.test(comment.value);
+      });
+
+      if (!typedefComment) {
+        return;
+      }
+
+      // We can assume theres only 1 variable declaration  when a typedef
+      // annotation is found. This is because Closure Compiler does not allow
+      // declaration of multiple variable with a shared type information.
+      const typedefName = node.declarations[0].id.name;
+
+      const typedefLocation = typedefs.get(typedefName);
+      if (!typedefLocation) {
+        typedefs.set(typedefName, context.getFilename());
+        return;
+      }
+
+      context.report({
+        node,
+        message:
+          `Duplicate typedef name found: ${typedefName}. Another ` +
+          `typedef with the same name is found in ${typedefLocation}. ` +
+          'Suggestion: Add an infix version indicator like MyType_0_1_Def.',
+      });
+    },
+  };
+};

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -66,7 +66,7 @@ const DEFAULT_MESSAGES = {
  *   sandbox: (boolean|undefined),
  * }}
  */
-let LaterpayConfigDef;
+let LaterpayConfig_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @typedef {{
@@ -79,18 +79,18 @@ let LaterpayConfigDef;
  *   validity_value: number
  * }}
  */
-let PurchaseOptionDef;
+let PurchaseOption_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @typedef {{
  *   access: boolean,
  *   apl: string,
- *   premiumcontent: !PurchaseOptionDef,
- *   timepasses: (!Array<PurchaseOptionDef>|undefined),
- *   subscriptions: (!Array<PurchaseOptionDef>|undefined)
+ *   premiumcontent: !PurchaseOption_0_1_Def,
+ *   timepasses: (!Array<PurchaseOption_0_1_Def>|undefined),
+ *   subscriptions: (!Array<PurchaseOption_0_1_Def>|undefined)
  * }}
  */
-let PurchaseConfigDef;
+let PurchaseConfig_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @implements {../../amp-access/0.1/access-vendor.AccessVendor}
@@ -110,10 +110,10 @@ export class LaterpayVendor {
     /** @private @const {!../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(this.ampdoc);
 
-    /** @const @private {!JsonObject} For shape see LaterpayConfigDef */
+    /** @const @private {!JsonObject} For shape see LaterpayConfig_0_1_Def */
     this.laterpayConfig_ = this.accessSource_.getAdapterConfig();
 
-    /** @private {?JsonObject} For shape see PurchaseConfigDef */
+    /** @private {?JsonObject} For shape see PurchaseConfig_0_1_Def */
     this.purchaseConfig_ = null;
 
     /** @private {?Function} */
@@ -413,7 +413,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!JsonObject} option Shape: PurchaseOptionDef
+   * @param {!JsonObject} option Shape: PurchaseOption_0_1_Def
    * @return {!Element}
    * @private
    */
@@ -439,7 +439,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!JsonObject} option Shape: PurchaseOptionDef
+   * @param {!JsonObject} option Shape: PurchaseOption_0_1_Def
    * @return {!Element}
    * @private
    */

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -70,7 +70,7 @@ const DEFAULT_MESSAGES = {
  *   sandbox: (boolean|undefined),
  * }}
  */
-let LaterpayConfigDef;
+let LaterpayConfig_0_2_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @typedef {{
@@ -99,21 +99,21 @@ let ExpiryDef;
  *   expiry: ExpiryDef,
  * }}
  */
-let PurchaseOptionDef;
+let PurchaseOption_0_2_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @typedef {{
  *   identify_url: string,
- *   purchase_options: Array<PurchaseOptionDef>,
+ *   purchase_options: Array<PurchaseOption_0_2_Def>,
  * }}
  */
-let PurchaseConfigDef;
+let PurchaseConfig_0_2_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @typedef {{
- *   singlePurchases: Array<PurchaseOptionDef>,
- *   timepasses: Array<PurchaseOptionDef>,
- *   subscriptions: Array<PurchaseOptionDef>,
+ *   singlePurchases: Array<PurchaseOption_0_2_Def>,
+ *   timepasses: Array<PurchaseOption_0_2_Def>,
+ *   subscriptions: Array<PurchaseOption_0_2_Def>,
  * }}
  */
 let PurchaseOptionsDef;
@@ -136,10 +136,10 @@ export class LaterpayVendor {
     /** @private @const {!../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(this.ampdoc);
 
-    /** @const @private {!JsonObject} For shape see LaterpayConfigDef */
+    /** @const @private {!JsonObject} For shape see LaterpayConfig_0_2_Def */
     this.laterpayConfig_ = this.accessSource_.getAdapterConfig();
 
-    /** @private {?JsonObject} For shape see PurchaseConfigDef */
+    /** @private {?JsonObject} For shape see PurchaseConfig_0_2_Def */
     this.purchaseConfig_ = null;
 
     /** @private {?Object} For shape see PurchaseOptionsDef */
@@ -294,7 +294,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {Array<PurchaseOptionDef>} purchaseOptionsList
+   * @param {Array<PurchaseOption_0_2_Def>} purchaseOptionsList
    * @return {!Object}
    * @private
    */
@@ -471,7 +471,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!JsonObject} option Shape: PurchaseOptionDef
+   * @param {!JsonObject} option Shape: PurchaseOption_0_2_Def
    * @return {!Element}
    * @private
    */
@@ -497,7 +497,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!JsonObject} option Shape: PurchaseOptionDef
+   * @param {!JsonObject} option Shape: PurchaseOption_0_2_Def
    * @return {!Element}
    * @private
    */

--- a/extensions/amp-story/0.1/logging.js
+++ b/extensions/amp-story/0.1/logging.js
@@ -19,7 +19,7 @@ import {scopedQuerySelectorAll} from '../../../src/dom';
 import {tryResolve} from '../../../src/utils/promise';
 
 /** @typedef {function(!Element): (boolean|!Promise<boolean>)} */
-let ElementPredicateDef;
+let ElementPredicate_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * A log type is an abstract rule or best practice that should be followed when
@@ -48,11 +48,11 @@ let ElementPredicateDef;
  *   level: !LogLevel,
  *   moreInfo: (string|undefined),
  *   selector: (string|undefined),
- *   precondition: (!ElementPredicateDef|undefined),
- *   predicate: (!ElementPredicateDef|undefined),
+ *   precondition: (!ElementPredicate_0_1_Def|undefined),
+ *   predicate: (!ElementPredicate_0_1_Def|undefined),
  * }}
  */
-let AmpStoryLogTypeDef;
+let AmpStoryLogType_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * A log entry is a more concrete version of a rule or best practice; it refers
@@ -86,7 +86,7 @@ function getPosterFromVideo(el) {
   });
 }
 
-/** @enum {!AmpStoryLogTypeDef} */
+/** @enum {!AmpStoryLogType_0_1_Def} */
 const LogType = {
   /** Errors */
   VIDEOS_POSTER_SPECIFIED: {
@@ -155,7 +155,7 @@ const LogType = {
 /**
  * Gets the log type associated with the specified key.
  * @param {string} logTypeKey
- * @return {!AmpStoryLogTypeDef}
+ * @return {!AmpStoryLogType_0_1_Def}
  */
 function getLogType(logTypeKey) {
   const logType = LogType[logTypeKey];
@@ -174,7 +174,7 @@ function getLogType(logTypeKey) {
 
 /**
  * @param {!Element} rootElement
- * @param {!AmpStoryLogTypeDef} logType
+ * @param {!AmpStoryLogType_0_1_Def} logType
  * @param {!Element} element
  * @return {!Promise<!AmpStoryLogEntryDef>}
  */
@@ -199,7 +199,7 @@ function getLogEntry(rootElement, logType, element) {
 
 /**
  * @param {!Element} rootElement
- * @param {!AmpStoryLogTypeDef} logType
+ * @param {!AmpStoryLogType_0_1_Def} logType
  * @return {!Array<!Promise<!AmpStoryLogEntryDef>>}
  */
 function getLogEntriesForType(rootElement, logType) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -53,7 +53,7 @@ export let ElementDistanceFnDef;
  * Represents a task to be executed on a media element.
  * @typedef {function(!HTMLMediaElement, *): !Promise}
  */
-let ElementTaskDef;
+let ElementTask_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @const {string}

--- a/extensions/amp-story/0.1/pagination-buttons.js
+++ b/extensions/amp-story/0.1/pagination-buttons.js
@@ -22,9 +22,9 @@ import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
 /** @struct @typedef {{className: string, triggers: (string|undefined)}} */
-let ButtonStateDef;
+let ButtonState_0_1_Def; // eslint-disable-line google-camelcase/google-camelcase
 
-/** @const {!Object<string, !ButtonStateDef>} */
+/** @const {!Object<string, !ButtonState_0_1_Def>} */
 const BackButtonStates = {
   CLOSE_BOOKEND: {
     className: 'i-amphtml-story-back-close-bookend',
@@ -38,7 +38,7 @@ const BackButtonStates = {
   },
 };
 
-/** @const {!Object<string, !ButtonStateDef>} */
+/** @const {!Object<string, !ButtonState_0_1_Def>} */
 const ForwardButtonStates = {
   NEXT_PAGE: {
     className: 'i-amphtml-story-fwd-next',
@@ -91,11 +91,11 @@ function setClassOnHover(hoverEl, targetEl, className) {
 class PaginationButton {
   /**
    * @param {!Document} doc
-   * @param {!ButtonStateDef} initialState
+   * @param {!ButtonState_0_1_Def} initialState
    * @param {!./amp-story-store-service.AmpStoryStoreService} storeService
    */
   constructor(doc, initialState, storeService) {
-    /** @private {!ButtonStateDef} */
+    /** @private {!ButtonState_0_1_Def} */
     this.state_ = initialState;
 
     /** @public @const {!Element} */
@@ -109,7 +109,7 @@ class PaginationButton {
     this.storeService_ = storeService;
   }
 
-  /** @param {!ButtonStateDef} state */
+  /** @param {!ButtonState_0_1_Def} state */
   updateState(state) {
     if (state === this.state_) {
       return;

--- a/extensions/amp-story/1.0/logging.js
+++ b/extensions/amp-story/1.0/logging.js
@@ -18,7 +18,7 @@ import {scopedQuerySelectorAll} from '../../../src/dom';
 import {tryResolve} from '../../../src/utils/promise';
 
 /** @typedef {function(!Element): (boolean|!Promise<boolean>)} */
-let ElementPredicateDef;
+let ElementPredicate_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * A log type is an abstract rule or best practice that should be followed when
@@ -47,11 +47,11 @@ let ElementPredicateDef;
  *   level: !LogLevel,
  *   moreInfo: (string|undefined),
  *   selector: (string|undefined),
- *   precondition: (!ElementPredicateDef|undefined),
- *   predicate: (!ElementPredicateDef|undefined),
+ *   precondition: (!ElementPredicate_1_0_Def|undefined),
+ *   predicate: (!ElementPredicate_1_0_Def|undefined),
  * }}
  */
-let AmpStoryLogTypeDef;
+let AmpStoryLogType_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * A log entry is a more concrete version of a rule or best practice; it refers
@@ -85,7 +85,7 @@ function getPosterFromVideo(el) {
   });
 }
 
-/** @enum {!AmpStoryLogTypeDef} */
+/** @enum {!AmpStoryLogType_1_0_Def} */
 const LogType = {
   /** Errors */
   VIDEOS_POSTER_SPECIFIED: {
@@ -154,7 +154,7 @@ const LogType = {
 /**
  * Gets the log type associated with the specified key.
  * @param {string} logTypeKey
- * @return {!AmpStoryLogTypeDef}
+ * @return {!AmpStoryLogType_1_0_Def}
  */
 function getLogType(logTypeKey) {
   const logType = LogType[logTypeKey];
@@ -173,7 +173,7 @@ function getLogType(logTypeKey) {
 
 /**
  * @param {!Element} rootElement
- * @param {!AmpStoryLogTypeDef} logType
+ * @param {!AmpStoryLogType_1_0_Def} logType
  * @param {!Element} element
  * @return {!Promise<!AmpStoryLogEntryDef>}
  */
@@ -196,7 +196,7 @@ function getLogEntry(rootElement, logType, element) {
 
 /**
  * @param {!Element} rootElement
- * @param {!AmpStoryLogTypeDef} logType
+ * @param {!AmpStoryLogType_1_0_Def} logType
  * @return {!Array<!Promise<!AmpStoryLogEntryDef>>}
  */
 function getLogEntriesForType(rootElement, logType) {

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -81,7 +81,7 @@ export let ElementDistanceFnDef;
  * Represents a task to be executed on a media element.
  * @typedef {function(!PoolBoundElementDef, *): !Promise}
  */
-let ElementTaskDef;
+let ElementTask_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
 
 /**
  * @const {string}

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -26,9 +26,9 @@ import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
 /** @struct @typedef {{className: string, triggers: (string|undefined)}} */
-let ButtonStateDef;
+let ButtonState_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
 
-/** @const {!Object<string, !ButtonStateDef>} */
+/** @const {!Object<string, !ButtonState_1_0_Def>} */
 const BackButtonStates = {
   CLOSE_BOOKEND: {
     className: 'i-amphtml-story-back-close-bookend',
@@ -42,7 +42,7 @@ const BackButtonStates = {
   },
 };
 
-/** @const {!Object<string, !ButtonStateDef>} */
+/** @const {!Object<string, !ButtonState_1_0_Def>} */
 const ForwardButtonStates = {
   HIDDEN: {className: 'i-amphtml-story-button-hidden'},
   NEXT_PAGE: {
@@ -96,12 +96,12 @@ function setClassOnHover(hoverEl, targetEl, className) {
 class PaginationButton {
   /**
    * @param {!Document} doc
-   * @param {!ButtonStateDef} initialState
+   * @param {!ButtonState_1_0_Def} initialState
    * @param {!./amp-story-store-service.AmpStoryStoreService} storeService
    * @param {!Window} win
    */
   constructor(doc, initialState, storeService, win) {
-    /** @private {!ButtonStateDef} */
+    /** @private {!ButtonState_1_0_Def} */
     this.state_ = initialState;
 
     /** @public @const {!Element} */
@@ -118,7 +118,7 @@ class PaginationButton {
     this.win_ = win;
   }
 
-  /** @param {!ButtonStateDef} state */
+  /** @param {!ButtonState_1_0_Def} state */
   updateState(state) {
     if (state === this.state_) {
       return;
@@ -129,7 +129,7 @@ class PaginationButton {
   }
 
   /**
-   * @return {!ButtonStateDef}
+   * @return {!ButtonState_1_0_Def}
    */
   getState() {
     return this.state_;
@@ -197,10 +197,10 @@ export class PaginationButtons {
     this.forwardButton_.element.classList.add('next-container');
     this.backButton_.element.classList.add('prev-container');
 
-    /** @private {?ButtonStateDef} */
+    /** @private {?ButtonState_1_0_Def} */
     this.backButtonStateToRestore_ = null;
 
-    /** @private {?ButtonStateDef} */
+    /** @private {?ButtonState_1_0_Def} */
     this.forwardButtonStateToRestore_ = null;
 
     /** @private {function():Promise<boolean>} */
@@ -329,12 +329,12 @@ export class PaginationButtons {
   onSystemUiIsVisibleStateUpdate_(isVisible) {
     if (isVisible) {
       this.backButton_.updateState(
-        /** @type {!ButtonStateDef} */ (devAssert(
+        /** @type {!ButtonState_1_0_Def} */ (devAssert(
           this.backButtonStateToRestore_
         ))
       );
       this.forwardButton_.updateState(
-        /** @type {!ButtonStateDef} */ (devAssert(
+        /** @type {!ButtonState_1_0_Def} */ (devAssert(
           this.forwardButtonStateToRestore_
         ))
       );


### PR DESCRIPTION
Since we plan on hosting typedefs to externs, Duplicate names should be prevented to avoid collision and replacement complexity.

The hoisting of typedefs is part of the single pass effort, it will prevent us from obfuscating fields that were cast from JsonObject types. We will eventually unhoist the typefs at some point when we are confident will all the typing.