### PR TITLE
✨ Enable swipe-to-dismiss for amp sidebar with gestures

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -26,6 +26,7 @@
   "amp-list-load-more": 1,
   "amp-list-viewport-resize": 1,
   "amp-playbuzz": 1,
+  "amp-sidebar-swipe-to-dismiss": 0.1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "ampdoc-closest": 1,

--- a/extensions/amp-lightbox-gallery/0.1/utils.js
+++ b/extensions/amp-lightbox-gallery/0.1/utils.js
@@ -17,6 +17,7 @@
  * @fileoverview Description of this file.
  */
 import {Services} from '../../../src/services';
+import {padStart} from '../../../src/string';
 /**
  * Runs a delay after deferring to the event loop. This is useful to call from
  * within an animation frame, as you can be sure that at least duration
@@ -35,25 +36,6 @@ export function delayAfterDeferringToEventLoop(win, duration) {
   // requestAnimationFrame, this will place us after render. Second, wait
   // for duration to elapse.
   return timer.promise(eventLoopDelay).then(() => timer.promise(duration));
-}
-
-/**
- * Pads the beginning of a string with a substring to a target length.
- * @param {string} s
- * @param {number} targetLength
- * @param {string} padString
- * @return {*} TODO(#23582): Specify return type
- */
-function padStart(s, targetLength, padString) {
-  if (s.length >= targetLength) {
-    return s;
-  }
-  targetLength = targetLength - s.length;
-  let padding = padString;
-  while (targetLength > padding.length) {
-    padding += padString;
-  }
-  return padding.slice(0, targetLength) + s;
 }
 
 /**

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -86,9 +86,10 @@ amp-sidebar[side] {
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
+  opacity: 0.2;
   /* Prevent someone from making this a full-sceen image */
   background-image: none !important;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: #000;
   z-index: 2147483646;
 }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -51,9 +51,9 @@ amp-sidebar[side="right"][open] {
   animation-name: i-amphtml-sidebar-slide-in-right;
 }
 
