### PR TITLE
✨adds support for amp-embed type=yahoonativeads

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -259,6 +259,7 @@ import {wpmedia} from '../ads/wpmedia';
 import {xlift} from '../ads/xlift';
 import {yahoo} from '../ads/yahoo';
 import {yahoojp} from '../ads/yahoojp';
+import {yahoonativeads} from '../ads/yahoonativeads';
 import {yandex} from '../ads/yandex';
 import {yengo} from '../ads/yengo';
 import {yieldbot} from '../ads/yieldbot';
@@ -298,15 +299,16 @@ const AMP_EMBED_ALLOWED = {
   postquare: true,
   pubexchange: true,
   rbinfox: true,
+  runative: true,
   smartclip: true,
   smi2: true,
-  svknative: true,
+  speakol: true,
   strossle: true,
+  svknative: true,
   taboola: true,
+  yahoonativeads: true,
   zen: true,
   zergnet: true,
-  runative: true,
-  speakol: true,
 };
 
 init(window);
@@ -527,6 +529,7 @@ register('wpmedia', wpmedia);
 register('xlift', xlift);
 register('yahoo', yahoo);
 register('yahoojp', yahoojp);
+register('yahoonativeads', yahoonativeads);
 register('yandex', yandex);
 register('yengo', yengo);
 register('yieldbot', yieldbot);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1079,7 +1079,9 @@ export const adConfig = {
     preconnect: 'https://yads.yahoo.co.jp',
   },
 
-  'yahoonativeads': {},
+  'yahoonativeads': {
+    renderStartImplemented: true,
+  },
 
   'yandex': {
     prefetch: 'https://yastatic.net/partner-code/loaders/context_amp.js',

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1079,6 +1079,8 @@ export const adConfig = {
     preconnect: 'https://yads.yahoo.co.jp',
   },
 
+  'yahoonativeads': {},
+
   'yandex': {
     prefetch: 'https://yastatic.net/partner-code/loaders/context_amp.js',
     renderStartImplemented: true,

--- a/ads/yahoonativeads.js
+++ b/ads/yahoonativeads.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ads/yahoonativeads.js
+++ b/ads/yahoonativeads.js
@@ -40,5 +40,7 @@ export function yahoonativeads(global, data) {
     });
   });
 
-  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js', () => global.context.renderStart());
+  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js', () =>
+    global.context.renderStart()
+  );
 }

--- a/ads/yahoonativeads.js
+++ b/ads/yahoonativeads.js
@@ -21,7 +21,7 @@ import {loadScript, validateData} from '../3p/3p';
  * @param {!Object} data
  */
 export function yahoonativeads(global, data) {
-  validateData(data, ['section']);
+  validateData(data, ['section'], ['module']);
 
   (global.readmo = global.readmo || []).push({
     section: data.section,
@@ -40,5 +40,5 @@ export function yahoonativeads(global, data) {
     });
   });
 
-  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js');
+  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js', () => global.context.renderStart());
 }

--- a/ads/yahoonativeads.js
+++ b/ads/yahoonativeads.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function yahoonativeads(global, data) {
+  validateData(data, ['section']);
+
+  (global.readmo = global.readmo || []).push({
+    section: data.section,
+    container: '#c',
+    module: data.module,
+    amp: true,
+  });
+
+  global.context.observeIntersection(function(entries) {
+    entries.forEach(function(entry) {
+      if (global.Readmo) {
+        global.Readmo.onViewChange({
+          rects: entry,
+        });
+      }
+    });
+  });
+
+  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js');
+}

--- a/ads/yahoonativeads.md
+++ b/ads/yahoonativeads.md
@@ -1,0 +1,31 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Yahoo Native Ads
+
+## Example
+
+Yahoo Native Ads only requires a configured section code to run. Please work with your account manager to configure your AMP page sections.
+
+### Basic
+
+```html
+  <amp-embed width="100" height="283"
+             type="yahoonativeads"
+             layout="responsive"
+             data-section="1234567">
+  </amp-embed>
+```

--- a/ads/yahoonativeads.md
+++ b/ads/yahoonativeads.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,3 +29,11 @@ Yahoo Native Ads only requires a configured section code to run. Please work wit
              data-section="1234567">
   </amp-embed>
 ```
+
+### Required parameters
+
+- `data-section` : Unique section id that represents your site and placement
+
+### Optional parameters
+
+- `data-module` : Type of module to render (ex: `end-of-article`, `smart-feed`, `smart-feed-video`, `side-rail`)

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -263,6 +263,7 @@
         <option>xlift</option>
         <option>yahoo</option>
         <option>yahoojp</option>
+        <option>yahoonativeads</option>
         <option>yandex</option>
         <option>yengo</option>
         <option>yieldbot</option>
@@ -2080,6 +2081,15 @@
       data-site="news"
       data-sa='{"LREC":"300x250","secure":"true","content":"no_expandable;"}'>
   </amp-ad>
+
+  <h2>Yahoo Native Ads</h2>
+  <amp-embed width="300" height="250"
+      type="yahoonativeads"
+      layout="responsive"
+      heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+      data-section="5591639"
+      data-module="end-of-article-stacked">
+  </amp-embed>
 
   <h2>YahooJP YDN</h2>
   <amp-ad width="300" height="250"

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -442,5 +442,6 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [SVK-Native](../../ads/svknative.md)
 - [Strossle](../../ads/strossle.md)
 - [Taboola](../../ads/taboola.md)
+- [Yahoo Native Ads](../../ads/yahoonativeads.md)
 - [Zen](../../ads/zen.md)
 - [ZergNet](../../ads/zergnet.md)


### PR DESCRIPTION
Adds support to render Yahoo Native Ad units using the `amp-embed` tag. 

Sample Rendering

<img width="1271" alt="Screen Shot 2019-08-15 at 11 01 51 AM" src="https://user-images.githubusercontent.com/1918732/63115686-92a1ae80-bf4c-11e9-86b8-3ad2faeb66f4.png">
