### PR TITLE
🏗🐛 Disable `no-duplicate-name-typedef` rule during on-the-fly IDE linting

### DIFF
--- a/build-system/eslint-rules/no-duplicate-name-typedef.js
+++ b/build-system/eslint-rules/no-duplicate-name-typedef.js
@@ -15,12 +15,19 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
+
 // Global cache of typedefName: typedefLocation.
 const typedefs = new Map();
 
 module.exports = function(context) {
   return {
     VariableDeclaration(node) {
+      // This rule does not work with per-file on-the-fly linting done by IDEs.
+      if (!argv._.includes('lint')) {
+        return;
+      }
+
       if (!node.leadingComments) {
         return;
       }


### PR DESCRIPTION
#23472 added the `no-duplicate-name-typedef` rule, which keeps track of typedefs in a global map during `gulp lint`. The rule breaks eslint IDE plugins that do on-the-fly linting because the global map isn't cleared between runs.

For example, closing and reopening `tools/experiments/experiments.js` in VS code results in this bogus error:

<img width="1053" alt="" src="https://user-images.githubusercontent.com/26553114/62649971-a6289600-b90a-11e9-94a4-9bcbebeb940f.png">

This PR disables the rule unless `gulp lint` is being run.

Follow up to #23472