### PR TITLE
Revert "Fully launch inabox-css-cleanup"

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -3,6 +3,7 @@
     "amp-next-page",
     "disable-amp-story-desktop",
     "inabox-viewport-friendly",
+    "inabox-css-cleanup",
     "inabox-no-chunking"
   ],
   "allow-url-opt-in": [

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -3,6 +3,7 @@
     "amp-next-page",
     "disable-amp-story-desktop",
     "inabox-viewport-friendly",
+    "inabox-css-cleanup",
     "inabox-no-chunking"
   ],
   "allow-url-opt-in": [

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -22,6 +22,7 @@ import '../polyfills';
 import {Navigation} from '../service/navigation';
 import {Services} from '../services';
 import {adopt} from '../runtime';
+import {cssText as ampDocCss} from '../../build/ampdoc.css';
 import {cssText as ampSharedCss} from '../../build/ampshared.css';
 import {deactivateChunking, startupChunk} from '../chunk';
 import {doNotTrackImpression} from '../impression';
@@ -82,10 +83,14 @@ startupChunk(self.document, function initial() {
   perf.tick('is');
 
   self.document.documentElement.classList.add('i-amphtml-inabox');
+  const fullCss =
+    (isExperimentOn(self, 'inabox-css-cleanup')
+      ? ampSharedCss
+      : ampDocCss + ampSharedCss) +
+    'html.i-amphtml-inabox{width:100%!important;height:100%!important}';
   installStylesForDoc(
     ampdoc,
-    ampSharedCss +
-      'html.i-amphtml-inabox{width:100%!important;height:100%!important}',
+    fullCss,
     () => {
       startupChunk(self.document, function services() {
         // Core services.

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -347,6 +347,14 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/22418',
   },
   {
+    id: 'inabox-css-cleanup',
+    name:
+      'Experiment to prevent regression after a major CSS clean up' +
+      ' for AMPHTML Ads in inabox rendering mode',
+    spec: 'https://github.com/ampproject/amphtml/issues/22418',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/22418',
+  },
+  {
     id: 'inabox-no-chunking',
     name: 'Experiment to disable startup chunking in inabox runtime',
     spec: 'https://github.com/ampproject/amphtml/issues/23573',


### PR DESCRIPTION
Reverts ampproject/amphtml#23819

lightbox ads is broken. See #23946 as a fix. But obviously we are lacking e2e/visual tests for this. Let's unlaunch first.
