### PR TITLE
Add stop propagation parameter in gestures

### DIFF
--- a/src/gesture.js
+++ b/src/gesture.js
@@ -63,12 +63,21 @@ export class Gestures {
    * the specified element.
    * @param {!Element} element
    * @param {boolean=} opt_shouldNotPreventDefault
+   * @param {boolean=} opt_shouldStopPropagation
    * @return {!Gestures}
    */
-  static get(element, opt_shouldNotPreventDefault = false) {
+  static get(
+    element,
+    opt_shouldNotPreventDefault = false,
+    opt_shouldStopPropagation = false
+  ) {
     let res = element[PROP_];
     if (!res) {
-      res = new Gestures(element, opt_shouldNotPreventDefault);
+      res = new Gestures(
+        element,
+        opt_shouldNotPreventDefault,
+        opt_shouldStopPropagation
+      );
       element[PROP_] = res;
     }
     return res;
@@ -77,8 +86,9 @@ export class Gestures {
   /**
    * @param {!Element} element
    * @param {boolean} shouldNotPreventDefault
+   * @param {boolean} shouldStopPropagation
    */
-  constructor(element, shouldNotPreventDefault) {
+  constructor(element, shouldNotPreventDefault, shouldStopPropagation) {
     /** @private {!Element} */
     this.element_ = element;
 
@@ -99,6 +109,9 @@ export class Gestures {
 
     /** @private {boolean} */
     this.shouldNotPreventDefault_ = shouldNotPreventDefault;
+
+    /** @private {boolean} */
+    this.shouldStopPropagation_ = shouldStopPropagation;
 
     /**
      * This variable indicates that the eventing has stopped on this
@@ -437,6 +450,8 @@ export class Gestures {
       if (!this.shouldNotPreventDefault_) {
         event.preventDefault();
       }
+    } else if (this.shouldStopPropagation_) {
+      event.stopPropagation();
     }
     if (this.passAfterEvent_) {
       this.passAfterEvent_ = false;

--- a/test/unit/test-gesture.js
+++ b/test/unit/test-gesture.js
@@ -496,4 +496,54 @@ describe('Gestures', () => {
       expect(event.stopPropagation).to.have.not.been.called;
     });
   });
+
+  describe('Gestures - with shouldStopPropagation', () => {
+    let sandbox;
+    let element;
+    let recognizer;
+    let recognizerMock;
+    let gestures;
+    let eventListeners;
+    let onGesture;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox;
+
+      eventListeners = {};
+      element = {
+        addEventListener: (eventType, handler) => {
+          eventListeners[eventType] = handler;
+        },
+        ownerDocument: {
+          defaultView: window,
+        },
+      };
+
+      onGesture = sandbox.spy();
+
+      gestures = Gestures.get(
+        element,
+        undefined,
+        /* shouldStopPropagation */ true
+      );
+      gestures.onGesture(TestRecognizer, onGesture);
+      expect(gestures.recognizers_.length).to.equal(1);
+      recognizer = gestures.recognizers_[0];
+      recognizerMock = sandbox.mock(recognizer);
+    });
+
+    afterEach(() => {
+      recognizerMock.verify();
+      sandbox.restore();
+    });
+
+    it('should stop event from propagating', () => {
+      const event = {
+        type: 'touchend',
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.stopPropagation).to.have.be.calledOnce;
+    });
+  });
 });


### PR DESCRIPTION
Add `shouldStopPropagation` parameter to `Gestures.get()`, default false. This will help with handling sidebar swipe-to-dismiss inside `amp-viewer`.

@sparhami 