### PR TITLE
Increase play & error message font size.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -815,7 +815,7 @@ amp-story .amp-video-eq,
 .i-amphtml-story-page-play-label {
   color: #fff !important;
   font-family: 'Roboto', sans-serif !important;
-  font-size: 14px !important;
+  font-size: 16px !important;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.36) !important;
 }
 


### PR DESCRIPTION
Really couldn't find a responsive font-size that works across all experiences (desktop - tablet - mobile), so I just increased the size to match the other UI we have (especially the sound UI messages).
If we want to customize the font size further, I think we should have different media query breakpoints, and target each experience differently: desktop three panels vs full bleed are different, tablet vs mobile are different, etc.

Fixes #22804