### PR TITLE
[hidden] should be in shared CSS

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -54,16 +54,6 @@ body {
 }
 
 /**
- * We intentionally break with HTML5's default [hidden] styling to apply
- * !important.
- */
-[hidden] {
-  /* This must be !important, else the toggle helper system would break down
-     due to specificity */
-  display: none !important;
-}
-
-/**
  * The enables passive touch handlers, e.g. for document swipe, since they
  * no will longer need to try to cancel vertical scrolls during swipes.
  * This is only done in the embedded mode because (a) the document swipe

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
+/**
+ * We intentionally break with HTML5's default [hidden] styling to apply
+ * !important.
+ */
+[hidden] {
+  /* This must be !important, else the toggle helper system would break down
+     due to specificity */
+  display: none !important;
+}
+
 .i-amphtml-element {
   display: inline-block;
 }
-
 
 .i-amphtml-blurry-placeholder {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;


### PR DESCRIPTION
This broke light box ads.

Problem get surfaced after the inabox-css-cleanup launch. (#23819  Not in canary yet. It's in the recent cut https://github.com/ampproject/amphtml/releases/tag/untagged-3e6b3211ec8f7e5ab371)