### PR TITLE
✨add support for amp-embed type=readmo

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -210,6 +210,7 @@ import {pulsepoint} from '../ads/pulsepoint';
 import {purch} from '../ads/purch';
 import {quoraad} from '../ads/quoraad';
 import {rbinfox} from '../ads/rbinfox';
+import {readmo} from '../ads/readmo';
 import {realclick} from '../ads/realclick';
 import {recomad} from '../ads/recomad';
 import {relap} from '../ads/relap';
@@ -299,6 +300,7 @@ const AMP_EMBED_ALLOWED = {
   postquare: true,
   pubexchange: true,
   rbinfox: true,
+  readmo: true,
   runative: true,
   smartclip: true,
   smi2: true,
@@ -478,6 +480,7 @@ register('pulsepoint', pulsepoint);
 register('purch', purch);
 register('quoraad', quoraad);
 register('rbinfox', rbinfox);
+register('readmo', readmo);
 register('realclick', realclick);
 register('reddit', reddit);
 register('recomad', recomad);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -829,6 +829,10 @@ const adConfig = jsonConfiguration({
     renderStartImplemented: true,
   },
 
+  'readmo': {
+    renderStartImplemented: true,
+  },
+
   'realclick': {
     renderStartImplemented: true,
   },

--- a/ads/readmo.js
+++ b/ads/readmo.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function readmo(global, data) {
+  validateData(data, ['section'], ['module', 'infinite']);
+
+  (global.readmo = global.readmo || []).push({
+    section: data.section,
+    module: data.module,
+    infinite: data.infinite,
+    container: '#c',
+    amp: true,
+  });
+
+  global.context.observeIntersection(function(entries) {
+    entries.forEach(function(entry) {
+      if (global.Readmo) {
+        global.Readmo.onViewChange({
+          rects: entry,
+        });
+      }
+    });
+  });
+
+  loadScript(global, 'https://s.yimg.com/dy/ads/readmo.js', () =>
+    global.context.renderStart()
+  );
+}

--- a/ads/readmo.md
+++ b/ads/readmo.md
@@ -1,0 +1,41 @@
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# ReadMo
+
+## Example
+
+ReadMo only requires a configured section code to run. Please work with your account manager to configure your AMP page sections.
+
+### Basic
+
+```html
+  <amp-embed width="320" height="320"
+             type="readmo"
+             layout="responsive"
+             data-infinite="true"
+             data-section="1234567">
+  </amp-embed>
+```
+
+### Required parameters
+
+- `data-section` : Unique section id that represents your site and placement
+
+### Optional parameters
+
+- `data-module` : Type of module to render (ex: `end-of-article`, `smart-feed`, `smart-feed-video`, `side-rail`)
+- `data-infinite` : If true, will enable infinite feed

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -214,6 +214,7 @@
         <option>pulsepoint</option>
         <option>purch</option>
         <option>rbinfox</option>
+        <option>readmo</option>
         <option>realclick</option>
         <option>recomad</option>
         <option>relap</option>
@@ -1730,6 +1731,15 @@
   <amp-embed width="240" height="400"
       type="rbinfox"
       src="https://rb.infox.sg/infox/503">
+  </amp-embed>
+
+  <h2>ReadMo</h2>
+  <amp-embed width="300" height="250"
+      type="readmo"
+      layout="responsive"
+      heights="(min-width:1907px) 50%, (min-width:1200px) 50%, (min-width:780px) 50%, (min-width:480px) 75%, (min-width:460px) 100%, 100%"
+      data-section="5591639"
+      data-module="end-of-article-stacked">
   </amp-embed>
 
   <h2>Realclick</h2>

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -438,6 +438,7 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Outbrain](../../ads/outbrain.md)
 - [Postquare](../../ads/postquare.md)
 - [PubExchange](../../ads/pubexchange.md)
+- [ReadMo](../../ads/readmo.md)
 - [Smi2](../../ads/smi2.md)
 - [SVK-Native](../../ads/svknative.md)
 - [Strossle](../../ads/strossle.md)


### PR DESCRIPTION
Adds support for Verizon Media ReadMo modules (content circulation units) using the `amp-embed` tag. 

----
Sample Rendering

**Mobile**

<img width="465" alt="Screen Shot 2019-08-19 at 9 24 47 PM" src="https://user-images.githubusercontent.com/1918732/63317493-f0752400-c2c7-11e9-9eae-55cd8756e8fe.png">

**Stream**

<img width="499" alt="Screen Shot 2019-08-19 at 10 08 28 PM" src="https://user-images.githubusercontent.com/1918732/63319151-e81fe780-c2cd-11e9-8011-f9ef9ce35ea4.png">

**Recommendation blocks**

<img width="1411" alt="Screen Shot 2019-08-20 at 5 27 04 PM" src="https://user-images.githubusercontent.com/1918732/63393412-d131d180-c36f-11e9-8b55-c8fc2697eae8.png">



