### PR TITLE
Double-escape regex backslash for C++ textproto.

### DIFF
--- a/extensions/amp-iframe/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/validator-amp-iframe.protoascii
@@ -62,7 +62,7 @@ tags: {  # <amp-iframe>
   }
   attrs: {
     name: "tabindex"
-    value_regex: "-?\d+"
+    value_regex: "-?\\d+"
   }
   attrs: {
     name: "src"


### PR DESCRIPTION
The C++ textproto parser check-fails on this line (introduced in #23482); this 
change fixes that. OTOH, `gulp validator` seems to be happy both before and
after this change, so I think it's safe.
