### PR TITLE
amp-bind: Add "global" reference

### DIFF
--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -109,7 +109,7 @@ export class BindEvaluator {
   /**
    * Evaluates all expressions with the given `scope` data returns two maps:
    * expression strings to results and expression strings to errors.
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @return {!BindEvaluateBindingsResultDef}
    */
   evaluateBindings(scope) {
@@ -117,6 +117,8 @@ export class BindEvaluator {
     const cache = Object.create(null);
     /** @type {!Object<string, !BindEvaluatorErrorDef>} */
     const errors = Object.create(null);
+
+    this.setGlobals_(scope);
 
     // First, evaluate all of the expression strings in the bindings.
     this.bindings_.forEach(binding => {
@@ -173,7 +175,7 @@ export class BindEvaluator {
   /**
    * Evaluates and returns a single expression string.
    * @param {string} expressionString
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @return {!BindEvaluateExpressionResultDef}
    */
   evaluateExpression(expressionString, scope) {
@@ -181,11 +183,22 @@ export class BindEvaluator {
     if (!parsed.expression) {
       return {result: null, error: parsed.error};
     }
+    this.setGlobals_(scope);
     const evaluated = this.evaluate_(parsed.expression, scope);
     if (!evaluated.result) {
       return {result: null, error: evaluated.error};
     }
     return {result: evaluated.result, error: null};
+  }
+
+  /**
+   * Sets global references in scope if they're not already set or overriden.
+   * @param {!JsonObject} scope
+   */
+  setGlobals_(scope) {
+    if (!('global' in scope)) {
+      scope['global'] = scope;
+    }
   }
 
   /**
@@ -211,7 +224,7 @@ export class BindEvaluator {
   /**
    * Evaluate a single expression with the given scope.
    * @param {!BindExpression} expression
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @return {{result: ?BindExpressionResultDef, error: ?BindEvaluatorErrorDef}}
    * @private
    */

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -243,7 +243,7 @@ export class BindExpression {
 
   /**
    * Evaluates the expression given a scope.
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @throws {Error} On illegal function invocation.
    * @return {BindExpressionResultDef}
    */
@@ -326,7 +326,7 @@ export class BindExpression {
   /**
    * Recursively evaluates and returns value of `node` and its children.
    * @param {./bind-expr-defines.AstNode} node
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @throws {Error}
    * @return {BindExpressionResultDef}
    * @private

--- a/extensions/amp-bind/0.1/bind-macro.js
+++ b/extensions/amp-bind/0.1/bind-macro.js
@@ -36,17 +36,17 @@ export class BindMacro {
   }
 
   /**
-   * @param {!Object} state
+   * @param {!JsonObject} scope
    * @param {!Array} args
    * @throws {Error} On illegal function invocation.
    * @return {BindExpressionResultDef}
    */
-  evaluate(state, args) {
-    const scope = Object.assign({}, state);
+  evaluate(scope, args) {
+    const copy = /** @type {!JsonObject} */ (Object.assign({}, scope));
     for (let i = 0; i < this.argumentNames_.length; i++) {
-      scope[this.argumentNames_[i]] = args[i];
+      copy[this.argumentNames_[i]] = args[i];
     }
-    return this.expression_.evaluate(scope);
+    return this.expression_.evaluate(copy);
   }
 
   /**

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -137,19 +137,41 @@ describe('BindEvaluator', () => {
     expect(errors['oneplusone + 2']).to.be.undefined;
   });
 
-  it('should treat out-of-scope vars as null', () => {
+  it('should support "global"', () => {
+    evaluator.addBindings([
+      {
+        tagName: 'P',
+        property: 'text',
+        expressionString: 'global',
+      },
+    ]);
+    let {results, errors} = evaluator.evaluateBindings({x: 1});
+    expect(results['global']).to.deep.include({x: 1});
+    expect(results['global']).to.have.property('global');
+    expect(errors['global']).to.be.undefined;
+
+    // "global" should be overridable by user-defined variables.
+    ({results, errors} = evaluator.evaluateBindings({
+      x: 1,
+      global: {x: 2},
+    }));
+    expect(results['global']).to.deep.equal({x: 2});
+    expect(errors['global']).to.be.undefined;
+  });
+
+  it('should treat undefined vars as null', () => {
     expect(numberOfBindings()).to.equal(0);
     evaluator.addBindings([
       {
         tagName: 'P',
         property: 'text',
-        expressionString: 'outOfScope',
+        expressionString: 'doesntExist',
       },
     ]);
     expect(numberOfBindings()).to.equal(1);
     const {results, errors} = evaluator.evaluateBindings({});
-    expect(results['outOfScope']).to.be.null;
-    expect(errors['outOfScope']).to.be.undefined;
+    expect(results['doesntExist']).to.be.null;
+    expect(errors['doesntExist']).to.be.undefined;
   });
 
   it('should validate a common expression on each respective binding', () => {


### PR DESCRIPTION
Fixes #20167.

Useful for referencing amp-state with non-alphanumeric in `id`, e.g.

```html
<amp-state id="x-1">...</amp-state>

<!-- Need to use bracket notation due to "-" in [id]. -->
<p [text]="global['x-1']"></p>
```

Also some unrelated documentation tweaks in amp-bind.md.

/to @jridgewell 