### PR TITLE
Make cache cid timeout an expected error

### DIFF
--- a/src/service/cache-cid-api.js
+++ b/src/service/cache-cid-api.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../services';
-import {dev, user} from '../log';
+import {dev} from '../log';
 import {dict} from '../utils/object';
 import {getSourceOrigin} from '../url';
 

--- a/src/service/cache-cid-api.js
+++ b/src/service/cache-cid-api.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../services';
-import {dev} from '../log';
+import {dev, user} from '../log';
 import {dict} from '../utils/object';
 import {getSourceOrigin} from '../url';
 
@@ -102,6 +102,7 @@ export class CacheCidApi {
     });
 
     // Make the XHR request to the cache endpoint.
+    const timeoutMessage = 'fetchCidTimeout';
     return this.timer_
       .timeoutPromise(
         TIMEOUT_,
@@ -111,7 +112,8 @@ export class CacheCidApi {
           credentials: 'include',
           mode: 'cors',
           body: payload,
-        })
+        }),
+        timeoutMessage
       )
       .then(res => {
         return res.json().then(response => {
@@ -134,7 +136,12 @@ export class CacheCidApi {
             dev().error(TAG_, JSON.stringify(res));
           });
         } else {
-          dev().error(TAG_, e);
+          const isTimeout = e && e.message == timeoutMessage;
+          if (isTimeout) {
+            dev().expectedError(TAG_, e);
+          } else {
+            dev().error(TAG_, e);
+          }
         }
         return null;
       });

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -365,7 +365,7 @@ export class Viewer {
       return null;
     }
     return Services.timerFor(this.win)
-      .timeoutPromise(20000, messagingPromise)
+      .timeoutPromise(20000, messagingPromise, 'initMessagingChannel')
       .catch(reason => {
         const error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)


### PR DESCRIPTION
Fixes #20120. 

There are two sources of timeout in that bug: cache-cid-api.js and history-impl.js. This PR makes the former an expected dev error. 

I think the latter is due to viewer messaging init timeout but I'm not 100% sure, so changed the message for that `timeoutPromise` to see what happens.

/to @jridgewell 