### PR TITLE
🐛 Regression: add back babel replace plugin

### DIFF
--- a/build-system/build.conf.js
+++ b/build-system/build.conf.js
@@ -27,6 +27,7 @@ const defaultPlugins = [
   localPlugin('transform-amp-extension-call'),
   localPlugin('transform-html-template'),
   localPlugin('transform-version-call'),
+  getReplacePlugin(),
 ];
 
 const esmRemovedImports = {


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/22146 refactored `build.conf.js` and accidentally removed the `minify-replace` plugin. This PR adds it back.