### PR TITLE
Support some new img attributes for those within noscript.

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2287,9 +2287,9 @@ tags: {
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "importance" } # Not yet part of the html spec
-  attrs: { name: "intrinsicsize" } # Not yet part of the html spec
-  attrs: { name: "loading" } # Not yet part of the html spec
+  attrs: { name: "importance" }  # Not yet part of the html spec
+  attrs: { name: "intrinsicsize" }  # Not yet part of the html spec
+  attrs: { name: "loading" }  # Not yet part of the html spec
   attrs: {
     name: "src"
     alternative_names: "srcset"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2287,6 +2287,9 @@ tags: {
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "importance" } # Not yet part of the html spec
+  attrs: { name: "intrinsicsize" } # Not yet part of the html spec
+  attrs: { name: "loading" } # Not yet part of the html spec
   attrs: {
     name: "src"
     alternative_names: "srcset"


### PR DESCRIPTION
These attributes help to get some of the nice features of AMP (layout
stability, async loading) when scripts are not enabled for browsers that support them.

We might consider allowing `<img intrinsicsize="blah x blah" loading="lazy">`
as an alternative to `<amp-img>` in the future if polyfilling the attributes is
feasible.

Closes #22802