### PR TITLE
Fix a test isolation problem caused by the use of Object.defineProperty w/o restore.

### DIFF
--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -1570,9 +1570,11 @@ describe('createViewport', () => {
       let win;
       let ampDoc;
       let viewer;
+      let sandbox;
 
       beforeEach(() => {
         win = env.win;
+        sandbox = env.sandbox;
         installPlatformService(win);
         installTimerService(win);
         installVsyncService(win);
@@ -1684,7 +1686,7 @@ describe('createViewport', () => {
 
       it('should only bind to "iOS embed SD" when SD is supported', () => {
         // Reset SD support.
-        Object.defineProperty(win.Element.prototype, 'attachShadow', {
+        sandbox.defineProperty(win.Element.prototype, 'attachShadow', {
           value: null,
         });
         sandbox


### PR DESCRIPTION
Also introduced a helper method to automatically restore properties in `afterEach`: `sandbox.defineProperty(...)` 

closes #23689