### PR TITLE
Failing to retrieve experiments should be a warning

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -204,7 +204,7 @@ function getExperimentToggles(win) {
       experimentsString = win.localStorage.getItem(LOCAL_STORAGE_KEY);
     }
   } catch (e) {
-    dev().expectedError(TAG, 'localStorage not supported.');
+    dev().warn(TAG, 'Failed to retrieve experiments from localStorage.');
   }
   const tokens = experimentsString ? experimentsString.split(/\s*,\s*/g) : [];
 


### PR DESCRIPTION
This expected error report is not really actionable by us so we can avoid reporting it (or forwarding it to the viewer) and simply warn.