### PR TITLE
CSS reset for shadow trees.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+@import './amp-story-shadow-reset.css';
 @import './amp-story-share.css';
 
 .i-amphtml-story-bookend {
   display: flex !important;
+  font-family: 'Roboto', sans-serif !important;
   flex-direction: column !important;
   background: #202125 !important;
   border-radius: 8px 8px 0 0 !important;

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import './amp-story-shadow-reset.css';
+
 .i-amphtml-story-consent {
   position: absolute !important;
   display: flex !important;

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import './amp-story-shadow-reset.css';
+
 .i-amphtml-story-draggable-drawer-header {
   display: flex !important;
   position: relative !important;

--- a/extensions/amp-story/1.0/amp-story-info-dialog.css
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.css
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+@import './amp-story-shadow-reset.css';
 @import './amp-story-share.css';
 
 .i-amphtml-story-info-dialog {

--- a/extensions/amp-story/1.0/amp-story-shadow-reset.css
+++ b/extensions/amp-story/1.0/amp-story-shadow-reset.css
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  all: initial !important;
+  color: initial !important;
+}

--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@import './amp-story-shadow-reset.css';
 @import './amp-story-share.css';
 
 .i-amphtml-story-share-menu {

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import './amp-story-shadow-reset.css';
+
 .i-amphtml-story-no-rotation-overlay {
   position: absolute !important;
   z-index: 200000!important; /** unsupported-browser-overlay - 1 */


### PR DESCRIPTION
Here's what we learned today: https://developers.google.com/web/fundamentals/web-components/shadowdom#reset

So here's a reset for our shadow trees that inherited from other properties :)
I tested most properties that can be inherited and it turns out you were able to do pretty fun stuff to mess up with our UI, despite the shadow DOM:

![image](https://user-images.githubusercontent.com/1492044/62811129-8e9a0a80-bace-11e9-8f0e-b8bfd23f726f.png)

Fixes #23663