### PR TITLE
✨adds support for amp-ad type=readmo

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -210,6 +210,7 @@ import {pulsepoint} from '../ads/pulsepoint';
 import {purch} from '../ads/purch';
 import {quoraad} from '../ads/quoraad';
 import {rbinfox} from '../ads/rbinfox';
+import {readmo} from '../ads/readmo';
 import {realclick} from '../ads/realclick';
 import {recomad} from '../ads/recomad';
 import {relap} from '../ads/relap';
@@ -294,6 +295,7 @@ const AMP_EMBED_ALLOWED = {
   lentainform: true,
   opinary: true,
   outbrain: true,
+  readmo: true,
   plista: true,
   postquare: true,
   pubexchange: true,
@@ -476,6 +478,7 @@ register('pulsepoint', pulsepoint);
 register('purch', purch);
 register('quoraad', quoraad);
 register('rbinfox', rbinfox);
+register('readmo', readmo);
 register('realclick', realclick);
 register('reddit', reddit);
 register('recomad', recomad);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -827,6 +827,8 @@ export const adConfig = {
     renderStartImplemented: true,
   },
 
+  'readmo': {},
+
   'realclick': {
     renderStartImplemented: true,
   },

--- a/ads/readmo.js
+++ b/ads/readmo.js
@@ -1,0 +1,20 @@
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function readmo(global, data) {
+
+  validateData(data, ['section']);
+
+  (global.readmo = global.readmo || []).push({
+    section: data.section,
+    container: '#c',
+    module: data.module,
+    url: data.url || global.context.canonicalUrl,
+    referrer: data.referrer || global.context.referrer
+  });
+
+  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js');
+}

--- a/ads/readmo.md
+++ b/ads/readmo.md
@@ -1,0 +1,31 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Readmo
+
+## Example
+
+Readmo only requires a configured section code to run. Please work with your account manager to configure your AMP page sections.
+
+### Basic
+
+```html
+  <amp-embed width="100" height="283"
+             type="readmo"
+             layout="responsive"
+             data-section="1234567">
+  </amp-embed>
+```

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -214,6 +214,7 @@
         <option>pulsepoint</option>
         <option>purch</option>
         <option>rbinfox</option>
+        <option>readmo</option>
         <option>realclick</option>
         <option>recomad</option>
         <option>relap</option>
@@ -1729,6 +1730,15 @@
   <amp-embed width="240" height="400"
       type="rbinfox"
       src="https://rb.infox.sg/infox/503">
+  </amp-embed>
+
+  <h2>Readmo</h2>
+  <amp-embed width="300" height="250"
+      type="readmo"
+      layout="responsive"
+      heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+      data-section="5591639"
+      data-module="end-of-article-stacked">
   </amp-embed>
 
   <h2>Realclick</h2>

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -438,6 +438,7 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Outbrain](../../ads/outbrain.md)
 - [Postquare](../../ads/postquare.md)
 - [PubExchange](../../ads/pubexchange.md)
+- [Readmo](../../ads/readmo.md)
 - [Smi2](../../ads/smi2.md)
 - [SVK-Native](../../ads/svknative.md)
 - [Strossle](../../ads/strossle.md)


### PR DESCRIPTION
Adds support to render the Verizon Media Readmo recommendation modules using the `amp-embed` tags. 

Rendering
-----
<img width="1199" alt="Screen Shot 2019-08-11 at 11 26 38 AM" src="https://user-images.githubusercontent.com/1918732/62837981-f2394a80-bc2a-11e9-8673-e95770aa272f.png">
