### PR TITLE
✨Implements `amp-megaphone` for embedding Megaphone.fm podcasts

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -537,6 +537,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-megaphone',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MEDIA,
+  },
+  {
     name: 'amp-mustache',
     version: ['0.1', '0.2'],
     latestVersion: '0.2',

--- a/examples/megaphone.amp.html
+++ b/examples/megaphone.amp.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Megaphone examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-megaphone" src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <h2>Megaphone Episode (Dark)</h2>
+
+  <amp-megaphone height="150"
+    layout="fixed-height"
+    data-episode="OSC7749686951"></amp-megaphone>
+
+  <h2>Megaphone Episode (Light)</h2>
+
+  <amp-megaphone height="150"
+    layout="fixed-height"
+    data-episode="OSC7749686951"
+    data-light="true"></amp-megaphone>
+
+  <h2>Megaphone Episode (Tile)</h2>
+
+  <amp-megaphone height="455"
+    width="275"
+    layout="fixed"
+    data-episode="OSC7749686951"
+    data-tile="true"></amp-megaphone>
+
+  <h2>Megaphone Episode (Custom Start Time)</h2>
+
+  <amp-megaphone height="150"
+    layout="fixed-height"
+    data-episode="OSC7749686951"
+    data-start="300"></amp-megaphone>
+
+  <h2>Megaphone Episode (Disabled sharing controls)</h2>
+
+  <amp-megaphone height="150"
+    layout="fixed-height"
+    data-episode="OSC7749686951"
+    data-sharing="false"></amp-megaphone>
+  
+  <h2>Megaphone Playlist (With limited number of episodes)</h2>
+  <amp-megaphone height="450"
+    layout="fixed-height"
+    data-playlist="DEM6640968282"
+    data-episodes="5"></amp-megaphone>
+
+  <h2>Megaphone Playlist (Disabled sharing controls)</h2>
+  <amp-megaphone height="450"
+    layout="fixed-height"
+    data-playlist="DEM6640968282"
+    data-sharing="false"></amp-megaphone>
+  </body>
+</html>

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Embeds a Megaphone podcast
+ *
+ * Example:
+ * <code>
+ * <amp-megaphone
+ *   height=166
+ *   data-episode="DEM6617440160"
+ *   data-light="true"
+ *   layout="fixed-height">
+ * </amp-megaphone>
+ */
+
+import {Layout} from '../../../src/layout';
+import {addParamsToUrl} from '../../../src/url';
+import {dict} from '../../../src/utils/object';
+import {getData, listen} from '../../../src/event-helper';
+import {isObject} from '../../../src/types';
+import {removeElement} from '../../../src/dom';
+import {startsWith} from '../../../src/string';
+import {tryParseJson} from '../../../src/json';
+import {userAssert} from '../../../src/log';
+
+class AmpMegaphone extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.iframe_ = null;
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+
+    /** @private {boolean} */
+    this.isPlaylist_ = false;
+
+    /** @private {string} */
+    this.baseUrl_ = '';
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url(this.baseUrl_, opt_onLayout);
+    this.preconnect.url('https://assets.megaphone.fm', opt_onLayout);
+    this.preconnect.url('https://megaphone.imgix.net', opt_onLayout);
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return (
+      layout == Layout.FIXED ||
+      layout == Layout.FIXED_HEIGHT ||
+      layout == Layout.FILL ||
+      layout == Layout.NODISPLAY
+    );
+  }
+
+  /** @override */
+  buildCallback() {
+    this.updateBaseUrl_();
+  }
+
+  /** @override */
+  mutatedAttributesCallback(mutations) {
+    const playlist = mutations['data-playlist'];
+    const episode = mutations['data-playlist'];
+    if (playlist !== undefined || episode !== undefined) {
+      this.updateBaseUrl_();
+    }
+
+    const light = mutations['data-light'];
+    const sharing = mutations['data-sharing'];
+    const episodes = mutations['data-episodes'];
+    const start = mutations['data-start'];
+    const tile = mutations['data-tile'];
+    if (
+      light !== undefined ||
+      sharing !== undefined ||
+      episodes !== undefined ||
+      start !== undefined ||
+      tile !== undefined
+    ) {
+      if (this.iframe_) {
+        this.iframe_.src = this.getIframeSrc_();
+      }
+    }
+  }
+
+  /**@override*/
+  layoutCallback() {
+    const height = this.element.getAttribute('height');
+    const iframe = this.element.ownerDocument.createElement('iframe');
+
+    iframe.setAttribute('frameborder', 'no');
+    iframe.setAttribute('scrolling', 'no');
+
+    iframe.src = this.getIframeSrc_();
+
+    this.unlistenMessage_ = listen(
+      this.win,
+      'message',
+      this.handleMegaphoneMessages_.bind(this)
+    );
+
+    this.applyFillContent(iframe);
+    iframe.height = height;
+    this.element.appendChild(iframe);
+
+    this.iframe_ = iframe;
+
+    return this.loadPromise(iframe);
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+    }
+    if (this.unlistenMessage_) {
+      this.unlistenMessage_();
+    }
+    return true; // Call layoutCallback again.
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getIframeSrc_() {
+    this.updateBaseUrl_();
+    let url = this.baseUrl_ + '/';
+    const mediaid = userAssert(
+      this.element.getAttribute('data-playlist') ||
+        this.element.getAttribute('data-episode'),
+      'data-playlist or data-episode is required for <amp-megaphone> %s',
+      this.element
+    );
+
+    if (!this.isPlaylist_) {
+      url += mediaid + '/';
+    }
+
+    const hasLightTheme = this.element.getAttribute('data-light') === 'true';
+    const hasSharingDisabled =
+      this.element.getAttribute('data-sharing') === 'false';
+    const episodes = this.element.getAttribute('data-episodes');
+    const start = this.element.getAttribute('data-start');
+    const hasTile = this.element.getAttribute('data-tile') === 'true';
+
+    const queryParams = dict({
+      'p': this.isPlaylist_ ? mediaid : undefined,
+      'light': hasLightTheme || undefined,
+      'sharing': hasSharingDisabled ? 'false' : undefined,
+      'episodes': (this.isPlaylist_ && episodes) || undefined,
+      'start': (!this.isPlaylist_ && start) || undefined,
+      'tile': (!this.isPlaylist_ && hasTile) || undefined,
+    });
+
+    return addParamsToUrl(url, queryParams);
+  }
+
+  /**
+   * @private
+   */
+  updateBaseUrl_() {
+    this.isPlaylist_ = !!this.element.hasAttribute('data-playlist');
+    this.baseUrl_ = `https://${
+      this.isPlaylist_ ? 'playlist' : 'player'
+    }.megaphone.fm`;
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   * */
+  handleMegaphoneMessages_(event) {
+    if (
+      event.origin != this.baseUrl_ ||
+      event.source != this.iframe_.contentWindow
+    ) {
+      return;
+    }
+    const eventData = getData(event);
+    if (
+      !eventData ||
+      !(
+        isObject(eventData) ||
+        startsWith(/** @type {string} */ (eventData), '{')
+      )
+    ) {
+      return;
+    }
+    const data = isObject(eventData) ? eventData : tryParseJson(eventData);
+    if (data['context'] == 'iframe.resize') {
+      const height = data['height'];
+      this.attemptChangeHeight(height).catch(() => {});
+    }
+  }
+
+  /** @override */
+  pauseCallback() {
+    if (this.iframe_ && this.iframe_.contentWindow) {
+      this.iframe_.contentWindow./*OK*/ postMessage(
+        JSON.stringify(dict({'method': 'pause'})),
+        this.baseUrl_
+      );
+    }
+  }
+}
+
+AMP.extension('amp-megaphone', '0.1', AMP => {
+  AMP.registerElement('amp-megaphone', AmpMegaphone);
+});

