### PR TITLE
🏗 Improve serving from non-localhost host

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1304,7 +1304,7 @@ function addViewerIntegrationScript(ampJsVersion, file) {
 }
 
 function getUrlPrefix(req) {
-  return req.protocol + '://' + req.headers.host;
+  return '//' + req.headers.host;
 }
 
 function generateInfo(filePath) {

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1260,7 +1260,7 @@ app.use('/shadow/', (req, res) => {
     : `${path.dirname(url)}/`;
 
   const viewerHtml = renderShadowViewer({
-    src: req.url.replace(/^\//, ''),
+    src: '//' + req.hostname + '/' + req.url.replace(/^\//, ''),
     baseHref,
   });
 

--- a/build-system/shadow-viewer.js
+++ b/build-system/shadow-viewer.js
@@ -144,7 +144,7 @@ const SCRIPT = `
 };
 `;
 
-const renderShadowViewer = ({src, baseHref, port = 8000}) =>
+const renderShadowViewer = ({src, baseHref}) =>
   html`
     <!DOCTYPE html>
     <html>
@@ -156,7 +156,7 @@ const renderShadowViewer = ({src, baseHref, port = 8000}) =>
         </script>
       </head>
       <body style="padding: 0; margin: 0">
-        <amp-viewer src="http://localhost:${port}/${src}"></amp-viewer>
+        <amp-viewer src="${src}"></amp-viewer>
       </body>
     </html>
   `;


### PR DESCRIPTION
This cherry-picks/rebases commits from https://github.com/ampproject/amphtml/pull/23213.

This PR improves the ability for `gulp serve` to be used with a host other than `localhost:8000`. It uses schemeless URLs for the AMP proxy viewer and AMP shadow viewer so that the HTTPS protocol will be used (and successfully loaded) when `gulp serve` is invoked with `--https` or when SSL termination happens higher in the network stack.

See companion pull request for the Local AMP Chrome extension: #24029. 