### PR TITLE
🐛Fixes race condition in `amp-video-iframe`

### DIFF
--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -385,14 +385,14 @@ class AmpVideoIframe extends AMP.BaseElement {
    * @private
    */
   postMessage_(message) {
-    if (!this.iframe_ || !this.iframe_.contentWindow) {
-      return;
-    }
     const {promise} = this.readyDeferred_;
     if (!promise) {
       return;
     }
     promise.then(() => {
+      if (!this.iframe_ || !this.iframe_.contentWindow) {
+        return;
+      }
       this.iframe_.contentWindow./*OK*/ postMessage(
         JSON.stringify(message),
         '*'


### PR DESCRIPTION
Closes #23989

Need help creating a test for this (if needed), I tried stubbing the iframe's `postMessage` call but sinon is unable to stub it because the test video iframe is served from `http://iframe.localhost:9876/` which is apparently not the same origin as `localhost:9876` so sinon can't access the `contentWindow`.