### PR TITLE
🐛✨`<amp-carousel>` 0.2 minor fixes

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -53,8 +53,9 @@ class AmpCarousel extends AMP.BaseElement {
     );
     this.registerAction(
       'toggleAutoplay',
-      ({args = {}}) => {
-        this.toggleAutoplay_(args['toggleOn']);
+      ({args}) => {
+        const toggle = args ? args['toggleOn'] : undefined;
+        this.toggleAutoplay_(toggle);
       },
       ActionTrust.LOW
     );

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -133,6 +133,7 @@ class AmpCarousel extends AMP.BaseElement {
 
     // Setup actions and listeners
     this.setupActions_();
+    this.stopTouchMovePropagation_();
     this.element.addEventListener('indexchange', event => {
       this.onIndexChanged_(event);
     });
@@ -158,7 +159,7 @@ class AmpCarousel extends AMP.BaseElement {
     this.childLayoutManager_.updateChildren(this.slides_);
     this.carousel_.updateSlides(this.slides_);
     // Need to wait for slides to exist first.
-    this.carousel_.goToSlide(Number(this.element.getAttribute('slide') || "0"));
+    this.carousel_.goToSlide(Number(this.element.getAttribute('slide') || '0'));
     // Signal for runtime to check children for layout.
     return this.mutateElement(() => {});
   }
@@ -595,6 +596,24 @@ class AmpCarousel extends AMP.BaseElement {
     this.element.dispatchCustomEvent(name, data);
     this.hadTouch_ = this.hadTouch_ || actionSource == ActionSource.TOUCH;
     this.updateCurrentIndex_(index);
+  }
+
+  /**
+   * Stops touchmove events from propagating up to the viewer. Ideally we would
+   * have a separate piece of logic to not forward touchmoves if they occurred
+   * in a scrollable container instead of stopping propagation entirely for
+   * horizontal and vertical swipes. See:
+   * https://github.com/ampproject/amphtml/issues/4754.
+   * @private
+   */
+  stopTouchMovePropagation_() {
+    this.scrollContainer_.addEventListener(
+      'touchmove',
+      event => event.stopPropagation(),
+      {
+        passive: true,
+      }
+    );
   }
 }
 

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -54,6 +54,7 @@ class AmpCarousel extends AMP.BaseElement {
     this.registerAction(
       'toggleAutoplay',
       ({args}) => {
+        // args will be `null` if not present, so we cannot use a default value above
         const toggle = args ? args['toggleOn'] : undefined;
         this.toggleAutoplay_(toggle);
       },

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -153,8 +153,11 @@ class AmpCarousel extends AMP.BaseElement {
         }
       },
     });
+
     this.childLayoutManager_.updateChildren(this.slides_);
     this.carousel_.updateSlides(this.slides_);
+    // Need to wait for slides to exist first.
+    this.carousel_.goToSlide(Number(this.element.getAttribute('slide') || "0"));
     // Signal for runtime to check children for layout.
     return this.mutateElement(() => {});
   }
@@ -320,6 +323,7 @@ class AmpCarousel extends AMP.BaseElement {
     });
     this.toggleAutoplay_(autoAdvance);
     this.updateType_(type, slides);
+
     this.updateUi_();
   }
 

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -55,6 +55,10 @@ attr_lists: {
     name: "loop"
     value: ""
   }
+    attrs: {
+    name: "slide"
+    value_regex: "[0-9]+"
+  }
   # <amp-bind>
   attrs: { name: "[slide]" }
 }


### PR DESCRIPTION
- Support initial (non-bound) value for `slide` (for #11734)
- Fix `toggleAutoplay` when no argument is specified
- Stop propagation on touchmove like carousel 0.1 so it does not cause a viewer swipe