### PR TITLE
AdSense/Doubleclick Fast Fetch 15k URL length

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -37,7 +37,7 @@ import {whenUpgradedToCustomElement} from '../../../src/dom';
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
 
 /** @const {number} */
-const MAX_URL_LENGTH = 16384;
+const MAX_URL_LENGTH = 15360;
 
 /** @enum {string} */
 const AmpAdImplementation = {


### PR DESCRIPTION
For AdSense/Doubleclick fast fetch, reduce max URL length (after which it will be truncated with &trunc=1 appended) from 16k to 15k to allow for length of headers in the ad request.