### PR TITLE
<amp-experiment> style mutation fix and improvment

### DIFF
--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -42,7 +42,7 @@
                   "type": "attributes",
                   "target": "h1",
                   "attributeName": "style",
-                  "value": "background-color: #FFFF00"
+                  "value": "background-color: red; color: #FFFFFF"
                 }
               ]
             },
@@ -53,7 +53,7 @@
                   "type": "attributes",
                   "target": "h1",
                   "attributeName": "style",
-                  "value": "background-color: #FF0000"
+                  "value": "background-color: blue"
                 }
               ]
             }

--- a/extensions/amp-experiment/1.0/apply-experiment.js
+++ b/extensions/amp-experiment/1.0/apply-experiment.js
@@ -93,10 +93,10 @@ export function applyExperimentToVariant(ampdoc, config, experimentToVariant) {
       mutationRecordsAndElements
     );
 
-    // Validate all mutations
+    // Parse and validate all mutations
     mutations.forEach(mutation => {
       userAssert(
-        mutation.validate(),
+        mutation.parseAndValidate(),
         'Mutation %s has an an unsupported value.',
         mutation.toString()
       );
@@ -179,7 +179,7 @@ export function createMutationsFromMutationRecordsAndElements(
       // TODO: Allow for innerHTML mutations
       // Therefore, return a noop mutation.
       mutation = {
-        validate: () => true,
+        parseAndValidate: () => true,
         mutate: () => {},
       };
     }

--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-class.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-class.js
@@ -33,7 +33,7 @@ export class AttributeMutationDefaultClass {
   }
 
   /** @override */
-  validate() {
+  parseAndValidate() {
     const value = this.mutationRecord_['value'];
 
     // Don't allow the .i-amphtml class

--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
@@ -15,6 +15,16 @@
  */
 
 import {assertAttributeMutationFormat} from './mutation';
+import {assertDoesNotContainDisplay, setStyles} from '../../../../src/style';
+import {dev} from '../../../../src/log';
+import {dict, hasOwn} from '../../../../src/utils/object';
+
+const SUPPORTED_STYLE_VALUE = {
+  'color': /#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/,
+  'background-color': /.*/,
+};
+
+const NON_SPACE_REGEX = /\S/;
 
 /**
  * Mutation for attribute (style) mutations on unspecified elements.
@@ -27,40 +37,80 @@ export class AttributeMutationDefaultStyle {
    * @param {!Array<Element>} elements
    */
   constructor(mutationRecord, elements) {
+    /** @private {!JsonObject} */
     this.mutationRecord_ = mutationRecord;
+
+    /** @private {!Array<Element>} */
     this.elements_ = elements;
+
+    /** @private {!JsonObject} */
+    this.styles_ = dict({});
+
     assertAttributeMutationFormat(this.mutationRecord_);
   }
 
   /** @override */
-  validate() {
+  parseAndValidate() {
     const value = this.mutationRecord_['value'];
-
-    // Do not allow Important or HTML Comments
-    if (value.match(/(!\s*important|<!--)/)) {
+    // First check for !important and <;
+    if (value.match(/(!\s*important|<)/)) {
       return false;
     }
 
-    // Allow Color
-    if (value.match(/^color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/)) {
-      return true;
+    // Then seperate the style values to pairs in the format "name : value;"
+    // Already guareentee that ['value'] is defined
+    const pairs = value.split(';');
+    for (let i = 0; i < pairs.length; i++) {
+      if (!NON_SPACE_REGEX.test(pairs[i])) {
+        // Note: treat empty string as valid;
+        continue;
+      }
+      // In format of key:value
+      const pair = pairs[i].split(':');
+      if (pair.length != 2) {
+        // more than one :
+        return false;
+      }
+
+      const key = pair[0].trim();
+      if (pair[1] === undefined) {
+        // invalid format, value not defined;
+        return false;
+      }
+      const value = pair[1].trim();
+      if (!this.validateStylePair_(key, value)) {
+        return false;
+      }
+      this.styles_[key] = value;
     }
 
-    // Allow Background color
-    if (
-      value.match(/^background-color:\s*#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3});?$/)
-    ) {
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   /** @override */
   mutate() {
     this.elements_.forEach(element => {
-      element.setAttribute('style', this.mutationRecord_['value']);
+      setStyles(
+        dev().assertElement(element),
+        assertDoesNotContainDisplay(this.styles_)
+      );
     });
+  }
+
+  /**
+   * Validate the style key value pair is valid
+   * @param {string} key
+   * @param {string} value
+   * @return {boolean}
+   */
+  validateStylePair_(key, value) {
+    if (!hasOwn(SUPPORTED_STYLE_VALUE, key)) {
+      return false;
+    }
+    if (value.match(SUPPORTED_STYLE_VALUE[key])) {
+      return true;
+    }
+    return false;
   }
 
   /** @override */

--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
@@ -34,7 +34,7 @@ const NON_SPACE_REGEX = /\S/;
 export class AttributeMutationDefaultStyle {
   /**
    * @param {!JsonObject} mutationRecord
-   * @param {!Array<Element>} elements
+   * @param {!Array<!Element>} elements
    */
   constructor(mutationRecord, elements) {
     /** @private {!JsonObject} */
@@ -68,15 +68,12 @@ export class AttributeMutationDefaultStyle {
       // In format of key:value
       const pair = pairs[i].split(':');
       if (pair.length != 2) {
-        // more than one :
+        // more than one ":" or no ":"
+        // invalid format
         return false;
       }
 
       const key = pair[0].trim();
-      if (pair[1] === undefined) {
-        // invalid format, value not defined;
-        return false;
-      }
       const value = pair[1].trim();
       if (!this.validateStylePair_(key, value)) {
         return false;

--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-url.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-url.js
@@ -41,7 +41,7 @@ export class AttributeMutationDefaultUrl {
   }
 
   /** @override */
-  validate() {
+  parseAndValidate() {
     for (let i = 0; i < this.elements_.length; i++) {
       const element = this.elements_[i];
       if (SUPPORTED_TAG_NAMES.indexOf(element.tagName) < 0) {

--- a/extensions/amp-experiment/1.0/mutation/character-data-mutation.js
+++ b/extensions/amp-experiment/1.0/mutation/character-data-mutation.js
@@ -33,7 +33,7 @@ export class CharacterDataMutation {
   }
 
   /** @override */
-  validate() {
+  parseAndValidate() {
     return true;
   }
 

--- a/extensions/amp-experiment/1.0/mutation/mutation.js
+++ b/extensions/amp-experiment/1.0/mutation/mutation.js
@@ -25,10 +25,10 @@ import {userAssert} from '../../../../src/log';
  */
 export class Mutation {
   /**
-   * Called to validate the value of a mutation
+   * Called to parse and validate the value of a mutation
    * @return {boolean}
    */
-  validate() {}
+  parseAndValidate() {}
 
   /**
    * Called to apply the changes to the selected

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -109,7 +109,7 @@ describes.realWin(
           );
           expect(attributeMutation.parseAndValidate()).to.be.equal(false);
 
-          // <
+          // invalid style attribute value "<"
           attributeMutation = getAttributeMutationDefaultStyle(
             'color: <#000000;'
           );
@@ -155,7 +155,7 @@ describes.realWin(
 
         it('background-color mutation', () => {
           let attributeMutation = getAttributeMutationDefaultStyle(
-            'background-color: #000000'
+            'background-color: #o7FogD'
           );
           expect(attributeMutation.parseAndValidate()).to.be.equal(true);
 
@@ -171,8 +171,13 @@ describes.realWin(
         });
 
         it('color mutations', () => {
-          const attributeMutation = getAttributeMutationDefaultStyle(
+          let attributeMutation = getAttributeMutationDefaultStyle(
             'color: #000000'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'color: #a0F'
           );
           expect(attributeMutation.parseAndValidate()).to.be.equal(true);
         });

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -107,79 +107,79 @@ describes.realWin(
           let attributeMutation = getAttributeMutationDefaultStyle(
             'color: #000000 !important;'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
 
           // invalid style attribute value "<"
           attributeMutation = getAttributeMutationDefaultStyle(
             'color: <#000000;'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
 
         it('NOT allowed style mutations', () => {
           const attributeMutation = getAttributeMutationDefaultStyle(
             'random: abc'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
 
         it('style mutations format', () => {
           let attributeMutation = getAttributeMutationDefaultStyle('');
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color red'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color ::red'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: '
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: red; ;'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             '  background-color: red      ;background-color:green;   '
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
 
         it('background-color mutation', () => {
           let attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: #o7FogD'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: red'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: invalid'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
 
         it('color mutations', () => {
           let attributeMutation = getAttributeMutationDefaultStyle(
             'color: #000000'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
 
           attributeMutation = getAttributeMutationDefaultStyle(
             'color: #a0F'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
       });
 
@@ -188,21 +188,21 @@ describes.realWin(
           const attributeMutation = getAttributeMutationDefaultUrl(
             'https://amp.dev/'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
 
         it('should not allow http:// mutations', () => {
           const attributeMutation = getAttributeMutationDefaultUrl(
             'http://amp.dev/'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
 
         it('should not allow non HTTPS mutations', () => {
           const attributeMutation = getAttributeMutationDefaultUrl(
             'tel:555-555-5555'
           );
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
 
         it('should not allow unsupported element mutations', () => {
@@ -210,7 +210,7 @@ describes.realWin(
             'tel:555-555-5555'
           );
           attributeMutation.elements = [doc.createElement('div')];
-          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
       });
     });
@@ -224,7 +224,7 @@ describes.realWin(
         attributeMutation.mutate();
 
         attributeMutation.elements_.forEach(element => {
-          expect(element.getAttribute(attributeName)).to.be.equal(value);
+          expect(element.getAttribute(attributeName)).to.equal(value);
         });
       });
 
@@ -237,7 +237,7 @@ describes.realWin(
           attributeMutation.mutate();
 
           attributeMutation.elements_.forEach(element => {
-            expect(element.getAttribute('style')).to.be.equal(
+            expect(element.getAttribute('style')).to.equal(
               'background-color: rgb(0, 0, 0); color: rgb(0, 0, 0);'
             );
           });
@@ -255,7 +255,7 @@ describes.realWin(
           attributeMutation.parseAndValidate();
           attributeMutation.mutate();
 
-          expect(elements[0].getAttribute('style')).to.be.equal(
+          expect(elements[0].getAttribute('style')).to.equal(
             'width: 30px; ' +
               'background-color: rgb(0, 0, 0); ' +
               'color: rgb(0, 0, 0);'
@@ -272,7 +272,7 @@ describes.realWin(
         attributeMutation.mutate();
 
         attributeMutation.elements_.forEach(element => {
-          expect(element.getAttribute(attributeName)).to.be.equal(value);
+          expect(element.getAttribute(attributeName)).to.equal(value);
         });
       });
     });

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -176,9 +176,7 @@ describes.realWin(
           );
           expect(attributeMutation.parseAndValidate()).to.equal(true);
 
-          attributeMutation = getAttributeMutationDefaultStyle(
-            'color: #a0F'
-          );
+          attributeMutation = getAttributeMutationDefaultStyle('color: #a0F');
           expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
       });

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -28,17 +28,18 @@ describes.realWin(
   },
   env => {
     let win, doc;
+    let elements;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
 
       toggleExperiment(win, 'amp-experiment-1.0', true);
-
+      elements = [doc.createElement('test1'), doc.createElement('test2')];
       doc.body.innerHTML = '';
     });
 
-    function getAttributeMutationParamsObject(attributeName, value, tagName) {
+    function getAttributeMutationParamsObject(attributeName, value) {
       return {
         mutationRecord: {
           'type': 'characterData',
@@ -46,7 +47,7 @@ describes.realWin(
           'value': value,
           'attributeName': attributeName,
         },
-        elements: [doc.createElement(tagName), doc.createElement(tagName)],
+        elements,
       };
     }
 
@@ -75,71 +76,105 @@ describes.realWin(
     }
 
     function getAttributeMutationDefaultUrl(value) {
-      const paramsObject = getAttributeMutationParamsObject('href', value, 'a');
+      elements = [doc.createElement('a')];
+      const paramsObject = getAttributeMutationParamsObject('href', value);
       return new AttributeMutationDefaultUrl(
         paramsObject.mutationRecord,
         paramsObject.elements
       );
     }
 
-    describe('validate', () => {
+    describe('parseAndValidate', () => {
       describe('default class', () => {
         it('should allow valid mutations', () => {
           const attributeMutation = getAttributeMutationDefaultClass(
             'my-class'
           );
-          expect(attributeMutation.validate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
         });
 
         it('should not allow i-amphtml-*', () => {
           const attributeMutation = getAttributeMutationDefaultClass(
             'i-amphtml-my-class'
           );
-          expect(attributeMutation.validate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
       });
 
       describe('default style', () => {
-        it('should allow valid mutations', () => {
-          const attributeMutation = getAttributeMutationDefaultStyle(
-            'background-color: #000000'
+        it('forbid keywords', () => {
+          // !important
+          let attributeMutation = getAttributeMutationDefaultStyle(
+            'color: #000000 !important;'
           );
-          expect(attributeMutation.validate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+
+          // <
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'color: <#000000;'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
 
-        it('should allow background-color mutations', () => {
+        it('NOT allowed style mutations', () => {
           const attributeMutation = getAttributeMutationDefaultStyle(
-            'background-color: #000000'
+            'random: abc'
           );
-          expect(attributeMutation.validate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
 
-        it('should allow color mutations', () => {
+        it('style mutations format', () => {
+          let attributeMutation = getAttributeMutationDefaultStyle('');
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color red'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color ::red'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: '
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: red; ;'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            '  background-color: red      ;background-color:green;   '
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+        });
+
+        it('background-color mutation', () => {
+          let attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: #000000'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: red'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: invalid'
+          );
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
+        });
+
+        it('color mutations', () => {
           const attributeMutation = getAttributeMutationDefaultStyle(
             'color: #000000'
           );
-          expect(attributeMutation.validate()).to.be.equal(true);
-        });
-
-        it('should not allow !important mutations', () => {
-          const attributeMutation = getAttributeMutationDefaultStyle(
-            'color: #000000 !important;'
-          );
-          expect(attributeMutation.validate()).to.be.equal(false);
-        });
-
-        it('should not allow HTML Comment mutations', () => {
-          const attributeMutation = getAttributeMutationDefaultStyle(
-            '<!-- color: #000000;'
-          );
-          expect(attributeMutation.validate()).to.be.equal(false);
-        });
-
-        it('should not allow unallowed style mutations', () => {
-          const attributeMutation = getAttributeMutationDefaultStyle(
-            'position: fixed;'
-          );
-          expect(attributeMutation.validate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
         });
       });
 
@@ -148,21 +183,21 @@ describes.realWin(
           const attributeMutation = getAttributeMutationDefaultUrl(
             'https://amp.dev/'
           );
-          expect(attributeMutation.validate()).to.be.equal(true);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(true);
         });
 
         it('should not allow http:// mutations', () => {
           const attributeMutation = getAttributeMutationDefaultUrl(
             'http://amp.dev/'
           );
-          expect(attributeMutation.validate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
 
         it('should not allow non HTTPS mutations', () => {
           const attributeMutation = getAttributeMutationDefaultUrl(
             'tel:555-555-5555'
           );
-          expect(attributeMutation.validate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
 
         it('should not allow unsupported element mutations', () => {
@@ -170,7 +205,7 @@ describes.realWin(
             'tel:555-555-5555'
           );
           attributeMutation.elements = [doc.createElement('div')];
-          expect(attributeMutation.validate()).to.be.equal(false);
+          expect(attributeMutation.parseAndValidate()).to.be.equal(false);
         });
       });
     });
@@ -180,6 +215,7 @@ describes.realWin(
         const attributeMutation = getAttributeMutationDefaultClass('my-class');
         const {attributeName, value} = attributeMutation.mutationRecord_;
 
+        attributeMutation.parseAndValidate();
         attributeMutation.mutate();
 
         attributeMutation.elements_.forEach(element => {
@@ -187,16 +223,38 @@ describes.realWin(
         });
       });
 
-      it('should mutate default style mutations', () => {
-        const attributeMutation = getAttributeMutationDefaultStyle(
-          'background-color: #000000'
-        );
-        const {attributeName, value} = attributeMutation.mutationRecord_;
+      describe('style mutations', () => {
+        it('should mutate default style mutations with multi', () => {
+          const attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: #000000; color: #000000'
+          );
+          attributeMutation.parseAndValidate();
+          attributeMutation.mutate();
 
-        attributeMutation.mutate();
+          attributeMutation.elements_.forEach(element => {
+            expect(element.getAttribute('style')).to.be.equal(
+              'background-color: rgb(0, 0, 0); color: rgb(0, 0, 0);'
+            );
+          });
+        });
 
-        attributeMutation.elements_.forEach(element => {
-          expect(element.getAttribute(attributeName)).to.be.equal(value);
+        it('should not override', () => {
+          const attributeMutation = getAttributeMutationDefaultStyle(
+            'background-color: #000000; color: #000000'
+          );
+
+          elements[0].setAttribute(
+            'style',
+            'width: 30px; background-color: #ffffff'
+          );
+          attributeMutation.parseAndValidate();
+          attributeMutation.mutate();
+
+          expect(elements[0].getAttribute('style')).to.be.equal(
+            'width: 30px; ' +
+              'background-color: rgb(0, 0, 0); ' +
+              'color: rgb(0, 0, 0);'
+          );
         });
       });
 
@@ -205,7 +263,7 @@ describes.realWin(
           'https://amp.dev/'
         );
         const {attributeName, value} = attributeMutation.mutationRecord_;
-
+        attributeMutation.parseAndValidate();
         attributeMutation.mutate();
 
         attributeMutation.elements_.forEach(element => {


### PR DESCRIPTION
This PR fixes how the style attribute should be set. So now it doesn't override the existing value. 
We also allow setting multiple style pairs now. 

Rename `validate` to `parseAndValidate` as well. 