### PR TITLE
🏗🐛 Don't call `travisBuildNumber()` in the global scope

### DIFF
--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -23,7 +23,8 @@ const {cyan, green} = require('ansi-colors');
 const {gitCommitHash} = require('../git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../app-utils');
 const {travisBuildNumber} = require('../travis');
-const hostName = `https://storage.googleapis.com/amp-test-website-1/amp_dist_${travisBuildNumber()}`;
+
+const hostNamePrefix = 'https://storage.googleapis.com/amp-test-website-1';
 
 async function walk(dest) {
   const filelist = [];
@@ -42,6 +43,7 @@ async function walk(dest) {
 
 async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
+  const hostName = `${hostNamePrefix}/amp_dist_${travisBuildNumber()}`;
   const inabox = false;
   const storyV1 = true;
   const result = replaceUrlsAppUtil(


### PR DESCRIPTION
Calling `travisBuildNumber()` in the global scope results in an error while running any `gulp` task locally.

```
ERROR: This is not a Travis build. Cannot get process.env.TRAVIS_BUILD_NUMBER.
```

This PR moves the call to local scope.

Addresses https://github.com/ampproject/amphtml/pull/23976/files#r314841349