### PR TITLE
🐛 Fix forEach is not a function error

### DIFF
--- a/extensions/amp-link-rewriter/0.1/scope.js
+++ b/extensions/amp-link-rewriter/0.1/scope.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {iterateCursor} from '../../../src/dom';
+
 /**
  *
  * @param {?../../../src/service/ampdoc-impl.AmpDoc} ampDoc
@@ -31,7 +33,7 @@ export function getScopeElements(ampDoc, configOpts) {
     selection = doc.querySelectorAll(cssSelector);
   }
 
-  selection.forEach(element => {
+  iterateCursor(selection, element => {
     if (hasAttributeValues(element, configOpts)) {
       filteredSelection.push(element);
     }


### PR DESCRIPTION
Classic forEach on a `NodeList` error. We could save ourselves a lot of trouble if we added a conformance check for this.