### PR TITLE
🏗🐛Manually update `build-system/tasks/visual-diff/yarn.lock` to address security vulnerabilities

### DIFF
--- a/build-system/tasks/visual-diff/yarn.lock
+++ b/build-system/tasks/visual-diff/yarn.lock
@@ -972,9 +972,9 @@ jest-validate@^23.5.0:
     pretty-format "^23.6.0"
 
 js-yaml@^3.9.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1121,9 +1121,9 @@ listr@^0.14.1:
     rxjs "^6.1.0"
 
 lodash@^4.13.1, lodash@^4.17.5:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The visual tests use v0.4.0 of `@percy/puppeteer`, which has dependencies with known security vulnerabilities. 

https://github.com/ampproject/amphtml/blob/cfc17637d064b5d747d9c810f0a39de8f6c9b98c/build-system/tasks/visual-diff/package.json#L6-L9

<img width="735" alt="Screen Shot 2019-08-07 at 1 27 30 PM" src="https://user-images.githubusercontent.com/26553114/62655571-2228db00-b917-11e9-85e7-0813403152c0.png">
<img width="734" alt="Screen Shot 2019-08-07 at 1 28 11 PM" src="https://user-images.githubusercontent.com/26553114/62655620-38cf3200-b917-11e9-9b41-6c40593dee29.png">


v1.0.0 of `@percy/puppeteer` fixes these vulnerabilities, but we can't upgrade because of breaking  API changes. See #23462.

Until then, this PR manually upgrades the offending dependencies to safe versions. (Future task: Upgrade to v1.0.0 of `@percy/puppeteer`.)