### PR TITLE
Ensure that expanded slots are correctly centered.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -51,6 +51,10 @@ import {
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
 import {FIE_CSS_CLEANUP_EXP} from '../../../src/friendly-iframe-embed';
+import {
+  FlexibleAdSlotDataTypeDef,
+  getFlexibleAdSlotData,
+} from './flexible-ad-slot-utils';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Navigation} from '../../../src/service/navigation';
 import {RTC_VENDORS} from '../../amp-a4a/0.1/callout-vendors';
@@ -66,7 +70,11 @@ import {
   serializeTargeting,
   sraBlockCallbackHandler,
 } from './sra-utils';
-import {createElementWithAttributes, removeElement} from '../../../src/dom';
+import {
+  createElementWithAttributes,
+  isRTL,
+  removeElement,
+} from '../../../src/dom';
 import {deepMerge, dict} from '../../../src/utils/object';
 import {dev, devAssert, user} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
@@ -74,7 +82,6 @@ import {
   extractUrlExperimentId,
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
-import {getFlexibleAdSlotRequestParams} from './flexible-ad-slot-utils';
 import {getMode} from '../../../src/mode';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
@@ -287,6 +294,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /** @private {boolean} */
     this.sendFlexibleAdSlotParams_ = false;
+
+    /**
+     * Set after the ad request is built.
+     * @private {?FlexibleAdSlotDataTypeDef}
+     */
+    this.flexibleAdSlotData_ = null;
   }
 
   /**
@@ -535,10 +548,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     let psz = null;
     let fws = null;
     if (this.sendFlexibleAdSlotParams_) {
-      const {fwSignal, slotWidth, parentWidth} = getFlexibleAdSlotRequestParams(
+      this.flexibleAdSlotData_ = getFlexibleAdSlotData(
         this.win,
         this.element.parentElement
       );
+      const {fwSignal, slotWidth, parentWidth} = this.flexibleAdSlotData_;
       // If slotWidth is -1, that means its width must be determined by its
       // parent container, and so should have the same value as parentWidth.
       msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
@@ -1235,7 +1249,62 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       isFluidRequestAndFixedResponse ||
       (returnedSizeDifferent && heightNotIncreased)
     ) {
-      this.attemptChangeSize(newHeight, newWidth).catch(() => {});
+      this.attemptChangeSize(newHeight, newWidth)
+        .then(() => {
+          if (newWidth > width) {
+            this.adjustSlotPostExpansion(newWidth);
+          }
+        })
+        .catch(() => {});
+    }
+  }
+
+  /**
+   * Ensures that slot is properly centered after being expanded.
+   * @param {number} newWidth The new width of the slot.
+   */
+  adjustSlotPostExpansion(newWidth) {
+    if (this.flexibleAdSlotData_ == null) {
+      dev().warn(
+        TAG,
+        'Attempted to expand slot without flexible ad slot data.'
+      );
+      return;
+    }
+    const isRtl = isRTL(this.win.document);
+    const dirStr = isRtl ? 'Right' : 'Left';
+    // Guaranteed to be set after exiting if/else.
+    let /** ?number */ newMargin = null;
+    if (newWidth <= this.flexibleAdSlotData_.parentWidth) {
+      // Must center creative within its parent container
+      const {parentStyle} = this.flexibleAdSlotData_;
+      const parentPadding = parseInt(parentStyle[`padding${dirStr}`], 10) || 0;
+      const parentBorder =
+        parseInt(parentStyle[`border${dirStr}Width`], 10) || 0;
+      const whitespace = (this.flexibleAdSlotData_.parentWidth - newWidth) / 2;
+      newMargin = whitespace - parentPadding - parentBorder;
+    } else {
+      // Must center creative within the viewport
+      const viewportWidth = this.getViewport().getRect().width;
+      const pageLayoutBox = this.element.getPageLayoutBox();
+      const whitespace = (viewportWidth - newWidth) / 2;
+      if (isRtl) {
+        newMargin = pageLayoutBox.right + whitespace - viewportWidth;
+      } else {
+        newMargin = -(pageLayoutBox.left - whitespace);
+      }
+    }
+    // setStyles cannot have computed style names, so we must do this by cases.
+    if (isRtl) {
+      setStyles(this.element, {
+        'z-index': '30',
+        'margin-right': `${newMargin}px`,
+      });
+    } else {
+      setStyles(this.element, {
+        'z-index': '30',
+        'margin-left': `${newMargin}px`,
+      });
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1249,13 +1249,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       isFluidRequestAndFixedResponse ||
       (returnedSizeDifferent && heightNotIncreased)
     ) {
-      this.attemptChangeSize(newHeight, newWidth)
-        .then(() => {
-          if (newWidth > width) {
-            this.adjustSlotPostExpansion(newWidth);
-          }
-        })
-        .catch(() => {});
+      this.attemptChangeSize(newHeight, newWidth).catch(() => {});
+      if (newWidth > width) {
+        this.adjustSlotPostExpansion(newWidth);
+      }
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1262,20 +1262,21 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @private
    */
   adjustSlotPostExpansion_(newWidth) {
-    if (this.flexibleAdSlotData_ == null) {
-      dev().warn(
-        TAG,
+    if (
+      !devAssert(
+        this.flexibleAdSlotData_,
         'Attempted to expand slot without flexible ad slot data.'
-      );
+      )
+    ) {
       return;
     }
     const isRtl = isRTL(this.win.document);
     const dirStr = isRtl ? 'Right' : 'Left';
     // Guaranteed to be set after exiting if/else.
     let /** ?number */ newMargin = null;
-    if (newWidth <= this.flexibleAdSlotData_.parentWidth) {
+    const {parentWidth, parentStyle} = this.flexibleAdSlotData_;
+    if (newWidth <= parentWidth) {
       // Must center creative within its parent container
-      const {parentStyle} = this.flexibleAdSlotData_;
       const parentPadding = parseInt(parentStyle[`padding${dirStr}`], 10) || 0;
       const parentBorder =
         parseInt(parentStyle[`border${dirStr}Width`], 10) || 0;
@@ -1296,12 +1297,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (isRtl) {
       setStyles(this.element, {
         'z-index': '30',
-        'margin-right': `${newMargin}px`,
+        'margin-right': `${Math.round(newMargin)}px`,
       });
     } else {
       setStyles(this.element, {
         'z-index': '30',
-        'margin-left': `${newMargin}px`,
+        'margin-left': `${Math.round(newMargin)}px`,
       });
     }
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1251,7 +1251,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     ) {
       this.attemptChangeSize(newHeight, newWidth).catch(() => {});
       if (newWidth > width) {
-        this.adjustSlotPostExpansion(newWidth);
+        this.adjustSlotPostExpansion_(newWidth);
       }
     }
   }
@@ -1259,8 +1259,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /**
    * Ensures that slot is properly centered after being expanded.
    * @param {number} newWidth The new width of the slot.
+   * @private
    */
-  adjustSlotPostExpansion(newWidth) {
+  adjustSlotPostExpansion_(newWidth) {
     if (this.flexibleAdSlotData_ == null) {
       dev().warn(
         TAG,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
@@ -65,7 +65,9 @@ function getElementWidthVisitor(setWidth) {
         setWidth(0);
         return true;
       default:
-        // If no layout is provided, we must use getComputedStyle.
+        // If no layout is provided, we must use getComputedStyle. Padding is
+        // not included in the overall computed width, so we must manually
+        // include it.
         const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
         const paddingRight = parseInt(style.paddingRight, 10) || 0;
         const totalPadding = paddingLeft + paddingRight;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
@@ -65,13 +65,16 @@ function getElementWidthVisitor(setWidth) {
         setWidth(0);
         return true;
       default:
-        // If no layout is provided, we must use getComputedStyle. Padding is
-        // not included in the overall computed width, so we must manually
-        // include it.
+        // If no layout is provided, we must use getComputedStyle. Padding and
+        // border is not included in the overall computed width, so we must
+        // manually include them.
         const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
         const paddingRight = parseInt(style.paddingRight, 10) || 0;
         const totalPadding = paddingLeft + paddingRight;
-        setWidth((parseInt(style.width, 10) || 0) + totalPadding);
+        const borderLeft = parseInt(style.borderLeftWidth, 10) || 0;
+        const borderRight = parseInt(style.borderRightWidth, 10) || 0;
+        const totalBorder = borderLeft + borderRight;
+        setWidth((parseInt(style.width, 10) || 0) + totalPadding + totalBorder);
         return true;
     }
   };

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/flexible-ad-slot-utils.js
@@ -66,7 +66,10 @@ function getElementWidthVisitor(setWidth) {
         return true;
       default:
         // If no layout is provided, we must use getComputedStyle.
-        setWidth(parseInt(style.width, 10) || 0);
+        const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
+        const paddingRight = parseInt(style.paddingRight, 10) || 0;
+        const totalPadding = paddingLeft + paddingRight;
+        setWidth((parseInt(style.width, 10) || 0) + totalPadding);
         return true;
     }
   };
@@ -93,26 +96,28 @@ function getFullWidthSignalVisitor(setSignal) {
 }
 
 /** @typedef {{
- *    fwSignal: ?number,
- *    slotWidth: ?number,
- *    parentWidth: ?number,
+ *    fwSignal: number,
+ *    slotWidth: number,
+ *    parentWidth: number,
+ *    parentStyle: ?Object<string, string>,
  * }}
  */
-let ParamsTypeDef;
+export let FlexibleAdSlotDataTypeDef;
 
 /**
  * Returns the fixed size of the given element, or the fixed size of its nearest
  * ancestor that has a fixed size, if the given element has none.
  * @param {!Window} win
  * @param {?Element} element
- * @return {!ParamsTypeDef} The width of the given
- *    element, or of the nearest ancestor with a fixed size, if the given
- *    element has none.
+ * @return {!FlexibleAdSlotDataTypeDef} A record containing data needed for
+ *   generating flex ad slot ad requests, and for adjusting the slot
+ *   post-response. See type def for more details.
  */
-export function getFlexibleAdSlotRequestParams(win, element) {
+export function getFlexibleAdSlotData(win, element) {
   let fwSignal = 0;
   let slotWidth = -1;
   let parentWidth = -1;
+  let parentStyle = null;
   const setFws = val => (fwSignal = val);
   const setMsz = val => (slotWidth = val);
   const setPsz = val => (parentWidth = val);
@@ -120,6 +125,8 @@ export function getFlexibleAdSlotRequestParams(win, element) {
     .addVisitor(getElementWidthVisitor(setMsz), 1 /* maxDepth */)
     .addVisitor(getElementWidthVisitor(setPsz), 100 /* maxDepth */)
     .addVisitor(getFullWidthSignalVisitor(setFws), 100 /* maxDepth */)
+    // Used to acquire the parentStyle object so as to not recompute it later
+    .addVisitor((el, style) => (parentStyle = style), 1 /* maxDepth */)
     .visitAncestorsStartingFrom(element);
-  return {fwSignal, slotWidth, parentWidth};
+  return {fwSignal, slotWidth, parentWidth, parentStyle};
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1301,20 +1301,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('should attempt resize for fluid request + fixed response case', () => {
       impl.isFluidRequest_ = true;
-      impl.handleResize_(350, 300);
-      expect(impl.element.getAttribute('style')).to.match(/width: 350/);
-      expect(impl.element.getAttribute('style')).to.match(/height: 300/);
-    });
-
-    it('should attempt resize for larger width response', () => {
-      impl.handleResize_(350, 50);
-      expect(impl.element.getAttribute('style')).to.match(/width: 350/);
-      expect(impl.element.getAttribute('style')).to.match(/height: 50/);
-    });
-
-    it('should not attempt resize for larger height response', () => {
-      impl.handleResize_(350, 300);
-      expect(impl.element.getAttribute('style')).to.match(/width: 200/);
+      impl.handleResize_(150, 50);
+      expect(impl.element.getAttribute('style')).to.match(/width: 150/);
       expect(impl.element.getAttribute('style')).to.match(/height: 50/);
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -305,6 +305,85 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
       expect(impl.sandboxHTMLCreativeFrame()).to.be.true;
     });
+
+    [{
+      direction: 'ltr',
+      parentWidth: 300,
+      newWidth: 250,
+      margin: '-25px',
+    }, {
+      direction: 'rtl',
+      parentWidth: 300,
+      newWidth: 250,
+      margin: '-25px',
+    }, {
+      direction: 'ltr',
+      parentWidth: 300,
+      newWidth: 300,
+      margin: '-50px',
+    }, {
+      direction: 'rtl',
+      parentWidth: 300,
+      newWidth: 300,
+      margin: '-50px',
+    }, {
+      direction: 'ltr',
+      parentWidth: 300,
+      newWidth: 380,
+      margin: '-15px',
+    }, {
+      direction: 'rtl',
+      parentWidth: 300,
+      newWidth: 380,
+      margin: '-365px',
+    }, {
+      direction: 'ltr',
+      parentWidth: 300,
+      newWidth: 400,
+      margin: '-25px',
+    }, {
+      direction: 'rtl',
+      parentWidth: 300,
+      newWidth: 400,
+      margin: '-375px',
+    }].forEach((testCase, testNum) => {
+      it(`should adjust slot CSS after expanding width #${testNum}`, () => {
+        sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
+          impl.element.style.width = `${width}px`;
+          return {
+            catch: () => {},
+          }
+        });
+        sandbox.stub(impl, 'getViewport').callsFake(() => ({
+          getRect: () => ({width: 400}),
+        }));
+        sandbox.stub(impl.element, 'getPageLayoutBox').callsFake(() => ({
+          left: 25,
+          right: 25
+        }));
+        const dirStr = testCase.direction == 'ltr' ? 'Left' : 'Right';
+        impl.flexibleAdSlotData_ = {
+          parentWidth: testCase.parentWidth,
+          parentStyle: {
+            [`padding${dirStr}`]: '50px',
+          },
+        }
+        impl.win.document.body.dir = testCase.direction;
+        impl.extractSize({
+          get(name) {
+            switch (name) {
+              case 'X-CreativeSize':
+                return `${testCase.newWidth}x50`;
+            }
+          },
+          has(name) {
+            return !!this.get(name);
+          },});
+        expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
+        // We use a fixed '30' value for z-index.
+        expect(impl.element.style.zIndex).to.equal('30');
+      });
+    });
   });
 
   describe('#onCreativeRender', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -306,60 +306,69 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(impl.sandboxHTMLCreativeFrame()).to.be.true;
     });
 
-    [{
-      direction: 'ltr',
-      parentWidth: 300,
-      newWidth: 250,
-      margin: '-25px',
-    }, {
-      direction: 'rtl',
-      parentWidth: 300,
-      newWidth: 250,
-      margin: '-25px',
-    }, {
-      direction: 'ltr',
-      parentWidth: 300,
-      newWidth: 300,
-      margin: '-50px',
-    }, {
-      direction: 'rtl',
-      parentWidth: 300,
-      newWidth: 300,
-      margin: '-50px',
-    }, {
-      direction: 'ltr',
-      parentWidth: 300,
-      newWidth: 380,
-      margin: '-15px',
-    }, {
-      direction: 'rtl',
-      parentWidth: 300,
-      newWidth: 380,
-      margin: '-365px',
-    }, {
-      direction: 'ltr',
-      parentWidth: 300,
-      newWidth: 400,
-      margin: '-25px',
-    }, {
-      direction: 'rtl',
-      parentWidth: 300,
-      newWidth: 400,
-      margin: '-375px',
-    }].forEach((testCase, testNum) => {
+    [
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 250,
+        margin: '-25px',
+      },
+      {
+        direction: 'rtl',
+        parentWidth: 300,
+        newWidth: 250,
+        margin: '-25px',
+      },
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 300,
+        margin: '-50px',
+      },
+      {
+        direction: 'rtl',
+        parentWidth: 300,
+        newWidth: 300,
+        margin: '-50px',
+      },
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 380,
+        margin: '-15px',
+      },
+      {
+        direction: 'rtl',
+        parentWidth: 300,
+        newWidth: 380,
+        margin: '-365px',
+      },
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 400,
+        margin: '-25px',
+      },
+      {
+        direction: 'rtl',
+        parentWidth: 300,
+        newWidth: 400,
+        margin: '-375px',
+      },
+    ].forEach((testCase, testNum) => {
       it(`should adjust slot CSS after expanding width #${testNum}`, () => {
         sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
           impl.element.style.width = `${width}px`;
           return {
             catch: () => {},
-          }
+          };
         });
         sandbox.stub(impl, 'getViewport').callsFake(() => ({
           getRect: () => ({width: 400}),
         }));
         sandbox.stub(impl.element, 'getPageLayoutBox').callsFake(() => ({
           left: 25,
-          right: 25
+          right: 25,
         }));
         const dirStr = testCase.direction == 'ltr' ? 'Left' : 'Right';
         impl.flexibleAdSlotData_ = {
@@ -367,7 +376,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           parentStyle: {
             [`padding${dirStr}`]: '50px',
           },
-        }
+        };
         impl.win.document.body.dir = testCase.direction;
         impl.extractSize({
           get(name) {
@@ -378,7 +387,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
           has(name) {
             return !!this.get(name);
-          },});
+          },
+        });
         expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
         // We use a fixed '30' value for z-index.
         expect(impl.element.style.zIndex).to.equal('30');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-flexible-ad-slot-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-flexible-ad-slot-utils.js
@@ -15,9 +15,9 @@
  */
 import {Services} from '../../../../src/services';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {getFlexibleAdSlotRequestParams} from '../flexible-ad-slot-utils';
+import {getFlexibleAdSlotData} from '../flexible-ad-slot-utils';
 
-describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
+describes.realWin('#getFlexibleAdSlotData', {amp: true}, env => {
   let doc, win;
   beforeEach(() => {
     win = env.win;
@@ -38,48 +38,36 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
 
   it('should return the fixed width for FIXED layout', () => {
     const element = createResource({width: 300, height: 250}, 'fixed');
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return 0 for FIXED layout and invalid width', () => {
     allowConsoleError(() => {
       const element = createResource({width: 'auto', height: 250}, 'fixed');
-      expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-        0
-      );
+      expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(0);
     });
   });
 
   it('should return 0 for NODISPLAY layout', () => {
     const element = createResource({width: 500}, 'nodisplay');
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      0
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(0);
   });
 
   it('should return 0 for FLEX_ITEM layout', () => {
     const element = createResource({width: 500}, 'flex-item');
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      0
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(0);
   });
 
   it('should return 0 for invalid layout', () => {
     allowConsoleError(() => {
       const element = createResource({width: 500}, 'qwerty');
-      expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-        0
-      );
+      expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(0);
     });
   });
 
   it('should return the max-width, if present, for FILL layout', () => {
     const element = createResource({maxWidth: 300}, 'fill');
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it("should return parent's fixed width for FILL layout", () => {
@@ -88,17 +76,13 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     parent.setAttribute('layout', 'fixed');
     doc.body.appendChild(parent);
     const element = createResource({} /* config */, 'fill', 'amp-ad', parent);
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return the max-width, if present, for FIXED_HEIGHT layout', () => {
     const element = createResource({height: 300}, 'fixed-height');
     element.style.maxWidth = '250px';
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      250
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(250);
   });
 
   it("should return parent's fixed width for FIXED_HEIGHT layout", () => {
@@ -112,17 +96,13 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
       'amp-ad',
       parent
     );
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return the max-width, if present, for FLUID layout', () => {
     const element = createResource({height: 300}, 'fluid');
     element.style.maxWidth = '250px';
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      250
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(250);
   });
 
   it("should return parent's fixed width for FLUID layout", () => {
@@ -131,17 +111,13 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     parent.setAttribute('layout', 'fixed');
     doc.body.appendChild(parent);
     const element = createResource({height: 250}, 'fluid', 'amp-ad', parent);
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return the max-width, if present, for RESPONSIVE layout', () => {
     const element = createResource({height: 200, width: 200}, 'responsive');
     element.style.maxWidth = '250px';
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      250
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(250);
   });
 
   it("should return parent's fixed width for RESPONSIVE layout", () => {
@@ -155,9 +131,7 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
       'amp-ad',
       parent
     );
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return the viewport width for CONTAINER layout', () => {
@@ -165,9 +139,7 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     sandbox
       .stub(Services.viewportForDoc(element), 'getSize')
       .returns({width: 300});
-    expect(getFlexibleAdSlotRequestParams(win, element).parentWidth).to.equal(
-      300
-    );
+    expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);
   });
 
   it('should return msz=-1 for non-fixed layouts', () => {
@@ -177,9 +149,7 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
       parent.setAttribute('layout', 'fixed');
       doc.body.appendChild(parent);
       const element = createResource({height: 250}, layout, 'amp-ad', parent);
-      expect(getFlexibleAdSlotRequestParams(win, element).slotWidth).to.equal(
-        -1
-      );
+      expect(getFlexibleAdSlotData(win, element).slotWidth).to.equal(-1);
     });
   });
 
