### PR TITLE
Make DocInfo.pageViewId64 async

### DIFF
--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -73,7 +73,7 @@ export class DocInfo {
     this.ampdoc_ = ampdoc;
     /** @private {?DocumentInfoDef} */
     this.info_ = null;
-    /** @private {string} */
+    /** @private {?Promise<string>} */
     this.pageViewId64_ = null;
   }
 

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -73,6 +73,8 @@ export class DocInfo {
     this.ampdoc_ = ampdoc;
     /** @private {?DocumentInfoDef} */
     this.info_ = null;
+    /** @private {string} */
+    this.pageViewId64_ = null;
   }
 
   /** @return {!DocumentInfoDef} */
@@ -92,7 +94,6 @@ export class DocInfo {
         : sourceUrl;
     }
     const pageViewId = getPageViewId(ampdoc.win);
-    const pageViewId64 = getRandomString64(ampdoc.win);
     const linkRels = getLinkRels(ampdoc.win.document);
     const metaTags = getMetaTags(ampdoc.win.document);
     const replaceParams = getReplaceParams(ampdoc);
@@ -104,7 +105,15 @@ export class DocInfo {
       },
       canonicalUrl,
       pageViewId,
-      pageViewId64,
+      get pageViewId64() {
+        // Must be calculated async since getRandomString64() can load the
+        // amp-crypto-polyfill on some browsers, and extensions service
+        // may not be registered yet.
+        if (!this.pageViewId64_) {
+          this.pageViewId64_ = getRandomString64(ampdoc.win);
+        }
+        return this.pageViewId64_;
+      },
       linkRels,
       metaTags,
       replaceParams,


### PR DESCRIPTION
Fixes #23988.

Bug introduced in: https://github.com/ampproject/amphtml/pull/23451/files#r314530969

Affects browsers that don't implement `WebCrypto` or `Crypto.getRandomValues`: https://caniuse.com/#search=getRandomValues