### PR TITLE
Turn the share button into a self-link for each STAMP

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -272,7 +272,7 @@ export class SystemLayer {
     // embedded STAMPs always have a back-link to themselves, and to make
     // gestures like right-clicks work.
     this.systemLayerEl_.querySelector(
-      '.' + SHARE_CLASS
+      '.i-amphtml-story-share-control'
     ).href = Services.documentInfoForDoc(this.parentEl_).canonicalUrl;
 
     createShadowRootWithStyle(this.root_, this.systemLayerEl_, CSS);

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -175,7 +175,7 @@ const TEMPLATE = {
           ],
         },
         {
-          tag: 'div',
+          tag: 'a',
           attrs: dict({
             'role': 'button',
             'class': SHARE_CLASS + ' i-amphtml-story-button',
@@ -268,6 +268,12 @@ export class SystemLayer {
 
     this.root_ = this.win_.document.createElement('div');
     this.systemLayerEl_ = renderAsElement(this.win_.document, TEMPLATE);
+    // Make the share button link to the current document to make sure
+    // embedded STAMPs always have a back-link to themselves, and to make
+    // gestures like right-clicks work.
+    this.systemLayerEl_.querySelector(
+      '.' + SHARE_CLASS
+    ).href = Services.documentInfoForDoc(this.parentEl_).canonicalUrl;
 
     createShadowRootWithStyle(this.root_, this.systemLayerEl_, CSS);
 
@@ -342,7 +348,7 @@ export class SystemLayer {
       } else if (matches(target, `.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
         this.onAudioIconClick_(false);
       } else if (matches(target, `.${SHARE_CLASS}, .${SHARE_CLASS} *`)) {
-        this.onShareClick_();
+        this.onShareClick_(event);
       } else if (matches(target, `.${INFO_CLASS}, .${INFO_CLASS} *`)) {
         this.onInfoClick_();
       } else if (matches(target, `.${SIDEBAR_CLASS}, .${SIDEBAR_CLASS} *`)) {
@@ -665,9 +671,11 @@ export class SystemLayer {
 
   /**
    * Handles click events on the share button and toggles the share menu.
+   * @param {!Event} event
    * @private
    */
-  onShareClick_() {
+  onShareClick_(event) {
+    event.preventDefault();
     const isOpen = this.storeService_.get(StateProperty.SHARE_MENU_STATE);
     this.storeService_.dispatch(Action.TOGGLE_SHARE_MENU, !isOpen);
   }

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -52,7 +52,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
       mutate: fn => fn(),
     });
 
-    systemLayer = new SystemLayer(win);
+    systemLayer = new SystemLayer(win, win.document.body);
   });
 
   it('should build UI', () => {
@@ -125,5 +125,16 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     systemLayer.build();
     storeService.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
     expect(systemLayer.getShadowRoot()).to.have.class('i-amphtml-story-hidden');
+  });
+
+  it('should link the share button to the canonical URL', () => {
+    systemLayer.build();
+    const shareButton = systemLayer
+      .getShadowRoot()
+      .querySelector('.i-amphtml-story-share-control');
+    expect(shareButton).to.not.be.null;
+    expect(shareButton.tagName).to.equal('A');
+    // Default "canonical"
+    expect(shareButton.href).to.equal('http://localhost:9876/context.html');
   });
 });


### PR DESCRIPTION
This ensures that STAMPs, even if embedded, always have a discoverable link to themselves.

