### PR TITLE
use the --debug flag on CC directly to generate pseudo names

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -106,6 +106,7 @@ function cleanupBuildDir() {
 exports.cleanupBuildDir = cleanupBuildDir;
 
 function compile(entryModuleFilenames, outputDir, outputFilename, options) {
+  const debug = !!(argv.debug || argv.pseudo_names);
   const hideWarningsFor = [
     'third_party/amp-toolbox-cache-url/',
     'third_party/caja/',
@@ -295,10 +296,10 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       jscomp_off: [],
       define,
       hide_warnings_for: hideWarningsFor,
-      debug: !!argv.pseudo_names,
+      debug,
     };
-    if (argv.pseudo_names) {
-      // Some optimizations get turned off when pseudo_names is on.
+    if (debug) {
+      // Some optimizations get turned off when debug is on.
       // This causes some errors caused by the babel transformations
       // that we apply like unreachable code because we turn a conditional
       // falsey. (ex. is IS_DEV transformation which causes some conditionals

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -135,9 +135,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     'third_party/react-externs/externs.js',
   ];
   const define = [`VERSION=${internalRuntimeVersion}`];
-  if (argv.pseudo_names) {
-    define.push('PSEUDO_NAMES=true');
-  }
   if (argv.fortesting) {
     define.push('FORTESTING=true');
   }
@@ -298,6 +295,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       jscomp_off: [],
       define,
       hide_warnings_for: hideWarningsFor,
+      debug: !!argv.pseudo_names,
     };
     if (argv.pseudo_names) {
       // Some optimizations get turned off when pseudo_names is on.

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -94,6 +94,7 @@ extensions = [].concat.apply([], extensions);
 const jsFilesToWrap = [];
 
 exports.getFlags = function(config) {
+  const debug = !!(argv.debug || argv.pseudo_names);
   config.define.push('SINGLE_FILE_COMPILATION=true');
   config.define.push(`VERSION=${internalRuntimeVersion}`);
   /* eslint "google-camelcase/google-camelcase": 0 */
@@ -124,7 +125,7 @@ exports.getFlags = function(config) {
     jscomp_warning: ['checkTypes', 'checkVars', 'moduleLoad'],
     jscomp_error: ['const', 'constantProperty', 'globalThis'],
     hide_warnings_for: config.hideWarningsFor,
-    debug: !!argv.pseudo_names,
+    debug,
   };
   if (argv.pretty_print) {
     flags.formatting = 'PRETTY_PRINT';

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -124,6 +124,7 @@ exports.getFlags = function(config) {
     jscomp_warning: ['checkTypes', 'checkVars', 'moduleLoad'],
     jscomp_error: ['const', 'constantProperty', 'globalThis'],
     hide_warnings_for: config.hideWarningsFor,
+    debug: !!argv.pseudo_names,
   };
   if (argv.pretty_print) {
     flags.formatting = 'PRETTY_PRINT';

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -36,8 +36,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    */
   private boolean typecheck_only = false;
 
-  private boolean pseudo_names = false;
-
   private boolean is_production_env = true;
 
   /**
@@ -81,7 +79,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setRenamingPolicy(VariableRenamingPolicy.ALL,
         PropertyRenamingPolicy.ALL_UNQUOTED);
     options.setDisambiguatePrivateProperties(true);
-    options.setGeneratePseudoNames(pseudo_names);
     return options;
   }
 
@@ -109,8 +106,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.typecheck_only = true;
       } else if (arg.contains("FORTESTING=true")) {
         runner.is_production_env = false;
-      } else if (arg.contains("PSEUDO_NAMES=true")) {
-        runner.pseudo_names = true;
       }
     }
 

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -20,6 +20,7 @@ const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
 const log = require('fancy-log');
+const sleep = require('sleep-promise');
 const {
   buildExtensions,
   extensionAliasFilePath,
@@ -58,7 +59,7 @@ const {isTravisBuild} = require('../travis');
 const {maybeUpdatePackages} = require('./update-packages');
 const {VERSION} = require('../internal-version');
 
-const {green, cyan} = colors;
+const {green, cyan, bold, yellow} = colors;
 const argv = require('minimist')(process.argv.slice(2));
 
 const babel = require('@babel/core');
@@ -98,6 +99,13 @@ function transferSrcsToTempDir() {
  * @return {!Promise}
  */
 async function dist() {
+  if (argv.pseudo_names) {
+    log(
+      bold(yellow('--pseudo_names is deprecated, Please use --debug instead.'))
+    );
+    // Give a 3 second delay for user to see the warning.
+    await sleep(3000);
+  }
   maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -444,7 +444,7 @@ module.exports = {
 
 dist.description = 'Build production binaries';
 dist.flags = {
-  pseudo_names:
+  debug:
     '  Compiles with readable names. ' +
     'Great for profiling and debugging production code.',
   pretty_print:


### PR DESCRIPTION
since we removed the runner dependency for single pass, we werent able to generate pseudo names for debugging purposes. lets use --debug directly (CC option) to allow for this and remove the `--DEFINE='PSEUDO_NAMES=true'` indirection