### PR TITLE
✨ Make tweet id a bindable attribute

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -313,6 +313,9 @@ function createElementRules_() {
       'datetime': null,
       'title': null,
     },
+    'AMP-TWITTER': {
+      'data-tweetid': null,
+    },
     'AMP-VIDEO': {
       'alt': null,
       'attribution': null,

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -489,6 +489,11 @@ Only binding to the following components and attributes are allowed:
     <td>Fetches JSON from the new URL and merges it into the existing state. <em>Note the following update will ignore <code>&lt;amp-state&gt;</code> elements to prevent cycles.</em></td>
   </tr>
   <tr>
+    <td><code>&lt;amp-twitter&gt;</code></td>
+    <td><code>[data-tweetid]</code></td>
+    <td>Changes the displayed Tweet.</td>
+  </tr>
+  <tr>
     <td><code>&lt;amp-video&gt;</code></td>
     <td><code>[alt]</code><br><code>[attribution]</code><br><code>[controls]</code><br><code>[loop]</code><br><code>[poster]</code><br><code>[preload]</code><br><code>[src]</code></td>
     <td>See corresponding <a href="https://www.ampproject.org/docs/reference/components/media/amp-video#attributes">amp-video attributes</a>.</td>

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -124,7 +124,6 @@ class AmpTwitter extends AMP.BaseElement {
       if (this.userPlaceholder_) {
         this.togglePlaceholder(false);
       }
-
       this./*OK*/ changeHeight(height);
     });
   }

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -120,15 +120,17 @@ class AmpTwitter extends AMP.BaseElement {
    */
   updateForSuccessState_(height) {
     this.mutateElement(() => {
+      this.toggleLoading(false);
       if (this.userPlaceholder_) {
         this.togglePlaceholder(false);
       }
+
       this./*OK*/ changeHeight(height);
     });
   }
 
   /**
-   * Updates wheen the tweet that failed to load. This uses the fallback
+   * Updates when the tweet failed to load. This uses the fallback
    * provided if available. If not, it uses the user specified placeholder.
    * @private
    */
@@ -137,6 +139,7 @@ class AmpTwitter extends AMP.BaseElement {
     const content = fallback || this.userPlaceholder_;
 
     this.mutateElement(() => {
+      this.toggleLoading(false);
       if (fallback) {
         this.togglePlaceholder(false);
         this.toggleFallback(true);
@@ -146,6 +149,14 @@ class AmpTwitter extends AMP.BaseElement {
         this./*OK*/ changeHeight(content./*OK*/ offsetHeight);
       }
     });
+  }
+
+  /**
+   * amp-twitter reuses the loading indicator when id changes via bind mutation
+   * @override
+   */
+  isLoadingReused() {
+    return true;
   }
 
   /** @override */
@@ -181,6 +192,15 @@ class AmpTwitter extends AMP.BaseElement {
       this.iframe_ = null;
     }
     return true;
+  }
+
+  /** @override */
+  mutatedAttributesCallback(mutations) {
+    if (this.iframe_ && mutations['data-tweetid'] != null) {
+      this.unlayoutCallback();
+      this.toggleLoading(true, /* opt_force */ true);
+      this.layoutCallback();
+    }
   }
 }
 

--- a/extensions/amp-twitter/0.1/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/0.1/test/test-amp-twitter.js
@@ -128,6 +128,18 @@ describes.realWin(
       });
     });
 
+    it('should replace iframe after tweetid mutation', () => {
+      const newTweetId = '638793490521001985';
+      return getAmpTwitter(tweetId).then(ampTwitter => {
+        const spy = sandbox.spy(ampTwitter.implementation_, 'toggleLoading');
+        const iframe = ampTwitter.querySelector('iframe');
+        ampTwitter.setAttribute('data-tweetid', newTweetId);
+        ampTwitter.mutatedAttributesCallback({'data-tweetid': newTweetId});
+        expect(spy).to.be.calledWith(true);
+        expect(ampTwitter.querySelector('iframe')).to.not.equal(iframe);
+      });
+    });
+
     describe('cleanupTweetId_', () => {
       it('does not affect valid tweet ids', () => {
         const good = '585110598171631616';


### PR DESCRIPTION
Resolves #17953 

Allow mutation of `data-tweetid` in amp-twitter via amp-bind so that displayed tweet can be changed dynamically.

/to @cathyxz 