### PR TITLE
✅ Unblock data url for visual diff test

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -244,7 +244,8 @@ async function newPage(browser, viewport = null) {
     );
 
     if (
-      requestUrl.hostname == HOST ||
+      requestUrl.protocol === 'data:' ||
+      requestUrl.hostname === HOST ||
       requestUrl.hostname.endsWith(`.${HOST}`)
     ) {
       return interceptedRequest.continue();


### PR DESCRIPTION
I am unsure of any history why we block data URLs in the visual test, but this seems unnecessary since there are a few SVGs, small images embedded in the HTML and they are deterministic. This PR removes this restriction.

This PR is expected to change various existing snapshots from visual diff.