### PR TITLE
🏗 Adds me to OWNERS file for `amp-subscriptions-google`

### DIFF
--- a/extensions/amp-subscriptions-google/OWNERS.yaml
+++ b/extensions/amp-subscriptions-google/OWNERS.yaml
@@ -4,3 +4,4 @@
 - jpettitt
 - prateekbh
 - sohanirao 
+- chrisantaki


### PR DESCRIPTION
This PR just adds me to the OWNERS file for the SwG extension