### PR TITLE
🐛Change loader code to no longer add a default placeholder.

### DIFF
--- a/extensions/amp-loader/0.1/amp-loader.css
+++ b/extensions/amp-loader/0.1/amp-loader.css
@@ -17,7 +17,12 @@
 
 
 /* Placeholder */
-.i-amphtml-default-placeholder {
+.i-amphtml-loader-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   background-color: #f8f8f8;
 }
 
@@ -161,7 +166,7 @@
   animation-play-state: paused;
 }
 
-.i-amphtml-new-loader.amp-active * {
+.amp-active > .i-amphtml-new-loader * {
   animation-play-state: running;
 }
 

--- a/extensions/amp-loader/0.1/amp-loader.js
+++ b/extensions/amp-loader/0.1/amp-loader.js
@@ -34,13 +34,13 @@ import {setImportantStyles, setStyle} from '../../../src/style';
 const LOADER_APPEAR_TIME = 600;
 
 /**
- * Elements will get a default gray placeholder if they don't already have a
+ * Elements will get a default gray background if they don't already have a
  * placeholder. This list does not include video players which are detected
  * using `isIframeVideoPlayerComponent`
  * @enum {boolean}
  * @private  Visible for testing only!
  */
-const DEFAULT_LOADING_BACKGROUND_WHITELIST_NON_VIDEO = {
+const LOADER_BACKGROUND_TAGS = {
   'AMP-IMG': true,
   'AMP-ANIM': true,
   'AMP-PINTEREST': true,
@@ -186,27 +186,39 @@ class LoaderBuilder {
   }
 
   /**
-   * Add a gray loading background if there isn't a placeholder already and
-   * other special cases.
+   * @return {boolean} True if the currently loading element has background
+   * content via a placeholder or poster.
+   * @private
+   */
+  hasBackgroundContent_() {
+    const hasPlaceholder = !!this.element_.getPlaceholder();
+    const hasPoster = this.element_.hasAttribute('poster');
+
+    return hasPlaceholder || hasPoster;
+  }
+
+  /**
+   * @return {boolean} True if the loaderBackground should be used for the
+   * element.
+   * @private
+   */
+  tagNeedsBackground_() {
+    const {tagName} = this.element_;
+
+    return (
+      LOADER_BACKGROUND_TAGS[tagName] || isIframeVideoPlayerComponent(tagName)
+    );
+  }
+
+  /**
+   * Add a gray loading background if needed based on the element's content
+   * and tagName.
    * @private
    */
   maybeAddLoadingBackground_() {
-    const hasPlaceholder = !!this.element_.getPlaceholder();
-    const hasPoster = this.element_.hasAttribute('poster');
-    if (hasPlaceholder || hasPoster) {
-      return;
+    if (!this.hasBackgroundContent_() && this.tagNeedsBackground_()) {
+      this.domRoot_.classList.add('i-amphtml-loader-background');
     }
-
-    // Is it whitelisted for default placeholder?
-    const {tagName} = this.element_;
-    if (
-      !DEFAULT_LOADING_BACKGROUND_WHITELIST_NON_VIDEO[tagName] &&
-      !isIframeVideoPlayerComponent(tagName)
-    ) {
-      return;
-    }
-
-    this.domRoot_.classList.add('i-amphtml-loader-background');
   }
 
   /**

--- a/src/loader.js
+++ b/src/loader.js
@@ -91,7 +91,6 @@ export function createNewLoaderElement(
   // synchronously. We create the actually element with animations when the
   // service is ready.
   const loaderRoot = element.ownerDocument.createElement('div');
-  loaderRoot.className = 'i-amphtml-new-loader';
 
   getLoaderServicePromise(ampDoc, element).then(loaderService => {
     const endTime = Date.now();


### PR DESCRIPTION
Instead, create the background as part of the as a part of the loader
element itself. This makes sure the background is removed when the
loader is removed.

This avoids an issue where the placeholder appears on top of an
`<amp-img>` if the image finishes downloading before the loaders code
runs.

Closes #23964
