### PR TITLE
Updating default story sidebar width.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -206,13 +206,13 @@ amp-story-page[active] {
 }
 
 [desktop] .i-amphtml-story-sidebar[open] {
-  max-width: 320px !important;
+  min-width: 25% !important;
+  max-width: 600px !important;
 }
 
 .i-amphtml-story-sidebar {
-  max-width: 280px !important;
-  min-width: 280px !important;
-  width: 280px !important;
+  min-width: 75% !important;
+  max-width: 360px !important;
   animation-timing-function: cubic-bezier(0.4, 0.0, 1, 1)  !important;
   animation-duration: 0.2s !important;
   animation-name: i-amphtml-sidebar-slide-out-right;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -205,7 +205,7 @@ amp-story-page[active] {
   animation-name: i-amphtml-sidebar-slide-in-right;
 }
 
-[desktop] .i-amphtml-story-sidebar[open] {
+[desktop] .i-amphtml-story-sidebar {
   min-width: 25% !important;
   max-width: 600px !important;
 }


### PR DESCRIPTION
From @hongwei1990:

> breakpoint 1: 320≤  viewport width < 1024，menu width = 75% of the viewport. Max width = 360pt
> breakpoint 2: viewport width ≥ 1024，menu width = 25% of the viewport. Max width = 600pt

Here we use `[desktop]` for the 1024px breakpoint.
The `width` CSS property is not specified so publishers can use it to specify it to anything in between the set `min-width` and `max-width`. It will default to the `min-width`.