### PR TITLE
🏗🚮 Enable property inlining

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -98,6 +98,7 @@
     "local/prefer-destructuring": 2,
     "local/private-prop-names": 2,
     "local/query-selector": 2,
+    "local/split-single-pass-comment": 2,
     "local/todo-format": 0,
     "local/unused-private-field": 2,
     "local/vsync": 0,

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -60,7 +60,7 @@ if (!singlePassDest.endsWith('/')) {
   singlePassDest = `${singlePassDest}/`;
 }
 
-const SPLIT_MARKER = `/** SPLIT${Math.floor(Math.random() * 10000)} */`;
+const SPLIT_MARKER = `/** SPLIT_SINGLE_PASS */`;
 
 // Used to store transforms and compile v0.js
 const transformDir = tempy.directory();

--- a/build-system/eslint-rules/split-single-pass-comment.js
+++ b/build-system/eslint-rules/split-single-pass-comment.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function(context) {
+  return {
+    Program(node) {
+      const {comments} = node;
+
+      const comment = comments.find(c => c.value.includes('SPLIT_SINGLE_PASS'));
+      if (!comment) {
+        return;
+      }
+
+      context.report({
+        node: comment,
+        message:
+          'Comments that contain "SPLIT_SINGLE_PASS" are reserved for single pass build',
+      });
+    },
+  };
+};

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -75,7 +75,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     // might override a method. In the future this might be doable
     // with using a more complete extern file instead.
     options.setRemoveUnusedPrototypeProperties(false);
-    options.setInlineProperties(false);
     options.setComputeFunctionSideEffects(false);
     // Property renaming. Relies on AmpCodingConvention to be safe.
     options.setRenamingPolicy(VariableRenamingPolicy.ALL,


### PR DESCRIPTION
Supersedes https://github.com/ampproject/amphtml/pull/24027.

This allows Closure to inline known-constant properties into any accesses, which allows it to DCE if-statement branches that are known to never run.