### PR TITLE
🚮 Disable layers in production

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -39,7 +39,6 @@
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 1,
   "ios-scrollable-iframe": 0,
-  "layers": 1,
   "new-loaders": 1,
   "pump-early-frame": 1,
   "version-locking": 1,

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -20,10 +20,10 @@ import {BaseCarousel} from './base-carousel';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
-import {getMode} from '../../../src/mode';
 
 /** @const {string} */
 const TAG = 'amp-scrollable-carousel';
@@ -66,7 +66,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.element.appendChild(this.container_);
 
     this.useLayersPrioritization_ =
-      (getMode().localDev || getMode().test) &&
+      getMode().localDev &&
       isExperimentOn(this.win, 'layers') &&
       isExperimentOn(this.win, 'layers-prioritization');
 

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -23,6 +23,7 @@ import {dev} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
+import {getMode} from '../../../src/mode';
 
 /** @const {string} */
 const TAG = 'amp-scrollable-carousel';
@@ -48,7 +49,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.scrollTimerId_ = null;
 
     /** @private {boolean} */
-    this.useLayers_ = false;
+    this.useLayersPrioritization_ = false;
   }
 
   /** @override */
@@ -64,12 +65,13 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');
     this.element.appendChild(this.container_);
 
-    this.useLayers_ =
+    this.useLayersPrioritization_ =
+      (getMode().localDev || getMode().test) &&
       isExperimentOn(this.win, 'layers') &&
       isExperimentOn(this.win, 'layers-prioritization');
 
     this.cells_.forEach(cell => {
-      if (!this.useLayers_) {
+      if (!this.useLayersPrioritization_) {
         Services.ownersForDoc(this.element).setOwner(cell, this.element);
       }
       cell.classList.add('amp-carousel-slide');
@@ -93,7 +95,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
       ActionTrust.LOW
     );
 
-    if (this.useLayers_) {
+    if (this.useLayersPrioritization_) {
       this.declareLayer(this.container_);
     }
   }
@@ -112,7 +114,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   layoutCallback() {
-    if (!this.useLayers_) {
+    if (!this.useLayersPrioritization_) {
       this.doLayout_(this.pos_);
       this.preloadNext_(this.pos_, 1);
     }
@@ -122,7 +124,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   onViewportCallback(unusedInViewport) {
-    if (!this.useLayers_) {
+    if (!this.useLayersPrioritization_) {
       this.updateInViewport_(this.pos_, this.pos_);
     }
   }
@@ -263,7 +265,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    * @private
    */
   commitSwitch_(pos) {
-    if (!this.useLayers_) {
+    if (!this.useLayersPrioritization_) {
       this.updateInViewport_(pos, this.oldPos_);
       this.doLayout_(pos);
       this.preloadNext_(pos, Math.sign(pos - this.oldPos_));

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -48,8 +48,11 @@ export class AmpScrollableCarousel extends BaseCarousel {
     /** @private {?number} */
     this.scrollTimerId_ = null;
 
-    /** @private {boolean} */
-    this.useLayersPrioritization_ = false;
+    /** @private @const {boolean} */
+    this.useLayersPrioritization_ =
+      getMode().localDev &&
+      isExperimentOn(this.win, 'layers') &&
+      isExperimentOn(this.win, 'layers-prioritization');
   }
 
   /** @override */
@@ -64,11 +67,6 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');
     this.element.appendChild(this.container_);
-
-    this.useLayersPrioritization_ =
-      getMode().localDev &&
-      isExperimentOn(this.win, 'layers') &&
-      isExperimentOn(this.win, 'layers-prioritization');
 
     this.cells_.forEach(cell => {
       if (!this.useLayersPrioritization_) {

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -26,6 +26,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
+import {getMode} from '../../../src/mode';
 
 export class AmpImageSlider extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -103,6 +104,12 @@ export class AmpImageSlider extends AMP.BaseElement {
 
     /** @public {boolean} */
     this.isEventRegistered = false; // for test purpose
+
+    /** @private @const {boolean} */
+    this.useLayersPrioritization_ =
+      (getMode().localDev || getMode().test) &&
+      isExperimentOn(this.win, 'layers') &&
+      isExperimentOn(this.win, 'layers-prioritization');
   }
 
   /** @override */
@@ -145,10 +152,7 @@ export class AmpImageSlider extends AMP.BaseElement {
     );
 
     // TODO(kqian): remove this after layer launch
-    if (
-      !isExperimentOn(this.win, 'layers') ||
-      !isExperimentOn(this.win, 'layers-prioritization')
-    ) {
+    if (!this.useLayersPrioritization_) {
       // see comment in layoutCallback
       // When layers not enabled
       const owners = Services.ownersForDoc(this.element);

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -22,11 +22,11 @@ import {Services} from '../../../src/services';
 import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '../../../src/utils/math';
 import {dev, user, userAssert} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
-import {getMode} from '../../../src/mode';
 
 export class AmpImageSlider extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -107,7 +107,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
     /** @private @const {boolean} */
     this.useLayersPrioritization_ =
-      (getMode().localDev || getMode().test) &&
+      getMode().localDev &&
       isExperimentOn(this.win, 'layers') &&
       isExperimentOn(this.win, 'layers-prioritization');
   }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -23,9 +23,9 @@ import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
 import {Layout} from '../../../src/layout';
 import {childElementByAttr} from '../../../src/dom';
+import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {user, userAssert} from '../../../src/log';
-import {getMode} from '../../../src/mode';
 
 /**
  * @enum {string}
@@ -999,7 +999,7 @@ export class AmpLiveList extends AMP.BaseElement {
    * @return {boolean}
    */
   isElementBelowViewport_(element) {
-    if ((getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers')) {
+    if (getMode().localDev && isExperimentOn(this.win, 'layers')) {
       // Well, if the scroller is above the viewport, but the element is way
       // down in the box, is it above or below?
       return this.viewport_.getLayoutRect(element).top > 0;

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -25,6 +25,7 @@ import {Layout} from '../../../src/layout';
 import {childElementByAttr} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {user, userAssert} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 
 /**
  * @enum {string}
@@ -998,7 +999,7 @@ export class AmpLiveList extends AMP.BaseElement {
    * @return {boolean}
    */
   isElementBelowViewport_(element) {
-    if (isExperimentOn(this.win, 'layers')) {
+    if ((getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers')) {
       // Well, if the scroller is above the viewport, but the element is way
       // down in the box, is it above or below?
       return this.viewport_.getLayoutRect(element).top > 0;

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -1037,7 +1037,7 @@ export class BaseElement {
    */
   declareLayer(opt_element) {
     devAssert(
-      (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers'),
+      getMode().localDev && isExperimentOn(this.win, 'layers'),
       'Layers must be enabled to declare layer.'
     );
     if (opt_element) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -1037,7 +1037,7 @@ export class BaseElement {
    */
   declareLayer(opt_element) {
     devAssert(
-      isExperimentOn(this.win, 'layers'),
+      (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers'),
       'Layers must be enabled to declare layer.'
     );
     if (opt_element) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -854,7 +854,7 @@ function createBaseCustomElementClass(win) {
         // Resources can now be initialized since the ampdoc is now available.
         this.resources_ = Services.resourcesForDoc(this.ampdoc_);
       }
-      if ((getMode().localDev || getMode().test) && isExperimentOn(this.ampdoc_.win, 'layers')) {
+      if (getMode().localDev && isExperimentOn(this.ampdoc_.win, 'layers')) {
         if (!this.layers_) {
           // Resources can now be initialized since the ampdoc is now available.
           this.layers_ = Services.layersForDoc(this.ampdoc_);
@@ -1000,7 +1000,7 @@ function createBaseCustomElementClass(win) {
 
       this.isConnected_ = false;
       this.getResources().remove(this);
-      if ((getMode().localDev || getMode().test) && isExperimentOn(this.ampdoc_.win, 'layers')) {
+      if (getMode().localDev && isExperimentOn(this.ampdoc_.win, 'layers')) {
         this.getLayers().remove(this);
       }
       this.implementation_.detachedCallback();

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -854,7 +854,7 @@ function createBaseCustomElementClass(win) {
         // Resources can now be initialized since the ampdoc is now available.
         this.resources_ = Services.resourcesForDoc(this.ampdoc_);
       }
-      if (isExperimentOn(this.ampdoc_.win, 'layers')) {
+      if ((getMode().localDev || getMode().test) && isExperimentOn(this.ampdoc_.win, 'layers')) {
         if (!this.layers_) {
           // Resources can now be initialized since the ampdoc is now available.
           this.layers_ = Services.layersForDoc(this.ampdoc_);
@@ -1000,7 +1000,7 @@ function createBaseCustomElementClass(win) {
 
       this.isConnected_ = false;
       this.getResources().remove(this);
-      if (isExperimentOn(this.ampdoc_.win, 'layers')) {
+      if ((getMode().localDev || getMode().test) && isExperimentOn(this.ampdoc_.win, 'layers')) {
         this.getLayers().remove(this);
       }
       this.implementation_.detachedCallback();

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -21,6 +21,7 @@ import {ViewportBindingDef} from '../service/viewport/viewport-binding-def';
 import {ViewportImpl} from '../service/viewport/viewport-impl';
 import {canInspectWindow} from '../iframe-helper';
 import {dev, devAssert} from '../log';
+import {getMode} from '../mode';
 import {getPositionObserver} from '../../ads/inabox/position-observer';
 import {iframeMessagingClientFor} from './inabox-iframe-messaging-client';
 import {isExperimentOn} from '../experiments';
@@ -28,7 +29,6 @@ import {layoutRectLtwh, moveLayoutRect} from '../layout-rect';
 import {px, resetStyles, setImportantStyles} from '../style';
 import {registerServiceBuilderForDoc} from '../service';
 import {throttle} from '../utils/rate-limit';
-import {getMode} from '../mode';
 
 /** @const {string} */
 const TAG = 'inabox-viewport';
@@ -153,7 +153,7 @@ export class ViewportBindingInabox {
     );
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(this.win, 'layers');
 
     /** @private {?../../ads/inabox/position-observer.PositionObserver} */
     this.topWindowPositionObserver_ = null;

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -28,6 +28,7 @@ import {layoutRectLtwh, moveLayoutRect} from '../layout-rect';
 import {px, resetStyles, setImportantStyles} from '../style';
 import {registerServiceBuilderForDoc} from '../service';
 import {throttle} from '../utils/rate-limit';
+import {getMode} from '../mode';
 
 /** @const {string} */
 const TAG = 'inabox-viewport';
@@ -152,7 +153,7 @@ export class ViewportBindingInabox {
     );
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
 
     /** @private {?../../ads/inabox/position-observer.PositionObserver} */
     this.topWindowPositionObserver_ = null;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -19,6 +19,7 @@ import {Layout} from '../layout';
 import {Services} from '../services';
 import {computedStyle, toggle} from '../style';
 import {dev, devAssert} from '../log';
+import {getMode} from '../mode';
 import {isBlockedByConsent} from '../error';
 import {isExperimentOn} from '../experiments';
 import {
@@ -29,7 +30,6 @@ import {
 } from '../layout-rect';
 import {startsWith} from '../string';
 import {toWin} from '../types';
-import {getMode} from '../mode';
 
 const TAG = 'Resource';
 const RESOURCE_PROP_ = '__AMP__RESOURCE';
@@ -215,13 +215,12 @@ export class Resource {
     this.loadPromiseResolve_ = deferred.resolve;
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.hostWin, 'layers');
+    this.useLayers_ =
+      getMode().localDev && isExperimentOn(this.hostWin, 'layers');
 
     /** @private @const {boolean} */
-    this.useLayersPrioritization_ = this.useLayers_ && isExperimentOn(
-      this.hostWin,
-      'layers-prioritization'
-    );
+    this.useLayersPrioritization_ =
+      this.useLayers_ && isExperimentOn(this.hostWin, 'layers-prioritization');
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -29,6 +29,7 @@ import {
 } from '../layout-rect';
 import {startsWith} from '../string';
 import {toWin} from '../types';
+import {getMode} from '../mode';
 
 const TAG = 'Resource';
 const RESOURCE_PROP_ = '__AMP__RESOURCE';
@@ -214,10 +215,10 @@ export class Resource {
     this.loadPromiseResolve_ = deferred.resolve;
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.hostWin, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.hostWin, 'layers');
 
     /** @private @const {boolean} */
-    this.useLayersPrioritization_ = isExperimentOn(
+    this.useLayersPrioritization_ = this.useLayers_ && isExperimentOn(
       this.hostWin,
       'layers-prioritization'
     );
@@ -749,7 +750,7 @@ export class Resource {
 
   /** @return {!ViewportRatioDef} */
   getDistanceViewportRatio() {
-    if (this.useLayers_ && this.useLayersPrioritization_) {
+    if (this.useLayersPrioritization_) {
       const {element} = this;
       return {
         distance: element
@@ -811,7 +812,7 @@ export class Resource {
     }
     const {distance, scrollPenalty, viewportHeight} =
       opt_viewportRatio || this.getDistanceViewportRatio();
-    if (this.useLayers_ && this.useLayersPrioritization_) {
+    if (this.useLayersPrioritization_) {
       return dev().assertNumber(distance) < multiplier;
     }
     if (typeof distance == 'boolean') {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -27,6 +27,7 @@ import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {computedStyle} from '../style';
 import {dev, devAssert, user} from '../log';
 import {dict, hasOwn} from '../utils/object';
+import {getMode} from '../mode';
 import {getSourceUrl, isProxyOrigin} from '../url';
 import {checkAndFix as ieMediaCheckAndFix} from './ie-media-bug';
 import {isArray} from '../types';
@@ -35,7 +36,6 @@ import {isExperimentOn} from '../experiments';
 import {loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
-import {getMode} from '../mode';
 
 const TAG_ = 'Resources';
 const READY_SCAN_SIGNAL_ = 'ready-scan';
@@ -403,13 +403,11 @@ export class Resources {
     this.queue_ = new TaskQueue();
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(this.win, 'layers');
 
     /** @private @const {boolean} */
-    this.useLayersPrioritization_ = this.useLayers_ && isExperimentOn(
-      this.win,
-      'layers-prioritization'
-    );
+    this.useLayersPrioritization_ =
+      this.useLayers_ && isExperimentOn(this.win, 'layers-prioritization');
 
     let boundScorer;
     if (this.useLayersPrioritization_) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -35,6 +35,7 @@ import {isExperimentOn} from '../experiments';
 import {loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
+import {getMode} from '../mode';
 
 const TAG_ = 'Resources';
 const READY_SCAN_SIGNAL_ = 'ready-scan';
@@ -402,16 +403,16 @@ export class Resources {
     this.queue_ = new TaskQueue();
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
 
     /** @private @const {boolean} */
-    this.useLayersPrioritization_ = isExperimentOn(
+    this.useLayersPrioritization_ = this.useLayers_ && isExperimentOn(
       this.win,
       'layers-prioritization'
     );
 
     let boundScorer;
-    if (this.useLayers_ && this.useLayersPrioritization_) {
+    if (this.useLayersPrioritization_) {
       boundScorer = this.calcTaskScoreLayers_.bind(this);
     } else {
       boundScorer = this.calcTaskScore_.bind(this);

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -33,6 +33,7 @@ import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
 import {waitForBodyOpen} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
+import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -170,7 +171,7 @@ export class ViewportBindingIosEmbedShadowRoot_ {
     this.boundResizeEventListener_ = this.onResized_.bind(this);
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
 
     /** @private {boolean} */
     this.bodySyncScheduled_ = false;

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -28,12 +28,12 @@ import {
   setInitialDisplay,
 } from '../../style';
 import {dev} from '../../log';
+import {getMode} from '../../mode';
 import {htmlFor} from '../../static-template';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
 import {waitForBodyOpen} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
-import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -171,7 +171,7 @@ export class ViewportBindingIosEmbedShadowRoot_ {
     this.boundResizeEventListener_ = this.onResized_.bind(this);
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(this.win, 'layers');
 
     /** @private {boolean} */
     this.bodySyncScheduled_ = false;

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -22,11 +22,11 @@ import {
 } from './viewport-binding-def';
 import {computedStyle, px, setImportantStyles} from '../../style';
 import {dev} from '../../log';
+import {getMode} from '../../mode';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
 import {waitForBodyOpen} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
-import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -75,7 +75,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(this.win, 'layers');
 
     /** @private {number} */
     this.paddingTop_ = 0;

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -26,6 +26,7 @@ import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
 import {waitForBodyOpen} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
+import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -74,7 +75,7 @@ export class ViewportBindingIosEmbedWrapper_ {
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
 
     /** @private {number} */
     this.paddingTop_ = 0;

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -22,9 +22,9 @@ import {
 } from './viewport-binding-def';
 import {computedStyle, px, setImportantStyles} from '../../style';
 import {dev} from '../../log';
+import {getMode} from '../../mode';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -68,7 +68,7 @@ export class ViewportBindingNatural_ {
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(this.win, 'layers');
 
     dev().fine(TAG_, 'initialized natural viewport');
   }

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -24,6 +24,7 @@ import {computedStyle, px, setImportantStyles} from '../../style';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
+import {getMode} from '../../mode';
 
 const TAG_ = 'Viewport';
 
@@ -67,7 +68,7 @@ export class ViewportBindingNatural_ {
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(this.win, 'layers');
 
     dev().fine(TAG_, 'initialized natural viewport');
   }

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -139,7 +139,7 @@ export class ViewportImpl {
     this.originalViewportMetaString_ = undefined;
 
     /** @private @const {boolean} */
-    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(win, 'layers');
+    this.useLayers_ = getMode().localDev && isExperimentOn(win, 'layers');
     if (this.useLayers_) {
       installLayersServiceForDoc(
         ampdoc,

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -139,7 +139,7 @@ export class ViewportImpl {
     this.originalViewportMetaString_ = undefined;
 
     /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(win, 'layers');
+    this.useLayers_ = (getMode().localDev || getMode().test) && isExperimentOn(win, 'layers');
     if (this.useLayers_) {
       installLayersServiceForDoc(
         ampdoc,


### PR DESCRIPTION
This disables layers unless you've locally built the AMP codebase (for manual testing) or are running in a test environment (automatic testing).

Pending our [go/layers-go-nogo](http://go/layers-go-nogo) decision.