### PR TITLE
🏗 Synchronize `gulp dep-check` and make error output more readable

### DIFF
--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -18,7 +18,6 @@
 const babelify = require('babelify');
 const BBPromise = require('bluebird');
 const browserify = require('browserify');
-const colors = require('ansi-colors');
 const depCheckConfig = require('../dep-check-config');
 const fs = BBPromise.promisifyAll(require('fs-extra'));
 const gulp = require('gulp');
@@ -30,11 +29,11 @@ const through = require('through2');
 const {BABELIFY_GLOBAL_TRANSFORM} = require('./helpers');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
 const {css} = require('./css');
+const {cyan, red, yellow} = require('ansi-colors');
 const {isTravisBuild} = require('../travis');
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
-const red = msg => log(colors.red(msg));
 
 /**
  * @typedef {{
@@ -141,8 +140,7 @@ Rule.prototype.matchBadDeps = function(moduleName, deps) {
           return;
         }
         mustNotDependErrors.push(
-          `${moduleName} must not depend on ${dep}. ` +
-            `Rule: ${JSON.stringify(this.config_)}.`
+          cyan(moduleName) + ' must not depend on ' + cyan(dep)
         );
       }
     });
@@ -287,8 +285,9 @@ function runRules(modules) {
 
     if (errors.length) {
       errorsFound = true;
-      // Report errors.
-      errors.forEach(red);
+      errors.forEach(error => {
+        log(red('ERROR:'), error);
+      });
     }
   });
   return errorsFound;
@@ -311,7 +310,14 @@ async function depCheck() {
     .then(runRules)
     .then(errorsFound => {
       if (errorsFound) {
-        process.exit(1);
+        log(
+          yellow('NOTE:'),
+          'If a dependency is valid, add it to one of the whitelists in',
+          cyan('build-system/dep-check-config.js')
+        );
+        const reason = new Error('Dependency checks failed');
+        reason.showStack = false;
+        return Promise.reject(reason);
       }
     })
     .then(() => exitCtrlcHandler(handlerProcess));

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -273,8 +273,8 @@ function flattenGraph(entryPoints) {
 /**
  * Run Module dependency graph against the rules.
  *
- * @param {!Array<!ModuleDef>} modules
- * @return {*} TODO(#23582): Specify return type
+ * @param {!ModuleDef} modules
+ * @return {boolean}
  */
 function runRules(modules) {
   let errorsFound = false;


### PR DESCRIPTION
The `gulp dep-check` task has a few problems when it detects a dependency error:
- It repeatedly prints all dependency rules for every error, which makes the output extremely verbose and unreadable
- It does not suggest a fix for valid dependencies
- It doesn't cleanly exit and causes `gulp` to [complain](https://travis-ci.org/ampproject/amphtml/jobs/565138133#L664) about async completion

This PR fixes all the above problems.

**Before:**
<img width="1434" alt="Screen Shot 2019-07-29 at 6 44 26 PM" src="https://user-images.githubusercontent.com/26553114/62087866-44dd3480-b231-11e9-89b2-d98b55d85b4e.png">

**After:**
<img width="1066" alt="Screen Shot 2019-07-29 at 6 58 22 PM" src="https://user-images.githubusercontent.com/26553114/62088288-dbf6bc00-b232-11e9-99c6-c4cc91171372.png">
