### PR TITLE
Delay firing early analytic events

### DIFF
--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import {
+  AmpStoryEventTracker,
+  AnalyticsEvent,
+  AnalyticsEventType,
+  CustomEventTracker,
+  getTrackerKeyName,
+} from './events';
 import {AmpdocAnalyticsRoot, EmbedAnalyticsRoot} from './analytics-root';
-import {AnalyticsEvent, AnalyticsEventType, CustomEventTracker} from './events';
 import {AnalyticsGroup} from './analytics-group';
 import {Services} from '../../../src/services';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
@@ -68,6 +74,19 @@ export class InstrumentationService {
   }
 
   /**
+   * @param {string} trackerName
+   * @private
+   */
+  getTrackerClass_(trackerName) {
+    switch (trackerName) {
+      case AnalyticsEventType.AMP_STORY:
+        return AmpStoryEventTracker;
+      default:
+        return CustomEventTracker;
+    }
+  }
+
+  /**
    * Triggers the analytics event with the specified type.
    *
    * @param {!Element} target
@@ -77,10 +96,12 @@ export class InstrumentationService {
   triggerEventForTarget(target, eventType, opt_vars) {
     const event = new AnalyticsEvent(target, eventType, opt_vars);
     const root = this.findRoot_(target);
-    const tracker = /** @type {!CustomEventTracker} */ (root.getTracker(
-      AnalyticsEventType.CUSTOM,
-      CustomEventTracker
-    ));
+    const trackerName = getTrackerKeyName(eventType);
+    const tracker = root.getTracker(
+      trackerName,
+      this.getTrackerClass_(trackerName)
+    );
+
     tracker.trigger(event);
   }
 

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -15,7 +15,10 @@
  */
 import {Services} from '../../../src/services';
 import {StateProperty, getStoreService} from './amp-story-store-service';
-import {StoryAnalyticsEvent} from '../../../src/analytics';
+import {
+  StoryAnalyticsEvent,
+  triggerAnalyticsEvent,
+} from '../../../src/analytics';
 import {getVariableService} from './variable-service';
 import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
@@ -110,7 +113,11 @@ export class StoryAnalyticsService {
    * @param {!StoryAnalyticsEvent} eventType
    */
   triggerEvent(eventType) {
-    this.element_.dispatchCustomEvent(eventType, this.getDetails_(eventType));
+    triggerAnalyticsEvent(
+      this.element_,
+      eventType,
+      this.getDetails_(eventType)
+    );
   }
 
   /**


### PR DESCRIPTION
We just noticed some early analytic events (e.g. `story-page-visible` on the first page) aren't being logged correctly since the `amp-analytics` service isn't ready to listen for these events yet. This has been happening since #23030 was pushed since it stopped buffering early events.

This PR stores early events in a buffer until they are ready to be fired.

If this implementation looks good enough I'll move forward to write unit tests.

Thanks!