### PR TITLE
🐛 FIX: check all fields' dirtiness on AMP form init

### DIFF
--- a/extensions/amp-form/0.1/form-dirtiness.js
+++ b/extensions/amp-form/0.1/form-dirtiness.js
@@ -58,6 +58,11 @@ export class FormDirtiness {
     this.wasDirty_ = false;
 
     this.installEventHandlers_();
+
+    // New forms are usually clean. However, if `amp-bind` mutates a form field
+    // before the `amp-form` is initialized, the `amp-form` will miss the
+    // `FORM_VALUE_CHANGE` event dispatched.
+    this.determineInitialDirtiness_();
   }
 
   /**
@@ -134,6 +139,14 @@ export class FormDirtiness {
       AmpEvents.FORM_VALUE_CHANGE,
       this.onInput_.bind(this)
     );
+  }
+
+  /** @private */
+  determineInitialDirtiness_() {
+    for (let i = 0; i < this.form_.elements.length; ++i) {
+      this.checkDirtinessAfterUserInteraction_(this.form_.elements[i]);
+    }
+    this.updateClassAndDispatchEventIfDirtyStateChanged_();
   }
 
   /**

--- a/extensions/amp-form/0.1/test/test-form-dirtiness.js
+++ b/extensions/amp-form/0.1/test/test-form-dirtiness.js
@@ -454,4 +454,26 @@ describes.realWin('form-dirtiness', {}, env => {
       expect(eventDispatched).to.not.exist;
     });
   });
+
+  describe('initial dirtiness', () => {
+    let newForm, input;
+
+    beforeEach(() => {
+      newForm = getForm(doc);
+      input = createElement(doc, 'input', {type: 'text', name: 'text'});
+      newForm.appendChild(input);
+    });
+
+    it('adds the dirtiness class if the form already has dirty fields', () => {
+      changeInput(input, 'changed');
+      dirtinessHandler = new FormDirtiness(newForm, env.win);
+
+      expect(newForm).to.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+
+    it('does not add the dirtiness class if the form does not have dirty fields', () => {
+      dirtinessHandler = new FormDirtiness(newForm, env.win);
+      expect(newForm).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+    });
+  });
 });


### PR DESCRIPTION
New forms are usually clean. However, if `amp-bind` mutates a form field
before the `amp-form` is initialized, the `amp-form` will miss the
`FORM_VALUE_CHANGE` event dispatched.

Part of #22534.

cc/ @GoTcWang @choumx Thanks!