### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-carousel/0.1/test/validator-amp-carousel-error-msg.out
+++ b/extensions/amp-carousel/0.1/test/validator-amp-carousel-error-msg.out
@@ -32,19 +32,15 @@ FAIL
 |    <!-- Invalid: Missing script, test is to see if the error message is OK. -->
 |    <amp-carousel layout=fill></amp-carousel>
 >>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:32:2 The specified layout 'FILL' is not supported by tag 'AMP-CAROUSEL [lightbox] [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [AMP_LAYOUT_PROBLEM]
+amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:32:2 The specified layout 'FILL' is not supported by tag 'AMP-CAROUSEL [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:32:2 The tag 'AMP-CAROUSEL [lightbox] [type=carousel]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:32:2 The tag 'AMP-CAROUSEL [lightbox] [type=carousel]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:32:2 The tag 'AMP-CAROUSEL [type=carousel]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    <amp-carousel width="600" height="522" layout="responsive" type="slides" controls></amp-carousel>
 >>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The specified layout 'RESPONSIVE' is not supported by tag 'AMP-CAROUSEL [lightbox] [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [AMP_LAYOUT_PROBLEM]
+amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The specified layout 'RESPONSIVE' is not supported by tag 'AMP-CAROUSEL [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The attribute 'type' in tag 'AMP-CAROUSEL [lightbox] [type=carousel]' is set to the invalid value 'slides'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
+amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The attribute 'type' in tag 'AMP-CAROUSEL [type=carousel]' is set to the invalid value 'slides'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The tag 'AMP-CAROUSEL [lightbox] [type=carousel]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>   ^~~~~~~~~
-amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The tag 'AMP-CAROUSEL [lightbox] [type=carousel]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-carousel/0.1/test/validator-amp-carousel-error-msg.html:33:2 The tag 'AMP-CAROUSEL [type=carousel]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |  </body>
 |  </html>

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -57,6 +57,23 @@ attr_lists: {
   # <amp-bind>
   attrs: { name: "[slide]" }
 }