--- a/extensions/amp-megaphone/0.1/test/test-amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/test/test-amp-megaphone.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-megaphone';
+
+describes.realWin(
+  'amp-megaphone',
+  {
+    amp: {
+      extensions: ['amp-megaphone'],
+    },
+  },
+  env => {
+    const episodeEmbedUrl = 'https://player.megaphone.fm/OSC7749686951/';
+    const playlistEmbedUrl = 'https://playlist.megaphone.fm/?p=DEM6640968282';
+
+    let win, doc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+    });
+
+    function getMegaphone(mediaid, isPlaylist, opt_attrs) {
+      const mpplayer = doc.createElement('amp-megaphone');
+      if (isPlaylist) {
+        mpplayer.setAttribute('data-playlist', mediaid);
+      } else {
+        mpplayer.setAttribute('data-episode', mediaid);
+      }
+      mpplayer.setAttribute('height', '150');
+
+      if (opt_attrs) {
+        for (const attr in opt_attrs) {
+          mpplayer.setAttribute(attr, opt_attrs[attr]);
+        }
+      }
+
+      doc.body.appendChild(mpplayer);
+      return mpplayer
+        .build()
+        .then(() => mpplayer.layoutCallback())
+        .then(() => mpplayer);
+    }
+
+    it('renders episode', () => {
+      return getMegaphone('OSC7749686951').then(mpplayer => {
+        const iframe = mpplayer.firstChild;
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.src).to.equal(episodeEmbedUrl);
+      });
+    });
+
+    it('renders playlist', () => {
+      return getMegaphone('DEM6640968282', true).then(mpplayer => {
+        const iframe = mpplayer.firstChild;
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.src).to.equal(playlistEmbedUrl);
+      });
+    });
+
+    it('renders fixed-height', () => {
+      return getMegaphone('OSC7749686951', false, {
+        layout: 'fixed-height',
+      }).then(mpplayer => {
+        expect(mpplayer.className).to.match(/i-amphtml-layout-fixed-height/);
+      });
+    });
+
+    it('renders with optional parameters for an episode', () => {
+      return getMegaphone('OSC7749686951', false, {
+        'data-light': true,
+        'data-start': '5.4',
+        'data-tile': 'true',
+        'data-sharing': 'false',
+        'data-episodes': '4',
+      }).then(scplayer => {
+        const iframe = scplayer.firstChild;
+        expect(iframe.src).to.include('light=true');
+        expect(iframe.src).to.include('start=5.4');
+        expect(iframe.src).to.include('tile=true');
+        expect(iframe.src).to.include('sharing=false');
+        expect(iframe.src).not.to.include('episodes');
+      });
+    });
+
+    it('renders with optional parameters for a playlist', () => {
+      return getMegaphone('DEM6640968282', true, {
+        'data-light': true,
+        'data-start': '5.4',
+        'data-tile': 'true',
+        'data-sharing': 'false',
+        'data-episodes': '4',
+      }).then(scplayer => {
+        const iframe = scplayer.firstChild;
+        expect(iframe.src).to.include('light=true');
+        expect(iframe.src).to.include('sharing=false');
+        expect(iframe.src).to.include('episodes=4');
+        expect(iframe.src).not.to.include('start');
+        expect(iframe.src).not.to.include('tile');
+      });
+    });
+  }
+);

