### PR TITLE
🐛 Fix merge conflict between #23577 and #23559

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -44,7 +44,7 @@ export function getUniqueId(win) {
 /**
  * Finds all meta tags starting with `amp4ads-vars-`.
  * @param {Document} doc
- * @return {*} TODO(#23582): Specify return type
+ * @return {!IArrayLike}
  */
 export function getA4AMetaTags(doc) {
   const selector = 'meta[name^=amp4ads-vars-]';


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/pull/23577#pullrequestreview-268064478

See https://travis-ci.org/ampproject/amphtml/jobs/565201762#L383
```js
...Type checking failed:
extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js:986: ERROR - [JSC_TYPE_MISMATCH] actual parameter 1 of iterateCursor$$module$src$dom does not match formal parameter
found   : *
required: IArrayLike<?>
    iterateCursor(tags, tag => {
                  ^^^^
```