### PR TITLE
amp-bind: Rate-limit history operations

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -422,7 +422,7 @@ export class Bind {
       if (op === HistoryOp.REPLACE) {
         // Skip consecutive "replace" operations.
         const next = this.historyQueue_[i + 1];
-        if (next && next.operation === HistoryOp.REPLACE) {
+        if (next && next.op === HistoryOp.REPLACE) {
           continue;
         }
         this.history_.replace(data);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -424,9 +424,9 @@ export class Bind {
     let enqueue = true;
 
     // Collapse if consecutive "replace" operations.
-    if (task.op === HistoryOp.REPLACE) {
+    if (task.op === HistoryOp.REPLACE && this.historyQueue_.length > 0) {
       const lastTask = this.historyQueue_[this.historyQueue_.length - 1];
-      if (lastTask && lastTask.op === HistoryOp.REPLACE) {
+      if (lastTask.op === HistoryOp.REPLACE) {
         lastTask.data = task.data;
         enqueue = false;
       }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -374,7 +374,10 @@ export class Bind {
       .then(() => {
         return this.getDataForHistory_().then(data => {
           if (data) {
-            this.historyQueue_.push({op: HistoryOp.REPLACE, data});
+            // Use deep copy of `data` so subsequent modifications won't
+            // affect the stored object reference.
+            const copy = this.copyJsonObject_(data);
+            this.historyQueue_.push({op: HistoryOp.REPLACE, data: copy});
             // Debounce flush queue on "replace" to rate limit History.replace.
             this.debouncedFlushHistoryQueue_();
           }
@@ -407,12 +410,10 @@ export class Bind {
       const onPop = () => this.setState(oldState);
       return this.setState(result).then(() => {
         return this.getDataForHistory_().then(data => {
-          if (data) {
-            this.historyQueue_.push({op: HistoryOp.PUSH, data, onPop});
-            // Immediately flush queue on "push" to avoid adding latency to
-            // the browser "back" functionality.
-            this.flushHistoryQueue_();
-          }
+          this.historyQueue_.push({op: HistoryOp.PUSH, data, onPop});
+          // Immediately flush queue on "push" to avoid adding latency to
+          // the browser "back" functionality.
+          this.flushHistoryQueue_();
         });
       });
     });

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -858,7 +858,10 @@ describe
               return promise.then(() => {
                 expect(history.push).to.be.called;
                 // `data` param should be null on untrusted viewers.
-                expect(history.push).to.be.calledWith(sinon.match.func, null);
+                expect(history.push).to.be.calledWith(
+                  sinon.match.func,
+                  undefined
+                );
               });
             });
           });

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -907,6 +907,21 @@ describe
               });
             });
 
+            it('should collapse consecutive replaces', async () => {
+              await bind.setStateWithExpression('{foo: 1}', {});
+              await bind.setStateWithExpression('{foo: 2}', {});
+
+              expect(history.replace).to.not.be.called;
+
+              clock.tick(1000);
+
+              expect(history.replace).calledOnce;
+              expect(history.replace).calledWith({
+                data: {'amp-bind': {foo: 2}},
+                title: '',
+              });
+            });
+
             it('should flush history immediately after push', async () => {
               await bind.setStateWithExpression('{foo: 1}', {});
 


### PR DESCRIPTION
Fixes #17969.

- Use a queue to store history replace/push. 
- Debounce queue flushes on replace but immediately flush on push.
- Collapse consecutive queued replaces.