+# There are 4 variants here, due to two independent axis of differences:
+#  1) type=slides vs. type=carousel
+#     - type=slides is the implied default if type is unspecified. This is
+#       encoded in the rules by making type=carousel mandatory, and
+#       type=slides optional.
+#     - slides vs. carousel implies different sets up supported layouts.
+#  2) presence of `lightbox` attribute.
+#     - lightbox is only allowed in AMP html format.
+#     - lightbox implies additional reference_point requirements of the
+#       amp-lightbox children.
+# The attribute implied rules (different layouts or different children) is not
+# a feature of the validator rules engine. Thus the only supportable ruleset is
+# to implement 1 tagspec for each combination. This produces the desired rules
+# but has undesirable results for some of the error messages, as seen in some
+# of the test cases. The main issue is that since there are two tagspecs with
+# each combination, we cannot use the usual dispatch_key trick for either
+# attribute.
 tags: {  # <amp-carousel type=slides>
   html_format: AMP
   html_format: AMP4ADS

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -111,7 +111,6 @@ tags: {  # <amp-carousel type=carousel>
     name: "type"
     value: "carousel"
     mandatory: true
-    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"

--- a/validator/testdata/amp4email_feature_tests/amp_carousel.out
+++ b/validator/testdata/amp4email_feature_tests/amp_carousel.out
@@ -44,7 +44,11 @@ FAIL
 |  -->
 |  <amp-carousel
 >> ^~~~~~~~~
-amp4email_feature_tests/amp_carousel.html:44:0 The attribute 'arrows' may not appear in tag 'AMP-CAROUSEL [type=slides]'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_carousel.html:44:0 The specified layout 'RESPONSIVE' is not supported by tag 'AMP-CAROUSEL [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [AMP_LAYOUT_PROBLEM]
+>> ^~~~~~~~~
+amp4email_feature_tests/amp_carousel.html:44:0 The attribute 'arrows' may not appear in tag 'AMP-CAROUSEL [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
+>> ^~~~~~~~~
+amp4email_feature_tests/amp_carousel.html:44:0 The attribute 'type' in tag 'AMP-CAROUSEL [type=carousel]' is set to the invalid value 'slides'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
 |    arrows
 |    width="800" height="600"
 |    layout="responsive"

--- a/validator/testdata/amp4email_feature_tests/amp_form.html
+++ b/validator/testdata/amp4email_feature_tests/amp_form.html
@@ -81,6 +81,15 @@
     <input name="googlesearch">
     <input type="submit" value="OK">
   </form>
+  <!-- Invalid: only absolute URL is allowed. -->
+  <form method="GET" action-xhr="endpoint">
+    <input name="googlesearch">
+    <input type="submit" value="OK">
+  </form>
+  <form method="POST" action-xhr="endpoint">
+    <input name="googlesearch">
+    <input type="submit" value="OK">
+  </form>
   <!-- Invalid: the action and target attributes are disallowed. -->
   <form method="GET"
     action="/components/amp-form/submit-form"

--- a/validator/testdata/amp4email_feature_tests/amp_form.out
+++ b/validator/testdata/amp4email_feature_tests/amp_form.out
@@ -84,12 +84,25 @@ amp4email_feature_tests/amp_form.html:80:2 Invalid URL protocol 'http:' for attr
 |      <input name="googlesearch">
 |      <input type="submit" value="OK">
 |    </form>
+|    <!-- Invalid: only absolute URL is allowed. -->
+|    <form method="GET" action-xhr="endpoint">
+>>   ^~~~~~~~~
+amp4email_feature_tests/amp_form.html:85:2 The relative URL 'endpoint' for attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+|      <input name="googlesearch">
+|      <input type="submit" value="OK">
+|    </form>
+|    <form method="POST" action-xhr="endpoint">
+>>   ^~~~~~~~~
+amp4email_feature_tests/amp_form.html:89:2 The relative URL 'endpoint' for attribute 'action-xhr' in tag 'FORM [method=POST] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+|      <input name="googlesearch">
+|      <input type="submit" value="OK">
+|    </form>
 |    <!-- Invalid: the action and target attributes are disallowed. -->
 |    <form method="GET"
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:85:2 The attribute 'action' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:94:2 The attribute 'action' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:85:2 The attribute 'target' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:94:2 The attribute 'target' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      action="/components/amp-form/submit-form"
 |      target="_top">
 |      <div>
@@ -101,37 +114,37 @@ amp4email_feature_tests/amp_form.html:85:2 The attribute 'target' may not appear
 |    <form method="post" action-xhr="https://example.com/subscribe">
 |      <input type="button" name="button">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:95:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:104:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'button'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      <input type="image" name="image">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:96:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'image'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:105:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'image'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid: input can not be type="password" -->
 |    <form method="post" action-xhr="https://example.com/subscribe">
 |      <input type="password" name="password">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:100:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'password'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:109:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'password'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      <input type="file" name="file">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:101:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'file'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:110:4 The attribute 'type' in tag 'INPUT (AMP4EMAIL)' is set to the invalid value 'file'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid: invalid attribute xhr-verify -->
 |    <form method="post" action-xhr="https://example.com/subscribe"
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:104:2 The attribute 'xhr-verify' may not appear in tag 'FORM [method=POST] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:113:2 The attribute 'xhr-verify' may not appear in tag 'FORM [method=POST] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      xhr-verify="https://example.com/subscribe">
 |    </form>
 |    <!-- Invalid: invalid attribute xhr-verify -->
 |    <form method="get" action-xhr="https://example.com/subscribe"
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:108:2 The attribute 'xhr-verify' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:117:2 The attribute 'xhr-verify' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |      xhr-verify="https://example.com/subscribe">
 |    </form>
 |    <!-- Invalid: amp-bind usage for type in input -->
 |    <form method="get" action-xhr="https://example.com/subscribe">
 |      <input [type]="state.type" name="name">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:113:4 The attribute '[type]' may not appear in tag 'INPUT (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:122:4 The attribute '[type]' may not appear in tag 'INPUT (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid: invalid usage of submitting attribute with nested template -->
 |    <form method="post" action-xhr="https://example.com/subscribe">
@@ -139,7 +152,7 @@ amp4email_feature_tests/amp_form.html:113:4 The attribute '[type]' may not appea
 |      <div submitting>
 |        <template type="amp-mustache">
 >>       ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:119:6 The tag 'TEMPLATE (AMP4EMAIL)' may not appear as a descendant of tag 'form div [submitting]'. (see https://amp.dev/documentation/components/amp-mustache) [GENERIC]
+amp4email_feature_tests/amp_form.html:128:6 The tag 'TEMPLATE (AMP4EMAIL)' may not appear as a descendant of tag 'form div [submitting]'. (see https://amp.dev/documentation/components/amp-mustache) [GENERIC]
 |          Submitting... {{a}}
 |        </template>
 |      </div>
@@ -149,7 +162,7 @@ amp4email_feature_tests/amp_form.html:119:6 The tag 'TEMPLATE (AMP4EMAIL)' may n
 |      <input type="email" name="email">
 |      <div submitting template="abc">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:127:4 The attribute 'template' may not appear in tag 'FORM DIV [submitting]'. [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:136:4 The attribute 'template' may not appear in tag 'FORM DIV [submitting]'. [DISALLOWED_HTML]
 |      </div>
 |    </form>
 |    <!-- Invalid: invalid template within a template -->
@@ -160,7 +173,7 @@ amp4email_feature_tests/amp_form.html:127:4 The attribute 'template' may not app
 |          {{a}}
 |          <template type="amp-mustache">
 >>         ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:136:8 The tag 'TEMPLATE (AMP4EMAIL)' may not appear as a descendant of tag 'template (amp4email)'. (see https://amp.dev/documentation/components/amp-mustache) [GENERIC]
+amp4email_feature_tests/amp_form.html:145:8 The tag 'TEMPLATE (AMP4EMAIL)' may not appear as a descendant of tag 'template (amp4email)'. (see https://amp.dev/documentation/components/amp-mustache) [GENERIC]
 |            {{b}}
 |          </template>
 |        </template>
@@ -170,7 +183,7 @@ amp4email_feature_tests/amp_form.html:136:8 The tag 'TEMPLATE (AMP4EMAIL)' may n
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:144:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '{{foo}}'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:153:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '{{foo}}'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="{{foo}}">
 |        <div>
 |          <input name="googlesearch">
@@ -181,7 +194,7 @@ amp4email_feature_tests/amp_form.html:144:4 The attribute 'action-xhr' in tag 'F
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:153:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '{{foo}}{{bar}}'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:162:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '{{foo}}{{bar}}'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="{{foo}}{{bar}}">
 |        <div>
 |          <input name="googlesearch">
@@ -192,7 +205,7 @@ amp4email_feature_tests/amp_form.html:153:4 The attribute 'action-xhr' in tag 'F
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:162:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value 'foo{{bar'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:171:4 The relative URL 'foo{{bar' for attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="foo{{bar">
 |        <div>
 |          <input name="googlesearch">
@@ -203,7 +216,7 @@ amp4email_feature_tests/amp_form.html:162:4 The attribute 'action-xhr' in tag 'F
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:171:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value 'foo}}bar'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:180:4 The relative URL 'foo}}bar' for attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="foo}}bar">
 |        <div>
 |          <input name="googlesearch">
@@ -214,7 +227,7 @@ amp4email_feature_tests/amp_form.html:171:4 The attribute 'action-xhr' in tag 'F
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:180:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '{{'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:189:4 The relative URL '{{' for attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="{{">
 |        <div>
 |          <input name="googlesearch">
@@ -225,7 +238,7 @@ amp4email_feature_tests/amp_form.html:180:4 The attribute 'action-xhr' in tag 'F
 |    <template type="amp-mustache">
 |      <form method="GET"
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:189:4 The attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is set to the invalid value '}}'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:198:4 The relative URL '}}' for attribute 'action-xhr' in tag 'FORM [method=GET] (AMP4EMAIL)' is disallowed. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |        action-xhr="}}">
 |        <div>
 |          <input name="googlesearch">
@@ -236,12 +249,12 @@ amp4email_feature_tests/amp_form.html:189:4 The attribute 'action-xhr' in tag 'F
 |    <!-- Invalid POST form with name. -->
 |    <form method="post" name="post-form" action-xhr="https://example.com/subscribe">
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:198:2 The attribute 'name' may not appear in tag 'FORM [method=POST] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:207:2 The attribute 'name' may not appear in tag 'FORM [method=POST] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid GET form with name. -->
 |    <form method="GET" name="get-form" action-xhr="https://someserver.com/endpoint">
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:201:2 The attribute 'name' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:210:2 The attribute 'name' may not appear in tag 'FORM [method=GET] (AMP4EMAIL)'. (see https://amp.dev/documentation/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -125,11 +125,9 @@ feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires inclu
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://amp.dev/documentation/components/amp-fit-text) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-carousel height="42"></amp-carousel>
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'AMP-CAROUSEL [lightbox] [type=slides]'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
+feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'type' is missing in tag 'AMP-CAROUSEL [type=carousel]'. (see https://amp.dev/documentation/components/amp-carousel) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox] [type=slides]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox] [type=slides]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [type=carousel]' requires including the 'amp-carousel' extension JavaScript. (see https://amp.dev/documentation/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
 >>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://amp.dev/documentation/components/amp-youtube) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 914
+spec_file_revision: 915
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -4153,6 +4153,7 @@ tags {  # <form method=GET ...>
     name: "action-xhr"
     value_url: {
       protocol: "https"
+      allow_relative: false
     }
     blacklisted_value_regex: "__amp_source_origin|"
         "{{|}}"    # Mustache is disallowed in action-xhr.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 919
+spec_file_revision: 920
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 916
+spec_file_revision: 917
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 917
+spec_file_revision: 918
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 912
+spec_file_revision: 913
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 918
+spec_file_revision: 919
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 915
+spec_file_revision: 916
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 913
+spec_file_revision: 914
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"


### PR DESCRIPTION
 - cl/259988931 Revision bump for #23482
 - cl/259662509 Revision bump for #23148
 - cl/259661215 Fix #23012 by removing the dispatch key on amp-carousel type=carousel.
 - cl/259587993 Add a descriptive comment to amp-carousel rules.
 - cl/259565186 Revision bump for #23386
 - cl/258870451 Fix incorrect allowance of `<form method="get">` with relative URLs
 - cl/258634966 Revision bump for #23349
 - cl/258377914 Revision bump for #23122