### PR TITLE
Add bfcache test examples and remove unload listener unless pagehide is unsupported

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -895,12 +895,15 @@ app.get(
     const mode = pc.env.SERVE_MODE;
     const inabox = req.query['inabox'];
     const stream = Number(req.query['stream']);
+    const index = Number(req.query['index']);
+
     fs.readFileAsync(pc.cwd() + filePath, 'utf8')
       .then(file => {
         if (req.query['amp_js_v']) {
           file = addViewerIntegrationScript(req.query['amp_js_v'], file);
         }
         file = file.replace(/__TEST_SERVER_PORT__/g, TEST_SERVER_PORT);
+        file = file.replace(/__PAGE_INDEX__/g, isNaN(index) ? 0 : index + 1);
 
         if (inabox && req.headers.origin && req.query.__amp_source_origin) {
           // Allow CORS requests for A4A.

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -895,15 +895,12 @@ app.get(
     const mode = pc.env.SERVE_MODE;
     const inabox = req.query['inabox'];
     const stream = Number(req.query['stream']);
-    const index = Number(req.query['index']);
-
     fs.readFileAsync(pc.cwd() + filePath, 'utf8')
       .then(file => {
         if (req.query['amp_js_v']) {
           file = addViewerIntegrationScript(req.query['amp_js_v'], file);
         }
         file = file.replace(/__TEST_SERVER_PORT__/g, TEST_SERVER_PORT);
-        file = file.replace(/__PAGE_INDEX__/g, isNaN(index) ? 0 : index + 1);
 
         if (inabox && req.headers.origin && req.query.__amp_source_origin) {
           // Allow CORS requests for A4A.

--- a/examples/bfcache/analytics-report-when.html
+++ b/examples/bfcache/analytics-report-when.html
@@ -59,17 +59,17 @@
   <h2>Wow 1</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img id="target" src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="analytics-report-when.html?page=QUERY_PARAM(page)0" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 2</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="analytics-report-when.html?page=QUERY_PARAM(page)1" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 3</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="analytics-report-when.html?page=QUERY_PARAM(page)2" data-amp-replace="QUERY_PARAM">Next page</a>
   <amp-list src="/list/infinite-scroll-random/animals" layout="fixed-height" height="300" load-more="manual">
     <template type="amp-mustache">
       <amp-img layout=responsive width=3 height=2 src={{src}}></amp-img>
@@ -80,12 +80,12 @@
   <h2>Wow 4</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="analytics-report-when.html?page=QUERY_PARAM(page)3" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 5</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="analytics-report-when.html?page=QUERY_PARAM(page)4" data-amp-replace="QUERY_PARAM">Next page</a>
 </main>
 </body>
 </html>

--- a/examples/bfcache/analytics-report-when.html
+++ b/examples/bfcache/analytics-report-when.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <style amp-custom>
+  main {
+    margin: 0 auto;
+    width: 50vw;
+    min-width: 320px;
+    max-width: 800px;
+  }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <link rel="canonical" href=".">
+  <title>AMP BFCache example</title>
+</head>
+<body>
+<main>
+  <amp-analytics id="analytics1">
+  <script type="application/json">
+  {
+    "transport": {"beacon": true, "xhrpost": false},
+    "requests": {
+      "endpoint": "/analytics?totalTime=${totalTime}&totalVisibleTime=${totalVisibleTime}&maxContinuousVisibleTime=${maxContinuousVisibleTime}&minVisiblePercentage=${minVisiblePercentage}&maxVisiblePercentage=${maxVisiblePercentage}&firstVisibleTime=${firstVisibleTime}"
+    },
+    "triggers": {
+      "image_viewed": {
+        "on": "visible",
+        "request": ["endpoint"],
+        "selector": "#target",
+        "visibilitySpec": {
+          "reportWhen": "documentExit"
+        }
+      },
+      "50pct_visible_time": {
+        "on": "visible",
+        "request": ["endpoint"],
+        "selector": "#target",
+        "visibilitySpec": {
+          "reportWhen": "documentExit",
+          "visiblePercentageMin": 50
+        },
+        "extraUrlParams": {
+          "50PctMin": true
+        }
+      }
+    }
+  }
+  </script>
+  </amp-analytics>
+
+  <h1>AMP BFCache example</h1>
+  <h2>Wow 1</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img id="target" src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 2</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 3</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+  <amp-list src="/list/infinite-scroll-random/animals" layout="fixed-height" height="300" load-more="manual">
+    <template type="amp-mustache">
+      <amp-img layout=responsive width=3 height=2 src={{src}}></amp-img>
+    </template>
+    <!-- <button overflow>Show more</button> -->
+  </amp-list>
+
+  <h2>Wow 4</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 5</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="analytics.html?index=__PAGE_INDEX__">Next page</a>
+</main>
+</body>
+</html>

--- a/examples/bfcache/no-unload.html
+++ b/examples/bfcache/no-unload.html
@@ -25,17 +25,17 @@
   <h2>Wow 1</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="no-unload.html?page=QUERY_PARAM(page)0" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 2</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="no-unload.html?page=QUERY_PARAM(page)1" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 3</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="no-unload.html?page=QUERY_PARAM(page)2" data-amp-replace="QUERY_PARAM">Next page</a>
   <amp-list src="/list/infinite-scroll-random/animals" layout="fixed-height" height="300" load-more="manual">
     <template type="amp-mustache">
       <amp-img layout=responsive width=3 height=2 src={{src}}></amp-img>
@@ -46,12 +46,12 @@
   <h2>Wow 4</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="no-unload.html?page=QUERY_PARAM(page)3" data-amp-replace="QUERY_PARAM">Next page</a>
 
   <h2>Wow 5</h2>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
   <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
-  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <a href="no-unload.html?page=QUERY_PARAM(page)4" data-amp-replace="QUERY_PARAM">Next page</a>
 </main>
 </body>
 </html>

--- a/examples/bfcache/no-unload.html
+++ b/examples/bfcache/no-unload.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp-custom>
+  main {
+    margin: 0 auto;
+    width: 50vw;
+    min-width: 320px;
+    max-width: 800px;
+  }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <link rel="canonical" href=".">
+  <title>AMP BFCache example</title>
+</head>
+<body>
+<main>
+  <h1>AMP BFCache example</h1>
+  <h2>Wow 1</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 2</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 3</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+  <amp-list src="/list/infinite-scroll-random/animals" layout="fixed-height" height="300" load-more="manual">
+    <template type="amp-mustache">
+      <amp-img layout=responsive width=3 height=2 src={{src}}></amp-img>
+    </template>
+    <button overflow>Show more</button>
+  </amp-list>
+
+  <h2>Wow 4</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+
+  <h2>Wow 5</h2>
+  <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Molestias quas laborum voluptate culpa error asperiores similique facere, natus ullam beatae quos. Asperiores reiciendis, assumenda placeat architecto eius iusto distinctio nesciunt.</p>
+  <amp-img src="/examples/img/hero@1x.jpg" layout="responsive" width="640" height="480"></amp-img>
+  <a href="no-unload.html?index=__PAGE_INDEX__">Next page</a>
+</main>
+</body>
+</html>

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -1503,7 +1503,7 @@ export class VisibilityTracker extends EventTracker {
     // to give developers control over the behavior, and the unload listener
     // interferes with it. To allow publishers to use the default BFCache
     // behavior, we should not add an unload listener.
-    if (!'onpagehide' in window) {
+    if (!this.supportsPageHide_()) {
       win.addEventListener(
         'unload',
         (unloadListener = () => {
@@ -1528,6 +1528,18 @@ export class VisibilityTracker extends EventTracker {
       })
     );
     return deferred.promise;
+  }
+
+  /**
+   * Detect support for the pagehide event.
+   * IE<=10 and Opera Mini do not support the pagehide event and
+   * possibly others, so we feature-detect support with this method.
+   * This is in a stubbable method for testing.
+   * @return {boolean}
+   * @private visible for testing
+   */
+  supportsPageHide_() {
+    return 'onpagehide' in this.root.ampdoc.win;
   }
 
   /**

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -1496,27 +1496,22 @@ export class VisibilityTracker extends EventTracker {
     const {win} = this.root.ampdoc;
     let unloadListener, pageHideListener;
 
-    // Listeners are provided below for both 'unload' and 'pagehide'. Fore
-    // more info, see https://developer.mozilla.org/en-US/docs/Web/Events/unload
-    // and https://developer.mozilla.org/en-US/docs/Web/Events/pagehide, but in
-    // short the difference between them is:
-    // * unload is fired when document is being unloaded. Does not fire on
-    //   Safari.
-    // * pagehide is fired when traversing away from a session history item.
-    // Usually, if one is fired, the other is too, with pagehide being fired
-    // first. An exception is that in Safari (desktop and mobile), pagehide is
-    // fired when navigating to another page, but unload is not.
-    // On mobile Chrome, and mobile Firefox, neither of these will fire if the
-    // user presses the home button, uses the OS task switcher to switch to
-    // a different app, answers an incoming call, etc.
-
-    win.addEventListener(
-      'unload',
-      (unloadListener = () => {
-        win.removeEventListener('unload', unloadListener);
-        deferred.resolve();
-      })
-    );
+    // Do not add an unload listener unless pagehide is not available.
+    // If an unload listener is present, the back/forward cache will not work.
+    // The BFCache saves pages to be instantly loaded when navigating back
+    // or forward and pauses their JavaScript. The pagehide event was added
+    // to give developers control over the behavior, and the unload listener
+    // interferes with it. To allow publishers to use the default BFCache
+    // behavior, we should not add an unload listener.
+    if (!'onpagehide' in window) {
+      win.addEventListener(
+        'unload',
+        (unloadListener = () => {
+          win.removeEventListener('unload', unloadListener);
+          deferred.resolve();
+        })
+      );
+    }
 
     // Note: pagehide is currently not supported on Opera Mini, nor IE<=10.
     // Documentation conflicts as to whether Safari on iOS will also fire it


### PR DESCRIPTION
This is part of the stateful AMP effort. The first step is to get out of the browser's way when it caches documents in the back/forward cache. amp-analytics was adding an `unload` listener if the document includes a visibility spec with `"reportWhen": "documentExit"`, but if `pagehide` is supported then `unload` is not needed.  `unload` listeners cause browsers to not cache pages in the bfcache on navigation.

Related to #23527 

/to @cathyxz @sparhami 
/cc @nainar 


