### PR TITLE
🚮 Remove XML self-closing slash from rel=canonical link tags in validator example pages

### DIFF
--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -39,7 +39,7 @@
       '\x3Chtml ⚡>\n' +
       '\x3Chead>\n' +
       '  \x3Cmeta charset="utf-8">\n' +
-      '  \x3Clink rel="canonical" href="self.html" />\n' +
+      '  \x3Clink rel="canonical" href="self.html">\n' +
       '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
       '  \x3Cstyle amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}\x3C/style>\x3Cnoscript>\x3Cstyle amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\x3C/style>\x3C/noscript>\n' +
       '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +
@@ -89,7 +89,7 @@
       '\x3Chtml ⚡ actions>\n' +
       '\x3Chead>\n' +
       '  \x3Cmeta charset="utf-8">\n' +
-      '  \x3Clink rel="canonical" href="self.html" />\n' +
+      '  \x3Clink rel="canonical" href="self.html">\n' +
       '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
       '  \x3Cstyle amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}\x3C/style>\x3Cnoscript>\x3Cstyle amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\x3C/style>\x3C/noscript>\n' +
       '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +


### PR DESCRIPTION
The AMP documents shown at https://validator.ampproject.org/ are not actually as minimally valid as they can be: the XML self-closing slash should be removed.

```diff
- <link rel="canonical" href="self.html" />
+ <link rel="canonical" href="self.html">
```

The `meta`  tags lack the self-closing slashes and there's no treason for the `link` tags to have them. This is HTML not XHTML.