### PR TITLE
Fix amp-date-picker closure compiler warnings

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -331,13 +331,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       );
       compilerOptions.conformance_configs =
         'build-system/conformance-config.textproto';
-      // TODO(cvializ, #23417): Remove these after fixing React.Component type errors.
-      compilerOptions.hide_warnings_for.push(
-        'extensions/amp-date-picker/0.1/date-picker-common.js',
-        'extensions/amp-date-picker/0.1/react-utils.js',
-        'extensions/amp-date-picker/0.1/single-date-picker.js',
-        'extensions/amp-date-picker/0.1/wrappers/maximum-nights.js'
-      );
     } else {
       compilerOptions.jscomp_warning.push('accessControls', 'moduleLoad');
       compilerOptions.jscomp_off.push('unknownDefines');

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -40,7 +40,6 @@ requirement: {
   error_message: 'History.p.state is broken in IE11. Please use the helper methods provided in src/history.js'
   value: 'History.prototype.state'
   whitelist: 'src/history.js'
-  whitelist: 'extensions/amp-date-picker/0.1/react-utils.js'
 }
 
 # Strings

--- a/extensions/amp-date-picker/0.1/date-picker-common.js
+++ b/extensions/amp-date-picker/0.1/date-picker-common.js
@@ -28,7 +28,7 @@ export function withDatePickerCommon(WrappedComponent) {
   const isSameDay = reactDates['isSameDay'];
   const isInclusivelyAfterDay = reactDates['isInclusivelyAfterDay'];
   const isInclusivelyBeforeDay = reactDates['isInclusivelyBeforeDay'];
-  const React = requireExternal('react');
+  const react = requireExternal('react');
   const Moment = requireExternal('moment');
 
   /**
@@ -124,27 +124,67 @@ export function withDatePickerCommon(WrappedComponent) {
   }
 
   /**
+   * Creates an instance of Component.
+   * @param {!JsonObject} props
    * @struct
+   * @constructor
+   * @extends {React.Component}
    */
-  class Component extends React.Component {
-    /**
-     * Creates an instance of Component.
-     * @param {!JsonObject} props
-     */
-    constructor(props) {
-      super(props);
+  function DateComponent(props) {
+    react.Component.call(this, props);
 
-      /** @type {!JsonObject} */
-      this.props;
+    /** @type {!JsonObject} */
+    this.props;
 
-      const allowBlockedEndDate = props['allowBlockedEndDate'];
-      const blocked = props['blocked'];
-      const endDate = props['endDate'];
-      const highlighted = props['highlighted'];
-      const max = props['max'];
-      const min = props['min'];
-      const startDate = props['startDate'];
+    const allowBlockedEndDate = props['allowBlockedEndDate'];
+    const blocked = props['blocked'];
+    const endDate = props['endDate'];
+    const highlighted = props['highlighted'];
+    const max = props['max'];
+    const min = props['min'];
+    const startDate = props['startDate'];
 
+    this.isDayBlocked = isDayBlocked.bind(
+      null,
+      blocked,
+      startDate,
+      endDate,
+      allowBlockedEndDate
+    );
+    this.isDayHighlighted = datesListContains.bind(null, highlighted);
+    this.isOutsideRange = isOutsideRange.bind(null, min, max);
+  }
+
+  DateComponent.prototype = Object.create(react.Component.prototype);
+  DateComponent.prototype.constructor = DateComponent;
+
+  /** @override */
+  DateComponent.prototype.componentDidMount = function() {
+    if (this.props['onMount']) {
+      this.props['onMount']();
+    }
+  };
+
+  /** @override */
+  DateComponent.prototype.componentWillReceiveProps = function(nextProps) {
+    const allowBlockedEndDate = nextProps['allowBlockedEndDate'];
+    const blocked = nextProps['blocked'];
+    const endDate = nextProps['endDate'];
+    const highlighted = nextProps['highlighted'];
+    const max = nextProps['max'];
+    const min = nextProps['min'];
+    const startDate = nextProps['startDate'];
+
+    if (min != this.props['min'] || max != this.props['max']) {
+      this.isOutsideRange = isOutsideRange.bind(null, min, max);
+    }
+
+    if (
+      blocked != this.props['blocked'] ||
+      allowBlockedEndDate != this.props['allowBlockedEndDate'] ||
+      startDate != this.props['startDate'] ||
+      endDate != this.props['endDate']
+    ) {
       this.isDayBlocked = isDayBlocked.bind(
         null,
         blocked,
@@ -152,86 +192,47 @@ export function withDatePickerCommon(WrappedComponent) {
         endDate,
         allowBlockedEndDate
       );
+    }
+
+    if (highlighted != this.props['highlighted']) {
       this.isDayHighlighted = datesListContains.bind(null, highlighted);
-      this.isOutsideRange = isOutsideRange.bind(null, min, max);
     }
+  };
 
-    /** @override */
-    componentDidMount() {
-      if (this.props['onMount']) {
-        this.props['onMount']();
-      }
-    }
+  /** @override */
+  DateComponent.prototype.render = function() {
+    const props = /** @type {!JsonObject} */ (omit(
+      this.props,
+      Object.keys(defaultProps)
+    ));
 
-    /** @override */
-    componentWillReceiveProps(nextProps) {
-      const allowBlockedEndDate = nextProps['allowBlockedEndDate'];
-      const blocked = nextProps['blocked'];
-      const endDate = nextProps['endDate'];
-      const highlighted = nextProps['highlighted'];
-      const max = nextProps['max'];
-      const min = nextProps['min'];
-      const startDate = nextProps['startDate'];
+    const date = props['date'];
+    const daySize = props['daySize'];
+    const endDate = props['endDate'];
+    const initialVisibleMonth = props['initialVisibleMonth'];
+    const startDate = props['startDate'];
 
-      if (min != this.props['min'] || max != this.props['max']) {
-        this.isOutsideRange = isOutsideRange.bind(null, min, max);
-      }
+    const initialDate =
+      initialVisibleMonth || date || startDate || endDate || undefined;
+    props['initialVisibleMonth'] = () => Moment(initialDate);
 
-      if (
-        blocked != this.props['blocked'] ||
-        allowBlockedEndDate != this.props['allowBlockedEndDate'] ||
-        startDate != this.props['startDate'] ||
-        endDate != this.props['endDate']
-      ) {
-        this.isDayBlocked = isDayBlocked.bind(
-          null,
-          blocked,
-          startDate,
-          endDate,
-          allowBlockedEndDate
-        );
-      }
-
-      if (highlighted != this.props['highlighted']) {
-        this.isDayHighlighted = datesListContains.bind(null, highlighted);
-      }
-    }
-
-    /** @override */
-    render() {
-      const props = /** @type {!JsonObject} */ (omit(
-        this.props,
-        Object.keys(defaultProps)
-      ));
-
-      const date = props['date'];
-      const daySize = props['daySize'];
-      const endDate = props['endDate'];
-      const initialVisibleMonth = props['initialVisibleMonth'];
-      const startDate = props['startDate'];
-
-      const initialDate =
-        initialVisibleMonth || date || startDate || endDate || undefined;
-      props['initialVisibleMonth'] = () => Moment(initialDate);
-
-      return React.createElement(
-        WrappedComponent,
-        Object.assign(
-          {},
-          props,
-          dict({
-            'daySize': Number(daySize),
-            'isDayBlocked': this.isDayBlocked,
-            'isDayHighlighted': this.isDayHighlighted,
-            'isOutsideRange': this.isOutsideRange,
-          })
-        )
-      );
-    }
-  }
+    return react.createElement(
+      WrappedComponent,
+      Object.assign(
+        {},
+        props,
+        dict({
+          'daySize': Number(daySize),
+          'isDayBlocked': this.isDayBlocked,
+          'isDayHighlighted': this.isDayHighlighted,
+          'isOutsideRange': this.isOutsideRange,
+        })
+      )
+    );
+  };
 
   /** @dict */
-  Component['defaultProps'] = defaultProps;
+  DateComponent['defaultProps'] = defaultProps;
 
-  return Component;
+  return DateComponent;
 }

--- a/extensions/amp-date-picker/0.1/react-utils.js
+++ b/extensions/amp-date-picker/0.1/react-utils.js
@@ -23,44 +23,52 @@ import {requireExternal} from '../../../src/module';
  * @return {function(new:React.Component, !Object)}
  */
 function createDeferred_() {
-  const React = requireExternal('react');
+  const react = requireExternal('react');
 
-  class DeferredType extends React.Component {
-    /**
-     * @param {!Object} props
-     */
-    constructor(props) {
-      super(props);
-      this.state = {value: this.props.initial};
-    }
-
-    /** @override */
-    componentWillReceiveProps(nextProps) {
-      const promise = nextProps['promise'];
-      if (promise) {
-        promise.then(value => this.setState({value}));
-      }
-    }
-
-    /** @override */
-    shouldComponentUpdate(props, state) {
-      return (
-        shallowDiffers(this.props, props) || shallowDiffers(this.state, state)
-      );
-    }
-
-    /** @override */
-    componentDidMount() {
-      this.props.promise.then(value => this.setState({value}));
-    }
-
-    /** @override */
-    render() {
-      return this.props.then(this.state.value);
-    }
+  /**
+   * Creates an instance of DeferredType.
+   * @param {!Object} props
+   * @struct
+   * @constructor
+   * @extends {React.Component}
+   */
+  function DeferredType(props) {
+    react.Component.call(this, props);
+    const self = /** @type {!React.Component} */ (this);
+    self.state = {value: this.props.initial};
   }
 
-  DeferredType.defaultProps = {
+  DeferredType.prototype = Object.create(react.Component.prototype);
+  DeferredType.prototype.constructor = DeferredType;
+
+  /** @override */
+  DeferredType.prototype.componentWillReceiveProps = function(nextProps) {
+    const promise = nextProps['promise'];
+    if (promise) {
+      promise.then(value => this.setState({value}));
+    }
+  };
+
+  /** @override */
+  DeferredType.prototype.shouldComponentUpdate = function(props, state) {
+    const self = /** @type {!React.Component} */ (this);
+    return Boolean(
+      shallowDiffers(this.props, props) || shallowDiffers(self.state, state)
+    );
+  };
+
+  /** @override */
+  DeferredType.prototype.componentDidMount = function() {
+    this.props.promise.then(value => this.setState({value}));
+  };
+
+  /** @override */
+  DeferredType.prototype.render = function() {
+    const self = /** @type {!React.Component} */ (this);
+    return this.props.then(self.state.value);
+  };
+
+  DeferredType['defaultProps'] = {
     initial: '',
   };
 

--- a/extensions/amp-date-picker/0.1/single-date-picker.js
+++ b/extensions/amp-date-picker/0.1/single-date-picker.js
@@ -100,15 +100,27 @@ function createSingleDatePickerBase() {
  * @return {function(new:React.Component, !JsonObject)} A class with a preset focused prop
  */
 function withFocusedTrueHack(WrappedComponent) {
-  const React = requireExternal('react');
+  const react = requireExternal('react');
 
-  class FocusedTrueHack extends React.Component {
-    /** @override */
-    render() {
-      const props = Object.assign({}, this.props, dict({'focused': true}));
-      return React.createElement(WrappedComponent, props);
-    }
+  /**
+   * Creates an instance of FocusedTrueHack.
+   * @param {!JsonObject} props
+   * @struct
+   * @constructor
+   * @extends {React.Component}
+   */
+  function FocusedTrueHack(props) {
+    react.Component.call(this, props);
   }
+
+  FocusedTrueHack.prototype = Object.create(react.Component.prototype);
+  FocusedTrueHack.prototype.constructor = FocusedTrueHack;
+
+  /** @override */
+  FocusedTrueHack.prototype.render = function() {
+    const props = Object.assign({}, this.props, dict({'focused': true}));
+    return react.createElement(WrappedComponent, props);
+  };
 
   return FocusedTrueHack;
 }

--- a/extensions/amp-date-picker/0.1/wrappers/maximum-nights.js
+++ b/extensions/amp-date-picker/0.1/wrappers/maximum-nights.js
@@ -22,7 +22,7 @@ import {requireExternal} from '../../../../src/module';
  * @return {function(new:React.Component, !JsonObject)}
  */
 export function wrap(WrappedComponent) {
-  const React = requireExternal('react');
+  const react = requireExternal('react');
   const reactDatesConstants = requireExternal('react-dates/constants');
   const reactDates = requireExternal('react-dates');
 
@@ -31,38 +31,44 @@ export function wrap(WrappedComponent) {
   const isInclusivelyAfterDay = reactDates['isInclusivelyAfterDay'];
   const isInclusivelyBeforeDay = reactDates['isInclusivelyBeforeDay'];
 
-  class MaximumNights extends React.Component {
-    /**
-     * @param {!JsonObject} props
-     */
-    constructor(props) {
-      super(props);
+  /**
+   * Creates an instance of FocusedTrueHack.
+   * @param {!JsonObject} props
+   * @struct
+   * @constructor
+   * @extends {React.Component}
+   */
+  function MaximumNights(props) {
+    react.Component.call(this, props);
 
-      /** @private */
-      this.isOutsideRange_ = getIsOutsideRange(props);
-    }
-
-    /** @override */
-    componentWillReceiveProps(nextProps) {
-      const {props} = this;
-      const shouldUpdate =
-        props['isOutsideRange'] != nextProps['isOutsideRange'] ||
-        props['startDate'] != nextProps['startDate'] ||
-        props['endDate'] != nextProps['endDate'] ||
-        props['focusedInput'] != nextProps['focusedInput'] ||
-        props['maximumNights'] != nextProps['maximumNights'];
-      if (shouldUpdate) {
-        this.isOutsideRange_ = getIsOutsideRange(nextProps);
-      }
-    }
-
-    /** @override */
-    render() {
-      const props = Object.assign({}, this.props);
-      props['isOutsideRange'] = this.isOutsideRange_;
-      return React.createElement(WrappedComponent, props);
-    }
+    /** @private */
+    this.isOutsideRange_ = getIsOutsideRange(props);
   }
+
+  MaximumNights.prototype = Object.create(react.Component.prototype);
+  MaximumNights.prototype.constructor = MaximumNights;
+
+  /** @override */
+  MaximumNights.prototype.componentWillReceiveProps = function(nextProps) {
+    const {props} = this;
+    const shouldUpdate =
+      props['isOutsideRange'] != nextProps['isOutsideRange'] ||
+      props['startDate'] != nextProps['startDate'] ||
+      props['endDate'] != nextProps['endDate'] ||
+      props['focusedInput'] != nextProps['focusedInput'] ||
+      props['maximumNights'] != nextProps['maximumNights'];
+    if (shouldUpdate) {
+      this.isOutsideRange_ = getIsOutsideRange(nextProps);
+    }
+  };
+
+  /** @override */
+  MaximumNights.prototype.render = function() {
+    const props = Object.assign({}, this.props);
+    props['isOutsideRange'] = this.isOutsideRange_;
+    return react.createElement(WrappedComponent, props);
+  };
+
   /** @private @const visible for testing */
   MaximumNights.getIsOutsideRange = getIsOutsideRange;
 


### PR DESCRIPTION
Fixes #23429

It turns out the solution was to make Closure Compiler stop checking the `extends` and to use ES5 class syntax with manual prototype chaining. Not ideal, but at least it's an established pattern that works.