### PR TITLE
♿ Read validation messages politely

### DIFF
--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -132,6 +132,7 @@ export class FormValidator {
 
   /**
    * @return {string} A unique ID.
+   * @protected
    */
   createUniqueAriaDescId_() {
     return (

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -96,18 +96,6 @@ export class FormValidator {
      * @private {boolean|null}
      */
     this.formValidity_ = null;
-
-    /** @private {string} */
-    this.uniqueFormId_ = this.form.id
-      ? this.form.id
-      : String(Date.now() + Math.floor(Math.random() * 100));
-
-    /**
-     * Counter used to create a unique id for every validation message
-     * to be used with `aria-describedby`.
-     * @protected {number}
-     */
-    this.ariaDescCounter_ = 0;
   }
 
   /**
@@ -128,16 +116,6 @@ export class FormValidator {
   /** @return {!NodeList} */
   inputs() {
     return this.form.querySelectorAll('input,select,textarea');
-  }
-
-  /**
-   * @return {string} A unique ID.
-   * @protected
-   */
-  createUniqueAriaDescId_() {
-    return (
-      ARIA_DESC_ID_PREFIX + this.uniqueFormId_ + '-' + this.ariaDescCounter_++
-    );
   }
 
   /**
@@ -292,6 +270,18 @@ export class AbstractCustomValidator extends FormValidator {
    */
   constructor(form) {
     super(form);
+
+    /** @private {string} */
+    this.uniqueFormId_ = this.form.id
+      ? this.form.id
+      : String(Date.now() + Math.floor(Math.random() * 100));
+
+    /**
+     * Counter used to create a unique id for every validation message
+     * to be used with `aria-describedby`.
+     * @private {number}
+     */
+    this.ariaDescCounter_ = 0;
   }
 
   /**
@@ -302,6 +292,15 @@ export class AbstractCustomValidator extends FormValidator {
     if (invalidType) {
       this.showValidationFor(input, invalidType);
     }
+  }
+
+  /**
+   * @return {string} A unique ID.
+   * @private
+   */
+  createUniqueAriaDescId_() {
+    return `${ARIA_DESC_ID_PREFIX}${this.uniqueFormId_}-${this
+      .ariaDescCounter_++}`;
   }
 
   /**
@@ -376,11 +375,9 @@ export class AbstractCustomValidator extends FormValidator {
       validation.setAttribute('id', validationId);
     }
 
-    this.resources.mutateElement(input, () => {
-      input.setAttribute('aria-invalid', 'true');
-      dev().assertString(validationId);
-      input.setAttribute('aria-describedby', validationId);
-    });
+    input.setAttribute('aria-invalid', 'true');
+    input.setAttribute('aria-describedby', validationId);
+
     this.resources.mutateElement(validation, () =>
       validation.classList.add('visible')
     );
@@ -396,10 +393,9 @@ export class AbstractCustomValidator extends FormValidator {
     }
     delete input[VISIBLE_VALIDATION_CACHE];
 
-    this.resources.mutateElement(input, () => {
-      input.removeAttribute('aria-invalid');
-      input.removeAttribute('aria-describedby');
-    });
+    input.removeAttribute('aria-invalid');
+    input.removeAttribute('aria-describedby');
+
     this.resources.mutateElement(visibleValidation, () =>
       visibleValidation.classList.remove('visible')
     );

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -101,6 +101,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     const invalidEmail = doc.createElement('div');
     invalidEmail.setAttribute('visible-when-invalid', 'typeMismatch');
     invalidEmail.setAttribute('validation-for', 'email1');
+    invalidEmail.setAttribute('id', 'invalidformat-for-email1');
     invalidEmail.textContent = emailTypeValidationMsg;
 
     const invalidText = doc.createElement('div');
@@ -325,6 +326,25 @@ describes.realWin('form-validators', {amp: true}, env => {
       expect(validations[1].className).to.not.contain('visible');
       expect(validations[2].className).to.not.contain('visible');
       expect(validations[3].className).to.not.contain('visible');
+    });
+
+    it('should set aria-describedby to the first validation message', () => {
+      validator.report();
+      expect(validations[0].getAttribute('id')).to.be.a('string');
+      expect(form.elements[0].getAttribute('aria-describedby')).to.equal(
+        validations[0].getAttribute('id')
+      );
+    });
+
+    it('should set aria-describedby to the second validation message with preset id', () => {
+      form.elements[0].value = 'John Miller';
+      form.elements[1].value = 'invalidemail';
+      form.elements[1].validationMessage = 'Email format is wrong';
+      validator.report();
+      validator.onInput({target: form.elements[1]});
+      expect(form.elements[1].getAttribute('aria-describedby')).to.equal(
+        'invalidformat-for-email1'
+      );
     });
 
     it('should not report on interaction for non-active inputs', () => {

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -328,7 +328,7 @@ describes.realWin('form-validators', {amp: true}, env => {
       expect(validations[3].className).to.not.contain('visible');
     });
 
-    it('should set aria-describedby to the first validation message', () => {
+    it('should set aria-describedby to the first validation message (generated ID)', () => {
       validator.report();
       expect(validations[0].getAttribute('id')).to.be.a('string');
       expect(form.elements[0].getAttribute('aria-describedby')).to.equal(
@@ -336,7 +336,7 @@ describes.realWin('form-validators', {amp: true}, env => {
       );
     });
 
-    it('should set aria-describedby to the second validation message with preset id', () => {
+    it('should set aria-describedby to the second validation message (existing ID)', () => {
       form.elements[0].value = 'John Miller';
       form.elements[1].value = 'invalidemail';
       form.elements[1].validationMessage = 'Email format is wrong';


### PR DESCRIPTION
Closes #12717 

### Changes
- Assigns a unique ID to validation messages when necessary (needed for an a11y attr)
- Sets the `aria-describedby` attribute on the invalid form element to its corresponding validation message
- Adds tests for the changes

@jamesshannon This should do what was described in the issue but I am not sure if it fixes the issue and actually "reads validation messages politely" so it would be great to test with Voice Over and let me know if this is the desired behavior.