### PR TITLE
👨🏻‍🔬E2E: Add ability to pierce shadow DOM

### DIFF
--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -664,9 +664,18 @@ class PuppeteerController {
     this.currentFrame_ = frame;
   }
 
-  async switchToShadow(handle) {
-    const shadowHost = handle.getElement();
+  switchToShadow(handle) {
     const getter = shadowHost => shadowHost.shadowRoot.body;
+    return this.switchToShadowInternal_(handle, getter);
+  }
+
+  switchToShadowRoot(handle) {
+    const getter = shadowHost => shadowHost.shadowRoot;
+    return this.switchToShadowInternal_(handle, getter);
+  }
+
+  async switchToShadowInternal_(handle, getter) {
+    const shadowHost = handle.getElement();
     const shadowRootBodyHandle = await this.evaluate(getter, shadowHost);
     this.shadowRoot_ = shadowRootBodyHandle.asElement();
   }

--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -664,16 +664,30 @@ class PuppeteerController {
     this.currentFrame_ = frame;
   }
 
+  /**
+   * Switch controller to shadowRoot body hosted by given element.
+   * @param {!ElementHandle<!PuppeteerHandle} handle
+   * @return {!Promise}
+   */
   switchToShadow(handle) {
     const getter = shadowHost => shadowHost.shadowRoot.body;
     return this.switchToShadowInternal_(handle, getter);
   }
 
+  /**
+   * Switch controller to shadowRoot hosted by given element.
+   * @param {!ElementHandle<!PuppeteerHandle>} handle
+   * @return {!Promise}
+   */
   switchToShadowRoot(handle) {
     const getter = shadowHost => shadowHost.shadowRoot;
     return this.switchToShadowInternal_(handle, getter);
   }
 
+  /**.
+   * @param {!ElementHandle<!PuppeteerHandle>} handle
+   * @param {!Function} getter
+   */
   async switchToShadowInternal_(handle, getter) {
     const shadowHost = handle.getElement();
     const shadowRootBodyHandle = await this.evaluate(getter, shadowHost);

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -610,16 +610,30 @@ class SeleniumWebDriverController {
     await this.driver.switchTo().defaultContent();
   }
 
+  /**
+   * Switch controller to shadowRoot body hosted by given element.
+   * @param {!ElementHandle<!WebElement>} handle
+   * @return {!Promise}
+   */
   async switchToShadow(handle) {
     const getter = shadowHost => shadowHost.shadowRoot.body;
     return this.switchToShadowInternal_(handle, getter);
   }
 
+  /**
+   * Switch controller to shadowRoot hosted by given element.
+   * @param {!ElementHandle<!WebElement>} handle
+   * @return {!Promise}
+   */
   async switchToShadowRoot(handle) {
     const getter = shadowHost => shadowHost.shadowRoot;
     return this.switchToShadowInternal_(handle, getter);
   }
 
+  /**.
+   * @param {!ElementHandle<!WebElement>} handle
+   * @param {!Function} getter
+   */
   async switchToShadowInternal_(handle, getter) {
     const shadowHost = handle.getElement();
     const shadowRootBody = await this.evaluate(getter, shadowHost);

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -611,11 +611,18 @@ class SeleniumWebDriverController {
   }
 
   async switchToShadow(handle) {
+    const getter = shadowHost => shadowHost.shadowRoot.body;
+    return this.switchToShadowInternal_(handle, getter);
+  }
+
+  async switchToShadowRoot(handle) {
+    const getter = shadowHost => shadowHost.shadowRoot;
+    return this.switchToShadowInternal_(handle, getter);
+  }
+
+  async switchToShadowInternal_(handle, getter) {
     const shadowHost = handle.getElement();
-    const shadowRootBody = await this.evaluate(
-      shadowHost => shadowHost.shadowRoot.body,
-      shadowHost
-    );
+    const shadowRootBody = await this.evaluate(getter, shadowHost);
     this.shadowRoot_ = shadowRootBody;
   }
 


### PR DESCRIPTION
Existing `controller.switchToShadow` explicitly looks for body in shadow root. Adds a new method `switchToShadowRoot` (happy to bikeshed naming :) ) that switches the controller root to shadow root inside the given host (without body)

Many elements in AMP Stories / Story Ads are inside Shadow DOM, this is helpful to test them.