### PR TITLE
🔥 Revert "📈 Initial StorySpec Implementation (#23030)"

### DIFF
--- a/examples/amp-story/analytics.html
+++ b/examples/amp-story/analytics.html
@@ -56,10 +56,7 @@
               },
               "trackPageview": {
                 "on": "story-page-visible",
-                "request": "pageView",
-                "storySpec": {
-                  "repeat": false
-                }
+                "request": "pageView"
               },
               "trackBookendEnter": {
                 "on": "story-bookend-enter",

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -48,159 +48,159 @@ Container for analytics tags. Positioned far away from top to make sure that doe
   </script>
 </amp-analytics>
 <amp-analytics id="analytics1">
-  <script type="application/json">
-  {
-    "transport": {"beacon": true, "xhrpost": false},
-    "requests": {
-      "endpoint": "/analytics",
-      "base": "${endpoint}/${type}?path=${canonicalPath}",
-      "event": "${base}&scrollY=${scrollTop}&scrollX=${scrollLeft}&height=${availableScreenHeight}&width=${availableScreenWidth}&scrollBoundV=${verticalScrollBoundary}&scrollBoundH=${horizontalScrollBoundary}",
-      "visibility": "${base}&a=${maxContinuousVisibleTime}&b=${totalVisibleTime}&c=${firstSeenTime}&d=${lastSeenTime}&e=${firstVisibleTime}&f=${lastVisibleTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&i=${elementX}&j=${elementY}&k=${elementWidth}&l=${elementHeight}&m=${totalTime}&n=${loadTimeVisibility}&o=${backgroundedAtStart}&p=${backgrounded}&subTitle=${subTitle}",
-      "timer": "${base}&backgroundState=${backgroundState}&timerStart=${timerStart}&duration=${timerDuration}",
-      "video": "${base}&type=${type}&currentTime=${currentTime}&f=${fullscreen}&a=${autoplay}"
-    },
-    "vars": {
-      "title": "Example Request"
-    },
-    "extraUrlParams": {
-      "param1": "${random}",
-      "platform": "AMP"
-    },
-    "extraUrlParamsReplaceMap": {
-      "param": "p"
-    },
-    "triggers": {
-      "pageview": {
-        "on": "visible",
-        "request": "base",
-        "vars": {
-          "type": "pageLoad"
-        },
-        "extraUrlParams": {
-          "param1": "Another value"
-        }
+<script type="application/json">
+{
+  "transport": {"beacon": true, "xhrpost": false},
+  "requests": {
+    "endpoint": "/analytics",
+    "base": "${endpoint}/${type}?path=${canonicalPath}",
+    "event": "${base}&scrollY=${scrollTop}&scrollX=${scrollLeft}&height=${availableScreenHeight}&width=${availableScreenWidth}&scrollBoundV=${verticalScrollBoundary}&scrollBoundH=${horizontalScrollBoundary}",
+    "visibility": "${base}&a=${maxContinuousVisibleTime}&b=${totalVisibleTime}&c=${firstSeenTime}&d=${lastSeenTime}&e=${firstVisibleTime}&f=${lastVisibleTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&i=${elementX}&j=${elementY}&k=${elementWidth}&l=${elementHeight}&m=${totalTime}&n=${loadTimeVisibility}&o=${backgroundedAtStart}&p=${backgrounded}&subTitle=${subTitle}",
+    "timer": "${base}&backgroundState=${backgroundState}&timerStart=${timerStart}&duration=${timerDuration}",
+    "video": "${base}&type=${type}&currentTime=${currentTime}&f=${fullscreen}&a=${autoplay}"
+  },
+  "vars": {
+    "title": "Example Request"
+  },
+  "extraUrlParams": {
+    "param1": "${random}",
+    "platform": "AMP"
+  },
+  "extraUrlParamsReplaceMap": {
+    "param": "p"
+  },
+  "triggers": {
+    "pageview": {
+      "on": "visible",
+      "request": "base",
+      "vars": {
+        "type": "pageLoad"
       },
-      "visibility": {
-        "on": "visible",
-        "request": "visibility",
+      "extraUrlParams": {
+        "param1": "Another value"
+      }
+    },
+    "visibility": {
+      "on": "visible",
+      "request": "visibility",
+      "selector": "#anim-id",
+      "visibilitySpec": {
+        "visiblePercentageMin": 20,
+        "visiblePercentageMax": 80,
+        "totalTimeMin": 5000,
+        "continuousTimeMin": 2000,
+        "waitFor": "ini-load"
+      },
+      "vars": {
+        "type": "visible"
+      }
+    },
+    "hidden": {
+      "on": "hidden",
+      "request": "visibility",
+      "visibilitySpec": {
         "selector": "#anim-id",
-        "visibilitySpec": {
-          "visiblePercentageMin": 20,
-          "visiblePercentageMax": 80,
-          "totalTimeMin": 5000,
-          "continuousTimeMin": 2000,
-          "waitFor": "ini-load"
-        },
-        "vars": {
-          "type": "visible"
-        }
+        "visiblePercentageMin": 20,
+        "visiblePercentageMax": 1000,
+        "continuousTimeMax": 5000
       },
-      "hidden": {
-        "on": "hidden",
-        "request": "visibility",
-        "visibilitySpec": {
-          "selector": "#anim-id",
-          "visiblePercentageMin": 20,
-          "visiblePercentageMax": 1000,
-          "continuousTimeMax": 5000
-        },
-        "vars": {
-          "type": "hidden"
-        }
+      "vars": {
+        "type": "hidden"
+      }
+    },
+    "scrollPings": {
+      "on": "scroll",
+      "request": "event",
+      "scrollSpec": {
+        "verticalBoundaries" : [1, 50, 90],
+        "horizontalBoundaries": [100]
       },
-      "scrollPings": {
-        "on": "scroll",
-        "request": "event",
-        "scrollSpec": {
-          "verticalBoundaries" : [1, 50, 90],
-          "horizontalBoundaries": [100]
-        },
-        "vars": {
-          "type": "scroll"
-        }
+      "vars": {
+        "type": "scroll"
+      }
+    },
+    "clickPings": {
+      "on": "click",
+      "selector": "${img}",
+      "request": ["endpoint", "base"],
+      "vars": {
+        "type": "click",
+        "img": "#anim-id, #container"
+      }
+    },
+    "timer": {
+      "on": "timer",
+      "timerSpec": {
+        "interval": 5,
+        "maxTimerLength": 20
       },
-      "clickPings": {
-        "on": "click",
-        "selector": "${img}",
-        "request": ["endpoint", "base"],
-        "vars": {
-          "type": "click",
-          "img": "#anim-id, #container"
-        }
+      "request": "timer",
+      "vars": {
+        "type": "timer"
+      }
+    },
+    "videoPlays": {
+      "on": "video-play",
+      "selector": "#myVideo",
+      "videoSpec": {
+        "exclude-autoplay": true
       },
-      "timer": {
-        "on": "timer",
-        "timerSpec": {
-          "interval": 5,
-          "maxTimerLength": 20
-        },
-        "request": "timer",
-        "vars": {
-          "type": "timer"
-        }
+      "request": "video",
+      "vars": {
+        "type": "video-play"
+      }
+    },
+    "videoPauses": {
+      "on": "video-pause",
+      "selector": "#myVideo",
+      "videoSpec": {
+        "exclude-autoplay": false
       },
-      "videoPlays": {
-        "on": "video-play",
-        "selector": "#myVideo",
-        "videoSpec": {
-          "exclude-autoplay": true
-        },
-        "request": "video",
-        "vars": {
-          "type": "video-play"
-        }
+      "request": "video",
+      "vars": {
+        "type": "video-pause"
+      }
+    },
+    "videoSession": {
+      "on": "video-session",
+      "selector": "#myVideo",
+      "videoSpec": {
+        "end-session-when-invisible": true,
+        "exclude-autoplay": false
       },
-      "videoPauses": {
-        "on": "video-pause",
-        "selector": "#myVideo",
-        "videoSpec": {
-          "exclude-autoplay": false
-        },
-        "request": "video",
-        "vars": {
-          "type": "video-pause"
-        }
+      "request": "video",
+      "vars": {
+        "type": "video-session"
+      }
+    },
+    "videoSecondsPlayed": {
+      "on": "video-seconds-played",
+      "selector": "#myVideo",
+      "videoSpec": {
+        "end-session-when-invisible": false,
+        "exclude-autoplay": false,
+        "interval": 3
       },
-      "videoSession": {
-        "on": "video-session",
-        "selector": "#myVideo",
-        "videoSpec": {
-          "end-session-when-invisible": true,
-          "exclude-autoplay": false
-        },
-        "request": "video",
-        "vars": {
-          "type": "video-session"
-        }
+      "request": "video",
+      "vars": {
+        "type": "video-seconds-played"
+      }
+    },
+    "videoEnded": {
+      "on": "video-ended",
+      "selector": "#myVideo",
+      "videoSpec": {
+        "end-session-when-invisible": true,
+        "exclude-autoplay": false
       },
-      "videoSecondsPlayed": {
-        "on": "video-seconds-played",
-        "selector": "#myVideo",
-        "videoSpec": {
-          "end-session-when-invisible": false,
-          "exclude-autoplay": false,
-          "interval": 3
-        },
-        "request": "video",
-        "vars": {
-          "type": "video-seconds-played"
-        }
-      },
-      "videoEnded": {
-        "on": "video-ended",
-        "selector": "#myVideo",
-        "videoSpec": {
-          "end-session-when-invisible": true,
-          "exclude-autoplay": false
-        },
-        "request": "video",
-        "vars": {
-          "type": "video-ended"
-        }
+      "request": "video",
+      "vars": {
+        "type": "video-ended"
       }
     }
   }
-  </script>
+}
+</script>
 </amp-analytics>
 
 <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -201,7 +201,7 @@ export class AnalyticsRoot {
    * has not been requested before, it will be created.
    *
    * @param {string} name
-   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.ScrollEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)|function(new:./events.AmpStoryEventTracker, !AnalyticsRoot)} klass
+   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.ScrollEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)} klass
    * @return {!./events.EventTracker}
    */
   getTracker(name, klass) {

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -21,7 +21,6 @@ import {
   PlayingStates,
   VideoAnalyticsEvents,
 } from '../../../src/video-interface';
-import {StoryAnalyticsEvent} from '../../../src/analytics';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
@@ -67,13 +66,6 @@ const ALLOWED_FOR_ALL_ROOT_TYPES = ['ampdoc', 'embed'];
  *   }>}
  */
 const TRACKER_TYPE = Object.freeze({
-  [AnalyticsEventType.AMP_STORY]: {
-    name: AnalyticsEventType.AMP_STORY,
-    allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
-    klass: function(root) {
-      return new AmpStoryEventTracker(root);
-    },
-  },
   [AnalyticsEventType.CLICK]: {
     name: AnalyticsEventType.CLICK,
     allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
@@ -155,14 +147,6 @@ function isVideoTriggerType(triggerType) {
  * @param {string} triggerType
  * @return {boolean}
  */
-function isAmpStoryTriggerType(triggerType) {
-  return startsWith(triggerType, 'story');
-}
-
-/**
- * @param {string} triggerType
- * @return {boolean}
- */
 function isReservedTriggerType(triggerType) {
   return isEnumValue(AnalyticsEventType, triggerType);
 }
@@ -174,9 +158,6 @@ function isReservedTriggerType(triggerType) {
 export function getTrackerKeyName(eventType) {
   if (isVideoTriggerType(eventType)) {
     return AnalyticsEventType.VIDEO;
-  }
-  if (isAmpStoryTriggerType(eventType)) {
-    return AnalyticsEventType.AMP_STORY;
   }
   if (!isReservedTriggerType(eventType)) {
     return AnalyticsEventType.CUSTOM;
@@ -402,64 +383,6 @@ export class CustomEventTracker extends EventTracker {
         this.buffer_[eventType].push(event);
       }
     }
-  }
-}
-
-export class AmpStoryEventTracker extends EventTracker {
-  /**
-   * @param {!./analytics-root.AnalyticsRoot} root
-   */
-  constructor(root) {
-    super(root);
-
-    /** @private {?Observable<!Event>} */
-    this.sessionObservable_ = new Observable();
-
-    /** @private {?function(!Event)} */
-    this.boundOnSession_ = this.sessionObservable_.fire.bind(
-      this.sessionObservable_
-    );
-
-    Object.keys(StoryAnalyticsEvent).forEach(key => {
-      this.root
-        .getRoot()
-        .addEventListener(StoryAnalyticsEvent[key], this.boundOnSession_);
-    });
-  }
-
-  /** @override */
-  dispose() {
-    const root = this.root.getRoot();
-    Object.keys(StoryAnalyticsEvent).forEach(key => {
-      root.removeEventListener(StoryAnalyticsEvent[key], this.boundOnSession_);
-    });
-    this.boundOnSession_ = null;
-    this.sessionObservable_ = null;
-  }
-
-  /** @override */
-  add(context, eventType, config, listener) {
-    const storySpec = config['storySpec'] || {};
-    const rootTarget = this.root.getRootElement();
-
-    const repeat = storySpec['repeat'];
-    const on = config['on'];
-
-    return this.sessionObservable_.add(event => {
-      const {type} = event;
-
-      if (type !== on) {
-        return;
-      }
-      const details = /** @type {?JsonObject|undefined} */ (getData(event));
-      const detailsForPage = details['detailsForPage'];
-
-      if (repeat === false && detailsForPage['repeated']) {
-        return;
-      }
-
-      listener(new AnalyticsEvent(rootTarget, type, details));
-    });
   }
 }
 

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -43,7 +43,6 @@ const TAG = 'amp-analytics/events';
  * @enum {string}
  */
 export const AnalyticsEventType = {
-  AMP_STORY: 'amp-story',
   CLICK: 'click',
   CUSTOM: 'custom',
   HIDDEN: 'hidden',

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -15,8 +15,8 @@
  */
 
 import * as lolex from 'lolex';
+import {AmpdocAnalyticsRoot} from '../analytics-root';
 import {
-  AmpStoryEventTracker,
   AnalyticsEvent,
   AnalyticsEventType,
   ClickEventTracker,
@@ -28,7 +28,6 @@ import {
   VisibilityTracker,
   trackerTypeForTesting,
 } from '../events';
-import {AmpdocAnalyticsRoot} from '../analytics-root';
 import {Deferred} from '../../../../src/utils/promise';
 import {Signals} from '../../../../src/utils/signals';
 import {macroTask} from '../../../../testing/yield';
@@ -413,99 +412,6 @@ describes.realWin('Events', {amp: 1}, env => {
         fn2
       );
       expect(fn2).to.be.calledOnce;
-    });
-  });
-
-  describe('AmpStoryEventTracker', () => {
-    let tracker;
-
-    beforeEach(() => {
-      tracker = root.getTracker('story', AmpStoryEventTracker);
-    });
-
-    it('should initialize', () => {
-      expect(tracker.root).to.equal(root);
-    });
-
-    it('should listen on story events', () => {
-      const analyticsEvent = sandbox.stub();
-
-      const defaultStoryConfig = {
-        'on': 'story-page-visible',
-      };
-
-      const defaultVars = {
-        'storyPageIndex': '0',
-        'storyPageId': 'p4',
-        'storyPageCount': '4',
-      };
-
-      tracker.add(
-        analyticsElement,
-        'story-page-visible',
-        defaultStoryConfig,
-        analyticsEvent
-      );
-
-      const event = new Event('story-page-visible');
-      event.data = defaultVars;
-
-      root.getRoot().dispatchEvent(event);
-
-      expect(analyticsEvent).to.be.calledOnce;
-      expect(analyticsEvent).to.be.calledWith(
-        new AnalyticsEvent(
-          root.getRootElement(),
-          'story-page-visible',
-          defaultVars
-        )
-      );
-    });
-
-    it('should only fire event once when repeat is false', () => {
-      const analyticsEvent = sandbox.stub();
-
-      const defaultStoryConfig = {
-        'on': 'story-page-visible',
-        'storySpec': {
-          'repeat': false,
-        },
-      };
-
-      const defaultVars = {
-        'storyPageIndex': '0',
-        'storyPageId': 'p4',
-        'storyPageCount': '4',
-        'detailsForPage': {'repeated': false},
-      };
-
-      tracker.add(
-        analyticsElement,
-        'story-page-visible',
-        defaultStoryConfig,
-        analyticsEvent
-      );
-
-      const event = new Event('story-page-visible');
-      event.data = defaultVars;
-
-      const rootEl = root.getRoot();
-      rootEl.dispatchEvent(event);
-
-      defaultVars['detailsForPage']['repeated'] = true;
-      event.data = defaultVars;
-
-      // Trigger event second time, with 'repeated'.
-      rootEl.dispatchEvent(event);
-
-      expect(analyticsEvent).to.be.calledOnce;
-      expect(analyticsEvent).to.be.calledWith(
-        new AnalyticsEvent(
-          root.getRootElement(),
-          'story-page-visible',
-          defaultVars
-        )
-      );
     });
   });
 

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -18,7 +18,6 @@ import {Action, StateProperty} from './amp-story-store-service';
 import {DraggableDrawer, DrawerState} from './amp-story-draggable-drawer';
 import {HistoryState, setHistoryState} from './utils';
 import {Services} from '../../../src/services';
-import {StoryAnalyticsEvent} from '../../../src/analytics';
 import {dev} from '../../../src/log';
 import {getAnalyticsService} from './story-analytics';
 import {getState} from '../../../src/history';
@@ -148,9 +147,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     });
 
     this.historyService_.push(() => this.closeInternal_(), historyState);
-    this.analyticsService_.triggerEvent(
-      StoryAnalyticsEvent.PAGE_ATTACHMENT_ENTER
-    );
+    this.analyticsService_.triggerEvent(AnalyticsEvent.PAGE_ATTACHMENT_ENTER);
   }
 
   /**
@@ -184,8 +181,6 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
 
-    this.analyticsService_.triggerEvent(
-      StoryAnalyticsEvent.PAGE_ATTACHMENT_EXIT
-    );
+    this.analyticsService_.triggerEvent(AnalyticsEvent.PAGE_ATTACHMENT_EXIT);
   }
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -15,11 +15,11 @@
  */
 
 import {Action, StateProperty} from './amp-story-store-service';
+import {AnalyticsEvent, getAnalyticsService} from './story-analytics';
 import {DraggableDrawer, DrawerState} from './amp-story-draggable-drawer';
 import {HistoryState, setHistoryState} from './utils';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
-import {getAnalyticsService} from './story-analytics';
 import {getState} from '../../../src/history';
 import {htmlFor} from '../../../src/static-template';
 import {toggle} from '../../../src/style';

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -37,7 +37,11 @@ import {
 } from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {AdvancementConfig, TapNavigationDirection} from './page-advancement';
-import {AdvancementMode, getAnalyticsService} from './story-analytics';
+import {
+  AdvancementMode,
+  AnalyticsEvent,
+  getAnalyticsService,
+} from './story-analytics';
 import {AmpEvents} from '../../../src/amp-events';
 import {AmpStoryAccess} from './amp-story-access';
 import {AmpStoryBookend} from './bookend/amp-story-bookend';
@@ -70,7 +74,6 @@ import {MediaPool, MediaType} from './media-pool';
 import {PaginationButtons} from './pagination-buttons';
 import {Services} from '../../../src/services';
 import {ShareMenu} from './amp-story-share-menu';
-import {StoryAnalyticsEvent} from '../../../src/analytics';
 import {
   SwipeXYRecognizer,
   SwipeYRecognizer,
@@ -642,9 +645,7 @@ export class AmpStory extends AMP.BaseElement {
         // We do not want to trigger an analytics event for the initialization of
         // the muted state.
         this.analyticsService_.triggerEvent(
-          isMuted
-            ? StoryAnalyticsEvent.STORY_MUTED
-            : StoryAnalyticsEvent.STORY_UNMUTED
+          isMuted ? AnalyticsEvent.STORY_MUTED : AnalyticsEvent.STORY_UNMUTED
         );
       },
       false /** callToInitialize */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -15,10 +15,21 @@
  */
 import {Services} from '../../../src/services';
 import {StateProperty, getStoreService} from './amp-story-store-service';
-import {StoryAnalyticsEvent} from '../../../src/analytics';
 import {getVariableService} from './variable-service';
-import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
+import {triggerAnalyticsEvent} from '../../../src/analytics';
+
+/** @enum {string} */
+export const AnalyticsEvent = {
+  BOOKEND_ENTER: 'story-bookend-enter',
+  BOOKEND_EXIT: 'story-bookend-exit',
+  LAST_PAGE_VISIBLE: 'story-last-page-visible',
+  PAGE_ATTACHMENT_ENTER: 'story-page-attachment-enter',
+  PAGE_ATTACHMENT_EXIT: 'story-page-attachment-exit',
+  PAGE_VISIBLE: 'story-page-visible',
+  STORY_MUTED: 'story-audio-muted',
+  STORY_UNMUTED: 'story-audio-unmuted',
+};
 
 /** @enum {string} */
 export const AdvancementMode = {
@@ -66,9 +77,6 @@ export class StoryAnalyticsService {
     /** @const @private {!./variable-service.AmpStoryVariableService} */
     this.variableService_ = getVariableService(win);
 
-    /** @private {!Object} */
-    this.eventsPerPage_ = map();
-
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(win);
 
@@ -79,9 +87,7 @@ export class StoryAnalyticsService {
   initializeListeners_() {
     this.storeService_.subscribe(StateProperty.BOOKEND_STATE, isActive => {
       this.triggerEvent(
-        isActive
-          ? StoryAnalyticsEvent.BOOKEND_ENTER
-          : StoryAnalyticsEvent.BOOKEND_EXIT
+        isActive ? AnalyticsEvent.BOOKEND_ENTER : AnalyticsEvent.BOOKEND_EXIT
       );
     });
 
@@ -92,14 +98,14 @@ export class StoryAnalyticsService {
           return;
         }
 
-        this.triggerEvent(StoryAnalyticsEvent.PAGE_VISIBLE);
+        this.triggerEvent(AnalyticsEvent.PAGE_VISIBLE);
 
         const pageIds = this.storeService_.get(StateProperty.PAGE_IDS);
         const pageIndex = this.storeService_.get(
           StateProperty.CURRENT_PAGE_INDEX
         );
         if (pageIndex === pageIds.length - 1) {
-          this.triggerEvent(StoryAnalyticsEvent.LAST_PAGE_VISIBLE);
+          this.triggerEvent(AnalyticsEvent.LAST_PAGE_VISIBLE);
         }
       },
       true /* callToInitialize */
@@ -107,34 +113,13 @@ export class StoryAnalyticsService {
   }
 
   /**
-   * @param {!StoryAnalyticsEvent} eventType
+   * @param {!AnalyticsEvent} eventType
    */
   triggerEvent(eventType) {
-    this.element_.dispatchCustomEvent(eventType, this.getDetails_(eventType));
-  }
-
-  /**
-   * Consolidates count of event types per page and variables of the event.
-   * @param {!StoryAnalyticsEvent} eventType
-   * @private
-   * @return {!Object}
-   */
-  getDetails_(eventType) {
-    const details = {};
-    const vars = this.variableService_.get();
-    const pageId = vars['storyPageId'];
-
-    this.eventsPerPage_[pageId] = this.eventsPerPage_[pageId] || {};
-
-    this.eventsPerPage_[pageId][eventType] =
-      this.eventsPerPage_[pageId][eventType] || 0;
-
-    this.eventsPerPage_[pageId][eventType]++;
-
-    if (this.eventsPerPage_[pageId][eventType] > 1) {
-      Object.assign(details, {repeated: true});
-    }
-
-    return Object.assign({detailsForPage: details}, vars);
+    triggerAnalyticsEvent(
+      this.element_,
+      eventType,
+      this.variableService_.get()
+    );
   }
 }

--- a/extensions/amp-story/1.0/test/test-analytics.js
+++ b/extensions/amp-story/1.0/test/test-analytics.js
@@ -53,48 +53,4 @@ describes.fakeWin('amp-story analytics', {}, env => {
 
     expect(trigger).to.have.been.calledWith('story-last-page-visible');
   });
-
-  it('should not mark an event as repeated the first time', () => {
-    analytics.element_.dispatchCustomEvent = () => {};
-    const dispatchStub = sandbox.stub(
-      analytics.element_,
-      'dispatchCustomEvent'
-    );
-
-    storeService.dispatch(Action.CHANGE_PAGE, {
-      id: 'test-page',
-      index: 1,
-    });
-
-    expect(dispatchStub).to.have.been.calledWithMatch('story-page-visible', {
-      'detailsForPage': {},
-    });
-  });
-
-  it('should mark event as repeated', () => {
-    analytics.element_.dispatchCustomEvent = () => {};
-    const dispatchStub = sandbox.stub(
-      analytics.element_,
-      'dispatchCustomEvent'
-    );
-
-    storeService.dispatch(Action.CHANGE_PAGE, {
-      id: 'test-page',
-      index: 1,
-    });
-
-    storeService.dispatch(Action.CHANGE_PAGE, {
-      id: 'test-page2',
-      index: 2,
-    });
-
-    storeService.dispatch(Action.CHANGE_PAGE, {
-      id: 'test-page',
-      index: 1,
-    });
-
-    expect(dispatchStub).to.have.been.calledWithMatch('story-page-visible', {
-      'detailsForPage': {'repeated': true},
-    });
-  });
 });

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -31,15 +31,3 @@ export function triggerAnalyticsEvent(target, eventType, opt_vars) {
     analytics.triggerEventForTarget(target, eventType, opt_vars);
   });
 }
-
-/** @enum {string} */
-export const StoryAnalyticsEvent = {
-  BOOKEND_ENTER: 'story-bookend-enter',
-  BOOKEND_EXIT: 'story-bookend-exit',
-  LAST_PAGE_VISIBLE: 'story-last-page-visible',
-  PAGE_ATTACHMENT_ENTER: 'story-page-attachment-enter',
-  PAGE_ATTACHMENT_EXIT: 'story-page-attachment-exit',
-  PAGE_VISIBLE: 'story-page-visible',
-  STORY_MUTED: 'story-audio-muted',
-  STORY_UNMUTED: 'story-audio-unmuted',
-};


### PR DESCRIPTION
Fixes #24017

We just noticed some early analytic events (e.g. story-page-visible on the first page) aren't being logged correctly since the amp-analytics service isn't ready to listen for these events yet. This has been happening since #23030 was pushed since it stopped buffering early events.

This reverts commit 1a3eb267ffe210579e35f47af4346af795576adf. #23030
