### PR TITLE
📖 Add missing quote to opening tip tag

### DIFF
--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -83,10 +83,10 @@ example, at the end of a news article or recipe, but before the footer or
 other content repeated across articles.
 
 The component will render a total maximum of three documents on screen in a
-component will render a maximum of three documents (total) on screen at one	single instance. This limit may be changed or removed in the future. 
+component will render a maximum of three documents (total) on screen at one	single instance. This limit may be changed or removed in the future.
 
-[tip type="important]
-**Important**	[`<amp-analytics>`](../amp-analytics/amp-analytics.md) is [currently unsupported](https://github.com/ampproject/amphtml/issues/15807) on pages users land on through `<amp-next-page>`. 
+[tip type="important"]
+**Important**	[`<amp-analytics>`](../amp-analytics/amp-analytics.md) is [currently unsupported](https://github.com/ampproject/amphtml/issues/15807) on pages users land on through `<amp-next-page>`.
 Measuring pageviews is supported through [`<amp-pixel>`](../../builtins/amp-pixel.md).
 [/tip]
 


### PR DESCRIPTION
Building amp.dev is currently [blocked](https://travis-ci.org/ampproject/amp.dev/jobs/569698147#L1329) by a syntax error in the `amp-next-page` docs which is fixed by this PR.

/cc @sebastianbenz