### PR TITLE
delete ad server in the preconnect list

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1020,10 +1020,7 @@ export const adConfig = {
 
   'valuecommerce': {
     prefetch: 'https://amp.valuecommerce.com/amp_bridge.js',
-    preconnect: [
-      'https://ad.jp.ap.valuecommerce.com',
-      'https://ad.omks.valuecommerce.com',
-    ],
+    preconnect: ['https://ad.jp.ap.valuecommerce.com'],
     renderStartImplemented: true,
   },
 


### PR DESCRIPTION
This PR is intended for delete in the ad server list.

As we have finished providing the functions,
by delete ad.omks.valuecommerce.com in preconnect array.

Corporation name: ValueCommerce Co., Ltd.