### PR TITLE
Correctness fixes for chunk queue

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -435,8 +435,7 @@ class Chunks {
         .then(() => {
           this.scheduledImmediateInvocation_ = false;
           this.durationOfLastExecution_ += Date.now() - before;
-          //dev().fine
-          console.log(
+          dev().fine(
             TAG,
             t.getName_(),
             'Chunk duration',
@@ -464,7 +463,6 @@ class Chunks {
       this.bodyIsVisible_ &&
       this.durationOfLastExecution_ > 5
     ) {
-      console.info('Macro please', this.durationOfLastExecution_);
       this.durationOfLastExecution_ = 0;
       this.requestMacroTask_();
       return;

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -66,12 +66,12 @@ export function startupChunk(document, fn, opt_makesBodyVisible) {
     return;
   }
   const service = chunkServiceForDoc(document.documentElement);
+  service.runForStartup(fn);
   if (opt_makesBodyVisible) {
     service.runForStartup(() => {
       service.bodyIsVisible_ = true;
     });
   }
-  service.runForStartup(fn);
 }
 
 /**
@@ -310,7 +310,7 @@ class Chunks {
     /** @private @const {function(?IdleDeadline)} */
     this.boundExecute_ = this.execute_.bind(this);
     /** @private {number} */
-    this.timeSinceLastExecution_ = Date.now();
+    this.durationOfLastExecution_ = 0;
     /** @private {boolean} */
     this.macroAfterLongTask_ = isExperimentOn(
       this.win_,
@@ -408,20 +408,44 @@ class Chunks {
    * @private
    */
   execute_(idleDeadline) {
-    this.scheduledImmediateInvocation_ = false;
     const t = this.nextTask_(/* opt_dequeue */ true);
     if (!t) {
+      this.scheduledImmediateInvocation_ = false;
+      this.durationOfLastExecution_ = 0;
       return false;
     }
+    let before;
     try {
-      const before = Date.now();
-      this.timeSinceLastExecution_ = before;
+      before = Date.now();
       t.runTask_(idleDeadline);
-      dev().fine(TAG, t.getName_(), 'Chunk duration', Date.now() - before);
     } finally {
-      resolved.then(() => {
-        this.schedule_();
-      });
+      // We want to capture the time of the entire task duration including
+      // scheduled immediate (from resolved promises) micro tasks.
+      // Lacking a better way to do this we just scheduled 10 nested
+      // micro tasks.
+      resolved
+        .then()
+        .then()
+        .then()
+        .then()
+        .then()
+        .then()
+        .then()
+        .then()
+        .then(() => {
+          this.scheduledImmediateInvocation_ = false;
+          this.durationOfLastExecution_ += Date.now() - before;
+          //dev().fine
+          console.log(
+            TAG,
+            t.getName_(),
+            'Chunk duration',
+            Date.now() - before,
+            this.durationOfLastExecution_
+          );
+
+          this.schedule_();
+        });
     }
     return true;
   }
@@ -438,8 +462,10 @@ class Chunks {
     if (
       this.macroAfterLongTask_ &&
       this.bodyIsVisible_ &&
-      Date.now() - this.timeSinceLastExecution_ > 5
+      this.durationOfLastExecution_ > 5
     ) {
+      console.info('Macro please', this.durationOfLastExecution_);
+      this.durationOfLastExecution_ = 0;
       this.requestMacroTask_();
       return;
     }

--- a/test/unit/test-chunk.js
+++ b/test/unit/test-chunk.js
@@ -25,7 +25,7 @@ import {
 import {installDocService} from '../../src/service/ampdoc-impl';
 import {toggleExperiment} from '../../src/experiments';
 
-describe('chunk', () => {
+describe('chunk2', () => {
   beforeEach(() => {
     activateChunkingForTesting();
   });
@@ -101,6 +101,22 @@ describe('chunk', () => {
       });
 
       basicTests(env);
+
+      it('should support nested micro tasks in chunks', done => {
+        let progress = '';
+        startupChunk(env.win.document, () => {
+          progress += '1';
+          Promise.resolve()
+            .then(() => (progress += 2))
+            .then(() => (progress += 3))
+            .then(() => (progress += 4))
+            .then(() => (progress += 5));
+        });
+        startupChunk(env.win.document, () => {
+          expect(progress).to.equal('12345');
+          done();
+        });
+      });
     }
   );
 
@@ -349,6 +365,7 @@ describe('long tasks', () => {
       let sandbox;
       let clock;
       let progress;
+      let postMessageCalls;
 
       function complete(str, long) {
         return function(unusedIdleDeadline) {
@@ -367,6 +384,7 @@ describe('long tasks', () => {
       }
 
       beforeEach(() => {
+        postMessageCalls = 0;
         subscriptions = {};
         sandbox = sinon.sandbox;
         clock = sandbox.useFakeTimers();
@@ -382,6 +400,8 @@ describe('long tasks', () => {
 
         env.win.postMessage = function(key) {
           expect(key).to.equal('amp-macro-task');
+          postMessageCalls++;
+          runSubs();
         };
 
         progress = '';
@@ -402,24 +422,54 @@ describe('long tasks', () => {
       });
 
       it('should execute chunks after long task in a macro task', done => {
-        startupChunk(env.win.document, complete('before', true));
+        startupChunk(env.win.document, complete('1', true));
+        startupChunk(env.win.document, complete('2', false));
         startupChunk(
           env.win.document,
-          complete('init', false),
+          function() {
+            complete('3', false)();
+            expect(progress).to.equal('123');
+            expect(postMessageCalls).to.equal(0);
+          },
           /* make body visible */ true
         );
-
-        startupChunk(env.win.document, complete('a', false));
-        startupChunk(env.win.document, complete('b', false));
         startupChunk(env.win.document, () => {
-          expect(progress).to.equal('beforeinitab');
-          complete('c', true)();
-          runSubs();
+          expect(postMessageCalls).to.equal(1);
+          expect(progress).to.equal('123');
+          complete('4', false)();
         });
         startupChunk(env.win.document, () => {
-          expect(progress).to.equal('beforeinitabc');
+          expect(postMessageCalls).to.equal(1);
+          expect(progress).to.equal('1234');
+        });
+        startupChunk(env.win.document, complete('5', true));
+        startupChunk(env.win.document, () => {
+          expect(postMessageCalls).to.equal(2);
+          expect(progress).to.equal('12345');
           done();
         });
+      });
+
+      it('should not issue a macro task after having been idle', done => {
+        (async function() {
+          startupChunk(
+            env.win.document,
+            complete('1', false),
+            /* make body visible */ true
+          );
+          // Unwind the promise queue so that subsequent invocations
+          // are scheduled into an empty task queue.
+          for (let i = 0; i < 100; i++) {
+            await Promise.resolve();
+          }
+          expect(progress).to.equal('1');
+          complete('2', true)();
+          startupChunk(env.win.document, () => {
+            expect(postMessageCalls).to.equal(0);
+            expect(progress).to.equal('12');
+            done();
+          });
+        })();
       });
     }
   );

--- a/test/unit/test-chunk.js
+++ b/test/unit/test-chunk.js
@@ -450,27 +450,31 @@ describe('long tasks', () => {
         });
       });
 
-      it('should not issue a macro task after having been idle', done => {
-        (async function() {
-          startupChunk(
-            env.win.document,
-            complete('1', false),
-            /* make body visible */ true
-          );
-          // Unwind the promise queue so that subsequent invocations
-          // are scheduled into an empty task queue.
-          for (let i = 0; i < 100; i++) {
-            await Promise.resolve();
-          }
-          expect(progress).to.equal('1');
-          complete('2', true)();
-          startupChunk(env.win.document, () => {
-            expect(postMessageCalls).to.equal(0);
-            expect(progress).to.equal('12');
-            done();
-          });
-        })();
-      });
+      // Skipping Firefox due to issues with the promise ordering in
+      // the async-await polyfill that this test relies on.
+      it.configure()
+        .skipFirefox()
+        .run('should not issue a macro task after having been idle', done => {
+          (async function() {
+            startupChunk(
+              env.win.document,
+              complete('1', false),
+              /* make body visible */ true
+            );
+            // Unwind the promise queue so that subsequent invocations
+            // are scheduled into an empty task queue.
+            for (let i = 0; i < 100; i++) {
+              await Promise.resolve();
+            }
+            expect(progress).to.equal('1');
+            complete('2', true)();
+            startupChunk(env.win.document, () => {
+              expect(postMessageCalls).to.equal(0);
+              expect(progress).to.equal('12');
+              done();
+            });
+          })();
+        });
     }
   );
 });


### PR DESCRIPTION
- Schedules task after, not just before making body visible. Bug introduxed in #23750
- Measures total time spend in task including immediate micro tasks invoked from it.
- Does not schedule a tasks if last invocation was a while ago, but the queue unwound in between.

Related to #23618