### PR TITLE
🏗 Add progress indicators for `build` and `dist` on Travis

### DIFF
--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -455,9 +455,16 @@ function setupBundles(graph) {
  * @param {!Object} config
  */
 function transformPathsToTempDir(graph, config) {
-  if (!isTravisBuild()) {
-    log('Writing transforms to', colors.cyan(graph.tmp));
+  if (isTravisBuild()) {
+    // New line after all the compilation progress dots on Travis.
+    console.log('\n');
   }
+  log(
+    'Performing single-pass',
+    colors.cyan('babel'),
+    'transforms in',
+    colors.cyan(graph.tmp)
+  );
   // `sorted` will always have the files that we need.
   graph.sorted.forEach(f => {
     // For now, just copy node_module files instead of transforming them.
@@ -476,7 +483,9 @@ function transformPathsToTempDir(graph, config) {
       fs.outputFileSync(`${graph.tmp}/${f}`, code);
       fs.outputFileSync(`${graph.tmp}/${f}.map`, JSON.stringify(map));
     }
+    process.stdout.write('.');
   });
+  console.log('\n');
 }
 
 // Returns the extension bundle config for the given filename or null.
@@ -669,6 +678,12 @@ function postPrepend(extension, prependContents) {
 }
 
 function compile(flagsArray) {
+  if (isTravisBuild()) {
+    log(
+      'Minifying single-pass runtime targets with',
+      colors.cyan('closure-compiler')
+    );
+  }
   // TODO(@cramforce): Run the post processing step
   return new Promise(function(resolve, reject) {
     gulp

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -27,6 +27,7 @@ const {
 const {buildExtensions} = require('./extension-helpers');
 const {compileCss} = require('./css');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
+const {isTravisBuild} = require('../travis');
 const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
 const {serve} = require('./serve');
@@ -61,16 +62,23 @@ async function performBuild(watch) {
   printNobuildHelp();
   printConfigHelp(watch ? 'gulp watch' : 'gulp build');
   parseExtensionFlags();
-  return compileCss(watch).then(() => {
-    return Promise.all([
-      polyfillsForTests(),
-      buildAlp({watch}),
-      buildExaminer({watch}),
-      buildWebWorker({watch}),
-      buildExtensions({watch}),
-      compileAllUnminifiedTargets(watch),
-    ]);
-  });
+  return compileCss(watch)
+    .then(() => {
+      return Promise.all([
+        polyfillsForTests(),
+        buildAlp({watch}),
+        buildExaminer({watch}),
+        buildWebWorker({watch}),
+        buildExtensions({watch}),
+        compileAllUnminifiedTargets(watch),
+      ]);
+    })
+    .then(() => {
+      if (isTravisBuild()) {
+        // New line after all the compilation progress dots on Travis.
+        console.log('\n');
+      }
+    });
 }
 
 /**

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -63,9 +63,12 @@ const babel = require('@babel/core');
 const deglob = require('globs-to-files');
 
 function transferSrcsToTempDir() {
-  if (!isTravisBuild()) {
-    log('Transforming and executing JS files to', cyan(SRC_TEMP_DIR));
-  }
+  log(
+    'Performing multi-pass',
+    colors.cyan('babel'),
+    'transforms in',
+    colors.cyan(SRC_TEMP_DIR)
+  );
   const files = deglob.sync(BABEL_SRC_GLOBS);
   files.forEach(file => {
     if (file.startsWith('node_modules/') || file.startsWith('third_party/')) {
@@ -83,7 +86,9 @@ function transferSrcsToTempDir() {
     });
     const name = `${SRC_TEMP_DIR}${file.replace(process.cwd(), '')}`;
     fs.outputFileSync(name, code);
+    process.stdout.write('.');
   });
+  console.log('\n');
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -99,6 +99,9 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
  * Compile all runtime targets in minified mode and drop them in dist/.
  */
 function compileAllMinifiedTargets() {
+  if (isTravisBuild()) {
+    log('Minifying multi-pass runtime targets with', cyan('closure-compiler'));
+  }
   return compile(/* watch */ false, /* shouldMinify */ true);
 }
 
@@ -107,6 +110,9 @@ function compileAllMinifiedTargets() {
  * @param {boolean} watch
  */
 function compileAllUnminifiedTargets(watch) {
+  if (isTravisBuild()) {
+    log('Compiling runtime with', cyan('browserify'));
+  }
   return compile(/* watch */ watch);
 }
 
@@ -484,6 +490,11 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       .then(() => {
         if (UNMINIFIED_TARGETS.includes(destFilename)) {
           return enableLocalTesting(`${destDir}/${destFilename}`);
+        }
+      })
+      .then(() => {
+        if (isTravisBuild()) {
+          process.stdout.write('.');
         }
       });
   }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -123,11 +123,13 @@ const forbiddenTerms = {
       'build-system/pr-check/validator-tests.js',
       'build-system/pr-check/visual-diff-tests.js',
       'build-system/pr-check/yarn-checks.js',
+      'build-system/tasks/build.js',
       'build-system/tasks/check-exact-versions.js',
       'build-system/tasks/check-types.js',
       'build-system/tasks/dist.js',
       'build-system/tasks/generate-runner.js',
       'build-system/tasks/helpers.js',
+      'build-system/compile/single-pass.js',
       'validator/nodejs/index.js', // NodeJs only.
       'validator/engine/parse-css.js',
       'validator/engine/validator-in-browser.js',


### PR DESCRIPTION
This PR adds informative progress indicators for `build` and `dist` on Travis. The goal is to understand why the running time of `gulp dist` on Travis has started fluctuating so much of late. See https://github.com/ampproject/amphtml/issues/23484#issue-471860642.

Partial fix for #23484
