### PR TITLE
add a way to change the destination directory of the built files

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -28,7 +28,7 @@ const {
   handleCompilerError,
   handleTypeCheckError,
 } = require('./closure-compile');
-const {CLOSURE_SRC_GLOBS, SRC_TEMP_DIR} = require('../sources');
+const {CLOSURE_SRC_GLOBS, SRC_TEMP_DIR, OUTPUT_DIR} = require('../sources');
 const {isTravisBuild} = require('../travis');
 const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {singlePassCompile} = require('./single-pass');
@@ -153,7 +153,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
 
     // Add babel plugin to remove unwanted polyfills in esm build
     if (options.esmPassCompilation) {
-      compilationOptions['dest'] = './dist/esm/';
+      compilationOptions['dest'] = `./${OUTPUT_DIR}esm/`;
       define.push('ESM_BUILD=true');
     }
 

--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 const fs = require('fs-extra');
+const {OUTPUT_DIR} = require('../sources');
 
-const pathPrefix = 'dist/log-messages';
+const pathPrefix = `${OUTPUT_DIR}log-messages`;
 
 /**
  * Source of truth for extracted messages during build, but should not be

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -53,11 +53,11 @@ const wrappers = require('../compile-wrappers');
 const {VERSION: internalRuntimeVersion} = require('../internal-version');
 
 const argv = minimist(process.argv.slice(2));
-let singlePassDest =
-  typeof argv.single_pass_dest === 'string' ? argv.single_pass_dest : './dist/';
+let destination =
+  typeof argv.destination === 'string' ? argv.destination : './dist/';
 
-if (!singlePassDest.endsWith('/')) {
-  singlePassDest = `${singlePassDest}/`;
+if (!destination.endsWith('/')) {
+  destination = `${destination}/`;
 }
 
 const SPLIT_MARKER = `/** SPLIT${Math.floor(Math.random() * 10000)} */`;
@@ -544,7 +544,7 @@ exports.singlePassCompile = async function(entryModule, options) {
   return exports
     .getFlags({
       modules: [entryModule].concat(extensions),
-      writeTo: singlePassDest,
+      writeTo: destination,
       define: options.define,
       externs: options.externs,
       hideWarningsFor: options.hideWarningsFor,
@@ -573,9 +573,9 @@ function wrapMainBinaries() {
   const prefix = pair[0];
   const suffix = pair[1];
   // Cache the v0 file so we can prepend it to alternative binaries.
-  const mainFile = readMagicString('dist/v0.js');
+  const mainFile = readMagicString(`${destination}/v0.js`);
   jsFilesToWrap.forEach(x => {
-    const path = `dist/${x}.js`;
+    const path = `${destination}/${x}.js`;
     const s = readMagicString(path);
     if (x === 'v0') {
       s.prepend(prefix);
@@ -609,8 +609,8 @@ function wrapMainBinaries() {
 function intermediateBundleConcat() {
   extensionBundles.forEach(extension => {
     const prependContents = [
-      'dist/v0/_base_i.js',
-      `dist/v0/${extension.type}.js`,
+      `${destination}/v0/_base_i.js`,
+      `${destination}/v0/${extension.type}.js`,
     ].map(readMagicString);
 
     // If there are third_party libraries to prepend too, ensure we inject a
@@ -641,7 +641,7 @@ function thirdPartyConcat() {
 
 function postPrepend(extension, prependContents) {
   function createFullPath(version) {
-    return `dist/v0/${extension.name}-${version}.js`;
+    return `${destination}/v0/${extension.name}-${version}.js`;
   }
 
   let targets = [];
@@ -693,7 +693,7 @@ function compile(flagsArray) {
 function eliminateIntermediateBundles() {
   extensionBundles.forEach(extension => {
     function createFullPath(version) {
-      return `dist/v0/${extension.name}-${version}.js`;
+      return `${destination}/v0/${extension.name}-${version}.js`;
     }
 
     let targets = [];
@@ -764,7 +764,7 @@ function readMagicString(file) {
 }
 
 function loadSourceMap(file) {
-  if (file.startsWith('dist')) {
+  if (file.startsWith(destination)) {
     return readFile(`${file}.map`);
   }
   return null;

--- a/build-system/sources.js
+++ b/build-system/sources.js
@@ -20,6 +20,7 @@
  * for both the babel and closure sources to be as close as possible.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const tempy = require('tempy');
 
 const SRC_TEMP_DIR = tempy.directory();
@@ -126,8 +127,16 @@ const CLOSURE_SRC_GLOBS = [
   '!node_modules/core-js/modules/library/**.js',
 ].concat(COMMON_GLOBS);
 
+let destination =
+  typeof argv.destination === 'string' ? argv.destination : './dist/';
+if (!destination.endsWith('/')) {
+  destination = `${destination}/`;
+}
+const OUTPUT_DIR = destination;
+
 module.exports = {
   BABEL_SRC_GLOBS,
   CLOSURE_SRC_GLOBS,
   SRC_TEMP_DIR,
+  OUTPUT_DIR,
 };

--- a/build-system/tasks/generate-vendor-jsons.js
+++ b/build-system/tasks/generate-vendor-jsons.js
@@ -22,6 +22,7 @@ const del = require('del');
 const file = require('gulp-file');
 const gulp = require('gulp');
 const {endBuildStep, toPromise, compileJs} = require('./helpers');
+const {OUTPUT_DIR} = require('../sources');
 
 /**
  * Generate all the vendor config JSONs from their respective JS files
@@ -32,7 +33,7 @@ function generateVendorJsons() {
 
   const srcDir = 'extensions/amp-analytics/0.1';
   const srcFile = 'vendors.js';
-  const tempPath = 'dist/temp-analytics/';
+  const tempPath = `${OUTPUT_DIR}temp-analytics/`;
   const destPath = 'extensions/amp-analytics/0.1/vendors/';
   const compileOptions = {
     browserifyOptions: {
@@ -50,7 +51,9 @@ function generateVendorJsons() {
 
   return compileJs(srcDir, srcFile, tempPath, compileOptions).then(() => {
     const promises = [];
-    const {ANALYTICS_CONFIG} = require('../../dist/temp-analytics/vendors.js');
+    const {
+      ANALYTICS_CONFIG,
+    } = require(`../../${OUTPUT_DIR}/temp-analytics/vendors.js`);
 
     // iterate over each vendor config and write to JSON file
     Object.keys(ANALYTICS_CONFIG).forEach(vendorName => {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -36,6 +36,7 @@ const {altMainBundles} = require('../../bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
 const {isTravisBuild} = require('../travis');
+const {OUTPUT_DIR} = require('../sources');
 const {thirdPartyFrames} = require('../config');
 const {transpileTs} = require('../typescript');
 const {VERSION: internalRuntimeVersion} = require('../internal-version');
@@ -175,7 +176,7 @@ function compile(watch, shouldMinify) {
     compileJs(
       './extensions/amp-viewer-integration/0.1/examples/',
       'amp-viewer-host.js',
-      './dist/v0/examples',
+      `./${OUTPUT_DIR}v0/examples`,
       {
         toName: 'amp-viewer-host.max.js',
         minifiedName: 'amp-viewer-host.js',
@@ -190,7 +191,7 @@ function compile(watch, shouldMinify) {
 
   if (!argv.single_pass && (!watch || argv.with_shadow)) {
     promises.push(
-      compileJs('./src/', 'amp-shadow.js', './dist', {
+      compileJs('./src/', 'amp-shadow.js', `./${OUTPUT_DIR}`, {
         minifiedName: 'shadow-v0.js',
         includePolyfills: true,
         watch,
@@ -201,7 +202,7 @@ function compile(watch, shouldMinify) {
 
   if (!watch || argv.with_video_iframe_integration) {
     promises.push(
-      compileJs('./src/', 'video-iframe-integration.js', './dist', {
+      compileJs('./src/', 'video-iframe-integration.js', `./${OUTPUT_DIR}`, {
         minifiedName: 'video-iframe-integration-v0.js',
         includePolyfills: false,
         watch,
@@ -214,7 +215,7 @@ function compile(watch, shouldMinify) {
     if (!argv.single_pass) {
       promises.push(
         // Entry point for inabox runtime.
-        compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+        compileJs('./src/inabox/', 'amp-inabox.js', `./${OUTPUT_DIR}`, {
           toName: 'amp-inabox.js',
           minifiedName: 'amp4ads-v0.js',
           includePolyfills: true,
@@ -226,7 +227,7 @@ function compile(watch, shouldMinify) {
     }
     promises.push(
       // inabox-host
-      compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+      compileJs('./ads/inabox/', 'inabox-host.js', `./${OUTPUT_DIR}`, {
         toName: 'amp-inabox-host.js',
         minifiedName: 'amp4ads-host-v0.js',
         includePolyfills: false,
@@ -251,7 +252,7 @@ function compile(watch, shouldMinify) {
   }
 
   return Promise.all(promises).then(() => {
-    return compileJs('./src/', 'amp.js', './dist', {
+    return compileJs('./src/', 'amp.js', `./${OUTPUT_DIR}`, {
       toName: 'amp.js',
       minifiedName: 'v0.js',
       includePolyfills: true,
@@ -342,7 +343,7 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
       if (argv.fortesting && options.singlePassCompilation) {
         const promises = [];
         altMainBundles.forEach(bundle => {
-          promises.push(enableLocalTesting(`dist/${bundle.name}.js`));
+          promises.push(enableLocalTesting(`${OUTPUT_DIR}${bundle.name}.js`));
         });
         return Promise.all(promises);
       }
@@ -688,7 +689,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  */
 function buildAlp(options) {
   options = options || {};
-  return compileJs('./ads/alp/', 'install-alp.js', './dist/', {
+  return compileJs('./ads/alp/', 'install-alp.js', `./${OUTPUT_DIR}`, {
     toName: 'alp.max.js',
     watch: options.watch,
     minify: options.minify || argv.minify,
@@ -703,7 +704,7 @@ function buildAlp(options) {
  * @param {!Object} options
  */
 function buildExaminer(options) {
-  return compileJs('./src/examiner/', 'examiner.js', './dist/', {
+  return compileJs('./src/examiner/', 'examiner.js', `./${OUTPUT_DIR}`, {
     toName: 'examiner.max.js',
     watch: options.watch,
     minify: options.minify || argv.minify,
@@ -718,7 +719,7 @@ function buildExaminer(options) {
  * @param {!Object} options
  */
 function buildWebWorker(options) {
-  return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
+  return compileJs('./src/web-worker/', 'web-worker.js', `./${OUTPUT_DIR}`, {
     toName: 'ww.max.js',
     minifiedName: 'ww.js',
     includePolyfills: true,

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -39,6 +39,7 @@ const {
 } = require('../../git');
 const {execOrDie, execScriptAsync} = require('../../exec');
 const {isTravisBuild} = require('../../travis');
+const {OUTPUT_DIR} = require('../../sources');
 const {PercyAssetsLoader} = require('./percy-assets-loader');
 
 // optional dependencies for local development (outside of visual diff tests)
@@ -827,7 +828,7 @@ async function performVisualTests() {
 async function ensureOrBuildAmpRuntimeInTestMode_() {
   if (argv.nobuild) {
     const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":true\b/.test(
-      fs.readFileSync('dist/v0.js', 'utf8')
+      fs.readFileSync(`${OUTPUT_DIR}/v0.js`, 'utf8')
     );
     if (!isInTestMode) {
       log(


### PR DESCRIPTION
This allows for us to build alternative "builds/experiments" of the source code without overwriting the `dest` folder. This is is useful when deploying these alternative builds/experiments into different directories without having to run the process of deployment multiple times.