--- a/extensions/amp-megaphone/0.1/test/validator-amp-megaphone.html
+++ b/extensions/amp-megaphone/0.1/test/validator-amp-megaphone.html
@@ -1,0 +1,84 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests validation for the amp-megaphone tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <script async custom-element="amp-megaphone" src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
+     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- valid: classic mode -->
+  <amp-megaphone height=166 data-episode="OSC7749686951"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- valid: tile mode -->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-tile="true"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- valid: light mode -->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-light="true"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- valid: integer start time -->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-start="56"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- valid: decimal start time -->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-start="300.32"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: bad start time -->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-start="300s"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: light mode must be 'true' or 'false'-->
+  <amp-megaphone height=166 data-trackid="243169232" data-light
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: bad episode id-->
+  <amp-megaphone height=166 data-episode="mahler_number_6.ogg"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: both episode and playlist specified-->
+  <amp-megaphone height=166 data-episode="OSC7749686951" data-playlist="DEM6640968282"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: limited episodes without a playlist -->
+  <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+                  layout="intrinsic" data-episodes="3"></amp-megaphone>
+  <!-- invalid: responsive layout -->
+  <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+                  layout="responsive"></amp-megaphone>
+  <!-- invalid: intrinsic layout -->
+  <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+                  layout="intrinsic"></amp-megaphone>
+  <!-- valid: fixed layout -->
+  <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+                  layout="fixed"></amp-megaphone>
+  <!-- valid: playlist -->
+  <amp-megaphone height=166 data-playlist="DEM6640968282"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: playlist with tile mode -->
+  <amp-megaphone height=166 data-playlist="DEM6640968282" data-tile="true"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- invalid: playlist with start time -->
+  <amp-megaphone height=166 data-playlist="DEM6640968282" data-start="56.4"
+                  layout="fixed-height"></amp-megaphone>
+  <!-- valid: playlist without sharing buttons -->
+  <amp-megaphone height=166 data-playlist="DEM6640968282" data-sharing="false"
+                  layout="fixed-height"></amp-megaphone>
+</body>
+</html>

