### PR TITLE
🐛Fixes `amp-imgur` issue with new id format

### DIFF
--- a/examples/amp-imgur.amp.html
+++ b/examples/amp-imgur.amp.html
@@ -10,6 +10,9 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+  <h3>Responsive</h3>
   <amp-imgur data-imgur-id="2CnX7" layout="responsive" width="1" height="1"></amp-imgur>
+  <h3>Fixed Height</h3>
+  <amp-imgur data-imgur-id="a/ZF7NS3V" height="350" layout="fixed-height"></amp-imgur> 
 </body>
 </html>

--- a/extensions/amp-imgur/0.1/amp-imgur.js
+++ b/extensions/amp-imgur/0.1/amp-imgur.js
@@ -79,10 +79,10 @@ export class AmpImgur extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
 
-    iframe.src =
-      'https://imgur.com/' +
-      encodeURIComponent(this.imgurid_) +
-      '/embed?pub=true';
+    const sanitizedID = this.imgurid_.startsWith('a/')
+      ? 'a/' + encodeURIComponent(this.imgurid_.replace('a/', ''))
+      : encodeURIComponent(this.imgurid_);
+    iframe.src = 'https://imgur.com/' + sanitizedID + '/embed?pub=true';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     return this.loadPromise(iframe);

--- a/extensions/amp-imgur/0.1/amp-imgur.js
+++ b/extensions/amp-imgur/0.1/amp-imgur.js
@@ -79,7 +79,7 @@ export class AmpImgur extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
 
-    const sanitizedID = this.imgurid_.startsWith('a/')
+    const sanitizedID = startsWith(this.imgurid_, 'a/')
       ? 'a/' + encodeURIComponent(this.imgurid_.replace('a/', ''))
       : encodeURIComponent(this.imgurid_);
     iframe.src = 'https://imgur.com/' + sanitizedID + '/embed?pub=true';

--- a/extensions/amp-imgur/0.1/amp-imgur.js
+++ b/extensions/amp-imgur/0.1/amp-imgur.js
@@ -79,9 +79,12 @@ export class AmpImgur extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
 
-    const sanitizedID = startsWith(this.imgurid_, 'a/')
-      ? 'a/' + encodeURIComponent(this.imgurid_.replace('a/', ''))
-      : encodeURIComponent(this.imgurid_);
+    const sanitizedID = this.imgurid_.replace(
+      /^(a\/)?(.*)/,
+      (match, aSlash, rest) => {
+        return (aSlash || '') + encodeURIComponent(rest);
+      }
+    );
     iframe.src = 'https://imgur.com/' + sanitizedID + '/embed?pub=true';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);

--- a/extensions/amp-imgur/0.1/test/test-amp-imgur.js
+++ b/extensions/amp-imgur/0.1/test/test-amp-imgur.js
@@ -31,34 +31,42 @@ describes.realWin(
       doc = win.document;
     });
 
-    function getIns(imgurId) {
-      const ins = doc.createElement('amp-imgur');
-      ins.setAttribute('data-imgur-id', imgurId);
-      ins.setAttribute('width', '1');
-      ins.setAttribute('height', '1');
-      ins.setAttribute('layout', 'responsive');
-      doc.body.appendChild(ins);
-      return ins
+    function getImgur(imgurId) {
+      const imgur = doc.createElement('amp-imgur');
+      imgur.setAttribute('data-imgur-id', imgurId);
+      imgur.setAttribute('width', '1');
+      imgur.setAttribute('height', '1');
+      imgur.setAttribute('layout', 'responsive');
+      doc.body.appendChild(imgur);
+      return imgur
         .build()
-        .then(() => ins.layoutCallback())
-        .then(() => ins);
+        .then(() => imgur.layoutCallback())
+        .then(() => imgur);
     }
 
-    function testIframe(iframe) {
+    function testIframe(iframe, id) {
       expect(iframe).to.not.be.null;
-      expect(iframe.src).to.equal('https://imgur.com/2CnX7/embed?pub=true');
+      expect(iframe.src).to.equal(
+        'https://imgur.com/' + id + '/embed?pub=true'
+      );
       expect(iframe.className).to.match(/i-amphtml-fill-content/);
     }
 
     it('renders', () => {
-      return getIns('2CnX7').then(ins => {
-        testIframe(ins.querySelector('iframe'));
+      return getImgur('2CnX7').then(imgur => {
+        testIframe(imgur.querySelector('iframe'), '2CnX7');
+      });
+    });
+
+    it('renders a/ type urls', () => {
+      return getImgur('a/ZF7NS3V').then(imgur => {
+        testIframe(imgur.querySelector('iframe'), 'a/ZF7NS3V');
       });
     });
 
     it('resizes with JSON String message', () => {
-      return getIns('2CnX7').then(ins => {
-        const impl = ins.implementation_;
+      return getImgur('2CnX7').then(imgur => {
+        const impl = imgur.implementation_;
         const changeHeightSpy = sandbox.spy(impl, 'attemptChangeHeight');
         expect(changeHeightSpy).not.to.have.been.called;
         const event = {
@@ -73,8 +81,8 @@ describes.realWin(
     });
 
     it('resizes with JSON Object message', () => {
-      return getIns('2CnX7').then(ins => {
-        const impl = ins.implementation_;
+      return getImgur('2CnX7').then(imgur => {
+        const impl = imgur.implementation_;
         const changeHeightSpy = sandbox.spy(impl, 'attemptChangeHeight');
         expect(changeHeightSpy).not.to.have.been.called;
         const event = {

--- a/extensions/amp-imgur/OWNERS.yaml
+++ b/extensions/amp-imgur/OWNERS.yaml
@@ -1,1 +1,2 @@
 - techhtml
+- wassgha


### PR DESCRIPTION
Closes #23816
### Changes
- Fixes an issue that caused slashes in `amp-imgur` IDs to be URIEncoded
- Added a test and an example to take into account the `a/` ID format
- Added myself as an owner since `techhtml` hasn't contributed in a while
- Clean up and renaming for some variables copied from `amp-instagram`
