### PR TITLE
Fix getRootClientRectAsync not working in cross domain inabox when compiled in single-pass mode

### DIFF
--- a/examples/amphtml-ads/scrollbound-animation-ad.a4a.html
+++ b/examples/amphtml-ads/scrollbound-animation-ad.a4a.html
@@ -95,7 +95,6 @@
 <!--
 The animations are implemented using [amp-animation]({{g.doc('/content/amp-dev/documentation/components/reference/amp-animation.md', locale=doc.locale).url.path}}) which is an AMP component that uses [Web Animations API](https://www.w3.org/TR/web-animations/) to support both __time__ and __scroll__ based animations.
 -->
-<div style="height: 200vh"></div>
 <amp-animation id="adAnim" layout="nodisplay">
   <script type="application/json">
     {

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -359,8 +359,8 @@ export class ViewportBindingInabox {
           MessageType.POSITION,
           data => {
             this.requestPositionPromise_ = null;
-            devAssert(data.targetRect, 'Host should send targetRect');
-            resolve(data.targetRect);
+            devAssert(data['targetRect'], 'Host should send targetRect');
+            resolve(data['targetRect']);
           }
         );
       });


### PR DESCRIPTION
/cc @lannka 

The bug broke some components like `amp-position-observer`.

I missed this change during #23201, which resolved some single pass issues.

Also removed the space filling div in the inabox example because I think it's meant to be loaded in the inabox envelope.

The e2e tests are not run with single pass right? Otherwise this would probably have been caught. Whether it's worth doing so though is up to you and the AMP folks.