### PR TITLE
🏗 Don't run all the runtime tests for validator-only changes

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -120,7 +120,7 @@ const targetMatchers = [
     },
   },
   {
-    targets: ['VALIDATOR', 'RUNTIME'], // Test the runtime for validator changes.
+    targets: ['VALIDATOR'],
     func: file => {
       if (file.startsWith('validator/webui/')) {
         return false;


### PR DESCRIPTION
As requested by @Gregable, since running all the runtime tests for validator-only changes is unnecessary, and makes the validator workflow slower than necessary.