### PR TITLE
<amp-experiment> 1.0 add style mutation support

### DIFF
--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-style.js
@@ -20,28 +20,31 @@ import {dev, user} from '../../../../src/log';
 import {dict, hasOwn} from '../../../../src/utils/object';
 import {isAmpElement} from '../../../../src/dom';
 
+/** @const {RegExp} */
+const NON_SPACE_REGEX = /\S/;
+
+/** @const {RegExp} */
+const ALL_VALUE_REGEX = /.*/;
+
 /** @const {Object<string, RegExp>} */
 const SUPPORTED_STYLE_VALUE = {
-  'color': /.*/,
-  'background-color': /.*/,
+  'color': ALL_VALUE_REGEX,
+  'background-color': ALL_VALUE_REGEX,
   'visibility': /^hidden$/,
   'display': /^none$/,
   'position': /^(static|relative|absolute|initial|inherit)$/,
-  'font-size': /.*/,
-  'background-image': /.*/,
-  'border-width': /.*/,
-  'border-style': /.*/,
-  'border-color': /.*/,
+  'font-size': ALL_VALUE_REGEX,
+  'background-image': ALL_VALUE_REGEX,
+  'border-width': ALL_VALUE_REGEX,
+  'border-style': ALL_VALUE_REGEX,
+  'border-color': ALL_VALUE_REGEX,
 };
 
 /** @const {Object<string, RegExp>} */
 const SUPPORTE_NON_AMP_STYLE_VALUE = {
-  'width': /.*/,
-  'height': /.*/,
+  'width': ALL_VALUE_REGEX,
+  'height': ALL_VALUE_REGEX,
 };
-
-/** @const {RegExp} */
-const NON_SPACE_REGEX = /\S/;
 
 /** @const {string} */
 const TAG = 'amp-experiment/style';

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -153,7 +153,7 @@ describes.realWin(
           expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
 
-        it('background-color mutation', () => {
+        it('allow all mutations', () => {
           let attributeMutation = getAttributeMutationDefaultStyle(
             'background-color: #o7FogD'
           );
@@ -170,14 +170,61 @@ describes.realWin(
           expect(attributeMutation.parseAndValidate()).to.equal(true);
         });
 
-        it('color mutations', () => {
+        it('visibility mutations', () => {
           let attributeMutation = getAttributeMutationDefaultStyle(
-            'color: #000000'
+            'visibility: hidden'
           );
           expect(attributeMutation.parseAndValidate()).to.equal(true);
 
-          attributeMutation = getAttributeMutationDefaultStyle('color: #a0F');
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'visibility: visible'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'visibility: hiddenhidden'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
+
+          attributeMutation = getAttributeMutationDefaultStyle('visibility: ');
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
+        });
+
+        it('display mutations', () => {
+          let attributeMutation = getAttributeMutationDefaultStyle(
+            'display: none'
+          );
           expect(attributeMutation.parseAndValidate()).to.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'display: nonehidden'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
+        });
+
+        it('position mutations', () => {
+          let attributeMutation = getAttributeMutationDefaultStyle(
+            'position: absolute'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
+
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'position: fixed'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
+        });
+
+        it('width height mutations', () => {
+          let attributeMutation = getAttributeMutationDefaultStyle(
+            'width: 100; height: inherit'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(true);
+
+          elements = [doc.createElement('amp-foo')];
+          attributeMutation = getAttributeMutationDefaultStyle(
+            'width: 100; height: inherit'
+          );
+          expect(attributeMutation.parseAndValidate()).to.equal(false);
         });
       });
 


### PR DESCRIPTION
Add the following list of style property support

Support all values:
`color`
`background-color`
`font-size`
`background-image`
`border-width`
`border-style`
`border-color`

Support a list of values
`visibility`: `hidden`
`display`: `none`
`position`: `static`/`relative`/`absolute`/`initial`/`inherit`

Support mutation for NON AMP elements only
`width` and `height` (all values)