### PR TITLE
Update amp-instagram to new embed version and remove certain classes of jank

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -223,7 +223,7 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
  * before the instagram implementation loads.
  */
 amp-instagram {
-  padding: 64px 0px 0px 0px !important;
+  padding: 54px 0px 0px 0px !important;
   background-color: white;
 }
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -36,6 +36,7 @@
  */
 
 import {CSS} from '../../../build/amp-instagram-0.1.css';
+import {Services} from '../../../src/services';
 import {getData, listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {isObject} from '../../../src/types';
@@ -106,18 +107,25 @@ class AmpInstagram extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('div');
     placeholder.setAttribute('placeholder', '');
-    const image = this.win.document.createElement('amp-img');
-    image.setAttribute('noprerender', '');
+    const image = this.win.document.createElement('img');
+
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
-    image.setAttribute(
-      'src',
-      'https://www.instagram.com/p/' +
-        encodeURIComponent(this.shortcode_) +
-        '/media/?size=l'
-    );
-    image.setAttribute('layout', 'fill');
+    Services.viewerForDoc(this.element)
+      .whenFirstVisible()
+      .then(() => {
+        image.setAttribute(
+          'src',
+          'https://www.instagram.com/p/' +
+            encodeURIComponent(this.shortcode_) +
+            '/media/?size=l'
+        );
+      });
     image.setAttribute('referrerpolicy', 'origin');
+    setStyles(image, {
+      'overflow': 'hidden',
+      'max-width': '100%',
+    });
 
     this.propagateAttributes(['alt'], image);
     /*
@@ -127,15 +135,13 @@ class AmpInstagram extends AMP.BaseElement {
       this.element.classList.add('amp-instagram-default-framing');
     }
 
-    // This makes the non-iframe image appear in the exact same spot
-    // where it will be inside of the iframe.
-    setStyles(image, {
-      'top': '0 px',
-      'bottom': '0 px',
-      'left': '0 px',
-      'right': '0 px',
-    });
     placeholder.appendChild(image);
+    // Must be kept in-sync with the amp-instagram style in ampdoc.css.
+    // This value is the height of the header of the plugin. Makes the
+    // placeholder start at the right spot.
+    setStyles(placeholder, {
+      'marginTop': '54px',
+    });
     return placeholder;
   }
 
@@ -168,7 +174,7 @@ class AmpInstagram extends AMP.BaseElement {
       encodeURIComponent(this.shortcode_) +
       '/embed/' +
       this.captioned_ +
-      '?cr=1&v=9';
+      '?cr=1&v=12';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     setStyles(iframe, {

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -59,14 +59,14 @@ function runTest(shouldKillPolyfillableApis) {
       .skipChrome()
       .run('all components should get loaded', function() {
         this.timeout(15000);
-        return pollForLayout(fixture.win, 13, 10000)
+        return pollForLayout(fixture.win, 12, 10000)
           .then(() => {
             expect(
               fixture.doc.querySelectorAll('.i-amphtml-element')
-            ).to.have.length(17);
+            ).to.have.length(16);
             expect(
               fixture.doc.querySelectorAll('.i-amphtml-layout')
-            ).to.have.length(13);
+            ).to.have.length(12);
             expect(
               fixture.doc.querySelectorAll('.i-amphtml-error')
             ).to.have.length(0);


### PR DESCRIPTION
- Switches embed version from 9 to 12
- Updates top padding to new value (`54px`) and makes this actually work
- Switches image to load with intrinsic size and hidden overflow because that just works much better in practice.