### PR TITLE
Add a "story" experiment ID to the performance service.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -18,8 +18,8 @@ import {Services} from '../services';
 import {VisibilityState} from '../visibility-state';
 import {dev} from '../log';
 import {dict, map} from '../utils/object';
-import {getAmpdoc, getService, registerServiceBuilder} from '../service';
 import {getMode} from '../mode';
+import {getService, registerServiceBuilder} from '../service';
 import {isCanary} from '../experiments';
 import {isStoryDocument} from '../utils/story';
 import {layoutRectLtwh} from '../layout-rect';
@@ -267,7 +267,8 @@ export class Performance {
    * @private
    */
   maybeAddStoryExperimentId_() {
-    return isStoryDocument(getAmpdoc(this.win.document)).then(isStory => {
+    const ampdoc = Services.ampdocServiceFor(this.win).getSingleDoc();
+    return isStoryDocument(ampdoc).then(isStory => {
       if (isStory) {
         this.addEnabledExperiment('story');
       }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -432,7 +432,7 @@ describes.realWin('performance', {amp: true}, env => {
               value: 1,
             });
             expect(
-              viewerSendMessageStub.withArgs('tick').getCall(5).args[1]
+              viewerSendMessageStub.withArgs('tick').getCall(4).args[1]
             ).to.be.jsonEqual({
               label: 'msr',
               delta: 1,

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -422,20 +422,20 @@ describes.realWin('performance', {amp: true}, env => {
             expect(
               viewerSendMessageStub.withArgs('tick').getCall(0).args[1]
             ).to.be.jsonEqual({
-              label: 'msr',
-              delta: 1,
-            });
-            expect(
-              viewerSendMessageStub.withArgs('tick').getCall(1).args[1]
-            ).to.be.jsonEqual({
               label: 'start0',
               value: 0,
             });
             expect(
-              viewerSendMessageStub.withArgs('tick').getCall(2).args[1]
+              viewerSendMessageStub.withArgs('tick').getCall(1).args[1]
             ).to.be.jsonEqual({
               label: 'start1',
               value: 1,
+            });
+            expect(
+              viewerSendMessageStub.withArgs('tick').getCall(5).args[1]
+            ).to.be.jsonEqual({
+              label: 'msr',
+              delta: 1,
             });
           });
         });
@@ -498,6 +498,21 @@ describes.realWin('performance', {amp: true}, env => {
             expect(viewerSendMessageStub.withArgs('sendCsi')).to.have.callCount(
               3
             );
+          });
+        });
+
+        it('should flush with the story experiment enabled', () => {
+          const storyEl = win.document.createElement('amp-story');
+          const bodyEl = win.document.body;
+          bodyEl.insertBefore(storyEl, bodyEl.firstElementChild || null);
+
+          return perf.coreServicesAvailable().then(() => {
+            expect(viewerSendMessageStub.withArgs('sendCsi')).to.have.callCount(
+              1
+            );
+            const call = viewerSendMessageStub.withArgs('sendCsi').getCall(0);
+            expect(call.args[1]).to.have.property('ampexp');
+            expect(call.args[1].ampexp).to.contain('story');
           });
         });
       });


### PR DESCRIPTION
Add a story experiment ID to the performance service so we can slice the performance metrics for AMP Story.

The only difference from the previous implementation is that the call to "messaging ready signal" is now queued so we don't have to delay it while we wait to know if the document is a story, but that is a no-op.