### PR TITLE
Ramp FlexAdSlot params to 5%.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,7 +37,7 @@
   "expAdsenseCanonical": 0.05,
   "expAdsenseUnconditionedCanonical": 0.05,
   "fixed-elements-in-lightbox": 1,
-  "flexAdSlots": 0.01,
+  "flexAdSlots": 0.95,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 1,
   "layers": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,7 +37,7 @@
   "expAdsenseCanonical": 0.05,
   "expAdsenseUnconditionedCanonical": 0.05,
   "fixed-elements-in-lightbox": 1,
-  "flexAdSlots": 0.95,
+  "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 1,
   "layers": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,7 +37,7 @@
   "expAdsenseCanonical": 0.05,
   "expAdsenseUnconditionedCanonical": 0.05,
   "fixed-elements-in-lightbox": 1,
-  "flexAdSlots": 0.01,
+  "flexAdSlots": 0.95,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "margin-bottom-in-content-height": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,7 +37,7 @@
   "expAdsenseCanonical": 0.05,
   "expAdsenseUnconditionedCanonical": 0.05,
   "fixed-elements-in-lightbox": 1,
-  "flexAdSlots": 0.95,
+  "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "margin-bottom-in-content-height": 1,


### PR DESCRIPTION
With this change, 5% of DoubleClick ad slot requests will contain the flexible ad request params ('msz' and 'psz'), enabling flexible creatives on those slots.