### PR TITLE
Ramp loaders up to 10% of prod traffic.

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,7 +37,7 @@
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "ios-scrollable-iframe": 0,
-  "new-loaders": 0.01,
+  "new-loaders": 0.1,
   "pump-early-frame": 1,
   "version-locking": 1
 }


### PR DESCRIPTION
Loaders is at 1% in the current RC (and 100% of canary traffic) and will go to 1% of prod traffic in the next push. This change ramps up to 10% for the next RC/prod cycle.

/cc @nainar 