### PR TITLE
🖍 Change mask styling for amp-sidebar and amp-story

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -81,10 +81,9 @@ amp-sidebar[side] {
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
-  opacity: 0.2;
   /* Prevent someone from making this a full-sceen image */
   background-image: none !important;
-  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.2);
   z-index: 2147483646;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -301,11 +301,11 @@ amp-story-page [data-text-background-color] {
   bottom: 0 !important;
   width: 100% !important;
   height: 100% !important;
-  opacity: 0.75 !important;
+  opacity: 1 !important;
   display: block !important;
   /* Prevent someone from making this a full-screen image */
   background-image: none !important;
-  background-color: #000 !important;
+  background-color: rgba(0, 0, 0, 0.75) !important;
   visibility: visible;
   z-index: 100003 !important;
   transition: visibility 0.3s, opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;


### PR DESCRIPTION
Use rgba `background-color` to set the opacity of masks in `amp-sidebar` and `amp-story` so that swipe-to-dismiss can animate mask independent of max opacity.

@sparhami @cathyxz @gmajoulet 