### PR TITLE
Add visual test for AMPHTML ads fallback

### DIFF
--- a/examples/visual-tests/amphtml-ads/amp-inabox-static.html
+++ b/examples/visual-tests/amphtml-ads/amp-inabox-static.html
@@ -18,13 +18,25 @@
   <h1>AMPHTML ad - Inabox - /amphtml-ads/resource/amp-creative.html</h1>
   <iframe
       class="inabox-test"
-      id="iframe"
+      id="iframe-1"
       src="/examples/visual-tests/amphtml-ads/resource/amp-creative.html"
       scrolling="no"
       marginwidth="0"
       marginheight="0"
       frameborder="0"
       width="300" height="200">
+  </iframe>
+
+  <h1>AMPHTML ad - Inabox - /amphtml-ads/resource/amp-creative.html</h1>
+  <iframe
+    class="inabox-test"
+    id="iframe-2"
+    src="/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html"
+    scrolling="no"
+    marginwidth="0"
+    marginheight="0"
+    frameborder="0"
+    width="300" height="200">
   </iframe>
   <script src="/examples/amphtml-ads/ads-tag-integration.js"></script>
 </body>

--- a/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
+++ b/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMPHTML Ad FIE test</title>
+  <link rel="canonical" href="https://amp.dev/documentation/examples/introduction/hello_world/index.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+</head>
+<body>
+<h1>AMPHTML ad - Fallback</h1>
+<amp-ad width="300" height="250"
+        type="fake"
+        id="i-amphtml-demo-id-1"
+        src="nonexistent">
+  <div fallback style="background-color: red;">Could not display the fake ad :(</div>
+</amp-ad>
+<h2 style="height: 1000px;">Placeholder</h2>
+</body>
+</html>


### PR DESCRIPTION
Part of https://github.com/ampproject/amphtml/issues/23864

Realizing from https://github.com/ampproject/amphtml/issues/23858 that we do not cover fallback in the visual test, this PR adds a test case to cover fallbacks for inabox.