-amp-sidebar[side][i-amphtml-scale-animation] {
+amp-sidebar[side][i-amphtml-sidebar-opened] {
   transform: none;
-  animation-fill-mode: none;
+  animation: none;
 }
 
 amp-sidebar[side] {

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -86,10 +86,9 @@ amp-sidebar[side] {
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
-  opacity: 0.2;
   /* Prevent someone from making this a full-sceen image */
   background-image: none !important;
-  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.2);
   z-index: 2147483646;
 }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -51,6 +51,11 @@ amp-sidebar[side="right"][open] {
   animation-name: i-amphtml-sidebar-slide-in-right;
 }
 
+amp-sidebar[side][i-amphtml-scale-animation] {
+  transform: none;
+  animation-fill-mode: none;
+}
+
 amp-sidebar[side] {
   /*
    * Note: This uses animations (instead of transitions) to make sure the

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -488,7 +488,12 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
-    const gestures = Gestures.get(dev().assertElement(element));
+    // stop propagation of swipe event inside amp-viewer
+    const gestures = Gestures.get(
+      dev().assertElement(element),
+      /* shouldNotPreventDefault */ false,
+      /* shouldStopPropagation */ true
+    );
     gestures.onGesture(SwipeXRecognizer, ({data}) => {
       this.handleSwipe_(data);
     });

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -126,7 +126,6 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @private @const */
     this.swipeToDismiss_ = new SwipeToDismiss(
       this.win,
-      this.element,
       cb => this.mutateElement(cb),
       // The sidebar is already animated by swipe to dismiss, so skip animation.
       () => this.close_(true)
@@ -445,7 +444,7 @@ export class AmpSidebar extends AMP.BaseElement {
    *     to "hidden".
    * @private
    */
-  close_(immediate) {
+  close_(immediate = false) {
     if (!this.opened_) {
       return false;
     }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -32,6 +32,7 @@ import {descendsFromStory} from '../../../src/utils/story';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {handleAutoscroll} from './autoscroll';
+import {isExperimentOn} from '../../../src/experiments';
 import {removeFragment} from '../../../src/url';
 import {setModalAsClosed, setModalAsOpen} from '../../../src/modal';
 import {setStyles, toggle} from '../../../src/style';
@@ -488,6 +489,9 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
+    if (!isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss')) {
+      return;
+    }
     // stop propagation of swipe event inside amp-viewer
     const gestures = Gestures.get(
       dev().assertElement(element),

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -381,6 +381,7 @@ export class AmpSidebar extends AMP.BaseElement {
       tryFocus(devAssert(this.closeButton_));
     }
     this.triggerEvent_(SidebarEvents.OPEN);
+    this.element.setAttribute('i-amphtml-sidebar-opened', '');
   }
 
   /**
@@ -388,15 +389,12 @@ export class AmpSidebar extends AMP.BaseElement {
    * @param {boolean} immediate
    */
   updateForClosing_(immediate) {
-    // Immediately hide the sidebar so that animation does not play.
-    if (immediate) {
-      toggle(this.element, /* display */ false);
-    }
     this.closeMask_();
     this.mutateElement(() => {
       setModalAsClosed(this.element);
     });
     this.element.removeAttribute('open');
+    this.element.removeAttribute('i-amphtml-sidebar-opened');
     this.element.setAttribute('aria-hidden', 'true');
     this.setUpdateFn_(
       () => this.updateForClosed_(),
@@ -457,6 +455,11 @@ export class AmpSidebar extends AMP.BaseElement {
       this.initialScrollTop_ == this.viewport_.getScrollTop();
     const sidebarIsActive = this.element.contains(this.document_.activeElement);
     this.setUpdateFn_(() => this.updateForClosing_(immediate));
+    // Immediately hide the sidebar so that animation does not play.
+    if (immediate) {
+      this.closeMask_();
+      toggle(this.element, /* display */ false);
+    }
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
       this.historyId_ = -1;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -128,7 +128,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.win,
       cb => this.mutateElement(cb),
       // The sidebar is already animated by swipe to dismiss, so skip animation.
-      () => this.close_(true)
+      () => this.dismiss_(true)
     );
   }
 
@@ -438,13 +438,23 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /**
    * Hides the sidebar.
+   * @return {boolean} Whether the sidebar actually transitioned from "visible"
+   *     to "hidden".
+   * @private
+   */
+  close_() {
+    this.dismiss_(false);
+  }
+
+  /**
+   * Dismisses the sidebar.
    * @param {boolean} immediate Whether sidebar should close immediately,
    *     without animation.
    * @return {boolean} Whether the sidebar actually transitioned from "visible"
    *     to "hidden".
    * @private
    */
-  close_(immediate = false) {
+  dismiss_(immediate) {
     if (!this.opened_) {
       return false;
     }
@@ -480,7 +490,7 @@ export class AmpSidebar extends AMP.BaseElement {
   setupGestures_(element) {
     const gestures = Gestures.get(dev().assertElement(element));
     gestures.onGesture(SwipeXRecognizer, ({data}) => {
-      this.swipeGesture_(data);
+      this.handleSwipe_(data);
     });
   }
 
@@ -488,7 +498,7 @@ export class AmpSidebar extends AMP.BaseElement {
    * Handles a swipe gesture, updating the current swipe to dismiss state.
    * @param {!SwipeDef} data
    */
-  swipeGesture_(data) {
+  handleSwipe_(data) {
     if (data.first) {
       this.swipeToDismiss_.startSwipe({
         swipeElement: dev().assertElement(this.element),

--- a/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
@@ -37,7 +37,7 @@ const SWIPE_TO_CLOSE_VELOCITY_TO_DISTANCE_FACTOR = 22.5;
  * How much time to spend, based on the distance to travel, when moving to the
  * final location of a swipe (after the user has released).
  */
-const SWIPE_TO_CLOSE_DISTANCE_TO_TIME_FACTOR = 0.5;
+const SWIPE_TO_CLOSE_DISTANCE_TO_TIME_FACTOR = 0.75;
 /**
  * How much time to spend, based on the distance to travel, when snapping back
  * after an cancelled swipe to close gesture.
@@ -123,8 +123,8 @@ export class SwipeToDismiss {
    */
   getSwipeElementLength_() {
     return this.orientation_ == Orientation.HORIZONTAL
-      ? this.swipeElement_.offsetWidth
-      : this.swipeElement_.offsetHeight;
+      ? this.swipeElement_./*OK*/ offsetWidth
+      : this.swipeElement_./*OK*/ offsetHeight;
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
@@ -73,16 +73,12 @@ export const Orientation = {
 export class SwipeToDismiss {
   /**
    * @param {!Window} win
-   * @param {!Element} element
    * @param {function(function())} mutateElement
    * @param {function()} onclose
    */
-  constructor(win, element, mutateElement, onclose) {
+  constructor(win, mutateElement, onclose) {
     /** @private @const */
     this.win_ = win;
-
-    /** @private @const */
-    this.element_ = element;
 
     /** @private @const */
     this.mutateElement_ = mutateElement;
@@ -90,10 +86,10 @@ export class SwipeToDismiss {
     /** @private @const */
     this.onclose_ = onclose;
 
-    /** @private @const */
+    /** @private {!Direction} */
     this.direction_ = Direction.BACKWARD;
 
-    /** @private @const */
+    /** @private {!Orientation} */
     this.orientation_ = Orientation.HORIZONTAL;
 
     /**
@@ -304,7 +300,6 @@ export class SwipeToDismiss {
   /**
    * Handles the start of a swipe to dimiss gesture:
    *  - Prevents a scroll event from the element during the swipe.
-   *  - Hides the source element on the page.
    * This should be called in a mutate context.
    * @private
    */
@@ -319,7 +314,6 @@ export class SwipeToDismiss {
         capture: true,
       }
     );
-    this.element_.setAttribute('i-amphtml-scale-animation', '');
   }
 
   /**
@@ -329,7 +323,6 @@ export class SwipeToDismiss {
    */
   endSwipeToDismiss_() {
     this.preventScrollUnlistener_();
-    this.element_.removeAttribute('i-amphtml-scale-animation');
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
@@ -1,0 +1,362 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SwipeDef} from '../../../src/gesture-recognizers';
+import {delayAfterDeferringToEventLoop} from './utils';
+import {dev} from '../../../src/log';
+import {listen} from '../../../src/event-helper';
+import {setStyles} from '../../../src/style';
+
+/**
+ * The distance needed to dismiss the swipe element, as fraction of its length.
+ */
+const SWIPE_TO_CLOSE_DISTANCE_THRESHOLD = 0.5;
+/**
+ * The velocity at which to close element from a swipe, regardless of distance.
+ */
+const SWIPE_TO_CLOSE_VELOCITY_THRESHOLD = 0.65;
+/**
+ * How much distance to cover, based on the velocity, when a user releases a
+ * swipe to close gesture.
+ */
+const SWIPE_TO_CLOSE_VELOCITY_TO_DISTANCE_FACTOR = 22.5;
+/**
+ * How much time to spend, based on the distance to travel, when moving to the
+ * final location of a swipe (after the user has released).
+ */
+const SWIPE_TO_CLOSE_DISTANCE_TO_TIME_FACTOR = 0.5;
+/**
+ * How much time to spend, based on the distance to travel, when snapping back
+ * after an cancelled swipe to close gesture.
+ */
+const SWIPE_TO_CLOSE_SNAP_BACK_TIME_FACTOR = 0.8;
+/**
+ * The timing function to use when carrying momentum after releasing a swipe to
+ * close gesture. This closely approximates an expontential decay of velocity.
+ */
+const SWIPE_TO_CLOSE_MOMENTUM_TIMING = 'cubic-bezier(0.15, .55, .3, 0.95)';
+
+/**
+ * Direction in which swipe to dismiss is allowed.
+ * @const @enum {string}
+ */
+export const Direction = {
+  BACKWARD: 'backward',
+  FORWARD: 'forward',
+};
+
+/**
+ * Orientation in which swipe to dismiss is allowed.
+ * @const @enum {string}
+ */
+export const Orientation = {
+  HORIZONTAL: 'horizontal',
+  VERTICAL: 'vertical',
+};
+
+/**
+ * Maintains state and updates the UI for a swipe to dismiss gesture.
+ */
+export class SwipeToDismiss {
+  /**
+   * @param {!Window} win
+   * @param {!Element} element
+   * @param {function(function())} mutateElement
+   * @param {function()} onclose
+   */
+  constructor(win, element, mutateElement, onclose) {
+    /** @private @const */
+    this.win_ = win;
+
+    /** @private @const */
+    this.element_ = element;
+
+    /** @private @const */
+    this.mutateElement_ = mutateElement;
+
+    /** @private @const */
+    this.onclose_ = onclose;
+
+    /** @private @const */
+    this.direction_ = Direction.BACKWARD;
+
+    /** @private @const */
+    this.orientation_ = Orientation.HORIZONTAL;
+
+    /**
+     * The element that is moving with the swipe to dismiss.
+     * @private {?Element}
+     */
+    this.swipeElement_ = null;
+
+    /**
+     * A background mask element behind the swipe element.
+     * @private {?Element}
+     */
+    this.mask_ = null;
+
+    /**
+     * A listener is set up to prevent scrolling on the swipe element when
+     * doing a swipe to dismiss gesture. This is used to clean up the listener
+     * when no longer needed.
+     * @private {?function()}
+     */
+    this.preventScrollUnlistener_ = null;
+  }
+
+  /**
+   * Get the swipe element's width or height, depending on orientation of swipe.
+   * @return {number} length in pixels
+   */
+  getSwipeElementLength_() {
+    return this.orientation_ == Orientation.HORIZONTAL
+      ? this.swipeElement_.offsetWidth
+      : this.swipeElement_.offsetHeight;
+  }
+
+  /**
+   * Caps the amount to shift swipe element based on orientation and direction.
+   * @param {number} deltaX
+   * @param {number} deltaY
+   * @return {number} The absolute shift distance in pixels.
+   */
+  capDistance_(deltaX, deltaY) {
+    const delta = this.orientation_ == Orientation.HORIZONTAL ? deltaX : deltaY;
+    return this.direction_ == Direction.BACKWARD
+      ? -Math.min(delta, 0)
+      : Math.max(delta, 0);
+  }
+
+  /**
+   * Builds a string for the transform property that translates by given amount.
+   * @param {number} value
+   * @param {string} unit
+   * @return {string}
+   */
+  translateBy_(value, unit = '') {
+    return `translate${
+      this.orientation_ == Orientation.HORIZONTAL ? 'X' : 'Y'
+    }(${this.direction_ == Direction.BACKWARD ? -value : value}${unit})`;
+  }
+
+  /**
+   * Handles the start of a swipe.
+   * @param {{
+   *   swipeElement: !Element,
+   *   mask: !Element,
+   * }} config
+   */
+  startSwipe({swipeElement, mask, direction, orientation}) {
+    this.swipeElement_ = swipeElement;
+    this.mask_ = mask;
+    this.direction_ = direction;
+    this.orientation_ = orientation;
+
+    this.mutateElement_(() => {
+      this.startSwipeToDismiss_();
+    });
+  }
+
+  /**
+   * Handles a swipe move.
+   * @param {!SwipeDef} data
+   */
+  swipeMove(data) {
+    this.swipeMove_(data, false);
+  }
+
+  /**
+   * Handles the end of a swipe.
+   * @param {!SwipeDef} data
+   */
+  endSwipe(data) {
+    this.swipeMove_(data, true);
+  }
+
+  /**
+   * Carries momentum for the swipe forwards to a final destination, with the
+   * duration depending on the velocity.
+   * @param {number} distance How far we should keep moving.
+   * @param {number} velocity The current velocity.
+   * @return {Promise} A Promise that resolves once momentum based movement ends.
+   * @private
+   */
+  carrySwipeMomentum_(distance, velocity) {
+    const duration = velocity * SWIPE_TO_CLOSE_DISTANCE_TO_TIME_FACTOR;
+
+    setStyles(dev().assertElement(this.swipeElement_), {
+      transform: this.translateBy_(distance, 'px'),
+      transition: `${duration}ms transform ${SWIPE_TO_CLOSE_MOMENTUM_TIMING}`,
+    });
+
+    return delayAfterDeferringToEventLoop(this.win_, duration);
+  }
+
+  /**
+   * Snaps back to the starting point, with the duration based on the distance
+   * that needs to be travelled.
+   * @param {number} finalDistance
+   * @return {Promise} A Promise that resolves once the snapping has completed.
+   * @private
+   */
+  snapBackFromSwipe_(finalDistance) {
+    const duration = finalDistance * SWIPE_TO_CLOSE_SNAP_BACK_TIME_FACTOR;
+
+    return this.mutateElement_(() => {
+      setStyles(dev().assertElement(this.swipeElement_), {
+        transform: this.translateBy_(0),
+        transition: `${duration}ms transform ease-in`,
+      });
+      setStyles(dev().assertElement(this.mask_), {
+        opacity: '',
+        transition: `${duration}ms opacity ease-in`,
+      });
+    }).then(() => {
+      return delayAfterDeferringToEventLoop(this.win_, duration);
+    });
+  }
+
+  /**
+   * Adjusts the UI elements for the current swipe position in a swipe to
+   * dismiss gesture. This should be called in a mutate context.
+   * @param {string} swipeElementTransform How to transform the swiping
+   *    element.
+   * @param {number|string} maskOpacity The opacity for the mask element.
+   *    container.
+   * @private
+   */
+  adjustForSwipePosition_(swipeElementTransform = '', maskOpacity = '') {
+    setStyles(dev().assertElement(this.swipeElement_), {
+      transform: swipeElementTransform,
+      transition: '',
+    });
+    setStyles(dev().assertElement(this.mask_), {
+      opacity: maskOpacity,
+      transition: '',
+    });
+  }
+
+  /**
+   * Releases the user's swipe to dismiss gesture. This carries the momentum
+   * forwards and either closes the lightbox or snaps back based on the speed
+   * and distance. This should be called in a mutate context.
+   * @param {number} velocityX The X velocity when the swipe was released.
+   * @param {number} velocityY The Y velocity when the swipe was released.
+   * @param {number} deltaX The x distance when the swipe was released.
+   * @param {number} deltaY The y distance when the swipe was released.
+   * @return {!Promise} A Promise that resolves once the release is completed,
+   *    either snapping back to the start or closing the carousel.
+   * @private
+   */
+  releaseSwipe_(velocityX, velocityY, deltaX, deltaY) {
+    const distanceX = velocityX * SWIPE_TO_CLOSE_VELOCITY_TO_DISTANCE_FACTOR;
+    const distanceY = velocityY * SWIPE_TO_CLOSE_VELOCITY_TO_DISTANCE_FACTOR;
+    const finalDeltaX = distanceX + deltaX;
+    const finalDeltaY = distanceY + deltaY;
+    // We want to figure out the final distance we will rest at if the user
+    // flicked the element and use that to determine we should animate to. We
+    // will then use that resting position to determine if we should snap back
+    // or close.
+    const finalDistance = this.capDistance_(finalDeltaX, finalDeltaY);
+    const finalVelocity = this.capDistance_(velocityX, velocityY);
+
+    const swipeToCloseDistance =
+      this.getSwipeElementLength_() * SWIPE_TO_CLOSE_DISTANCE_THRESHOLD;
+    if (
+      finalDistance < swipeToCloseDistance &&
+      finalVelocity < SWIPE_TO_CLOSE_VELOCITY_THRESHOLD
+    ) {
+      return this.carrySwipeMomentum_(finalDistance, finalVelocity).then(() =>
+        this.snapBackFromSwipe_(finalDistance)
+      );
+    }
+
+    const remainingDistance = this.getSwipeElementLength_() - finalDistance;
+    const duration = remainingDistance * SWIPE_TO_CLOSE_DISTANCE_TO_TIME_FACTOR;
+
+    return this.mutateElement_(() => {
+      setStyles(dev().assertElement(this.swipeElement_), {
+        transform: this.translateBy_(100, '%'),
+        transition: `${duration}ms transform ease-out`,
+      });
+      setStyles(dev().assertElement(this.mask_), {
+        opacity: 0,
+        transition: `${duration}ms opacity ease-out`,
+      });
+    })
+      .then(() => delayAfterDeferringToEventLoop(this.win_, duration))
+      .then(() => this.onclose_());
+  }
+
+  /**
+   * Handles the start of a swipe to dimiss gesture:
+   *  - Prevents a scroll event from the element during the swipe.
+   *  - Hides the source element on the page.
+   * This should be called in a mutate context.
+   * @private
+   */
+  startSwipeToDismiss_() {
+    this.preventScrollUnlistener_ = listen(
+      dev().assertElement(this.swipeElement_),
+      'scroll',
+      event => {
+        event.stopPropagation();
+      },
+      {
+        capture: true,
+      }
+    );
+    this.element_.setAttribute('i-amphtml-scale-animation', '');
+  }
+
+  /**
+   * Ends a drag swipe, cleaning up the effects from `startSwipeToDismiss_`.
+   * This should be called in a mutate context.
+   * @private
+   */
+  endSwipeToDismiss_() {
+    this.preventScrollUnlistener_();
+    this.element_.removeAttribute('i-amphtml-scale-animation');
+  }
+
+  /**
+   *
+   * @param {!SwipeDef} data The data for the swipe.
+   * @param {boolean} isLast If this move is the last movement for the swipe.
+   */
+  swipeMove_(data, isLast) {
+    const {deltaX, deltaY, velocityX, velocityY} = data;
+
+    this.mutateElement_(() => {
+      if (isLast) {
+        this.releaseSwipe_(velocityX, velocityY, deltaX, deltaY).then(() => {
+          this.adjustForSwipePosition_();
+          this.endSwipeToDismiss_();
+        });
+        return;
+      }
+
+      const swipeDistance = this.capDistance_(deltaX, deltaY);
+      const swipeFraction = swipeDistance / this.getSwipeElementLength_();
+      const maskOpacity = Math.max(0, 1 - swipeFraction);
+
+      this.adjustForSwipePosition_(
+        this.translateBy_(swipeDistance, 'px'),
+        maskOpacity
+      );
+    });
+  }
+}

--- a/extensions/amp-sidebar/0.1/utils.js
+++ b/extensions/amp-sidebar/0.1/utils.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Description of this file.
+ */
+import {Services} from '../../../src/services';
+/**
+ * Runs a delay after deferring to the event loop. This is useful to call from
+ * within an animation frame, as you can be sure that at least duration
+ * milliseconds has elapsed after the animation has started. Simply waiting
+ * for the desired duration may result in running code before an animation has
+ * completed.
+ * @param {!Window} win A Window object.
+ * @param {number} duration How long to wait for.
+ * @return {!Promise} A Promise that resolves after the specified duration.
+ */
+export function delayAfterDeferringToEventLoop(win, duration) {
+  const timer = Services.timerFor(win);
+  // Timer.promise does not defer to event loop for 0.
+  const eventLoopDelay = 1;
+  // First, defer to the JavaScript execution loop. If we are in a
+  // requestAnimationFrame, this will place us after render. Second, wait
+  // for duration to elapse.
+  return timer.promise(eventLoopDelay).then(() => timer.promise(duration));
+}
+
+/**
+ * Pads the beginning of a string with a substring to a target length.
+ * @param {string} s
+ * @param {number} targetLength
+ * @param {string} padString
+ * @return {*} TODO(#23582): Specify return type
+ */
+function padStart(s, targetLength, padString) {
+  if (s.length >= targetLength) {
+    return s;
+  }
+  targetLength = targetLength - s.length;
+  let padding = padString;
+  while (targetLength > padding.length) {
+    padding += padString;
+  }
+  return padding.slice(0, targetLength) + s;
+}
+
+/**
+ * Converts seconds to a timestamp formatted string.
+ * @param {number} seconds
+ * @return {string}
+ * @private
+ */
+export function secondsToTimestampString(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  const hh = padStart(h.toString(), 2, '0');
+  const mm = padStart(m.toString(), 2, '0');
+  const ss = padStart(s.toString(), 2, '0');
+  return hh + ':' + mm + ':' + ss;
+}

--- a/extensions/amp-sidebar/0.1/utils.js
+++ b/extensions/amp-sidebar/0.1/utils.js
@@ -36,38 +36,3 @@ export function delayAfterDeferringToEventLoop(win, duration) {
   // for duration to elapse.
   return timer.promise(eventLoopDelay).then(() => timer.promise(duration));
 }
-
-/**
- * Pads the beginning of a string with a substring to a target length.
- * @param {string} s
- * @param {number} targetLength
- * @param {string} padString
- * @return {*} TODO(#23582): Specify return type
- */
-function padStart(s, targetLength, padString) {
-  if (s.length >= targetLength) {
-    return s;
-  }
-  targetLength = targetLength - s.length;
-  let padding = padString;
-  while (targetLength > padding.length) {
-    padding += padString;
-  }
-  return padding.slice(0, targetLength) + s;
-}
-
-/**
- * Converts seconds to a timestamp formatted string.
- * @param {number} seconds
- * @return {string}
- * @private
- */
-export function secondsToTimestampString(seconds) {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  const hh = padStart(h.toString(), 2, '0');
-  const mm = padStart(m.toString(), 2, '0');
-  const ss = padStart(s.toString(), 2, '0');
-  return hh + ':' + mm + ':' + ss;
-}

--- a/extensions/amp-sidebar/0.1/utils.js
+++ b/extensions/amp-sidebar/0.1/utils.js
@@ -28,6 +28,8 @@ import {Services} from '../../../src/services';
  * @return {!Promise} A Promise that resolves after the specified duration.
  */
 export function delayAfterDeferringToEventLoop(win, duration) {
+  // TODO(spaharmi): generalize this to work outside requestAnimationFrame
+  // and move function to src/timer-impl.js
   const timer = Services.timerFor(win);
   // Timer.promise does not defer to event loop for 0.
   const eventLoopDelay = 1;

--- a/src/string.js
+++ b/src/string.js
@@ -172,3 +172,22 @@ export function trimStart(str) {
 
   return (str + '_').trim().slice(0, -1);
 }
+
+/**
+ * Pads the beginning of a string with a substring to a target length.
+ * @param {string} s
+ * @param {number} targetLength
+ * @param {string} padString
+ * @return {*} TODO(#23582): Specify return type
+ */
+export function padStart(s, targetLength, padString) {
+  if (s.length >= targetLength) {
+    return s;
+  }
+  targetLength = targetLength - s.length;
+  let padding = padString;
+  while (targetLength > padding.length) {
+    padding += padString;
+  }
+  return padding.slice(0, targetLength) + s;
+}

--- a/test/unit/test-string.js
+++ b/test/unit/test-string.js
@@ -20,6 +20,7 @@ import {
   endsWith,
   expandTemplate,
   includes,
+  padStart,
   trimEnd,
 } from '../../src/string';
 
@@ -155,5 +156,22 @@ describe('trimEnd', () => {
 
   it('should keep leading whitespace characters', () => {
     expect(trimEnd('\n\tabc')).to.equal('\n\tabc');
+  });
+});
+
+describe('padStart', () => {
+  it('should pad string to target length', () => {
+    expect(padStart('abc', 4, ' ')).to.equal(' abc');
+    expect(padStart('abc', 8, ' ')).to.equal('     abc');
+  });
+
+  it('should trim padString if necessary to fit target length', () => {
+    expect(padStart('abc', 4, 'xy')).to.equal('xabc');
+    expect(padStart('abc', 6, 'xy')).to.equal('xyxabc');
+  });
+
+  it('should return original string if equal or greater than target length', () => {
+    expect(padStart('abc', 3, ' ')).to.equal('abc');
+    expect(padStart('abc', 0, ' ')).to.equal('abc');
   });
 });


### PR DESCRIPTION
Resolves #23927 

Add the ability to dismiss `amp-sidebar` on swipe, with closing animation and mask opacity transition.
Demo: [https://amp-sidebar-swipe.firebaseapp.com/](https://amp-sidebar-swipe.firebaseapp.com/examples/playground.amp.html)

Following sidebar implementations in apps such as Gmail, Spotify and Discord, the dismiss threshold is currently set at 1/2 sidebar width, meaning the sidebar would bounce back if the swipe distance at the point of release is less than half of sidebar width (unless sufficient velocity is applied).

/to @sparhami @cathyxz for review; can also discuss potentials for refactoring and e2e tests.

@andrewwatterson @nainar Some parameters that could be tweaked:
- Speed at which sidebar closes after release
- Speed at which sidebar bounces back after release
- Force needed to dismiss sidebar regardless of swipe distance

@kristoferbaxter Might need your thoughts on performance, especially for lower-end devices which has seen some dropped frames. This seems like an issue with gestures in general, so could be worth investigating touch events in the future.

@gmajoulet I'm changing the sidebar mask to use rgba `background-color` rather than `opacity`, and I think the mask styling for `amp-story` would need to be changed concurrently?