### PR TITLE
Automatically preconnect to source origins on page loads.

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -46,6 +46,7 @@ import {
 import {internalRuntimeVersion} from './internal-version';
 import {maybeTrackImpression} from './impression';
 import {maybeValidate} from './validator-integration';
+import {preconnectToOrigin} from './preconnect';
 import {startupChunk} from './chunk';
 import {stubElementsForDoc} from './service/custom-element-registry';
 
@@ -132,6 +133,7 @@ if (shouldMainBootstrapRun) {
             installStandaloneExtension(ampdoc);
             maybeValidate(self);
             makeBodyVisible(self.document);
+            preconnectToOrigin(self.document);
           },
           /* makes the body visible */ true
         );

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -26,6 +26,7 @@ import {htmlFor} from './static-template';
 import {parseUrlDeprecated} from './url';
 import {startsWith} from './string';
 import {toWin} from './types';
+import {whenDocumentComplete} from './document-ready';
 
 const ACTIVE_CONNECTION_TIMEOUT_MS = 180 * 1000;
 const PRECONNECT_TIMEOUT_MS = 10 * 1000;
@@ -381,4 +382,21 @@ export function preconnectForElement(element) {
   registerServiceBuilder(serviceHolder, 'preconnect', PreconnectService);
   const preconnectService = getService(serviceHolder, 'preconnect');
   return new Preconnect(preconnectService, element);
+}
+
+/**
+ * Preconnects to the source URL and canonical domains to make sure
+ * outbound navigations are quick. Waits for onload to avoid blocking
+ * more high priority loads.
+ * @param {!Document} document
+ * @return {Promise} When work is done.
+ */
+export function preconnectToOrigin(document) {
+  return whenDocumentComplete(document).then(() => {
+    const element = document.documentElement;
+    const preconnect = preconnectForElement(element);
+    const info = Services.documentInfoForDoc(element);
+    preconnect.url(info.sourceUrl);
+    preconnect.url(info.canonicalUrl);
+  });
 }

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -15,13 +15,13 @@
  */
 
 import * as lolex from 'lolex';
-import {Services} from '../../src/services';
 import {createIframePromise} from '../../testing/iframe';
 import {
   preconnectForElement,
-  preconnectToOrigin,
   setPreconnectFeaturesForTesting,
+  preconnectToOrigin,
 } from '../../src/preconnect';
+import {Services} from '../../src/services';
 
 describe('preconnect', () => {
   let sandbox;
@@ -127,7 +127,8 @@ describe('preconnect', () => {
       sourceUrl: 'https://sourceurl.com/',
       canonicalUrl: 'https://canonicalurl.com/',
     });
-    await preconnectToOrigin(iframe.doc).then(() => visible);
+    await preconnectToOrigin(iframe.doc);
+    await Promise.resolve(); // Wait to become visible.
     const preconnects = iframe.doc.querySelectorAll('link[rel=preconnect]');
     expect(preconnects).to.have.length(2);
     expect(preconnects[0].href).to.equal('https://sourceurl.com/');

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -19,7 +19,9 @@ import {createIframePromise} from '../../testing/iframe';
 import {
   preconnectForElement,
   setPreconnectFeaturesForTesting,
+  preconnectToOrigin,
 } from '../../src/preconnect';
+import {Services} from '../../src/services';
 
 describe('preconnect', () => {
   let sandbox;
@@ -116,6 +118,21 @@ describe('preconnect', () => {
         expect(open).to.have.not.been.called;
       });
     });
+  });
+
+  it('should preconnect to origins', async function() {
+    isSafari = false;
+    const iframe = await getPreconnectIframe();
+    sandbox.stub(Services, 'documentInfoForDoc').returns({
+      sourceUrl: 'https://sourceurl.com/',
+      canonicalUrl: 'https://canonicalurl.com/',
+    });
+    await preconnectToOrigin(iframe.doc);
+    await visible;
+    const preconnects = iframe.doc.querySelectorAll('link[rel=preconnect]');
+    expect(preconnects).to.have.length(2);
+    expect(preconnects[0].href).to.equal('https://sourceurl.com/');
+    expect(preconnects[1].href).to.equal('https://canonicalurl.com/');
   });
 
   it('should preconnect with known support', () => {

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -127,8 +127,7 @@ describe('preconnect', () => {
       sourceUrl: 'https://sourceurl.com/',
       canonicalUrl: 'https://canonicalurl.com/',
     });
-    await preconnectToOrigin(iframe.doc);
-    await visible;
+    await preconnectToOrigin(iframe.doc).then(() => visible);
     const preconnects = iframe.doc.querySelectorAll('link[rel=preconnect]');
     expect(preconnects).to.have.length(2);
     expect(preconnects[0].href).to.equal('https://sourceurl.com/');

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -128,6 +128,7 @@ describe('preconnect', () => {
       canonicalUrl: 'https://canonicalurl.com/',
     });
     await preconnectToOrigin(iframe.doc);
+    await visible;
     const preconnects = iframe.doc.querySelectorAll('link[rel=preconnect]');
     expect(preconnects).to.have.length(2);
     expect(preconnects[0].href).to.equal('https://sourceurl.com/');

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -15,13 +15,13 @@
  */
 
 import * as lolex from 'lolex';
-import {Services} from '../../src/services';
 import {createIframePromise} from '../../testing/iframe';
 import {
   preconnectForElement,
-  preconnectToOrigin,
   setPreconnectFeaturesForTesting,
+  preconnectToOrigin,
 } from '../../src/preconnect';
+import {Services} from '../../src/services';
 
 describe('preconnect', () => {
   let sandbox;
@@ -128,7 +128,6 @@ describe('preconnect', () => {
       canonicalUrl: 'https://canonicalurl.com/',
     });
     await preconnectToOrigin(iframe.doc);
-    await visible;
     const preconnects = iframe.doc.querySelectorAll('link[rel=preconnect]');
     expect(preconnects).to.have.length(2);
     expect(preconnects[0].href).to.equal('https://sourceurl.com/');

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -15,13 +15,13 @@
  */
 
 import * as lolex from 'lolex';
+import {Services} from '../../src/services';
 import {createIframePromise} from '../../testing/iframe';
 import {
   preconnectForElement,
-  setPreconnectFeaturesForTesting,
   preconnectToOrigin,
+  setPreconnectFeaturesForTesting,
 } from '../../src/preconnect';
-import {Services} from '../../src/services';
 
 describe('preconnect', () => {
   let sandbox;


### PR DESCRIPTION
Ensures quicker onward journeys by preconnecting to the source URL and canonical URL of a document upon page load.

Fixes #24043