### PR TITLE
In browser validation support for other AMP HTML formats

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -98,7 +98,11 @@ function getMode_(win) {
     // Triggers validation or enable pub level logging. Validation can be
     // bypassed via #validate=0.
     // Note that AMP_DEV_MODE flag is used for testing purposes.
-    development: !!(hashQuery['development'] == '1' || win.AMP_DEV_MODE),
+    development: !!(
+      ['1', 'actions', 'amp', 'amp4ads', 'amp4email'].includes(
+        hashQuery['development']
+      ) || win.AMP_DEV_MODE
+    ),
     examiner: hashQuery['development'] == '2',
     // Allows filtering validation errors by error category. For the
     // available categories, see ErrorCategory in validator/validator.proto.

--- a/test/unit/test-mode.js
+++ b/test/unit/test-mode.js
@@ -54,6 +54,28 @@ describe('getMode', () => {
     const mode = getMode(getWin(url));
     expect(mode.lite).to.be.false;
   });
+
+  it('should support different html formats for development', () => {
+    let url = 'https://www.amp-site.org#development=1';
+    expect(getMode(getWin(url)).development).to.be.true;
+
+    url = 'https://www.amp-site.org#development=amp';
+    expect(getMode(getWin(url)).development).to.be.true;
+
+    url = 'https://www.amp-site.org#development=amp4email';
+    expect(getMode(getWin(url)).development).to.be.true;
+
+    url = 'https://www.amp-site.org#development=amp4ads';
+    expect(getMode(getWin(url)).development).to.be.true;
+
+    url = 'https://www.amp-site.org#development=actions';
+    expect(getMode(getWin(url)).development).to.be.true;
+  });
+
+  it('should not support invalid format for development', () => {
+    const url = 'https://www.amp-site.org#development=amp4invalid';
+    expect(getMode(getWin(url)).development).to.be.false;
+  });
 });
 
 describe('getRtvVersion', () => {


### PR DESCRIPTION
Add support for all AMP HTML (amp, amp4ads, actions, amp4email) formats during in browser development mode. The corresponding validator engine changes to support this will roll up. If this or the validator changes are not synced via the same release it is fine as the default behavior is to validate against the `AMP` format.