### PR TITLE
🐛 Propagate `tabindex` on amp-iframe

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -50,6 +50,7 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'frameborder',
   'referrerpolicy',
   'scrolling',
+  'tabindex',
 ];
 
 /** @type {number}  */

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -203,6 +203,7 @@ describes.realWin(
           allow: 'microphone; camera',
           referrerpolicy: 'no-referrer',
           frameborder: 3,
+          tabindex: -1,
           longdesc: 'foo',
           marginwidth: 5,
         });
@@ -214,6 +215,7 @@ describes.realWin(
         expect(iframe.getAttribute('allow')).to.equal('microphone; camera');
         expect(iframe.getAttribute('referrerpolicy')).to.equal('no-referrer');
         expect(iframe.getAttribute('frameborder')).to.equal('3');
+        expect(iframe.getAttribute('tabindex')).to.equal('-1');
         // unsupproted attributes
         expect(iframe.getAttribute('longdesc')).to.be.null;
         expect(iframe.getAttribute('marginwidth')).to.be.null;

--- a/extensions/amp-iframe/0.1/test/validator-amp-iframe.html
+++ b/extensions/amp-iframe/0.1/test/validator-amp-iframe.html
@@ -35,7 +35,7 @@
   <amp-iframe width="200" height="200" srcdoc="<p>Hello World</p>"></amp-iframe>
 
   <!-- Valid: Allowed attributes tests -->
-  <amp-iframe width="200" height="200" src="https://example.com" allow="geolocation; microphone" allowfullscreen allowpaymentrequest allowtransparency frameborder="0" referrerpolicy="origin" resizable sandbox="allow-same-origin allow-scripts" scrolling="no" ></amp-iframe>
+  <amp-iframe width="200" height="200" src="https://example.com" allow="geolocation; microphone" allowfullscreen allowpaymentrequest allowtransparency frameborder="0" referrerpolicy="origin" tabindex="-1" resizable sandbox="allow-same-origin allow-scripts" scrolling="no" ></amp-iframe>
 
   <!-- Valid: We allow the src attribute to be bindable -->
   <amp-iframe width="200" height="200" src="https://example.com" [src]="iframeurl"></amp-iframe>

--- a/extensions/amp-iframe/0.1/test/validator-amp-iframe.out
+++ b/extensions/amp-iframe/0.1/test/validator-amp-iframe.out
@@ -36,7 +36,7 @@ FAIL
 |    <amp-iframe width="200" height="200" srcdoc="<p>Hello World</p>"></amp-iframe>
 |
 |    <!-- Valid: Allowed attributes tests -->
-|    <amp-iframe width="200" height="200" src="https://example.com" allow="geolocation; microphone" allowfullscreen allowpaymentrequest allowtransparency frameborder="0" referrerpolicy="origin" resizable sandbox="allow-same-origin allow-scripts" scrolling="no" ></amp-iframe>
+|    <amp-iframe width="200" height="200" src="https://example.com" allow="geolocation; microphone" allowfullscreen allowpaymentrequest allowtransparency frameborder="0" referrerpolicy="origin" tabindex="-1" resizable sandbox="allow-same-origin allow-scripts" scrolling="no" ></amp-iframe>
 |
 |    <!-- Valid: We allow the src attribute to be bindable -->
 |    <amp-iframe width="200" height="200" src="https://example.com" [src]="iframeurl"></amp-iframe>

--- a/extensions/amp-iframe/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/validator-amp-iframe.protoascii
@@ -61,6 +61,10 @@ tags: {  # <amp-iframe>
     value: "yes"
   }
   attrs: {
+    name: "tabindex"
+    value_regex: "-?\d+"
+  }
+  attrs: {
     name: "src"
     mandatory_oneof: "['src', 'srcdoc']"
     value_url: {


### PR DESCRIPTION
Closes #23478 

### Changes
- Propagates the `tabindex` attribute to the internal iframe on `amp-iframe`
- Adds tests and validator changes