### PR TITLE
Story video failure play vs error message.

### DIFF
--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -94,6 +94,11 @@ const strings = {
       'Label for a button to open a drawer containing additional ' +
       'content via a "swipe up" user gesture.',
   },
+  [LocalizedStringId.AMP_STORY_PAGE_ERROR_VIDEO]: {
+    string: 'Video failed to play',
+    description:
+      'Label indicating that the video visible on the page failed to play.',
+  },
   [LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO]: {
     string: 'Play video',
     description: 'Label for a button to play the video visible on the page.',

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -758,6 +758,7 @@ amp-story .amp-video-eq,
   to { transform: rotate(-130deg) }
 }
 
+.i-amphtml-story-page-error,
 .i-amphtml-story-page-play-button {
   display: flex !important;
   align-items: center !important;
@@ -805,10 +806,12 @@ amp-story .amp-video-eq,
   }
 }
 
+.i-amphtml-story-page-error[hidden],
 .i-amphtml-story-page-play-button[hidden] {
   display: none !important;
 }
 
+.i-amphtml-story-page-error-label,
 .i-amphtml-story-page-play-label {
   color: #fff !important;
   font-family: 'Roboto', sans-serif !important;
@@ -816,6 +819,7 @@ amp-story .amp-video-eq,
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
 }
 
+.i-amphtml-story-page-error-icon,
 .i-amphtml-story-page-play-icon {
   display: inline-block !important;
   height: 24px !important;
@@ -823,6 +827,13 @@ amp-story .amp-video-eq,
   margin: 0 8px !important;
   border-radius: 24px !important;
   filter: drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.36)) !important;
+}
+
+.i-amphtml-story-page-error-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>') !important;
+}
+
+.i-amphtml-story-page-play-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 48 48" fill="#FFF"><path d="M0 0h48v48H0z" fill="none"/><path d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"/></svg>') !important;
 }
 

--- a/src/localized-strings.js
+++ b/src/localized-strings.js
@@ -24,7 +24,7 @@ import {parseJson} from './json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 65
+ * Next ID: 66
  *
  * @const @enum {string}
  */
@@ -45,6 +45,7 @@ export const LocalizedStringId = {
   AMP_STORY_HINT_UI_NEXT_LABEL: '2',
   AMP_STORY_HINT_UI_PREVIOUS_LABEL: '3',
   AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL: '35',
+  AMP_STORY_PAGE_ERROR_VIDEO: '65',
   AMP_STORY_PAGE_PLAY_VIDEO: '34',
   AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT: '4',
   AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT: '5',


### PR DESCRIPTION
Optimizing the "play video" button displayed when a video fails to play:

- If the video errors, display an error message instead of the "play video" button
- Display the "play video" button when autoplay was not allowed

![image](https://user-images.githubusercontent.com/1492044/62583255-73848c00-b87d-11e9-85fa-5b8b0cdaca07.png)

[Demo here](https://video-autoplay-6cd5a.firebaseapp.com/examples/s20/body-painting/index.html): enable "Battery saving mode", go on page 2, reload the story, and wait for the auto advance - you should see the "Play video" button.

Fixes #22473, #22820