### PR TITLE
 🐛 Fix race condition when opening/closing sidebar.

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -116,6 +116,9 @@ export class AmpSidebar extends AMP.BaseElement {
 
     /** @private {number} */
     this.initialScrollTop_ = 0;
+
+    /** @private {boolean} */
+    this.opened_ = false;
   }
 
   /** @override */
@@ -153,7 +156,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.fixIosElasticScrollLeak_();
     }
 
-    if (this.isOpen_()) {
+    if (element.hasAttribute('open')) {
       this.open_();
     } else {
       element.setAttribute('aria-hidden', 'true');
@@ -288,21 +291,12 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /**
-   * Returns true if the sidebar is opened.
-   * @return {boolean}
-   * @private
-   */
-  isOpen_() {
-    return this.element.hasAttribute('open');
-  }
-
-  /**
    * Toggles the open/close state of the sidebar.
    * @param {?../../../src/service/action-impl.ActionInvocation=} opt_invocation
    * @private
    */
   toggle_(opt_invocation) {
-    if (this.isOpen_()) {
+    if (this.opened_) {
       this.close_();
     } else {
       this.open_(opt_invocation);
@@ -408,9 +402,10 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   open_(opt_invocation) {
-    if (this.isOpen_()) {
+    if (this.opened_) {
       return;
     }
+    this.opened_ = true;
     this.viewport_.enterOverlayMode();
     this.setUpdateFn_(() => this.updateForOpening_());
     this.getHistory_()
@@ -431,9 +426,10 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   close_() {
-    if (!this.isOpen_()) {
+    if (!this.opened_) {
       return false;
     }
+    this.opened_ = false;
     this.viewport_.leaveOverlayMode();
     const scrollDidNotChange =
       this.initialScrollTop_ == this.viewport_.getScrollTop();
@@ -499,7 +495,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   fixIosElasticScrollLeak_() {
     this.element.addEventListener('scroll', e => {
-      if (this.isOpen_()) {
+      if (this.opened_) {
         if (this.element./*OK*/ scrollTop < 1) {
           this.element./*OK*/ scrollTop = 1;
           e.preventDefault();

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -156,11 +156,9 @@ export class AmpSidebar extends AMP.BaseElement {
       this.fixIosElasticScrollLeak_();
     }
 
-    if (element.hasAttribute('open')) {
-      this.open_();
-    } else {
-      element.setAttribute('aria-hidden', 'true');
-    }
+    // The element is always closed by default, so update the aria state to
+    // match.
+    element.setAttribute('aria-hidden', 'true');
 
     if (!element.hasAttribute('role')) {
       element.setAttribute('role', 'menu');

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -19,7 +19,7 @@ import * as lolex from 'lolex';
 import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
-import {clearModalStack} from '../../../../src/modal';
+import {clearModalStack, getModalStackLength} from '../../../../src/modal';
 
 // Represents the correct value of KeyboardEvent.which for the Escape key
 const KEYBOARD_EVENT_WHICH_ESCAPE = 27;
@@ -257,6 +257,26 @@ describes.realWin(
         expect(historyPopSpy).to.have.not.been.called;
       });
 
+      it('ignore repeated calls to open', async () => {
+        const sidebarElement = await getAmpSidebar({'stubHistory': true});
+        const impl = sidebarElement.implementation_;
+
+        impl.open_();
+        expect(getModalStackLength()).to.equal(1);
+        impl.open_();
+        expect(getModalStackLength()).to.equal(1);
+      });
+
+      it('ignore repeated calls to close', async () => {
+        const sidebarElement = await getAmpSidebar({'stubHistory': true});
+        const impl = sidebarElement.implementation_;
+
+        impl.open_();
+        impl.close_();
+        // If this was not ignored, it would throw an error.
+        impl.close_();
+      });
+
       it('should close sidebar on button click', async () => {
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
@@ -379,27 +399,27 @@ describes.realWin(
           owners.schedulePause = sandbox.spy();
           owners.scheduleResume = sandbox.spy();
 
-          expect(impl.isOpen_()).to.be.false;
+          expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.have.not.been.called;
           impl.toggle_();
-          expect(impl.isOpen_()).to.be.true;
+          expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.be.calledOnce;
           impl.toggle_();
-          expect(impl.isOpen_()).to.be.false;
+          expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.be.calledOnce;
           impl.toggle_();
-          expect(impl.isOpen_()).to.be.true;
+          expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.have.callCount(2);
           impl.toggle_();
-          expect(impl.isOpen_()).to.be.false;
+          expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.have.callCount(2);
           expect(owners.scheduleResume).to.have.callCount(2);

--- a/src/modal.js
+++ b/src/modal.js
@@ -256,3 +256,11 @@ export function setModalAsClosed(element) {
 export function clearModalStack() {
   modalEntryStack.length = 0;
 }
+
+/**
+ * @return {number} The number of entries in the stack, for testing.
+ * @package Visible for testing
+ */
+export function getModalStackLength() {
+  return modalEntryStack.length;
+}


### PR DESCRIPTION
- Keep track of the opened state as a variable and not an attribute, so
it is updated immediately. This makes sure multiple open/close calls in
a row do not cause issues for the modal or history stacks.

Fixes #23572
