### PR TITLE
Throw useful error if RequestBank teardown fails

### DIFF
--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -198,9 +198,11 @@ export class RequestBank {
         credentials: 'omit',
       })
       .catch(err => {
-        return err.response.text().then(msg => {
-          throw new Error(err.message + ': ' + msg);
-        });
+        return err.response
+          ? err.response.text().then(msg => {
+              throw new Error(err.message + ': ' + msg);
+            })
+          : err;
       });
   }
 }

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -198,11 +198,13 @@ export class RequestBank {
         credentials: 'omit',
       })
       .catch(err => {
-        return err.response
-          ? err.response.text().then(msg => {
-              throw new Error(err.message + ': ' + msg);
-            })
-          : err;
+        if (err.response != null) {
+          return err.response.text().then(msg => {
+            throw new Error(err.message + ': ' + msg);
+          });
+        } else {
+          throw err;
+        }
       });
   }
 }


### PR DESCRIPTION
When tearing down `RequestBank` and fetch fails, the error gets swallowed.

before fix
```
  ✗ TypeError: Cannot read property 'text' of undefined
      at testing/test-helper.js:201:29
``` 


after fix
```
✗ Error: XHR Failed fetching (http://localhost:9876/...): Failed to fetch​​​
      at createErrorVargs (src/log.js:688:13)
      at Log.createExpectedError (src/log.js:344:36)
      at src/service/xhr-impl.js:109:22
```