### PR TITLE
🏗✨ Add a `Version` section to the experiments page that links to the GitHub release

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -56,6 +56,7 @@ const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
 const {formatExtractedMessages} = require('../compile/log-messages');
 const {isTravisBuild} = require('../travis');
 const {maybeUpdatePackages} = require('./update-packages');
+const {VERSION} = require('../internal-version');
 
 const {green, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
@@ -364,10 +365,12 @@ async function preBuildExperiments() {
 
   // Build HTML.
   const html = fs.readFileSync(htmlPath, 'utf8');
-  const minHtml = html.replace(
-    '/dist.tools/experiments/experiments.js',
-    `https://${hostname}/v0/experiments.js`
-  );
+  const minHtml = html
+    .replace(
+      '/dist.tools/experiments/experiments.js',
+      `https://${hostname}/v0/experiments.js`
+    )
+    .replace(/\$internalRuntimeVersion\$/g, VERSION);
 
   await toPromise(
     gulp

--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -41,7 +41,8 @@
     }
 
     .version {
-      color: #3ab3eb;
+      color: gray;
+      font-family: 'Courier New', Courier, monospace;
     }
 
     .content {

--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -40,6 +40,10 @@
       color: #147bc1;
     }
 
+    .version {
+      color: #3ab3eb;
+    }
+
     .content {
       margin: 16px;
       display: block;
@@ -187,6 +191,15 @@
 
   <section class="hero">
     <h1>AMP Experiments</h1>
+  </section>
+
+  <section class="desc">
+    <h2>Version</h2>
+    <p>
+      This is version <span class="version">$internalRuntimeVersion$</span> of the AMP runtime.
+      For a list of commits contained in this release, click
+      <a target="_blank" href="https://github.com/ampproject/amphtml/releases/tag/$internalRuntimeVersion$">here</a>.
+    </p>
   </section>
 
   <section class="desc">


### PR DESCRIPTION
This PR adds a version section to the AMP experiments page. From here on, http://cdn.ampproject.org/experiments.html will show the current version, with a link to the GitHub release for that version.

<img width="774" alt="Screen Shot 2019-08-07 at 11 10 57 AM" src="https://user-images.githubusercontent.com/26553114/62646864-17187f80-b904-11e9-9275-f8b3207fe184.png">

Fixes #23544