### PR TITLE
🏗 Set Travis e2e job as non blocking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,11 +80,14 @@ jobs:
         - build-system/sauce_connect/stop_sauce_connect.sh
         - ps -ef
     - stage: test
-      name: "End to End Tests"
+      name: "[TEMPORARILY NON BLOCKING] End to End Tests"
       script:
         - unbuffer node build-system/pr-check/e2e-tests.js
       after_script:
         - ps -ef
+  allow_failures:
+    - script:
+      - unbuffer node build-system/pr-check/e2e-tests.js
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Set back to blocking once Chrome / ChromeDriver versioning issue is fixed.