### PR TITLE
Overhaul Chunks implementation and avoid macro tasks before body is visible.

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -123,13 +123,17 @@ if (shouldMainBootstrapRun) {
           // Pre-stub already known elements.
           stubElementsForDoc(ampdoc);
         });
-        startupChunk(self.document, function final() {
-          installPullToRefreshBlocker(self);
-          installAutoLightboxExtension(ampdoc);
+        startupChunk(
+          self.document,
+          function final() {
+            installPullToRefreshBlocker(self);
+            installAutoLightboxExtension(ampdoc);
 
-          maybeValidate(self);
-          makeBodyVisible(self.document);
-        });
+            maybeValidate(self);
+            makeBodyVisible(self.document);
+          },
+          /* makes the body visible */ true
+        );
         startupChunk(self.document, function finalTick() {
           perf.tick('e_is');
           Services.resourcesForDoc(ampdoc).ampInitComplete();

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -56,13 +56,21 @@ function chunkServiceForDoc(elementOrAmpDoc) {
  *
  * @param {!Document} document
  * @param {function(?IdleDeadline)} fn
+ * @param {boolean=} opt_makesBodyVisible Pass true if this service makes
+ *     the body visible. This is relevant because it may influence the
+ *     task scheduling strategy.
  */
-export function startupChunk(document, fn) {
+export function startupChunk(document, fn, opt_makesBodyVisible) {
   if (deactivated) {
     resolved.then(fn);
     return;
   }
   const service = chunkServiceForDoc(document.documentElement);
+  if (opt_makesBodyVisible) {
+    service.runForStartup(() => {
+      service.bodyIsVisible_ = true;
+    });
+  }
   service.runForStartup(fn);
 }
 
@@ -235,29 +243,16 @@ class StartupTask extends Task {
   /**
    * @param {function(?IdleDeadline)} fn
    * @param {!Window} win
-   * @param {!Promise<!./service/viewer-impl.Viewer>} viewerPromise
+   * @param {!Chunks} chunks
    */
-  constructor(fn, win, viewerPromise) {
+  constructor(fn, win, chunks) {
     super(fn);
 
-    /** @private {!Window} */
+    /** @private @const */
     this.win_ = win;
 
-    /** @private {?./service/viewer-impl.Viewer} */
-    this.viewer_ = null;
-
-    viewerPromise.then(viewer => {
-      this.viewer_ = viewer;
-
-      if (this.viewer_.isVisible()) {
-        this.runTask_(/* idleDeadline */ null);
-      }
-      this.viewer_.onVisibilityChanged(() => {
-        if (this.viewer_.isVisible()) {
-          this.runTask_(/* idleDeadline */ null);
-        }
-      });
-    });
+    /** @private @const */
+    this.chunks_ = chunks;
   }
 
   /** @override */
@@ -279,7 +274,7 @@ class StartupTask extends Task {
     // been initialized. Otherwise we risk starving ourselves
     // before we get into a state where the viewer can tell us
     // that we are visible.
-    return !!this.viewer_;
+    return !!this.chunks_.viewer;
   }
 
   /**
@@ -288,8 +283,8 @@ class StartupTask extends Task {
    */
   isVisible_() {
     // Ask the viewer first.
-    if (this.viewer_) {
-      return this.viewer_.isVisible();
+    if (this.chunks_.viewer) {
+      return this.chunks_.viewer.isVisible();
     }
     // There is no viewer yet. Lets try to guess whether we are visible.
     if (this.win_.document.hidden) {
@@ -314,9 +309,6 @@ class Chunks {
     this.tasks_ = new PriorityQueue();
     /** @private @const {function(?IdleDeadline)} */
     this.boundExecute_ = this.execute_.bind(this);
-
-    /** @private @const {!Promise<!./service/viewer-impl.Viewer>} */
-    this.viewerPromise_ = Services.viewerPromiseForDoc(ampDoc);
     /** @private {number} */
     this.timeSinceLastExecution_ = Date.now();
     /** @private {boolean} */
@@ -324,11 +316,36 @@ class Chunks {
       this.win_,
       'macro-after-long-task'
     );
+    /**
+     * Set to true if we scheduled a macro or micro task to execute the next
+     * task. If true, we don't schedule another one.
+     * Not set to true if we use rIC, because we always want to transition
+     * to immeditate invocation from that state.
+     * @private {boolean}
+     */
+    this.scheduledImmediateInvocation_ = false;
+    /** @private {boolean} Whether the document can actually be painted. */
+    this.bodyIsVisible_ = this.win_.document.documentElement.hasAttribute(
+      'i-amphtml-no-boilerplate'
+    );
 
     this.win_.addEventListener('message', e => {
       if (getData(e) == 'amp-macro-task') {
         this.execute_(/* idleDeadline */ null);
       }
+    });
+
+    /** @private @const {!Promise<!./service/viewer-impl.Viewer>} */
+    this.viewerPromise_ = Services.viewerPromiseForDoc(ampDoc);
+    /**  @protected {?./service/viewer-impl.Viewer} */
+    this.viewer = null;
+    this.viewerPromise_.then(viewer => {
+      this.viewer = viewer;
+      viewer.onVisibilityChanged(() => {
+        if (viewer.isVisible()) {
+          this.schedule_();
+        }
+      });
     });
   }
 
@@ -347,7 +364,7 @@ class Chunks {
    * @param {function(?IdleDeadline)} fn
    */
   runForStartup(fn) {
-    const t = new StartupTask(fn, this.win_, this.viewerPromise_);
+    const t = new StartupTask(fn, this.win_, this);
     this.enqueueTask_(t, Number.POSITIVE_INFINITY);
   }
 
@@ -359,9 +376,7 @@ class Chunks {
    */
   enqueueTask_(task, priority) {
     this.tasks_.enqueue(task, priority);
-    resolved.then(() => {
-      this.schedule_();
-    });
+    this.schedule_();
   }
 
   /**
@@ -393,17 +408,21 @@ class Chunks {
    * @private
    */
   execute_(idleDeadline) {
+    this.scheduledImmediateInvocation_ = false;
     const t = this.nextTask_(/* opt_dequeue */ true);
     if (!t) {
       return false;
     }
-    const before = Date.now();
-    this.timeSinceLastExecution_ = before;
-    t.runTask_(idleDeadline);
-    resolved.then(() => {
-      this.schedule_();
-    });
-    dev().fine(TAG, t.getName_(), 'Chunk duration', Date.now() - before);
+    try {
+      const before = Date.now();
+      this.timeSinceLastExecution_ = before;
+      t.runTask_(idleDeadline);
+      dev().fine(TAG, t.getName_(), 'Chunk duration', Date.now() - before);
+    } finally {
+      resolved.then(() => {
+        this.schedule_();
+      });
+    }
     return true;
   }
 
@@ -418,6 +437,7 @@ class Chunks {
     // 5 milliseconds is a magic number.
     if (
       this.macroAfterLongTask_ &&
+      this.bodyIsVisible_ &&
       Date.now() - this.timeSinceLastExecution_ > 5
     ) {
       this.requestMacroTask_();
@@ -433,11 +453,15 @@ class Chunks {
    * @private
    */
   schedule_() {
+    if (this.scheduledImmediateInvocation_) {
+      return;
+    }
     const nextTask = this.nextTask_();
     if (!nextTask) {
       return;
     }
     if (nextTask.immediateTriggerCondition_()) {
+      this.scheduledImmediateInvocation_ = true;
       this.executeAsap_(/* idleDeadline */ null);
       return;
     }

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -113,11 +113,15 @@ startupChunk(self.document, function initial() {
         // Pre-stub already known elements.
         stubElementsForDoc(ampdoc);
       });
-      startupChunk(self.document, function final() {
-        Navigation.installAnchorClickInterceptor(ampdoc, self);
-        maybeValidate(self);
-        makeBodyVisible(self.document);
-      });
+      startupChunk(
+        self.document,
+        function final() {
+          Navigation.installAnchorClickInterceptor(ampdoc, self);
+          maybeValidate(self);
+          makeBodyVisible(self.document);
+        },
+        /* makes the body visible */ true
+      );
       startupChunk(self.document, function finalTick() {
         perf.tick('e_is');
         Services.resourcesForDoc(ampdoc).ampInitComplete();


### PR DESCRIPTION
This change got much bigger than planned. On top of a functional change there is one major refactoring: We now never schedule another execution until after the current one is done. This ensures that we don't over-schedule which effectively voids the point of multiple scheduling strategies. In a way this is a risky change, because previously we always ensured that we'd schedule an execution if we added a task. Now this relies on the state machine being correct.

Unskips the tests for long tasks.

Functional change: Avoids scheduling macro-tasks if the body is still hidden, because we want to get out of this state ASAP. Improves FCP with the experiment on by about 20%.

Related to #23618
