### PR TITLE
🐛Prevent automatic sizing for amp-imgs with intrinsic layout

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -198,6 +198,11 @@ export class AmpImg extends BaseElement {
     if (sizes) {
       return;
     }
+    // Auto-sizes are not compatible with intrinsic layout.
+    const layout = this.getLayout();
+    if (layout === Layout.INTRINSIC) {
+      return;
+    }
     // Sizes is useless without the srcset attribute or if the srcset
     // attribute uses the x descriptor.
     const srcset = this.element.getAttribute('srcset');
@@ -215,7 +220,7 @@ export class AmpImg extends BaseElement {
     const entry = `(max-width: ${viewportWidth}px) ${width}px, `;
     let defaultSize = width + 'px';
 
-    if (this.getLayout() !== Layout.FIXED) {
+    if (layout !== Layout.FIXED) {
       const ratio = Math.round((width * 100) / viewportWidth);
       defaultSize = Math.max(ratio, 100) + 'vw';
     }

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -530,6 +530,26 @@ describe('amp-img', () => {
         });
     });
 
+    it('should not generate sizes for amp-imgs with layout intrinsic', () => {
+      let impl;
+      return getImg({
+        layout: Layout.INTRINSIC,
+        src: '/examples/img/sample.jpg',
+        srcset: SRCSET_STRING,
+        width: 300,
+        height: 200,
+      })
+        .then(ampImg => {
+          impl = ampImg.implementation_;
+          impl.buildCallback();
+          return impl.layoutCallback();
+        })
+        .then(() => {
+          const img = impl.img_;
+          expect(img.getAttribute('sizes')).to.be.null;
+        });
+    });
+
     it('should not generate sizes for amp-imgs without srcset', () => {
       let impl;
       return getImg({


### PR DESCRIPTION
Prevent images with "layout=intrinsic" from automatically generating sizes in order to retain their natural size.

Resolves #23453