### PR TITLE
Amphtml ads visual tests should use relative path against root

### DIFF
--- a/examples/visual-tests/amphtml-ads/resource/image.html
+++ b/examples/visual-tests/amphtml-ads/resource/image.html
@@ -22,12 +22,12 @@
       <div class="abgcp pea" id=abgcp>
         <div class=abgs id=abgs>
           <a class=abgl href="https://adssettings.google.com/whythisad" id=abgl target=_blank>
-            <amp-img height=15 src=./en.png width=75></amp-img>
+            <amp-img height=15 src=/examples/visual-tests/amphtml-ads/resource/en.png width=75></amp-img>
           </a>
         </div>
         <div class=abgb id=abgb>
           <a href="https://adssettings.google.com/whythisad" target=_blank>
-            <amp-img height=15 src=./icon.png width=15></amp-img>
+            <amp-img height=15 src=/examples/visual-tests/amphtml-ads/resource/icon.png width=15></amp-img>
           </a>
         </div>
       </div>

--- a/examples/visual-tests/amphtml-ads/resource/text.html
+++ b/examples/visual-tests/amphtml-ads/resource/text.html
@@ -115,12 +115,12 @@
   <div class="abgcp pea" id=abgcp>
     <div class=abgs id=abgs>
       <a class=abgl href="https://adssettings.google.com/whythisad" id=abgl target=_blank>
-        <amp-img height=15 src=./en.png width=75></amp-img>
+        <amp-img height=15 src=/examples/visual-tests/amphtml-ads/resource/en.png width=75></amp-img>
       </a>
     </div>
     <div class=abgb id=abgb>
       <a href="https://adssettings.google.com/whythisad" target=_blank>
-        <amp-img height=15 src=./icon.png width=15></amp-img>
+        <amp-img height=15 src=/examples/visual-tests/amphtml-ads/resource/icon.png width=15></amp-img>
       </a>
     </div>
   </div>


### PR DESCRIPTION
This has been passing in the past. Unsure about the reason but now it is breaking.
