### PR TITLE
Print user warning for oversized images

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -252,13 +252,13 @@ export class AmpImg extends BaseElement {
   warnAgainstOversizedImages_() {
     return this.measureElement(() => {
       const {naturalWidth, naturalHeight} = this.img_;
-      const {scrollWidth, scrollHeight} = this.element;
-      const widthRatio = naturalWidth / scrollWidth;
-      const heightRatio = naturalHeight / scrollHeight;
+      const {clientWidth, clientHeight} = this.element;
+      const widthRatio = naturalWidth / clientWidth;
+      const heightRatio = naturalHeight / clientHeight;
       if (widthRatio > this.getDpr() * 2 || heightRatio > this.getDpr() * 2) {
         this.user().warn(
           TAG,
-          `natural img dimensions ${naturalWidth} x ${naturalHeight} too large for actual img dimensions ${scrollWidth} x ${scrollHeight}.`
+          `natural img dimensions ${naturalWidth} x ${naturalHeight} too large for actual img dimensions ${clientWidth} x ${clientWidth}.`
         );
       }
     });

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -255,7 +255,7 @@ export class AmpImg extends BaseElement {
       const {clientWidth, clientHeight} = this.element;
       const widthRatio = naturalWidth / clientWidth;
       const heightRatio = naturalHeight / clientHeight;
-      // TODO: this check can be improved to handle object-fit and transform
+      // TODO (cathyxz): this check can be improved to handle object-fit and transform
       // but not worth the bundle size increase. We could ship more robust
       // checks as part of a developer-only bundle if possible in the future.
       if (widthRatio > this.getDpr() * 2 || heightRatio > this.getDpr() * 2) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -255,6 +255,9 @@ export class AmpImg extends BaseElement {
       const {clientWidth, clientHeight} = this.element;
       const widthRatio = naturalWidth / clientWidth;
       const heightRatio = naturalHeight / clientHeight;
+      // TODO: this check can be improved to handle object-fit and transform
+      // but not worth the bundle size increase. We could ship more robust
+      // checks as part of a developer-only bundle if possible in the future.
       if (widthRatio > this.getDpr() * 2 || heightRatio > this.getDpr() * 2) {
         this.user().warn(
           TAG,

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -195,6 +195,28 @@ describe('amp-img', () => {
     });
   });
 
+  it('warns on oversized images', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      width: 100,
+      height: 100,
+      layout: Layout.FIXED,
+    });
+    const impl = ampImg.implementation_;
+    const userWarnStub = sandbox.stub(impl.user(), 'warn');
+    const warning =
+      'natural img dimensions 641 x 481 too large for actual img dimensions 100 x 100.';
+
+    await impl.layoutCallback();
+    const img = ampImg.querySelector('img');
+    expect(img.naturalWidth).to.equal(641);
+    expect(img.naturalHeight).to.equal(481);
+    expect(img.offsetWidth).to.equal(100);
+    expect(img.offsetHeight).to.equal(100);
+    expect(userWarnStub).to.be.calledOnce;
+    expect(userWarnStub.args[0][1]).to.be.equal(warning);
+  });
+
   describe('#fallback on initial load', () => {
     let el;
     let impl;

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -211,8 +211,8 @@ describe('amp-img', () => {
     const img = ampImg.querySelector('img');
     expect(img.naturalWidth).to.equal(641);
     expect(img.naturalHeight).to.equal(481);
-    expect(img.offsetWidth).to.equal(100);
-    expect(img.offsetHeight).to.equal(100);
+    expect(img.clientWidth).to.equal(100);
+    expect(img.clientWidth).to.equal(100);
     expect(userWarnStub).to.be.calledOnce;
     expect(userWarnStub.args[0][1]).to.be.equal(warning);
   });


### PR DESCRIPTION
This PR makes `<amp-img>` emit a warning if the natural dimensions of the images are more than 2x DPR larger than the actual dimensions of the rendered image. Closes longstanding https://github.com/ampproject/amphtml/issues/302, a FR to emit developer warnings in case of oversized images. 