### PR TITLE
Allow not running visual-diff base test

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -438,9 +438,10 @@ async function generateSnapshots(percy, webpages) {
   // no interactions, and each test that has in interactive tests file should
   // load those tests here.
   for (const webpage of webpages) {
-    webpage.tests_ = {
-      '': async () => {},
-    };
+    webpage.tests_ = {};
+    if (!webpage.no_base_test) {
+      webpage.tests_[''] = async () => {};
+    }
     if (webpage.interactive_tests) {
       try {
         Object.assign(

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -126,6 +126,13 @@
    *   //   };
    *   "interactive_tests": "examples/visual-tests/foo/foo-test.js",
    *
+   *   // [optional, EXPERIMENTAL] If interactive_tests have been specified, both
+   *   // interactive tests and the base page without any interactive tests will
+   *   // be executed by default. However, if the result of the base execution
+   *   // is of no interest, setting no_base_test to true will cause the base test
+   *   // not to be executed.
+   *   "no_base_test": true,
+   *
    *   // [optional] Add this key and set to true to skip this test. You should
    *   // also add an explanation and a link to an example of a previous
    *   // snapshot on Percy that demonstrate the flakiness of this test.
@@ -724,7 +731,8 @@
     {
       "url": "examples/visual-tests/amp-ad/amp-ad.html",
       "name": "AMP ad",
-      "interactive_tests": "examples/visual-tests/amp-ad/amp-ad.js"
+      "interactive_tests": "examples/visual-tests/amp-ad/amp-ad.js",
+      "no_base_test": true
     },
     {
       "url": "examples/visual-tests/amp-ad/amp-inabox.html",
@@ -732,7 +740,8 @@
       "loading_complete_selectors": [
         ".view", ".activeview"
       ],
-      "interactive_tests": "examples/visual-tests/amp-ad/amp-inabox.js"
+      "interactive_tests": "examples/visual-tests/amp-ad/amp-inabox.js",
+      "no_base_test": true
     }
   ]
 }


### PR DESCRIPTION
A4A has a few visual tests where content is shown in an iframe, which is not visible by default since the content is not in the parent DOM when uploaded. As a workaround, we pull the iframe DOM out to the parent DOM (see examples/visual-tests/amp-ad/amp-ad.js) in order to make iframe entirely visible.

In these scenarios, we do not need base cases executed, and this PR proposes to add a flag not to run them.