@@ -191,7 +161,7 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     for (let el = parent.parentElement; el != null; el = el.parentElement) {
       el.setAttribute('style', 'overflow: visible !important;');
     }
-    expect(getFlexibleAdSlotRequestParams(win, element).fwSignal).to.equal(0);
+    expect(getFlexibleAdSlotData(win, element).fwSignal).to.equal(0);
   });
 
   it('should have fwSignal=128 when ancestor is hidden', () => {
@@ -203,7 +173,7 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     for (let el = parent.parentElement; el != null; el = el.parentElement) {
       el.setAttribute('style', 'overflow: visible !important;');
     }
-    expect(getFlexibleAdSlotRequestParams(win, element).fwSignal).to.equal(128);
+    expect(getFlexibleAdSlotData(win, element).fwSignal).to.equal(128);
   });
 
   it('should have fwSignal=4 when ancestor has overflow hidden', () => {
@@ -215,6 +185,11 @@ describes.realWin('#getFlexibleAdSlotRequestParams', {amp: true}, env => {
     for (let el = parent.parentElement; el != null; el = el.parentElement) {
       el.setAttribute('style', 'overflow: visible !important;');
     }
-    expect(getFlexibleAdSlotRequestParams(win, element).fwSignal).to.equal(4);
+    expect(getFlexibleAdSlotData(win, element).fwSignal).to.equal(4);
+  });
+
+  it('should have parentStyle', () => {
+    const element = createResource({height: 200, width: 200}, 'fixed');
+    expect(getFlexibleAdSlotData(win, element).parentStyle).to.be.ok;
   });
 });


### PR DESCRIPTION
Flexible ad slots enable slots to expand beyond their initially set width. When this occurs, it may be required to center the creative. This helps maintain a symmetric look, and prevents the creative from exiting the viewport.