### PR TITLE
🏗 Add lint rule for unload listener

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,6 +91,7 @@
     "local/no-style-display": 2,
     "local/no-style-property-setting": 2,
     "local/no-swallow-return-from-allow-console-error": 2,
+    "local/no-unload-listener": 2,
     "local/prefer-deferred-promise": 0,
     "local/prefer-destructuring": 2,
     "local/private-prop-names": 2,

--- a/build-system/eslint-rules/no-unload-listener.js
+++ b/build-system/eslint-rules/no-unload-listener.js
@@ -22,7 +22,7 @@ module.exports = function(context) {
   const call = `${listenCall}, ${addEventListenerCall}`;
 
   const displayMessage = [
-    'Do not add an "unload" listener, which breaks the back/forward cache.',
+    'Do not add "unload" listeners because they break the back/forward cache.',
     'Use the "pagehide" event instead, and if needed check `!event.persisted`.',
   ].join('\n\t');
 

--- a/build-system/eslint-rules/no-unload-listener.js
+++ b/build-system/eslint-rules/no-unload-listener.js
@@ -38,7 +38,7 @@ module.exports = function(context) {
     [call]: function(node) {
       const {callee} = node;
       const {name} = callee;
-      const argIndex = name && name.indexOf('listen') === 0 ? 1 : 0;
+      const argIndex = name && name.lastIndexOf('listen', 0) == 0 ? 1 : 0;
       const arg = node.arguments[argIndex];
       if (!arg) {
         return;

--- a/build-system/eslint-rules/no-unload-listener.js
+++ b/build-system/eslint-rules/no-unload-listener.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function(context) {
+  const listenCall = 'CallExpression[callee.name=listen]';
+  const addEventListenerCall =
+    'CallExpression[callee.property.name=addEventListener]';
+  const call = `${listenCall}, ${addEventListenerCall}`;
+
+  const displayMessage = [
+    'Do not add an "unload" listener, which breaks the back/forward cache.',
+    'Use the "pagehide" event instead, and if needed check `!event.persisted`.',
+  ].join('\n\t');
+
+  return {
+    [call]: function(node) {
+      const {callee} = node;
+      const argIndex = callee.name === 'listen' ? 1 : 0;
+      const arg = node.arguments[argIndex];
+      if (!arg) {
+        return;
+      }
+
+      const comments = context.getCommentsBefore(arg);
+      const ok = comments.some(comment => comment.value === 'OK');
+      if (ok) {
+        return;
+      }
+
+      if (arg.type !== 'Literal' || typeof arg.value !== 'string') {
+        return;
+      }
+
+      if (arg.value === 'unload') {
+        context.report({
+          node: arg,
+          message: displayMessage,
+        });
+      }
+    },
+  };
+};

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -1505,7 +1505,7 @@ export class VisibilityTracker extends EventTracker {
     // behavior, we should not add an unload listener.
     if (!this.supportsPageHide_()) {
       win.addEventListener(
-        'unload',
+        /*OK*/ 'unload',
         (unloadListener = () => {
           win.removeEventListener('unload', unloadListener);
           deferred.resolve();

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -222,7 +222,12 @@ export class AmpViewerIntegration {
 
     viewer.setMessageDeliverer(messaging.sendRequest.bind(messaging), origin);
 
-    listenOnce(this.win, 'unload', this.handleUnload_.bind(this, messaging));
+    // TODO(#23634): Remove, explain or adjust the usage of the unload listener
+    listenOnce(
+      this.win,
+      /*OK*/ 'unload',
+      this.handleUnload_.bind(this, messaging)
+    );
 
     if (viewer.hasCapability('swipe')) {
       this.initTouchHandler_(messaging);

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -208,6 +208,7 @@ export class Performance {
       // See https://bugs.webkit.org/show_bug.cgi?id=151234
       const platform = Services.platformFor(this.win);
       if (platform.isSafari()) {
+        // TODO(#23634): Remove, explain or adjust the usage of the unload listener
         this.win.addEventListener(
           BEFORE_UNLOAD_EVENT,
           this.boundTickLayoutJankScore_


### PR DESCRIPTION
Related to #23527 

This PR will trigger a linter warning if an `unload` listener is added. This will help prevent bfcache from becoming broken unintentionally.