### PR TITLE
🐛 Add several missing `@return` type annotations across the codebase

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,6 +65,7 @@
     "jsdoc/require-param": 2,
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,
+    "jsdoc/require-returns": 2,
     "jsdoc/require-returns-type": 2,
     "local/await-expect": 2,
     "local/closure-type-primitives": 2,
@@ -173,6 +174,7 @@
         "jsdoc/require-param": 0,
         "jsdoc/require-param-name": 0,
         "jsdoc/require-param-type": 0,
+        "jsdoc/require-returns": 0,
         "jsdoc/require-returns-type": 0
       },
       "globals": {

--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -120,7 +120,10 @@ export default class GltfViewer {
     return value * max + (1 - value) * min;
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   setupSize_() {
     let oldW = null;
     let oldH = null;

--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -122,7 +122,7 @@ export default class GltfViewer {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setupSize_() {
     let oldW = null;

--- a/3p/3p.js
+++ b/3p/3p.js
@@ -39,7 +39,7 @@ let syncScriptLoads = 0;
 
 /**
  * Returns the registration map
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getRegistrations() {
   if (!registrations) {

--- a/3p/3p.js
+++ b/3p/3p.js
@@ -39,6 +39,7 @@ let syncScriptLoads = 0;
 
 /**
  * Returns the registration map
+ * @return {*} TODO: Specify return type
  */
 export function getRegistrations() {
   if (!registrations) {

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -313,8 +313,9 @@ export class AbstractAmpContext {
   }
 
   /**
-   *  Calculate the hostWindow
-   *  @private
+   * Calculate the hostWindow
+   * @private
+   * @return {!Window}
    */
   getHostWindow_() {
     const sentinelMatch = this.sentinel.match(/((\d+)-\d+)/);

--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -45,6 +45,7 @@ function addCanonicalLinkTag(global) {
 /**
  * @param {!Window} global
  * @param {!Object} data
+ * @return {?Node}
  */
 function createContainer(global, data) {
   // add canonical link tag

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -78,6 +78,7 @@ export class IframeMessagingClient {
    * @param {string} responseType The type of the response message.
    * @param {function(JsonObject)} callback The callback function to call
    *   when a message with type responseType is received.
+   * @return {function()}
    */
   makeRequest(requestType, responseType, callback) {
     const unlisten = this.registerCallback(responseType, callback);
@@ -93,6 +94,7 @@ export class IframeMessagingClient {
    * @param {string} responseType The type of the response message.
    * @param {function(Object)} callback The callback function to call
    *   when a message with type responseType is received.
+   * @return {*} TODO: Specify return type
    */
   requestOnce(requestType, responseType, callback) {
     const unlisten = this.registerCallback(responseType, event => {
@@ -111,6 +113,7 @@ export class IframeMessagingClient {
    * @param {string} messageType The type of the message.
    * @param {function(?JsonObject)} callback The callback function to call
    *   when a message with type messageType is received.
+   * @return {function()}
    */
   registerCallback(messageType, callback) {
     // NOTE : no validation done here. any callback can be register

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -94,7 +94,7 @@ export class IframeMessagingClient {
    * @param {string} responseType The type of the response message.
    * @param {function(Object)} callback The callback function to call
    *   when a message with type responseType is received.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   requestOnce(requestType, responseType, callback) {
     const unlisten = this.registerCallback(responseType, event => {

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -126,6 +126,7 @@ export function twitter(global, data) {
   /**
    * @param {string} input
    * @param {string} prefix
+   * @return {*} TODO: Specify return type
    */
   function stripPrefixCamelCase(input, prefix) {
     const stripped = input.replace(new RegExp('^' + prefix), '');
@@ -136,6 +137,7 @@ export function twitter(global, data) {
 /**
  * @param {string} tweetid
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function cleanupTweetId_(tweetid) {
   // 1)

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -126,7 +126,7 @@ export function twitter(global, data) {
   /**
    * @param {string} input
    * @param {string} prefix
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   function stripPrefixCamelCase(input, prefix) {
     const stripped = input.replace(new RegExp('^' + prefix), '');
@@ -137,7 +137,7 @@ export function twitter(global, data) {
 /**
  * @param {string} tweetid
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function cleanupTweetId_(tweetid) {
   // 1)

--- a/ads/a9.js
+++ b/ads/a9.js
@@ -107,6 +107,7 @@ export function a9(global, data) {
 
 /**
  * @param {!Object} data
+ * @return {string}
  */
 function getURL(data) {
   let url = 'https://z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US';

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -264,6 +264,7 @@ export function getA2AAncestor(win) {
  * Returns the Nth parent of the given window.
  * @param {!Window} win
  * @param {number} distance frames above us.
+ * @return {!Window}
  */
 function getNthParentWindow(win, distance) {
   let parent = win;

--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -74,7 +74,7 @@ export function capirs(global, data) {
 /**
  * @param {!Window} global
  * @param {!Object} banner
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function getWidth(global, banner) {
   let width;

--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -74,6 +74,7 @@ export function capirs(global, data) {
 /**
  * @param {!Window} global
  * @param {!Object} banner
+ * @return {*} TODO: Specify return type
  */
 function getWidth(global, banner) {
   let width;

--- a/ads/google/a4a/experiment-utils.js
+++ b/ads/google/a4a/experiment-utils.js
@@ -29,6 +29,7 @@ import {addExperimentIdToElement} from './traffic-experiments';
  * @param {!Array<string>} branches
  * @param {string} expName
  * @param {boolean=} optAddExpIdToElement
+ * @return {*} TODO: Specify return type
  */
 export function selectAndSetExperiments(
   win,
@@ -59,6 +60,7 @@ export class ExperimentUtils {
    * @param {!Element} element
    * @param {!Array<string>} selectionBranches
    * @param {string} experimentName
+   * @return {?string}
    */
   maybeSelectExperiment(win, element, selectionBranches, experimentName) {
     const experimentInfoMap = /** @type {!Object<string, !ExperimentInfo>} */ ({});

--- a/ads/google/a4a/experiment-utils.js
+++ b/ads/google/a4a/experiment-utils.js
@@ -29,7 +29,7 @@ import {addExperimentIdToElement} from './traffic-experiments';
  * @param {!Array<string>} branches
  * @param {string} expName
  * @param {boolean=} optAddExpIdToElement
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function selectAndSetExperiments(
   win,

--- a/ads/google/a4a/line-delimited-response-handler.js
+++ b/ads/google/a4a/line-delimited-response-handler.js
@@ -72,6 +72,7 @@ export function lineDelimitedStreamer(win, response, lineCallback) {
  * html unescaped.
  * @param {function(string, !Object<string, *>, boolean)} callback
  * @private
+ * @return {function(string, boolean)}
  */
 export function metaJsonCreativeGrouper(callback) {
   let first;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -628,21 +628,18 @@ export function getCsiAmpAnalyticsVariables(analyticsTrigger, a4a, qqid) {
   const ampdoc = a4a.getAmpDoc();
   const viewer = Services.viewerForDoc(ampdoc);
   const navStart = getNavigationTiming(win, 'navigationStart');
-  const vars = Object.assign(
-    {},
-    {
-      'correlator': getCorrelator(win, ampdoc),
-      'slotId': a4a.element.getAttribute('data-amp-slot-index'),
-      'viewerLastVisibleTime': viewer.getLastVisibleTime() - navStart,
-    }
-  );
+  const vars = /** @type {!JsonObject} */ ({
+    'correlator': getCorrelator(win, ampdoc),
+    'slotId': a4a.element.getAttribute('data-amp-slot-index'),
+    'viewerLastVisibleTime': viewer.getLastVisibleTime() - navStart,
+  });
   if (qqid) {
     vars['qqid'] = qqid;
   }
   if (analyticsTrigger == 'ad-render-start') {
     vars['scheduleTime'] = a4a.element.layoutScheduleTime - navStart;
   }
-  return /** @type {!JsonObject} */ (vars);
+  return vars;
 }
 
 /**

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -621,24 +621,28 @@ export function getCsiAmpAnalyticsConfig() {
  * @param {!AMP.BaseElement} a4a The A4A element.
  * @param {?string} qqid The query ID or null if the query ID has not been set
  *     yet.
+ * @return {!JsonObject}
  */
 export function getCsiAmpAnalyticsVariables(analyticsTrigger, a4a, qqid) {
   const {win} = a4a;
   const ampdoc = a4a.getAmpDoc();
   const viewer = Services.viewerForDoc(ampdoc);
   const navStart = getNavigationTiming(win, 'navigationStart');
-  const vars = {
-    'correlator': getCorrelator(win, ampdoc),
-    'slotId': a4a.element.getAttribute('data-amp-slot-index'),
-    'viewerLastVisibleTime': viewer.getLastVisibleTime() - navStart,
-  };
+  const vars = Object.assign(
+    {},
+    {
+      'correlator': getCorrelator(win, ampdoc),
+      'slotId': a4a.element.getAttribute('data-amp-slot-index'),
+      'viewerLastVisibleTime': viewer.getLastVisibleTime() - navStart,
+    }
+  );
   if (qqid) {
     vars['qqid'] = qqid;
   }
   if (analyticsTrigger == 'ad-render-start') {
     vars['scheduleTime'] = a4a.element.layoutScheduleTime - navStart;
   }
-  return vars;
+  return /** @type {!JsonObject} */ (vars);
 }
 
 /**

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1019,8 +1019,8 @@ export function updateUi(currentTime, duration) {
  * Formats an int in seconds into a string of the format X:XX:XX. Omits the
  * hour if the content is less than one hour.
  * @param {number} time
- * @visibleForTesting
  * @return {*} TODO: Specify return type
+ * @visibleForTesting
  */
 export function formatTime(time) {
   if (isNaN(time)) {
@@ -1045,8 +1045,8 @@ export function formatTime(time) {
 /**
  * Zero-pads the provided int and returns a string of length 2.
  * @param {string|number} input
- * @visibleForTesting
  * @return {*} TODO: Specify return type
+ * @visibleForTesting
  */
 export function zeroPad(input) {
   input = String(input);
@@ -1511,8 +1511,8 @@ function postMessage(data) {
 /**
  * Returns the properties we need to access for testing.
  *
- * @visibleForTesting
  * @return {*} TODO: Specify return type
+ * @visibleForTesting
  */
 export function getPropertiesForTesting() {
   return {

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1020,6 +1020,7 @@ export function updateUi(currentTime, duration) {
  * hour if the content is less than one hour.
  * @param {number} time
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function formatTime(time) {
   if (isNaN(time)) {
@@ -1045,6 +1046,7 @@ export function formatTime(time) {
  * Zero-pads the provided int and returns a string of length 2.
  * @param {string|number} input
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function zeroPad(input) {
   input = String(input);
@@ -1510,6 +1512,7 @@ function postMessage(data) {
  * Returns the properties we need to access for testing.
  *
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPropertiesForTesting() {
   return {

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1019,7 +1019,7 @@ export function updateUi(currentTime, duration) {
  * Formats an int in seconds into a string of the format X:XX:XX. Omits the
  * hour if the content is less than one hour.
  * @param {number} time
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  * @visibleForTesting
  */
 export function formatTime(time) {
@@ -1045,7 +1045,7 @@ export function formatTime(time) {
 /**
  * Zero-pads the provided int and returns a string of length 2.
  * @param {string|number} input
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  * @visibleForTesting
  */
 export function zeroPad(input) {
@@ -1511,7 +1511,7 @@ function postMessage(data) {
 /**
  * Returns the properties we need to access for testing.
  *
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  * @visibleForTesting
  */
 export function getPropertiesForTesting() {

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -103,6 +103,7 @@ export class PositionObserver {
 
   /**
    * A  method to get viewport rect
+   * @return {LayoutRectDef}
    */
   getViewportRect() {
     const {scrollingElement_: scrollingElement, win_: win} = this;

--- a/ads/nativo.js
+++ b/ads/nativo.js
@@ -89,6 +89,7 @@ export function nativo(global, data) {
     }
     /**
      * @param {*} positions
+     * @return {*} TODO: Specify return type
      */
     function getLastPositionCoordinates(positions) {
       return positions[positions.length - 1];

--- a/ads/nativo.js
+++ b/ads/nativo.js
@@ -89,7 +89,7 @@ export function nativo(global, data) {
     }
     /**
      * @param {*} positions
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     function getLastPositionCoordinates(positions) {
       return positions[positions.length - 1];

--- a/ads/runative.js
+++ b/ads/runative.js
@@ -54,6 +54,7 @@ export function runative(global, data) {
 
 /**
  * @param {!Object} data
+ * @return {*} TODO: Specify return type
  */
 function getInitData(data) {
   const initKeys = requiredParams.concat(optionsParams);
@@ -74,6 +75,7 @@ function getInitData(data) {
 
 /**
  * @param {!Window} global
+ * @return {?Node}
  */
 function getAdContainer(global) {
   const container = global.document.createElement('div');
@@ -86,10 +88,11 @@ function getAdContainer(global) {
 /**
  * @param {!Window} global
  * @param {!Object} data
+ * @return {?Node}
  */
 function getInitAdScript(global, data) {
   const scriptElement = global.document.createElement('script');
-  const initData = getInitData(data);
+  const initData = /** @type {JsonObject} */ (getInitData(data));
   const initScript = global.document.createTextNode(
     `NativeAd(${JSON.stringify(initData)});`
   );

--- a/ads/runative.js
+++ b/ads/runative.js
@@ -15,6 +15,7 @@
  */
 
 import {loadScript, validateData} from '../3p/3p';
+import {parseJson} from '../src/json';
 
 const requiredParams = ['spot'];
 const optionsParams = [
@@ -54,7 +55,7 @@ export function runative(global, data) {
 
 /**
  * @param {!Object} data
- * @return {*} TODO: Specify return type
+ * @return {JsonObject}
  */
 function getInitData(data) {
   const initKeys = requiredParams.concat(optionsParams);
@@ -70,7 +71,7 @@ function getInitData(data) {
 
   initParams['element_id'] = adContainerId;
 
-  return initParams;
+  return parseJson(initParams);
 }
 
 /**
@@ -92,7 +93,7 @@ function getAdContainer(global) {
  */
 function getInitAdScript(global, data) {
   const scriptElement = global.document.createElement('script');
-  const initData = /** @type {JsonObject} */ (getInitData(data));
+  const initData = getInitData(data);
   const initScript = global.document.createTextNode(
     `NativeAd(${JSON.stringify(initData)});`
   );

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -66,7 +66,7 @@ export function uzou(global, data) {
 /**
  * encode URI based on RFC 3986
  * @param {string} str url string
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function fixedEncodeURIComponent(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {

--- a/ads/uzou.js
+++ b/ads/uzou.js
@@ -66,6 +66,7 @@ export function uzou(global, data) {
 /**
  * encode URI based on RFC 3986
  * @param {string} str url string
+ * @return {*} TODO: Specify return type
  */
 function fixedEncodeURIComponent(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -238,6 +238,7 @@ app.get('/a4a/:bid', (req, res) => {
 
 /**
  * @param {{body: string, css: string|undefined, extensions: Array<string>|undefined, head: string|undefined, spec: string|undefined}} config
+ * @return {*} TODO: Specify return type
  */
 function composeDocument(config) {
   const {body, css, extensions, head, spec, mode} = config;

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -238,7 +238,7 @@ app.get('/a4a/:bid', (req, res) => {
 
 /**
  * @param {{body: string, css: string|undefined, extensions: Array<string>|undefined, head: string|undefined, spec: string|undefined}} config
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function composeDocument(config) {
   const {body, css, extensions, head, spec, mode} = config;

--- a/build-system/app-utils.js
+++ b/build-system/app-utils.js
@@ -20,6 +20,7 @@
  * @param {string=} hostName
  * @param {boolean=} inabox
  * @param {boolean=} storyV1
+ * @return {*} TODO: Specify return type
  */
 const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
   hostName = hostName || '';

--- a/build-system/app-utils.js
+++ b/build-system/app-utils.js
@@ -20,7 +20,7 @@
  * @param {string=} hostName
  * @param {boolean=} inabox
  * @param {boolean=} storyV1
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
   hostName = hostName || '';

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1313,6 +1313,7 @@ app.use('/shadow/', (req, res) => {
 /**
  * @param {string} ampJsVersion
  * @param {string} file
+ * @return {*} TODO: Specify return type
  */
 function addViewerIntegrationScript(ampJsVersion, file) {
   ampJsVersion = parseFloat(ampJsVersion);

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1313,7 +1313,7 @@ app.use('/shadow/', (req, res) => {
 /**
  * @param {string} ampJsVersion
  * @param {string} file
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function addViewerIntegrationScript(ampJsVersion, file) {
   ampJsVersion = parseFloat(ampJsVersion);

--- a/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
@@ -18,7 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 module.exports = function({types: t}) {
   return {

--- a/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
@@ -18,6 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
+ * @return {*} TODO: Specify return type
  */
 module.exports = function({types: t}) {
   return {

--- a/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
@@ -18,7 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 module.exports = function(babelTypes) {
   const {types: t} = babelTypes;

--- a/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
@@ -18,6 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
+ * @return {*} TODO: Specify return type
  */
 module.exports = function(babelTypes) {
   const {types: t} = babelTypes;

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -26,7 +26,7 @@ let compilerErrors = '';
  * dropping the closure compiler plugin's logging prefix and then syntax
  * highlighting the error text.
  * @param {string} message
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function formatClosureCompilerError(message) {
   const closurePluginLoggingPrefix = /^.*?gulp-google-closure-compiler.*?: /;

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -26,6 +26,7 @@ let compilerErrors = '';
  * dropping the closure compiler plugin's logging prefix and then syntax
  * highlighting the error text.
  * @param {string} message
+ * @return {*} TODO: Specify return type
  */
 function formatClosureCompilerError(message) {
   const closurePluginLoggingPrefix = /^.*?gulp-google-closure-compiler.*?: /;

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -73,6 +73,7 @@ const PATHS = [
 /**
  * We can replace full-text of standard licenses with a pre-approved shorten
  * version.
+ * @return {*} TODO: Specify return type
  */
 exports.shortenLicense = function() {
   const streams = LICENSES.map(tuple => {
@@ -86,6 +87,7 @@ exports.shortenLicense = function() {
 /**
  * Returns true if a source file has a license that needs to be shortened.
  * @param {Vinyl} file
+ * @return {*} TODO: Specify return type
  */
 exports.shouldShortenLicense = function(file) {
   return PATHS.some(path => file.path.endsWith(path));

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -73,7 +73,7 @@ const PATHS = [
 /**
  * We can replace full-text of standard licenses with a pre-approved shorten
  * version.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 exports.shortenLicense = function() {
   const streams = LICENSES.map(tuple => {
@@ -87,7 +87,7 @@ exports.shortenLicense = function() {
 /**
  * Returns true if a source file has a license that needs to be shortened.
  * @param {Vinyl} file
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 exports.shouldShortenLicense = function(file) {
   return PATHS.some(path => file.path.endsWith(path));

--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -29,6 +29,7 @@ const killSuffix = process.platform == 'win32' ? '>NUL' : '';
  * the ongoing `gulp watch | build | dist` task.
  *
  * @param {string} command
+ * @return {*} TODO: Specify return type
  */
 exports.createCtrlcHandler = function(command) {
   if (!isTravisBuild()) {

--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -29,7 +29,7 @@ const killSuffix = process.platform == 'win32' ? '>NUL' : '';
  * the ongoing `gulp watch | build | dist` task.
  *
  * @param {string} command
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 exports.createCtrlcHandler = function(command) {
   if (!isTravisBuild()) {

--- a/build-system/eslint-rules/await-expect.js
+++ b/build-system/eslint-rules/await-expect.js
@@ -22,7 +22,7 @@
  *   expect(actual).to.equal(expected);
  * Good:
  *   await expect(actual).to.equal(expected);
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/await-expect.js
+++ b/build-system/eslint-rules/await-expect.js
@@ -22,6 +22,7 @@
  *   expect(actual).to.equal(expected);
  * Good:
  *   await expect(actual).to.equal(expected);
+ * @return {*} TODO: Specify return type
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/no-deep-destructuring.js
+++ b/build-system/eslint-rules/no-deep-destructuring.js
@@ -22,6 +22,7 @@
  *   const { x: { y } } = obj.prop;
  * Good:
  *   const { y } = obj.prop.x;
+ * @return {*} TODO: Specify return type
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/no-deep-destructuring.js
+++ b/build-system/eslint-rules/no-deep-destructuring.js
@@ -22,7 +22,7 @@
  *   const { x: { y } } = obj.prop;
  * Good:
  *   const { y } = obj.prop.x;
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/private-prop-names.js
+++ b/build-system/eslint-rules/private-prop-names.js
@@ -18,7 +18,7 @@
 /**
  * Enforces naming rules for private properties.
  *
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 module.exports = function(context) {
   /**

--- a/build-system/eslint-rules/private-prop-names.js
+++ b/build-system/eslint-rules/private-prop-names.js
@@ -15,7 +15,11 @@
  */
 'use strict';
 
-/** Enforces naming rules for private properties. */
+/**
+ * Enforces naming rules for private properties.
+ *
+ * @return {*} TODO: Specify return type
+ */
 module.exports = function(context) {
   /**
    * @param {!Array<!Node>|undefined} commentLines

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -53,6 +53,7 @@ function exec(cmd, options) {
  *
  * @param {string} script
  * @param {?Object} options
+ * @return {*} TODO: Specify return type
  */
 function execScriptAsync(script, options) {
   return childProcess.spawn(shellCmd, [shellFlag, script], options);

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -53,7 +53,7 @@ function exec(cmd, options) {
  *
  * @param {string} script
  * @param {?Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function execScriptAsync(script, options) {
   return childProcess.spawn(shellCmd, [shellFlag, script], options);

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -21,7 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Runs ava tests.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function ava() {
   return gulp

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -21,6 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Runs ava tests.
+ * @return {*} TODO: Specify return type
  */
 async function ava() {
   return gulp

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -21,6 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Simple wrapper around the jest tests for custom babel plugins.
+ * @return {*} TODO: Specify return type
  */
 function babelPluginTests() {
   return gulp.src('./build-system/babel-plugins/testSetupFile.js').pipe(

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -21,7 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Simple wrapper around the jest tests for custom babel plugins.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function babelPluginTests() {
   return gulp.src('./build-system/babel-plugins/testSetupFile.js').pipe(

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -31,6 +31,7 @@ const checkerExecutable = 'npx npm-exact-versions';
 
 /**
  * Makes sure all package.json files in the repo use exact versions.
+ * @return {*} TODO: Specify return type
  */
 async function checkExactVersions() {
   let success = true;

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -31,7 +31,7 @@ const checkerExecutable = 'npx npm-exact-versions';
 
 /**
  * Makes sure all package.json files in the repo use exact versions.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function checkExactVersions() {
   let success = true;

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -19,6 +19,7 @@ const del = require('del');
 
 /**
  * Clean up the build artifacts
+ * @return {*} TODO: Specify return type
  */
 async function clean() {
   return del([

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -19,7 +19,7 @@ const del = require('del');
 
 /**
  * Clean up the build artifacts
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function clean() {
   return del([

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -111,6 +111,7 @@ function compileCss(watch, opt_compileAll) {
    * @param {string} outJs
    * @param {string} outCss
    * @param {boolean} append
+   * @return {*} TODO: Specify return type
    */
   function writeCssEntryPoint(path, outJs, outCss, append) {
     return jsifyCssAsync(`css/${path}`).then(css =>

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -111,7 +111,7 @@ function compileCss(watch, opt_compileAll) {
    * @param {string} outJs
    * @param {string} outCss
    * @param {boolean} append
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   function writeCssEntryPoint(path, outJs, outCss, append) {
     return jsifyCssAsync(`css/${path}`).then(css =>

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -276,6 +276,7 @@ function flattenGraph(entryPoints) {
  * Run Module dependency graph against the rules.
  *
  * @param {!Array<!ModuleDef>} modules
+ * @return {*} TODO: Specify return type
  */
 function runRules(modules) {
   let errorsFound = false;
@@ -337,6 +338,7 @@ function toArrayOrDefault(value, defaultValue) {
  * Flatten array of arrays.
  *
  * @param {!Array<!Array>} arr
+ * @return {*} TODO: Specify return type
  */
 function flatten(arr) {
   return [].concat.apply([], arr);

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -276,7 +276,7 @@ function flattenGraph(entryPoints) {
  * Run Module dependency graph against the rules.
  *
  * @param {!Array<!ModuleDef>} modules
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function runRules(modules) {
   let errorsFound = false;
@@ -338,7 +338,7 @@ function toArrayOrDefault(value, defaultValue) {
  * Flatten array of arrays.
  *
  * @param {!Array<!Array>} arr
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function flatten(arr) {
   return [].concat.apply([], arr);

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -22,7 +22,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Run all the dev dashboard tests
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function devDashboardTests() {
   const mocha = new Mocha({reporter: isTravisBuild() ? 'dot' : 'spec'});

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -22,6 +22,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Run all the dev dashboard tests
+ * @return {*} TODO: Specify return type
  */
 async function devDashboardTests() {
   const mocha = new Mocha({reporter: isTravisBuild() ? 'dot' : 'spec'});

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -175,6 +175,7 @@ async function dist() {
  * Build AMP experiments.js.
  *
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildExperiments(options) {
   return compileJs(
@@ -195,6 +196,7 @@ function buildExperiments(options) {
  *
  * @param {string} version
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildLoginDone(version, options) {
   const buildDir = `build/all/amp-access-${version}/`;
@@ -218,6 +220,7 @@ function buildLoginDone(version, options) {
  * Build amp-web-push publisher files HTML page.
  *
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildWebPushPublisherFiles(options) {
   const distDir = 'dist/v0';
@@ -352,6 +355,7 @@ function postBuildWebPushPublisherFilesVersion() {
 
 /**
  * Precompilation steps required to build experiment js binaries.
+ * @return {*} TODO: Specify return type
  */
 async function preBuildExperiments() {
   const path = 'tools/experiments';

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -175,7 +175,7 @@ async function dist() {
  * Build AMP experiments.js.
  *
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildExperiments(options) {
   return compileJs(
@@ -196,7 +196,7 @@ function buildExperiments(options) {
  *
  * @param {string} version
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildLoginDone(version, options) {
   const buildDir = `build/all/amp-access-${version}/`;
@@ -220,7 +220,7 @@ function buildLoginDone(version, options) {
  * Build amp-web-push publisher files HTML page.
  *
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildWebPushPublisherFiles(options) {
   const distDir = 'dist/v0';
@@ -355,7 +355,7 @@ function postBuildWebPushPublisherFilesVersion() {
 
 /**
  * Precompilation steps required to build experiment js binaries.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function preBuildExperiments() {
   const path = 'tools/experiments';

--- a/build-system/tasks/e2e/controller-promise.js
+++ b/build-system/tasks/e2e/controller-promise.js
@@ -82,8 +82,8 @@ class ControllerPromise {
  * the inner opt_mutate function.
  * @param {function(TYPE,function(TYPE): ?TYPE): !Promise=} wait
  * @param {function(TYPE): TYPE} mutate
- * @template TYPE
  * @return {*} TODO: Specify return type
+ * @template TYPE
  */
 function wrapWait(wait, mutate) {
   return (condition, opt_mutate) => {

--- a/build-system/tasks/e2e/controller-promise.js
+++ b/build-system/tasks/e2e/controller-promise.js
@@ -82,7 +82,7 @@ class ControllerPromise {
  * the inner opt_mutate function.
  * @param {function(TYPE,function(TYPE): ?TYPE): !Promise=} wait
  * @param {function(TYPE): TYPE} mutate
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  * @template TYPE
  */
 function wrapWait(wait, mutate) {

--- a/build-system/tasks/e2e/controller-promise.js
+++ b/build-system/tasks/e2e/controller-promise.js
@@ -83,6 +83,7 @@ class ControllerPromise {
  * @param {function(TYPE,function(TYPE): ?TYPE): !Promise=} wait
  * @param {function(TYPE): TYPE} mutate
  * @template TYPE
+ * @return {*} TODO: Specify return type
  */
 function wrapWait(wait, mutate) {
   return (condition, opt_mutate) => {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -109,7 +109,7 @@ function getConfig() {
 /**
  * Configure and launch a Puppeteer instance
  * @param {!PuppeteerConfigDef=} opt_config
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function createPuppeteer(opt_config = {}) {
   const browser = await puppeteer.launch({
@@ -263,7 +263,7 @@ class ItConfig {
  * that also sets up the provided fixtures and returns the corresponding
  * environment objects of each fixture to the test method.
  * @param {function(!Object):!Array<?Fixture>} factory
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function describeEnv(factory) {
   /**
@@ -271,7 +271,7 @@ function describeEnv(factory) {
    * @param {!Object} spec
    * @param {function(!Object)} fn
    * @param {function(string, function())} describeFunc
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   const templateFunc = function(suiteName, spec, fn, describeFunc) {
     const fixture = factory(spec);
@@ -377,7 +377,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   const mainFunc = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe);
@@ -387,7 +387,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   mainFunc.only = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe./*OK*/ only);
@@ -446,7 +446,7 @@ class EndToEndFixture {
  * Get the controller object for the configured engine.
  * @param {!DescribesConfigDef} describesConfig
  * @param {string} browserName
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function getController(
   {engine = 'selenium', headless = false},

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -109,6 +109,7 @@ function getConfig() {
 /**
  * Configure and launch a Puppeteer instance
  * @param {!PuppeteerConfigDef=} opt_config
+ * @return {*} TODO: Specify return type
  */
 async function createPuppeteer(opt_config = {}) {
   const browser = await puppeteer.launch({
@@ -262,6 +263,7 @@ class ItConfig {
  * that also sets up the provided fixtures and returns the corresponding
  * environment objects of each fixture to the test method.
  * @param {function(!Object):!Array<?Fixture>} factory
+ * @return {*} TODO: Specify return type
  */
 function describeEnv(factory) {
   /**
@@ -269,6 +271,7 @@ function describeEnv(factory) {
    * @param {!Object} spec
    * @param {function(!Object)} fn
    * @param {function(string, function())} describeFunc
+   * @return {*} TODO: Specify return type
    */
   const templateFunc = function(suiteName, spec, fn, describeFunc) {
     const fixture = factory(spec);
@@ -374,6 +377,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
+   * @return {*} TODO: Specify return type
    */
   const mainFunc = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe);
@@ -383,6 +387,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
+   * @return {*} TODO: Specify return type
    */
   mainFunc.only = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe./*OK*/ only);
@@ -441,6 +446,7 @@ class EndToEndFixture {
  * Get the controller object for the configured engine.
  * @param {!DescribesConfigDef} describesConfig
  * @param {string} browserName
+ * @return {*} TODO: Specify return type
  */
 async function getController(
   {engine = 'selenium', headless = false},

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -44,7 +44,7 @@ function installRepl(global, env) {
   /**
    * Usage: in a test, await repl();
    * @param {*} mochaThis
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   global.repl = function(mochaThis) {
     mochaThis.timeout(REPL_INFINITE_TIMEOUT);

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -44,6 +44,7 @@ function installRepl(global, env) {
   /**
    * Usage: in a test, await repl();
    * @param {*} mochaThis
+   * @return {*} TODO: Specify return type
    */
   global.repl = function(mochaThis) {
     mochaThis.timeout(REPL_INFINITE_TIMEOUT);

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -404,6 +404,7 @@ function buildExtension(
  * @param {string} name
  * @param {string} version
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildExtensionCss(path, name, version, options) {
   /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -404,7 +404,7 @@ function buildExtension(
  * @param {string} name
  * @param {string} version
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildExtensionCss(path, name, version, options) {
   /**

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -103,7 +103,7 @@ function writeGeneratedAtCommitFile(runnerJarDir) {
  * given subdirectory of build-system/runner/dist/ (to enable concurrent usage)
  * @param {string} subDir
  *
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function generateRunner(subDir) {
   const generateCmd = `${antExecutable} -buildfile ${buildFile} -Ddist.dir dist/${subDir} jar`;

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -103,6 +103,7 @@ function writeGeneratedAtCommitFile(runnerJarDir) {
  * given subdirectory of build-system/runner/dist/ (to enable concurrent usage)
  * @param {string} subDir
  *
+ * @return {*} TODO: Specify return type
  */
 async function generateRunner(subDir) {
   const generateCmd = `${antExecutable} -buildfile ${buildFile} -Ddist.dir dist/${subDir} jar`;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -97,6 +97,7 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
  * Compile all runtime targets in minified mode and drop them in dist/.
+ * @return {*} TODO: Specify return type
  */
 function compileAllMinifiedTargets() {
   if (isTravisBuild()) {
@@ -108,6 +109,7 @@ function compileAllMinifiedTargets() {
 /**
  * Compile all runtime targets in unminified mode and drop them in dist/.
  * @param {boolean} watch
+ * @return {*} TODO: Specify return type
  */
 function compileAllUnminifiedTargets(watch) {
   if (isTravisBuild()) {
@@ -609,6 +611,7 @@ function printNobuildHelp() {
  * Enables runtime to be used for local testing by writing AMP_CONFIG to file.
  * Called at the end of "gulp build" and "gulp dist --fortesting".
  * @param {string} targetFile File to which the config is to be written.
+ * @return {*} TODO: Specify return type
  */
 async function enableLocalTesting(targetFile) {
   const config = argv.config === 'canary' ? 'canary' : 'prod';
@@ -695,6 +698,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  * Build ALP JS.
  *
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildAlp(options) {
   options = options || {};
@@ -711,6 +715,7 @@ function buildAlp(options) {
  * Build Examiner JS.
  *
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildExaminer(options) {
   return compileJs('./src/examiner/', 'examiner.js', './dist/', {
@@ -726,6 +731,7 @@ function buildExaminer(options) {
  * Build web worker JS.
  *
  * @param {!Object} options
+ * @return {*} TODO: Specify return type
  */
 function buildWebWorker(options) {
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -97,7 +97,7 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
  * Compile all runtime targets in minified mode and drop them in dist/.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function compileAllMinifiedTargets() {
   if (isTravisBuild()) {
@@ -109,7 +109,7 @@ function compileAllMinifiedTargets() {
 /**
  * Compile all runtime targets in unminified mode and drop them in dist/.
  * @param {boolean} watch
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function compileAllUnminifiedTargets(watch) {
   if (isTravisBuild()) {
@@ -611,7 +611,7 @@ function printNobuildHelp() {
  * Enables runtime to be used for local testing by writing AMP_CONFIG to file.
  * Called at the end of "gulp build" and "gulp dist --fortesting".
  * @param {string} targetFile File to which the config is to be written.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function enableLocalTesting(targetFile) {
   const config = argv.config === 'canary' ? 'canary' : 'prod';
@@ -698,7 +698,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  * Build ALP JS.
  *
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildAlp(options) {
   options = options || {};
@@ -715,7 +715,7 @@ function buildAlp(options) {
  * Build Examiner JS.
  *
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildExaminer(options) {
   return compileJs('./src/examiner/', 'examiner.js', './dist/', {
@@ -731,7 +731,7 @@ function buildExaminer(options) {
  * Build web worker JS.
  *
  * @param {!Object} options
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildWebWorker(options) {
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -25,7 +25,7 @@ const expectedCaches = ['cloudflare', 'google'];
 
 /**
  * Fail if caches.json is missing some expected caches.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function cachesJson() {
   return gulp.src(['caches.json']).pipe(
@@ -61,7 +61,7 @@ async function cachesJson() {
 
 /**
  * Fail if JSON files are valid.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function jsonSyntax() {
   let hasError = false;

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -25,6 +25,7 @@ const expectedCaches = ['cloudflare', 'google'];
 
 /**
  * Fail if caches.json is missing some expected caches.
+ * @return {*} TODO: Specify return type
  */
 async function cachesJson() {
   return gulp.src(['caches.json']).pipe(
@@ -60,6 +61,7 @@ async function cachesJson() {
 
 /**
  * Fail if JSON files are valid.
+ * @return {*} TODO: Specify return type
  */
 async function jsonSyntax() {
   let hasError = false;

--- a/build-system/tasks/nailgun.js
+++ b/build-system/tasks/nailgun.js
@@ -38,7 +38,7 @@ const NAILGUN_STARTUP_TIMEOUT_MS = 5 * 1000;
 
 /**
  * Replaces the default compiler binary with nailgun on linux and macos
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function maybeReplaceDefaultCompiler() {
   if (process.platform == 'darwin') {

--- a/build-system/tasks/nailgun.js
+++ b/build-system/tasks/nailgun.js
@@ -38,6 +38,7 @@ const NAILGUN_STARTUP_TIMEOUT_MS = 5 * 1000;
 
 /**
  * Replaces the default compiler binary with nailgun on linux and macos
+ * @return {*} TODO: Specify return type
  */
 function maybeReplaceDefaultCompiler() {
   if (process.platform == 'darwin') {

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1029,7 +1029,7 @@ function isInBuildSystemFixtureFolder(filePath) {
 /**
  * Strip Comments
  * @param {string} contents
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function stripComments(contents) {
   // Multi-line comments
@@ -1207,7 +1207,7 @@ function isMissingTerms(file) {
 /**
  * Check a file for all the required terms and
  * any forbidden terms and log any errors found.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function presubmit() {
   let forbiddenFound = false;

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1029,6 +1029,7 @@ function isInBuildSystemFixtureFolder(filePath) {
 /**
  * Strip Comments
  * @param {string} contents
+ * @return {*} TODO: Specify return type
  */
 function stripComments(contents) {
   // Multi-line comments
@@ -1206,6 +1207,7 @@ function isMissingTerms(file) {
 /**
  * Check a file for all the required terms and
  * any forbidden terms and log any errors found.
+ * @return {*} TODO: Specify return type
  */
 function presubmit() {
   let forbiddenFound = false;

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -105,6 +105,7 @@ const NUM_BATCHES = 14;
 
 /**
  * Calculate the reviewer this week, based on rotation calendar
+ * @return {*} TODO: Specify return type
  */
 function calculateReviewer() {
   const now = Date.now();
@@ -116,6 +117,7 @@ function calculateReviewer() {
 
 /**
  * Main function for auto triaging
+ * @return {*} TODO: Specify return type
  */
 function process3pGithubPr() {
   if (!GITHUB_ACCESS_TOKEN) {
@@ -186,6 +188,7 @@ function getIssues(opt_page) {
 /**
  * API call to get all changed files of a pull request.
  * @param {!Object} pr
+ * @return {*} TODO: Specify return type
  */
 function getPullRequestFiles(pr) {
   const options = extend({}, defaultOption);
@@ -205,6 +208,7 @@ function getPullRequestFiles(pr) {
 /**
  * Determine the type of a give pull request
  * @param {?Array<!Object>} files
+ * @return {*} TODO: Specify return type
  */
 function analyzeChangedFiles(files) {
   if (!files) {
@@ -237,6 +241,7 @@ function analyzeChangedFiles(files) {
 /**
  * Determine if we need to reply to an issue
  * @param {!Object} issue
+ * @return {*} TODO: Specify return type
  */
 function isQualifiedPR(issue) {
   // All issues are opened has no assignee
@@ -262,6 +267,7 @@ function isQualifiedPR(issue) {
  * Auto reply
  * @param {!Object} pr
  * @param {ANALYZE_OUTCOME} outcome
+ * @return {*} TODO: Specify return type
  */
 function replyToPR(pr, outcome) {
   let promise = Promise.resolve();
@@ -284,6 +290,7 @@ function replyToPR(pr, outcome) {
  * API call to comment on a give issue.
  * @param {!Object} issue
  * @param {string} comment
+ * @return {*} TODO: Specify return type
  */
 function applyComment(issue, comment) {
   const {number} = issue;
@@ -310,6 +317,7 @@ function applyComment(issue, comment) {
  * API call to assign an issue with a list of assignees
  * @param {!Object} issue
  * @param {!Array<string>} assignees
+ * @return {*} TODO: Specify return type
  */
 function assignIssue(issue, assignees) {
   const {number} = issue;

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -105,7 +105,7 @@ const NUM_BATCHES = 14;
 
 /**
  * Calculate the reviewer this week, based on rotation calendar
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function calculateReviewer() {
   const now = Date.now();
@@ -117,7 +117,7 @@ function calculateReviewer() {
 
 /**
  * Main function for auto triaging
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function process3pGithubPr() {
   if (!GITHUB_ACCESS_TOKEN) {
@@ -188,7 +188,7 @@ function getIssues(opt_page) {
 /**
  * API call to get all changed files of a pull request.
  * @param {!Object} pr
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function getPullRequestFiles(pr) {
   const options = extend({}, defaultOption);
@@ -208,7 +208,7 @@ function getPullRequestFiles(pr) {
 /**
  * Determine the type of a give pull request
  * @param {?Array<!Object>} files
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function analyzeChangedFiles(files) {
   if (!files) {
@@ -241,7 +241,7 @@ function analyzeChangedFiles(files) {
 /**
  * Determine if we need to reply to an issue
  * @param {!Object} issue
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function isQualifiedPR(issue) {
   // All issues are opened has no assignee
@@ -267,7 +267,7 @@ function isQualifiedPR(issue) {
  * Auto reply
  * @param {!Object} pr
  * @param {ANALYZE_OUTCOME} outcome
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function replyToPR(pr, outcome) {
   let promise = Promise.resolve();
@@ -290,7 +290,7 @@ function replyToPR(pr, outcome) {
  * API call to comment on a give issue.
  * @param {!Object} issue
  * @param {string} comment
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function applyComment(issue, comment) {
   const {number} = issue;
@@ -317,7 +317,7 @@ function applyComment(issue, comment) {
  * API call to assign an issue with a list of assignees
  * @param {!Object} issue
  * @param {!Array<string>} assignees
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function assignIssue(issue, assignees) {
   const {number} = issue;

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -112,6 +112,7 @@ function getIssues(opt_page) {
  * gets all the Labels we are interested in,
  * depending if missing milestone or label,
  * tasks applied as per design go/ampgithubautomation
+ * @return {*} TODO: Specify return type
  */
 function updateGitHubIssues() {
   let promise = Promise.resolve();

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -112,7 +112,7 @@ function getIssues(opt_page) {
  * gets all the Labels we are interested in,
  * depending if missing milestone or label,
  * tasks applied as per design go/ampgithubautomation
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function updateGitHubIssues() {
   let promise = Promise.resolve();

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -118,7 +118,7 @@ function githubRequest(path, opt_method, opt_data) {
 
 /**
  * todos:find-closed task.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function todosFindClosed() {
   let foundCount = 0;

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -118,6 +118,7 @@ function githubRequest(path, opt_method, opt_data) {
 
 /**
  * todos:find-closed task.
+ * @return {*} TODO: Specify return type
  */
 function todosFindClosed() {
   let foundCount = 0;

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -39,7 +39,7 @@ const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
  * Escapes a string of HTML elements to HTML entities.
  *
  * @param {string} html HTML as string to escape.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function escapeHtml(html) {
   return html.replace(HTML_ESCAPE_REGEX, c => HTML_ESCAPE_CHARS[c]);

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -39,6 +39,7 @@ const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
  * Escapes a string of HTML elements to HTML entities.
  *
  * @param {string} html HTML as string to escape.
+ * @return {*} TODO: Specify return type
  */
 function escapeHtml(html) {
   return html.replace(HTML_ESCAPE_REGEX, c => HTML_ESCAPE_CHARS[c]);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -223,7 +223,7 @@ async function launchBrowser() {
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
  * @param {JsonObject} viewport optional viewport size object with numeric
  *     fields `width` and `height`.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function newPage(browser, viewport = null) {
   log('verbose', 'Creating new tab');
@@ -763,7 +763,7 @@ async function createEmptyBuild() {
 
 /**
  * Runs the AMP visual diff tests.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 async function visualDiff() {
   ensureOrBuildAmpRuntimeInTestMode_();

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -223,6 +223,7 @@ async function launchBrowser() {
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
  * @param {JsonObject} viewport optional viewport size object with numeric
  *     fields `width` and `height`.
+ * @return {*} TODO: Specify return type
  */
 async function newPage(browser, viewport = null) {
   log('verbose', 'Creating new tab');
@@ -762,6 +763,7 @@ async function createEmptyBuild() {
 
 /**
  * Runs the AMP visual diff tests.
+ * @return {*} TODO: Specify return type
  */
 async function visualDiff() {
   ensureOrBuildAmpRuntimeInTestMode_();

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -210,8 +210,8 @@ export class AmpImg extends BaseElement {
 
   /**
    * @param {number} newWidth
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   shouldSetSizes_(newWidth) {
     if (!this.img_.hasAttribute('sizes')) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -211,6 +211,7 @@ export class AmpImg extends BaseElement {
   /**
    * @param {number} newWidth
    * @private
+   * @return {*} TODO: Specify return type
    */
   shouldSetSizes_(newWidth) {
     if (!this.img_.hasAttribute('sizes')) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -210,7 +210,7 @@ export class AmpImg extends BaseElement {
 
   /**
    * @param {number} newWidth
-   * @return {*} TODO: Specify return type
+   * @return {boolean}
    * @private
    */
   shouldSetSizes_(newWidth) {

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -71,7 +71,7 @@ export class AmpPixel extends BaseElement {
 
   /**
    * Triggers the signal.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   trigger_() {

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -72,6 +72,7 @@ export class AmpPixel extends BaseElement {
   /**
    * Triggers the signal.
    * @private
+   * @return {*} TODO: Specify return type
    */
   trigger_() {
     if (this.triggerPromise_) {

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -71,8 +71,8 @@ export class AmpPixel extends BaseElement {
 
   /**
    * Triggers the signal.
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   trigger_() {
     if (this.triggerPromise_) {

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -153,10 +153,13 @@ export class Amp3dGltf extends AMP.BaseElement {
     return this.willBeLoaded_.promise;
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {?Function}
+   */
   listenGltfViewerMessages_() {
     if (!this.iframe_) {
-      return;
+      return null;
     }
 
     const listenIframe = (evName, cb) =>

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -16,7 +16,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {Deferred} from '../../../src/utils/promise';
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -146,7 +146,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
     this.applyFillContent(iframe, true);
     this.iframe_ = iframe;
-    this.unlistenMessage_ = this.listenGltfViewerMessages_();
+    this.unlistenMessage_ = devAssert(this.listenGltfViewerMessages_());
 
     this.element.appendChild(this.iframe_);
 
@@ -155,11 +155,11 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {?Function}
+   * @return {Function|undefined}
    */
   listenGltfViewerMessages_() {
     if (!this.iframe_) {
-      return null;
+      return;
     }
 
     const listenIframe = (evName, cb) =>

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -155,7 +155,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {Function|undefined}
+   * @return {function()|undefined}
    */
   listenGltfViewerMessages_() {
     if (!this.iframe_) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1629,6 +1629,7 @@ export class AmpA4A extends AMP.BaseElement {
    * call render-start, rather than triggering it itself. Example use case
    * is that amp-sticky-ad should trigger render-start itself so that the
    * sticky container isn't shown before an ad is ready.
+   * @return {boolean}
    */
   letCreativeTriggerRenderStart() {
     return false;
@@ -1924,6 +1925,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /**
    * @param {string=} headerValue Method as given in header.
+   * @return {?XORIGIN_MODE}
    */
   getNonAmpCreativeRenderingMethod(headerValue) {
     if (headerValue) {
@@ -1933,7 +1935,7 @@ export class AmpA4A extends AMP.BaseElement {
           `cross-origin render mode header ${headerValue}`
         );
       } else {
-        return headerValue;
+        return /** @type {XORIGIN_MODE} */ (headerValue);
       }
     }
     return Services.platformFor(this.win).isIos()

--- a/extensions/amp-a4a/0.1/cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/cryptographic-validator.js
@@ -27,7 +27,10 @@ export const SIGNATURE_VERIFIER_PROPERTY_NAME =
 const TAG = 'amp-ad-cryptographic-validator';
 
 export class CryptographicValidator extends Validator {
-  /** @param {!Window} win */
+  /**
+   * @param {!Window} win
+   * @return {*} TODO: Specify return type
+   */
   getSignatureVerifier_(win) {
     // TODO(levitzky) extract this into a service registered to ampdoc.
     return (

--- a/extensions/amp-a4a/0.1/cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/cryptographic-validator.js
@@ -29,7 +29,7 @@ const TAG = 'amp-ad-cryptographic-validator';
 export class CryptographicValidator extends Validator {
   /**
    * @param {!Window} win
-   * @return {*} TODO: Specify return type
+   * @return {!SignatureVerifier}
    */
   getSignatureVerifier_(win) {
     // TODO(levitzky) extract this into a service registered to ampdoc.

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -270,6 +270,7 @@ export class RealTimeConfigManager {
    * Assigns constant macros that should exist for all RTC to object of custom
    * per-network macros.
    * @param {!Object<string, !../../../src/service/variable-source.AsyncResolverDef>} macros
+   * @return {!Object<string, !../../../src/service/variable-source.AsyncResolverDef>}
    */
   assignMacros(macros) {
     macros['TIMEOUT'] = () => this.rtcConfig_.timeoutMillis;
@@ -369,6 +370,7 @@ export class RealTimeConfigManager {
      * async call. Thus, however long the URL replacement took is treated as a
      * time penalty.
      * @param {string} url
+     * @return {*} TODO: Specify return type
      */
     const send = url => {
       if (Object.keys(this.seenUrls_).length == MAX_RTC_CALLOUTS) {

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -370,7 +370,7 @@ export class RealTimeConfigManager {
      * async call. Thus, however long the URL replacement took is treated as a
      * time penalty.
      * @param {string} url
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     const send = url => {
       if (Object.keys(this.seenUrls_).length == MAX_RTC_CALLOUTS) {

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -22,7 +22,7 @@ AMP.extension('amp-access-laterpay', '0.1', function(AMP) {
     'laterpay',
     /**
      * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -20,7 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
     'laterpay',
-    /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    /**
+     * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     * @return {*} TODO: Specify return type
+     */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();
       return Services.accessServiceForDoc(element).then(accessService => {

--- a/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
@@ -22,7 +22,7 @@ AMP.extension('amp-access-laterpay', '0.2', function(AMP) {
     'laterpay',
     /**
      * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();

--- a/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/amp-access-laterpay.js
@@ -20,7 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.2', function(AMP) {
   AMP.registerServiceForDoc(
     'laterpay',
-    /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    /**
+     * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     * @return {*} TODO: Specify return type
+     */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();
       return Services.accessServiceForDoc(element).then(accessService => {

--- a/extensions/amp-access-poool/0.1/amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/amp-access-poool.js
@@ -22,7 +22,7 @@ AMP.extension('amp-access-poool', '0.1', function(AMP) {
     'poool',
     /**
      * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();

--- a/extensions/amp-access-poool/0.1/amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/amp-access-poool.js
@@ -20,7 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-poool', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
     'poool',
-    /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    /**
+     * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     * @return {*} TODO: Specify return type
+     */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();
       return Services.accessServiceForDoc(element).then(accessService => {

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.js
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.js
@@ -22,7 +22,7 @@ AMP.extension('amp-access-scroll', '0.1', function(AMP) {
     'scroll',
     /**
      * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.js
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.js
@@ -20,7 +20,10 @@ import {Services} from '../../../src/services';
 AMP.extension('amp-access-scroll', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
     'scroll',
-    /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    /**
+     * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     * @return {*} TODO: Specify return type
+     */
     function(ampdoc) {
       const element = ampdoc.getHeadNode();
       return Services.accessServiceForDoc(element).then(accessService => {

--- a/extensions/amp-access-scroll/0.1/read-depth-tracker.js
+++ b/extensions/amp-access-scroll/0.1/read-depth-tracker.js
@@ -56,8 +56,8 @@ export class ReadDepthTracker {
 
   /**
    * Reviews positions of each paragraph relative to vieport, finds top.
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   findTopParagraph_() {
     return Promise.all(

--- a/extensions/amp-access-scroll/0.1/read-depth-tracker.js
+++ b/extensions/amp-access-scroll/0.1/read-depth-tracker.js
@@ -56,7 +56,7 @@ export class ReadDepthTracker {
 
   /**
    * Reviews positions of each paragraph relative to vieport, finds top.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   findTopParagraph_() {

--- a/extensions/amp-access-scroll/0.1/read-depth-tracker.js
+++ b/extensions/amp-access-scroll/0.1/read-depth-tracker.js
@@ -57,6 +57,7 @@ export class ReadDepthTracker {
   /**
    * Reviews positions of each paragraph relative to vieport, finds top.
    * @private
+   * @return {*} TODO: Specify return type
    */
   findTopParagraph_() {
     return Promise.all(

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -771,7 +771,10 @@ AMP.extension(TAG, '0.1', function(AMP) {
   });
 });
 
-/** @package Visible for testing only. */
+/**
+ * @package Visible for testing only.
+ * @return {*} TODO: Specify return type
+ */
 export function getAccessVarsClassForTesting() {
   return AccessVars;
 }

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -773,7 +773,7 @@ AMP.extension(TAG, '0.1', function(AMP) {
 
 /**
  * @package Visible for testing only.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getAccessVarsClassForTesting() {
   return AccessVars;

--- a/extensions/amp-access/0.1/iframe-api/iframe-api.js
+++ b/extensions/amp-access/0.1/iframe-api/iframe-api.js
@@ -68,7 +68,7 @@ export class AmpAccessIframeApi {
   }
 
   /**
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   connect() {
     this.messenger_.connect(this.handleCommand_.bind(this));
@@ -127,7 +127,7 @@ export class AmpAccessIframeApi {
 
 /**
  * @package Visible for testing.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getAccessControllerForTesting() {
   return AccessController;

--- a/extensions/amp-access/0.1/iframe-api/iframe-api.js
+++ b/extensions/amp-access/0.1/iframe-api/iframe-api.js
@@ -68,6 +68,7 @@ export class AmpAccessIframeApi {
   }
 
   /**
+   * @return {*} TODO: Specify return type
    */
   connect() {
     this.messenger_.connect(this.handleCommand_.bind(this));
@@ -124,7 +125,10 @@ export class AmpAccessIframeApi {
   }
 }
 
-/** @package Visible for testing. */
+/**
+ * @package Visible for testing.
+ * @return {*} TODO: Specify return type
+ */
 export function getAccessControllerForTesting() {
   return AccessController;
 }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -312,11 +312,13 @@ export class AmpAdExit extends AMP.BaseElement {
         this.defaultFilters_.splice(
           0,
           1,
-          /** @type {!./filters/filter.Filter} */ (createFilter(
-            'minDelay',
-            makeClickDelaySpec(1000, config['options']['startTimingEvent']),
-            this
-          ))
+          devAssert(
+            createFilter(
+              'minDelay',
+              makeClickDelaySpec(1000, config['options']['startTimingEvent']),
+              this
+            )
+          )
         );
       }
       for (const name in config['filters']) {

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -312,11 +312,11 @@ export class AmpAdExit extends AMP.BaseElement {
         this.defaultFilters_.splice(
           0,
           1,
-          createFilter(
+          /** @type {!./filters/filter.Filter} */ (createFilter(
             'minDelay',
             makeClickDelaySpec(1000, config['options']['startTimingEvent']),
             this
-          )
+          ))
         );
       }
       for (const name in config['filters']) {

--- a/extensions/amp-ad-exit/0.1/filters/factory.js
+++ b/extensions/amp-ad-exit/0.1/filters/factory.js
@@ -23,6 +23,7 @@ import {InactiveElementFilter} from './inactive-element';
  * @param {string} name
  * @param {!../config.FilterConfig} spec
  * @param {!../amp-ad-exit.AmpAdExit} adExitInstance
+ * @return {!./filter.Filter|undefined}
  */
 export function createFilter(name, spec, adExitInstance) {
   switch (spec.type) {

--- a/extensions/amp-ad-exit/0.1/filters/inactive-element.js
+++ b/extensions/amp-ad-exit/0.1/filters/inactive-element.js
@@ -54,6 +54,7 @@ function isValidInactiveElementSpec(spec) {
 
 /**
  * @param {string} selector A CSS selector matching elements to ignore.
+ * @return {!../config.ClickLocationConfig}
  */
 export function makeInactiveElementSpec(selector) {
   return {type: FilterType.INACTIVE_ELEMENT, selector};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -687,6 +687,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * category exclusions.
    * @param {?Array<!rtcResponseDef>} rtcResponseArray
    * @private
+   * @return {?Object|undefined}
    */
   mergeRtcResponses_(rtcResponseArray) {
     if (!rtcResponseArray) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -686,8 +686,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * Merges all of the rtcResponses into the JSON targeting and
    * category exclusions.
    * @param {?Array<!rtcResponseDef>} rtcResponseArray
-   * @private
    * @return {?Object|undefined}
+   * @private
    */
   mergeRtcResponses_(rtcResponseArray) {
     if (!rtcResponseArray) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -600,6 +600,7 @@ export class SafeframeHostApi {
    * @param {number} width In pixels.
    * @param {string} messageType
    * @param {boolean=} optIsCollapse Whether this is a collapse attempt.
+   * @return {*} TODO: Specify return type
    */
   handleSizeChange(height, width, messageType, optIsCollapse) {
     return this.viewport_

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -600,7 +600,7 @@ export class SafeframeHostApi {
    * @param {number} width In pixels.
    * @param {string} messageType
    * @param {boolean=} optIsCollapse Whether this is a collapse attempt.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   handleSizeChange(height, width, messageType, optIsCollapse) {
     return this.viewport_

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -61,7 +61,7 @@ export class AmpAdUIHandler {
   /**
    * Create a default placeholder if not provided.
    * Should be called in baseElement createPlaceholderCallback.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   createPlaceholder() {
     return this.addDefaultUiComponent_('placeholder');

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -61,6 +61,7 @@ export class AmpAdUIHandler {
   /**
    * Create a default placeholder if not provided.
    * Should be called in baseElement createPlaceholderCallback.
+   * @return {*} TODO: Specify return type
    */
   createPlaceholder() {
     return this.addDefaultUiComponent_('placeholder');

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -498,8 +498,8 @@ export class AmpAdXOriginIframeHandler {
 
   /**
    * Retrieve iframe position entry in next animation frame.
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   getIframePositionPromise_() {
     return this.viewport_

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -498,7 +498,7 @@ export class AmpAdXOriginIframeHandler {
 
   /**
    * Retrieve iframe position entry in next animation frame.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   getIframePositionPromise_() {

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -499,6 +499,7 @@ export class AmpAdXOriginIframeHandler {
   /**
    * Retrieve iframe position entry in next animation frame.
    * @private
+   * @return {*} TODO: Specify return type
    */
   getIframePositionPromise_() {
     return this.viewport_

--- a/extensions/amp-addthis/0.1/addthis-utils/rot13.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/rot13.js
@@ -23,8 +23,8 @@ const CHAR_Z_UPPER = 90;
  * For "good enough" obfuscation.
  *
  * @param {string} input
- * @private
  * @return {*} TODO: Specify return type
+ * @private
  */
 const rot13 = input => {
   return input.replace(RE_ALPHA, match => {

--- a/extensions/amp-addthis/0.1/addthis-utils/rot13.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/rot13.js
@@ -24,6 +24,7 @@ const CHAR_Z_UPPER = 90;
  *
  * @param {string} input
  * @private
+ * @return {*} TODO: Specify return type
  */
 const rot13 = input => {
   return input.replace(RE_ALPHA, match => {

--- a/extensions/amp-addthis/0.1/addthis-utils/rot13.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/rot13.js
@@ -23,7 +23,7 @@ const CHAR_Z_UPPER = 90;
  * For "good enough" obfuscation.
  *
  * @param {string} input
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  * @private
  */
 const rot13 = input => {

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -88,6 +88,7 @@ let shouldRegisterView = true;
 
 /**
  * Redirection to prevent eslint issues.
+ * @return {*} TODO: Specify return type
  */
 export function getConfigManager() {
   return configManager;

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -88,7 +88,7 @@ let shouldRegisterView = true;
 
 /**
  * Redirection to prevent eslint issues.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getConfigManager() {
   return configManager;

--- a/extensions/amp-addthis/0.1/post-message-dispatcher.js
+++ b/extensions/amp-addthis/0.1/post-message-dispatcher.js
@@ -56,8 +56,8 @@ export class PostMessageDispatcher {
   /**
    * Utility method to parse out the data from the supplied `postMessage` event.
    * @param {!Event} event
-   * @private
    * @return {?JsonObject|undefined}
+   * @private
    */
   getMessageData_(event) {
     const data = getData(event);

--- a/extensions/amp-addthis/0.1/post-message-dispatcher.js
+++ b/extensions/amp-addthis/0.1/post-message-dispatcher.js
@@ -57,12 +57,13 @@ export class PostMessageDispatcher {
    * Utility method to parse out the data from the supplied `postMessage` event.
    * @param {!Event} event
    * @private
+   * @return {?JsonObject|undefined}
    */
   getMessageData_(event) {
     const data = getData(event);
 
     if (isObject(data)) {
-      return data;
+      return /** @type {!JsonObject} */ (data);
     }
 
     if (typeof data === 'string' && startsWith(data, '{')) {
@@ -84,7 +85,7 @@ export class PostMessageDispatcher {
 
     const data = this.getMessageData_(event) || {};
 
-    switch (data.event) {
+    switch (data['event']) {
       case CONFIGURATION_EVENT: {
         this.emit_(
           CONFIGURATION_EVENT,
@@ -95,7 +96,7 @@ export class PostMessageDispatcher {
         break;
       }
       case SHARE_EVENT: {
-        this.emit_(SHARE_EVENT, data);
+        this.emit_(SHARE_EVENT, /** @type {!JsonObject} */ (data));
         break;
       }
     }

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -207,7 +207,10 @@ export class Activity {
     this.setUpActivityListeners_();
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {number}
+   */
   getTimeSinceStart_() {
     const timeSinceStart = Date.now() - this.startTime_;
     // Ensure that a negative time is never returned. This may cause loss of

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -467,7 +467,7 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
 /**
  * Expand config's request to object
  * @param {!JsonObject} config
- * @return {?Object}
+ * @return {?JsonObject}
  * @visibleForTesting
  */
 export function expandConfigRequest(config) {

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -412,7 +412,7 @@ export class AnalyticsConfig {
  * @param {Object|Array} from Object or array to merge from
  * @param {Object|Array} to Object or Array to merge into
  * @param {boolean=} opt_predefinedConfig
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function mergeObjects(from, to, opt_predefinedConfig) {
   if (to === null || to === undefined) {
@@ -486,7 +486,7 @@ export function expandConfigRequest(config) {
 /**
  * Expand single request to an object
  * @param {!JsonObject} request
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function expandRequestStr(request) {
   if (isObject(request)) {

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -467,8 +467,8 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
 /**
  * Expand config's request to object
  * @param {!JsonObject} config
- * @visibleForTesting
  * @return {?Object}
+ * @visibleForTesting
  */
 export function expandConfigRequest(config) {
   if (!config['requests']) {

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -141,6 +141,7 @@ export class AnalyticsConfig {
    * Handles logic if configRewriter is enabled.
    * @param {!JsonObject} config
    * @param {string} configRewriterUrl
+   * @return {!Promise<undefined>}
    */
   handleConfigRewriter_(config, configRewriterUrl) {
     assertHttpsUrl(configRewriterUrl, this.element_);
@@ -411,6 +412,7 @@ export class AnalyticsConfig {
  * @param {Object|Array} from Object or array to merge from
  * @param {Object|Array} to Object or Array to merge into
  * @param {boolean=} opt_predefinedConfig
+ * @return {*} TODO: Specify return type
  */
 export function mergeObjects(from, to, opt_predefinedConfig) {
   if (to === null || to === undefined) {
@@ -466,6 +468,7 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
  * Expand config's request to object
  * @param {!JsonObject} config
  * @visibleForTesting
+ * @return {?Object}
  */
 export function expandConfigRequest(config) {
   if (!config['requests']) {
@@ -483,6 +486,7 @@ export function expandConfigRequest(config) {
 /**
  * Expand single request to an object
  * @param {!JsonObject} request
+ * @return {*} TODO: Specify return type
  */
 function expandRequestStr(request) {
   if (isObject(request)) {

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -966,7 +966,10 @@ class TimerEventHandler {
     this.listenForStart_();
   }
 
-  /** @private @return {number} */
+  /**
+   * @private
+   * @return {number}
+   */
   calculateDuration_() {
     if (this.startTime_) {
       return Date.now() - (this.lastRequestTime_ || this.startTime_);

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -83,6 +83,7 @@ export class LinkerManager {
    * and register the callback with the navigation service. Since macro
    * resolution is asynchronous the callback may be looking for these values
    * before they are ready.
+   * @return {*} TODO: Specify return type
    */
   init() {
     if (!isObject(this.config_)) {
@@ -320,6 +321,7 @@ export class LinkerManager {
    * @param {string} url
    * @param {string} name Name given in linker config.
    * @param {?Array} domains
+   * @return {*} TODO: Specify return type
    */
   isDomainMatch_(url, name, domains) {
     const {hostname} = this.urlService_.parse(url);
@@ -434,6 +436,7 @@ export class LinkerManager {
    * @param {!Element} form
    * @param {function(string)} actionXhrMutator
    * @param {string} linkerName
+   * @return {*} TODO: Specify return type
    */
   addDataToForm_(form, actionXhrMutator, linkerName) {
     const ids = this.resolvedIds_[linkerName];
@@ -511,6 +514,7 @@ function getBaseDomain(domain) {
 /**
  * Escape any regex flags other than `*`
  * @param {string} str
+ * @return {*} TODO: Specify return type
  */
 function regexEscape(str) {
   return str.replace(/[-\/\\^$+?.()|[\]{}]/g, '\\$&');

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -83,7 +83,7 @@ export class LinkerManager {
    * and register the callback with the navigation service. Since macro
    * resolution is asynchronous the callback may be looking for these values
    * before they are ready.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   init() {
     if (!isObject(this.config_)) {
@@ -321,7 +321,7 @@ export class LinkerManager {
    * @param {string} url
    * @param {string} name Name given in linker config.
    * @param {?Array} domains
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isDomainMatch_(url, name, domains) {
     const {hostname} = this.urlService_.parse(url);
@@ -436,7 +436,7 @@ export class LinkerManager {
    * @param {!Element} form
    * @param {function(string)} actionXhrMutator
    * @param {string} linkerName
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   addDataToForm_(form, actionXhrMutator, linkerName) {
     const ids = this.resolvedIds_[linkerName];
@@ -514,7 +514,7 @@ function getBaseDomain(domain) {
 /**
  * Escape any regex flags other than `*`
  * @param {string} str
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function regexEscape(str) {
   return str.replace(/[-\/\\^$+?.()|[\]{}]/g, '\\$&');

--- a/extensions/amp-analytics/0.1/linker.js
+++ b/extensions/amp-analytics/0.1/linker.js
@@ -201,6 +201,7 @@ function getMinSinceEpoch() {
  * Function that encodesURIComponent but also tilde, since we are using it as
  * our delimiter.
  * @param {string} value
+ * @return {*} TODO: Specify return type
  */
 function encode(value) {
   return base64UrlEncodeFromString(String(value));

--- a/extensions/amp-analytics/0.1/linker.js
+++ b/extensions/amp-analytics/0.1/linker.js
@@ -201,7 +201,7 @@ function getMinSinceEpoch() {
  * Function that encodesURIComponent but also tilde, since we are using it as
  * our delimiter.
  * @param {string} value
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function encode(value) {
   return base64UrlEncodeFromString(String(value));

--- a/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
+++ b/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
@@ -133,6 +133,7 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
 /**
  * @param {!Window} win
  * @private
+ * @return {*} TODO: Specify return type
  */
 function getOrAddWorkletModule(win) {
   if (workletModulePromise) {

--- a/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
+++ b/extensions/amp-animation/0.1/runners/scrolltimeline-worklet-runner.js
@@ -133,7 +133,7 @@ export class ScrollTimelineWorkletRunner extends AnimationRunner {
 /**
  * @param {!Window} win
  * @private
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function getOrAddWorkletModule(win) {
   if (workletModulePromise) {

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -242,6 +242,7 @@ export class Builder {
    * @param {?Object<string, *>} vars
    * @param {?WebAnimationTimingDef} timing
    * @private
+   * @return {*} TODO: Specify return type
    */
   createScanner_(path, target, index, vars, timing) {
     return new MeasureScanner(

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -242,7 +242,7 @@ export class Builder {
    * @param {?Object<string, *>} vars
    * @param {?WebAnimationTimingDef} timing
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   createScanner_(path, target, index, vars, timing) {
     return new MeasureScanner(

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -76,6 +76,7 @@ export function getPlatform() {
 /**
  * Extracts tags from a given element .
  * @param {!Node} element
+ * @return {*} TODO: Specify return type
  */
 export function extractElementTags(element) {
   const tagsAttribute = element && element.getAttribute('data-apester-tags');
@@ -117,6 +118,7 @@ export function extratctTitle(root) {
 /**
  * Extracts article meta keywords
  * @param {*} root
+ * @return {*} TODO: Specify return type
  */
 export function extractArticleTags(root) {
   const metaKeywords = root.querySelector('meta[name="keywords"]') || {
@@ -186,6 +188,7 @@ export function registerEvent(eventName, callback, win, iframe, unlisteners) {
  * Generates a pixel url
  * @param {string} publisherId
  * @param {string} affiliateId
+ * @return {string}
  */
 export function generatePixelURL(publisherId, affiliateId) {
   const qsObj = {

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -76,7 +76,7 @@ export function getPlatform() {
 /**
  * Extracts tags from a given element .
  * @param {!Node} element
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function extractElementTags(element) {
   const tagsAttribute = element && element.getAttribute('data-apester-tags');
@@ -118,7 +118,7 @@ export function extratctTitle(root) {
 /**
  * Extracts article meta keywords
  * @param {*} root
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function extractArticleTags(root) {
   const metaKeywords = root.querySelector('meta[name="keywords"]') || {

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -101,7 +101,10 @@ export class AbstractAppBanner extends AMP.BaseElement {
     );
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {string}
+   */
   getStorageKey_() {
     const elementId = userAssert(
       this.element.id,
@@ -110,7 +113,10 @@ export class AbstractAppBanner extends AMP.BaseElement {
     return 'amp-app-banner:' + elementId;
   }
 
-  /** @protected */
+  /**
+   * @protected
+   * @return {*} TODO: Specify return type
+   */
   isDismissed() {
     return Services.storageForDoc(this.getAmpDoc())
       .then(storage => storage.get(this.getStorageKey_()))
@@ -136,7 +142,10 @@ export class AbstractAppBanner extends AMP.BaseElement {
     });
   }
 
-  /** @protected */
+  /**
+   * @protected
+   * @return {*} TODO: Specify return type
+   */
   hide_() {
     return this.getVsync().runPromise(
       {

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -115,7 +115,7 @@ export class AbstractAppBanner extends AMP.BaseElement {
 
   /**
    * @protected
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isDismissed() {
     return Services.storageForDoc(this.getAmpDoc())
@@ -144,7 +144,7 @@ export class AbstractAppBanner extends AMP.BaseElement {
 
   /**
    * @protected
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   hide_() {
     return this.getVsync().runPromise(

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -68,6 +68,7 @@ export class AmpAudio extends AMP.BaseElement {
 
   /**
    * Builds the internal <audio> element
+   * @return {*} TODO: Specify return type
    */
   buildAudioElement() {
     const audio = this.element.ownerDocument.createElement('audio');

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -68,7 +68,7 @@ export class AmpAudio extends AMP.BaseElement {
 
   /**
    * Builds the internal <audio> element
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   buildAudioElement() {
     const audio = this.element.ownerDocument.createElement('audio');

--- a/extensions/amp-base-carousel/0.1/array-util.js
+++ b/extensions/amp-base-carousel/0.1/array-util.js
@@ -23,6 +23,7 @@ import {mod} from '../../../src/utils/math';
  * @param {number} a A start index.
  * @param {number} b An end index.
  * @param {!IArrayLike} arr An array like Object.
+ * @return {number}
  */
 export function forwardWrappingDistance(a, b, {length}) {
   return a === b ? length : mod(b - a, length);
@@ -35,6 +36,7 @@ export function forwardWrappingDistance(a, b, {length}) {
  * @param {number} a A start index.
  * @param {number} b An end index.
  * @param {!IArrayLike} arr An array like Object.
+ * @return {number}
  */
 export function backwardWrappingDistance(a, b, {length}) {
   return a === b ? length : mod(a - b, length);

--- a/extensions/amp-base-carousel/0.1/responsive-attributes.js
+++ b/extensions/amp-base-carousel/0.1/responsive-attributes.js
@@ -81,7 +81,7 @@ function getMatchingValue(mediaQueryListsAndValues) {
  * * "(min-width: 600px) true"
  *
  * @param {string} str The media query/value string.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getResponsiveAttributeValue(str) {
   return getMatchingValue(getMediaQueryListsAndValues(str));

--- a/extensions/amp-base-carousel/0.1/responsive-attributes.js
+++ b/extensions/amp-base-carousel/0.1/responsive-attributes.js
@@ -81,6 +81,7 @@ function getMatchingValue(mediaQueryListsAndValues) {
  * * "(min-width: 600px) true"
  *
  * @param {string} str The media query/value string.
+ * @return {*} TODO: Specify return type
  */
 export function getResponsiveAttributeValue(str) {
   return getMatchingValue(getMediaQueryListsAndValues(str));

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -231,7 +231,7 @@ export class AmpBysideContent extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   composeSrcUrl_() {
     const src = this.baseUrl_ + 'placeholder.php';

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -216,7 +216,10 @@ export class AmpBysideContent extends AMP.BaseElement {
       });
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {string}
+   */
   composeOrigin_() {
     const subDomain =
       this.webcareZone_ === MAIN_WEBCARE_ZONE_
@@ -226,7 +229,10 @@ export class AmpBysideContent extends AMP.BaseElement {
     return 'https://' + encodeURIComponent(subDomain) + '.' + BYSIDE_DOMAIN_;
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   composeSrcUrl_() {
     const src = this.baseUrl_ + 'placeholder.php';
     const params = dict({

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -68,6 +68,7 @@ export class BaseCarousel extends AMP.BaseElement {
    * Builds a carousel button for next/prev.
    * @param {string} className
    * @param {function()} onInteraction
+   * @return {?Element}
    */
   buildButton(className, onInteraction) {
     const button = this.element.ownerDocument.createElement('div');

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -161,6 +161,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    * Scrolls to the slide at the given slide index.
    * @param {number} index
    * @private
+   * @return {*} TODO: Specify return type
    */
   goToSlide_(index) {
     const noOfSlides = this.cells_.length;
@@ -203,6 +204,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
   /**
    * Calculates the target scroll position for the given slide index.
    * @param {number} index
+   * @return {number}
    */
   getPosForSlideIndex_(index) {
     const containerWidth = this.element./*OK*/ offsetWidth;

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -161,7 +161,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    * Scrolls to the slide at the given slide index.
    * @param {number} index
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   goToSlide_(index) {
     const noOfSlides = this.cells_.length;

--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -58,6 +58,7 @@ export class ConsentConfig {
   /**
    * Convert the inline config to new format
    * @param {!JsonObject} config
+   * @return {!Object}
    */
   convertInlineConfigFormat_(config) {
     const consentsConfigDepr = config['consents'];

--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -103,6 +103,7 @@ export function hasDirtyBit(consentInfo) {
  * Return the new consent state value based on stored state and new state
  * @param {!CONSENT_ITEM_STATE} newState
  * @param {!CONSENT_ITEM_STATE} previousState
+ * @return {!CONSENT_ITEM_STATE}
  */
 export function recalculateConsentStateValue(newState, previousState) {
   if (!isEnumValue(CONSENT_ITEM_STATE, newState)) {
@@ -239,6 +240,7 @@ export function constructConsentInfo(
 /**
  * Helper function to convert stored value to CONSENT_ITEM_STATE value
  * @param {*} value
+ * @return {!CONSENT_ITEM_STATE}
  */
 function convertValueToState(value) {
   if (value === true || value === 1) {

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -181,6 +181,7 @@ export class ConsentStateManager {
 
   /**
    * Returns a promise that's resolved when consent instance is ready.
+   * @return {*} TODO: Specify return type
    */
   whenConsentReady() {
     if (this.instance_) {
@@ -246,6 +247,7 @@ export class ConsentInstance {
   /**
    * Set dirtyBit to current consent info. Refresh stored consent value with
    * dirtyBit
+   * @return {*} TODO: Specify return type
    */
   setDirtyBit() {
     // Note: this.hasDirtyBitNext_ is only set to true when 'forcePromptNext'

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -181,7 +181,7 @@ export class ConsentStateManager {
 
   /**
    * Returns a promise that's resolved when consent instance is ready.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   whenConsentReady() {
     if (this.instance_) {
@@ -247,7 +247,7 @@ export class ConsentInstance {
   /**
    * Set dirtyBit to current consent info. Refresh stored consent value with
    * dirtyBit
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setDirtyBit() {
     // Note: this.hasDirtyBitNext_ is only set to true when 'forcePromptNext'

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -342,6 +342,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
   /**
    * @param {!Element} element
    * @private
+   * @return {*} TODO: Specify return type
    */
   rendered_(element) {
     return this.mutateElement(() => {

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -342,7 +342,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
   /**
    * @param {!Element} element
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   rendered_(element) {
     return this.mutateElement(() => {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -698,6 +698,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   /**
    * Set the date via a string.
    * @param {string} date
+   * @return {*} TODO: Specify return type
    */
   handleSetDateFromString_(date) {
     const momentDate = this.createOffsetMoment_(date);
@@ -869,6 +870,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Merge the supplied state object with the existing state and re-render the
    * React tree.
    * @param {!JsonObject} newState
+   * @return {*} TODO: Specify return type
    */
   setState_(newState) {
     return this.render(
@@ -1129,6 +1131,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * closing the date picker.
    * @param {!Event} e
    * @private
+   * @return {*} TODO: Specify return type
    */
   handleKeydown_(e) {
     const target = dev().assertElement(e.target);
@@ -1143,6 +1146,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Close the date picker overlay when the escape key is pressed.
    * @param {!Event} e
    * @private
+   * @return {*} TODO: Specify return type
    */
   handleDocumentKeydown_(e) {
     if (
@@ -1638,6 +1642,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @param {?moment} endDate
    * @param {function(!moment)} cb
    * @private
+   * @return {*} TODO: Specify return type
    */
   iterateDateRange_(startDate, endDate, cb) {
     const normalizedEndDate = endDate || startDate;
@@ -1683,6 +1688,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   /**
    * Render a day in the calendar view.
    * @param {!moment} date
+   * @return {*} TODO: Specify return type
    */
   renderDay_(date) {
     const key = date.format(DEFAULT_FORMAT);
@@ -1747,6 +1753,7 @@ export class AmpDatePicker extends AMP.BaseElement {
 
   /**
    * Render the info section of the calendar view.
+   * @return {*} TODO: Specify return type
    */
   renderInfo() {
     if (!this.infoTemplatePromise_) {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -698,7 +698,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   /**
    * Set the date via a string.
    * @param {string} date
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   handleSetDateFromString_(date) {
     const momentDate = this.createOffsetMoment_(date);
@@ -870,7 +870,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Merge the supplied state object with the existing state and re-render the
    * React tree.
    * @param {!JsonObject} newState
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setState_(newState) {
     return this.render(
@@ -1131,7 +1131,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * closing the date picker.
    * @param {!Event} e
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   handleKeydown_(e) {
     const target = dev().assertElement(e.target);
@@ -1146,7 +1146,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Close the date picker overlay when the escape key is pressed.
    * @param {!Event} e
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   handleDocumentKeydown_(e) {
     if (
@@ -1642,7 +1642,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @param {?moment} endDate
    * @param {function(!moment)} cb
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   iterateDateRange_(startDate, endDate, cb) {
     const normalizedEndDate = endDate || startDate;
@@ -1688,7 +1688,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   /**
    * Render a day in the calendar view.
    * @param {!moment} date
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   renderDay_(date) {
     const key = date.format(DEFAULT_FORMAT);
@@ -1753,7 +1753,7 @@ export class AmpDatePicker extends AMP.BaseElement {
 
   /**
    * Render the info section of the calendar view.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   renderInfo() {
     if (!this.infoTemplatePromise_) {

--- a/extensions/amp-date-picker/0.1/date-picker-common.js
+++ b/extensions/amp-date-picker/0.1/date-picker-common.js
@@ -111,7 +111,7 @@ export function withDatePickerCommon(WrappedComponent) {
    * @param {?moment} endDate
    * @param {boolean} allowBlockedEndDate
    * @param {!moment} day
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   function isDayBlocked(list, startDate, endDate, allowBlockedEndDate, day) {
     const isBlocked = datesListContains(list, day);

--- a/extensions/amp-date-picker/0.1/date-picker-common.js
+++ b/extensions/amp-date-picker/0.1/date-picker-common.js
@@ -111,6 +111,7 @@ export function withDatePickerCommon(WrappedComponent) {
    * @param {?moment} endDate
    * @param {boolean} allowBlockedEndDate
    * @param {!moment} day
+   * @return {*} TODO: Specify return type
    */
   function isDayBlocked(list, startDate, endDate, allowBlockedEndDate, day) {
     const isBlocked = datesListContains(list, day);

--- a/extensions/amp-date-picker/0.1/react-utils.js
+++ b/extensions/amp-date-picker/0.1/react-utils.js
@@ -73,6 +73,7 @@ function createDeferred_() {
  * Shallow compare a and b.
  * @param {*} a
  * @param {*} b
+ * @return {*} TODO: Specify return type
  */
 function shallowDiffers(a, b) {
   for (const i in a) {

--- a/extensions/amp-date-picker/0.1/react-utils.js
+++ b/extensions/amp-date-picker/0.1/react-utils.js
@@ -73,7 +73,7 @@ function createDeferred_() {
  * Shallow compare a and b.
  * @param {*} a
  * @param {*} b
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function shallowDiffers(a, b) {
   for (const i in a) {

--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -155,6 +155,7 @@ export class FontLoader {
    * Font download is detected by comparing the elements height and width with
    * measurements between default fonts and custom font.
    * @private
+   * @return {*} TODO: Specify return type
    */
   loadWithPolyfill_() {
     return new Promise((resolve, reject) => {

--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -155,7 +155,7 @@ export class FontLoader {
    * Font download is detected by comparing the elements height and width with
    * measurements between default fonts and custom font.
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   loadWithPolyfill_() {
     return new Promise((resolve, reject) => {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1185,6 +1185,7 @@ export class AmpForm {
    * Returns a promise that resolves when tempalte render finishes. The promise
    * will be null if the template render has not started.
    * @visibleForTesting
+   * @return {*} TODO: Specify return type
    */
   renderTemplatePromiseForTesting() {
     return this.renderTemplatePromise_;
@@ -1194,6 +1195,7 @@ export class AmpForm {
    * Returns a promise that resolves when xhr submit finishes. The promise
    * will be null if xhr submit has not started.
    * @visibleForTesting
+   * @return {*} TODO: Specify return type
    */
   xhrSubmitPromiseForTesting() {
     return this.xhrSubmitPromise_;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1185,7 +1185,7 @@ export class AmpForm {
    * Returns a promise that resolves when tempalte render finishes. The promise
    * will be null if the template render has not started.
    * @visibleForTesting
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   renderTemplatePromiseForTesting() {
     return this.renderTemplatePromise_;
@@ -1195,7 +1195,7 @@ export class AmpForm {
    * Returns a promise that resolves when xhr submit finishes. The promise
    * will be null if xhr submit has not started.
    * @visibleForTesting
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   xhrSubmitPromiseForTesting() {
     return this.xhrSubmitPromise_;

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -313,7 +313,7 @@ export class AbstractCustomValidator extends FormValidator {
    * Wraps the validity type for inputs to support pattern on <textarea>
    * @param {!Element} input
    * @param {string=} inputInvalidType
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getInvalidType_(input, inputInvalidType = undefined) {
     const {tagName, validationMessage} = input;

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -313,6 +313,7 @@ export class AbstractCustomValidator extends FormValidator {
    * Wraps the validity type for inputs to support pattern on <textarea>
    * @param {!Element} input
    * @param {string=} inputInvalidType
+   * @return {*} TODO: Specify return type
    */
   getInvalidType_(input, inputInvalidType = undefined) {
     const {tagName, validationMessage} = input;

--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -44,6 +44,7 @@ let UpdatedErrorsDef;
  * a config block is present.
  * @param {!HTMLFormElement} form
  * @param {function():Promise<!Response>} xhr
+ * @return {!FormVerifier}
  */
 export function getFormVerifier(form, xhr) {
   if (form.hasAttribute('verify-xhr')) {

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -199,7 +199,7 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
    * nodes that only contain whitespace since they do not contribute anything
    * visually, only their surrounding Elements or non-whitespace Texts do.
    * @param {!Array<!Node>} nodes
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   visibileChildren_(nodes) {

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -200,6 +200,7 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
    * visually, only their surrounding Elements or non-whitespace Texts do.
    * @param {!Array<!Node>} nodes
    * @private
+   * @return {*} TODO: Specify return type
    */
   visibileChildren_(nodes) {
     return nodes.filter(node => {

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -199,8 +199,8 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
    * nodes that only contain whitespace since they do not contribute anything
    * visually, only their surrounding Elements or non-whitespace Texts do.
    * @param {!Array<!Node>} nodes
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   visibileChildren_(nodes) {
     return nodes.filter(node => {

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -194,6 +194,7 @@ export class GwdAnimation extends AMP.BaseElement {
    * Returns whether the given action invocation should be executed.
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
    * @private
+   * @return {*} TODO: Specify return type
    */
   shouldExecuteInvocation_(invocation) {
     if (invocation.method == 'setCurrentPage') {

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -194,7 +194,7 @@ export class GwdAnimation extends AMP.BaseElement {
    * Returns whether the given action invocation should be executed.
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   shouldExecuteInvocation_(invocation) {
     if (invocation.method == 'setCurrentPage') {

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -1243,7 +1243,10 @@ class AmpImageLightbox extends AMP.BaseElement {
     });
   }
 
-  /** @private @return {!../../../src/service/history-impl.History} */
+  /**
+   * @private
+   * @return {!../../../src/service/history-impl.History}
+   */
   getHistory_() {
     return Services.historyForDoc(this.getAmpDoc());
   }

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -560,6 +560,7 @@ export class AmpImageSlider extends AMP.BaseElement {
    * Get current slider's percentage to the left
    * Should be wrapped inside measureElement
    * @private
+   * @return {number}
    */
   getCurrentSliderPercentage_() {
     const {left: barLeft} = this.bar_./*OK*/ getBoundingClientRect();
@@ -693,6 +694,7 @@ export class AmpImageSlider extends AMP.BaseElement {
    * Limit percentage between 0 and 1
    * @param {number} percentage
    * @private
+   * @return {number}
    */
   limitPercentage_(percentage) {
     return clamp(percentage, 0, 1);

--- a/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
@@ -28,7 +28,10 @@ export function factory(Inputmask) {
     dict({
       'payment-card': {
         'postValidation': buffer => /[\s\d]+/.test(buffer.join('')),
-        /** @param {!JsonObject} opts */
+        /**
+         * @param {!JsonObject} opts
+         * @return {*} TODO: Specify return type
+         */
         'mask': function(opts) {
           opts['definitions'] = dict({
             'x': {

--- a/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-payment-card-alias.js
@@ -30,7 +30,7 @@ export function factory(Inputmask) {
         'postValidation': buffer => /[\s\d]+/.test(buffer.join('')),
         /**
          * @param {!JsonObject} opts
-         * @return {*} TODO: Specify return type
+         * @return {*} TODO(#23582): Specify return type
          */
         'mask': function(opts) {
           opts['definitions'] = dict({

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -191,6 +191,7 @@ const NONALPHANUMERIC_REGEXP = /[^0-9\xB2\xB3\xB9\xBC-\xBE\u0660-\u0669\u06F0-\u
 /**
  * Removes special characters from the provided string.
  * @param {string} value
+ * @return {string}
  */
 function getAlphaNumeric(value) {
   return value.replace(NONALPHANUMERIC_REGEXP, '');

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -160,7 +160,7 @@ class AmpJWPlayer extends AMP.BaseElement {
   }
   /**
    *
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getContextualVal() {
     if (this.contentSearch_ === '__CONTEXTUAL__') {

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -160,6 +160,7 @@ class AmpJWPlayer extends AMP.BaseElement {
   }
   /**
    *
+   * @return {*} TODO: Specify return type
    */
   getContextualVal() {
     if (this.contentSearch_ === '__CONTEXTUAL__') {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -279,8 +279,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * Return a cleaned clone of the given element for building
    * carousel slides with.
    * @param {!Element} element
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   cloneLightboxableElement_(element) {
     const deepClone = !element.classList.contains('i-amphtml-element');

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -279,7 +279,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * Return a cleaned clone of the given element for building
    * carousel slides with.
    * @param {!Element} element
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   cloneLightboxableElement_(element) {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -280,6 +280,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * carousel slides with.
    * @param {!Element} element
    * @private
+   * @return {*} TODO: Specify return type
    */
   cloneLightboxableElement_(element) {
     const deepClone = !element.classList.contains('i-amphtml-element');

--- a/extensions/amp-lightbox-gallery/0.1/utils.js
+++ b/extensions/amp-lightbox-gallery/0.1/utils.js
@@ -42,6 +42,7 @@ export function delayAfterDeferringToEventLoop(win, duration) {
  * @param {string} s
  * @param {number} targetLength
  * @param {string} padString
+ * @return {*} TODO: Specify return type
  */
 function padStart(s, targetLength, padString) {
   if (s.length >= targetLength) {

--- a/extensions/amp-lightbox-gallery/0.1/utils.js
+++ b/extensions/amp-lightbox-gallery/0.1/utils.js
@@ -42,7 +42,7 @@ export function delayAfterDeferringToEventLoop(win, duration) {
  * @param {string} s
  * @param {number} targetLength
  * @param {string} padString
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function padStart(s, targetLength, padString) {
   if (s.length >= targetLength) {

--- a/extensions/amp-link-rewriter/0.1/amp-link-rewriter.js
+++ b/extensions/amp-link-rewriter/0.1/amp-link-rewriter.js
@@ -66,6 +66,7 @@ export class AmpLinkRewriter extends AMP.BaseElement {
 
   /**
    * @private
+   * @return {*} TODO: Specify return type
    */
   attachClickEvent_() {
     this.navigation_.registerAnchorMutator(anchor => {

--- a/extensions/amp-link-rewriter/0.1/amp-link-rewriter.js
+++ b/extensions/amp-link-rewriter/0.1/amp-link-rewriter.js
@@ -66,7 +66,7 @@ export class AmpLinkRewriter extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   attachClickEvent_() {
     this.navigation_.registerAnchorMutator(anchor => {

--- a/extensions/amp-link-rewriter/0.1/config-options.js
+++ b/extensions/amp-link-rewriter/0.1/config-options.js
@@ -61,7 +61,7 @@ function getConfigJson(element) {
 
 /**
  * @param {!Object} attribute
- * return {Object}
+ * @return {Object}
  */
 function parseAttribute(attribute) {
   const newAttr = {};

--- a/extensions/amp-link-rewriter/0.1/scope.js
+++ b/extensions/amp-link-rewriter/0.1/scope.js
@@ -48,6 +48,7 @@ export function getScopeElements(ampDoc, configOpts) {
  * corresponding value of the anchor element attribute
  * @param {!Node} htmlElement
  * @param {!Object} configOpts
+ * @return {*} TODO: Specify return type
  */
 function hasAttributeValues(htmlElement, configOpts) {
   const anchorAttr = configOpts.attribute;

--- a/extensions/amp-link-rewriter/0.1/scope.js
+++ b/extensions/amp-link-rewriter/0.1/scope.js
@@ -48,7 +48,7 @@ export function getScopeElements(ampDoc, configOpts) {
  * corresponding value of the anchor element attribute
  * @param {!Node} htmlElement
  * @param {!Object} configOpts
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function hasAttributeValues(htmlElement, configOpts) {
   const anchorAttr = configOpts.attribute;

--- a/extensions/amp-loader/0.1/amp-loader.js
+++ b/extensions/amp-loader/0.1/amp-loader.js
@@ -233,7 +233,7 @@ class LoaderBuilder {
   /**
    * Adds the default or branded logo.
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getLogo_() {
     const customLogo = this.getCustomLogo_();

--- a/extensions/amp-loader/0.1/amp-loader.js
+++ b/extensions/amp-loader/0.1/amp-loader.js
@@ -133,6 +133,7 @@ class LoaderBuilder {
   /**
    * Sets the size of the loader based element's size and a few special cases.
    * @private
+   * @return {undefined}
    */
   setSize_() {
     const sizeClassDefault = 'i-amphtml-new-loader-size-default';
@@ -210,6 +211,7 @@ class LoaderBuilder {
 
   /**
    * @param {string} color
+   * @return {!Node}
    */
   getSpinner_(color) {
     const svg = svgFor(this.element_);
@@ -231,6 +233,7 @@ class LoaderBuilder {
   /**
    * Adds the default or branded logo.
    * @private
+   * @return {*} TODO: Specify return type
    */
   getLogo_() {
     const customLogo = this.getCustomLogo_();

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -130,7 +130,7 @@ export class AmpMustache extends AMP.BaseTemplate {
   /**
    *
    * @param {string} html
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   purifyAndSetHtml_(html) {

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -131,6 +131,7 @@ export class AmpMustache extends AMP.BaseTemplate {
    *
    * @param {string} html
    * @private
+   * @return {*} TODO: Specify return type
    */
   purifyAndSetHtml_(html) {
     const diffing = isExperimentOn(self, 'amp-list-diffing');

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -130,8 +130,8 @@ export class AmpMustache extends AMP.BaseTemplate {
   /**
    *
    * @param {string} html
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   purifyAndSetHtml_(html) {
     const diffing = isExperimentOn(self, 'amp-list-diffing');

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -242,6 +242,7 @@ export class AmpNextPage extends AMP.BaseElement {
   /**
    * Appends the element too page
    * @param {!Element} element
+   * @return {!Promise}
    */
   appendPage_(element) {
     return this.mutateElement(() => this.element.appendChild(element));
@@ -250,6 +251,7 @@ export class AmpNextPage extends AMP.BaseElement {
   /**
    * Fetches the element config from the URL specified in [src].
    * @private
+   * @return {*} TODO: Specify return type
    */
   fetchConfig_() {
     const ampdoc = this.getAmpDoc();
@@ -296,6 +298,7 @@ function extractAdSenseImageUrl(el) {
  * Returns the text content of an element, with leading/trailing whitespace
  * trimmed.
  * @param {Element} el
+ * @return {*} TODO: Specify return type
  */
 function extractAdSenseTextContent(el) {
   const content = (el && el.textContent) || '';

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -251,7 +251,7 @@ export class AmpNextPage extends AMP.BaseElement {
   /**
    * Fetches the element config from the URL specified in [src].
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   fetchConfig_() {
     const ampdoc = this.getAmpDoc();
@@ -298,7 +298,7 @@ function extractAdSenseImageUrl(el) {
  * Returns the text content of an element, with leading/trailing whitespace
  * trimmed.
  * @param {Element} el
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function extractAdSenseTextContent(el) {
   const content = (el && el.textContent) || '';

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -118,7 +118,7 @@ export class NextPageService {
   /**
    * Returns true if the service has already been initialized.
    *
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isActive() {
     return this.config_ !== null;

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -115,7 +115,11 @@ export class NextPageService {
     this.history_ = null;
   }
 
-  /** Returns true if the service has already been initialized. */
+  /**
+   * Returns true if the service has already been initialized.
+   *
+   * @return {*} TODO: Specify return type
+   */
   isActive() {
     return this.config_ !== null;
   }

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -92,8 +92,8 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * Parses the provided ranges
    * @param {string} rangeName
    * @param {Array} originalRange
-   * @private
    * @return {?Array<number>}
+   * @private
    */
   parseAttributes_(rangeName, originalRange) {
     const providedRange = this.element.getAttribute(rangeName);

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -93,6 +93,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * @param {string} rangeName
    * @param {Array} originalRange
    * @private
+   * @return {?Array<number>}
    */
   parseAttributes_(rangeName, originalRange) {
     const providedRange = this.element.getAttribute(rangeName);

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -434,8 +434,8 @@ export class AmpPanZoom extends AMP.BaseElement {
    * Given a x offset relative to the viewport, return the x offset
    * relative to the amp-pan-zoom component.
    * @param {number} clientX
-   * @private
    * @return {number}
+   * @private
    */
   getOffsetX_(clientX) {
     const {left} = this.elementBox_;
@@ -446,8 +446,8 @@ export class AmpPanZoom extends AMP.BaseElement {
    * Given a y offset relative to the viewport, return the y offset
    * relative to the amp-pan-zoom component.
    * @param {number} clientY
-   * @private
    * @return {number}
+   * @private
    */
   getOffsetY_(clientY) {
     const {top} = this.elementBox_;

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -198,6 +198,7 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @param {number} x
    * @param {number} y
    * @param {number} scale
+   * @return {*} TODO: Specify return type
    */
   transform(x, y, scale) {
     this.updatePanZoomBounds_(scale);
@@ -434,6 +435,7 @@ export class AmpPanZoom extends AMP.BaseElement {
    * relative to the amp-pan-zoom component.
    * @param {number} clientX
    * @private
+   * @return {number}
    */
   getOffsetX_(clientX) {
     const {left} = this.elementBox_;
@@ -445,6 +447,7 @@ export class AmpPanZoom extends AMP.BaseElement {
    * relative to the amp-pan-zoom component.
    * @param {number} clientY
    * @private
+   * @return {number}
    */
   getOffsetY_(clientY) {
     const {top} = this.elementBox_;
@@ -828,6 +831,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /**
    * @param {number} clientX
    * @param {number} clientY
+   * @return {*} TODO: Specify return type
    */
   onDoubletapZoom_(clientX, clientY) {
     const newScale =

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -198,7 +198,7 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @param {number} x
    * @param {number} y
    * @param {number} scale
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   transform(x, y, scale) {
     this.updatePanZoomBounds_(scale);
@@ -831,7 +831,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /**
    * @param {number} clientX
    * @param {number} clientY
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   onDoubletapZoom_(clientX, clientY) {
     const newScale =

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -89,6 +89,7 @@ class AmpPinterest extends AMP.BaseElement {
 
   /**
    * Renders the component
+   * @return {*} TODO: Specify return type
    */
   render() {
     switch (this.type_) {

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -89,7 +89,7 @@ class AmpPinterest extends AMP.BaseElement {
 
   /**
    * Renders the component
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   render() {
     switch (this.type_) {

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -98,6 +98,7 @@ export class PinWidget {
 
   /**
    * @param {!JsonObject} pin
+   * @return {*} TODO: Specify return type
    */
   renderPin(pin) {
     // start setting our class name

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -98,7 +98,7 @@ export class PinWidget {
 
   /**
    * @param {!JsonObject} pin
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   renderPin(pin) {
     // start setting our class name

--- a/extensions/amp-playbuzz/0.1/utils.js
+++ b/extensions/amp-playbuzz/0.1/utils.js
@@ -32,6 +32,7 @@ import {rethrowAsync} from './../../../src/log';
  * @param {Function} func
  * @param {number} wait
  * @param {boolean=} immediate
+ * @return {Function}
  */
 export function debounce(func, wait, immediate) {
   let timeout;

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -428,6 +428,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * Readjusts the given rect using the configured exclusion margins.
    * @param {!../../../src/layout-rect.LayoutRectDef} rect viewport rect adjusted for margins.
    * @private
+   * @return {!../../../src/layout-rect.LayoutRectDef}
    */
   applyMargins_(rect) {
     devAssert(rect);

--- a/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js
@@ -168,6 +168,7 @@ export class AmpRecaptchaService {
    * Function to create our recaptcha boostrap iframe.
    * Should be assigned to this.iframeLoadPromise_
    * @private
+   * @return {?Promise}
    */
   initialize_() {
     return this.createRecaptchaFrame_().then(iframe => {

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -225,7 +225,10 @@ export class AmpShareTracking extends AMP.BaseElement {
     return result;
   }
 
-  /** @private @return {!../../../src/service/history-impl.History} */
+  /**
+   * @private
+   * @return {!../../../src/service/history-impl.History}
+   */
   getHistory_() {
     return Services.historyForDoc(this.getAmpDoc());
   }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -528,7 +528,8 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /**
-   * @private @return {!../../../src/service/history-impl.History}
+   * @private
+   * @return {!../../../src/service/history-impl.History}
    */
   getHistory_() {
     return Services.historyForDoc(this.getAmpDoc());

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
@@ -219,8 +219,8 @@ export class LinkRewriter {
    * Filter the list of anchors to returns only the ones
    * that were not in the page at the time of the last page scan.
    * @param {!Array<!HTMLElement>} anchorList
-   * @private
    * @return {!Array<HTMLElement>}
+   * @private
    */
   getUnknownAnchors_(anchorList) {
     const unknownAnchors = [];

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
@@ -220,6 +220,7 @@ export class LinkRewriter {
    * that were not in the page at the time of the last page scan.
    * @param {!Array<!HTMLElement>} anchorList
    * @private
+   * @return {!Array<HTMLElement>}
    */
   getUnknownAnchors_(anchorList) {
     const unknownAnchors = [];

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -181,7 +181,7 @@ class AmpSocialShare extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   systemShareSupported_() {
     // Chrome exports navigator.share in WebView but does not implement it.

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -179,7 +179,10 @@ class AmpSocialShare extends AMP.BaseElement {
     }
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   systemShareSupported_() {
     // Chrome exports navigator.share in WebView but does not implement it.
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=765923

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -700,7 +700,11 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       return false;
     }
 
-    return this.createCtaLayer_(adPageElement, ctaText, ctaUrl);
+    return this.createCtaLayer_(
+      adPageElement,
+      dev().assertString(ctaText),
+      ctaUrl
+    );
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -538,6 +538,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * create an `amp-story-page` containing an `amp-ad`
    * @private
+   * @return {!Element}
    */
   createAdPage_() {
     const ampStoryAdPage = this.createPageElement_();
@@ -668,6 +669,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * Validate ad-server response has requirements to build outlink
    * @param {!Element} adPageElement
    * @param {!Object} a4aVars
+   * @return {*} TODO: Specify return type
    */
   maybeCreateCtaLayer_(adPageElement, a4aVars) {
     // if making a CTA layer we need a button name & outlink url
@@ -900,6 +902,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * Place ad based on user config
    * @param {string} pageBeforeAdId
    * @private
+   * @return {*} TODO: Specify return type
    */
   tryToPlaceAdAfterPage_(pageBeforeAdId) {
     const nextAdPageEl = this.adPageEls_[this.adPageEls_.length - 1];

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -669,7 +669,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * Validate ad-server response has requirements to build outlink
    * @param {!Element} adPageElement
    * @param {!Object} a4aVars
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   maybeCreateCtaLayer_(adPageElement, a4aVars) {
     // if making a CTA layer we need a button name & outlink url
@@ -905,7 +905,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Place ad based on user config
    * @param {string} pageBeforeAdId
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   tryToPlaceAdAfterPage_(pageBeforeAdId) {

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -901,8 +901,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Place ad based on user config
    * @param {string} pageBeforeAdId
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   tryToPlaceAdAfterPage_(pageBeforeAdId) {
     const nextAdPageEl = this.adPageEls_[this.adPageEls_.length - 1];

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -44,7 +44,7 @@ export function getUniqueId(win) {
 /**
  * Finds all meta tags starting with `amp4ads-vars-`.
  * @param {Document} doc
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getA4AMetaTags(doc) {
   const selector = 'meta[name^=amp4ads-vars-]';

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -44,6 +44,7 @@ export function getUniqueId(win) {
 /**
  * Finds all meta tags starting with `amp4ads-vars-`.
  * @param {Document} doc
+ * @return {*} TODO: Specify return type
  */
 export function getA4AMetaTags(doc) {
   const selector = 'meta[name^=amp4ads-vars-]';

--- a/extensions/amp-story/0.1/amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/amp-story-info-dialog.js
@@ -194,6 +194,7 @@ export class InfoDialog {
 
   /**
    * Sets the heading on the dialog.
+   * @return {*} TODO: Specify return type
    */
   setHeading_() {
     const label = this.localizationService_.getLocalizedString(
@@ -211,6 +212,7 @@ export class InfoDialog {
   /**
    * @param {string} pageUrl The URL to the canonical version of the current
    *     document.
+   * @return {*} TODO: Specify return type
    */
   setPageLink_(pageUrl) {
     const linkEl = dev().assertElement(
@@ -229,6 +231,7 @@ export class InfoDialog {
   /**
    * @param {?string} moreInfoUrl The URL to the "more info" page, if there is
    * one.
+   * @return {*} TODO: Specify return type
    */
   setMoreInfoLinkUrl_(moreInfoUrl) {
     if (!moreInfoUrl) {

--- a/extensions/amp-story/0.1/amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/amp-story-info-dialog.js
@@ -194,7 +194,7 @@ export class InfoDialog {
 
   /**
    * Sets the heading on the dialog.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setHeading_() {
     const label = this.localizationService_.getLocalizedString(
@@ -212,7 +212,7 @@ export class InfoDialog {
   /**
    * @param {string} pageUrl The URL to the canonical version of the current
    *     document.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setPageLink_(pageUrl) {
     const linkEl = dev().assertElement(
@@ -231,7 +231,7 @@ export class InfoDialog {
   /**
    * @param {?string} moreInfoUrl The URL to the "more info" page, if there is
    * one.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setMoreInfoLinkUrl_(moreInfoUrl) {
     if (!moreInfoUrl) {

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -204,7 +204,10 @@ export class ShareWidget {
     this.requestService_ = Services.storyRequestServiceV01(this.win);
   }
 
-  /** @param {!Window} win */
+  /**
+   * @param {!Window} win
+   * @return {!ShareWidget}
+   */
   static create(win) {
     return new ShareWidget(win);
   }
@@ -449,7 +452,10 @@ export class ScrollableShareWidget extends ShareWidget {
     this.containerWidth_ = null;
   }
 
-  /** @param {!Window} win */
+  /**
+   * @param {!Window} win
+   * @return {!ScrollableShareWidget}
+   */
   static create(win) {
     return new ScrollableShareWidget(win);
   }

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -276,7 +276,7 @@ export class ShareWidget {
         const failureString = localizationService.getLocalizedString(
           LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT
         );
-        Toast.show(this.win, failureString);
+        Toast.show(this.win, dev().assertString(failureString));
       });
       return;
     }

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -64,6 +64,7 @@ export class UnsupportedBrowserLayer {
 
   /**
    * Builds and appends the component in the story.
+   * @return {?Element}
    */
   build() {
     if (this.root_) {

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -453,7 +453,7 @@ export class AnimationManager {
   /**
    * Determines if there is an entrance animation running.
    *
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   hasAnimationStarted() {
     return this.getRunners_().some(runner => runner.hasStarted());
@@ -461,7 +461,7 @@ export class AnimationManager {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getRunners_() {
     return devAssert(this.runners_, 'Executed before applyFirstFrame');

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -450,12 +450,19 @@ export class AnimationManager {
     this.getRunners_().forEach(runner => runner.cancel());
   }
 
-  /** Determines if there is an entrance animation running. */
+  /**
+   * Determines if there is an entrance animation running.
+   *
+   * @return {*} TODO: Specify return type
+   */
   hasAnimationStarted() {
     return this.getRunners_().some(runner => runner.hasStarted());
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   getRunners_() {
     return devAssert(this.runners_, 'Executed before applyFirstFrame');
   }
@@ -573,7 +580,11 @@ class AnimationSequence {
     this.subscriptionResolvers_ = map();
   }
 
-  /** Decouples constructor for testing. */
+  /**
+   * Decouples constructor for testing.
+   *
+   * @return {!AnimationSequence}
+   */
   static create() {
     return new AnimationSequence();
   }

--- a/extensions/amp-story/0.1/development-ui.js
+++ b/extensions/amp-story/0.1/development-ui.js
@@ -76,6 +76,7 @@ export class DevelopmentModeLogButtonSet {
 
   /**
    * @param {!Window} win
+   * @return {!DevelopmentModeLogButtonSet}
    */
   static create(win) {
     return new DevelopmentModeLogButtonSet(win);
@@ -184,6 +185,7 @@ export class DevelopmentModeLog {
 
   /**
    * @param {!Window} win
+   * @return {!DevelopmentModeLog}
    */
   static create(win) {
     return new DevelopmentModeLog(win);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -254,6 +254,7 @@ export class MediaPool {
    * @param {!HTMLMediaElement} mediaA The first element to compare.
    * @param {!HTMLMediaElement} mediaB The second element to compare.
    * @private
+   * @return {number}
    */
   compareMediaDistances_(mediaA, mediaB) {
     const distanceA = this.distanceFn_(mediaA);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -253,8 +253,8 @@ export class MediaPool {
    * current position in the document.
    * @param {!HTMLMediaElement} mediaA The first element to compare.
    * @param {!HTMLMediaElement} mediaB The second element to compare.
-   * @private
    * @return {number}
+   * @private
    */
   compareMediaDistances_(mediaA, mediaB) {
     const distanceA = this.distanceFn_(mediaA);

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -174,6 +174,7 @@ export class MediaTask {
    * @param {!HTMLMediaElement} unusedMediaEl The media element on which this
    *     task should be executed.
    * @protected
+   * @return {*} TODO: Specify return type
    */
   executeInternal(unusedMediaEl) {
     return Promise.resolve();

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -173,7 +173,7 @@ export class MediaTask {
   /**
    * @param {!HTMLMediaElement} unusedMediaEl The media element on which this
    *     task should be executed.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @protected
    */
   executeInternal(unusedMediaEl) {

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -173,8 +173,8 @@ export class MediaTask {
   /**
    * @param {!HTMLMediaElement} unusedMediaEl The media element on which this
    *     task should be executed.
-   * @protected
    * @return {*} TODO: Specify return type
+   * @protected
    */
   executeInternal(unusedMediaEl) {
     return Promise.resolve();

--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -390,7 +390,10 @@ class ImageElement extends PageElement {
  * Video interface.
  */
 class VideoInterfaceElement extends PageElement {
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   isLaidOut_() {
     return this.element.hasAttribute('i-amphtml-layout');
   }

--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -392,7 +392,7 @@ class ImageElement extends PageElement {
 class VideoInterfaceElement extends PageElement {
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isLaidOut_() {
     return this.element.hasAttribute('i-amphtml-layout');

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -66,6 +66,7 @@ export class ProgressBar {
 
   /**
    * @param {!Window} win
+   * @return {!ProgressBar}
    */
   static create(win) {
     return new ProgressBar(win);

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -173,6 +173,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * Handles click events and maybe closes the paywall.
    * @param {!Event} event
    * @private
+   * @return {*} TODO: Specify return type
    */
   onClick_(event) {
     const el = dev().assertElement(event.target);
@@ -323,6 +324,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @param {string=} namespace
    * @param {string=} type
    * @private
+   * @return {*} TODO: Specify return type
    */
   getActionObject_(namespace = undefined, type = undefined) {
     const method = ['login', namespace, type].filter(s => !!s).join('-');

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -172,7 +172,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
   /**
    * Handles click events and maybe closes the paywall.
    * @param {!Event} event
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   onClick_(event) {
@@ -323,7 +323,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * Whitelists an action for the given namespace / type pair.
    * @param {string=} namespace
    * @param {string=} type
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   getActionObject_(namespace = undefined, type = undefined) {

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -172,8 +172,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
   /**
    * Handles click events and maybe closes the paywall.
    * @param {!Event} event
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   onClick_(event) {
     const el = dev().assertElement(event.target);
@@ -323,8 +323,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * Whitelists an action for the given namespace / type pair.
    * @param {string=} namespace
    * @param {string=} type
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   getActionObject_(namespace = undefined, type = undefined) {
     const method = ['login', namespace, type].filter(s => !!s).join('-');

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -678,8 +678,8 @@ export class AmpStoryEmbeddedComponent {
   /**
    * Gets href from an element containing a url.
    * @param {!Element} target
-   * @private
    * @return {string}
+   * @private
    */
   getElementHref_(target) {
     const elUrl = target.getAttribute('href');

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -480,6 +480,7 @@ export class AmpStoryEmbeddedComponent {
   /**
    * Builds the tooltip overlay and appends it to the provided story.
    * @private
+   * @return {Node}
    */
   buildFocusedState_() {
     this.shadowRoot_ = this.win_.document.createElement('div');
@@ -678,12 +679,13 @@ export class AmpStoryEmbeddedComponent {
    * Gets href from an element containing a url.
    * @param {!Element} target
    * @private
+   * @return {string}
    */
   getElementHref_(target) {
     const elUrl = target.getAttribute('href');
     if (!isProtocolValid(elUrl)) {
       user().error(TAG, 'The tooltip url is invalid');
-      return;
+      return '';
     }
 
     return parseUrlDeprecated(elUrl).href;

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -198,6 +198,7 @@ export class InfoDialog {
 
   /**
    * Sets the heading on the dialog.
+   * @return {*} TODO: Specify return type
    */
   setHeading_() {
     const label = this.localizationService_.getLocalizedString(
@@ -215,6 +216,7 @@ export class InfoDialog {
   /**
    * @param {string} pageUrl The URL to the canonical version of the current
    *     document.
+   * @return {*} TODO: Specify return type
    */
   setPageLink_(pageUrl) {
     const linkEl = dev().assertElement(
@@ -233,6 +235,7 @@ export class InfoDialog {
   /**
    * @param {?string} moreInfoUrl The URL to the "more info" page, if there is
    * one.
+   * @return {*} TODO: Specify return type
    */
   setMoreInfoLinkUrl_(moreInfoUrl) {
     if (!moreInfoUrl) {

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -198,7 +198,7 @@ export class InfoDialog {
 
   /**
    * Sets the heading on the dialog.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setHeading_() {
     const label = this.localizationService_.getLocalizedString(
@@ -216,7 +216,7 @@ export class InfoDialog {
   /**
    * @param {string} pageUrl The URL to the canonical version of the current
    *     document.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setPageLink_(pageUrl) {
     const linkEl = dev().assertElement(
@@ -235,7 +235,7 @@ export class InfoDialog {
   /**
    * @param {?string} moreInfoUrl The URL to the "more info" page, if there is
    * one.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   setMoreInfoLinkUrl_(moreInfoUrl) {
     if (!moreInfoUrl) {

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -221,7 +221,7 @@ export class ShareMenu {
   /**
    * Handles click events and maybe closes the menu for the fallback UI.
    * @param  {!Event} event
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   onShareMenuClick_(event) {
     const el = dev().assertElement(event.target);

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -221,6 +221,7 @@ export class ShareMenu {
   /**
    * Handles click events and maybe closes the menu for the fallback UI.
    * @param  {!Event} event
+   * @return {*} TODO: Specify return type
    */
   onShareMenuClick_(event) {
     const el = dev().assertElement(event.target);

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -358,7 +358,7 @@ export class ShareWidget {
         const failureString = localizationService.getLocalizedString(
           LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT
         );
-        Toast.show(this.storyEl, failureString);
+        Toast.show(this.storyEl, dev().assertString(failureString));
       });
       return;
     }

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -86,7 +86,7 @@ export class UnsupportedBrowserLayer {
 
   /**
    * Builds and appends the component in the story.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   build() {
     if (this.root_) {

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -86,6 +86,7 @@ export class UnsupportedBrowserLayer {
 
   /**
    * Builds and appends the component in the story.
+   * @return {*} TODO: Specify return type
    */
   build() {
     if (this.root_) {

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -493,12 +493,19 @@ export class AnimationManager {
     this.getRunners_().forEach(runner => runner.resume());
   }
 
-  /** Determines if there is an entrance animation running. */
+  /**
+   * Determines if there is an entrance animation running.
+   *
+   * @return {*} TODO: Specify return type
+   */
   hasAnimationStarted() {
     return this.getRunners_().some(runner => runner.hasStarted());
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   getRunners_() {
     return devAssert(this.runners_, 'Executed before applyFirstFrame');
   }
@@ -676,7 +683,11 @@ class AnimationSequence {
     this.subscriptionResolvers_ = map();
   }
 
-  /** Decouples constructor for testing. */
+  /**
+   * Decouples constructor for testing.
+   *
+   * @return {!AnimationSequence}
+   */
   static create() {
     return new AnimationSequence();
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -496,7 +496,7 @@ export class AnimationManager {
   /**
    * Determines if there is an entrance animation running.
    *
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   hasAnimationStarted() {
     return this.getRunners_().some(runner => runner.hasStarted());
@@ -504,7 +504,7 @@ export class AnimationManager {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getRunners_() {
     return devAssert(this.runners_, 'Executed before applyFirstFrame');

--- a/extensions/amp-story/1.0/development-ui.js
+++ b/extensions/amp-story/1.0/development-ui.js
@@ -76,6 +76,7 @@ export class DevelopmentModeLogButtonSet {
 
   /**
    * @param {!Window} win
+   * @return {!DevelopmentModeLogButtonSet}
    */
   static create(win) {
     return new DevelopmentModeLogButtonSet(win);
@@ -184,6 +185,7 @@ export class DevelopmentModeLog {
 
   /**
    * @param {!Window} win
+   * @return {!DevelopmentModeLog}
    */
   static create(win) {
     return new DevelopmentModeLog(win);

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -306,8 +306,8 @@ export class MediaPool {
    * current position in the document.
    * @param {!PoolBoundElementDef} mediaA The first element to compare.
    * @param {!PoolBoundElementDef} mediaB The second element to compare.
-   * @private
    * @return {number}
+   * @private
    */
   compareMediaDistances_(mediaA, mediaB) {
     const distanceA = this.distanceFn_(mediaA);

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -307,6 +307,7 @@ export class MediaPool {
    * @param {!PoolBoundElementDef} mediaA The first element to compare.
    * @param {!PoolBoundElementDef} mediaB The second element to compare.
    * @private
+   * @return {number}
    */
   compareMediaDistances_(mediaA, mediaB) {
     const distanceA = this.distanceFn_(mediaA);

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -177,8 +177,8 @@ export class MediaTask {
   /**
    * @param {!HTMLMediaElement} unusedMediaEl The element on which this task
    *     should be executed.
-   * @protected
    * @return {*} TODO: Specify return type
+   * @protected
    */
   executeInternal(unusedMediaEl) {
     return Promise.resolve();

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -177,7 +177,7 @@ export class MediaTask {
   /**
    * @param {!HTMLMediaElement} unusedMediaEl The element on which this task
    *     should be executed.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @protected
    */
   executeInternal(unusedMediaEl) {

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -178,6 +178,7 @@ export class MediaTask {
    * @param {!HTMLMediaElement} unusedMediaEl The element on which this task
    *     should be executed.
    * @protected
+   * @return {*} TODO: Specify return type
    */
   executeInternal(unusedMediaEl) {
     return Promise.resolve();

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -616,6 +616,7 @@ class ManualAdvancement extends AdvancementConfig {
    * settings.
    * @param {!Object} page
    * @private
+   * @return {number}
    */
   getTapDirection_(page) {
     const {left, right} = this.sections_;

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -615,8 +615,8 @@ class ManualAdvancement extends AdvancementConfig {
    * individual section has been previously defined depending on the language
    * settings.
    * @param {!Object} page
-   * @private
    * @return {number}
+   * @private
    */
   getTapDirection_(page) {
     const {left, right} = this.sections_;

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -76,6 +76,7 @@ export class ProgressBar {
 
   /**
    * @param {!Window} win
+   * @return {!ProgressBar}
    */
   static create(win) {
     return new ProgressBar(win);

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -540,7 +540,7 @@ AMP.extension(TAG, '0.1', function(AMP) {
     'subscriptions-google',
     /**
      * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      */
     ampdoc => {
       const platformService = new GoogleSubscriptionsPlatformService(ampdoc);
@@ -565,7 +565,7 @@ AMP.extension(TAG, '0.1', function(AMP) {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getFetcherClassForTesting() {
   return Fetcher;
@@ -575,7 +575,7 @@ export function getFetcherClassForTesting() {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;
@@ -585,7 +585,7 @@ export function getPageConfigClassForTesting() {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getSubscribeResponseClassForTesting() {
   return SubscribeResponse;

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -563,7 +563,8 @@ AMP.extension(TAG, '0.1', function(AMP) {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @visibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getFetcherClassForTesting() {
@@ -572,7 +573,8 @@ export function getFetcherClassForTesting() {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @visibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
@@ -581,7 +583,8 @@ export function getPageConfigClassForTesting() {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @visibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getSubscribeResponseClassForTesting() {

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -538,7 +538,10 @@ class AmpFetcher {
 AMP.extension(TAG, '0.1', function(AMP) {
   AMP.registerServiceForDoc(
     'subscriptions-google',
-    /** @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    /**
+     * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     * @return {*} TODO: Specify return type
+     */
     ampdoc => {
       const platformService = new GoogleSubscriptionsPlatformService(ampdoc);
       const element = ampdoc.getHeadNode();
@@ -561,6 +564,7 @@ AMP.extension(TAG, '0.1', function(AMP) {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getFetcherClassForTesting() {
   return Fetcher;
@@ -569,6 +573,7 @@ export function getFetcherClassForTesting() {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;
@@ -577,6 +582,7 @@ export function getPageConfigClassForTesting() {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getSubscribeResponseClassForTesting() {
   return SubscribeResponse;

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -664,7 +664,10 @@ export class SubscriptionService {
   }
 }
 
-/** @package @VisibleForTesting */
+/**
+ * @package @VisibleForTesting
+ * @return {*} TODO: Specify return type
+ */
 export function getPlatformClassForTesting() {
   return SubscriptionPlatform;
 }
@@ -672,6 +675,7 @@ export function getPlatformClassForTesting() {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @VisibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -667,7 +667,7 @@ export class SubscriptionService {
 /**
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPlatformClassForTesting() {
   return SubscriptionPlatform;
@@ -677,7 +677,7 @@ export function getPlatformClassForTesting() {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -665,7 +665,8 @@ export class SubscriptionService {
 }
 
 /**
- * @package @VisibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPlatformClassForTesting() {
@@ -674,7 +675,8 @@ export function getPlatformClassForTesting() {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @VisibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {

--- a/extensions/amp-subscriptions/0.1/doc-impl.js
+++ b/extensions/amp-subscriptions/0.1/doc-impl.js
@@ -67,7 +67,10 @@ export class DocImpl {
   }
 }
 
-/** @package Visible for testing only. */
+/**
+ * @package Visible for testing only.
+ * @return {*} TODO: Specify return type
+ */
 export function getDocClassForTesting() {
   return Doc;
 }

--- a/extensions/amp-subscriptions/0.1/doc-impl.js
+++ b/extensions/amp-subscriptions/0.1/doc-impl.js
@@ -69,7 +69,7 @@ export class DocImpl {
 
 /**
  * @package Visible for testing only.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getDocClassForTesting() {
   return Doc;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -49,7 +49,7 @@ export class LocalSubscriptionPlatformRenderer {
   /**
    *
    * @param {!JsonObject} renderState
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   render(renderState) {
     return Promise.all([
@@ -177,7 +177,7 @@ export class LocalSubscriptionPlatformRenderer {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getEntitlementClassForTesting() {
   return Entitlement;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -175,7 +175,8 @@ export class LocalSubscriptionPlatformRenderer {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @VisibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getEntitlementClassForTesting() {

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -49,6 +49,7 @@ export class LocalSubscriptionPlatformRenderer {
   /**
    *
    * @param {!JsonObject} renderState
+   * @return {*} TODO: Specify return type
    */
   render(renderState) {
     return Promise.all([
@@ -175,6 +176,7 @@ export class LocalSubscriptionPlatformRenderer {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @VisibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getEntitlementClassForTesting() {
   return Entitlement;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -49,7 +49,7 @@ export function localSubscriptionPlatformFactory(
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -47,7 +47,8 @@ export function localSubscriptionPlatformFactory(
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @VisibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -48,6 +48,7 @@ export function localSubscriptionPlatformFactory(
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @VisibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -119,7 +119,8 @@ export class ServiceAdapter {
 }
 
 /**
- * @package @VisibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigForTesting() {

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -121,7 +121,7 @@ export class ServiceAdapter {
 /**
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -118,7 +118,10 @@ export class ServiceAdapter {
   }
 }
 
-/** @package @VisibleForTesting */
+/**
+ * @package @VisibleForTesting
+ * @return {*} TODO: Specify return type
+ */
 export function getPageConfigForTesting() {
   return PageConfig;
 }

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -107,7 +107,8 @@ export class SubscriptionPlatform {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @visibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -109,7 +109,7 @@ export class SubscriptionPlatform {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -108,6 +108,7 @@ export class SubscriptionPlatform {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -260,7 +260,7 @@ export class ViewerSubscriptionPlatform {
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package
  * @visibleForTesting
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -259,6 +259,7 @@ export class ViewerSubscriptionPlatform {
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
  * @package @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {
   return PageConfig;

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -258,7 +258,8 @@ export class ViewerSubscriptionPlatform {
 
 /**
  * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
- * @package @visibleForTesting
+ * @package
+ * @visibleForTesting
  * @return {*} TODO: Specify return type
  */
 export function getPageConfigClassForTesting() {

--- a/extensions/amp-truncate-text/0.1/shadow-utils.js
+++ b/extensions/amp-truncate-text/0.1/shadow-utils.js
@@ -21,7 +21,7 @@
  * @param {!Element} element An Element to create a ShadowRoot for.
  * @param {string} styleText The style text for the ShadowRoot.
  * @param {!Element} content The content of the shadowRoot.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function createShadowRoot(element, styleText, content) {
   // TODO(sparhami) Where is the right place to put this? Runtime? What about

--- a/extensions/amp-truncate-text/0.1/shadow-utils.js
+++ b/extensions/amp-truncate-text/0.1/shadow-utils.js
@@ -21,6 +21,7 @@
  * @param {!Element} element An Element to create a ShadowRoot for.
  * @param {string} styleText The style text for the ShadowRoot.
  * @param {!Element} content The content of the shadowRoot.
+ * @return {*} TODO: Specify return type
  */
 export function createShadowRoot(element, styleText, content) {
   // TODO(sparhami) Where is the right place to put this? Runtime? What about

--- a/extensions/amp-truncate-text/0.1/truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/truncate-text.js
@@ -198,6 +198,7 @@ export function truncateText({container, overflowNodes} = {}) {
  * @param {function(!Node): boolean} filter A filter function for which nodes
  *    (and their subtrees) to include.
  * @param {!Array<!Node>} nodes An optional Array of initial nodes to include.
+ * @return {*} TODO: Specify return type
  */
 function getAllNodes(root, filter, nodes = []) {
   if (!filter(root)) {
@@ -264,6 +265,7 @@ function underflowAtPosition(container, node, text, offset) {
  * @param {!Text} node A Text Node to ellipsize.
  * @param {!Element} container The container that should have no overflow.
  * @param {!ClientRect} containerRect The ClientRect for `container`.
+ * @return {*} TODO: Specify return type
  */
 function maybeEllipsizeNode(node, container, containerRect) {
   // The Node can have no rects if an ancestor has `display: none`. We need to

--- a/extensions/amp-truncate-text/0.1/truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/truncate-text.js
@@ -198,7 +198,7 @@ export function truncateText({container, overflowNodes} = {}) {
  * @param {function(!Node): boolean} filter A filter function for which nodes
  *    (and their subtrees) to include.
  * @param {!Array<!Node>} nodes An optional Array of initial nodes to include.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function getAllNodes(root, filter, nodes = []) {
   if (!filter(root)) {
@@ -265,7 +265,7 @@ function underflowAtPosition(container, node, text, offset) {
  * @param {!Text} node A Text Node to ellipsize.
  * @param {!Element} container The container that should have no overflow.
  * @param {!ClientRect} containerRect The ClientRect for `container`.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function maybeEllipsizeNode(node, container, containerRect) {
   // The Node can have no rects if an ancestor has `display: none`. We need to

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -93,6 +93,7 @@ export class AmpUserLocation extends AMP.BaseElement {
    * On user interaction, request the location
    * and fire the resulting AMP Events
    * @private
+   * @return {*} TODO: Specify return type
    */
   userLocationInteraction_() {
     return Promise.all([
@@ -131,6 +132,7 @@ export class AmpUserLocation extends AMP.BaseElement {
 
   /**
    * Retrieve and normalize the element's config
+   * @return {*} TODO: Specify return type
    */
   getConfig_() {
     return this.configLoader_

--- a/extensions/amp-user-location/0.1/amp-user-location.js
+++ b/extensions/amp-user-location/0.1/amp-user-location.js
@@ -93,7 +93,7 @@ export class AmpUserLocation extends AMP.BaseElement {
    * On user interaction, request the location
    * and fire the resulting AMP Events
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   userLocationInteraction_() {
     return Promise.all([
@@ -132,7 +132,7 @@ export class AmpUserLocation extends AMP.BaseElement {
 
   /**
    * Retrieve and normalize the element's config
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getConfig_() {
     return this.configLoader_

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -264,7 +264,7 @@ export class UserLocationService {
    * @param {string} expr
    * @param {string} type
    * @param {boolean=} poll
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getReplacementLocation(expr, type, poll = false) {
     return this.getLocation(poll).then(position => {

--- a/extensions/amp-user-location/0.1/user-location-service.js
+++ b/extensions/amp-user-location/0.1/user-location-service.js
@@ -264,6 +264,7 @@ export class UserLocationService {
    * @param {string} expr
    * @param {string} type
    * @param {boolean=} poll
+   * @return {*} TODO: Specify return type
    */
   getReplacementLocation(expr, type, poll = false) {
     return this.getLocation(poll).then(position => {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -904,6 +904,7 @@ export class VideoDocking {
    * @param {!DockTargetDef} target
    * @param {number=} opt_step
    * @private
+   * @return {*} TODO: Specify return type
    */
   dockInTransferLayerStep_(video, target, opt_step) {
     // Do this in a multi-step process due to a browser quirk in transferring
@@ -1082,6 +1083,7 @@ export class VideoDocking {
    * @param {number} transitionDurationMs
    * @param {RelativeX=} opt_relativeX
    * @private
+   * @return {!Promise}
    */
   placeAt_(video, x, y, scale, step, transitionDurationMs, opt_relativeX) {
     if (this.alreadyPlacedAt_(x, y, scale)) {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -903,7 +903,7 @@ export class VideoDocking {
    * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
    * @param {!DockTargetDef} target
    * @param {number=} opt_step
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   dockInTransferLayerStep_(video, target, opt_step) {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -903,8 +903,8 @@ export class VideoDocking {
    * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
    * @param {!DockTargetDef} target
    * @param {number=} opt_step
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   dockInTransferLayerStep_(video, target, opt_step) {
     // Do this in a multi-step process due to a browser quirk in transferring
@@ -1082,8 +1082,8 @@ export class VideoDocking {
    * @param {number} step in [0..1]
    * @param {number} transitionDurationMs
    * @param {RelativeX=} opt_relativeX
-   * @private
    * @return {!Promise}
+   * @private
    */
   placeAt_(video, x, y, scale, step, transitionDurationMs, opt_relativeX) {
     if (this.alreadyPlacedAt_(x, y, scale)) {

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -109,6 +109,7 @@ class AmpVideoIframe extends AMP.BaseElement {
     /**
      * @param {!Event} e
      * @private
+     * @return {*} TODO: Specify return type
      */
     this.boundOnMessage_ = e => this.onMessage_(e);
   }

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -108,7 +108,7 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     /**
      * @param {!Event} e
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      * @private
      */
     this.boundOnMessage_ = e => this.onMessage_(e);

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -108,8 +108,8 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     /**
      * @param {!Event} e
-     * @private
      * @return {*} TODO: Specify return type
+     * @private
      */
     this.boundOnMessage_ = e => this.onMessage_(e);
   }

--- a/extensions/amp-viewer-integration/0.1/findtext.js
+++ b/extensions/amp-viewer-integration/0.1/findtext.js
@@ -43,6 +43,7 @@ export class CircularBuffer {
 
   /**
    * @param {number} index The index of an element to get.
+   * @return {!TextPosDef}
    */
   get(index) {
     if (this.buff_.length >= this.max_) {

--- a/extensions/amp-viewer-integration/0.1/viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/viewer-for-testing.js
@@ -157,6 +157,7 @@ export class ViewerForTesting {
   /**
    * This is used in test-amp-viewer-integration to test the handshake and make
    * sure the test waits for everything to get executed.
+   * @return {*} TODO: Specify return type
    */
   waitForDocumentLoaded() {
     return this.documentLoadedPromise_;
@@ -164,6 +165,7 @@ export class ViewerForTesting {
 
   /**
    * This is only used for a unit test.
+   * @return {*} TODO: Specify return type
    */
   hasCapability() {
     return false;

--- a/extensions/amp-viewer-integration/0.1/viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/viewer-for-testing.js
@@ -157,7 +157,7 @@ export class ViewerForTesting {
   /**
    * This is used in test-amp-viewer-integration to test the handshake and make
    * sure the test waits for everything to get executed.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   waitForDocumentLoaded() {
     return this.documentLoadedPromise_;
@@ -165,7 +165,7 @@ export class ViewerForTesting {
 
   /**
    * This is only used for a unit test.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   hasCapability() {
     return false;

--- a/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
@@ -142,6 +142,7 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} e
+   * @return {*} TODO: Specify return type
    */
   isChannelOpen_(e) {
     return (
@@ -195,6 +196,7 @@ export class WebviewViewerForTesting {
    * Fake docs for testing
    * @param {*} eventData
    * @visibleForTesting
+   * @return {*} TODO: Specify return type
    */
   processRequest_(eventData) {
     const data = eventData;

--- a/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
@@ -142,7 +142,7 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} e
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isChannelOpen_(e) {
     return (
@@ -195,7 +195,7 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} eventData
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @visibleForTesting
    */
   processRequest_(eventData) {

--- a/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/viewer-initiated-handshake-viewer-for-testing.js
@@ -195,8 +195,8 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} eventData
-   * @visibleForTesting
    * @return {*} TODO: Specify return type
+   * @visibleForTesting
    */
   processRequest_(eventData) {
     const data = eventData;

--- a/extensions/amp-viewer-integration/0.1/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/webview-viewer-for-testing.js
@@ -149,7 +149,7 @@ export class WebviewViewerForTesting {
 
   /**
    * @param {!Event} e
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isChannelOpen_(e) {
     const data = JSON.parse(e.data);
@@ -233,7 +233,7 @@ export class WebviewViewerForTesting {
    * @param {*} type
    * @param {*} data
    * @param {*} awaitResponse
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   sendRequest_(type, data, awaitResponse) {
     this.log('Viewer.prototype.sendRequest_');
@@ -259,7 +259,7 @@ export class WebviewViewerForTesting {
   /**
    * This is used in test-amp-viewer-integration to test the handshake and make
    * sure the test waits for everything to get executed.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   waitForDocumentLoaded() {
     return this.documentLoadedPromise_;
@@ -268,7 +268,7 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} eventData
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   processRequest_(eventData) {
     const data = JSON.parse(eventData);

--- a/extensions/amp-viewer-integration/0.1/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/webview-viewer-for-testing.js
@@ -149,6 +149,7 @@ export class WebviewViewerForTesting {
 
   /**
    * @param {!Event} e
+   * @return {*} TODO: Specify return type
    */
   isChannelOpen_(e) {
     const data = JSON.parse(e.data);
@@ -232,6 +233,7 @@ export class WebviewViewerForTesting {
    * @param {*} type
    * @param {*} data
    * @param {*} awaitResponse
+   * @return {*} TODO: Specify return type
    */
   sendRequest_(type, data, awaitResponse) {
     this.log('Viewer.prototype.sendRequest_');
@@ -257,6 +259,7 @@ export class WebviewViewerForTesting {
   /**
    * This is used in test-amp-viewer-integration to test the handshake and make
    * sure the test waits for everything to get executed.
+   * @return {*} TODO: Specify return type
    */
   waitForDocumentLoaded() {
     return this.documentLoadedPromise_;
@@ -265,6 +268,7 @@ export class WebviewViewerForTesting {
   /**
    * Fake docs for testing
    * @param {*} eventData
+   * @return {*} TODO: Specify return type
    */
   processRequest_(eventData) {
     const data = JSON.parse(eventData);

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -88,8 +88,8 @@ class AmpVimeo extends AMP.BaseElement {
 
     /**
      * @param {!Event} e
-     * @private
      * @return {*} TODO: Specify return type
+     * @private
      */
     this.boundOnMessage_ = e => this.onMessage_(e);
 

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -89,6 +89,7 @@ class AmpVimeo extends AMP.BaseElement {
     /**
      * @param {!Event} e
      * @private
+     * @return {*} TODO: Specify return type
      */
     this.boundOnMessage_ = e => this.onMessage_(e);
 

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -88,7 +88,7 @@ class AmpVimeo extends AMP.BaseElement {
 
     /**
      * @param {!Event} e
-     * @return {*} TODO: Specify return type
+     * @return {*} TODO(#23582): Specify return type
      * @private
      */
     this.boundOnMessage_ = e => this.onMessage_(e);

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -222,7 +222,7 @@ export class AmpVizVega extends AMP.BaseElement {
     return parsePromise.then(
       /**
        * @param {!VegaChartFactory} chartFactory
-       * @return {*} TODO: Specify return type
+       * @return {*} TODO(#23582): Specify return type
        */
       chartFactory => {
         return Services.vsyncFor(this.win).mutatePromise(() => {

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -220,7 +220,10 @@ export class AmpVizVega extends AMP.BaseElement {
     });
 
     return parsePromise.then(
-      /** @param {!VegaChartFactory} chartFactory */
+      /**
+       * @param {!VegaChartFactory} chartFactory
+       * @return {*} TODO: Specify return type
+       */
       chartFactory => {
         return Services.vsyncFor(this.win).mutatePromise(() => {
           dom.removeChildren(dev().assertElement(this.container_));

--- a/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
@@ -229,7 +229,7 @@ export class AmpWebPushPermissionDialog {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   onPermissionDefaultOrGranted_() {
     // Prompt for permissions

--- a/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
@@ -227,7 +227,10 @@ export class AmpWebPushPermissionDialog {
     }
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   onPermissionDefaultOrGranted_() {
     // Prompt for permissions
     return this.requestNotificationPermission().then(permission => {

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -253,6 +253,7 @@ export class WebPushService {
    * Given a URL string, returns the URL without the permission dialog URL query
    * parameter fragment indicating a redirect.
    * @param {string} url
+   * @return {string}
    */
   removePermissionPopupUrlFragmentFromUrl(url) {
     let urlWithoutFragment = url.replace(
@@ -610,7 +611,10 @@ export class WebPushService {
       });
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   updateWidgetVisibilitiesServiceWorkerActivated_() {
     return Services.timerFor(this.ampdoc.win).timeoutPromise(
       5000,
@@ -758,6 +762,7 @@ export class WebPushService {
    * notification permissions when subscribing.
    *
    * @param {Array<?>} result
+   * @return {*} TODO: Specify return type
    */
   handlePermissionDialogInteraction(result) {
     /*
@@ -786,7 +791,10 @@ export class WebPushService {
     }
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   onPermissionGrantedSubscribe_() {
     return this.subscribeForPushRemotely().then(() => {
       return this.updateWidgetVisibilities();

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -613,7 +613,7 @@ export class WebPushService {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   updateWidgetVisibilitiesServiceWorkerActivated_() {
     return Services.timerFor(this.ampdoc.win).timeoutPromise(
@@ -762,7 +762,7 @@ export class WebPushService {
    * notification permissions when subscribing.
    *
    * @param {Array<?>} result
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   handlePermissionDialogInteraction(result) {
     /*
@@ -793,7 +793,7 @@ export class WebPushService {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   onPermissionGrantedSubscribe_() {
     return this.subscribeForPushRemotely().then(() => {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -248,7 +248,8 @@ export class BaseElement {
 
   /**
    * DO NOT CALL. Retained for backward compat during rollout.
-   * @public @return {!Window}
+   * @public
+   * @return {!Window}
    */
   getWin() {
     return this.win;
@@ -263,7 +264,10 @@ export class BaseElement {
     return this.element.getAmpDoc();
   }
 
-  /** @public @return {!./service/vsync-impl.Vsync} */
+  /**
+   * @public
+   * @return {!./service/vsync-impl.Vsync}
+   */
   getVsync() {
     return Services.vsyncFor(this.win);
   }
@@ -643,6 +647,7 @@ export class BaseElement {
    *   for the element to be resolved, upgraded and built.
    * @final
    * @package
+   * @return {*} TODO: Specify return type
    */
   executeAction(invocation, unusedDeferred) {
     let {method} = invocation;
@@ -1081,6 +1086,7 @@ export class BaseElement {
   /**
    * Declares a child element (or ourselves) as a Layer
    * @param {!Element=} opt_element
+   * @return {*} TODO: Specify return type
    */
   declareLayer(opt_element) {
     devAssert(

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -1086,7 +1086,7 @@ export class BaseElement {
   /**
    * Declares a child element (or ourselves) as a Layer
    * @param {!Element=} opt_element
-   * @return {*} TODO: Specify return type
+   * @return {undefined}
    */
   declareLayer(opt_element) {
     devAssert(

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -647,7 +647,7 @@ export class BaseElement {
    *   for the element to be resolved, upgraded and built.
    * @final
    * @package
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   executeAction(invocation, unusedDeferred) {
     let {method} = invocation;

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -100,7 +100,7 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
   if (opt_options && opt_options.domain) {
     domain = opt_options.domain;
   } else if (opt_options && opt_options.highestAvailableDomain) {
-    domain = getHighestAvailableDomain(win);
+    domain = /** @type {string} */ (getHighestAvailableDomain(win));
   }
   trySetCookie(win, name, value, expirationTime, domain);
 }
@@ -108,6 +108,7 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
 /**
  * Attemp to find the HighestAvailableDomain on
  * @param {!Window} win
+ * @return {?string}
  */
 export function getHighestAvailableDomain(win) {
   // <meta name='amp-cookie-scope'>. Need to respect the meta first.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1867,7 +1867,10 @@ function createBaseCustomElementClass(win) {
   return win.BaseCustomElementClass;
 }
 
-/** @param {!Element} element */
+/**
+ * @param {!Element} element
+ * @return {*} TODO: Specify return type
+ */
 function isInputPlaceholder(element) {
   return 'placeholder' in element;
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1869,7 +1869,7 @@ function createBaseCustomElementClass(win) {
 
 /**
  * @param {!Element} element
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  */
 function isInputPlaceholder(element) {
   return 'placeholder' in element;

--- a/src/document-fetcher.js
+++ b/src/document-fetcher.js
@@ -60,6 +60,7 @@ export function fetchDocument(win, input, opt_init) {
  * @param {string} input
  * @param {!FetchInitDef} init
  * @private
+ * @return {*} TODO: Specify return type
  */
 function xhrRequest(input, init) {
   return new Promise((resolve, reject) => {

--- a/src/document-fetcher.js
+++ b/src/document-fetcher.js
@@ -59,7 +59,7 @@ export function fetchDocument(win, input, opt_init) {
  *
  * @param {string} input
  * @param {!FetchInitDef} init
- * @return {*} TODO: Specify return type
+ * @return {!Promise<!{response: !Response, xhr: !XMLHttpRequest}>}
  * @private
  */
 function xhrRequest(input, init) {

--- a/src/document-fetcher.js
+++ b/src/document-fetcher.js
@@ -59,8 +59,8 @@ export function fetchDocument(win, input, opt_init) {
  *
  * @param {string} input
  * @param {!FetchInitDef} init
- * @private
  * @return {*} TODO: Specify return type
+ * @private
  */
 function xhrRequest(input, init) {
   return new Promise((resolve, reject) => {

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -231,7 +231,7 @@ export function isExtensionScriptInNode(ampdoc, extensionId) {
  * installation.
  * @param {HTMLHeadElement|Element|ShadowRoot} head
  * @param {string} extensionId
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  * @private
  */
 function extensionScriptInNode(head, extensionId) {

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -232,6 +232,7 @@ export function isExtensionScriptInNode(ampdoc, extensionId) {
  * @param {HTMLHeadElement|Element|ShadowRoot} head
  * @param {string} extensionId
  * @private
+ * @return {*} TODO: Specify return type
  */
 function extensionScriptInNode(head, extensionId) {
   return extensionScriptsInNode(head).includes(extensionId);

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -231,8 +231,8 @@ export function isExtensionScriptInNode(ampdoc, extensionId) {
  * installation.
  * @param {HTMLHeadElement|Element|ShadowRoot} head
  * @param {string} extensionId
- * @private
  * @return {*} TODO: Specify return type
+ * @private
  */
 function extensionScriptInNode(head, extensionId) {
   return extensionScriptsInNode(head).includes(extensionId);

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -178,6 +178,7 @@ export class CustomEventReporterBuilder {
    * matter) before #build() is called.
    * @param {string} eventType
    * @param {string|!Array<string>} request
+   * @return {*} TODO: Specify return type
    */
   track(eventType, request) {
     request = isArray(request) ? request : [request];
@@ -202,6 +203,7 @@ export class CustomEventReporterBuilder {
    * Call the #build() method to build and get the CustomEventReporter instance.
    * One CustomEventReporterBuilder instance can only build one reporter, which
    * means #build() should only be called once after all eventType are added.
+   * @return {!Object}
    */
   build() {
     devAssert(this.config_, 'CustomEventReporter already built');

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -178,7 +178,7 @@ export class CustomEventReporterBuilder {
    * matter) before #build() is called.
    * @param {string} eventType
    * @param {string|!Array<string>} request
-   * @return {*} TODO: Specify return type
+   * @return {!CustomEventReporterBuilder}
    */
   track(eventType, request) {
     request = isArray(request) ? request : [request];
@@ -203,7 +203,7 @@ export class CustomEventReporterBuilder {
    * Call the #build() method to build and get the CustomEventReporter instance.
    * One CustomEventReporterBuilder instance can only build one reporter, which
    * means #build() should only be called once after all eventType are added.
-   * @return {!Object}
+   * @return {!CustomEventReporter}
    */
   build() {
     devAssert(this.config_, 'CustomEventReporter already built');

--- a/src/form.js
+++ b/src/form.js
@@ -148,6 +148,7 @@ function isSubmitButton(element) {
 /**
  * Checks if a field is disabled.
  * @param {!Element} element
+ * @return {boolean}
  */
 export function isDisabled(element) {
   if (element.disabled) {

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -347,8 +347,8 @@ function mergeHtml(spec) {
 /**
  * Exposes `mergeHtml` for testing purposes.
  * @param {!FriendlyIframeSpec} spec
- * @visibleForTesting
  * @return {*} TODO: Specify return type
+ * @visibleForTesting
  */
 export function mergeHtmlForTesting(spec) {
   return mergeHtml(spec);

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -288,6 +288,7 @@ function isIframeReady(iframe) {
 /**
  * Merges base and fonts into html document.
  * @param {!FriendlyIframeSpec} spec
+ * @return {string}
  */
 function mergeHtml(spec) {
   const originalHtml = spec.html;
@@ -347,6 +348,7 @@ function mergeHtml(spec) {
  * Exposes `mergeHtml` for testing purposes.
  * @param {!FriendlyIframeSpec} spec
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function mergeHtmlForTesting(spec) {
   return mergeHtml(spec);

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -347,7 +347,7 @@ function mergeHtml(spec) {
 /**
  * Exposes `mergeHtml` for testing purposes.
  * @param {!FriendlyIframeSpec} spec
- * @return {*} TODO: Specify return type
+ * @return {string}
  * @visibleForTesting
  */
 export function mergeHtmlForTesting(spec) {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -553,6 +553,7 @@ export function isAdLike(element) {
 /**
  * @param {!Element} iframe
  * @private
+ * @return {!Element}
  */
 export function disableScrollingOnIframe(iframe) {
   addAttributesToElement(iframe, dict({'scrolling': 'no'}));

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -552,8 +552,8 @@ export function isAdLike(element) {
 
 /**
  * @param {!Element} iframe
- * @private
  * @return {!Element}
+ * @private
  */
 export function disableScrollingOnIframe(iframe) {
   addAttributesToElement(iframe, dict({'scrolling': 'no'}));

--- a/src/impression.js
+++ b/src/impression.js
@@ -168,7 +168,7 @@ function handleReplaceUrl(win) {
 
 /**
  * @param {string} referrer
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  * @visibleForTesting
  */
 export function isTrustedReferrer(referrer) {

--- a/src/impression.js
+++ b/src/impression.js
@@ -169,6 +169,7 @@ function handleReplaceUrl(win) {
 /**
  * @param {string} referrer
  * @visibleForTesting
+ * @return {*} TODO: Specify return type
  */
 export function isTrustedReferrer(referrer) {
   const url = parseUrlDeprecated(referrer);

--- a/src/impression.js
+++ b/src/impression.js
@@ -168,8 +168,8 @@ function handleReplaceUrl(win) {
 
 /**
  * @param {string} referrer
- * @visibleForTesting
  * @return {*} TODO: Specify return type
+ * @visibleForTesting
  */
 export function isTrustedReferrer(referrer) {
   const url = parseUrlDeprecated(referrer);

--- a/src/inabox/inabox-cid.js
+++ b/src/inabox/inabox-cid.js
@@ -35,7 +35,7 @@ class InaboxCid {
 
 /**
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function installInaboxCidService(ampdoc) {
   return registerServiceBuilderForDoc(ampdoc, 'cid', InaboxCid);

--- a/src/inabox/inabox-cid.js
+++ b/src/inabox/inabox-cid.js
@@ -35,6 +35,7 @@ class InaboxCid {
 
 /**
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {*} TODO: Specify return type
  */
 export function installInaboxCidService(ampdoc) {
   return registerServiceBuilderForDoc(ampdoc, 'cid', InaboxCid);

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -38,8 +38,8 @@ const MIN_EVENT_INTERVAL = 100;
 /**
  * @param {!Window} win
  * @param {!Element} bodyElement
- * @visibleForTesting
  * @return {!Promise}
+ * @visibleForTesting
  */
 export function prepareBodyForOverlay(win, bodyElement) {
   return Services.vsyncFor(win).runPromise(
@@ -71,8 +71,8 @@ export function prepareBodyForOverlay(win, bodyElement) {
 /**
  * @param {!Window} win
  * @param {!Element} bodyElement
- * @visibleForTesting
  * @return {!Promise}
+ * @visibleForTesting
  */
 export function resetBodyForOverlay(win, bodyElement) {
   return Services.vsyncFor(win).mutatePromise(() => {

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -39,6 +39,7 @@ const MIN_EVENT_INTERVAL = 100;
  * @param {!Window} win
  * @param {!Element} bodyElement
  * @visibleForTesting
+ * @return {!Promise}
  */
 export function prepareBodyForOverlay(win, bodyElement) {
   return Services.vsyncFor(win).runPromise(
@@ -71,6 +72,7 @@ export function prepareBodyForOverlay(win, bodyElement) {
  * @param {!Window} win
  * @param {!Element} bodyElement
  * @visibleForTesting
+ * @return {!Promise}
  */
 export function resetBodyForOverlay(win, bodyElement) {
   return Services.vsyncFor(win).mutatePromise(() => {

--- a/src/pass.js
+++ b/src/pass.js
@@ -47,8 +47,13 @@ export class Pass {
     /** @private {boolean} */
     this.running_ = false;
 
-    /** @private @const {!Function} */
-    this.boundPass_ = () => this.pass_();
+    /**
+     * @private
+     * @const {!Function}
+     */
+    this.boundPass_ = () => {
+      this.pass_();
+    };
   }
 
   /**

--- a/src/pass.js
+++ b/src/pass.js
@@ -49,7 +49,7 @@ export class Pass {
 
     /**
      * @private
-     * @const {!Function}
+     * @const {function()}
      */
     this.boundPass_ = () => {
       this.pass_();

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -783,7 +783,7 @@ function polyfill(win) {
 function wrapHTMLElement(win) {
   const {HTMLElement, Reflect, Object} = win;
   /**
-   * @return {*} TODO: Specify return type
+   * @return {!Element}
    */
   function HTMLElementWrapper() {
     const ctor = /** @type {function(...?):?|undefined} */ (this.constructor);

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -727,7 +727,7 @@ function polyfill(win) {
    * You can't use the real HTMLElement constructor, because you can't subclass
    * it without using native classes. So, mock its approximation using
    * createElement.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   function HTMLElementPolyfill() {
     const {constructor} = this;

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -727,6 +727,7 @@ function polyfill(win) {
    * You can't use the real HTMLElement constructor, because you can't subclass
    * it without using native classes. So, mock its approximation using
    * createElement.
+   * @return {*} TODO: Specify return type
    */
   function HTMLElementPolyfill() {
     const {constructor} = this;
@@ -782,6 +783,7 @@ function polyfill(win) {
 function wrapHTMLElement(win) {
   const {HTMLElement, Reflect, Object} = win;
   /**
+   * @return {*} TODO: Specify return type
    */
   function HTMLElementWrapper() {
     const ctor = /** @type {function(...?):?|undefined} */ (this.constructor);

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -276,6 +276,7 @@ export function sanitizeTagsForTripleMustache(html) {
  * Tag policy for handling what is valid html in templates.
  * @param {string} tagName
  * @param {!Array<string>} attribs
+ * @return {*} TODO: Specify return type
  */
 function tripleMustacheTagPolicy(tagName, attribs) {
   if (tagName == 'template') {

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -276,7 +276,7 @@ export function sanitizeTagsForTripleMustache(html) {
  * Tag policy for handling what is valid html in templates.
  * @param {string} tagName
  * @param {!Array<string>} attribs
- * @return {*} TODO: Specify return type
+ * @return {?{tagName: string, attribs: !Array<string>}}
  */
 function tripleMustacheTagPolicy(tagName, attribs) {
   if (tagName == 'template') {

--- a/src/service.js
+++ b/src/service.js
@@ -254,6 +254,7 @@ export function getServiceForDoc(elementOrAmpDoc, id) {
  * If service `id` is not registered, returns null.
  * @param {!Element|!ShadowRoot} element
  * @param {string} id
+ * @return {?Object}
  */
 function getServiceForDocOrNullInternal(element, id) {
   const ampdoc = getAmpdoc(element);

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -666,7 +666,7 @@ function getNewCidForCookie(win) {
 
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function installCidService(ampdoc) {
   return registerServiceBuilderForDoc(ampdoc, 'cid', Cid);

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -666,6 +666,7 @@ function getNewCidForCookie(win) {
 
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ * @return {*} TODO: Specify return type
  */
 export function installCidService(ampdoc) {
   return registerServiceBuilderForDoc(ampdoc, 'cid', Cid);

--- a/src/service/crypto-impl.js
+++ b/src/service/crypto-impl.js
@@ -217,7 +217,7 @@ export class Crypto {
 
 /**
  * @param {!Window} win
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function installCryptoService(win) {
   return registerServiceBuilder(win, 'crypto', Crypto);

--- a/src/service/crypto-impl.js
+++ b/src/service/crypto-impl.js
@@ -217,6 +217,7 @@ export class Crypto {
 
 /**
  * @param {!Window} win
+ * @return {*} TODO: Specify return type
  */
 export function installCryptoService(win) {
   return registerServiceBuilder(win, 'crypto', Crypto);

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -54,6 +54,7 @@ export let DocumentInfoDef;
 
 /**
  * @param {!Node|!./ampdoc-impl.AmpDoc} nodeOrDoc
+ * @return {*} TODO: Specify return type
  */
 export function installDocumentInfoServiceForDoc(nodeOrDoc) {
   return registerServiceBuilderForDoc(nodeOrDoc, 'documentInfo', DocInfo);

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -54,7 +54,7 @@ export let DocumentInfoDef;
 
 /**
  * @param {!Node|!./ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function installDocumentInfoServiceForDoc(nodeOrDoc) {
   return registerServiceBuilderForDoc(nodeOrDoc, 'documentInfo', DocInfo);

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -43,6 +43,7 @@ const LIGHTBOX_ELEMENT_CLASS = 'i-amphtml-lightbox-element';
 
 /**
  * @param {!Element} el
+ * @return {boolean}
  */
 function isLightbox(el) {
   return el.tagName.indexOf('LIGHTBOX') !== -1;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -1341,6 +1341,7 @@ function frameParent(doc) {
  * destroyed (eg, a node inside an iframe that was disconnected from the DOM).
  *
  * @param {!Node} node
+ * @return {*} TODO: Specify return type
  */
 function isDestroyed(node) {
   const {ownerDocument} = node;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -1341,7 +1341,7 @@ function frameParent(doc) {
  * destroyed (eg, a node inside an iframe that was disconnected from the DOM).
  *
  * @param {!Node} node
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  */
 function isDestroyed(node) {
   const {ownerDocument} = node;

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -37,6 +37,7 @@ const LANGUAGE_CODE_CHUNK_REGEX = /\w+/gi;
  * @param {!Object<string, !../localized-strings.LocalizedStringBundleDef>} localizedStringBundles
  * @param {!Array<string>} languageCodes
  * @param {!LocalizedStringId} localizedStringId
+ * @return {string}
  */
 function findLocalizedString(
   localizedStringBundles,
@@ -141,6 +142,7 @@ export class LocalizationService {
    *     used.  The language is based on the language at that part of the
    *     document.  If unspecified, will use the document-level language, if
    *     one exists, or the default otherwise.
+   * @return {string}
    */
   getLocalizedString(localizedStringId, elementToUse = undefined) {
     const languageCodes = elementToUse

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -37,7 +37,7 @@ const LANGUAGE_CODE_CHUNK_REGEX = /\w+/gi;
  * @param {!Object<string, !../localized-strings.LocalizedStringBundleDef>} localizedStringBundles
  * @param {!Array<string>} languageCodes
  * @param {!LocalizedStringId} localizedStringId
- * @return {string}
+ * @return {string|null}
  */
 function findLocalizedString(
   localizedStringBundles,
@@ -142,7 +142,7 @@ export class LocalizationService {
    *     used.  The language is based on the language at that part of the
    *     document.  If unspecified, will use the document-level language, if
    *     one exists, or the default otherwise.
-   * @return {string}
+   * @return {string|null}
    */
   getLocalizedString(localizedStringId, elementToUse = undefined) {
     const languageCodes = elementToUse

--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -223,6 +223,7 @@ export class Platform {
 
 /**
  * @param {!Window} window
+ * @return {*} TODO: Specify return type
  */
 export function installPlatformService(window) {
   return registerServiceBuilder(window, 'platform', Platform);

--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -223,7 +223,7 @@ export class Platform {
 
 /**
  * @param {!Window} window
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 export function installPlatformService(window) {
   return registerServiceBuilder(window, 'platform', Platform);

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -407,7 +407,7 @@ export function installTemplatesService(win) {
  * @param {!Window} win
  * @param {string} type
  * @param {!TemplateClassDef} templateClass
- * @return {*} TODO: Specify return type
+ * @return {undefined}
  */
 export function registerExtendedTemplate(win, type, templateClass) {
   const templatesService = getService(win, 'templates');

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -407,6 +407,7 @@ export function installTemplatesService(win) {
  * @param {!Window} win
  * @param {string} type
  * @param {!TemplateClassDef} templateClass
+ * @return {*} TODO: Specify return type
  */
 export function registerExtendedTemplate(win, type, templateClass) {
   const templatesService = getService(win, 'templates');

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -292,7 +292,7 @@ export class Expander {
    *    the FOO binding opt_args will be [[Result of BAR, Result of BAR], [123]].
    *    This structure is so that the outer array will have the correct number of
    *    arguments, but we still can resolve each macro separately.
-   * @return {*} TODO: Specify return type
+   * @return {string|!Promise<string>}
    */
   evaluateBinding_(bindingInfo, opt_args) {
     const {encode, name} = bindingInfo;

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -292,6 +292,7 @@ export class Expander {
    *    the FOO binding opt_args will be [[Result of BAR, Result of BAR], [123]].
    *    This structure is so that the outer array will have the correct number of
    *    arguments, but we still can resolve each macro separately.
+   * @return {*} TODO: Specify return type
    */
   evaluateBinding_(bindingInfo, opt_args) {
     const {encode, name} = bindingInfo;
@@ -443,6 +444,7 @@ export class Expander {
    * This will cast all arguments to string before calling the macro.
    *  [[Result of BAR, Result of BAR], 123]. => ['resultresult', '123']
    * @param {Array<!Array>|undefined} argsArray
+   * @return {Array<string>|undefined}
    */
   processArgsSync_(argsArray) {
     if (!argsArray) {

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -214,6 +214,7 @@ export class VariableSource {
    * @param {!Object<string, *>=} opt_bindings
    * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
    *   that can be substituted.
+   * @return {!RegExp}
    */
   getExpr(opt_bindings, opt_whiteList) {
     if (!this.initialized_) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -100,7 +100,10 @@ export class VideoManager {
     /** @private @const */
     this.actions_ = Services.actionServiceForDoc(ampdoc.getHeadNode());
 
-    /** @private @const */
+    /**
+     * @private @const
+     * @return {*} TODO: Specify return type
+     */
     this.boundSecondsPlaying_ = () => this.secondsPlaying_();
 
     /** @private @const {function():!AutoFullscreenManager} */
@@ -405,6 +408,7 @@ class VideoEntry {
       analyticsEvent(this, VideoAnalyticsEvents.SESSION_VISIBLE)
     );
 
+    // eslint-disable-next-line jsdoc/require-returns
     /** @private @const {function(): !Promise<boolean>} */
     this.supportsAutoplay_ = () => {
       const {win} = this.ampdoc_;
@@ -991,6 +995,7 @@ export class AutoFullscreenManager {
     /** @private @const {!Array<!../video-interface.VideoOrBaseElementDef>} */
     this.entries_ = [];
 
+    // eslint-disable-next-line jsdoc/require-returns
     /** @private @const {function()} */
     this.boundSelectBestCentered_ = () => this.selectBestCenteredInPortrait_();
 
@@ -1147,6 +1152,7 @@ export class AutoFullscreenManager {
    * @param {!../video-interface.VideoOrBaseElementDef} video
    * @param {?string=} optPos
    * @private
+   * @return {*} TODO: Specify return type
    */
   scrollIntoIfNotVisible_(video, optPos = null) {
     const {element} = video;
@@ -1169,18 +1175,27 @@ export class AutoFullscreenManager {
     });
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   getViewport_() {
     return Services.viewportForDoc(this.ampdoc_);
   }
 
-  /** @private @return {!Promise} */
+  /**
+   * @private
+   * @return {!Promise}
+   */
   onceOrientationChanges_() {
     const magicNumber = 330;
     return Services.timerFor(this.ampdoc_.win).promise(magicNumber);
   }
 
-  /** @private */
+  /**
+   * @private
+   * @return {*} TODO: Specify return type
+   */
   selectBestCenteredInPortrait_() {
     if (this.isInLandscape()) {
       return this.currentlyCentered_;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -101,7 +101,8 @@ export class VideoManager {
     this.actions_ = Services.actionServiceForDoc(ampdoc.getHeadNode());
 
     /**
-     * @private @const
+     * @private
+     * @const
      * @return {*} TODO: Specify return type
      */
     this.boundSecondsPlaying_ = () => this.secondsPlaying_();
@@ -1151,8 +1152,8 @@ export class AutoFullscreenManager {
    * Scrolls to a video if it's not in view.
    * @param {!../video-interface.VideoOrBaseElementDef} video
    * @param {?string=} optPos
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   scrollIntoIfNotVisible_(video, optPos = null) {
     const {element} = video;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -103,7 +103,7 @@ export class VideoManager {
     /**
      * @private
      * @const
-     * @return {*} TODO: Specify return type
+     * @return {undefined}
      */
     this.boundSecondsPlaying_ = () => this.secondsPlaying_();
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1152,7 +1152,7 @@ export class AutoFullscreenManager {
    * Scrolls to a video if it's not in view.
    * @param {!../video-interface.VideoOrBaseElementDef} video
    * @param {?string=} optPos
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   scrollIntoIfNotVisible_(video, optPos = null) {
@@ -1178,7 +1178,7 @@ export class AutoFullscreenManager {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   getViewport_() {
     return Services.viewportForDoc(this.ampdoc_);
@@ -1195,7 +1195,7 @@ export class AutoFullscreenManager {
 
   /**
    * @private
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   selectBestCenteredInPortrait_() {
     if (this.isInLandscape()) {

--- a/src/service/video-session-manager.js
+++ b/src/service/video-session-manager.js
@@ -55,6 +55,7 @@ export class VideoSessionManager {
 
   /**
    * Get the current session state.
+   * @return {*} TODO: Specify return type
    */
   isSessionActive() {
     return this.isSessionActive_;

--- a/src/service/video-session-manager.js
+++ b/src/service/video-session-manager.js
@@ -55,7 +55,7 @@ export class VideoSessionManager {
 
   /**
    * Get the current session state.
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    */
   isSessionActive() {
     return this.isSessionActive_;

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -69,6 +69,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     /** @const {function()} */
     this.boundScrollEventListener_ = this.onScrolled_.bind(this);
 
+    // eslint-disable-next-line jsdoc/require-returns
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -62,6 +62,7 @@ export class ViewportBindingNatural_ {
       this.scrollObservable_.fire();
     };
 
+    // eslint-disable-next-line jsdoc/require-returns
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -452,8 +452,8 @@ export class Vsync {
  * For optimization reasons to stop try/catch from blocking optimization.
  * @param {function(!VsyncStateDef):undefined|undefined} callback
  * @param {!VsyncStateDef} state
- * @noinline
  * @return {*} TODO: Specify return type
+ * @noinline
  */
 function callTask_(callback, state) {
   devAssert(callback);

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -452,7 +452,7 @@ export class Vsync {
  * For optimization reasons to stop try/catch from blocking optimization.
  * @param {function(!VsyncStateDef):undefined|undefined} callback
  * @param {!VsyncStateDef} state
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  * @noinline
  */
 function callTask_(callback, state) {

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -453,6 +453,7 @@ export class Vsync {
  * @param {function(!VsyncStateDef):undefined|undefined} callback
  * @param {!VsyncStateDef} state
  * @noinline
+ * @return {*} TODO: Specify return type
  */
 function callTask_(callback, state) {
   devAssert(callback);

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -73,6 +73,7 @@ export class SsrTemplateHelper {
    *     element is not attempted.
    * @param {!Object=} opt_attributes Additional JSON to send to viewer.
    * return {!Promise<{data:{?JsonObject|string|undefined}}>}
+   * @return {*} TODO: Specify return type
    */
   fetchAndRenderTemplate(
     element,

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -72,8 +72,7 @@ export class SsrTemplateHelper {
    *     the payload. If provided, finding the template in the passed in
    *     element is not attempted.
    * @param {!Object=} opt_attributes Additional JSON to send to viewer.
-   * return {!Promise<{data:{?JsonObject|string|undefined}}>}
-   * @return {*} TODO: Specify return type
+   * @return {!Promise<?JsonObject|string|undefined>}
    */
   fetchAndRenderTemplate(
     element,

--- a/src/string.js
+++ b/src/string.js
@@ -112,7 +112,7 @@ export function includes(string, substring, start) {
  *   Defaults to 1, but should be set to a larger value your placeholder tokens
  *   can be expanded to other placeholder tokens. Take caution with large values
  *   as recursively expanding a string can be exponentially expensive.
- * @return {*} TODO: Specify return type
+ * @return {string}
  */
 export function expandTemplate(template, getter, opt_maxIterations) {
   const maxIterations = opt_maxIterations || 1;

--- a/src/string.js
+++ b/src/string.js
@@ -112,6 +112,7 @@ export function includes(string, substring, start) {
  *   Defaults to 1, but should be set to a larger value your placeholder tokens
  *   can be expanded to other placeholder tokens. Take caution with large values
  *   as recursively expanding a string can be exponentially expensive.
+ * @return {*} TODO: Specify return type
  */
 export function expandTemplate(template, getter, opt_maxIterations) {
   const maxIterations = opt_maxIterations || 1;

--- a/src/url.js
+++ b/src/url.js
@@ -238,6 +238,7 @@ export function addParamsToUrl(url, params) {
  * exist in current query string.
  * @param {string} url
  * @param {!JsonObject<string, string|!Array<string>>} params
+ * @return {string}
  */
 export function addMissingParamsToUrl(url, params) {
   const location = parseUrlDeprecated(url);

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -363,7 +363,7 @@ function normalizeMethod_(method) {
 /**
  * If 415 or in the 5xx range.
  * @param {number} status
- * @return {*} TODO: Specify return type
+ * @return {boolean}
  */
 function isRetriable(status) {
   return status == 415 || (status >= 500 && status < 600);

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -245,6 +245,7 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
  * @param {string} input
  * @param {!FetchInitDef} init The options of the XHR which may get
  * intercepted.
+ * @return {string}
  */
 export function setupInput(win, input, init) {
   devAssert(typeof input == 'string', 'Only URL supported: %s', input);
@@ -362,6 +363,7 @@ function normalizeMethod_(method) {
 /**
  * If 415 or in the 5xx range.
  * @param {number} status
+ * @return {*} TODO: Specify return type
  */
 function isRetriable(status) {
   return status == 415 || (status >= 500 && status < 600);

--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -327,8 +327,8 @@ export class AmpVideoIntegration {
 
   /**
    * @param {function()} callback
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   safePlayOrPause_(callback) {
     return () => {
@@ -373,8 +373,8 @@ export class AmpVideoIntegration {
   /**
    * @param {!JsonObject} data
    * @param {function()=} opt_callback
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   postToParent_(data, opt_callback) {
     const id = this.callCounter_++;
@@ -403,8 +403,8 @@ export class AmpVideoIntegration {
    * Returns message id for testing. Private as message id is an implementation
    * detail that others should not rely on.
    * @param {function(!JsonObject)} callback
-   * @private
    * @return {*} TODO: Specify return type
+   * @private
    */
   getIntersectionForTesting_(callback) {
     return this.postToParent_(dict({'method': 'getIntersection'}), callback);

--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -327,7 +327,7 @@ export class AmpVideoIntegration {
 
   /**
    * @param {function()} callback
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   safePlayOrPause_(callback) {
@@ -373,7 +373,7 @@ export class AmpVideoIntegration {
   /**
    * @param {!JsonObject} data
    * @param {function()=} opt_callback
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   postToParent_(data, opt_callback) {
@@ -403,7 +403,7 @@ export class AmpVideoIntegration {
    * Returns message id for testing. Private as message id is an implementation
    * detail that others should not rely on.
    * @param {function(!JsonObject)} callback
-   * @return {*} TODO: Specify return type
+   * @return {*} TODO(#23582): Specify return type
    * @private
    */
   getIntersectionForTesting_(callback) {

--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -328,6 +328,7 @@ export class AmpVideoIntegration {
   /**
    * @param {function()} callback
    * @private
+   * @return {*} TODO: Specify return type
    */
   safePlayOrPause_(callback) {
     return () => {
@@ -373,6 +374,7 @@ export class AmpVideoIntegration {
    * @param {!JsonObject} data
    * @param {function()=} opt_callback
    * @private
+   * @return {*} TODO: Specify return type
    */
   postToParent_(data, opt_callback) {
     const id = this.callCounter_++;
@@ -402,6 +404,7 @@ export class AmpVideoIntegration {
    * detail that others should not rely on.
    * @param {function(!JsonObject)} callback
    * @private
+   * @return {*} TODO: Specify return type
    */
   getIntersectionForTesting_(callback) {
     return this.postToParent_(dict({'method': 'getIntersection'}), callback);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -458,6 +458,7 @@ function build() {
 /**
  * Builds one row in the channel or experiments table.
  * @param {!ExperimentDef} experiment
+ * @return {*} TODO: Specify return type
  */
 function buildExperimentRow(experiment) {
   const tr = document.createElement('tr');
@@ -640,6 +641,7 @@ function showConfirmation_(message, callback) {
  * Loads the AMP_CONFIG objects from whatever the v0.js is that the
  * user has (depends on whether they opted into canary or RC), so that
  * experiment state can reflect the default activated experiments.
+ * @return {*} TODO: Specify return type
  */
 function getAmpConfig() {
   const deferred = new Deferred();

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -458,7 +458,7 @@ function build() {
 /**
  * Builds one row in the channel or experiments table.
  * @param {!ExperimentDef} experiment
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function buildExperimentRow(experiment) {
   const tr = document.createElement('tr');
@@ -641,7 +641,7 @@ function showConfirmation_(message, callback) {
  * Loads the AMP_CONFIG objects from whatever the v0.js is that the
  * user has (depends on whether they opted into canary or RC), so that
  * experiment state can reflect the default activated experiments.
- * @return {*} TODO: Specify return type
+ * @return {*} TODO(#23582): Specify return type
  */
 function getAmpConfig() {
   const deferred = new Deferred();


### PR DESCRIPTION
It turns out there are hundreds of missing `@return` annotations across the AMP codebase, which means closure compiler has incomplete type information during minification.

**PR highlights:**
- Enables the `jsdoc/require-returns` lint rule to detect functions that return a value without specifying its type
- Adds `@return {*}` to all functions that are missing an annotation (with a `TODO` to specify the actual type )
- Specifies the correct return type for all errors detected by `gulp check-types`
    
**Notes:**
- This PR was written with the goal of making as few code changes as possible while satisfying the type checker
- The remaining `@return {*}` annotations that don't result in type errors can be gradually fixed in follow up PRs
- From here on, adding a function definition with a missing `@return` annotation will be flagged by `gulp lint`, and adding a function call where the return type is unspecified will be flagged by `gulp check-types`