### PR TITLE
🐛 Move `facebook-loader.js` into its component directory

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -241,10 +241,9 @@ exports.rules = [
       'extensions/amp-carousel/0.2/amp-carousel.js->extensions/amp-base-carousel/0.1/child-layout-manager.js',
 
       // Facebook components
-      'extensions/amp-facebook/0.1/amp-facebook.js->extensions/amp-facebook/facebook-loader.js',
-      'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/facebook-loader.js',
-      'extensions/amp-facebook-comments/0.1/amp-facebook-comments.js->extensions/amp-facebook/facebook-loader.js',
-      'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/facebook-loader.js',
+      'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/0.1/facebook-loader.js',
+      'extensions/amp-facebook-comments/0.1/amp-facebook-comments.js->extensions/amp-facebook/0.1/facebook-loader.js',
+      'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/0.1/facebook-loader.js',
 
       // Amp geo in group enum
       'extensions/amp-consent/0.1/amp-consent.js->extensions/amp-geo/0.1/amp-geo-in-group.js',

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createLoaderLogo} from '../../amp-facebook/facebook-loader';
+import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createLoaderLogo} from '../../amp-facebook/facebook-loader';
+import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createLoaderLogo} from '../facebook-loader';
+import {createLoaderLogo} from './facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';

--- a/extensions/amp-facebook/0.1/facebook-loader.js
+++ b/extensions/amp-facebook/0.1/facebook-loader.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {htmlFor} from '../../src/static-template';
+import {htmlFor} from '../../../src/static-template';
 
 /**
  * Common function to create the facebook loader logo for all amp-facebook-*


### PR DESCRIPTION
This PR moves `facebook-loader.js` into its component directory to fix these (currently silenced) type checking errors, which stem from the fact that extension code is expected to live in a directory of the format `amp-foo/0.x/`. See https://github.com/ampproject/amphtml/pull/23084#discussion_r299597394 for more details.

```js
Type checking failed:
extensions/amp-facebook-comments/0.1/amp-facebook-comments.js:17: ERROR - [JSC_JS_MODULE_LOAD_WARNING] Failed to load module "../../amp-facebook/facebook-loader"
import {createLoaderLogo} from '../../amp-facebook/facebook-loader';
^

extensions/amp-facebook-page/0.1/amp-facebook-page.js:17: ERROR - [JSC_JS_MODULE_LOAD_WARNING] Failed to load module "../../amp-facebook/facebook-loader"
import {createLoaderLogo} from '../../amp-facebook/facebook-loader';
^

extensions/amp-facebook/0.1/amp-facebook.js:17: ERROR - [JSC_JS_MODULE_LOAD_WARNING] Failed to load module "../facebook-loader"
import {createLoaderLogo} from '../facebook-loader';
^
```
Addresses https://github.com/ampproject/amphtml/pull/23084#discussion_r299597394