### PR TITLE
🏗 Clean up deprecated closure compiler flags

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -259,10 +259,8 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
       // Turns on more optimizations.
       assume_function_wrapper: true,
-      /*
-       * Transpile from ES6 to ES5 if not running with `--esm`
-       * otherwise transpilation is done by Babel
-       */
+      // Transpile from ES6 to ES5 if not running with `--esm`
+      // otherwise transpilation is done by Babel
       language_in: 'ECMASCRIPT6',
       language_out: argv.esm ? 'NO_TRANSPILE' : 'ECMASCRIPT5',
       // We do not use the polyfills provided by closure compiler.
@@ -282,7 +280,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       process_common_js_modules: true,
       // This strips all files from the input set that aren't explicitly
       // required.
-      only_closure_dependencies: true,
+      dependency_mode: 'PRUNE',
       output_wrapper: wrapper,
       source_map_include_content: !!argv.full_sourcemaps,
       source_map_location_mapping: '|' + sourceMapBase,

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -113,7 +113,7 @@ exports.getFlags = function(config) {
     // to `_` and everything imported across modules is is accessed through `_`.
     rename_prefix_namespace: '_',
     language_out: config.language_out || 'ES5',
-    module_output_path_prefix: config.writeTo || 'out/',
+    chunk_output_path_prefix: config.writeTo || 'out/',
     module_resolution: 'NODE',
     process_common_js_modules: true,
     externs: config.externs,
@@ -210,7 +210,7 @@ exports.getBundleFlags = function(g) {
         name,
       };
     }
-    // And now build --module $name:$numberOfJsFiles:$bundleDeps
+    // And now build --chunk $name:$numberOfJsFiles:$bundleDeps
     let cmd = name + ':' + bundle.modules.length;
     const bundleDeps = [];
     if (!isMain) {
@@ -229,7 +229,7 @@ exports.getBundleFlags = function(g) {
         }
       }
     }
-    flagsArray.push('--module', cmd);
+    flagsArray.push('--chunk', cmd);
     if (bundleKeys.length > 1) {
       function massageWrapper(w) {
         return w.replace('<%= contents %>', '%s');
@@ -244,7 +244,7 @@ exports.getBundleFlags = function(g) {
         const configEntry = getExtensionBundleConfig(originalName);
         const marker = configEntry ? SPLIT_MARKER : '';
         flagsArray.push(
-          '--module_wrapper',
+          '--chunk_wrapper',
           name +
             ':' +
             massageWrapper(


### PR DESCRIPTION
#23759 upgraded closure compiler to v20190729. With this, it's time to clean up a few flags:

- `--only_closure_dependencies` has been [deprecated](https://github.com/google/closure-compiler/blob/maven-v20190729/src/com/google/javascript/jscomp/CommandLineRunner.java#L610-L616) in favor of `--dependency_mode=PRUNE`
- `--module` has been [replaced](https://github.com/google/closure-compiler/blob/maven-v20190729/src/com/google/javascript/jscomp/CommandLineRunner.java#L274-L286) by `--chunk`
- `--module_wrapper` has been [replaced](https://github.com/google/closure-compiler/blob/maven-v20190729/src/com/google/javascript/jscomp/CommandLineRunner.java#L365-L375) by `--chunk_wrapper`
- `--module_output_path_prefix` has been [replaced](https://github.com/google/closure-compiler/blob/maven-v20190729/src/com/google/javascript/jscomp/CommandLineRunner.java#L377-L382) by `--chunk_output_path_prefix`
