### PR TITLE
🏗 Update Local AMP extension to allow custom base URLs

### DIFF
--- a/testing/local-amp-chrome-extension/background.js
+++ b/testing/local-amp-chrome-extension/background.js
@@ -37,7 +37,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       path = path.replace(/\.js$/, '.max.js');
     }
     return {
-      redirectUrl: ( baseUrl || defaultBaseUrl ) + path
+      redirectUrl: baseUrl + path
     };
   },
   {
@@ -62,7 +62,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       path = path.replace(/\/f\.js$/, '/integration.js');
     }
     return {
-      redirectUrl: ( baseUrl || defaultBaseUrl ) + path
+      redirectUrl: baseUrl + path
     };
   },
   {

--- a/testing/local-amp-chrome-extension/background.js
+++ b/testing/local-amp-chrome-extension/background.js
@@ -16,6 +16,10 @@
 
 var disabled = false;
 
+var defaultBaseUrl = 'http://localhost:8000/';
+
+var baseUrl = defaultBaseUrl;
+
 // Rewrite cdn.ampproject.org
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
@@ -33,7 +37,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       path = path.replace(/\.js$/, '.max.js');
     }
     return {
-      redirectUrl: 'http://localhost:8000/' + path
+      redirectUrl: ( baseUrl || defaultBaseUrl ) + path
     };
   },
   {
@@ -58,7 +62,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       path = path.replace(/\/f\.js$/, '/integration.js');
     }
     return {
-      redirectUrl: 'http://localhost:8000/' + path
+      redirectUrl: ( baseUrl || defaultBaseUrl ) + path
     };
   },
   {

--- a/testing/local-amp-chrome-extension/manifest.json
+++ b/testing/local-amp-chrome-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Local AMP",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "manifest_version": 2,
   "description": "Run prod AMP pages with the local AMP runtime.",
   "homepage_url": "https://www.ampproject.org",

--- a/testing/local-amp-chrome-extension/popup.html
+++ b/testing/local-amp-chrome-extension/popup.html
@@ -115,6 +115,10 @@
         Local AMP
        </span>
     </div>
+    <div id="base-url-holder">
+      <label for="base-url">Base URL:</label>
+      <input id="base-url" type="url">
+    </div>
     <br><br>
     <span id="copyright">
       &copy; Copyright 2017 The AMP HTML Authors.<br> All Rights Reserved.

--- a/testing/local-amp-chrome-extension/popup.js
+++ b/testing/local-amp-chrome-extension/popup.js
@@ -32,9 +32,10 @@ document.addEventListener('DOMContentLoaded', function() {
   baseUrlInput.placeholder = background.defaultBaseUrl;
   baseUrlInput.value = background.baseUrl;
   baseUrlInput.addEventListener('input', () => {
-    background.baseUrl = document.getElementById('base-url').value;
-    if ( '/' !== background.baseUrl.substr( -1 ) ) {
-      background.baseUrl += '/';
+    const url = new URL(baseUrlInput.value.trim() || background.defaultBaseUrl);
+    if (!url.pathname.endsWith('/')) {
+      url.pathname += '/';
     }
+    background.baseUrl = url.href;
   });
 });

--- a/testing/local-amp-chrome-extension/popup.js
+++ b/testing/local-amp-chrome-extension/popup.js
@@ -27,4 +27,14 @@ document.addEventListener('DOMContentLoaded', function() {
   if (!background.disabled) {
     switchButton.checked = true;
   }
+
+  const baseUrlInput = document.getElementById('base-url');
+  baseUrlInput.placeholder = background.defaultBaseUrl;
+  baseUrlInput.value = background.baseUrl;
+  baseUrlInput.addEventListener('input', () => {
+    background.baseUrl = document.getElementById('base-url').value;
+    if ( '/' !== background.baseUrl.substr( -1 ) ) {
+      background.baseUrl += '/';
+    }
+  });
 });


### PR DESCRIPTION
This is split off from #23213. 

When calling `gulp serve` you can specify a host to use that is different from the default `localhost:8000` (default arguments `--host=localhost` and `--port=8000`).  However, the Local AMP browser extension does not support anything but the default. This PR updates the extension popup to include a URL input field for the actual base URL to be supplied (e.g. `https://amphtml.lndo.site/`).

Importantly, this allows for the extension to be successfully used on HTTPS sites. Previously, I would get insecure mixed content warnings on HTTPS sites since the script URLs would be loaded from `http://localhost:8000`.

![image](https://user-images.githubusercontent.com/134745/60924750-d111c280-a256-11e9-964a-c78bb5204bc3.png)