### PR TITLE
Revert "Set the new loaders experiment to 1% of traffic."

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -40,7 +40,6 @@
   "ios-fixed-no-transfer": 1,
   "ios-scrollable-iframe": 0,
   "layers": 1,
-  "new-loaders": 1,
   "pump-early-frame": 1,
   "version-locking": 1,
   "macro-after-long-task": 1

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,7 +37,6 @@
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "ios-scrollable-iframe": 0,
-  "new-loaders": 0.01,
   "pump-early-frame": 1,
   "version-locking": 1
 }


### PR DESCRIPTION
Reverts ampproject/amphtml#23780

This has a race condition where the default placeholder may not be removed with amp-img and potentially other components.

Fixes #23964