--- a/extensions/amp-megaphone/0.1/test/validator-amp-megaphone.out
+++ b/extensions/amp-megaphone/0.1/test/validator-amp-megaphone.out
@@ -1,0 +1,97 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-megaphone tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-megaphone" src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- valid: classic mode -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- valid: tile mode -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-tile="true"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- valid: light mode -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-light="true"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- valid: integer start time -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-start="56"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- valid: decimal start time -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-start="300.32"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: bad start time -->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-start="300s"
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:48:2 The mandatory attribute 'data-playlist' is missing in tag 'amp-megaphone'. (see https://amp.dev/documentation/components/amp-megaphone) [AMP_TAG_PROBLEM]
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: light mode must be 'true' or 'false'-->
+|    <amp-megaphone height=166 data-trackid="243169232" data-light
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:51:2 The attribute 'data-light' in tag 'amp-megaphone' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-megaphone) [DISALLOWED_HTML]
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: bad episode id-->
+|    <amp-megaphone height=166 data-episode="mahler_number_6.ogg"
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:54:2 The mandatory attribute 'data-playlist' is missing in tag 'amp-megaphone'. (see https://amp.dev/documentation/components/amp-megaphone) [AMP_TAG_PROBLEM]
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: both episode and playlist specified-->
+|    <amp-megaphone height=166 data-episode="OSC7749686951" data-playlist="DEM6640968282"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: limited episodes without a playlist -->
+|    <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:60:2 The specified layout 'INTRINSIC' is not supported by tag 'amp-megaphone'. (see https://amp.dev/documentation/components/amp-megaphone) [AMP_LAYOUT_PROBLEM]
+|                    layout="intrinsic" data-episodes="3"></amp-megaphone>
+|    <!-- invalid: responsive layout -->
+|    <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:63:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-megaphone'. (see https://amp.dev/documentation/components/amp-megaphone) [AMP_LAYOUT_PROBLEM]
+|                    layout="responsive"></amp-megaphone>
+|    <!-- invalid: intrinsic layout -->
+|    <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+>>   ^~~~~~~~~
+amp-megaphone/0.1/test/validator-amp-megaphone.html:66:2 The specified layout 'INTRINSIC' is not supported by tag 'amp-megaphone'. (see https://amp.dev/documentation/components/amp-megaphone) [AMP_LAYOUT_PROBLEM]
+|                    layout="intrinsic"></amp-megaphone>
+|    <!-- valid: fixed layout -->
+|    <amp-megaphone height=166 width=42 data-episode="OSC7749686951"
+|                    layout="fixed"></amp-megaphone>
+|    <!-- valid: playlist -->
+|    <amp-megaphone height=166 data-playlist="DEM6640968282"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: playlist with tile mode -->
+|    <amp-megaphone height=166 data-playlist="DEM6640968282" data-tile="true"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- invalid: playlist with start time -->
+|    <amp-megaphone height=166 data-playlist="DEM6640968282" data-start="56.4"
+|                    layout="fixed-height"></amp-megaphone>
+|    <!-- valid: playlist without sharing buttons -->
+|    <amp-megaphone height=166 data-playlist="DEM6640968282" data-sharing="false"
+|                    layout="fixed-height"></amp-megaphone>
+|  </body>
+|  </html>

--- a/extensions/amp-megaphone/OWNERS.yaml
+++ b/extensions/amp-megaphone/OWNERS.yaml
@@ -1,0 +1,1 @@
+- wassgha

--- a/extensions/amp-megaphone/amp-megaphone.md
+++ b/extensions/amp-megaphone/amp-megaphone.md
@@ -1,0 +1,106 @@
+---
+$category@: media
+formats:
+  - websites
+teaser:
+  text: Displays a Megaphone.fm podcast episode or playlist.
+---
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-megaphone
+
+Displays a <a href="https://megaphone.fm/">Megaphone.fm</a> podcast episode or playlist.
+
+<table>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-megaphone" src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, nodisplay</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://amp.dev/documentation/examples/components/amp-megaphone/">Annotated code example for amp-megaphone</a></td>
+  </tr>
+</table>
+
+[TOC]
+
+## Examples
+
+With the fixed height layout, the element will expand to fill the width of the page while keeping the `height` constant:
+
+Light Mode:
+```html
+<amp-megaphone height="166"
+    layout="fixed-height"
+    data-episode="OSC7749686951"
+    data-light="true"></amp-megaphone>
+```
+
+Dark Mode:
+```html
+<amp-megaphone height="166"
+    layout="fixed-height"
+    data-episode="OSC7749686951"
+    data-light="true"></amp-megaphone>
+```
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><strong>data-episode</strong></td>
+    <td>This attribute is required if <code>data-playlist</code> is not defined.<br />
+The value for this attribute is the Megaphone.fm ID of a track, an integer.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-playlist</strong></td>
+    <td>This attribute is required if <code>data-episode</code> is not defined.
+The value for this attribute is the Megaphone.fm ID of a playlist.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-start (optional)</strong></td>
+    <td>(for episodes only) The time at which to start the episode in seconds.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-episodes (optional)</strong></td>
+    <td>(for playlists only) Limits the number of episodes to display.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-tile (optional)</strong></td>
+    <td>(for episodes only) If set to <code>true</code>, displays the player in a "tile" mode where the internal components are layed out vertically. The default value is <code>false</code>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-light (optional)</strong></td>
+    <td>If set to <code>true</code>, this will switch the player theme to the "light" scheme as opposed to the default dark version. The default value is <code>false</code>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-sharing (optional)</strong></td>
+    <td>If set to <code>false</code>, this will disable the social sharing button on the embedded player. The default value is <code>false</code>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>width and height</strong></td>
+    <td>The layout for <code>amp-megaphone</code> is set to <code>fixed-height</code> and it fills all of the available horizontal space. This is ideal for the "classic" mode, but for "tile" mode, it's recommended that the height is 455px, and the width is 275px, as per the Megaphone embed code.</td>
+  </tr>
+</table>
+
+## Validation
+
+See [amp-megaphone rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-megaphone/validator-amp-megaphone.protoascii) in the AMP validator specification.

--- a/extensions/amp-megaphone/validator-amp-megaphone.protoascii
+++ b/extensions/amp-megaphone/validator-amp-megaphone.protoascii
@@ -1,0 +1,98 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-megaphone
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-megaphone"
+    version: "0.1"
+    version: "latest"
+    requires_usage: GRANDFATHERED
+    deprecated_allow_duplicates: true
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-megaphone> for playlists
+  html_format: AMP
+  tag_name: "AMP-MEGAPHONE"
+  requires_extension: "amp-megaphone"
+  attrs: {
+    name: "data-playlist"
+    mandatory: true
+    value_regex: "[A-Za-z0-9]+"
+  }
+  attrs: {
+    name: "data-light"
+    value_casei: "false"
+    value_casei: "true"
+  }
+  attrs: {
+    name: "data-sharing"
+    value_casei: "false"
+    value_casei: "true"
+  }
+  attrs: {
+    name: "data-episodes"
+    value_regex: "[0-9]+"
+  }
+
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: NODISPLAY
+  }
+}
+
+tags: {  # <amp-megaphone> for episodes
+  html_format: AMP
+  tag_name: "AMP-MEGAPHONE"
+  requires_extension: "amp-megaphone"
+  attrs: {
+    name: "data-episode"
+    mandatory: true
+    value_regex: "[A-Za-z0-9]+"
+  }
+  attrs: {
+    name: "data-start"
+    value_regex: "\d+(\.\d+)?"
+  }
+  attrs: {
+    name: "data-tile"
+    value_casei: "false"
+    value_casei: "true"
+  }
+  attrs: {
+    name: "data-light"
+    value_casei: "false"
+    value_casei: "true"
+  }
+  attrs: {
+    name: "data-sharing"
+    value_casei: "false"
+    value_casei: "true"
+  }
+
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: NODISPLAY
+  }
+}

