### PR TITLE
Include amp-base-carousel in amp-carousel's build.

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -194,6 +194,9 @@ exports.rules = [
   },
 
   // Rules for extensions.
+  // Note: For the multipass build to correctly include depended on code, you
+  // need to add the depended on code to `CLOSURE_SRC_GLOBS` in
+  // build-system/sources.js.
   {
     // Extensions can't depend on other extensions.
     filesMatching: 'extensions/**/*.js',

--- a/build-system/sources.js
+++ b/build-system/sources.js
@@ -87,6 +87,8 @@ const CLOSURE_SRC_GLOBS = [
   'extensions/amp-analytics/**/*.js',
   // Needed for WebAnimationService
   'extensions/amp-animation/**/*.js',
+  // Needed for amp-carousel 0.2, amp-inline-gallery, amp-stream-gallery
+  'extensions/amp-base-carousel/**/*.js',
   // For amp-bind in the web worker (ww.js).
   'extensions/amp-bind/**/*.js',
   // Needed to access to Variant interface from other extensions


### PR DESCRIPTION
- Add a comment to dep-check-config to indicate you need to update
sources.js

Fixes #23966