### PR TITLE
🐛 Do not use `origin/master` during Travis builds

### DIFF
--- a/build-system/git.js
+++ b/build-system/git.js
@@ -46,10 +46,13 @@ function gitBranchCreationPoint() {
 
 /**
  * Returns the `master` parent of the merge commit (current HEAD) on Travis.
+ * Note: This is not the same as origin/master (a moving target), since new
+ * commits can be merged while a Travis build is in progress.
+ * See https://travis-ci.community/t/origin-master-moving-forward-between-build-stages/4189/6
  * @return {string}
  */
 function gitTravisMasterBaseline() {
-  return getStdout('git rev-parse origin/master').trim();
+  return getStdout('git merge-base origin/master HEAD').trim();
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -64,8 +64,8 @@ function printChangeSummary(fileName) {
 
   if (isTravisBuild()) {
     console.log(
-      `${fileLogPrefix} ${colors.cyan('origin/master')} is currently at ` +
-        `commit ${colors.cyan(shortSha(gitTravisMasterBaseline()))}`
+      `${fileLogPrefix} Latest commit from ${colors.cyan('master')} included ` +
+        `in this build: ${colors.cyan(shortSha(gitTravisMasterBaseline()))}`
     );
     commitSha = travisPullRequestSha();
   } else {


### PR DESCRIPTION
AMP Travis builds use `origin/master` as the baseline while determining the list of files changed by a PR. This used to work back when our build matrix had a single stage, but it occasionally breaks when new commits have been merged to `master` while a multi-stage build is in progress.

After reaching out to Travis support, the recommended approach to determining the latest commit merged to `master` that is included in a Travis build is to run the following command, which returns the common ancestor of `origin/master` and the `HEAD` commit of the PR branch. See [this](https://travis-ci.community/t/origin-master-moving-forward-between-build-stages/4189/6) post.

```
git merge-base origin/master HEAD
```

This PR implements the recommended approach. For the most part, it is a no-op and causes no change in behavior, since the SHA returned is the same as `origin/master`. However, when one or more new commits are merged during a Travis build, we continue to use the correct commit SHA from `master` instead of chasing `origin/master`.

This should fix the odd case where visual diff and bundle size checks end up using the wrong baseline commit.

Fixes #21527
Partial fix for #23514