### PR TITLE
Remove duplicate GetCidDef type definition. Leave it in extern

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -543,6 +543,7 @@ AccessService.prototype.getAuthdataField = function(field) {};
  * @typedef {{
  *   scope: string,
  *   createCookieIfNotPresent: (boolean|undefined),
+ *   cookieName: (string|undefined),
  * }}
  */
 var GetCidDef;

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -85,18 +85,6 @@ const API_KEYS = {
 let BaseCidInfoDef;
 
 /**
- * The "get CID" parameters.
- * - createCookieIfNotPresent: Whether CID is allowed to create a cookie when.
- *   Default value is `false`.
- * @typedef {{
- *   scope: string,
- *   createCookieIfNotPresent: (boolean|undefined),
- *   cookieName: (string|undefined),
- * }}
- */
-let GetCidDef;
-
-/**
  * @interface
  */
 export class CidDef {


### PR DESCRIPTION
Looks like we had two definitions of GetCidDef, this is causing me some issues with the typedef hoisting as there are 2 items in the extern when we hoist the one in the source code.