### PR TITLE
Testing: synchronize hidden and visibilityState in fake-dom

### DIFF
--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -127,7 +127,6 @@ export class FakeWindow {
         this.visibilityState_ = value;
         this.documentHidden_ = value != 'visible';
         this.document.eventListeners.fire({type: 'visibilitychange'});
-        console.log('QQQQ: fakeDom.visibilityState set: ', value);
       },
     });
 

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -102,14 +102,32 @@ export class FakeWindow {
     EventListeners.intercept(this.document.documentElement);
     EventListeners.intercept(this.document.body);
 
-    // Document.hidden property.
+    // Document.hidden and document.visibilityState properties.
     /** @private {boolean} */
     this.documentHidden_ = spec.hidden !== undefined ? spec.hidden : false;
+    /** @private {?string} */
+    this.visibilityState_ = null;
+
     Object.defineProperty(this.document, 'hidden', {
       get: () => this.documentHidden_,
       set: value => {
         this.documentHidden_ = value;
+        this.visibilityState_ = null;
         this.document.eventListeners.fire({type: 'visibilitychange'});
+      },
+    });
+    Object.defineProperty(this.document, 'visibilityState', {
+      get: () => {
+        if (this.visibilityState_) {
+          return this.visibilityState_;
+        }
+        return this.documentHidden_ ? 'hidden' : 'visible';
+      },
+      set: value => {
+        this.visibilityState_ = value;
+        this.documentHidden_ = value != 'visible';
+        this.document.eventListeners.fire({type: 'visibilitychange'});
+        console.log('QQQQ: fakeDom.visibilityState set: ', value);
       },
     });
 


### PR DESCRIPTION
Currently, fake-dom overrides `document.hidden`, but not `document.visibilityState`. Since the `document.visibilityState` comes from the `DOMImplementation`, they often get out-of-sync in tests which creates test uncertainty.