### PR TITLE
🏗 Speed up `browserify` while building the runtime and running tests

### DIFF
--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -311,6 +311,7 @@ exports.getGraph = function(entryModules, config) {
     debug: true,
     deps: true,
     detectGlobals: false,
+    fast: true,
   })
     // The second stage are transforms that closure compiler supports
     // directly and which we don't want to apply during deps finding.

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -204,7 +204,10 @@ function getGraph(entryModule) {
 
   // TODO(erwinm): Try and work this in with `gulp build` so that
   // we're not running browserify twice on travis.
-  const bundler = browserify(entryModule, {debug: true}).transform(
+  const bundler = browserify(entryModule, {
+    debug: true,
+    fast: true,
+  }).transform(
     babelify,
     Object.assign({}, BABELIFY_GLOBAL_TRANSFORM, {compact: false})
   );

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -429,6 +429,7 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
     {
       entries: entryPoint,
       debug: true,
+      fast: true,
     },
     options.browserifyOptions
   );

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -81,6 +81,7 @@ module.exports = {
   browserify: {
     watch: true,
     debug: true,
+    fast: true,
     basedir: __dirname + '/../../',
     transform: [['babelify', BABELIFY_CONFIG]],
     // Prevent "cannot find module" errors on Travis. See #14166.


### PR DESCRIPTION
This PR enables the `fast: true` option for `browserify`.

**Reference:** The "Advanced Options" section at https://github.com/browserify/browserify#usage