### PR TITLE
amp-img: Remove [srcset] when [src] is mutated

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -23,6 +23,9 @@ import {listen} from '../src/event-helper';
 import {propagateObjectFitStyles, setImportantStyles} from '../src/style';
 import {registerElement} from '../src/service/custom-element-registry';
 
+/** @const {string} */
+const TAG = 'amp-img';
+
 /**
  * Attributes to propagate to internal image when changed externally.
  * @type {!Array<string>}
@@ -72,6 +75,23 @@ export class AmpImg extends BaseElement {
       const attrs = ATTRIBUTES_TO_PROPAGATE.filter(
         value => mutations[value] !== undefined
       );
+      // Mutating src should override existing srcset, so remove the latter.
+      if (
+        mutations['src'] &&
+        !mutations['srcset'] &&
+        this.element.hasAttribute('srcset')
+      ) {
+        // propagateAttributes() will remove [srcset] from this.img_.
+        this.element.removeAttribute('srcset');
+        attrs.push('srcset');
+
+        this.user().warn(
+          TAG,
+          'Removed [srcset] since [src] was mutated. Recommend adding a ' +
+            '[srcset] binding to support responsive images.',
+          this.element
+        );
+      }
       this.propagateAttributes(
         attrs,
         this.img_,
@@ -148,7 +168,7 @@ export class AmpImg extends BaseElement {
     if (this.element.getAttribute('role') == 'img') {
       this.element.removeAttribute('role');
       this.user().error(
-        'AMP-IMG',
+        TAG,
         'Setting role=img on amp-img elements breaks ' +
           'screen readers please just set alt or ARIA attributes, they will ' +
           'be correctly propagated for the underlying <img> element.'
@@ -307,5 +327,5 @@ export class AmpImg extends BaseElement {
  * @this {undefined}  // Make linter happy
  */
 export function installImg(win) {
-  registerElement(win, 'amp-img', AmpImg);
+  registerElement(win, TAG, AmpImg);
 }

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -462,7 +462,7 @@ Only binding to the following components and attributes are allowed:
   <tr>
     <td><code>&lt;amp-img&gt;</code></td>
     <td><code>[alt]</code><br><code>[attribution]</code><br><code>[src]</code><br><code>[srcset]</code></td>
-    <td>When binding to <code>[src]</code>, make sure you also bind to <code>[srcset]</code> in order to make the binding work on cache.<br>See corresponding <a href="https://www.ampproject.org/docs/reference/components/media/amp-img#attributes">amp-img attributes</a>.</td>
+    <td>Recommend binding to <code>[srcset]</code> instead of <code>[src]</code> to support responsive images.<br>See corresponding <a href="https://www.ampproject.org/docs/reference/components/media/amp-img#attributes">amp-img attributes</a>.</td>
   </tr>
   <tr>
     <td><code>&lt;amp-lightbox&gt;</code></td>

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -153,30 +153,23 @@ describe('amp-img', () => {
     });
   });
 
-  // TODO(cvializ, #12336): unskip
-  it.skip('should handle attribute mutations', () => {
-    return getImg({
-      src: 'test.jpg',
-      srcset: 'large.jpg 2000w, small.jpg 1000w',
+  it('should handle attribute mutations', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      srcset: SRCSET_STRING,
       width: 300,
       height: 200,
-    }).then(ampImg => {
-      const impl = ampImg.implementation_;
-
-      ampImg.setAttribute('srcset', 'mutated-srcset.jpg 500w');
-      ampImg.setAttribute('src', 'mutated-src.jpg');
-
-      // `srcset` mutation should take precedence over `src` mutation.
-      impl.mutatedAttributesCallback({
-        srcset: 'mutated-srcset.jpg 1000w',
-        src: 'mutated-src.jpg',
-      });
-      expect(impl.img_.getAttribute('src')).to.equal('mutated-srcset.jpg');
-
-      // `src` mutation should override existing `srcset` attribute.
-      impl.mutatedAttributesCallback({src: 'mutated-src.jpg'});
-      expect(impl.img_.getAttribute('src')).to.equal('mutated-src.jpg');
     });
+    const impl = ampImg.implementation_;
+
+    expect(impl.img_.hasAttribute('srcset')).to.be.true;
+
+    ampImg.setAttribute('src', 'foo.jpg');
+    impl.mutatedAttributesCallback({src: 'foo.jpg'});
+
+    expect(impl.img_.getAttribute('src')).to.equal('foo.jpg');
+    // src mutation should override existing srcset attribute.
+    expect(impl.img_.hasAttribute('srcset')).to.be.false;
   });
 
   it('should propagate srcset and sizes', () => {


### PR DESCRIPTION
Fixes #10207. 

- Mutating [src] is a no-op if [srcset] already exists, so remove the latter.
- Originally fixed in #11493 but regressed as part of the "native srcset" feature in #16404.

/to @cathyxz 