### PR TITLE
🏗 Print a message before a Karma browser starts running tests

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -182,6 +182,11 @@ function maybePrintCoverageMessage() {
   opn(url, {wait: false});
 }
 
+function karmaBrowserStart(browser) {
+  console./*OK*/ log('\n');
+  log(`${browser.name}: ${green('STARTED')}`);
+}
+
 function karmaBrowserComplete(browser) {
   const result = browser.lastResult;
   result.total = result.success + result.failed + result.skipped;
@@ -389,6 +394,7 @@ async function createKarmaServer(
   karmaServer
     .on('run_start', () => karmaRunStart())
     .on('browsers_ready', () => karmaBrowsersReady())
+    .on('browser_start', browser => karmaBrowserStart(browser))
     .on('browser_complete', browser => karmaBrowserComplete(browser))
     .on('run_complete', runCompleteFn);
 


### PR DESCRIPTION
Karma tests are run in batches on Sauce Labs browsers. If a batch stalls for some reason, it's hard to tell which browsers were in that batch, and which browser stalled.

This PR prints a message for each `browser_start` event to help figure out which browsers are currently running tests.