### PR TITLE
🏗 Add a way to opt out of Nailgun during `dist` and `check-types`

### DIFF
--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const closureCompiler = require('google-closure-compiler');
 const colors = require('ansi-colors');
 const {highlight} = require('cli-highlight');
@@ -83,9 +84,13 @@ function gulpClosureCompile(compilerOptions, nailgunPort) {
       '../../node_modules/google-closure-compiler-java/compiler.jar'
     );
   } else {
-    // On Mac OS and Linux, speed up compilation using nailgun.
+    // On Mac OS and Linux, speed up compilation using nailgun (unless the
+    // --disable_nailgun flag was passed in)
     // See https://github.com/facebook/nailgun.
-    if (process.platform == 'darwin' || process.platform == 'linux') {
+    if (
+      !argv.disable_nailgun &&
+      (process.platform == 'darwin' || process.platform == 'linux')
+    ) {
       compilerOptions = [
         '--nailgun-port',
         nailgunPort,
@@ -95,7 +100,8 @@ function gulpClosureCompile(compilerOptions, nailgunPort) {
       pluginOptions.platform = ['native']; // nailgun-runner isn't a java binary
       initOptions.extraArguments = null; // Already part of nailgun-server
     } else {
-      // For other platforms, use AMP's custom runner.jar
+      // For other platforms, or if nailgun is explicitly disabled, use AMP's
+      // custom runner.jar
       closureCompiler.compiler.JAR_PATH = require.resolve(
         `../runner/dist/${nailgunPort}/runner.jar`
       );

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -136,4 +136,10 @@ module.exports = {
   checkTypes,
 };
 
+/* eslint "google-camelcase/google-camelcase": 0 */
+
 checkTypes.description = 'Check source code for JS type errors';
+checkTypes.flags = {
+  disable_nailgun:
+    "  Doesn't use nailgun to invoke closure compiler (much slower)",
+};

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -460,4 +460,6 @@ dist.flags = {
     '  The directory closure compiler will write out to ' +
     'with --single_pass mode. The default directory is `dist`',
   full_sourcemaps: '  Includes source code content in sourcemaps',
+  disable_nailgun:
+    "  Doesn't use nailgun to invoke closure compiler (much slower)",
 };

--- a/build-system/tasks/nailgun.js
+++ b/build-system/tasks/nailgun.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 const sleep = require('sleep-promise');
@@ -74,12 +75,16 @@ function maybeReplaceDefaultCompiler() {
  * @param {boolean} detached
  */
 async function startNailgunServer(port, detached) {
+  await maybeGenerateRunner(port);
+
+  if (argv.disable_nailgun) {
+    return;
+  }
+
   nailgunRunnerReplacer = maybeReplaceDefaultCompiler();
   if (!nailgunRunnerReplacer) {
     return;
   }
-
-  await maybeGenerateRunner(port);
 
   // Start up the nailgun server after cleaning up old instances (if any)
   const customRunner = require.resolve(`../runner/dist/${port}/runner.jar`);
@@ -131,6 +136,10 @@ async function startNailgunServer(port, detached) {
  * @param {string} port
  */
 async function stopNailgunServer(port) {
+  if (argv.disable_nailgun) {
+    return;
+  }
+
   if (nailgunRunnerReplacer) {
     nailgunRunnerReplacer.restore();
   }


### PR DESCRIPTION
There appear to be some development environments for which using nailgun to invoke closure compiler causes compilation to fail. This PR provides developers with a way to opt out of nailgun by using the `--disable_nailgun` flag with `gulp dist` or `gulp check-types`.

Mitigates #23801