--- a/extensions/amp-story/amp-story-page-attachment.md
+++ b/extensions/amp-story/amp-story-page-attachment.md
@@ -128,6 +128,7 @@ Story page attachments allow the same HTML elements as AMP Story along with addi
   <li><code>&lt;amp-list></code></li>
   <li><code>&lt;amp-live-list></code></li>
   <li><code>&lt;amp-mathml></code></li>
+  <li><code>&lt;amp-megaphone></code></li>
   <li><code>&lt;amp-mowplayer></code></li>
   <li><code>&lt;amp-nexxtv-player></code></li>
   <li><code>&lt;amp-o2-player></code></li>

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -1061,6 +1061,7 @@ Story page attachments allow the same HTML elements as AMP Story along with addi
     <li><code>&lt;amp-list></code></li>
     <li><code>&lt;amp-live-list></code></li>
     <li><code>&lt;amp-mathml></code></li>
+    <li><code>&lt;amp-megaphone></code></li>
     <li><code>&lt;amp-mowplayer></code></li>
     <li><code>&lt;amp-nexxtv-player></code></li>
     <li><code>&lt;amp-o2-player></code></li>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -804,6 +804,7 @@ descendant_tag_list {
   tag: "AMP-LIVE-LIST"
   tag: "AMP-LIVE-LIST"
   tag: "AMP-MATHML"
+  tag: "AMP-MEGAPHONE"
   tag: "AMP-MOWPLAYER"
   tag: "AMP-NEXXTV-PLAYER"
   tag: "AMP-O2-PLAYER"

--- a/test/manual/amp-megaphone.amp.html
+++ b/test/manual/amp-megaphone.amp.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-megaphone</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-megaphone" src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
+  <style>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+  </style>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js" development></script>
+</head>
+<body>
+  <h1>Megaphone.fm test</h1>
+
+  <h2>Minimum Viable Episode</h2>
+
+  <amp-megaphone height=166
+    layout="fixed-height"
+    data-episode="OSC7749686951"></amp-megaphone>
+  
+  <h2>Minimum Playlist</h2>
+
+  <amp-megaphone height=455
+    layout="fixed-height"
+    data-playlist="DEM6640968282"></amp-megaphone>
+  </body>
+</html>
+
+

--- a/validator/testdata/amp4ads_feature_tests/extensions.html
+++ b/validator/testdata/amp4ads_feature_tests/extensions.html
@@ -86,6 +86,8 @@
      src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-element="amp-live-list"
      src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+  <script async custom-element="amp-megaphone"
+     src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
   <script async custom-element="amp-o2-player"
      src="https://cdn.ampproject.org/v0/amp-o2-player-0.1.js"></script>
   <script async custom-element="amp-pinterest"

--- a/validator/testdata/amp4ads_feature_tests/extensions.out
+++ b/validator/testdata/amp4ads_feature_tests/extensions.out
@@ -121,55 +121,59 @@ amp4ads_feature_tests/extensions.html:85:2 Custom JavaScript is not allowed. (se
 >>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:87:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
-|    <script async custom-element="amp-o2-player"
+|    <script async custom-element="amp-megaphone"
 >>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:89:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-megaphone-0.1.js"></script>
+|    <script async custom-element="amp-o2-player"
+>>   ^~~~~~~~~
+amp4ads_feature_tests/extensions.html:91:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-o2-player-0.1.js"></script>
 |    <script async custom-element="amp-pinterest"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:91:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:93:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js"></script>
 |    <script async custom-element="amp-reach-player"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:93:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:95:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js"></script>
 |    <script async custom-element="amp-sidebar"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:95:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:97:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
 |    <script async custom-element="amp-slides"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:97:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:99:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-slides-0.1.js"></script>
 |    <script async custom-element="amp-social-share"
 |       src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
 |    <script async custom-element="amp-soundcloud"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:101:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:103:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
 |    <script async custom-element="amp-springboard-player"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:103:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:105:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js"></script>
 |    <script async custom-element="amp-sticky-ad"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:105:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:107:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
 |    <script async custom-element="amp-twitter"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:107:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:109:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
 |    <script async custom-element="amp-user-notification"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:109:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:111:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
 |    <script async custom-element="amp-vimeo"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:111:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:113:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
 |    <script async custom-element="amp-vine"
 >>   ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:113:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp4ads_feature_tests/extensions.html:115:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |       src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
 |    <script async custom-element="amp-youtube"
 |       src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
@@ -179,8 +183,8 @@ amp4ads_feature_tests/extensions.html:113:2 Custom JavaScript is not allowed. (s
 |  </head>
 |  <body></body></html>
 >>                    ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:121:19 The extension 'amp-animation' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+amp4ads_feature_tests/extensions.html:123:19 The extension 'amp-animation' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
 >>                    ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:121:19 The extension 'amp-lightbox' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+amp4ads_feature_tests/extensions.html:123:19 The extension 'amp-lightbox' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
 >>                    ^~~~~~~~~
-amp4ads_feature_tests/extensions.html:121:19 The extension 'amp-mustache' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+amp4ads_feature_tests/extensions.html:123:19 The extension 'amp-mustache' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]


### PR DESCRIPTION
Closes #22662 

### Changes
- Creates a new AMP component `amp-megaphone` for embedding podcast episodes and playlists from [http://megaphone.fm](http://megaphone.fm) (requested by CNN)
- Adds unit and manual tests
- Adds validator changes
- Adds appropriate documentation for the extensions attributes
- Allows the new component to be embedded inside `amp-story`
