### PR TITLE
Relaxes requirement that amp-sidebar be a direct child of body

### DIFF
--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -67,7 +67,7 @@ for content within the sidebar to be displayed on other parts of the main conten
 - The max-height of the sidebar is 100vh, if the height exceeds 100vh then a vertical scrollbar appears. The default height is set to 100vh in CSS and is overridable in CSS.
 - The width of the sidebar can be set and adjusted using CSS (minimum width is 45px).
 - Touch zoom is disabled on the `amp-sidebar` and its mask when the sidebar is open.
-- `<amp-sidebar>` is *recommended* to be be a direct child of the `<body>` to preserve a logical DOM order (for accessibility) as well as to avoid altering its behavior by a container element.
+- `<amp-sidebar>` is *recommended* to be be a direct child of the `<body>` to preserve a logical DOM order (for accessibility) as well as to avoid altering its behavior by a container element. Note that having an ancestor of `amp-sidebar` with a set `z-index` may cause the sidebar to appear below other elements (such as headers), breaking its functionality.
 
 *Example:*
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -55,7 +55,6 @@ for content within the sidebar to be displayed on other parts of the main conten
 
 ## Behavior
 
-- The `<amp-sidebar>` should be a direct child of the `<body>`.
 - The sidebar can only appear on the left or right side of a page.
 - The `<amp-sidebar>` may contain any valid HTML elements (supported by AMP).
 - The `<amp-sidebar>` may contain any of the following AMP elements:
@@ -67,7 +66,8 @@ for content within the sidebar to be displayed on other parts of the main conten
     - `<amp-social-share>`
 - The max-height of the sidebar is 100vh, if the height exceeds 100vh then a vertical scrollbar appears. The default height is set to 100vh in CSS and is overridable in CSS.
 - The width of the sidebar can be set and adjusted using CSS (minimum width is 45px).
-- Touch zoom is disabled on the `amp-sidebar` and it's mask when the sidebar is open.
+- Touch zoom is disabled on the `amp-sidebar` and its mask when the sidebar is open.
+- `<amp-sidebar>` is *recommended* to be be a direct child of the `<body>` to preserve a logical DOM order (for accessibility) as well as to avoid altering its behavior by a container element.
 
 *Example:*
 

--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -44,7 +44,6 @@ tags: {  # <amp-sidebar> not in amp-story
   tag_name: "AMP-SIDEBAR"
   # There is an alternate spec for amp-sidebar in amp-story.
   disallowed_ancestor: "AMP-STORY"
-  mandatory_parent: "BODY"
   requires_extension: "amp-sidebar"
   attrs: {
     name: "side"


### PR DESCRIPTION
Closes #21895

Removes requirement for `amp-sidebar` to be a direct descendant of `body`.