### PR TITLE
Allow regular AMPHTML validation rules on amp-video within page-attachments.

### DIFF
--- a/extensions/amp-story/1.0/test/validator-amp-story-video-controls.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-controls.html
@@ -34,7 +34,7 @@
   <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
-        <!-- This should fail because amp-video has the [controls] attribute. -->
+        <!-- This should show a deprecation warning because amp-video has the [controls] attribute. -->
         <amp-video width="480"
                    height="270"
                    src="/video/tokyo.mp4"
@@ -49,6 +49,27 @@
              <source type="video/webm" src="/video/tokyo.webm">
          </amp-video>
       </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-page id="2">
+      <amp-story-grid-layer template="horizontal">
+        <p>Foo</p>
+      </amp-story-grid-layer>
+      <amp-story-page-attachment layout="nodisplay">
+        <!-- Controls attribute is allowed within a page attachment. -->
+        <amp-video width="480"
+                   height="270"
+                   src="/video/tokyo.mp4"
+                   layout="responsive"
+                   poster="/foo.jpg"
+                   autoplay
+                   controls>
+             <div fallback>
+               <p>Your browser doesn't support HTML5 video.</p>
+             </div>
+             <source type="video/mp4" src="/video/tokyo.mp4">
+             <source type="video/webm" src="/video/tokyo.webm">
+         </amp-video>
+      </amp-story-page-attachment>
     </amp-story-page>
   </amp-story>
 </body>

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-controls.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-controls.out
@@ -35,7 +35,7 @@ PASS
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
-|          <!-- This should fail because amp-video has the [controls] attribute. -->
+|          <!-- This should show a deprecation warning because amp-video has the [controls] attribute. -->
 |          <amp-video width="480"
 >>         ^~~~~~~~~
 amp-story/1.0/test/validator-amp-story-video-controls.html:38:8 The attribute 'controls' in tag 'amp-story >> amp-video' is deprecated - use '- no replacement' instead. (see https://github.com/ampproject/amphtml/issues/23798) [DEPRECATION]
@@ -52,6 +52,27 @@ amp-story/1.0/test/validator-amp-story-video-controls.html:38:8 The attribute 'c
 |               <source type="video/webm" src="/video/tokyo.webm">
 |           </amp-video>
 |        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-page id="2">
+|        <amp-story-grid-layer template="horizontal">
+|          <p>Foo</p>
+|        </amp-story-grid-layer>
+|        <amp-story-page-attachment layout="nodisplay">
+|          <!-- Controls attribute is allowed within a page attachment. -->
+|          <amp-video width="480"
+|                     height="270"
+|                     src="/video/tokyo.mp4"
+|                     layout="responsive"
+|                     poster="/foo.jpg"
+|                     autoplay
+|                     controls>
+|               <div fallback>
+|                 <p>Your browser doesn't support HTML5 video.</p>
+|               </div>
+|               <source type="video/mp4" src="/video/tokyo.mp4">
+|               <source type="video/webm" src="/video/tokyo.webm">
+|           </amp-video>
+|        </amp-story-page-attachment>
 |      </amp-story-page>
 |    </amp-story>
 |  </body>

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -137,7 +137,7 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
   html_format: AMP4ADS
   html_format: ACTIONS
   tag_name: "AMP-VIDEO"
-  spec_name: "amp-story >> amp-page-attachment >> amp-video"
+  spec_name: "amp-story >> amp-story-page-attachment >> amp-video"
   mandatory_ancestor: "AMP-STORY-PAGE-ATTACHMENT"
   also_requires_tag_warning: "amp-video extension .js script"
   attrs: { name: "poster" }
@@ -154,7 +154,6 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
     supported_layouts: RESPONSIVE
   }
 }
-
 
 tags: {  # <amp-video> in amp-story
   html_format: AMP

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -132,6 +132,30 @@ tags: {  # <amp-video> not in amp-story.
   }
 }
 
+tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHTML).
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: ACTIONS
+  tag_name: "AMP-VIDEO"
+  spec_name: "amp-story >> amp-page-attachment >> amp-video"
+  mandatory_ancestor: "AMP-STORY-PAGE-ATTACHMENT"
+  also_requires_tag_warning: "amp-video extension .js script"
+  attrs: { name: "poster" }
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-video-common"
+  attr_lists: "lightboxable-elements"
+  spec_url: "https://amp.dev/documentation/components/amp-video"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+
 tags: {  # <amp-video> in amp-story
   html_format: AMP
   html_format: AMP4ADS


### PR DESCRIPTION
Allow regular AMPHTML validation rules on `amp-video` within `amp-story-page-attachments`.