### PR TITLE
Move updateInViewport to from resource to owners service impl

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -344,12 +344,20 @@ export class AmpScrollableCarousel extends BaseCarousel {
     const seen = [];
     this.withinWindow_(newPos, cell => {
       seen.push(cell);
-      this.updateInViewport(cell, true);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        cell,
+        true
+      );
     });
     if (oldPos != newPos) {
       this.withinWindow_(oldPos, cell => {
         if (!seen.includes(cell)) {
-          this.updateInViewport(cell, false);
+          Services.ownersForDoc(this.element).updateInViewport(
+            this.element,
+            cell,
+            false
+          );
           this.schedulePause(cell);
         }
       });

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -338,7 +338,8 @@ export class AmpSlideScroll extends BaseSlides {
   /** @override */
   updateViewportState(inViewport) {
     if (this.slideIndex_ !== null) {
-      this.updateInViewport(
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
         this.slides_[
           user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
         ],
@@ -684,7 +685,8 @@ export class AmpSlideScroll extends BaseSlides {
       showIndexArr.push(nextIndex);
     }
     if (this.slideIndex_ !== null) {
-      this.updateInViewport(
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
         this.slides_[
           user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
         ],
@@ -702,7 +704,11 @@ export class AmpSlideScroll extends BaseSlides {
       );
       return false;
     }
-    this.updateInViewport(newSlideInView, true);
+    Services.ownersForDoc(this.element).updateInViewport(
+      this.element,
+      newSlideInView,
+      true
+    );
     showIndexArr.forEach((showIndex, loopIndex) => {
       if (this.shouldLoop) {
         setStyle(this.slideWrappers_[showIndex], 'order', loopIndex + 1);

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -15,6 +15,7 @@
  */
 
 import '../amp-carousel';
+import {Services} from '../../../../src/services';
 
 describes.realWin(
   'test-scrollable-carousel',
@@ -128,7 +129,11 @@ describes.realWin(
       () => {
         return getAmpScrollableCarousel().then(carousel => {
           const impl = carousel.implementation_;
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -142,24 +147,29 @@ describes.realWin(
           // load new slides in viewport
           expect(updateInViewportSpy).to.have.callCount(5);
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[2],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[3],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[4],
             true
           );
 
           // unload and pause old slides in viewport
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[0],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[1],
             false
           );
@@ -200,7 +210,11 @@ describes.realWin(
           // click on the next button the first time
           impl.goCallback(1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -215,24 +229,29 @@ describes.realWin(
           // load new slides in viewport
           expect(updateInViewportSpy).to.have.callCount(5);
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[4],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[5],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[6],
             true
           );
 
           // unload and pause old slides in viewport
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[2],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[3],
             false
           );
@@ -272,7 +291,11 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -286,24 +309,29 @@ describes.realWin(
           // load new slides in viewport
           expect(updateInViewportSpy).to.have.callCount(5);
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[2],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[3],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[4],
             true
           );
 
           // unload and pause old slides in viewport
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[5],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[6],
             false
           );
@@ -347,7 +375,11 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(-1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -361,24 +393,29 @@ describes.realWin(
           // load new slides in viewport
           expect(updateInViewportSpy).to.have.callCount(5);
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[0],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[1],
             true
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[2],
             true
           );
 
           // unload and pause old slides in viewport
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[3],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.cells_[4],
             false
           );

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -25,13 +25,14 @@ describes.realWin(
     },
   },
   env => {
-    let win, doc;
+    let win, doc, ownerImpl;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
       env.iframe.width = '300';
       env.iframe.height = '200';
+      ownerImpl = Services.ownersForDoc(doc);
     });
 
     function getAmpScrollableCarousel() {
@@ -129,7 +130,6 @@ describes.realWin(
       () => {
         return getAmpScrollableCarousel().then(carousel => {
           const impl = carousel.implementation_;
-          const ownerImpl = Services.ownersForDoc(impl.element);
           const updateInViewportSpy = sandbox.spy(
             ownerImpl,
             'updateInViewport'
@@ -210,7 +210,6 @@ describes.realWin(
           // click on the next button the first time
           impl.goCallback(1, /*animate*/ false);
 
-          const ownerImpl = Services.ownersForDoc(impl.element);
           const updateInViewportSpy = sandbox.spy(
             ownerImpl,
             'updateInViewport'
@@ -291,7 +290,6 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(1, /*animate*/ false);
 
-          const ownerImpl = Services.ownersForDoc(impl.element);
           const updateInViewportSpy = sandbox.spy(
             ownerImpl,
             'updateInViewport'
@@ -375,7 +373,6 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(-1, /*animate*/ false);
 
-          const ownerImpl = Services.ownersForDoc(impl.element);
           const updateInViewportSpy = sandbox.spy(
             ownerImpl,
             'updateInViewport'

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -25,7 +25,7 @@ describes.realWin(
     },
   },
   env => {
-    let win, doc, ownerImpl;
+    let win, doc, ownerImpl, updateInViewportSpy;
 
     beforeEach(() => {
       win = env.win;
@@ -33,6 +33,7 @@ describes.realWin(
       env.iframe.width = '300';
       env.iframe.height = '200';
       ownerImpl = Services.ownersForDoc(doc);
+      updateInViewportSpy = sandbox.spy(ownerImpl, 'updateInViewport');
     });
 
     function getAmpScrollableCarousel() {
@@ -130,10 +131,6 @@ describes.realWin(
       () => {
         return getAmpScrollableCarousel().then(carousel => {
           const impl = carousel.implementation_;
-          const updateInViewportSpy = sandbox.spy(
-            ownerImpl,
-            'updateInViewport'
-          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -210,10 +207,6 @@ describes.realWin(
           // click on the next button the first time
           impl.goCallback(1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(
-            ownerImpl,
-            'updateInViewport'
-          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -290,10 +283,6 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(
-            ownerImpl,
-            'updateInViewport'
-          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
@@ -373,10 +362,6 @@ describes.realWin(
           impl.goCallback(1, /*animate*/ false);
           impl.goCallback(-1, /*animate*/ false);
 
-          const updateInViewportSpy = sandbox.spy(
-            ownerImpl,
-            'updateInViewport'
-          );
           const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -15,6 +15,7 @@
  */
 
 import '../amp-carousel';
+import {Services} from '../../../../src/services';
 
 describes.realWin(
   'SlideScroll',
@@ -143,7 +144,8 @@ describes.realWin(
     it.skip('should show the correct slide', () => {
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+        const ownerImpl = Services.ownersForDoc(impl.element);
+        const updateInViewportSpy = sandbox.spy(ownerImpl, 'updateInViewport');
         const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
         const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
         const hideRestOfTheSlidesSpy = sandbox.spy(
@@ -179,10 +181,12 @@ describes.realWin(
 
         expect(impl.showSlide_(1)).to.be.true;
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[0],
           false
         );
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[1],
           true
         );
@@ -220,10 +224,12 @@ describes.realWin(
 
         expect(impl.showSlide_(0)).to.be.true;
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[1],
           false
         );
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[0],
           true
         );
@@ -257,10 +263,12 @@ describes.realWin(
 
         expect(impl.showSlide_(4)).to.be.true;
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[0],
           false
         );
         expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.element,
           impl.slides_[4],
           true
         );
@@ -645,7 +653,11 @@ describes.realWin(
       it.skip('should show the correct slides when looping', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
           const hideRestOfTheSlidesSpy = sandbox.spy(
@@ -661,10 +673,12 @@ describes.realWin(
           impl.showSlide_(1);
 
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[0],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[1],
             true
           );
@@ -727,10 +741,12 @@ describes.realWin(
           impl.showSlide_(4);
 
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[0],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[4],
             true
           );
@@ -762,7 +778,11 @@ describes.realWin(
       it('show correct slides when looping with `autoplay` for 2 slides', () => {
         return getAmpSlideScroll(true, 2).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+          const ownerImpl = Services.ownersForDoc(impl.element);
+          const updateInViewportSpy = sandbox.spy(
+            ownerImpl,
+            'updateInViewport'
+          );
           const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
           const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
           const hideRestOfTheSlidesSpy = sandbox.spy(
@@ -777,10 +797,12 @@ describes.realWin(
           impl.showSlide_(1);
 
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[0],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[1],
             true
           );
@@ -806,10 +828,12 @@ describes.realWin(
           impl.showSlide_(0);
 
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[1],
             false
           );
           expect(updateInViewportSpy).to.have.been.calledWith(
+            impl.element,
             impl.slides_[0],
             true
           );

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -17,6 +17,7 @@
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-fx-flying-carpet-0.1.css';
 import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
 import {dev, userAssert} from '../../../src/log';
 import {listen} from '../../../src/event-helper';
 import {setStyle} from '../../../src/style';
@@ -108,7 +109,11 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
 
   /** @override */
   viewportCallback(inViewport) {
-    this.updateInViewport(this.children_, inViewport);
+    Services.ownersForDoc(this.element).updateInViewport(
+      this.element,
+      this.children_,
+      inViewport
+    );
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -761,7 +761,11 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       .then(() => {
         this.isActive_ = true;
 
-        this.updateInViewport(dev().assertElement(this.container_), true);
+        Services.ownersForDoc(this.element).updateInViewport(
+          this.element,
+          dev().assertElement(this.container_),
+          true
+        );
         this.scheduleLayout(dev().assertElement(this.container_));
 
         this.doc_.documentElement.addEventListener(

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -349,7 +349,11 @@ class AmpLightbox extends AMP.BaseElement {
 
     const container = dev().assertElement(this.container_);
     if (!this.isScrollable_) {
-      this.updateInViewport(container, true);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        container,
+        true
+      );
     } else {
       this.scrollHandler_();
       this.updateChildrenInViewport_(this.pos_, this.pos_);
@@ -582,13 +586,21 @@ class AmpLightbox extends AMP.BaseElement {
     const seen = [];
     this.forEachVisibleChild_(newPos, cell => {
       seen.push(cell);
-      this.updateInViewport(cell, true);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        cell,
+        true
+      );
       this.scheduleLayout(cell);
     });
     if (oldPos != newPos) {
       this.forEachVisibleChild_(oldPos, cell => {
         if (!seen.includes(cell)) {
-          this.updateInViewport(cell, false);
+          Services.ownersForDoc(this.element).updateInViewport(
+            this.element,
+            cell,
+            false
+          );
         }
       });
     }

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -97,7 +97,11 @@ class AmpStickyAd extends AMP.BaseElement {
       toggle(this.element, true);
       const borderBottom = this.element./*OK*/ offsetHeight;
       this.viewport_.updatePaddingBottom(borderBottom);
-      this.updateInViewport(dev().assertElement(this.ad_), true);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        dev().assertElement(this.ad_),
+        true
+      );
       this.scheduleLayout(dev().assertElement(this.ad_));
     }
     return Promise.resolve();
@@ -193,7 +197,11 @@ class AmpStickyAd extends AMP.BaseElement {
    */
   layoutAd_() {
     const ad = dev().assertElement(this.ad_);
-    this.updateInViewport(ad, true);
+    Services.ownersForDoc(this.element).updateInViewport(
+      this.element,
+      ad,
+      true
+    );
     this.scheduleLayout(ad);
     // Wait for the earliest: `render-start` or `load-end` signals.
     // `render-start` is expected to arrive first, but it's not emitted by

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -528,7 +528,11 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
     }).then(() => {
       this.scheduleLayout(this.ampComponents_);
       this.scheduleResume(this.ampComponents_);
-      this.updateInViewport(this.ampComponents_, true);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        this.ampComponents_,
+        true
+      );
     });
 
     const currentHistoryState = /** @type {!Object} */ (getState(
@@ -592,7 +596,11 @@ export class AmpStoryPageAttachment extends AMP.BaseElement {
       );
     }).then(() => {
       this.schedulePause(this.ampComponents_);
-      this.updateInViewport(this.ampComponents_, false);
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        this.ampComponents_,
+        false
+      );
     });
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -884,20 +884,6 @@ export class BaseElement {
   }
 
   /**
-   * Update inViewport state of the specified children element or elements.
-   * Resource manager will perform the actual changes to the inViewport state
-   * based on the state of these elements and their parent subtree.
-   * @param {!Element|!Array<!Element>} elements
-   * @param {boolean} inLocalViewport
-   * @public
-   */
-  updateInViewport(elements, inLocalViewport) {
-    this.element
-      .getResources()
-      .updateInViewport(this.element, elements, inLocalViewport);
-  }
-
-  /**
    * Requests the runtime to update the height of this element to the specified
    * value. The runtime will schedule this request and attempt to process it
    * as soon as possible.

--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -29,5 +29,16 @@ export class Owners {
    * @param {!Element|!Array<!Element>} subElements
    */
   scheduleUnlayout(parentElement, subElements) {}
+
+  /**
+   * A parent resource, especially in when it's an owner (see {@link setOwner}),
+   * may request the Resources manager to update children's inViewport state.
+   * A child's inViewport state is a logical AND between inLocalViewport
+   * specified here and parent's own inViewport state.
+   * @param {!Element} parentElement
+   * @param {!Element|!Array<!Element>} subElements
+   * @param {boolean} inLocalViewport
+   */
+  updateInViewport(parentElement, subElements, inLocalViewport) {}
 }
 /* eslint-enable no-unused-vars */

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -124,17 +124,6 @@ class OwnersDef extends Owners {
    * @param {!Element|!Array<!Element>} subElements
    */
   schedulePreload(parentElement, subElements) {}
-
-  /**
-   * A parent resource, especially in when it's an owner (see {@link setOwner}),
-   * may request the Resources manager to update children's inViewport state.
-   * A child's inViewport state is a logical AND between inLocalViewport
-   * specified here and parent's own inViewport state.
-   * @param {!Element} parentElement
-   * @param {!Element|!Array<!Element>} subElements
-   * @param {boolean} inLocalViewport
-   */
-  updateInViewport(parentElement, subElements, inLocalViewport) {}
 }
 
 /**


### PR DESCRIPTION
This PR moves updateInViewport to owners-impl.

1. Some unit tests have been disabled for other reasons so the fix cannot be validated.
2. There are references to methods in resources-impl from building-an-amp-extension.md. I think it would be better to update it once we finish rather than piece-by-piece.