### PR TITLE
🏗 Fix detection for failure to generateRunner

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -47,6 +47,10 @@ tooling:
     service: appserver
     cmd: "yarn gulp watch"
     description: "Watches for changes in files, re-builds when detected"
+  lint:
+    service: appserver
+    cmd: "yarn gulp lint"
+    description: "Validates against Google Closure Linter"
   check-types:
     service: appserver
     cmd: "yarn gulp check-types"

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -27,7 +27,8 @@ const runnerDir = 'build-system/runner';
 const buildFile = `${runnerDir}/build.xml`;
 const runnerDistDir = `${runnerDir}/dist`;
 const generatedAtCommitFile = 'GENERATED_AT_COMMIT';
-const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server';
+const setupInstructionsUrl =
+  'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server';
 
 /**
  * Determines if runner.jar needs to be regenerated

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -17,7 +17,7 @@
 
 const fs = require('fs-extra');
 const log = require('fancy-log');
-const {cyan, red} = require('ansi-colors');
+const {cyan, green, red} = require('ansi-colors');
 const {getOutput} = require('../exec');
 const {gitCommitHash, gitDiffPath} = require('../git');
 const {isTravisBuild} = require('../travis');
@@ -27,6 +27,7 @@ const runnerDir = 'build-system/runner';
 const buildFile = `${runnerDir}/build.xml`;
 const runnerDistDir = `${runnerDir}/dist`;
 const generatedAtCommitFile = 'GENERATED_AT_COMMIT';
+const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server';
 
 /**
  * Determines if runner.jar needs to be regenerated
@@ -115,12 +116,11 @@ async function generateRunner(subDir) {
       'Could not generate custom closure compiler',
       cyan(`${runnerJarDir}/runner.jar`)
     );
-    console.error(
-      red(result.stdout),
-      red(result.stderr),
-      red(
-        'See instructions for setting up Java at https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server'
-      )
+    console.error(red(result.stdout), red(result.stderr));
+    log(
+      green('INFO:'),
+      'If the errors above are in java execution, see',
+      cyan(`${setupInstructionsUrl}`)
     );
     const reason = new Error('Compiler generation failed');
     reason.showStack = false;

--- a/build-system/tasks/generate-runner.js
+++ b/build-system/tasks/generate-runner.js
@@ -109,13 +109,19 @@ async function generateRunner(subDir) {
   const runnerJarDir = `${runnerDistDir}/${subDir}`;
   writeGeneratedAtCommitFile(runnerJarDir);
   const result = getOutput(generateCmd);
-  if (result.stderr) {
+  if (0 !== result.status) {
     log(
       red('ERROR:'),
       'Could not generate custom closure compiler',
       cyan(`${runnerJarDir}/runner.jar`)
     );
-    console.error(red(result.stdout), red(result.stderr));
+    console.error(
+      red(result.stdout),
+      red(result.stderr),
+      red(
+        'See instructions for setting up Java at https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server'
+      )
+    );
     const reason = new Error('Compiler generation failed');
     reason.showStack = false;
     return Promise.reject(reason);


### PR DESCRIPTION
In `generateRunner()` it currently is detecting for an error for running `ant` by checking for the response `stderr`. This turns out to not always work. When Java is not installed, then the only `stdout` is populated. The proper way to detect for an error is to check the exit code. This PR does that, as well as add a link to where instructions can be found to install Java as required.