### PR TITLE
Test should not initialize AMP runtime on Karma top window

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -56,17 +56,6 @@ global.describes = describes;
 // during the normal 2000 allowance.
 const BEFORE_AFTER_TIMEOUT = 5000;
 
-// Override AMP.extension to buffer extension installers.
-/**
- * @param {string} name
- * @param {string} version
- * @param {function(!Object)} installer
- * @const
- */
-global.AMP.extension = function(name, version, installer) {
-  describes.bufferExtension(`${name}:${version}`, installer);
-};
-
 // Make amp section in karma config readable by tests.
 window.ampTestRuntimeConfig = parent.karma ? parent.karma.config.amp : {};
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -57,10 +57,6 @@ global.describes = describes;
 // during the normal 2000 allowance.
 const BEFORE_AFTER_TIMEOUT = 5000;
 
-// Needs to be called before the custom elements are first made.
-beforeTest();
-adopt(window);
-
 // Override AMP.extension to buffer extension installers.
 /**
  * @param {string} name

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -20,7 +20,6 @@ import * as describes from '../testing/describes';
 import * as log from '../src/log';
 import {Services} from '../src/services';
 import {activateChunkingForTesting} from '../src/chunk';
-import {adopt} from '../src/runtime';
 import {
   installAmpdocServices,
   installRuntimeServices,


### PR DESCRIPTION
This should fail a bunch of tests that relying on global window state.