### PR TITLE
Sanitize non-whitelisted AMP elements in AMP4EMAIL

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -36,6 +36,7 @@ import {findIndex, remove} from '../../../src/utils/array';
 import {getMode} from '../../../src/mode';
 import {installServiceInEmbedScope} from '../../../src/service';
 import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
+import {isAmp4Email} from '../../../src/format';
 import {isArray, isFiniteNumber, isObject, toArray} from '../../../src/types';
 import {reportError} from '../../../src/error';
 import {rewriteAttributesForElement} from '../../../src/url-rewrite';
@@ -531,7 +532,7 @@ export class Bind {
    */
   initialize_(root) {
     // Disallow URL property bindings in AMP4EMAIL.
-    const allowUrlProperties = !this.isAmp4Email_();
+    const allowUrlProperties = !isAmp4Email(this.localWin_.document);
     this.validator_ = new BindValidator(allowUrlProperties);
 
     // The web worker's evaluator also has an instance of BindValidator
@@ -569,17 +570,6 @@ export class Bind {
         this.viewer_.sendMessage('bindReady', undefined);
         this.dispatchEventForTesting_(BindEvents.INITIALIZE);
       });
-  }
-
-  /**
-   * @return {boolean}
-   * @private
-   */
-  isAmp4Email_() {
-    const html = this.localWin_.document.documentElement;
-    const amp4email =
-      html.hasAttribute('amp4email') || html.hasAttribute('⚡4email');
-    return amp4email;
   }
 
   /**

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -326,7 +326,7 @@ export class SanitizerImpl {
     this.purifier_ = createPurifier(win.document, dict({'IN_PLACE': true}));
 
     /** @private @const {!Object<string, boolean>} */
-    this.allowedTags_ = getAllowedTags(win.document);
+    this.allowedTags_ = getAllowedTags();
 
     // TODO(choumx): Support opt-in for variable substitutions.
     // For now, only allow built-in AMP components except amp-pixel.

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -16,13 +16,15 @@
 
 import {
   BIND_PREFIX,
+  BLACKLISTED_TAGS,
+  EMAIL_WHITELISTED_AMP_TAGS,
   TRIPLE_MUSTACHE_WHITELISTED_TAGS,
   WHITELISTED_ATTRS,
   WHITELISTED_ATTRS_BY_TAGS,
   WHITELISTED_TARGETS,
-  blacklistedTags,
   isValidAttr,
 } from './sanitation';
+import {isAmp4Email} from './format';
 import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';
