### PR TITLE
add validator template for amp-date-display

### DIFF
--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -42,6 +42,9 @@ tags: {  # <amp-date-display>
     value_regex: "-?\\d+"
   }
   attrs: { name: "locale" }
+  # TODO(gregable): Implement validation that requires the template attr value
+  # to reference the id of an existing template element.
+  attrs: { name: "template" }
   attrs: {
     name: "timestamp-ms"
     mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"

--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -44,6 +44,7 @@ tags: {  # <amp-date-display>
   attrs: { name: "locale" }
   # TODO(gregable): Implement validation that requires the template attr value
   # to reference the id of an existing template element.
+  
   attrs: { name: "template" }
   attrs: {
     name: "timestamp-ms"


### PR DESCRIPTION
Add attribute "template" into validator rules of amp-date-display
To fix the issue: https://github.com/ampproject/amphtml/issues/22524