### PR TITLE
Revert "Revert "Set the new loaders experiment to 1% of traffic.""

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -40,6 +40,7 @@
   "ios-fixed-no-transfer": 1,
   "ios-scrollable-iframe": 0,
   "layers": 1,
+  "new-loaders": 1,
   "pump-early-frame": 1,
   "version-locking": 1,
   "macro-after-long-task": 1

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,6 +37,7 @@
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "ios-scrollable-iframe": 0,
+  "new-loaders": 0.01,
   "pump-early-frame": 1,
   "version-locking": 1
 }


### PR DESCRIPTION
Roll forwards of loaders experiment ramp up. The loaders should render correctly when the image is cached and the extension loads slowly now that #23964 is fixed.

Reverts ampproject/amphtml#23963