### PR TITLE
Fix illegal invocation

### DIFF
--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -29,7 +29,7 @@ export class Platform {
     this.navigator_ = /** @type {!Navigator} */ (win.navigator);
 
     /** @const @private */
-    this.matchMedia_ = win.matchMedia;
+    this.win_ = win;
   }
 
   /**
@@ -135,7 +135,7 @@ export class Platform {
     return (
       (this.isIos() && this.navigator_.standalone) ||
       (this.isChrome() &&
-        this.matchMedia_('(display-mode: standalone)').matches)
+        this.win_.matchMedia('(display-mode: standalone)').matches)
     );
   }
 


### PR DESCRIPTION
Fixes #23882

Uses the win object when calling `matchMedia().matches` to make sure the right context is being passed.