### PR TITLE
✨ Add audio support to amp-access-scroll extension

### DIFF
--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -32,3 +32,29 @@
   border-bottom: 1px solid #eee;
   box-sizing: border-box;
 }
+
+.amp-access-scroll-audio {
+  position: fixed;
+  background-color: #fff;
+  position: fixed;
+  z-index: 2147483647;
+  display: block;
+
+  /* mobile */
+  bottom: 44px;
+  height: 100px;
+  left: 0;
+  width: 100%;
+  border-top: 1px solid #e1e6e5; /* gray2 */
+  border-bottom: 1px solid transparent;
+}
+@media (min-width: 600px) {
+  .amp-access-scroll-audio {
+    bottom: 63px;
+    height: 56px;
+    left: auto;
+    right: 16px;
+    width: 475px;
+    border: 1px solid #e1e6e5; /* gray2 */
+  }
+}

--- a/extensions/amp-access-scroll/0.1/read-depth-tracker.js
+++ b/extensions/amp-access-scroll/0.1/read-depth-tracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-access-scroll/0.1/scroll-audio.js
+++ b/extensions/amp-access-scroll/0.1/scroll-audio.js
@@ -50,7 +50,7 @@ export class Audio extends ScrollComponent {
    * @private
    */
   render_(state) {
-    setTimeout(() => {
+    this.mutate_(() => {
       if (!this.frame_) {
         this.frame_ = this.makeIframe_();
         this.setWindow_(this.frame_.contentWindow);
@@ -60,7 +60,7 @@ export class Audio extends ScrollComponent {
         this.frame_.setAttribute('src', state.url);
       }
       toggle(this.frame_, state.open);
-    }, 0);
+    });
   }
 
   /**

--- a/extensions/amp-access-scroll/0.1/scroll-audio.js
+++ b/extensions/amp-access-scroll/0.1/scroll-audio.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ScrollComponent} from './scroll-component';
+import {dict} from '../../../src/utils/object';
+import {toggle} from '../../../src/style';
+
+/** Provides iframe for the Scroll Audio Player. */
+export class Audio extends ScrollComponent {
+  /**
+   *  Creates an instance of Audio.
+   *
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} doc
+   */
+  constructor(doc) {
+    super(doc);
+    /** @private {!Audio.State} */
+    this.state_ = {
+      url: '',
+      open: false,
+    };
+  }
+  /**
+   * @param {!JsonObject} action
+   */
+  update(action) {
+    this.state_ = {
+      url: action['url'] !== undefined ? action['url'] : this.state_.url,
+      open: action['open'],
+    };
+
+    this.render_(this.state_);
+  }
+
+  /**
+   * @param {!Audio.State} state
+   * @private
+   */
+  render_(state) {
+    setTimeout(() => {
+      if (!this.frame_) {
+        this.frame_ = this.makeIframe_();
+        this.setWindow_(this.frame_.contentWindow);
+      }
+
+      if (this.frame_.src !== state.url) {
+        this.frame_.setAttribute('src', state.url);
+      }
+      toggle(this.frame_, state.open);
+    }, 0);
+  }
+
+  /**
+   * @return {!HTMLIFrameElement}
+   * @private
+   * */
+  makeIframe_() {
+    const frame = this.el(
+      'iframe',
+      dict({
+        'class': 'amp-access-scroll-audio',
+        'scrolling': 'no',
+        'frameborder': '0',
+        'allowtransparency': 'true',
+        'title': 'Scroll Audio',
+        'sandbox':
+          'allow-scripts allow-same-origin ' +
+          'allow-top-navigation allow-popups ' +
+          'allow-popups-to-escape-sandbox',
+      })
+    );
+
+    this.mount_(frame);
+    return /** @type {!HTMLIFrameElement} */ (frame);
+  }
+}
+
+/**
+ * @typedef {{
+ *    open: boolean,
+ *    url: string
+ * }}
+ */
+Audio.State;

--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ScrollComponent} from './scroll-component';
+import {dict} from '../../../src/utils/object';
+
+/**
+ * UI for Scroll users.
+ *
+ * Presents a fixed bar at the bottom of the screen with Scroll content.
+ * @abstract
+ */
+class Bar extends ScrollComponent {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} doc
+   * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
+   * @param {string} baseUrl
+   */
+  constructor(doc, accessSource, baseUrl) {
+    super(doc);
+
+    /** @protected */
+    this.accessSource_ = accessSource;
+
+    /** @protected */
+    this.baseUrl_ = baseUrl;
+
+    this.render_();
+  }
+
+  /** @private */
+  render_() {
+    setTimeout(() => {
+      if (!this.frame_) {
+        this.frame_ = this.makeIframe_();
+        this.setWindow_(this.frame_.contentWindow);
+      }
+    }, 0);
+  }
+
+  /**
+   * @return {!HTMLIFrameElement}
+   * @protected
+   * */
+  makeIframe_() {
+    const frame = this.el(
+      'iframe',
+      dict({
+        'scrolling': 'no',
+        'frameborder': '0',
+        'allowtransparency': 'true',
+        'title': 'Scroll',
+        'width': '100%',
+        'height': '100%',
+        'sandbox':
+          'allow-scripts allow-same-origin ' +
+          'allow-top-navigation allow-popups ' +
+          'allow-popups-to-escape-sandbox',
+      })
+    );
+
+    const root = this.el(
+      'div',
+      dict({
+        'class': 'amp-access-scroll-bar',
+      }),
+      [frame]
+    );
+
+    this.mount_(root);
+
+    return /** @type {!HTMLIFrameElement} */ (frame);
+  }
+}
+
+export class ScrollUserBar extends Bar {
+  /**
+   * Add a scrollbar placeholder and then load the scrollbar URL in the iframe.
+   *
+   * @override
+   * */
+  makeIframe_() {
+    const frame = Bar.prototype.makeIframe_.call(this);
+    // Add a placeholder element to display while scrollbar iframe loads.
+    const placeholder = this.el(
+      'div',
+      dict({
+        'class': 'amp-access-scroll-bar amp-access-scroll-placeholder',
+      }),
+      [
+        this.el(
+          'img',
+          dict({
+            'src':
+              'https://static.scroll.com/assets/icn-scroll-logo32-9f4ceef399905139bbd26b87bfe94542.svg',
+            'layout': 'fixed',
+            'width': 32,
+            'height': 32,
+          })
+        ),
+      ]
+    );
+
+    this.doc_.getBody().appendChild(placeholder);
+
+    // Set iframe to scrollbar URL.
+    this.accessSource_
+      .buildUrl(
+        `${this.baseUrl_}/amp/scrollbar` +
+          '?rid=READER_ID' +
+          '&cid=CLIENT_ID(scroll1)' +
+          '&c=CANONICAL_URL' +
+          '&o=AMPDOC_URL',
+        false
+      )
+      .then(scrollbarUrl => {
+        frame.onload = () => {
+          // On iframe load, remove placeholder element.
+          this.doc_.getBody().removeChild(placeholder);
+        };
+        frame.setAttribute('src', scrollbarUrl);
+      });
+    return frame;
+  }
+}
+/**
+ * Add link to the Scroll App connect page.
+ */
+export class ActivateBar extends Bar {
+  /** @override */
+  makeIframe_() {
+    Bar.prototype.makeIframe_.call(this);
+
+    this.accessSource_
+      .buildUrl(
+        `${this.baseUrl_}/html/amp/activate` +
+          '?rid=READER_ID' +
+          '&cid=CLIENT_ID(scroll1)' +
+          '&c=CANONICAL_URL' +
+          '&o=AMPDOC_URL' +
+          '&x=QUERY_PARAM(scrollx)',
+        false
+      )
+      .then(url => {
+        this.frame_.setAttribute('src', url);
+      });
+    return this.frame_;
+  }
+}

