### PR TITLE
🐛 Add check to disable toggling for amp internal classes

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -52,6 +52,13 @@ export function getAutofocusElementForShowAction(element) {
 const TAG = 'STANDARD-ACTIONS';
 
 /**
+ * Regular expression that identifies AMP CSS classes.
+ * Includes 'i-amphtml-', '-amp-', and 'amp-' prefixes.
+ * @type {!RegExp}
+ */
+const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
+
+/**
  * This service contains implementations of some of the most typical actions,
  * such as hiding DOM elements.
  * @implements {../service.EmbeddableService}
@@ -414,6 +421,10 @@ export class StandardActions {
       args['class'],
       "Argument 'class' must be a string."
     );
+    // prevent toggling amp internal classes
+    if (AMP_CSS_RE.test(className)) {
+      return;
+    }
 
     this.resources_.mutateElement(target, () => {
       if (args['force'] !== undefined) {

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -421,9 +421,9 @@ export class StandardActions {
       args['class'],
       "Argument 'class' must be a string."
     );
-    // prevent toggling amp internal classes
+    // prevent toggling of amp internal classes
     if (AMP_CSS_RE.test(className)) {
-      return;
+      return null;
     }
 
     this.resources_.mutateElement(target, () => {

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -395,7 +395,12 @@ describes.sandboxed('StandardActions', {}, () => {
   });
 
   describe('"toggleClass" action', () => {
-    const dummyClass = 'i-amphtml-test-class-toggle';
+    const dummyClass = 'test-class-toggle';
+    const dummyInternalClasses = [
+      'i-amphtml-test-class-toggle',
+      '-amp-test-class-toggle',
+      'amp-test-class-toggle',
+    ];
 
     it('should add class when not in classList', () => {
       const element = createElement();
@@ -422,6 +427,37 @@ describes.sandboxed('StandardActions', {}, () => {
       };
       standardActions.handleToggleClass_(invocation);
       expectElementToDropClass(element, dummyClass);
+    });
+
+    it('should not add amp internal classes', () => {
+      const element = createElement();
+      dummyInternalClasses.forEach(dummyInternalClass => {
+        const invocation = {
+          node: element,
+          satisfiesTrust: () => true,
+          args: {
+            'class': dummyInternalClass,
+          },
+        };
+        standardActions.handleToggleClass_(invocation);
+        expect(element.classList.contains(dummyInternalClass)).to.be.false;
+      });
+    });
+
+    it('should not delete amp internal classes', () => {
+      const element = createElement();
+      dummyInternalClasses.forEach(dummyInternalClass => {
+        element.classList.add(dummyInternalClass);
+        const invocation = {
+          node: element,
+          satisfiesTrust: () => true,
+          args: {
+            'class': dummyInternalClass,
+          },
+        };
+        standardActions.handleToggleClass_(invocation);
+        expect(element.classList.contains(dummyInternalClass)).to.be.true;
+      });
     });
 
     it('should add class when not in classList, when force=true', () => {


### PR DESCRIPTION
Fixes #22435

Add a check in the `handleToggleClass` method to prevent toggling when class name is internal to amp (prefixed by 'i-amphtml-', '-amp-', or 'amp-').