### PR TITLE
🐛Gulp watch: watch all sub folders

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -399,7 +399,7 @@ function buildExtension(
   // recompiles JS.
   if (options.watch) {
     options.watch = false;
-    watch(path + '/*', function() {
+    watch(path + '/**/*', function() {
       buildExtension(
         name,
         version,


### PR DESCRIPTION
Found the issue while debugging with a component that has sub folders. This would significantly ease my local development experience. 

This now includes all test folders, but I think that's fine because I don't expect files in test folders to be changed during manual testing. Thanks. 