### PR TITLE
🚮 Removes `beforeunload` event use in performance impl

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -35,9 +35,6 @@ const QUEUE_LIMIT = 50;
 /** @const {string} */
 const VISIBILITY_CHANGE_EVENT = 'visibilitychange';
 
-/** @const {string} */
-const BEFORE_UNLOAD_EVENT = 'beforeunload';
-
 /**
  * Fields:
  * {{
@@ -162,7 +159,6 @@ export class Performance {
       this.win.PerformanceObserver.supportedEntryTypes.includes('layout-shift');
 
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
-    this.boundTickLayoutShiftScore_ = this.tickLayoutShiftScore_.bind(this);
     this.onViewerVisibilityChange_ = this.onViewerVisibilityChange_.bind(this);
 
     // Add RTV version as experiment ID, so we can slice the data by version.
@@ -233,17 +229,6 @@ export class Performance {
         this.boundOnVisibilityChange_,
         {capture: true}
       );
-
-      // Safari does not reliably fire the `pagehide` or `visibilitychange`
-      // events when closing a tab, so we have to use `beforeunload`.
-      // See https://bugs.webkit.org/show_bug.cgi?id=151234
-      const platform = Services.platformFor(this.win);
-      if (platform.isSafari()) {
-        this.win.addEventListener(
-          BEFORE_UNLOAD_EVENT,
-          this.boundTickLayoutShiftScore_
-        );
-      }
 
       this.viewer_.onVisibilityChanged(this.onViewerVisibilityChange_);
     }
@@ -496,10 +481,6 @@ export class Performance {
         VISIBILITY_CHANGE_EVENT,
         this.boundOnVisibilityChange_,
         {capture: true}
-      );
-      this.win.removeEventListener(
-        BEFORE_UNLOAD_EVENT,
-        this.boundTickLayoutShiftScore_
       );
     }
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -162,7 +162,6 @@ export class Performance {
       this.win.PerformanceObserver.supportedEntryTypes.includes('layout-shift');
 
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
-    this.boundTickLayoutJankScore_ = this.tickLayoutJankScore_.bind(this);
     this.boundTickLayoutShiftScore_ = this.tickLayoutShiftScore_.bind(this);
     this.onViewerVisibilityChange_ = this.onViewerVisibilityChange_.bind(this);
 
@@ -219,18 +218,6 @@ export class Performance {
         this.boundOnVisibilityChange_,
         {capture: true}
       );
-
-      // Safari does not reliably fire the `pagehide` or `visibilitychange`
-      // events when closing a tab, so we have to use `beforeunload`.
-      // See https://bugs.webkit.org/show_bug.cgi?id=151234
-      const platform = Services.platformFor(this.win);
-      if (platform.isSafari()) {
-        // TODO(#23634): Remove, explain or adjust the usage of the unload listener
-        this.win.addEventListener(
-          BEFORE_UNLOAD_EVENT,
-          this.boundTickLayoutJankScore_
-        );
-      }
 
       this.viewer_.onVisibilityChanged(this.onViewerVisibilityChange_);
     }
@@ -478,10 +465,6 @@ export class Performance {
         VISIBILITY_CHANGE_EVENT,
         this.boundOnVisibilityChange_,
         {capture: true}
-      );
-      this.win.removeEventListener(
-        BEFORE_UNLOAD_EVENT,
-        this.boundTickLayoutJankScore_
       );
     }
   }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1161,38 +1161,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       expect(perf.events_.length).to.equal(2);
     });
 
-    it("for browsers that don't support the visibilitychange event", () => {
-      // Specify an iPhone Safari user agent, which does not support
-      // the visibilitychange event.
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(true);
-
-      // Document should be initially visible.
-      expect(fakeWin.document.visibilityState).to.equal('visible');
-
-      // Fake layoutJank that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType
-        .withArgs('layoutJank')
-        .returns([
-          {entryType: 'layoutJank', fraction: 0.25},
-          {entryType: 'layoutJank', fraction: 0.3},
-        ]);
-
-      const perf = getPerformance();
-      // visibilitychange/beforeunload listeners are now added.
-      perf.coreServicesAvailable();
-
-      // The document has become hidden, e.g. via the user switching tabs.
-      // Note: Don't fire visibilitychange (not supported in this case).
-      fakeWin.document.visibilityState = 'hidden';
-      fireEvent('beforeunload');
-
-      expect(perf.events_.length).to.equal(1);
-      expect(perf.events_[0]).to.be.jsonEqual({
-        label: 'lj',
-        delta: 0.55,
-      });
-    });
-
     it('forwards layout jank metric on viewer visibility change to inactive', () => {
       // Specify an Android Chrome user agent.
       sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
@@ -1435,43 +1403,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
 
       toggleVisibility(fakeWin, false);
       expect(perf.events_.length).to.equal(2);
-    });
-
-    it("for browsers that don't support the visibilitychange event", () => {
-      // Specify an iPhone Safari user agent, which does not support
-      // the visibilitychange event.
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(true);
-
-      // Fake the Performance API.
-      fakeWin.PerformanceObserver.supportedEntryTypes = ['layout-shift'];
-
-      // Document should be initially visible.
-      expect(fakeWin.document.visibilityState).to.equal('visible');
-
-      const perf = getPerformance();
-      // visibilitychange/beforeunload listeners are now added.
-      perf.coreServicesAvailable();
-
-      // Fake layout-shift that occured before the Performance service is started.
-      performanceObserver.triggerCallback({
-        getEntries() {
-          return [
-            {entryType: 'layout-shift', value: 0.25, hadRecentInput: false},
-            {entryType: 'layout-shift', value: 0.3, hadRecentInput: false},
-          ];
-        },
-      });
-
-      // The document has become hidden, e.g. via the user switching tabs.
-      // Note: Don't fire visibilitychange (not supported in this case).
-      fakeWin.document.visibilityState = 'hidden';
-      fireEvent('beforeunload');
-
-      expect(perf.events_.length).to.equal(1);
-      expect(perf.events_[0]).to.be.jsonEqual({
-        label: 'cls',
-        delta: 0.55,
-      });
     });
 
     it('when the viewer visibility changes to inactive', () => {


### PR DESCRIPTION
Closes #24071
Part of #23634 

/cc @ericandrewlewis for context