### PR TITLE
Revert the analytics linker hack to check href

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -129,7 +129,7 @@ export class LinkerManager {
         if (!element.href || event.type !== 'click') {
           return;
         }
-        this.maybeWriteHref_(element);
+        element.href = this.applyLinkers_(element.href);
       }, Priority.ANALYTICS_LINKER);
       navigation.registerNavigateToMutator(
         url => this.applyLinkers_(url),
@@ -140,20 +140,6 @@ export class LinkerManager {
     this.enableFormSupport_();
 
     return Promise.all(this.allLinkerPromises_);
-  }
-
-  /**
-   * TODO: Revisit this logic after #22787 is complete.
-   * Applys any matching linkers to the elements href. If no linkers exist,
-   * will not set href.
-   * @param {!Element} element
-   */
-  maybeWriteHref_(element) {
-    const {href} = element;
-    const maybeDecoratedUrl = this.applyLinkers_(href);
-    if (href !== maybeDecoratedUrl) {
-      element.href = maybeDecoratedUrl;
-    }
   }
 
   /**

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -651,23 +651,6 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       });
     });
 
-    it('should not rewrite url if href is fragment', async () => {
-      const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
-      await lm.init();
-      // Using a real anchor el here because of a.href getter will actually
-      // return the full url, not just the fragment.
-      const a = doc.createElement('a');
-      a.href = '#hello';
-      a.hostname = 'amp.source.com';
-
-      const get = (obj, prop) => obj[prop];
-      const set = sandbox.spy();
-      const aProxy = new Proxy(a, {get, set});
-
-      anchorClickHandlers.forEach(handler => handler(aProxy, {type: 'click'}));
-      expect(set, 'set on a[href=#fragment]').not.to.have.been.called;
-    });
-
     it('should not add linker if href is relative', () => {
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {

--- a/test/manual/amp-analytics/analytics-linker.html
+++ b/test/manual/amp-analytics/analytics-linker.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Analytics</title>
+  <link rel="canonical" href="analytics.amp.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .box {
+      background: #ccc;
+      border: 1px solid #aaa;
+      padding: 10px;
+      margin: 10px;
+    }
+    #container {
+      position: absolute;
+      top: 10000px;
+      height: 10px;
+    }
+    #ele1 {
+      background-color: red;
+      height: 100px;
+      width: 100px;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+
+</head>
+<p>
+  <a href='https://google.com'>Google</a>
+</p>
+<p>
+  <a href='#ele1'>Internal URL</a>
+</p>
+<p>
+    <a href='http://localhost:8000/test/manual/amp-analytics/analytics-linker.html#ele1'>Localhost Url</a>
+  </p>
+<p>
+  <a href='https://github.com'>GitHub</a>
+</p>
+<p>
+Integer dapibus egestas arcu. Nunc vitae velit congue, placerat augue quis, suscipit nisi. Donec suscipit imperdiet turpis pharetra feugiat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus aliquam eleifend dolor, at lacinia orci semper vel. Nunc semper sem vel tincidunt posuere. Nunc lobortis velit vitae condimentum mollis. Morbi eu ullamcorper mauris. Pellentesque ac eros maximus, pulvinar sapien vitae, semper nisi. Curabitur imperdiet non mauris vitae sollicitudin.
+</p>
+<p>
+Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Vestibulum nec ex odio. Quisque at elit nec nunc ultricies lacinia nec non lorem. Maecenas porttitor consequat mauris, vitae porttitor ligula pellentesque ut. Pellentesque rhoncus diam vel lacus lobortis imperdiet. Sed maximus dictum hendrerit. Vivamus ornare, purus in laoreet sagittis, est ante pretium mauris, vel vulputate arcu erat eget mauris. Suspendisse eu lorem metus. Aliquam tempus aliquet urna, vitae mollis lacus pretium vitae. Etiam semper gravida commodo. Maecenas at pulvinar quam. Nullam dolor ipsum, ornare a sollicitudin et, sodales porttitor neque.
+</p>
+<p>
+Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor, vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique. Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
+</p>
+<amp-analytics type="_ping_">
+  <script type="application/json">
+  {
+    "linkers": {
+      "test": {
+        "ids": {
+          "test": "${clientId(abc)}",
+          "test1": "123"
+        }
+      },
+      "proxyOnly": false,
+      "enabled": true,
+      "destinationDomains": ["google.com", "localhost"]
+    }
+  }
+  </script>
+</amp-analytics>
+<div id="ele1">click me</div>


### PR DESCRIPTION
Closes #22787

#23792 introduced the generic fix. Where no anchor mutator will be applied with same href. 
Revert the previous fix from #22753. 

Also I couldn't find a linker example page. Added one for future use. 

