### PR TITLE
Inabox: Don't register iframe messaging client if using top window measuring

### DIFF
--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -15,15 +15,17 @@
  */
 
 import {IframeMessagingClient} from '../../3p/iframe-messaging-client';
-import {getService, registerServiceBuilder} from '../service';
+import {canInspectWindow} from '../iframe-helper';
+import {getExistingServiceOrNull, registerServiceBuilder} from '../service';
+import {isExperimentOn} from '../experiments';
 import {tryParseJson} from '../json';
 
 /**
  * @param {!Window} win
- * @return {!../../3p/iframe-messaging-client.IframeMessagingClient}
+ * @return {?../../3p/iframe-messaging-client.IframeMessagingClient}
  */
 export function iframeMessagingClientFor(win) {
-  return /** @type {!../../3p/iframe-messaging-client.IframeMessagingClient} */ (getService(
+  return /** @type {!../../3p/iframe-messaging-client.IframeMessagingClient} */ (getExistingServiceOrNull(
     win,
     'iframeMessagingClient'
   ));
@@ -33,12 +35,17 @@ export function iframeMessagingClientFor(win) {
  * @param {!Window} win
  */
 export function installIframeMessagingClient(win) {
-  registerServiceBuilder(
-    win,
-    'iframeMessagingClient',
-    createIframeMessagingClient.bind(null, win),
-    /* opt_instantiate */ true
-  );
+  if (
+    isExperimentOn(win, 'inabox-viewport-friendly') &&
+    canInspectWindow(win.top)
+  ) {
+    registerServiceBuilder(
+      win,
+      'iframeMessagingClient',
+      createIframeMessagingClient.bind(null, win),
+      /* opt_instantiate */ true
+    );
+  }
 }
 
 /**

--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -25,7 +25,7 @@ import {tryParseJson} from '../json';
  * @return {?../../3p/iframe-messaging-client.IframeMessagingClient}
  */
 export function iframeMessagingClientFor(win) {
-  return /** @type {!../../3p/iframe-messaging-client.IframeMessagingClient} */ (getExistingServiceOrNull(
+  return /** @type {?../../3p/iframe-messaging-client.IframeMessagingClient} */ (getExistingServiceOrNull(
     win,
     'iframeMessagingClient'
   ));
@@ -36,8 +36,8 @@ export function iframeMessagingClientFor(win) {
  */
 export function installIframeMessagingClient(win) {
   if (
-    isExperimentOn(win, 'inabox-viewport-friendly') &&
-    canInspectWindow(win.top)
+    !isExperimentOn(win, 'inabox-viewport-friendly') ||
+    !canInspectWindow(win.top)
   ) {
     registerServiceBuilder(
       win,

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -136,7 +136,7 @@ export class ViewportBindingInabox {
      */
     this.boxRect_ = layoutRectLtwh(0, boxHeight + 1, boxWidth, boxHeight);
 
-    /** @private @const {!../../3p/iframe-messaging-client.IframeMessagingClient} */
+    /** @private @const {?../../3p/iframe-messaging-client.IframeMessagingClient} */
     this.iframeClient_ = iframeMessagingClientFor(win);
 
     /** @private {?Promise<!../layout-rect.LayoutRectDef>} */


### PR DESCRIPTION
This hopefully would cut down execution time further.

WIP: Lightbox actions (full-overlay-frame and cancel-full-overlay-frame) would be broken for the friendly iframe case because work for those is not done yet.