### PR TITLE
Swipe down to close the bookend.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -17,50 +17,21 @@
 @import './amp-story-share.css';
 
 .i-amphtml-story-bookend {
-  text-align: start !important;
-  color: #fff !important;
-  bottom: 0 !important;
   display: flex !important;
   flex-direction: column !important;
-  left: 0 !important;
-  position: absolute !important;
-  right: 0 !important;
-  top: 0 !important;
-  z-index: 100001 !important;
-  transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
-}
-
-.i-amphtml-story-bookend.i-amphtml-hidden {
-  transition: transform 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
-  transform: translateY(100vh) !important;
-  pointer-events: none !important;
-}
-
-.i-amphtml-story-bookend-overflow {
-  overflow: auto !important;
-  -webkit-overflow-scrolling: touch !important;
-  margin-top: auto !important; /* positions it at the bottom of container */
-}
-
-.i-amphtml-story-bookend-inner {
-  margin: 88px 0 0 !important;
-  font-family: 'Roboto', sans-serif !important;
-  position: relative !important;
-  padding-top: 32px !important;
-  overflow: hidden !important;
-}
-
-.i-amphtml-story-bookend-inner::before {
-  content: " " !important;
-  display: block !important;
-  z-index: -1 !important; /* places it under content */
   background: #202125 !important;
-  position: absolute !important;
-  left: 0 !important;
-  top: 0 !important;
-  bottom: 0 !important;
-  right: 0 !important;
   border-radius: 8px 8px 0 0 !important;
+  color: #fff !important;
+  text-align: start !important;
+  z-index: 100001 !important;
+}
+
+.i-amphtml-story-bookend-handle {
+  height: 4px !important;
+  width: 40px !important;
+  margin: 12px auto 24px !important;
+  background: rgba(255, 255, 255, 0.24) !important;
+  border-radius: 4px !important;
 }
 
 .i-amphtml-story-bookend-heading {
@@ -343,30 +314,14 @@
 }
 
 [desktop].i-amphtml-story-bookend {
-  transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
-  transform: translateY(0) !important;
-  opacity: 1 !important;
-}
-
-[desktop].i-amphtml-story-bookend.i-amphtml-hidden {
-  transition: opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
-  transform: translateY(100vh) !important;
-  opacity: 0 !important;
-}
-
-[desktop].i-amphtml-story-bookend .i-amphtml-story-share-widget {
-  /* TODO(alanorozco): Don't render at all when on desktop */
-  display: none !important;
-}
-
-[desktop] .i-amphtml-story-bookend-inner {
   box-sizing: border-box !important;
   min-height: 100vh !important;
   padding: 104px 156px 64px !important;
   margin: 0 !important;
 }
 
-[desktop] .i-amphtml-story-bookend-inner::before {
+[desktop].i-amphtml-story-bookend .i-amphtml-story-share-widget {
+  /* TODO(alanorozco): Don't render at all when on desktop */
   display: none !important;
 }
 
@@ -375,9 +330,8 @@
   display: none !important;
 }
 
