### PR TITLE
🏗 Synchronize exit and fix logging on Travis for dev dashboard tests

### DIFF
--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -25,7 +25,9 @@ const {isTravisBuild} = require('../travis');
  * @return {!Promise}
  */
 async function devDashboardTests() {
-  const mocha = new Mocha({reporter: isTravisBuild() ? 'dot' : 'spec'});
+  const mocha = new Mocha({
+    reporter: isTravisBuild() ? 'mocha-silent-reporter' : 'spec',
+  });
 
   // Add our files
   const allDevDashboardTests = deglob.sync(config.devDashboardTestPaths);
@@ -42,7 +44,7 @@ async function devDashboardTests() {
   // Run the tests.
   mocha.run(function(failures) {
     if (failures) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     resolver();
   });

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "minimatch": "3.0.4",
     "minimist": "1.2.0",
     "mocha": "6.2.0",
+    "mocha-silent-reporter": "1.0.0",
     "morgan": "1.9.1",
     "multer": "1.4.2",
     "nodemon": "1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9749,6 +9749,13 @@ mkdirp@0.5.1, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mocha-silent-reporter@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mocha-silent-reporter/-/mocha-silent-reporter-1.0.0.tgz#f1f2fcafa4e2eaee989ac6cd00b76b8204f890bb"
+  integrity sha1-8fL8r6Ti6u6YmsbNALdrggT4kLs=
+  dependencies:
+    chalk "^0.5.1"
+
 mocha@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.0.tgz#f896b642843445d1bb8bca60eabd9206b8916e56"


### PR DESCRIPTION
**PR highlights:**
- Synchronizes `gulp` task exit to prevent the `Did you forget to signal async completion?` error
- Makes Travis logging silent when tests pass and concise when they fail

**Before (tests fail):**
```
[20:46:20] Using gulpfile ~/src/amphtml/gulpfile.js
[20:46:20] Starting 'dev-dashboard-tests'...


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․!․․․․․․․․․․․․․․․․․․

  47 passing (473ms)
  1 failing

  1) devdash
       Test helpers
         parseHtmlChunk
           returns firstElementChild:

      AssertionError: expected 2 to equal 3
      + expected - actual

      -2
      +3
      
      at Context.it (build-system/app-index/test/test-self.js:38:22)
      at process.topLevelDomainCallback (domain.js:126:23)



[20:44:23] The following tasks did not complete: dev-dashboard-tests
[20:44:23] Did you forget to signal async completion?
```

**Before (tests pass):**
```
[20:56:23] Using gulpfile ~/src/amphtml/gulpfile.js
[20:56:23] Starting 'dev-dashboard-tests'...


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  48 passing (454ms)

[20:56:24] Finished 'dev-dashboard-tests' after 1.13 s
```

**After (tests fail):**
```
[20:47:34] Using gulpfile ~/src/amphtml/gulpfile.js
[20:47:34] Starting 'dev-dashboard-tests'...
devdash Test helpers parseHtmlChunk returns firstElementChild (build-system/app-index/test/test-self.js)
AssertionError: expected 2 to equal 3
    at Context.it (build-system/app-index/test/test-self.js:38:22)
    at process.topLevelDomainCallback (domain.js:126:23)

 1 test failed
[20:47:35] Finished 'dev-dashboard-tests' after 1.11 s
```

**After (tests pass):**
```
[20:48:03] Using gulpfile ~/src/amphtml/gulpfile.js
[20:48:03] Starting 'dev-dashboard-tests'...
[20:48:04] Finished 'dev-dashboard-tests' after 1.11 s
```