### PR TITLE
🏗 Add missing return types in `build-system/`

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -238,7 +238,7 @@ app.get('/a4a/:bid', (req, res) => {
 
 /**
  * @param {{body: string, css: string|undefined, extensions: Array<string>|undefined, head: string|undefined, spec: string|undefined}} config
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function composeDocument(config) {
   const {body, css, extensions, head, spec, mode} = config;

--- a/build-system/app-utils.js
+++ b/build-system/app-utils.js
@@ -20,7 +20,7 @@
  * @param {string=} hostName
  * @param {boolean=} inabox
  * @param {boolean=} storyV1
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
   hostName = hostName || '';

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1264,7 +1264,7 @@ app.use('/shadow/', (req, res) => {
 /**
  * @param {string} ampJsVersion
  * @param {string} file
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function addViewerIntegrationScript(ampJsVersion, file) {
   ampJsVersion = parseFloat(ampJsVersion);

--- a/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_dev-constant-transformer/index.js
@@ -18,7 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 module.exports = function({types: t}) {
   return {

--- a/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-is_minified-constant-transformer/index.js
@@ -18,7 +18,7 @@
  * Changes the values of IS_DEV to false and IS_MINIFIED to true.
  * The above said variables are in src/mode.js file.
  * @param {Object} babelTypes
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 module.exports = function(babelTypes) {
   const {types: t} = babelTypes;

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -26,7 +26,7 @@ let compilerErrors = '';
  * dropping the closure compiler plugin's logging prefix and then syntax
  * highlighting the error text.
  * @param {string} message
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function formatClosureCompilerError(message) {
   const closurePluginLoggingPrefix = /^.*?gulp-google-closure-compiler.*?: /;

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -73,7 +73,7 @@ const PATHS = [
 /**
  * We can replace full-text of standard licenses with a pre-approved shorten
  * version.
- * @return {Pumpify}
+ * @return {!Pumpify}
  */
 exports.shortenLicense = function() {
   const streams = LICENSES.map(tuple => {
@@ -86,7 +86,7 @@ exports.shortenLicense = function() {
 
 /**
  * Returns true if a source file has a license that needs to be shortened.
- * @param {Vinyl} file
+ * @param {!Vinyl} file
  * @return {boolean}
  */
 exports.shouldShortenLicense = function(file) {

--- a/build-system/compile/shorten-license.js
+++ b/build-system/compile/shorten-license.js
@@ -73,7 +73,7 @@ const PATHS = [
 /**
  * We can replace full-text of standard licenses with a pre-approved shorten
  * version.
- * @return {*} TODO(#23582): Specify return type
+ * @return {Pumpify}
  */
 exports.shortenLicense = function() {
   const streams = LICENSES.map(tuple => {
@@ -87,7 +87,7 @@ exports.shortenLicense = function() {
 /**
  * Returns true if a source file has a license that needs to be shortened.
  * @param {Vinyl} file
- * @return {*} TODO(#23582): Specify return type
+ * @return {boolean}
  */
 exports.shouldShortenLicense = function(file) {
   return PATHS.some(path => file.path.endsWith(path));

--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -29,7 +29,7 @@ const killSuffix = process.platform == 'win32' ? '>NUL' : '';
  * the ongoing `gulp watch | build | dist` task.
  *
  * @param {string} command
- * @return {*} TODO(#23582): Specify return type
+ * @return {number}
  */
 exports.createCtrlcHandler = function(command) {
   if (!isTravisBuild()) {

--- a/build-system/eslint-rules/await-expect.js
+++ b/build-system/eslint-rules/await-expect.js
@@ -22,7 +22,7 @@
  *   expect(actual).to.equal(expected);
  * Good:
  *   await expect(actual).to.equal(expected);
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/no-deep-destructuring.js
+++ b/build-system/eslint-rules/no-deep-destructuring.js
@@ -22,7 +22,7 @@
  *   const { x: { y } } = obj.prop;
  * Good:
  *   const { y } = obj.prop.x;
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 module.exports = function(context) {
   return {

--- a/build-system/eslint-rules/private-prop-names.js
+++ b/build-system/eslint-rules/private-prop-names.js
@@ -18,7 +18,7 @@
 /**
  * Enforces naming rules for private properties.
  *
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 module.exports = function(context) {
   /**

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -53,7 +53,7 @@ function exec(cmd, options) {
  *
  * @param {string} script
  * @param {?Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Object}
  */
 function execScriptAsync(script, options) {
   return childProcess.spawn(shellCmd, [shellFlag, script], options);

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -21,7 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Runs ava tests.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Vinyl}
  */
 async function ava() {
   return gulp

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -21,7 +21,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Simple wrapper around the jest tests for custom babel plugins.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Vinyl}
  */
 function babelPluginTests() {
   return gulp.src('./build-system/babel-plugins/testSetupFile.js').pipe(

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -31,7 +31,7 @@ const checkerExecutable = 'npx npm-exact-versions';
 
 /**
  * Makes sure all package.json files in the repo use exact versions.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function checkExactVersions() {
   let success = true;

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -19,7 +19,7 @@ const del = require('del');
 
 /**
  * Clean up the build artifacts
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function clean() {
   return del([

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -111,7 +111,7 @@ function compileCss(watch, opt_compileAll) {
    * @param {string} outJs
    * @param {string} outCss
    * @param {boolean} append
-   * @return {*} TODO(#23582): Specify return type
+   * @return {!Promise}
    */
   function writeCssEntryPoint(path, outJs, outCss, append) {
     return jsifyCssAsync(`css/${path}`).then(css =>

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -344,7 +344,7 @@ function toArrayOrDefault(value, defaultValue) {
  * Flatten array of arrays.
  *
  * @param {!Array<!Array>} arr
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Array}
  */
 function flatten(arr) {
   return [].concat.apply([], arr);

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -22,7 +22,7 @@ const {isTravisBuild} = require('../travis');
 
 /**
  * Run all the dev dashboard tests
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function devDashboardTests() {
   const mocha = new Mocha({reporter: isTravisBuild() ? 'dot' : 'spec'});

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -175,7 +175,7 @@ async function dist() {
  * Build AMP experiments.js.
  *
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildExperiments(options) {
   return compileJs(
@@ -196,7 +196,7 @@ function buildExperiments(options) {
  *
  * @param {string} version
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildLoginDone(version, options) {
   const buildDir = `build/all/amp-access-${version}/`;
@@ -220,7 +220,7 @@ function buildLoginDone(version, options) {
  * Build amp-web-push publisher files HTML page.
  *
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildWebPushPublisherFiles(options) {
   const distDir = 'dist/v0';
@@ -355,7 +355,7 @@ function postBuildWebPushPublisherFilesVersion() {
 
 /**
  * Precompilation steps required to build experiment js binaries.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function preBuildExperiments() {
   const path = 'tools/experiments';

--- a/build-system/tasks/e2e/controller-promise.js
+++ b/build-system/tasks/e2e/controller-promise.js
@@ -82,7 +82,7 @@ class ControllerPromise {
  * the inner opt_mutate function.
  * @param {function(TYPE,function(TYPE): ?TYPE): !Promise=} wait
  * @param {function(TYPE): TYPE} mutate
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  * @template TYPE
  */
 function wrapWait(wait, mutate) {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -459,7 +459,7 @@ class EndToEndFixture {
  * Get the controller object for the configured engine.
  * @param {!DescribesConfigDef} describesConfig
  * @param {string} browserName
- * @return {SeleniumWebDriverController}
+ * @return {!SeleniumWebDriverController}
  */
 async function getController(
   {engine = 'selenium', headless = false},

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -111,7 +111,7 @@ function getConfig() {
 /**
  * Configure and launch a Puppeteer instance
  * @param {!PuppeteerConfigDef=} opt_config
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function createPuppeteer(opt_config = {}) {
   const browser = await puppeteer.launch({
@@ -276,7 +276,7 @@ class ItConfig {
  * that also sets up the provided fixtures and returns the corresponding
  * environment objects of each fixture to the test method.
  * @param {function(!Object):!Array<?Fixture>} factory
- * @return {*} TODO(#23582): Specify return type
+ * @return {function()}
  */
 function describeEnv(factory) {
   /**
@@ -284,7 +284,7 @@ function describeEnv(factory) {
    * @param {!Object} spec
    * @param {function(!Object)} fn
    * @param {function(string, function())} describeFunc
-   * @return {*} TODO(#23582): Specify return type
+   * @return {function()}
    */
   const templateFunc = function(suiteName, spec, fn, describeFunc) {
     const fixture = factory(spec);
@@ -390,7 +390,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
-   * @return {*} TODO(#23582): Specify return type
+   * @return {function()}
    */
   const mainFunc = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe);
@@ -400,7 +400,7 @@ function describeEnv(factory) {
    * @param {string} name
    * @param {!Object} spec
    * @param {function(!Object)} fn
-   * @return {*} TODO(#23582): Specify return type
+   * @return {function()}
    */
   mainFunc.only = function(name, spec, fn) {
     return templateFunc(name, spec, fn, describe./*OK*/ only);
@@ -459,7 +459,7 @@ class EndToEndFixture {
  * Get the controller object for the configured engine.
  * @param {!DescribesConfigDef} describesConfig
  * @param {string} browserName
- * @return {*} TODO(#23582): Specify return type
+ * @return {SeleniumWebDriverController}
  */
 async function getController(
   {engine = 'selenium', headless = false},

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -44,7 +44,7 @@ function installRepl(global, env) {
   /**
    * Usage: in a test, await repl();
    * @param {*} mochaThis
-   * @return {*} TODO(#23582): Specify return type
+   * @return {!Promise}
    */
   global.repl = function(mochaThis) {
     mochaThis.timeout(REPL_INFINITE_TIMEOUT);

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -440,7 +440,7 @@ function buildExtension(
  * @param {string} name
  * @param {string} version
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildExtensionCss(path, name, version, options) {
   /**

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -102,8 +102,7 @@ function writeGeneratedAtCommitFile(runnerJarDir) {
  * Generates the custom closure compiler binary (runner.jar) and drops it in the
  * given subdirectory of build-system/runner/dist/ (to enable concurrent usage)
  * @param {string} subDir
- *
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function generateRunner(subDir) {
   const generateCmd = `${antExecutable} -buildfile ${buildFile} -Ddist.dir dist/${subDir} jar`;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -97,7 +97,7 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
  * Compile all runtime targets in minified mode and drop them in dist/.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function compileAllMinifiedTargets() {
   if (isTravisBuild()) {
@@ -109,7 +109,7 @@ function compileAllMinifiedTargets() {
 /**
  * Compile all runtime targets in unminified mode and drop them in dist/.
  * @param {boolean} watch
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function compileAllUnminifiedTargets(watch) {
   if (isTravisBuild()) {
@@ -611,7 +611,7 @@ function printNobuildHelp() {
  * Enables runtime to be used for local testing by writing AMP_CONFIG to file.
  * Called at the end of "gulp build" and "gulp dist --fortesting".
  * @param {string} targetFile File to which the config is to be written.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function enableLocalTesting(targetFile) {
   const config = argv.config === 'canary' ? 'canary' : 'prod';
@@ -698,7 +698,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  * Build ALP JS.
  *
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildAlp(options) {
   options = options || {};
@@ -715,7 +715,7 @@ function buildAlp(options) {
  * Build Examiner JS.
  *
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildExaminer(options) {
   return compileJs('./src/examiner/', 'examiner.js', './dist/', {
@@ -731,7 +731,7 @@ function buildExaminer(options) {
  * Build web worker JS.
  *
  * @param {!Object} options
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function buildWebWorker(options) {
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -25,7 +25,7 @@ const expectedCaches = ['cloudflare', 'google'];
 
 /**
  * Fail if caches.json is missing some expected caches.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function cachesJson() {
   return gulp.src(['caches.json']).pipe(
@@ -61,7 +61,7 @@ async function cachesJson() {
 
 /**
  * Fail if JSON files are valid.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function jsonSyntax() {
   let hasError = false;

--- a/build-system/tasks/nailgun.js
+++ b/build-system/tasks/nailgun.js
@@ -38,14 +38,13 @@ const NAILGUN_STARTUP_TIMEOUT_MS = 5 * 1000;
 
 /**
  * Replaces the default compiler binary with nailgun on linux and macos
- * @return {*} TODO(#23582): Specify return type
+ * @return {?NodeRequire}
  */
 function maybeReplaceDefaultCompiler() {
   if (process.platform == 'darwin') {
     return require('require-hijack')
       .replace('google-closure-compiler-osx')
       .with(nailgunRunner);
-    return true;
   } else if (process.platform == 'linux') {
     return require('require-hijack')
       .replace('google-closure-compiler-linux')

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1035,7 +1035,7 @@ function isInBuildSystemFixtureFolder(filePath) {
 /**
  * Strip Comments
  * @param {string} contents
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function stripComments(contents) {
   // Multi-line comments
@@ -1213,7 +1213,7 @@ function isMissingTerms(file) {
 /**
  * Check a file for all the required terms and
  * any forbidden terms and log any errors found.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function presubmit() {
   let forbiddenFound = false;

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -105,7 +105,7 @@ const NUM_BATCHES = 14;
 
 /**
  * Calculate the reviewer this week, based on rotation calendar
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function calculateReviewer() {
   const now = Date.now();
@@ -117,7 +117,7 @@ function calculateReviewer() {
 
 /**
  * Main function for auto triaging
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise|undefined}
  */
 function process3pGithubPr() {
   if (!GITHUB_ACCESS_TOKEN) {
@@ -188,7 +188,7 @@ function getIssues(opt_page) {
 /**
  * API call to get all changed files of a pull request.
  * @param {!Object} pr
- * @return {*} TODO(#23582): Specify return type
+ * @return {?Array<string>}
  */
 function getPullRequestFiles(pr) {
   const options = extend({}, defaultOption);
@@ -208,7 +208,7 @@ function getPullRequestFiles(pr) {
 /**
  * Determine the type of a give pull request
  * @param {?Array<!Object>} files
- * @return {*} TODO(#23582): Specify return type
+ * @return {number|undefined}
  */
 function analyzeChangedFiles(files) {
   if (!files) {
@@ -241,7 +241,7 @@ function analyzeChangedFiles(files) {
 /**
  * Determine if we need to reply to an issue
  * @param {!Object} issue
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function isQualifiedPR(issue) {
   // All issues are opened has no assignee
@@ -267,7 +267,7 @@ function isQualifiedPR(issue) {
  * Auto reply
  * @param {!Object} pr
  * @param {ANALYZE_OUTCOME} outcome
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function replyToPR(pr, outcome) {
   let promise = Promise.resolve();
@@ -290,7 +290,7 @@ function replyToPR(pr, outcome) {
  * API call to comment on a give issue.
  * @param {!Object} issue
  * @param {string} comment
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function applyComment(issue, comment) {
   const {number} = issue;
@@ -317,7 +317,7 @@ function applyComment(issue, comment) {
  * API call to assign an issue with a list of assignees
  * @param {!Object} issue
  * @param {!Array<string>} assignees
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function assignIssue(issue, assignees) {
   const {number} = issue;

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -165,7 +165,7 @@ function handleIssue(issue) {
  * Fetches issues?page=${opt_page}
  *
  * @param {number=} opt_page
- * @return {!Promise<!Array<}
+ * @return {!Promise<!Array>}
  */
 function getIssues(opt_page) {
   // We need to use the issue API because assignee is only available with it.
@@ -208,7 +208,7 @@ function getPullRequestFiles(pr) {
 /**
  * Determine the type of a give pull request
  * @param {?Array<!Object>} files
- * @return {number|undefined}
+ * @return {number|null|undefined}
  */
 function analyzeChangedFiles(files) {
   if (!files) {

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -112,7 +112,7 @@ function getIssues(opt_page) {
  * gets all the Labels we are interested in,
  * depending if missing milestone or label,
  * tasks applied as per design go/ampgithubautomation
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function updateGitHubIssues() {
   let promise = Promise.resolve();

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -118,7 +118,7 @@ function githubRequest(path, opt_method, opt_data) {
 
 /**
  * todos:find-closed task.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 function todosFindClosed() {
   let foundCount = 0;

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -39,7 +39,7 @@ const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
  * Escapes a string of HTML elements to HTML entities.
  *
  * @param {string} html HTML as string to escape.
- * @return {*} TODO(#23582): Specify return type
+ * @return {string}
  */
 function escapeHtml(html) {
   return html.replace(HTML_ESCAPE_REGEX, c => HTML_ESCAPE_CHARS[c]);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -223,7 +223,7 @@ async function launchBrowser() {
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
  * @param {JsonObject} viewport optional viewport size object with numeric
  *     fields `width` and `height`.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise<!Puppeteer.Page>}
  */
 async function newPage(browser, viewport = null) {
   log('verbose', 'Creating new tab');
@@ -763,7 +763,7 @@ async function createEmptyBuild() {
 
 /**
  * Runs the AMP visual diff tests.
- * @return {*} TODO(#23582): Specify return type
+ * @return {!Promise}
  */
 async function visualDiff() {
   ensureOrBuildAmpRuntimeInTestMode_();


### PR DESCRIPTION
This PR adds missing `@return` types to `build-system/`. Unlike runtime code, these are not type checked, and are merely for documentation. 

Partial fix for #23582
Partial fix for #19767
