### PR TITLE
🐛 Fix amp-selector in form not submitted when using selectUp/selectDown actions

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -465,8 +465,9 @@ export class AmpSelector extends AMP.BaseElement {
     const selectUpWhenNoneSelected = previousIndex === -1 && delta < 0;
     const index = selectUpWhenNoneSelected ? delta : previousIndex + delta;
     const normalizedIndex = mod(index, this.elements_.length);
+    const el = this.elements_[normalizedIndex];
 
-    this.setSelection_(this.elements_[normalizedIndex]);
+    this.setSelection_(el);
     const previousEl = this.elements_[previousIndex];
     if (previousEl) {
       this.clearSelection_(previousEl);

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -472,6 +472,9 @@ export class AmpSelector extends AMP.BaseElement {
     if (previousEl) {
       this.clearSelection_(previousEl);
     }
+
+    this.setInputs_();
+    this.fireSelectEvent_(el);
   }
 
   /**

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -905,7 +905,7 @@ describes.realWin(
 
       it(
         'should trigger `select` action when user uses ' +
-          '`selectUp`/`selectDown` action with default delta value of 1',
+          '`selectDown` action with default delta value of 1',
         () => {
           const ampSelector = getSelector({
             attributes: {
@@ -937,11 +937,41 @@ describes.realWin(
           expect(event).to.have.property('detail');
           expect(event.detail).to.have.property('targetOption', '1');
           expect(event.detail).to.have.deep.property('selectedOptions', ['1']);
+        }
+      );
+
+      it(
+        'should trigger `select` action when user uses ' +
+          '`selectUp` action with default delta value of 1',
+        () => {
+          const ampSelector = getSelector({
+            attributes: {
+              id: 'ampSelector',
+            },
+            config: {
+              count: 6,
+            },
+          });
+          ampSelector.children[0].setAttribute('selected', '');
+          ampSelector.build();
+          const impl = ampSelector.implementation_;
+          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+
+          expect(ampSelector.hasAttribute('multiple')).to.be.false;
+          expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
 
           impl.executeAction({method: 'selectUp', satisfiesTrust: () => true});
 
-          expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
-          expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
+          expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
+          expect(ampSelector.children[5].hasAttribute('selected')).to.be.true;
+
+          expect(triggerSpy).to.be.calledOnce;
+          expect(triggerSpy).to.have.been.calledWith(ampSelector, 'select');
+
+          const event = triggerSpy.firstCall.args[2];
+          expect(event).to.have.property('detail');
+          expect(event.detail).to.have.property('targetOption', '5');
+          expect(event.detail).to.have.deep.property('selectedOptions', ['5']);
         }
       );
 

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -378,6 +378,24 @@ describes.realWin(
           options[3],
         ]);
 
+        impl.executeAction({
+          method: 'selectDown',
+          satisfiesTrust: () => true,
+        });
+        expect(impl.inputs_.length).to.equal(1);
+        expect(impl.getSelectedElementsForTesting()).to.include.members([
+          options[0],
+        ]);
+
+        impl.executeAction({
+          method: 'selectUp',
+          satisfiesTrust: () => true,
+        });
+        expect(impl.inputs_.length).to.equal(1);
+        expect(impl.getSelectedElementsForTesting()).to.include.members([
+          options[3],
+        ]);
+
         ampSelector = getSelector({
           attributes: {
             name: 'muti_select',

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -918,6 +918,7 @@ describes.realWin(
           ampSelector.children[0].setAttribute('selected', '');
           ampSelector.build();
           const impl = ampSelector.implementation_;
+          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
 
           expect(ampSelector.hasAttribute('multiple')).to.be.false;
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
@@ -928,6 +929,14 @@ describes.realWin(
           });
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
           expect(ampSelector.children[1].hasAttribute('selected')).to.be.true;
+
+          expect(triggerSpy).to.be.calledOnce;
+          expect(triggerSpy).to.have.been.calledWith(ampSelector, 'select');
+
+          const event = triggerSpy.firstCall.args[2];
+          expect(event).to.have.property('detail');
+          expect(event.detail).to.have.property('targetOption', '1');
+          expect(event.detail).to.have.deep.property('selectedOptions', ['1']);
 
           impl.executeAction({method: 'selectUp', satisfiesTrust: () => true});
 


### PR DESCRIPTION
### Observed behaviour
- Have an `<amp-selector>` component inside a form
- Change the value of the `<amp-selector>` by using the `selectUp` or `selectDown` actions.
- _Result_: the `<amp-selector>`'s value is not submitted.

### The issue
The inner `<input>` components are not being recreated when using the `selectUp` or `selectDown` actions.

### Proposed solution
Added missing calls to `setInputs_()`.
Bonus: added missing call to `fireSelectEvent_()`.

/cc @nainar and @cvializ since you created & reviewed #13439