### PR TITLE
Make stories shadow trees inherit from the visibility property.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-shadow-reset.css
+++ b/extensions/amp-story/1.0/amp-story-shadow-reset.css
@@ -17,5 +17,4 @@
 :host {
   all: initial !important;
   color: initial !important;
-  visibility: inherit !important;
 }

--- a/extensions/amp-story/1.0/amp-story-shadow-reset.css
+++ b/extensions/amp-story/1.0/amp-story-shadow-reset.css
@@ -17,4 +17,5 @@
 :host {
   all: initial !important;
   color: initial !important;
+  visibility: inherit !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -40,6 +40,14 @@ amp-consent {
   z-index: initial !important;
 }
 
+/**
+ * amp-hidden uses visiblity: hidden that does not propagate to shadow trees
+ * because of amp-story-shadow-reset.css. Use display: none instead.
+ */
+amp-consent.amp-hidden {
+  display: none !important;
+}
+
 .i-amphtml-story-system-reset,
 .i-amphtml-story-system-reset * {
   border: none !important;


### PR DESCRIPTION
The bug this PR is fixing:
The `amp-consent` prompt on `amp-story` does not get hidden when you accept or reject the consent prompt, even though `amp-consent` did not change any of their code.

What actually happens:
CSS `visibility`, unlike `display`, is inherited.
If you add `display: none;` to an element, adding `display: block;` to one of its descendants will have no effect. But the equivalent with visibility will show the descendant.
Because inheritable CSS properties "pierce" the Shadow DOM, `visibility: hidden;` was applied to the consent UI, and sending #23876 broke this behavior.