### PR TITLE
🏗Increase Karma timeout for Sauce Labs tests

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -302,13 +302,13 @@ module.exports = {
   captureTimeout: 4 * 60 * 1000,
   failOnEmptyTestSuite: false,
 
-  // AMP tests on Sauce take ~9 minutes, so don't fail if the browser doesn't
-  // communicate with the proxy for up to 10 minutes.
+  // AMP tests on Sauce can take upto 12-13 minutes, so don't fail if the
+  // browser doesn't communicate with the proxy for up to 15 minutes.
   // TODO(rsimha): Reduce this number once keepalives are implemented by
   // karma-sauce-launcher.
   // See https://github.com/karma-runner/karma-sauce-launcher/pull/161.
-  browserDisconnectTimeout: 10 * 60 * 1000,
-  browserNoActivityTimeout: 10 * 60 * 1000,
+  browserDisconnectTimeout: 15 * 60 * 1000,
+  browserNoActivityTimeout: 15 * 60 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,


### PR DESCRIPTION
Due to the addition of more tests and a larger number of babel transforms, the Karma-based tests on Sauce Labs have started taking longer than 10 minutes to run, resulting in the "no activity after 10 minutes" error due to the absence of keepalives in `karma-sauce-launcher`.

This PR increases the timeout to 15 minutes to give tests more time to execute.