@@ -74,7 +76,7 @@ let KEY_COUNTER = 0;
  * @return {!Node}
  */
 export function purifyHtml(dirty, doc, diffing = false) {
-  const config = standardPurifyConfig(doc);
+  const config = standardPurifyConfig();
   addPurifyHooks(DomPurify, diffing, doc);
   const body = DomPurify.sanitize(dirty, config);
   DomPurify.removeAllHooks();
@@ -89,7 +91,7 @@ export function purifyHtml(dirty, doc, diffing = false) {
  */
 export function createPurifier(doc, opt_config) {
   const domPurify = purify(self);
-  const config = Object.assign(opt_config || {}, standardPurifyConfig(doc));
+  const config = Object.assign(opt_config || {}, standardPurifyConfig());
   domPurify.setConfig(config);
   addPurifyHooks(domPurify, /* diffing */ false, doc);
   return domPurify;
@@ -104,16 +106,15 @@ export function createPurifier(doc, opt_config) {
  * closure compiler from optimizing these fields here in this file and in the
  * 3rd party library file. See #19624 for further information.
  *
- * @param {!Document} doc
  * @return {!DomPurifyConfig}
  */
-function standardPurifyConfig(doc) {
+function standardPurifyConfig() {
   const config = Object.assign(
     {},
     PURIFY_PROFILES,
     /** @type {!DomPurifyConfig} */ ({
       ADD_ATTR: WHITELISTED_ATTRS,
-      FORBID_TAGS: Object.keys(blacklistedTags(doc)),
+      FORBID_TAGS: Object.keys(BLACKLISTED_TAGS),
       // Avoid reparenting of some elements to document head e.g. <script>.
       FORCE_BODY: true,
       // Avoid need for serializing to/from string by returning Node directly.
@@ -128,10 +129,9 @@ function standardPurifyConfig(doc) {
 
 /**
  * Gets a copy of the map of allowed tag names (standard DOMPurify config).
- * @param {!Document} doc
  * @return {!Object<string, boolean>}
  */
-export function getAllowedTags(doc) {
+export function getAllowedTags() {
   const allowedTags = {};
   // Use this hook to extract purifier's allowed tags.
   DomPurify.addHook('uponSanitizeElement', function(node, data) {
@@ -139,9 +139,8 @@ export function getAllowedTags(doc) {
   });
   // Sanitize dummy markup so that the hook is invoked.
   DomPurify.sanitize('<p></p>');
-  // Remove any blacklisted tags.
-  Object.keys(blacklistedTags(doc)).forEach(tag => {
-    delete allowedTags[tag];
+  Object.keys(BLACKLISTED_TAGS).forEach(tag => {
+    allowedTags[tag] = false;
   });
   // Pops the last hook added.
   DomPurify.removeHook('uponSanitizeElement');
@@ -155,6 +154,8 @@ export function getAllowedTags(doc) {
  * @param {!Document} doc
  */
 function addPurifyHooks(purifier, diffing, doc) {
+  const isEmail = isAmp4Email(doc);
+
   // Reference to DOMPurify's `allowedTags` whitelist.
   let allowedTags;
   const allowedTagsChanges = [];
@@ -182,7 +183,8 @@ function addPurifyHooks(purifier, diffing, doc) {
 
     // Allow all AMP elements.
     if (startsWith(tagName, 'amp-')) {
-      allowedTags[tagName] = true;
+      // Enforce AMP4EMAIL tag whitelist at runtime.
+      allowedTags[tagName] = !isEmail || EMAIL_WHITELISTED_AMP_TAGS[tagName];
       // AMP elements don't support arbitrary mutation, so don't DOM diff them.
       disableDiffingFor(node);
     }

--- a/src/sanitation.js
+++ b/src/sanitation.js
@@ -24,9 +24,9 @@ export const BIND_PREFIX = 'data-amp-bind-';
 
 /**
  * @const {!Object<string, boolean>}
- * See https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md
+ * @see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md
  */
-const BLACKLISTED_TAGS = Object.freeze({
+export const BLACKLISTED_TAGS = {
   'applet': true,
   'audio': true,
   'base': true,
@@ -40,29 +40,28 @@ const BLACKLISTED_TAGS = Object.freeze({
   'object': true,
   'style': true,
   'video': true,
-});
+};
 
 /**
- * Rules in addition to BLACKLISTED_TAGS for AMP4EMAIL.
+ * AMP elements allowed in AMP4EMAIL, modulo:
+ * - amp-list, which cannot be nested.
+ * - amp-lightbox and amp-image-lightbox, which are deprecated.
  * @const {!Object<string, boolean>}
+ * @see https://github.com/ampproject/amphtml/blob/master/spec/email/amp-email-components.md
  */
-const EMAIL_BLACKLISTED_TAGS = Object.freeze({
-  // See disallowed_ancestor in validator-amp-list.protoascii.
-  'amp-list': true,
-});
-
-/**
- *
- * @param {!Document} doc
- * @return {!Object<string, boolean>}
- */
-export function blacklistedTags(doc) {
-  return Object.assign(
-    map(),
-    BLACKLISTED_TAGS,
-    isAmp4Email(doc) ? EMAIL_BLACKLISTED_TAGS : {}
-  );
-}
+export const EMAIL_WHITELISTED_AMP_TAGS = {
+  'amp-accordion': true,
+  'amp-anim': true,
+  'amp-bind-macro': true,
+  'amp-carousel': true,
+  'amp-fit-text': true,
+  'amp-img': true,
+  'amp-layout': true,
+  'amp-selector': true,
+  'amp-sidebar': true,
+  'amp-state': true,
+  'amp-timeago': true,
+};
 
 /**
  * Whitelist of tags allowed in triple mustache e.g. {{{name}}}.

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -16,15 +16,17 @@
 
 import {
   BIND_PREFIX,
+  BLACKLISTED_TAGS,
+  EMAIL_WHITELISTED_AMP_TAGS,
   TRIPLE_MUSTACHE_WHITELISTED_TAGS,
   WHITELISTED_ATTRS,
   WHITELISTED_ATTRS_BY_TAGS,
   WHITELISTED_TARGETS,
-  blacklistedTags,
   isValidAttr,
 } from './sanitation';
 import {dict} from './utils/object';
 import {htmlSanitizer} from '../third_party/caja/html-sanitizer';
+import {isAmp4Email} from './format';
 import {rewriteAttributeValue} from './url-rewrite';
 import {startsWith} from './string';
 import {user} from './log';
@@ -98,7 +100,7 @@ export function sanitizeHtml(html, doc, diffing) {
   // No Caja support for <script> or <svg>.
   const cajaBlacklistedTags = Object.assign(
     {'script': true, 'svg': true},
-    blacklistedTags(doc)
+    BLACKLISTED_TAGS
   );
 
   const parser = htmlSanitizer.makeSaxParser({
@@ -130,7 +132,12 @@ export function sanitizeHtml(html, doc, diffing) {
 
       if (cajaBlacklistedTags[tagName]) {
         ignore++;
-      } else if (!isAmpElement) {
+      } else if (isAmpElement) {
+        // Enforce AMP4EMAIL tag whitelist at runtime.
+        if (isAmp4Email(doc) && !EMAIL_WHITELISTED_AMP_TAGS[tagName]) {
+          ignore++;
+        }
+      } else {
         // Ask Caja to validate the element as well.
         // Use the resulting properties.
         const savedAttribs = attribs.slice(0);

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -787,13 +787,10 @@ describe('validateAttributeChange', () => {
 });
 
 describe('getAllowedTags', () => {
-  let html;
   let allowedTags;
 
   beforeEach(() => {
-    html = document.createElement('html');
-    const doc = {documentElement: html};
-    allowedTags = getAllowedTags(doc);
+    allowedTags = getAllowedTags();
   });
 
   it('should contain html tags', () => {

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -422,8 +422,41 @@ describe
           expect(purify('<amp-anim controls></amp-anim>')).to.equal(
             '<amp-anim></amp-anim>'
           );
-          expect(purify('<amp-list>')).to.equal('');
         });
+      });
+
+      it('should only allow whitelisted AMP elements in AMP4EMAIL', () => {
+        html.setAttribute('amp4email', '');
+        allowConsoleError(() => {
+          expect(purify('<amp-analytics>')).to.equal('');
+          expect(purify('<amp-iframe>')).to.equal('');
+          expect(purify('<amp-list>')).to.equal('');
+          expect(purify('<amp-pixel>')).to.equal('');
+          expect(purify('<amp-twitter>')).to.equal('');
+          expect(purify('<amp-video>')).to.equal('');
+          expect(purify('<amp-youtube>')).to.equal('');
+        });
+
+        expect(purify('<amp-accordion>')).to.equal(
+          '<amp-accordion></amp-accordion>'
+        );
+        expect(purify('<amp-anim>')).to.equal('<amp-anim></amp-anim>');
+        expect(purify('<amp-bind-macro>')).to.equal(
+          '<amp-bind-macro></amp-bind-macro>'
+        );
+        expect(purify('<amp-carousel>')).to.equal(
+          '<amp-carousel></amp-carousel>'
+        );
+        expect(purify('<amp-fit-text>')).to.equal(
+          '<amp-fit-text></amp-fit-text>'
+        );
+        expect(purify('<amp-img>')).to.equal('<amp-img></amp-img>');
+        expect(purify('<amp-layout>')).to.equal('<amp-layout></amp-layout>');
+        expect(purify('<amp-selector>')).to.equal(
+          '<amp-selector></amp-selector>'
+        );
+        expect(purify('<amp-sidebar>')).to.equal('<amp-sidebar></amp-sidebar>');
+        expect(purify('<amp-timeago>')).to.equal('<amp-timeago></amp-timeago>');
       });
     });
 
@@ -773,14 +806,9 @@ describe('getAllowedTags', () => {
     expect(allowedTags).to.have.property('feblend', true);
   });
 
-  it('should not contain blacklisted tags', () => {
+  it('should have blacklisted tags set to false', () => {
     // Tags allowed in DOMPurify but disallowed in AMP.
-    expect(allowedTags).to.not.have.property('audio');
-    expect(allowedTags).to.not.have.property('img');
-  });
-
-  it('should not allow certain tags in amp4email', () => {
-    html.setAttribute('amp4email', '');
-    expect(allowedTags).to.not.have.property('amp-list');
+    expect(allowedTags).to.have.property('audio', false);
+    expect(allowedTags).to.have.property('img', false);
   });
 });

--- a/test/unit/test-sanitizer.js
+++ b/test/unit/test-sanitizer.js
@@ -428,6 +428,30 @@ function runSanitizerTests() {
         );
       });
     });
+
+    it('should only allow whitelisted AMP elements in AMP4EMAIL', () => {
+      html.setAttribute('amp4email', '');
+      allowConsoleError(() => {
+        expect(sanitize('<amp-analytics>')).to.equal('');
+        expect(sanitize('<amp-iframe>')).to.equal('');
+        expect(sanitize('<amp-list>')).to.equal('');
+        expect(sanitize('<amp-pixel>')).to.equal('');
+        expect(sanitize('<amp-twitter>')).to.equal('');
+        expect(sanitize('<amp-video>')).to.equal('');
+        expect(sanitize('<amp-youtube>')).to.equal('');
+      });
+
+      expect(sanitize('<amp-accordion>')).to.equal('<amp-accordion>');
+      expect(sanitize('<amp-anim>')).to.equal('<amp-anim>');
+      expect(sanitize('<amp-bind-macro>')).to.equal('<amp-bind-macro>');
+      expect(sanitize('<amp-carousel>')).to.equal('<amp-carousel>');
+      expect(sanitize('<amp-fit-text>')).to.equal('<amp-fit-text>');
+      expect(sanitize('<amp-img>')).to.equal('<amp-img>');
+      expect(sanitize('<amp-layout>')).to.equal('<amp-layout>');
+      expect(sanitize('<amp-selector>')).to.equal('<amp-selector>');
+      expect(sanitize('<amp-sidebar>')).to.equal('<amp-sidebar>');
+      expect(sanitize('<amp-timeago>')).to.equal('<amp-timeago>');
+    });
   });
 
   describe('sanitizeTagsForTripleMustache', () => {


### PR DESCRIPTION
Enforce the AMP component whitelist at runtime as well.