### PR TITLE
⏪  Add test vendor json to compilation

### DIFF
--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -44,7 +44,8 @@ function compileVendorConfigs(opt_options) {
   const srcPath = ['extensions/amp-analytics/0.1/vendors/*.json'];
   const destPath = 'dist/v0/analytics-vendors/';
 
-  if (argv.fortesting) {
+  // ignore test json if not fortesting
+  if (!argv.fortesting) {
     srcPath.push('!extensions/amp-analytics/0.1/vendors/_fake_.json');
   }
 

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const minimist = require('minimist');
+const argv = minimist(process.argv.slice(2));
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const gulpWatch = require('gulp-watch');
@@ -39,8 +41,12 @@ async function vendorConfigs() {
 function compileVendorConfigs(opt_options) {
   const options = opt_options || {};
 
-  const srcPath = 'extensions/amp-analytics/0.1/vendors/*.json';
+  const srcPath = ['extensions/amp-analytics/0.1/vendors/*.json'];
   const destPath = 'dist/v0/analytics-vendors/';
+
+  if (argv.fortesting) {
+    srcPath.push('!extensions/amp-analytics/0.1/vendors/_fake_.json');
+  }
 
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -39,10 +39,7 @@ async function vendorConfigs() {
 function compileVendorConfigs(opt_options) {
   const options = opt_options || {};
 
-  const srcPath = [
-    'extensions/amp-analytics/0.1/vendors/*.json',
-    '!extensions/amp-analytics/0.1/vendors/_fake_.json', // ignore test json
-  ];
+  const srcPath = 'extensions/amp-analytics/0.1/vendors/*.json';
   const destPath = 'dist/v0/analytics-vendors/';
 
   if (options.watch) {


### PR DESCRIPTION
Add the test vendor JSON `_fake_.json` into the final build because some integration tests rely on this. Specifically `test/integration/test-amp-analytics.js`

cc @zhouyx for review :)