### PR TITLE
🐛 Disable closure compiler parallelism during local development

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -40,10 +40,9 @@ const queue = [];
 let inProgress = 0;
 
 // There's a race in the gulp plugin of closure compiler that gets exposed
-// during slower compilation operations.
+// during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
-const MAX_PARALLEL_CLOSURE_INVOCATIONS =
-  argv.pseudo_names || argv.full_sourcemaps ? 1 : 4;
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild() ? 4 : 1;
 
 /**
  * Prefixes the the tmp directory if we need to shadow files that have been


### PR DESCRIPTION
This PR disables closure compiler parallelism during local development in order to prevent this error:

```js
[14:10:14] 'dist' errored after 1.83 min
[14:10:14] Error in plugin 'gulp-google-closure-compiler'
Error parsing json encoded files
```

**Note:** The error stems from Nailgun (see #21939), which significantly speeds up `gulp dist` by allowing for the reuse of a single closure compiler java process across multiple compilation invocations. Reducing parallelism to 1 will still retain the benefit of not having to restart the JVM multiple times, while avoiding the race that causes the `Error parsing json encoded files` error.

Fixes #23793
Fixes #23238