### PR TITLE
Update amp-date-display validation to allow template attribute

### DIFF
--- a/extensions/amp-date-display/0.1/test/validator-amp-date-display.html
+++ b/extensions/amp-date-display/0.1/test/validator-amp-date-display.html
@@ -94,6 +94,12 @@
     <template type="amp-mustache">{{iso}}</template>
   </amp-date-display>
 
+    <!-- valid, with referenced template -->
+    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+    </amp-date-display>
+    <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+
+
   <!-- invalid, no date provided -->
   <amp-date-display layout="fixed" width="360" height="20">
     <template type="amp-mustache">{{iso}}</template>

--- a/extensions/amp-date-display/0.1/test/validator-amp-date-display.html
+++ b/extensions/amp-date-display/0.1/test/validator-amp-date-display.html
@@ -27,6 +27,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript>
     <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
   </noscript>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-element="amp-date-display" src="https://cdn.ampproject.org/v0/amp-date-display-latest.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -94,11 +95,40 @@
     <template type="amp-mustache">{{iso}}</template>
   </amp-date-display>
 
-    <!-- valid, with referenced template -->
-    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
-    </amp-date-display>
-    <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+  <!-- valid, with referenced template -->
+  <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+  </amp-date-display>
+  <template type="amp-mustache" id="myTemplate">{{iso}}</template>
 
+  <!-- valid, within amp-list with script mustache -->
+  <amp-list src="https://cors-test.appspot.com/test"
+            single-item
+            items="."
+            layout="fixed-height"
+            height="50">
+
+    <script type="text/plain" template="amp-mustache">
+      This should be a proper formatted date:
+      <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+    </script>
+  </amp-list>
+
+  <template type="amp-mustache" id="date-template">
+    <small>{{ day }}.{{ month }}.{{ year }} {{ hourTwoDigit }}:{{ minuteTwoDigit }}</small>
+  </template>
+
+  <!-- valid, within amp-list with template mustache -->
+  <amp-list src="https://cors-test.appspot.com/test"
+            single-item
+            items="."
+            layout="fixed-height"
+            height="50">
+
+    <template type="amp-mustache">
+      This should be a proper formatted date:
+      <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+    </template>
+  </amp-list>
 
   <!-- invalid, no date provided -->
   <amp-date-display layout="fixed" width="360" height="20">

