### PR TITLE
🏗 [pr deploy] Replace url in html files with storage api host name

### DIFF
--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -260,7 +260,7 @@ function downloadOutput_(functionName, outputFileName, outputDirs) {
   );
   exec('echo travis_fold:start:unzip_results && echo');
   dirsToUnzip.forEach(dir => {
-    execOrDie(`unzip ${dir.replace('/', '/*')}`);
+    execOrDie(`unzip ${outputFileName} '${dir.replace('/', '/*')}'`);
   });
   exec('echo travis_fold:end:unzip_results');
 

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -42,8 +42,7 @@ const DIST_OUTPUT_FILE = isTravisBuild()
   : '';
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
-const DIST_OUTPUT_DIRS =
-  'build/ dist/ dist.3p/ dist.tools/ EXTENSIONS_CSS_MAP examples/ test/manual/';
+const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';
 
 const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
 const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';
@@ -244,6 +243,7 @@ function timedExecOrDie(cmd, fileName = 'utils.js') {
 function downloadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
   const buildOutputDownloadUrl = `${OUTPUT_STORAGE_LOCATION}/${outputFileName}`;
+  const dirsToUnzip = outputDirs.split(' ');
 
   console.log(
     `${fileLogPrefix} Downloading build output from ` +
@@ -259,7 +259,9 @@ function downloadOutput_(functionName, outputFileName, outputDirs) {
     `${fileLogPrefix} Extracting ` + colors.cyan(outputFileName) + '...'
   );
   exec('echo travis_fold:start:unzip_results && echo');
-  execOrDie(`unzip -o ${outputFileName}`);
+  dirsToUnzip.forEach(dir => {
+    execOrDie(`unzip ${dir.replace('/', '/*')}`);
+  });
   exec('echo travis_fold:end:unzip_results');
 
   console.log(fileLogPrefix, 'Verifying extracted files...');
@@ -327,7 +329,7 @@ function downloadBuildOutput(functionName) {
  * @param {string} functionName
  */
 function downloadDistOutput(functionName) {
-  downloadOutput_(functionName, DIST_OUTPUT_FILE, DIST_OUTPUT_DIRS);
+  downloadOutput_(functionName, DIST_OUTPUT_FILE, BUILD_OUTPUT_DIRS);
 }
 
 /**
@@ -343,7 +345,8 @@ function uploadBuildOutput(functionName) {
  * @param {string} functionName
  */
 function uploadDistOutput(functionName) {
-  uploadOutput_(functionName, DIST_OUTPUT_FILE, DIST_OUTPUT_DIRS);
+  const distOutputDirs = `${BUILD_OUTPUT_DIRS} ${APP_SERVING_DIRS}`;
+  uploadOutput_(functionName, DIST_OUTPUT_FILE, distOutputDirs);
 }
 
 /**

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -23,7 +23,7 @@ const {cyan, green} = require('ansi-colors');
 const {gitCommitHash} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
 const {travisBuildNumber} = require('../travis');
-const hostName = `https://storage.googleapis.com/amp-test-website-1/amp_dist_${travisBuildNumber}`;
+const hostName = `https://storage.googleapis.com/amp-test-website-1/amp_dist_${travisBuildNumber()}`;
 
 async function walk(dest) {
   const filelist = [];

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -23,6 +23,7 @@ const {cyan, green} = require('ansi-colors');
 const {gitCommitHash} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
 const {travisBuildNumber} = require('../travis');
+const hostName = `https://storage.googleapis.com/amp-test-website-1/amp_dist_${travisBuildNumber}`;
 
 async function walk(dest) {
   const filelist = [];
@@ -41,10 +42,15 @@ async function walk(dest) {
 
 async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
-
   const inabox = false;
   const storyV1 = true;
-  const result = replaceUrlsAppUtil('compiled', data, '', inabox, storyV1);
+  const result = replaceUrlsAppUtil(
+    'compiled',
+    data,
+    hostName,
+    inabox,
+    storyV1
+  );
 
   await fs.writeFile(filePath, result, 'utf8');
 }


### PR DESCRIPTION
Fixes `pr deploy bot` bug where urls in html files were being replaced with `/dist/v0.js` instead of `https://storage.googleapis.com/amp-test-website-1/amp_dist_<travisbuildnumber>/dist/v0.js`