### PR TITLE
Enable e2e tests for amp-lightbox for AMPHTML ads.

### DIFF
--- a/extensions/amp-lightbox/0.1/test-e2e/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/test-e2e/test-amp-lightbox.js
@@ -19,6 +19,7 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/fixtures/e2e/amp-lightbox/amp-lightbox.html',
+    environments: 'ampdoc-amp4ads-preset',
   },
   async env => {
     let controller;


### PR DESCRIPTION
Seems we already have the tests. Just need to enable them.

/cc @zombifier 