### PR TITLE
amp-bind: Don't validate non-primitive expression results

### DIFF
--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -148,6 +148,10 @@ export class BindEvaluator {
       if (result === undefined) {
         return;
       }
+      // Don't validate non-primitive expression results e.g. arrays, objects.
+      if (result !== null && typeof result === 'object') {
+        return;
+      }
       // IMPORTANT: We need to validate expression results on each binding
       // since validity depends on the `tagName` and `property` rather than
       // just the `result`.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1355,6 +1355,11 @@ export class Bind {
             // when a child option[selected] attribute changes.
             this.updateSelectForSafari_(element, property, newValue);
           }
+        } else if (typeof newValue === 'object' && newValue !== null) {
+          // If newValue is an object or array (e.g. amp-list[src] binding),
+          // don't bother updating the element since attribute values like
+          // "[Object object]" have no meaning in the DOM.
+          mutated = true;
         } else if (newValue !== oldValue) {
           mutated = this.rewriteAttributes_(
             element,

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -401,6 +401,17 @@ describe
           });
         });
 
+        it('should not update attribute for non-primitive new values', () => {
+          const list = createElement(env, container, `[src]="x"`, 'amp-list');
+          list.setAttribute('src', 'https://foo.example/data.json');
+
+          return onBindReadyAndSetState(env, bind, {x: [1, 2, 3]}).then(() => {
+            expect(list.getAttribute('src')).to.equal(
+              'https://foo.example/data.json'
+            );
+          });
+        });
+
         it('should scan fixed layer for bindings', () => {
           // Mimic FixedLayer by creating a sibling <body> element.
           const doc = env.win.document;

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -229,6 +229,19 @@ describe('BindEvaluator', () => {
     expect(errors['addThree(oneplusone, 2, 2)']).to.be.undefined;
   });
 
+  it('should evaluate non-primitives', () => {
+    evaluator.addBindings([
+      {
+        tagName: 'AMP-LIST',
+        property: 'src',
+        expressionString: '[0].map(x => ({a: x+1}))',
+      },
+    ]);
+    const {results, errors} = evaluator.evaluateBindings({});
+    expect(results['[0].map(x => ({a: x+1}))']).to.deep.equal([{a: 1}]);
+    expect(errors['[0].map(x => ({a: x+1}))']).to.be.undefined;
+  });
+
   it('should not allow recursive macros', () => {
     evaluator.addMacros([
       {

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -796,6 +796,11 @@ describe('BindExpression', () => {
       expect(() => evaluate('[1, 2, 3].map((x) => x * x)')).to.throw();
     });
 
+    it('return a non-primitive', () => {
+      expect(evaluate('[0].map(x => ({a: x + 1}))')).to.deep.equal([{a: 1}]);
+      expect(evaluate('[0].map(x => [x, x+1])')).to.deep.equal([[0, 1]]);
+    });
+
     it('Array#map()', () => {
       const a = [1, 2, 3];
       expect(evaluate('a.map(() => 5)', {a})).to.deep.equal([5, 5, 5]);


### PR DESCRIPTION
Fixes #20405.