### PR TITLE
:sparkles: Added support of consent macros in Criteo callout url

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -121,7 +121,7 @@ export const RTC_VENDORS = {
       'PUBLISHER_SUB_ID',
       'LINE_ITEM_RANGES',
       'CONSENT_STATE',
-      'CONSENT_STRING'
+      'CONSENT_STRING',
     ],
     disableKeyAppend: true,
   },

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -114,8 +114,8 @@ export const RTC_VENDORS = {
   },
   criteo: {
     url:
-      'https://bidder.criteo.com/amp/rtc?zid=ZONE_ID&nid=NETWORK_ID&psubid=PUBLISHER_SUB_ID&lir=LINE_ITEM_RANGES&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&timeout=TIMEOUT&curl=CANONICAL_URL&href=HREF',
-    macros: ['ZONE_ID', 'NETWORK_ID', 'PUBLISHER_SUB_ID', 'LINE_ITEM_RANGES'],
+      'https://bidder.criteo.com/amp/rtc?zid=ZONE_ID&nid=NETWORK_ID&psubid=PUBLISHER_SUB_ID&lir=LINE_ITEM_RANGES&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&timeout=TIMEOUT&curl=CANONICAL_URL&href=HREF&cst=CONSENT_STATE&cst_str=CONSENT_STRING',
+    macros: ['ZONE_ID', 'NETWORK_ID', 'PUBLISHER_SUB_ID', 'LINE_ITEM_RANGES', 'CONSENT_STATE', 'CONSENT_STRING'],
     disableKeyAppend: true,
   },
   navegg: {

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -115,7 +115,14 @@ export const RTC_VENDORS = {
   criteo: {
     url:
       'https://bidder.criteo.com/amp/rtc?zid=ZONE_ID&nid=NETWORK_ID&psubid=PUBLISHER_SUB_ID&lir=LINE_ITEM_RANGES&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&timeout=TIMEOUT&curl=CANONICAL_URL&href=HREF&cst=CONSENT_STATE&cst_str=CONSENT_STRING',
-    macros: ['ZONE_ID', 'NETWORK_ID', 'PUBLISHER_SUB_ID', 'LINE_ITEM_RANGES', 'CONSENT_STATE', 'CONSENT_STRING'],
+    macros: [
+      'ZONE_ID',
+      'NETWORK_ID',
+      'PUBLISHER_SUB_ID',
+      'LINE_ITEM_RANGES',
+      'CONSENT_STATE',
+      'CONSENT_STRING'
+    ],
     disableKeyAppend: true,
   },
   navegg: {


### PR DESCRIPTION
Mapped the CONSENT_STATE & CONSENT_STRING macros into the Criteo callout URL.