### PR TITLE
🖍 Make both bottom corners of info dialog rounded

### DIFF
--- a/extensions/amp-story/1.0/amp-story-info-dialog.css
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.css
@@ -57,7 +57,7 @@
   right: 0 !important;
   height: auto !important;
   background: #fff !important;
-  border-radius: 0 0 8px !important;
+  border-radius: 0 0 8px 8px !important;
   transform: translate3d(0, -100%, 0) !important;
   transition: transform 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
   padding: 20px !important;


### PR DESCRIPTION
Fixes #23662 

Before:
![Screenshot of info dialog with only bottom-right corner rounded](https://user-images.githubusercontent.com/1651960/62491610-6b075500-b79a-11e9-9fa2-8bc90bd77463.png)

After:
![Screenshot of info dialog with both bottom corners rounded](https://user-images.githubusercontent.com/1651960/62491617-6fcc0900-b79a-11e9-9949-38209a1b0b39.png)
