### PR TITLE
✨Story Ads: read amp-ad-exit 

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -257,6 +257,8 @@ exports.rules = [
       'extensions/amp-story/1.0/animation.js->extensions/amp-animation/0.1/web-animation-types.js',
       // Story ads
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/amp-story-store-service.js',
+      // TODO(ccordry): remove this after amp-ad-exit hack is gone.
+      'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-ad-exit/0.1/config.js',
       // TODO(ccordry): remove this after createShadowRootWithStyle is moved to src
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/utils.js',
 

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -257,7 +257,7 @@ exports.rules = [
       'extensions/amp-story/1.0/animation.js->extensions/amp-animation/0.1/web-animation-types.js',
       // Story ads
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/amp-story-store-service.js',
-      // TODO(ccordry): remove this after amp-ad-exit hack is gone.
+      // TODO(#24080) Remove this when story ads have full ad network support.
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-ad-exit/0.1/config.js',
       // TODO(ccordry): remove this after createShadowRootWithStyle is moved to src
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/utils.js',

--- a/build-system/sources.js
+++ b/build-system/sources.js
@@ -82,6 +82,9 @@ const CLOSURE_SRC_GLOBS = [
   'extensions/amp-ad-network*/**/*-config.js',
   'extensions/amp-ad/**/*.js',
   'extensions/amp-a4a/**/*.js',
+  // TODO(#24080) Remove this when story ads have full ad network support.
+  // Needed for amp-story-auto-ads to validate amp-ad-exit config.
+  'extensions/amp-ad-exit/0.1/config.js',
   // Currently needed for crypto.js and visibility.js.
   // Should consider refactoring.
   'extensions/amp-analytics/**/*.js',

--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -99,5 +99,16 @@
       </amp-img>
     </div>
   </div>
+  <amp-ad-exit id="exit-api">
+    <script type="application/json">
+    {
+      "targets": {
+        "url_0": {
+          "finalUrl": "https://www.google.com/webdesigner/"
+        }
+      }
+    }
+    </script>
+  </amp-ad-exit>
 </body>
 </html>

--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -8,7 +8,7 @@
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 
   <meta name="amp-cta-type" content="INSTALL">
-  <meta name="amp-cta-url" content="https://www.amp.dev">
+  <meta name="amp-cta-url" content="https://www.example.com">
   <meta name="amp4ads-vars-attribution-icon" content="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png">
   <meta name="amp4ads-vars-attribution-url" content="https://www.amp.dev">
 
@@ -104,7 +104,7 @@
     {
       "targets": {
         "url_0": {
-          "finalUrl": "https://www.google.com/webdesigner/"
+          "finalUrl": "https://www.amp.dev"
         }
       }
     }

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -27,6 +27,7 @@ import {
   UIType,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {CSS as adBadgeCSS} from '../../../build/amp-story-auto-ads-ad-badge-0.1.css';
+import {assertConfig} from '../../amp-ad-exit/0.1/config';
 import {assertHttpsUrl} from '../../../src/url';
 import {CSS as attributionCSS} from '../../../build/amp-story-auto-ads-attribution-0.1.css';
 import {
@@ -670,14 +671,26 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Validate ad-server response has requirements to build outlink
    * @param {!Element} adPageElement
-   * @param {!Object} a4aVars
-   * @return {*} TODO(#23582): Specify return type
+   * @return {boolean}
    */
-  maybeCreateCtaLayer_(adPageElement, a4aVars) {
-    // if making a CTA layer we need a button name & outlink url
+  maybeCreateCtaLayer_(adPageElement) {
+    let a4aVars = {};
+    let ampAdExitOutlink = null;
+
+    const {iframe} = this.lastCreatedAdImpl_;
+    // No iframe for custom ad.
+    if (iframe) {
+      const iframeDoc = getFrameDoc(iframe);
+      ampAdExitOutlink = this.readAmpAdExit_(iframeDoc);
+      a4aVars = this.extractA4AVars_(iframeDoc);
+    }
+
+    // If making a CTA layer we need a button name & outlink url.
     const ctaUrl =
+      ampAdExitOutlink ||
       a4aVars[A4AVarNames.CTA_URL] ||
       this.lastCreatedAdElement_.getAttribute(DataAttrs.CTA_URL);
+
     const ctaType =
       a4aVars[A4AVarNames.CTA_TYPE] ||
       this.lastCreatedAdElement_.getAttribute(DataAttrs.CTA_TYPE);
@@ -701,6 +714,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       user().error(TAG, 'invalid "CTA Type" in ad response');
       return false;
     }
+
+    this.maybeCreateAttribution_(adPageElement, a4aVars);
 
     return this.createCtaLayer_(
       adPageElement,
@@ -949,18 +964,13 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       return AD_STATE.PENDING;
     }
 
-    const a4aVars = this.extractA4AVars_();
-
     const ctaCreated = this.maybeCreateCtaLayer_(
-      dev().assertElement(nextAdPageEl),
-      a4aVars
+      dev().assertElement(nextAdPageEl)
     );
     if (!ctaCreated) {
       // failed on ad-server response format
       return AD_STATE.FAILED;
     }
-
-    this.maybeCreateAttribution_(nextAdPageEl, a4aVars);
 
     this.ampStory_.insertPage(pageBeforeAdId, nextAdPageEl.id);
 
@@ -977,11 +987,10 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * Find all `amp4ads-vars-` prefixed meta tags and return all kv pairs
    * in a single object.
    * @private
+   * @param {!Document} iframeDoc
    * @return {!Object}
    */
-  extractA4AVars_() {
-    const {iframe} = this.lastCreatedAdImpl_;
-    const iframeDoc = getFrameDoc(iframe);
+  extractA4AVars_(iframeDoc) {
     const tags = getA4AMetaTags(iframeDoc);
     const vars = {};
     iterateCursor(tags, tag => {
@@ -990,6 +999,38 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       vars[name] = content;
     });
     return vars;
+  }
+
+  /**
+   * This in intended to be a temporary hack so we can can support
+   * ad serving pipelines that are reliant on using amp-ad-exit for
+   * outlinks.
+   * Reads amp-ad-exit config and tries to extract a suitable outlink.
+   * If there are multiple exits present, behavior is unpredictable due to
+   * JSON parse.
+   * @private
+   * @param {!Document} iframeDoc
+   * @return {?string}
+   */
+  readAmpAdExit_(iframeDoc) {
+    const ampAdExit = iframeDoc.querySelector('amp-ad-exit');
+    if (!ampAdExit) {
+      return null;
+    }
+    const {children} = ampAdExit;
+    userAssert(
+      children.length == 1,
+      'The tag should contain exactly one <script> child.'
+    );
+    const child = children[0];
+    userAssert(
+      isJsonScriptTag(child),
+      'The amp-ad-exit config should ' +
+        'be inside a <script> tag with type="application/json"'
+    );
+    const config = assertConfig(parseJson(child.textContent));
+    const target = config['targets'][Object.keys(config['targets'])[0]];
+    return target['finalUrl'];
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -1018,20 +1018,25 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     if (!ampAdExit) {
       return null;
     }
-    const {children} = ampAdExit;
-    userAssert(
-      children.length == 1,
-      'The tag should contain exactly one <script> child.'
-    );
-    const child = children[0];
-    userAssert(
-      isJsonScriptTag(child),
-      'The amp-ad-exit config should ' +
-        'be inside a <script> tag with type="application/json"'
-    );
-    const config = assertConfig(parseJson(child.textContent));
-    const target = config['targets'][Object.keys(config['targets'])[0]];
-    return target['finalUrl'];
+    try {
+      const {children} = ampAdExit;
+      userAssert(
+        children.length == 1,
+        'The tag should contain exactly one <script> child.'
+      );
+      const child = children[0];
+      userAssert(
+        isJsonScriptTag(child),
+        'The amp-ad-exit config should ' +
+          'be inside a <script> tag with type="application/json"'
+      );
+      const config = assertConfig(parseJson(child.textContent));
+      const target = config['targets'][Object.keys(config['targets'])[0]];
+      return target['finalUrl'];
+    } catch (e) {
+      dev().error(TAG, e);
+      return null;
+    }
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -1002,6 +1002,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   }
 
   /**
+   * TODO(#24080) Remove this when story ads have full ad network support.
    * This in intended to be a temporary hack so we can can support
    * ad serving pipelines that are reliant on using amp-ad-exit for
    * outlinks.

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -164,6 +164,40 @@ describes.realWin(
       });
     });
 
+    describe('CTA button', () => {
+      beforeEach(async () => {
+        addStoryAutoAdsConfig(doc, adElement);
+        const storyImpl = new MockStoryImpl(storyElement);
+        storyElement.getImpl = () => Promise.resolve(storyImpl);
+        await addStoryPages(doc, storyImpl);
+        await autoAds.buildCallback();
+        await autoAds.layoutCallback();
+        fireBuildSignals(doc);
+        return Promise.resolve();
+      });
+
+      it('reads value from amp-ad-exit over meta tags', async () => {
+        const iframeContent = `
+          <amp-ad-exit id="exit-api">
+            <script type="application/json">
+            {
+              "targets": {
+                "url_0": {
+                  "finalUrl": "https://amp.dev/"
+                }
+              }
+            }
+            </script>
+          </amp-ad-exit>
+        `;
+        addCtaValues(autoAds, 'SHOP', 'https://example.com'); // This url should be ignored.
+        await insertAdContent(autoAds, iframeContent);
+        autoAds.forceRender('story-page-0' /* pageBeforeAdId */);
+        const cta = doc.querySelector('.i-amphtml-story-ad-link');
+        expect(cta.href).to.equal('https://amp.dev/');
+      });
+    });
+
     describe('ad choices', () => {
       beforeEach(async () => {
         addStoryAutoAdsConfig(doc, adElement);

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -54,7 +54,7 @@ export function getA4AMetaTags(doc) {
 /**
  * Returns document from given iframe, or null if non FIE.
  * @param {HTMLIFrameElement} iframe
- * @return {Document}
+ * @return {!Document}
  */
 export function getFrameDoc(iframe) {
   return iframe.contentDocument || iframe.contentWindow.document;


### PR DESCRIPTION
Temporary fix to allow reading of `amp-ad-exit` so that we can support ad networks that only include click tracking urls inside of `amp-ad-exit` config.

This should be deleted once these networks have first class support.