### PR TITLE
Remove @suppress in custom-element.js

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -408,7 +408,11 @@ var AmpElement;
 /** @return {!Signals} */
 AmpElement.prototype.signals = function() {};
 
-/** @return {string} */
+/**
+ * Must be externed to avoid Closure DCE'ing this function on
+ * custom-element.CustomAmpElement.prototype in single-pass compilation.
+ * @return {string}
+ */
 AmpElement.prototype.elementName = function() {};
 
 var Signals = class {};

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -408,6 +408,9 @@ var AmpElement;
 /** @return {!Signals} */
 AmpElement.prototype.signals = function() {};
 
+/** @return {string} */
+AmpElement.prototype.elementName = function() {};
+
 var Signals = class {};
 /**
   * @param {string} unusedName

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -137,7 +137,9 @@ function createBaseCustomElementClass(win) {
   if (win.BaseCustomElementClass) {
     return win.BaseCustomElementClass;
   }
-  const htmlElement = /** @type {function(new:HTMLElement)} */ (win.HTMLElement);
+  const htmlElement =
+    /** @type {function(new:HTMLElement)} */ (win.HTMLElement);
+
   /**
    * @abstract @extends {HTMLElement}
    */
@@ -156,7 +158,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Called when elements is created. Sets instance vars since there is no
      * constructor.
