### PR TITLE
🐛 Fix forEach on NodeList

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -32,6 +32,7 @@ import {CSS as attributionCSS} from '../../../build/amp-story-auto-ads-attributi
 import {
   createElementWithAttributes,
   isJsonScriptTag,
+  iterateCursor,
   openWindowDialog,
 } from '../../../src/dom';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
@@ -975,7 +976,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const iframeDoc = getFrameDoc(iframe);
     const tags = getA4AMetaTags(iframeDoc);
     const vars = {};
-    tags.forEach(tag => {
+    iterateCursor(tags, tag => {
       const name = tag.name.split('amp4ads-vars-')[1];
       const {content} = tag;
       vars[name] = content;


### PR DESCRIPTION
Related to #21234

`getA4AMetaTags` returns a `NodeList` and not an array, and calling `forEach` on it breaks in IE11.

https://github.com/ampproject/amphtml/blob/1d5d13943b0fdf941b6dc63c0941cf7953810589/extensions/amp-story-auto-ads/0.1/utils.js#L44-L51