--- a/extensions/amp-date-display/0.1/test/validator-amp-date-display.out
+++ b/extensions/amp-date-display/0.1/test/validator-amp-date-display.out
@@ -95,59 +95,65 @@ FAIL
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
+|      <!-- valid, with referenced template -->
+|      <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+|      </amp-date-display>
+|      <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+|
+|
 |    <!-- invalid, no date provided -->
 |    <amp-date-display layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:98:2 The tag 'amp-date-display' is missing a mandatory attribute - pick one of ['datetime', 'timestamp-ms', 'timestamp-seconds']. (see https://amp.dev/documentation/components/amp-date-display) [AMP_TAG_PROBLEM]
+amp-date-display/0.1/test/validator-amp-date-display.html:104:2 The tag 'amp-date-display' is missing a mandatory attribute - pick one of ['datetime', 'timestamp-ms', 'timestamp-seconds']. (see https://amp.dev/documentation/components/amp-date-display) [AMP_TAG_PROBLEM]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, wrong date format -->
 |    <amp-date-display datetime="20170802" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:103:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '20170802'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:109:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '20170802'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, date with time zone -->
 |    <amp-date-display datetime="2017-08-02+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:108:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:114:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, no minutes in time zone -->
 |    <amp-date-display datetime="2017-08-02T15:05:05+04" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:113:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05+04'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:119:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05+04'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, no date -->
 |    <amp-date-display datetime="T15:05:05.000Z" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:118:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value 'T15:05:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:124:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value 'T15:05:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, missing hour (hour > 23) -->
 |    <amp-date-display datetime="2017-08-02T59:05.000Z" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:123:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T59:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:129:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T59:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, sub miliseconds -->
 |    <amp-date-display datetime="2017-08-02T15:05:05.0001+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:128:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.0001+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:134:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.0001+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, missing fractions-->
 |    <amp-date-display datetime="2017-08-02T15:05:05.+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:133:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:139:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |  </body>

--- a/extensions/amp-date-display/0.1/test/validator-amp-date-display.out
+++ b/extensions/amp-date-display/0.1/test/validator-amp-date-display.out
@@ -28,6 +28,7 @@ FAIL
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript>
 |      <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
 |    </noscript>
+|    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
 |    <script async custom-element="amp-date-display" src="https://cdn.ampproject.org/v0/amp-date-display-latest.js"></script>
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -95,65 +96,94 @@ FAIL
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
-|      <!-- valid, with referenced template -->
-|      <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
-|      </amp-date-display>
-|      <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+|    <!-- valid, with referenced template -->
+|    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+|    </amp-date-display>
+|    <template type="amp-mustache" id="myTemplate">{{iso}}</template>
 |
+|    <!-- valid, within amp-list with script mustache -->
+|    <amp-list src="https://cors-test.appspot.com/test"
+|              single-item
+|              items="."
+|              layout="fixed-height"
+|              height="50">
+|
+|      <script type="text/plain" template="amp-mustache">
+|        This should be a proper formatted date:
+|        <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+|      </script>
+|    </amp-list>
+|
+|    <template type="amp-mustache" id="date-template">
+|      <small>{{ day }}.{{ month }}.{{ year }} {{ hourTwoDigit }}:{{ minuteTwoDigit }}</small>
+|    </template>
+|
+|    <!-- valid, within amp-list with template mustache -->
+|    <amp-list src="https://cors-test.appspot.com/test"
+|              single-item
+|              items="."
+|              layout="fixed-height"
+|              height="50">
+|
+|      <template type="amp-mustache">
+|        This should be a proper formatted date:
+|        <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+|      </template>
+|    </amp-list>
 |
 |    <!-- invalid, no date provided -->
 |    <amp-date-display layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:104:2 The tag 'amp-date-display' is missing a mandatory attribute - pick one of ['datetime', 'timestamp-ms', 'timestamp-seconds']. (see https://amp.dev/documentation/components/amp-date-display) [AMP_TAG_PROBLEM]
+amp-date-display/0.1/test/validator-amp-date-display.html:134:2 The tag 'amp-date-display' is missing a mandatory attribute - pick one of ['datetime', 'timestamp-ms', 'timestamp-seconds']. (see https://amp.dev/documentation/components/amp-date-display) [AMP_TAG_PROBLEM]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, wrong date format -->
 |    <amp-date-display datetime="20170802" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:109:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '20170802'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:139:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '20170802'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, date with time zone -->
 |    <amp-date-display datetime="2017-08-02+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:114:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:144:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, no minutes in time zone -->
 |    <amp-date-display datetime="2017-08-02T15:05:05+04" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:119:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05+04'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:149:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05+04'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, no date -->
 |    <amp-date-display datetime="T15:05:05.000Z" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:124:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value 'T15:05:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:154:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value 'T15:05:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, missing hour (hour > 23) -->
 |    <amp-date-display datetime="2017-08-02T59:05.000Z" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:129:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T59:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:159:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T59:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, sub miliseconds -->
 |    <amp-date-display datetime="2017-08-02T15:05:05.0001+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:134:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.0001+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:164:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.0001+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |
 |    <!-- invalid, missing fractions-->
 |    <amp-date-display datetime="2017-08-02T15:05:05.+04:00" layout="fixed" width="360" height="20">
 >>   ^~~~~~~~~
-amp-date-display/0.1/test/validator-amp-date-display.html:139:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
+amp-date-display/0.1/test/validator-amp-date-display.html:169:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.+04:00'. (see https://amp.dev/documentation/components/amp-date-display) [DISALLOWED_HTML]
 |      <template type="amp-mustache">{{iso}}</template>
 |    </amp-date-display>
 |  </body>

--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -42,6 +42,7 @@ tags: {  # <amp-date-display>
     value_regex: "-?\\d+"
   }
   attrs: { name: "locale" }
+  attrs: { name: "template" }
   attrs: {
     name: "timestamp-ms"
     mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/23731. 

Context: `amp-date-display` makes use of `<template>`s. It should therefore allow the `template` attribute to reference templates without causing template nesting when used inside of `<amp-list>`. 