### PR TITLE
✅ Adds e2e tests for amp-selector

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -417,7 +417,6 @@ export class AmpSelector extends AMP.BaseElement {
       return Promise.resolve();
     }
 
-    // TODO(wassgha, #23820): Add an e2e test to catch race conditions here
     // There is a change of the `selected` attribute for the element
     return this.mutateElement(() => {
       if (selectedIndex !== index) {

--- a/extensions/amp-selector/0.1/test-e2e/test-amp-selector-tabs.js
+++ b/extensions/amp-selector/0.1/test-e2e/test-amp-selector-tabs.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'amp-selector',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-selector/amp-selector-tabs.html',
+    environments: ['single', 'viewer-demo'],
+  },
+  async env => {
+    let controller;
+
+    beforeEach(() => {
+      controller = env.controller;
+    });
+
+    it('should render correctly', async () => {
+      const selector = await controller.findElement('#tabs');
+
+      await expect(controller.getElementAttribute(selector, 'role')).to.equal(
+        'tablist'
+      );
+
+      const firstTab = await controller.findElement('#tab1Selector');
+      await expect(controller.getElementAttribute(firstTab, 'selected')).to
+        .exist;
+
+      const image = await controller.findElement('#firstImage');
+      await expect(
+        controller.getElementProperty(image, 'clientWidth')
+      ).to.be.greaterThan(0);
+
+      const internalImg = await controller.findElement('#firstImage img');
+      await expect(internalImg).to.exist;
+    });
+
+    it('should switch tabs on button click', async () => {
+      const secondTab = await controller.findElement('#tab2Selector');
+      await expect(controller.getElementAttribute(secondTab, 'selected')).to.not
+        .exist;
+
+      await controller.click(secondTab);
+      await expect(controller.getElementAttribute(secondTab, 'selected')).to
+        .exist;
+
+      const image = await controller.findElement('#secondImage');
+      await expect(
+        controller.getElementProperty(image, 'clientWidth')
+      ).to.be.greaterThan(0);
+
+      const internalImg = await controller.findElement('#secondImage img');
+      await expect(internalImg).to.exist;
+    });
+
+    it('should switch tabs on toggle ', async () => {
+      const thirdTabToggle = await controller.findElement('#tab3Toggle');
+      const thirdTab = await controller.findElement('#tab3Selector');
+      await expect(controller.getElementAttribute(thirdTab, 'selected')).to.not
+        .exist;
+
+      await controller.click(thirdTabToggle);
+      await expect(controller.getElementAttribute(thirdTab, 'selected')).to
+        .exist;
+
+      const image = await controller.findElement('#thirdImage');
+      await expect(
+        controller.getElementProperty(image, 'clientWidth')
+      ).to.be.greaterThan(0);
+
+      const internalImg = await controller.findElement('#thirdImage img');
+      await expect(internalImg).to.exist;
+    });
+  }
+);

--- a/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
+++ b/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
@@ -61,11 +61,11 @@
 
         <amp-selector id="tabs" class="tabs-with-flex" role="tablist">
           <div id="tab1Selector" role="tab" aria-controls="tab1Selector" option selected>Tab one</div>
-          <div id="tab1Content" role="tabpanel" aria-labelledby="tab1Content">Tab one content... <amp-img src="https://picsum.photos/id/1001/200/200" width="200" height="200" layout="fixed" id="firstImage"></amp-img></div>
+          <div id="tab1Content" role="tabpanel" aria-labelledby="tab1Content">Tab one content... <amp-img src="/examples/img/sample.jpg" width="200" height="200" layout="fixed" id="firstImage"></amp-img></div>
           <div id="tab2Selector" role="tab" aria-controls="tab2Selector" option>Tab two</div>
-          <div id="tab2Content" role="tabpanel" aria-labelledby="tab2Content">Tab two content... <amp-img src="https://picsum.photos/id/1003/200/200" width="200" height="200" layout="fixed" id="secondImage"></amp-img></div>
+          <div id="tab2Content" role="tabpanel" aria-labelledby="tab2Content">Tab two content... <amp-img src="/examples/img/sample.jpg" width="200" height="200" layout="fixed" id="secondImage"></amp-img></div>
           <div id="tab3Selector" role="tab" aria-controls="tab3Selector" option>Tab three</div>
-          <div id="tab3Content" role="tabpanel" aria-labelledby="tab3Content">Tab three content... <amp-img src="https://picsum.photos/id/1005/200/200" width="200" height="200" layout="fixed" id="thirdImage"></amp-img></div>
+          <div id="tab3Content" role="tabpanel" aria-labelledby="tab3Content">Tab three content... <amp-img src="/examples/img/sample.jpg" width="200" height="200" layout="fixed" id="thirdImage"></amp-img></div>
         </amp-selector>
       </div>
   </body>

--- a/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
+++ b/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8">
+    
+    <title>amp-selector</title>
+    <link rel="canonical" href="//example.com" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
+    <style amp-custom>
+        :root {
+          --color-primary: #005AF0;
+          --space-1: .5rem;  /* 8px */
+          --space-4: 2rem;   /* 32px */
+        }
+        /* Styles for the flex layout based tabs */
+        amp-selector[role=tablist].tabs-with-flex {
+            display: flex;
+            flex-wrap: wrap;
+        }
+        amp-selector[role=tablist].tabs-with-flex [role=tab] {
+            flex-grow: 1;
+            /* custom styling, feel free to change */
+            text-align: center;
+            padding: var(--space-1);
+        }
+        amp-selector[role=tablist].tabs-with-flex [role=tab][selected] {
+            outline: none;
+            /* custom styling, feel free to change */
+            border-bottom: 2px solid var(--color-primary);
+        }
+        amp-selector[role=tablist].tabs-with-flex [role=tabpanel] {
+            display: none;
+            width: 100%;
+            order: 1; /* must be greater than the order of the tab buttons to flex to the next line */
+            /* custom styling, feel free to change */
+            padding: var(--space-4);
+        }
+        amp-selector[role=tablist].tabs-with-flex [role=tab][selected] + [role=tabpanel] {
+            display: block;
+        }
+        amp-selector.tabpanels [role=tabpanel] {
+          display: none;
+          /* custom styling, feel free to change */
+          padding: var(--space-4);
+        }
+        amp-selector.tabpanels [role=tabpanel][selected] {
+          outline: none;
+          display: block;
+        }
+    </style>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+  <body>
+      <div>
+        <button id="tab1Toggle" on="tap:tabs.toggle(index=0, value=true)">Select tab 1</button>
+        <button id="tab2Toggle" on="tap:tabs.toggle(index=1, value=true)">Select tab 2</button>
+        <button id="tab3Toggle" on="tap:tabs.toggle(index=2, value=true)">Select tab 3</button>
+
+        <amp-selector id="tabs" class="tabs-with-flex" role="tablist">
+          <div id="tab1Selector" role="tab" aria-controls="tab1Selector" option selected>Tab one</div>
+          <div id="tab1Content" role="tabpanel" aria-labelledby="tab1Content">Tab one content... <amp-img src="https://picsum.photos/id/1001/200/200" width="200" height="200" layout="fixed" id="firstImage"></amp-img></div>
+          <div id="tab2Selector" role="tab" aria-controls="tab2Selector" option>Tab two</div>
+          <div id="tab2Content" role="tabpanel" aria-labelledby="tab2Content">Tab two content... <amp-img src="https://picsum.photos/id/1003/200/200" width="200" height="200" layout="fixed" id="secondImage"></amp-img></div>
+          <div id="tab3Selector" role="tab" aria-controls="tab3Selector" option>Tab three</div>
+          <div id="tab3Content" role="tabpanel" aria-labelledby="tab3Content">Tab three content... <amp-img src="https://picsum.photos/id/1005/200/200" width="200" height="200" layout="fixed" id="thirdImage"></amp-img></div>
+        </amp-selector>
+      </div>
+  </body>
+</html>


### PR DESCRIPTION
Closes #23820 , Related to https://github.com/ampproject/amphtml/pull/23688#pullrequestreview-270935715 in #23688

## Changes
- Adds e2e tests that would've caught the issue of children not rendering correctly when toggling with `amp-selector`