-[desktop] .i-amphtml-story-bookend-overflow {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
+[desktop] .i-amphtml-story-bookend-handle {
+  display: none !important;
 }
 
 @media (min-width: 952px) {

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
@@ -55,6 +55,12 @@
   white-space: nowrap !important;
 }
 
+/** Overrides. */
+
 .i-amphtml-story-page-attachment-theme-dark .i-amphtml-story-page-attachment-title {
   color: #fff !important;
+}
+
+.i-amphtml-story-draggable-drawer-bookend {
+  display: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
@@ -61,6 +61,6 @@
   color: #fff !important;
 }
 
-.i-amphtml-story-draggable-drawer-bookend {
+.i-amphtml-story-draggable-drawer-header-bookend {
   display: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.css
@@ -28,6 +28,10 @@
   transition: transform 0.25s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
+.amp-story-draggable-drawer-root[hidden] {
+  display: none !important;
+}
+
 .amp-story-draggable-drawer-root.i-amphtml-story-draggable-drawer-open {
   transform: translate3d(0, 0, 0) !important;
   transition: transform 0.4s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
@@ -62,6 +66,7 @@
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
+
 .i-amphtml-story-draggable-drawer-container[hidden] .i-amphtml-story-draggable-drawer-content {
   opacity: 0 !important;
 }
@@ -90,4 +95,33 @@
   width: 800px !important;
   border-radius: 8px !important;
   overflow: hidden !important;
+}
+
+/** Bookend overrides. */
+
+.i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-container,
+.i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-container[hidden] {
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
+  background: transparent !important;
+  transition: none !important;
+}
+
+.i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-content {
+  margin-top: auto !important;
+  padding-top: 88px !important;
+}
+
+.i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-container[hidden] .i-amphtml-story-draggable-drawer-content {
+  opacity: 1 !important;
+}
+
+[desktop] .i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer {
+  height: 100% !important;
+  width: 100% !important;
+}
+
+[desktop] .i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-content {
+  padding-top: 0 !important;
 }

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -91,7 +91,7 @@ export class DraggableDrawer extends AMP.BaseElement {
     /** @protected {!DrawerState} */
     this.state_ = DrawerState.CLOSED;
 
-    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    /** @protected @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win);
 
     /** @private {boolean} */
@@ -179,7 +179,7 @@ export class DraggableDrawer extends AMP.BaseElement {
   /**
    * Reacts to UI state updates.
    * @param {!UIType} uiState
-   * @private
+   * @protected
    */
   onUIStateUpdate_(uiState) {
     uiState === UIType.MOBILE
@@ -191,21 +191,27 @@ export class DraggableDrawer extends AMP.BaseElement {
    * @private
    */
   startListeningForTouchEvents_() {
-    // Enforced by AMP validation rules.
-    const storyPageEl = dev().assertElement(this.element.parentElement);
+    // If the element is a direct descendant of amp-story-page, authorize
+    // swiping up by listening to events at the page level. Otherwise, only
+    // authorize swiping down to close by listening to events at the current
+    // element level.
+    const parentEl = this.element.parentElement;
+    const el = dev().assertElement(
+      parentEl.tagName === 'AMP-STORY-PAGE' ? parentEl : this.element
+    );
 
     this.touchEventUnlisteners_.push(
-      listen(storyPageEl, 'touchstart', this.onTouchStart_.bind(this), {
+      listen(el, 'touchstart', this.onTouchStart_.bind(this), {
         capture: true,
       })
     );
     this.touchEventUnlisteners_.push(
-      listen(storyPageEl, 'touchmove', this.onTouchMove_.bind(this), {
+      listen(el, 'touchmove', this.onTouchMove_.bind(this), {
         capture: true,
       })
     );
     this.touchEventUnlisteners_.push(
-      listen(storyPageEl, 'touchend', this.onTouchEnd_.bind(this), {
+      listen(el, 'touchend', this.onTouchEnd_.bind(this), {
         capture: true,
       })
     );
@@ -436,7 +442,6 @@ export class DraggableDrawer extends AMP.BaseElement {
 
     this.state_ = DrawerState.OPEN;
 
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
     this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
 
     this.mutateElement(() => {
@@ -479,7 +484,6 @@ export class DraggableDrawer extends AMP.BaseElement {
 
     this.state_ = DrawerState.CLOSED;
 
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
     this.storeService_.dispatch(Action.TOGGLE_PAUSED, false);
 
     this.mutateElement(() => {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {Action, StateProperty} from './amp-story-store-service';
 import {DraggableDrawer, DrawerState} from './amp-story-draggable-drawer';
 import {HistoryState, setHistoryState} from './utils';
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
 import {StoryAnalyticsEvent} from '../../../src/analytics';
 import {dev} from '../../../src/log';
 import {getAnalyticsService} from './story-analytics';
@@ -136,6 +136,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
   open(shouldAnimate = true) {
     super.open(shouldAnimate);
 
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
+
     const currentHistoryState = /** @type {!Object} */ (getState(
       this.win.history
     ));
@@ -177,6 +179,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    */
   closeInternal_() {
     super.closeInternal_();
+
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
 

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -34,6 +34,7 @@
 
 .i-amphtml-story-bookend-active.i-amphtml-story-system-layer {
   opacity: 0.3 !important;
+  z-index: 1 !important;
   transition: opacity 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -51,7 +51,7 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
   display: block !important;
 }
 
-[i-amphtml-vertical] amp-story-page-attachment {
+[i-amphtml-vertical] amp-story-draggable-drawer {
   position: relative !important;
   height: 178vw !important;
   transform: none !important;

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -51,7 +51,9 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
   display: block !important;
 }
 
-[i-amphtml-vertical] amp-story-draggable-drawer {
+[i-amphtml-vertical] amp-story-bookend,
+[i-amphtml-vertical] amp-story-page-attachment {
+  display: block !important;
   position: relative !important;
   height: 178vw !important;
   transform: none !important;
@@ -59,12 +61,6 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
 
 [i-amphtml-vertical].i-amphtml-story-bookend-active amp-story-page[active]::after {
   content: none !important;
-}
-
-[i-amphtml-vertical] amp-story-bookend {
-  position: relative !important;
-  display: block !important;
-  height: 178vw !important;
 }
 
 [i-amphtml-vertical] .i-amphtml-story-page-description {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -945,7 +945,7 @@ export class AmpStory extends AMP.BaseElement {
         if (bookendInHistory) {
           return this.hasBookend_().then(hasBookend => {
             if (hasBookend) {
-              this.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
+              return this.showBookend_();
             }
           });
         }
@@ -2072,7 +2072,6 @@ export class AmpStory extends AMP.BaseElement {
   onBookendStateUpdate_(isActive) {
     this.toggleElementsOnBookend_(/* display */ isActive);
     this.element.classList.toggle('i-amphtml-story-bookend-active', isActive);
-    setHistoryState(this.win, HistoryState.BOOKEND_ACTIVE, isActive);
   }
 
   /**
@@ -2285,9 +2284,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildAndPreloadBookend_() {
-    this.bookend_.build(
-      !!getHistoryState(this.win, HistoryState.BOOKEND_ACTIVE)
-    );
+    this.bookend_.build();
     return this.bookend_.loadConfigAndMaybeRenderBookend();
   }
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -219,9 +219,10 @@ export class AmpStoryBookend extends DraggableDrawer {
   buildCallback() {
     super.buildCallback();
 
-    const customClass = 'i-amphtml-story-draggable-drawer-bookend';
-    this.headerEl_.classList.add(customClass);
-    this.element.classList.add(customClass);
+    this.headerEl_.classList.add(
+      'i-amphtml-story-draggable-drawer-header-bookend'
+    );
+    this.element.classList.add('i-amphtml-story-draggable-drawer-bookend');
 
     const handleEl = this.win.document.createElement('div');
     handleEl.classList.add('i-amphtml-story-bookend-handle');

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -18,12 +18,12 @@ import {Action, StateProperty, UIType} from '../amp-story-store-service';
 import {ActionTrust} from '../../../../src/action-constants';
 import {BookendComponent} from './bookend-component';
 import {CSS} from '../../../../build/amp-story-bookend-1.0.css';
-import {DraggableDrawer} from '../amp-story-draggable-drawer';
 import {
   DEPRECATED_SHARE_PROVIDERS_KEY,
   SHARE_PROVIDERS_KEY,
   ScrollableShareWidget,
 } from '../amp-story-share';
+import {DraggableDrawer} from '../amp-story-draggable-drawer';
 import {EventType, dispatch} from '../events';
 import {
   HistoryState,
@@ -43,9 +43,6 @@ import {getRequestService} from '../amp-story-request-service';
 import {isArray} from '../../../../src/types';
 import {renderAsElement} from '../simple-template';
 import {toggle} from '../../../../src/style';
-
-/** @private @const {string} */
-const HIDDEN_CLASSNAME = 'i-amphtml-hidden';
 
 // TODO(#14591): Clean when bookend API v0.1 is deprecated.
 const BOOKEND_VERSION_1 = 'v1.0';
@@ -209,9 +206,7 @@ export class AmpStoryBookend extends DraggableDrawer {
      */
     this.bookendEl_ = null;
 
-    const {win} = this;
-
-    /** @private {!Element} */
+    /** @private {?Element} */
     this.shadowHost_ = null;
 
     /** @private {?ScrollableShareWidget} */

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
-import {
-  Action,
-  StateProperty,
-  UIType,
-  getStoreService,
-} from '../amp-story-store-service';
+import {Action, StateProperty, UIType} from '../amp-story-store-service';
 import {ActionTrust} from '../../../../src/action-constants';
 import {BookendComponent} from './bookend-component';
 import {CSS} from '../../../../build/amp-story-bookend-1.0.css';
+import {DraggableDrawer} from '../amp-story-draggable-drawer';
 import {
   DEPRECATED_SHARE_PROVIDERS_KEY,
   SHARE_PROVIDERS_KEY,
   ScrollableShareWidget,
 } from '../amp-story-share';
 import {EventType, dispatch} from '../events';
+import {
+  HistoryState,
+  createShadowRootWithStyle,
+  getHistoryState,
+  setHistoryState,
+} from '../utils';
 import {Keys} from '../../../../src/utils/key-codes';
 import {LocalizedStringId} from '../../../../src/localized-strings';
 import {Services} from '../../../../src/services';
 import {closest} from '../../../../src/dom';
-import {createShadowRootWithStyle} from '../utils';
 import {dev, devAssert, user, userAssert} from '../../../../src/log';
 import {dict} from '../../../../src/utils/object';
 import {getAmpdoc} from '../../../../src/service';
@@ -69,40 +70,28 @@ const DEPRECATED_BOOKEND_VERSION_KEY = 'bookend-version';
 const AMP_CUSTOM_LINKER_TARGET = '__AMP_CUSTOM_LINKER_TARGET__';
 
 /**
- * @param {string} hidden
- * @return {!../simple-template.ElementDef}
+ * @const {!../simple-template.ElementDef}
  */
-const buildRootTemplate = hidden => {
-  return /** @type {!../simple-template.ElementDef} */ ({
-    tag: 'section',
-    attrs: dict({
-      'class': 'i-amphtml-story-bookend i-amphtml-story-system-reset ' + hidden,
-    }),
-    children: [
-      // Overflow container that gets pushed to the bottom when content height
-      // is smaller than viewport.
-      {
-        tag: 'div',
-        attrs: dict({'class': 'i-amphtml-story-bookend-overflow'}),
-        children: [
-          // Holds bookend content.
-          {
-            tag: 'div',
-            attrs: dict({'class': 'i-amphtml-story-bookend-inner'}),
-          },
-        ],
-      },
-    ],
-  });
+const rootTemplate = {
+  tag: 'section',
+  attrs: dict({
+    'class': 'i-amphtml-story-bookend i-amphtml-story-system-reset',
+  }),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({'class': 'i-amphtml-story-bookend-handle'}),
+    },
+  ],
 };
 
-/** @private @const {!../simple-template.ElementDef} */
+/** @const {!../simple-template.ElementDef} */
 const REPLAY_ICON_TEMPLATE = {
   tag: 'div',
   attrs: dict({'class': 'i-amphtml-story-bookend-replay-icon'}),
 };
 
-/** @type {string} */
+/** @const {string} */
 const TAG = 'amp-story-bookend';
 
 /**
@@ -195,7 +184,7 @@ const buildPromptConsentTemplate = consentId => {
  * through the 'build' and 'loadConfig' method. It can then be toggled by
  * dispatching the store TOGGLE_BOOKEND action.
  */
-export class AmpStoryBookend extends AMP.BaseElement {
+export class AmpStoryBookend extends DraggableDrawer {
   /**
    * @param {!Element} element
    */
@@ -222,30 +211,51 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
     const {win} = this;
 
+    /** @private {!Element} */
+    this.shadowHost_ = null;
+
     /** @private {?ScrollableShareWidget} */
     this.shareWidget_ = null;
+  }
 
-    /** @private @const {!../amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(win);
+  /**
+   * @override
+   */
+  buildCallback() {
+    super.buildCallback();
+
+    const customClass = 'i-amphtml-story-draggable-drawer-bookend';
+    this.headerEl_.classList.add(customClass);
+    this.element.classList.add(customClass);
+
+    const handleEl = this.win.document.createElement('div');
+    handleEl.classList.add('i-amphtml-story-bookend-handle');
+    this.headerEl_.appendChild(handleEl);
+  }
+
+  /**
+   * @override
+   */
+  layoutCallback() {
+    return Promise.resolve();
   }
 
   /**
    * Builds the bookend components and appends it to the provided story.
-   * @param {boolean} skipAnimation Skips opening animation of the bookend.
    */
-  build(skipAnimation = false) {
+  build() {
     if (this.isBuilt_) {
       return;
     }
 
     this.isBuilt_ = true;
 
-    this.bookendEl_ = renderAsElement(
-      this.win.document,
-      buildRootTemplate(skipAnimation ? '' : HIDDEN_CLASSNAME)
-    );
+    this.bookendEl_ = renderAsElement(this.win.document, rootTemplate);
 
-    createShadowRootWithStyle(this.element, this.bookendEl_, CSS);
+    this.shadowHost_ = this.win.document.createElement('div');
+
+    createShadowRootWithStyle(this.shadowHost_, this.bookendEl_, CSS);
+    this.contentEl_.appendChild(this.shadowHost_);
 
     this.replayButton_ = this.buildReplayButton_();
 
@@ -254,9 +264,8 @@ export class AmpStoryBookend extends AMP.BaseElement {
       dev().assertElement(this.element.parentElement)
     );
 
-    const innerContainer = this.getInnerContainer_();
-    innerContainer.appendChild(this.replayButton_);
-    innerContainer.appendChild(
+    this.bookendEl_.appendChild(this.replayButton_);
+    this.bookendEl_.appendChild(
       this.shareWidget_.build(getAmpdoc(this.win.document))
     );
 
@@ -267,7 +276,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
         this.win.document,
         buildPromptConsentTemplate(String(consentId))
       );
-      innerContainer.appendChild(promptConsentEl);
+      this.bookendEl_.appendChild(promptConsentEl);
     }
 
     this.initializeListeners_();
@@ -278,12 +287,13 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
-   * @private
+   * @override
    */
   initializeListeners_() {
-    this.getShadowRoot().addEventListener('click', event =>
-      this.onClick_(event)
-    );
+    super.initializeListeners_();
+
+    this.element.addEventListener('click', event => this.onClick_(event));
+
     this.replayButton_.addEventListener('click', event =>
       this.onReplayButtonClick_(event)
     );
@@ -294,7 +304,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
       }
       if (event.key == Keys.ESCAPE) {
         event.preventDefault();
-        this.close_();
+        this.storeService_.dispatch(Action.TOGGLE_BOOKEND, false);
       }
     });
 
@@ -306,14 +316,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
       StateProperty.CAN_SHOW_SHARING_UIS,
       show => {
         this.onCanShowSharingUisUpdate_(show);
-      },
-      true /** callToInitialize */
-    );
-
-    this.storeService_.subscribe(
-      StateProperty.UI_STATE,
-      uiState => {
-        this.onUIStateUpdate_(uiState);
       },
       true /** callToInitialize */
     );
@@ -352,12 +354,24 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
+   * @override
+   */
+  close_() {
+    this.storeService_.dispatch(Action.TOGGLE_BOOKEND, false);
+  }
+
+  /**
    * Reacts to bookend state updates.
    * @param {boolean} isActive
    * @private
    */
   onBookendStateUpdate_(isActive) {
-    this.toggle_(isActive);
+    const shouldAnimate = !getHistoryState(
+      this.win,
+      HistoryState.BOOKEND_ACTIVE
+    );
+    isActive ? this.open(shouldAnimate) : this.closeInternal_();
+    setHistoryState(this.win, HistoryState.BOOKEND_ACTIVE, isActive);
   }
 
   /**
@@ -376,11 +390,11 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
-   * Reacts to UI state updates.
-   * @param {!UIType} uiState
-   * @private
+   * @override
    */
   onUIStateUpdate_(uiState) {
+    super.onUIStateUpdate_(uiState);
+
     this.mutateElement(() => {
       [UIType.DESKTOP_FULLBLEED, UIType.DESKTOP_PANELS].includes(uiState)
         ? this.getShadowRoot().setAttribute('desktop', '')
@@ -500,10 +514,9 @@ export class AmpStoryBookend extends AMP.BaseElement {
    */
   onClick_(event) {
     const target = dev().assertElement(event.target);
-
     if (this.elementOutsideUsableArea_(target)) {
       event.stopPropagation();
-      this.close_();
+      this.storeService_.dispatch(Action.TOGGLE_BOOKEND, false);
       return;
     }
 
@@ -518,30 +531,12 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
-   * Closes the bookend.
-   * @private
-   */
-  close_() {
-    this.storeService_.dispatch(Action.TOGGLE_BOOKEND, false);
-  }
-
-  /**
    * @param {!Element} el
    * @return {boolean}
    * @private
    */
   elementOutsideUsableArea_(el) {
-    return !closest(el, el => el == this.getInnerContainer_());
-  }
-
-  /**
-   * @param {boolean} show
-   * @private
-   */
-  toggle_(show) {
-    this.mutateElement(() => {
-      this.getShadowRoot().classList.toggle(HIDDEN_CLASSNAME, !show);
-    });
+    return !closest(el, el => el === this.shadowHost_);
   }
 
   /**
@@ -588,7 +583,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
         );
         const container = dev().assertElement(
           BookendComponent.buildContainer(
-            this.getInnerContainer_(),
+            this.getShadowRoot(),
             this.win.document
           )
         );
@@ -604,24 +599,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
   getShadowRoot() {
     this.assertBuilt_();
     return dev().assertElement(this.bookendEl_);
-  }
-
-  /**
-   * Gets container for bookend content.
-   * @return {!Element}
-   * @private
-   */
-  getInnerContainer_() {
-    return dev().assertElement(this.getOverflowContainer_().firstElementChild);
-  }
-
-  /**
-   * Gets outer container that gets scrolled.
-   * @return {!Element}
-   * @private
-   */
-  getOverflowContainer_() {
-    return dev().assertElement(this.getShadowRoot().firstElementChild);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -136,6 +136,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
     registerServiceBuilder(win, 'localization', () => localizationService);
 
     bookend = new AmpStoryBookend(bookendElem);
+    bookend.buildCallback();
 
     // Force sync mutateElement.
     sandbox.stub(bookend, 'mutateElement').callsArg(0);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -367,24 +367,6 @@ describes.realWin(
       });
     });
 
-    it('should update bookend status in browser history', () => {
-      const pageCount = 1;
-      createPages(story.element, pageCount, ['last-page']);
-
-      sandbox.stub(AmpStoryBookend.prototype, 'build');
-
-      story.buildCallback();
-
-      return story.layoutCallback().then(() => {
-        story.storeService_.dispatch(Action.TOGGLE_BOOKEND, true);
-
-        return expect(replaceStateStub).to.have.been.calledWith(
-          {ampStoryBookendActive: true},
-          ''
-        );
-      });
-    });
-
     it('should not block layoutCallback when bookend xhr fails', () => {
       createPages(story.element, 1, ['page-1']);
       sandbox.stub(AmpStoryBookend.prototype, 'build');


### PR DESCRIPTION
Re-using the new `draggable-drawer` abstract class extracted from page attachments to enable swiping down to close the bookend.

Animations + scrolling logic is now handled by the `draggable-drawer` and removed from the bookend implementation.

- Mobile: swipe down interactions + small handle on top of the bookend
- Desktop: no-op

[Demo here](http://draggable-bookend.firebaseapp.com/examples/s20/body-painting/index.html)

Part 2/2
Fixes #13833