-     * @final @this {!Element}
+     * @final
      */
     createdCallback() {
       // Flag "notbuilt" is removed by Resource manager when the resource is
@@ -255,11 +257,15 @@ function createBaseCustomElementClass(win) {
       /** @private {?Element|undefined} */
       this.overflowElement_ = undefined;
 
+      // Closure compiler appears to mark HTMLElement as @struct which
+      // disables bracket access. Force this with a type coercion.
+      const nonStructThis = /** @type {!Object} */ (this);
+
       // `opt_implementationClass` is only used for tests.
       let Ctor =
         win.ampExtendedElements && win.ampExtendedElements[this.elementName()];
-      if (getMode().test && this.implementationClassForTesting) {
-        Ctor = this.implementationClassForTesting;
+      if (getMode().test && nonStructThis['implementationClassForTesting']) {
+        Ctor = nonStructThis['implementationClassForTesting'];
       }
       devAssert(Ctor);
       /** @private {!./base-element.BaseElement} */
@@ -306,10 +312,10 @@ function createBaseCustomElementClass(win) {
       /** @private {?./layout-delay-meter.LayoutDelayMeter} */
       this.layoutDelayMeter_ = null;
 
-      if (this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER]) {
-        this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER](this);
-        delete this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
-        delete this[dom.UPGRADE_TO_CUSTOMELEMENT_PROMISE];
+      if (nonStructThis[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER]) {
+        nonStructThis[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER](nonStructThis);
+        delete nonStructThis[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
+        delete nonStructThis[dom.UPGRADE_TO_CUSTOMELEMENT_PROMISE];
       }
     }
 
@@ -329,7 +335,7 @@ function createBaseCustomElementClass(win) {
      * Returns the associated ampdoc. Only available after attachment. It throws
      * exception before the element is attached.
      * @return {!./service/ampdoc-impl.AmpDoc}
-     * @final @this {!Element}
+     * @final
      * @package
      */
     getAmpDoc() {
@@ -341,7 +347,7 @@ function createBaseCustomElementClass(win) {
      * Returns Resources manager. Only available after attachment. It throws
      * exception before the element is attached.
      * @return {!./service/resources-impl.ResourcesDef}
-     * @final @this {!Element}
+     * @final
      * @package
      */
     getResources() {
@@ -357,7 +363,7 @@ function createBaseCustomElementClass(win) {
      * Returns LayoutLayers. Only available after attachment. It throws
      * exception before the element is attached.
      * @return {!./service/layers-impl.LayoutLayers}
-     * @final @this {!Element}
+     * @final
      * @package
      */
     getLayers() {
@@ -371,7 +377,7 @@ function createBaseCustomElementClass(win) {
      * added to DOM, the value depends on the `BaseElement` implementation and
      * its `upgradeElement` callback.
      * @return {boolean}
-     * @final @this {!Element}
+     * @final
      */
     isUpgraded() {
       return this.upgradeState_ == UpgradeState.UPGRADED;
@@ -387,7 +393,7 @@ function createBaseCustomElementClass(win) {
      * has already been attached, it's layout validation and attachment flows
      * are repeated for the new implementation.
      * @param {function(new:./base-element.BaseElement, !Element)} newImplClass
-     * @final @package @this {!Element}
+     * @final @package
      */
     upgrade(newImplClass) {
       if (this.isInTemplate_) {
@@ -420,7 +426,7 @@ function createBaseCustomElementClass(win) {
      * Completes the upgrade of the element with the provided implementation.
      * @param {!./base-element.BaseElement} newImpl
      * @param {number} upgradeStartTime
-     * @final @private @this {!Element}
+     * @final @private
      */
     completeUpgrade_(newImpl, upgradeStartTime) {
       this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
@@ -459,7 +465,7 @@ function createBaseCustomElementClass(win) {
      * Whether the element has been built. A built element had its
      * {@link buildCallback} method successfully invoked.
      * @return {boolean}
-     * @final @this {!Element}
+     * @final
      */
     isBuilt() {
       return this.built_;
@@ -476,7 +482,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Get the priority to load the element.
-     * @return {number} @this {!Element}
+     * @return {number}
      */
     getLayoutPriority() {
       devAssert(this.isUpgraded(), 'Cannot get priority of unupgraded element');
@@ -503,7 +509,7 @@ function createBaseCustomElementClass(win) {
      * resource.js to ensure an element and its resource are in sync.
      *
      * @return {?Promise}
-     * @final @this {!Element}
+     * @final
      */
     build() {
       assertNotTemplate(this);
@@ -573,7 +579,6 @@ function createBaseCustomElementClass(win) {
      * Called to instruct the element to preconnect to hosts it uses during
      * layout.
      * @param {boolean} onLayout Whether this was called after a layout.
-     * @this {!Element}
      */
     preconnect(onLayout) {
       if (onLayout) {
@@ -599,7 +604,6 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the custom element declares that it has to be fixed.
      * @return {boolean}
-     * @this {!Element}
      */
     isAlwaysFixed() {
       return this.implementation_.isAlwaysFixed();
@@ -610,7 +614,6 @@ function createBaseCustomElementClass(win) {
      * See {@link BaseElement.getLayoutWidth} for details.
      * @param {!./layout-rect.LayoutRectDef} layoutBox
      * @param {boolean=} opt_measurementsChanged
-     * @this {!Element}
      */
     updateLayoutBox(layoutBox, opt_measurementsChanged) {
       this.layoutWidth_ = layoutBox.width;
@@ -692,7 +695,7 @@ function createBaseCustomElementClass(win) {
      * else.
      *
      * @final
-     * @package @this {!Element}
+     * @package
      */
     applySizesAndMediaQuery() {
       assertNotTemplate(this);
@@ -753,7 +756,7 @@ function createBaseCustomElementClass(win) {
      * @param {number|undefined} newWidth
      * @param {!./layout-rect.LayoutMarginsDef=} opt_newMargins
      * @final
-     * @package @this {!Element}
+     * @package
      */
     changeSize(newHeight, newWidth, opt_newMargins) {
       const sizer = this.getSizer_();
@@ -764,7 +767,9 @@ function createBaseCustomElementClass(win) {
         this.sizerElement = null;
         this.resetSizer_(sizer);
         this.mutateOrInvoke_(() => {
-          dom.removeElement(sizer);
+          if (sizer) {
+            dom.removeElement(sizer);
+          }
         });
       }
       if (newHeight !== undefined) {
@@ -804,7 +809,7 @@ function createBaseCustomElementClass(win) {
      * connectedCallback will later be called when the disconnected root is
      * connected to the document tree.
      *
-     * @final @this {!Element}
+     * @final
      */
     connectedCallback() {
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
@@ -913,7 +918,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Try to upgrade the element with the provided implementation.
-     * @private @final @this {!Element}
+     * @private @final
      */
     tryUpgrade_() {
       const impl = this.implementation_;
@@ -954,7 +959,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Called when the element is disconnected from the DOM.
      *
-     * @final @this {!Element}
+     * @final
      */
     disconnectedCallback() {
       this.disconnect(/* pretendDisconnected */ false);
@@ -1007,7 +1012,7 @@ function createBaseCustomElementClass(win) {
      *
      * @param {string} name
      * @param {!Object=} opt_data Event data.
-     * @final @this {!Element}
+     * @final
      */
     dispatchCustomEvent(name, opt_data) {
       const data = opt_data || {};
@@ -1023,7 +1028,7 @@ function createBaseCustomElementClass(win) {
      *
      * @param {string} name
      * @param {!Object=} opt_data Event data.
-     * @final @this {!Element}
+     * @final
      */
     dispatchCustomEventForTesting(name, opt_data) {
       if (!getMode().test) {
@@ -1035,7 +1040,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the element can pre-render.
      * @return {boolean}
-     * @final @this {!Element}
+     * @final
      */
     prerenderAllowed() {
       return this.implementation_.prerenderAllowed();
@@ -1044,7 +1049,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Creates a placeholder for the element.
      * @return {?Element}
-     * @final @this {!Element}
+     * @final
      */
     createPlaceholder() {
       return this.implementation_.createPlaceholderCallback();
@@ -1056,7 +1061,7 @@ function createBaseCustomElementClass(win) {
      *  content: (!Element|undefined),
      *  color: (string|undefined),
      * }}
-     * @final @this {!Element}
+     * @final
      */
     createLoaderLogo() {
       return this.implementation_.createLoaderLogoCallback();
@@ -1065,7 +1070,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the element should ever render when it is not in viewport.
      * @return {boolean|number}
-     * @final @this {!Element}
+     * @final
      */
     renderOutsideViewport() {
       return this.implementation_.renderOutsideViewport();
@@ -1075,7 +1080,7 @@ function createBaseCustomElementClass(win) {
      * Whether the element should render outside of renderOutsideViewport when
      * the scheduler is idle.
      * @return {boolean|number}
-     * @final @this {!Element}
+     * @final
      */
     idleRenderOutsideViewport() {
       return this.implementation_.idleRenderOutsideViewport();
@@ -1086,7 +1091,7 @@ function createBaseCustomElementClass(win) {
      * mainly affects fixed-position elements that are adjusted to be always
      * relative to the document position in the viewport.
      * @return {!./layout-rect.LayoutRectDef}
-     * @final @this {!Element}
+     * @final
      */
     getLayoutBox() {
       return this.getResource_().getLayoutBox();
@@ -1096,7 +1101,7 @@ function createBaseCustomElementClass(win) {
      * Returns a previously measured layout box relative to the page. The
      * fixed-position elements are relative to the top of the document.
      * @return {!./layout-rect.LayoutRectDef}
-     * @final @this {!Element}
+     * @final
      */
     getPageLayoutBox() {
       return this.getResource_().getPageLayoutBox();
@@ -1104,7 +1109,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * @return {?Element}
-     * @final @this {!Element}
+     * @final
      */
     getOwner() {
       return this.getResource_().getOwner();
@@ -1114,7 +1119,7 @@ function createBaseCustomElementClass(win) {
      * Returns a change entry for that should be compatible with
      * IntersectionObserverEntry.
      * @return {!IntersectionObserverEntry} A change entry.
-     * @final @this {!Element}
+     * @final
      */
     getIntersectionChangeEntry() {
       const box = this.implementation_.getIntersectionElementLayoutBox();
@@ -1146,7 +1151,7 @@ function createBaseCustomElementClass(win) {
      * The runtime calls this method to determine if {@link layoutCallback}
      * should be called again when layout changes.
      * @return {boolean}
-     * @package @final @this {!Element}
+     * @package @final
      */
     isRelayoutNeeded() {
       return this.implementation_.isRelayoutNeeded();
@@ -1183,7 +1188,7 @@ function createBaseCustomElementClass(win) {
      * Can only be called on a upgraded and built element.
      *
      * @return {!Promise}
-     * @package @final @this {!Element}
+     * @package @final
      */
     layoutCallback() {
       assertNotTemplate(this);
@@ -1236,7 +1241,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the resource is currently visible in the viewport.
      * @return {boolean}
-     * @final @package @this {!Element}
+     * @final @package
      */
     isInViewport() {
       return this.isInViewport_;
@@ -1249,7 +1254,7 @@ function createBaseCustomElementClass(win) {
      *
      * @param {boolean} inViewport Whether the element has entered or exited
      *   the visible viewport.
-     * @final @package @this {!Element}
+     * @final @package
      */
     viewportCallback(inViewport) {
       assertNotTemplate(this);
@@ -1289,7 +1294,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * @param {boolean} inViewport
-     * @private @this {!Element}
+     * @private
      */
     updateInViewport_(inViewport) {
       this.implementation_.inViewport_ = inViewport;
@@ -1302,7 +1307,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the resource is currently paused.
      * @return {boolean}
-     * @final @package @this {!Element}
+     * @final @package
      */
     isPaused() {
       return this.paused_;
@@ -1313,7 +1318,7 @@ function createBaseCustomElementClass(win) {
      * inactive state. The scope is up to the actual component. Among other
      * things the active playback of video or audio content must be stopped.
      *
-     * @package @final @this {!Element}
+     * @package @final
      */
     pauseCallback() {
       assertNotTemplate(this);
@@ -1333,7 +1338,7 @@ function createBaseCustomElementClass(win) {
      * other things the active playback of video or audio content may be
      * resumed.
      *
-     * @package @final @this {!Element}
+     * @package @final
      */
     resumeCallback() {
       assertNotTemplate(this);
@@ -1353,7 +1358,7 @@ function createBaseCustomElementClass(win) {
      * Calling this method on unbuilt or unupgraded element has no effect.
      *
      * @return {boolean}
-     * @package @final @this {!Element}
+     * @package @final
      */
     unlayoutCallback() {
       assertNotTemplate(this);
@@ -1384,7 +1389,7 @@ function createBaseCustomElementClass(win) {
      * video content), and so we must unlayout to stop playback.
      *
      * @return {boolean}
-     * @package @final @this {!Element}
+     * @package @final
      */
     unlayoutOnPause() {
       return this.implementation_.unlayoutOnPause();
@@ -1396,7 +1401,7 @@ function createBaseCustomElementClass(win) {
      * are better to be reconstructed from scratch.
      *
      * @return {boolean}
-     * @package @final @this {!Element}
+     * @package @final
      */
     reconstructWhenReparented() {
       return this.implementation_.reconstructWhenReparented();
@@ -1451,7 +1456,7 @@ function createBaseCustomElementClass(win) {
      * Otherwise the invocation is enqueued until the implementation is ready
      * to receive actions.
      * @param {!./service/action-impl.ActionInvocation} invocation
-     * @final @this {!Element}
+     * @final
      */
     enqueAction(invocation) {
       assertNotTemplate(this);
@@ -1468,7 +1473,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Dequeues events from the queue and dispatches them to the implementation
      * with "deferred" flag.
-     * @private @this {!Element}
+     * @private
      */
     dequeueActions_() {
       if (!this.actionQueue_) {
@@ -1489,7 +1494,7 @@ function createBaseCustomElementClass(win) {
      * @param {!./service/action-impl.ActionInvocation} invocation
      * @param {boolean} deferred
      * @final
-     * @private @this {!Element}
+     * @private
      */
     executionAction_(invocation, deferred) {
       try {
@@ -1533,7 +1538,7 @@ function createBaseCustomElementClass(win) {
      * nodes that could have been added for markup. These nodes can include
      * Text, Comment and other child nodes.
      * @return {!Array<!Node>}
-     * @package @final @this {!Element}
+     * @package @final
      */
     getRealChildNodes() {
       return dom.childNodes(this, node => !isInternalOrServiceNode(node));
@@ -1543,7 +1548,7 @@ function createBaseCustomElementClass(win) {
      * Returns the original children of the custom element without any service
      * nodes that could have been added for markup.
      * @return {!Array<!Element>}
-     * @package @final @this {!Element}
+     * @package @final
      */
     getRealChildren() {
       return dom.childElements(
@@ -1555,7 +1560,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Returns an optional placeholder element for this custom element.
      * @return {?Element}
-     * @package @final @this {!Element}
+     * @package @final
      */
     getPlaceholder() {
       return dom.lastChildElement(this, el => {
@@ -1572,7 +1577,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Hides or shows the placeholder, if available.
      * @param {boolean} show
-     * @package @final @this {!Element}
+     * @package @final
      */
     togglePlaceholder(show) {
       assertNotTemplate(this);
@@ -1599,7 +1604,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Returns an optional fallback element for this custom element.
      * @return {?Element}
-     * @package @final @this {!Element}
+     * @package @final
      */
     getFallback() {
       return dom.childElementByAttr(this, 'fallback');
@@ -1609,7 +1614,7 @@ function createBaseCustomElementClass(win) {
      * Hides or shows the fallback, if available. This function must only
      * be called inside a mutate context.
      * @param {boolean} show
-     * @package @final @this {!Element}
+     * @package @final
      */
     toggleFallback(show) {
       assertNotTemplate(this);
@@ -1642,7 +1647,7 @@ function createBaseCustomElementClass(win) {
     /**
      * An implementation can call this method to signal to the element that
      * it has started rendering.
-     * @package @final @this {!Element}
+     * @package @final
      */
     renderStarted() {
       this.signals_.signal(CommonSignals.RENDER_START);
@@ -1653,7 +1658,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Whether the loading can be shown for this element.
      * @return {boolean}
-     * @private @this {!Element}
+     * @private
      */
     isLoadingEnabled_() {
       // No loading indicator will be shown if either one of these conditions
@@ -1704,7 +1709,7 @@ function createBaseCustomElementClass(win) {
      * Creates a loading object. The caller must ensure that loading can
      * actually be shown. This method must also be called in the mutate
      * context.
-     * @private @this {!Element}
+     * @private
      */
     prepareLoading_() {
       if (!this.isLoadingEnabled_()) {
@@ -1744,8 +1749,8 @@ function createBaseCustomElementClass(win) {
     /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {{cleanup:boolean, force:boolean}=} opt_options
-     * @public @final @this {!Element}
+     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=} opt_options
+     * @public @final
      */
     toggleLoading(state, opt_options) {
       const cleanup = opt_options && opt_options.cleanup;
@@ -1819,7 +1824,6 @@ function createBaseCustomElementClass(win) {
     /**
      * Returns an optional overflow element for this custom element.
      * @return {?Element}
-     * @this {!Element}
      */
     getOverflowElement() {
       if (this.overflowElement_ === undefined) {
@@ -1842,7 +1846,7 @@ function createBaseCustomElementClass(win) {
      * @param {boolean} overflown
      * @param {number|undefined} requestedHeight
      * @param {number|undefined} requestedWidth
-     * @package @final @this {!Element}
+     * @package @final
      */
     overflowCallback(overflown, requestedHeight, requestedWidth) {
       this.getOverflowElement();

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -101,13 +101,12 @@ function isTemplateTagSupported() {
  * @return {!Function} The custom element class.
  */
 export function createCustomElementClass(win, name) {
-  const baseCustomElement = /** @type {Function} */ (createBaseCustomElementClass(
+  const baseCustomElement = /** @type {function(new:HTMLElement)} */ (createBaseCustomElementClass(
     win
   ));
   /**
    * @extends {HTMLElement}
-   * @suppress {checkTypes}
-   **/
+   */
   class CustomAmpElement extends baseCustomElement {
     /**
      * @see https://github.com/WebReflection/document-register-element#v1-caveat
@@ -138,11 +137,10 @@ function createBaseCustomElementClass(win) {
   if (win.BaseCustomElementClass) {
     return win.BaseCustomElementClass;
   }
-  const htmlElement = /** @type {Function} */ (win.HTMLElement);
+  const htmlElement = /** @type {function(new:HTMLElement)} */ (win.HTMLElement);
   /**
    * @abstract @extends {HTMLElement}
-   * @suppress {checkTypes}
-   **/
+   */
   class BaseCustomElement extends htmlElement {
     /**
      * @see https://github.com/WebReflection/document-register-element#v1-caveat
@@ -1634,7 +1632,7 @@ function createBaseCustomElementClass(win) {
         const fallbackElement = this.getFallback();
         if (fallbackElement) {
           Services.ownersForDoc(this.getAmpDoc()).scheduleLayout(
-            this.element,
+            this,
             fallbackElement
           );
         }
@@ -1723,7 +1721,7 @@ function createBaseCustomElementClass(win) {
         let loadingElement;
         if (isNewLoaderExperimentEnabled(this)) {
           loadingElement = createNewLoaderElement(
-            this.ampdoc_,
+            devAssert(this.ampdoc_),
             this,
             this.layoutWidth_,
             this.layoutHeight_

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -99,15 +99,12 @@ function isTemplateTagSupported() {
  *
  * @param {!Window} win The window in which to register the custom element.
  * @param {string} name The name of the custom element.
- * @return {!Function} The custom element class.
+ * @return {function(new:AmpElement)} The custom element class.
  */
 export function createCustomElementClass(win, name) {
   const baseCustomElement = /** @type {function(new:HTMLElement)} */ (createBaseCustomElementClass(
     win
   ));
-  /**
-   * @extends {HTMLElement}
-   */
   class CustomAmpElement extends baseCustomElement {
     /**
      * @see https://github.com/WebReflection/document-register-element#v1-caveat
@@ -125,14 +122,14 @@ export function createCustomElementClass(win, name) {
       return name;
     }
   }
-  return CustomAmpElement;
+  return /** @type {function(new:AmpElement)} */ (CustomAmpElement);
 }
 
 /**
  * Creates a base custom element class.
  *
  * @param {!Window} win The window in which to register the custom element.
- * @return {!Function}
+ * @return {function(new:HTMLElement)}
  */
 function createBaseCustomElementClass(win) {
   if (win.BaseCustomElementClass) {
@@ -1895,7 +1892,7 @@ function createBaseCustomElementClass(win) {
     }
   }
   win.BaseCustomElementClass = BaseCustomElement;
-  return win.BaseCustomElementClass;
+  return /** @type {function(new:HTMLElement)} */ (win.BaseCustomElementClass);
 }
 
 /**


### PR DESCRIPTION
Enables stronger type checking in custom-element.js by removing `@suppress` and `@this` annotations. I think these were originally needed on an older version of Closure compiler.

Fixed a few type errors that this caught and verified that this would've caught #23858.

/to @lannka @powerivq 