### PR TITLE
✨ Update analytics vendor split experiments config

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,7 +1,7 @@
 {
   "experimentA": {
     "name": "ANALYTICS_VENDOR_SPLIT",
-    "command": "gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
+    "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
     "expirationDateUTC": "2019-08-08",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -386,7 +386,7 @@ function buildExtension(
   }
 
   // minify and copy vendor configs for amp-analytics component
-  if (name === 'amp-analytics' && argv.compile_vendor_configs) {
+  if (name === 'amp-analytics') {
     promises.push(compileVendorConfigs(options));
   }
 


### PR DESCRIPTION
- Add `gulp generate-vendor-configs` to experiments command so that vendor JSONs are generated during the experiment build
- Enable `--compile_vendor_configs` by default, so no need to add this flag anymore