--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -43,12 +43,12 @@ class Bar extends ScrollComponent {
 
   /** @private */
   render_() {
-    setTimeout(() => {
+    this.mutate_(() => {
       if (!this.frame_) {
         this.frame_ = this.makeIframe_();
         this.setWindow_(this.frame_.contentWindow);
       }
-    }, 0);
+    });
   }
 
   /**

--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -142,7 +142,7 @@ export class ScrollUserBar extends Bar {
 export class ActivateBar extends Bar {
   /** @override */
   makeIframe_() {
-    Bar.prototype.makeIframe_.call(this);
+    const frame = Bar.prototype.makeIframe_.call(this);
 
     this.accessSource_
       .buildUrl(
@@ -155,8 +155,8 @@ export class ActivateBar extends Bar {
         false
       )
       .then(url => {
-        this.frame_.setAttribute('src', url);
+        frame.setAttribute('src', url);
       });
-    return this.frame_;
+    return frame;
   }
 }

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -24,8 +24,10 @@ export class ScrollComponent {
     /** @protected {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.doc_ = doc;
 
-    /** @protected @property {?function} */
+    /** @protected @property {?function(Window):undefined} */
     this.setWindow_ = null;
+    /** @protected {?HTMLIFrameElement} */
+    this.frame_ = null;
 
     /** @type {Promise<Window>} */
     this.window = new Promise(resolve => {

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-const TAG = 'amp-access-scroll-elt';
-import {CSS} from '../../../build/amp-access-scroll-0.1.css';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {installStylesForDoc} from '../../../src/style-installer';
-
-let init = false;
 
 /** @abstract */
 export class ScrollComponent {
   /** @param {!../../../src/service/ampdoc-impl.AmpDoc} doc */
   constructor(doc) {
-    if (!init) {
-      installStylesForDoc(doc, CSS, () => {}, false, TAG);
-      init = true;
-    }
     /** @protected {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.doc_ = doc;
 

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -72,4 +72,13 @@ export class ScrollComponent {
     this.doc_.getBody().appendChild(el);
     Services.viewportForDoc(this.doc_).addToFixedLayer(el);
   }
+
+  /**
+   * Enqueues a DOM mutation managed by the window's Vsync
+   * @param {function():undefined} mutator
+   * @protected
+   */
+  mutate_(mutator) {
+    Services.vsyncFor(this.doc_.win).mutate(mutator);
+  }
 }

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TAG = 'amp-access-scroll-elt';
+import {CSS} from '../../../build/amp-access-scroll-0.1.css';
+import {Services} from '../../../src/services';
+import {createElementWithAttributes} from '../../../src/dom';
+import {installStylesForDoc} from '../../../src/style-installer';
+
+let init = false;
+
+/** @abstract */
+export class ScrollComponent {
+  /** @param {!../../../src/service/ampdoc-impl.AmpDoc} doc */
+  constructor(doc) {
+    if (!init) {
+      installStylesForDoc(doc, CSS, () => {}, false, TAG);
+      init = true;
+    }
+    /** @protected {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.doc_ = doc;
+
+    /** @protected @property {?function} */
+    this.setWindow_ = null;
+
+    /** @type {Promise<Window>} */
+    this.window = new Promise(resolve => {
+      /** @protected */
+      this.setWindow_ = resolve;
+    });
+  }
+
+  /**
+   * Create an element with attributes and optional children.
+   * @param {string} elementName
+   * @param {!JsonObject} attrs
+   * @param {Array<Element>=} children
+   * @return {!Element}
+   * @protected
+   */
+  el(elementName, attrs, children) {
+    const e = createElementWithAttributes(
+      this.doc_.win.document,
+      elementName,
+      attrs
+    );
+    if (Array.isArray(children)) {
+      children.forEach(c => e.appendChild(c));
+    }
+    return e;
+  }
+
+  /**
+   * Add element to doc and promote to fixed layer.
+   * @param {!Element} el
+   * @protected
+   * */
+  mount_(el) {
+    this.doc_.getBody().appendChild(el);
+    Services.viewportForDoc(this.doc_).addToFixedLayer(el);
+  }
+}

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -17,13 +17,17 @@
 import {AccessClientAdapter} from '../../amp-access/0.1/amp-access-client';
 import {ActivateBar, ScrollUserBar} from './scroll-bar';
 import {Audio} from './scroll-audio';
+import {CSS} from '../../../build/amp-access-scroll-0.1.css';
 import {ReadDepthTracker} from './read-depth-tracker.js';
 import {Relay} from './scroll-relay';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
+import {installStylesForDoc} from '../../../src/style-installer';
 import {parseQueryString} from '../../../src/url';
+
+const TAG = 'amp-access-scroll-elt';
 /**
  * @param {string} baseUrl
  * @return {!JsonObject}
@@ -130,6 +134,9 @@ export class ScrollAccessVendor extends AccessClientAdapter {
       buildUrl: accessSource.buildUrl.bind(accessSource),
       collectUrlVars: accessSource.collectUrlVars.bind(accessSource),
     });
+
+    // Install styles
+    installStylesForDoc(ampdoc, CSS, () => {}, false, TAG);
 
     /** @private {!../../amp-access/0.1/amp-access-source.AccessSource} */
     this.accessSource_ = accessSource;

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,33 +15,31 @@
  */
 
 import {AccessClientAdapter} from '../../amp-access/0.1/amp-access-client';
-import {CSS} from '../../../build/amp-access-scroll-0.1.css';
+import {ActivateBar, ScrollUserBar} from './scroll-bar';
+import {Audio} from './scroll-audio';
 import {ReadDepthTracker} from './read-depth-tracker.js';
+import {Relay} from './scroll-relay';
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
-import {installStylesForDoc} from '../../../src/style-installer';
 import {parseQueryString} from '../../../src/url';
-
-const TAG = 'amp-access-scroll-elt';
-
 /**
- * @param {string} connectHostname
+ * @param {string} baseUrl
  * @return {!JsonObject}
  */
-const accessConfig = connectHostname => {
+const accessConfig = baseUrl => {
   /** @const {!JsonObject} */
   const ACCESS_CONFIG = /** @type {!JsonObject} */ ({
     'authorization':
-      `${connectHostname}/amp/access` +
+      `${baseUrl}/amp/access` +
       '?rid=READER_ID' +
       '&cid=CLIENT_ID(scroll1)' +
       '&c=CANONICAL_URL' +
       '&o=AMPDOC_URL' +
       '&x=QUERY_PARAM(scrollx)',
     'pingback':
-      `${connectHostname}/amp/pingback` +
+      `${baseUrl}/amp/pingback` +
       '?rid=READER_ID' +
       '&cid=CLIENT_ID(scroll1)' +
       '&c=CANONICAL_URL' +
@@ -56,14 +54,14 @@ const accessConfig = connectHostname => {
 };
 
 /**
- * @param {string} connectHostname
+ * @param {string} baseUrl
  * @return {!JsonObject}
  */
-const analyticsConfig = connectHostname => {
+const analyticsConfig = baseUrl => {
   const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     'requests': {
       'scroll':
-        `${connectHostname}/amp/analytics` +
+        `${baseUrl}/amp/analytics` +
         '?rid=ACCESS_READER_ID' +
         '&cid=CLIENT_ID(scroll1)' +
         '&c=CANONICAL_URL' +
@@ -127,13 +125,16 @@ export class ScrollAccessVendor extends AccessClientAdapter {
    */
   constructor(ampdoc, accessSource) {
     const scrollConfig = accessSource.getAdapterConfig();
-    super(ampdoc, accessConfig(connectHostname(scrollConfig)), {
+    const baseUrl = connectHostname(scrollConfig);
+    super(ampdoc, accessConfig(baseUrl), {
       buildUrl: accessSource.buildUrl.bind(accessSource),
       collectUrlVars: accessSource.collectUrlVars.bind(accessSource),
     });
 
     /** @private {!../../amp-access/0.1/amp-access-source.AccessSource} */
     this.accessSource_ = accessSource;
+    /** @private */
+    this.baseUrl_ = baseUrl;
   }
 
   /** @override */
@@ -143,13 +144,26 @@ export class ScrollAccessVendor extends AccessClientAdapter {
       const isStory = this.ampdoc
         .getRootNode()
         .querySelector('amp-story[standalone]');
+
       if (response && response['scroll']) {
         if (!isStory) {
-          const config = this.accessSource_.getAdapterConfig();
-          new ScrollElement(this.ampdoc).handleScrollUser(
+          // Display Scrollbar and set up features
+          const bar = new ScrollUserBar(
+            this.ampdoc,
             this.accessSource_,
-            config
+            this.baseUrl_
           );
+          const audio = new Audio(this.ampdoc);
+
+          const relay = new Relay(this.baseUrl_);
+          relay.register(audio.window, message => {
+            if (message['_scramp'] === 'au') {
+              audio.update(message);
+            }
+          });
+          relay.register(bar.window);
+
+          const config = this.accessSource_.getAdapterConfig();
           addAnalytics(this.ampdoc, config);
           if (response['features'] && response['features']['readDepth']) {
             new ReadDepthTracker(
@@ -211,9 +225,10 @@ class ScrollContentBlocker {
           // TODO(dbow): Ideally we would automatically redirect to the page
           // here, but for now we are adding a button so we redirect on user
           // action.
-          new ScrollElement(this.ampdoc_).addActivateButton(
+          new ActivateBar(
+            this.ampdoc_,
             this.accessSource_,
-            this.accessSource_.getAdapterConfig()
+            connectHostname(this.accessSource_.getAdapterConfig())
           );
         }
       });
@@ -234,110 +249,6 @@ class ScrollContentBlocker {
           'Resource blocked by content blocker'
       ) === 0
     );
-  }
-}
-
-/**
- * UI for Scroll users.
- *
- * Presents a fixed bar at the bottom of the screen with Scroll content.
- */
-class ScrollElement {
-  /**
-   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   */
-  constructor(ampdoc) {
-    installStylesForDoc(ampdoc, CSS, () => {}, false, TAG);
-
-    /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampdoc_ = ampdoc;
-
-    /** @const {!Element} */
-    this.scrollBar_ = document.createElement('div');
-    this.scrollBar_.classList.add('amp-access-scroll-bar');
-
-    /** @const {!Element} */
-    this.iframe_ = document.createElement('iframe');
-    this.iframe_.setAttribute('scrolling', 'no');
-    this.iframe_.setAttribute('frameborder', '0');
-    this.iframe_.setAttribute('allowtransparency', 'true');
-    this.iframe_.setAttribute('title', 'Scroll');
-    this.iframe_.setAttribute('width', '100%');
-    this.iframe_.setAttribute('height', '100%');
-    this.iframe_.setAttribute(
-      'sandbox',
-      'allow-scripts allow-same-origin ' +
-        'allow-top-navigation allow-popups ' +
-        'allow-popups-to-escape-sandbox'
-    );
-    this.scrollBar_.appendChild(this.iframe_);
-    ampdoc.getBody().appendChild(this.scrollBar_);
-
-    // Promote to fixed layer.
-    Services.viewportForDoc(ampdoc).addToFixedLayer(this.scrollBar_);
-  }
-
-  /**
-   * Add a scrollbar placeholder and then load the scrollbar URL in the iframe.
-   *
-   * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
-   * @param {!JsonObject} vendorConfig
-   */
-  handleScrollUser(accessSource, vendorConfig) {
-    // Add a placeholder element to display while scrollbar iframe loads.
-    const placeholder = document.createElement('div');
-    placeholder.classList.add('amp-access-scroll-bar');
-    placeholder.classList.add('amp-access-scroll-placeholder');
-    const img = document.createElement('img');
-    img.setAttribute(
-      'src',
-      'https://static.scroll.com/assets/icn-scroll-logo32-9f4ceef399905139bbd26b87bfe94542.svg'
-    );
-    img.setAttribute('layout', 'fixed');
-    img.setAttribute('width', 32);
-    img.setAttribute('height', 32);
-    placeholder.appendChild(img);
-    this.ampdoc_.getBody().appendChild(placeholder);
-
-    // Set iframe to scrollbar URL.
-    accessSource
-      .buildUrl(
-        `${connectHostname(vendorConfig)}/amp/scrollbar` +
-          '?rid=READER_ID' +
-          '&cid=CLIENT_ID(scroll1)' +
-          '&c=CANONICAL_URL' +
-          '&o=AMPDOC_URL',
-        false
-      )
-      .then(scrollbarUrl => {
-        this.iframe_.onload = () => {
-          // On iframe load, remove placeholder element.
-          this.ampdoc_.getBody().removeChild(placeholder);
-        };
-        this.iframe_.setAttribute('src', scrollbarUrl);
-      });
-  }
-
-  /**
-   * Add link to the Scroll App connect page.
-   *
-   * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
-   * @param {!JsonObject} vendorConfig
-   */
-  addActivateButton(accessSource, vendorConfig) {
-    accessSource
-      .buildUrl(
-        `${connectHostname(vendorConfig)}/html/amp/activate` +
-          '?rid=READER_ID' +
-          '&cid=CLIENT_ID(scroll1)' +
-          '&c=CANONICAL_URL' +
-          '&o=AMPDOC_URL' +
-          '&x=QUERY_PARAM(scrollx)',
-        false
-      )
-      .then(url => {
-        this.iframe_.setAttribute('src', url);
-      });
   }
 }
 

--- a/extensions/amp-access-scroll/0.1/scroll-relay.js
+++ b/extensions/amp-access-scroll/0.1/scroll-relay.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getData} from '../../../src/event-helper';
+import {listen} from '../../../src/3p-frame-messaging';
+
+/**
+ * Provides cross-frame postMessage for scroll frames.
+ */
+export class Relay {
+  /**
+   * @param {string} domain - origin restriction for postMessage
+   */
+  constructor(domain) {
+    /** @private @type {!Array<Window>} */
+    this.frames_ = [];
+    /** @private @type {!Array<function(JsonObject)>} */
+    this.listeners_ = [];
+    /** @private */
+    this.origin_ = domain;
+
+    this.onMessage_ = this.onMessage_.bind(this);
+
+    listen(window, 'message', this.onMessage_);
+  }
+
+  /**
+   * @param {!Event} e
+   * @private
+   */
+  onMessage_(e) {
+    const data = /** @type {!JsonObject} */ (getData(e));
+    const fromScrollOrigin = e.origin === this.origin_;
+    const isScrollAmpMessage = '_scramp' in data;
+    const fromFrameInRelay = this.frames_.indexOf(e.source) > -1;
+    if (!fromScrollOrigin || !fromFrameInRelay || !isScrollAmpMessage) {
+      return;
+    }
+
+    this.listeners_.forEach(listener => listener(data));
+
+    // send message to all other frames in the relay
+    this.frames_
+      .filter(f => f !== e.source)
+      .forEach(f => {
+        f./* REVIEW */ postMessage(data, this.origin_);
+      });
+  }
+
+  /**
+   * @param {Window | Promise<Window>} frame
+   * @param {function(JsonObject)=} messageListener
+   */
+  register(frame, messageListener) {
+    messageListener && this.listeners_.push(messageListener);
+    Promise.resolve(frame).then(frame => {
+      if (this.frames_.indexOf(frame) === -1) {
+        this.frames_.push(frame);
+      }
+    });
+  }
+}

--- a/extensions/amp-access-scroll/0.1/scroll-relay.js
+++ b/extensions/amp-access-scroll/0.1/scroll-relay.js
@@ -42,9 +42,9 @@ export class Relay {
    * @private
    */
   onMessage_(e) {
-    const data = /** @type {!JsonObject} */ (getData(e));
+    const data = /** @type {JsonObject} */ (getData(e));
     const fromScrollOrigin = e.origin === this.origin_;
-    const isScrollAmpMessage = '_scramp' in data;
+    const isScrollAmpMessage = typeof data === 'object' && '_scramp' in data;
     const fromFrameInRelay = this.frames_.indexOf(e.source) > -1;
     if (!fromScrollOrigin || !fromFrameInRelay || !isScrollAmpMessage) {
       return;

--- a/extensions/amp-access-scroll/0.1/scroll-relay.js
+++ b/extensions/amp-access-scroll/0.1/scroll-relay.js
@@ -56,7 +56,7 @@ export class Relay {
     this.frames_
       .filter(f => f !== e.source)
       .forEach(f => {
-        f./* REVIEW */ postMessage(data, this.origin_);
+        f./* OK */ postMessage(data, this.origin_);
       });
   }
 

--- a/extensions/amp-access-scroll/OWNERS.yaml
+++ b/extensions/amp-access-scroll/OWNERS.yaml
@@ -1,2 +1,3 @@
 - kushal
 - dbow
+- junoatscroll


### PR DESCRIPTION
This PR brings support for the article audio feature from desktop Scroll to the amp-access-scroll extension, plus some refactoring within the extension for cleanup and maintainability. 

- Adds audio player iframe when user taps audio icon in scrollbar:
![amp-access-scroll](https://user-images.githubusercontent.com/47402989/63132983-f7bec980-bf77-11e9-8298-9b5f748a8cfe.gif)


- Audio iframe is lazily created after user interaction
- Relay class uses postMessage to synchronize playing / paused state between Scroll bar and audio iframe. Messages are filtered down by origin and are only passed between frames created by this extension.
- Refactors Scroll bar iframe to use component pattern

cc @kushal @dbow