### PR TITLE
📖 Remove <amp-story> element documentation from "websites"

### DIFF
--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -1,7 +1,6 @@
 ---
 $category@: presentation
 formats:
-  - websites
   - stories
 teaser:
   text: A rich, visual storytelling format.


### PR DESCRIPTION
This removes amps-story's component reference documentation from the "websites" filter in the component reference docs.

Pro: This is technically fixes things, as you can not use the <amp-story> element on an AMP website.
Con: Comes at the expense of slight decrease of discoverability, as devs have to switch to stories format first to get all the story documentation.

/cc @sebastianbenz @CrystalOnScript 
