### PR TITLE
[Rollforward] Relatively drastically improve FCP for docs with a hidden body.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -633,6 +633,7 @@ const forbiddenTerms = {
       'src/inabox/amp-inabox.js',
       'src/runtime.js',
       'src/custom-element.js',
+      'src/service/resources-impl.js',
     ],
   },
   'AMP_CONFIG': {

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -28,6 +28,7 @@ describe('A4AVariableSource', () => {
       link.setAttribute('href', 'https://pinterest.com:8080/pin1');
       link.setAttribute('rel', 'canonical');
       iframe.doc.head.appendChild(link);
+      iframe.win.services.documentInfo = null;
       installDocumentInfoServiceForDoc(iframe.ampdoc);
       varSource = new A4AVariableSource(iframe.ampdoc, iframe.win);
     });

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -28,7 +28,7 @@ describe('A4AVariableSource', () => {
       link.setAttribute('href', 'https://pinterest.com:8080/pin1');
       link.setAttribute('rel', 'canonical');
       iframe.doc.head.appendChild(link);
-      iframe.win.services.documentInfo = null;
+      iframe.win.__AMP_SERVICES.documentInfo = null;
       installDocumentInfoServiceForDoc(iframe.ampdoc);
       varSource = new A4AVariableSource(iframe.ampdoc, iframe.win);
     });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -45,7 +45,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
     });
 
     it('should handle unload correctly', () => {
-      viewer.waitForDocumentLoaded().then(() => {
+      return viewer.waitForDocumentLoaded().then(() => {
         const stub = sandbox.stub(viewer, 'handleUnload_');
         window.eventListeners.fire({type: 'unload'});
         expect(stub).to.be.calledOnce;
@@ -67,6 +67,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       let integr;
 
       beforeEach(() => {
+        env.sandbox.useFakeTimers();
         integr = new AmpViewerIntegration(env.win);
       });
 

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -54,18 +54,18 @@ function chunkServiceForDoc(elementOrAmpDoc) {
  * time to do other things) and may even be further delayed until
  * there is time.
  *
- * @param {!Document} document
+ * @param {!Document|!./service/ampdoc-impl.AmpDoc} doc
  * @param {function(?IdleDeadline)} fn
  * @param {boolean=} opt_makesBodyVisible Pass true if this service makes
  *     the body visible. This is relevant because it may influence the
  *     task scheduling strategy.
  */
-export function startupChunk(document, fn, opt_makesBodyVisible) {
+export function startupChunk(doc, fn, opt_makesBodyVisible) {
   if (deactivated) {
     resolved.then(fn);
     return;
   }
-  const service = chunkServiceForDoc(document.documentElement);
+  const service = chunkServiceForDoc(doc.documentElement || doc);
   service.runForStartup(fn);
   if (opt_makesBodyVisible) {
     service.runForStartup(() => {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -588,9 +588,11 @@ export class Performance {
     const {documentElement} = this.win.document;
     const size = Services.viewportForDoc(documentElement).getSize();
     const rect = layoutRectLtwh(0, 0, size.width, size.height);
-    return this.resources_
-      .getResourcesInRect(this.win, rect, /* isInPrerender */ true)
-      .then(resources => Promise.all(resources.map(r => r.loadedOnce())));
+    return this.resources_.whenFirstPass().then(() => {
+      return this.resources_
+        .getResourcesInRect(this.win, rect, /* isInPrerender */ true)
+        .then(resources => Promise.all(resources.map(r => r.loadedOnce())));
+    });
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Deferred} from '../utils/promise';
 import {FiniteStateMachine} from '../finite-state-machine';
 import {FocusHistory} from '../focus-history';
 import {Owners} from './owners-impl';
@@ -35,6 +36,7 @@ import {isExperimentOn} from '../experiments';
 import {loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
+import {startupChunk} from '../chunk';
 
 const TAG_ = 'Resources';
 const READY_SCAN_SIGNAL_ = 'ready-scan';
@@ -279,6 +281,11 @@ export class ResourcesDef extends MutatorsAndOwnersDef {
   onNextPass(callback) {}
 
   /**
+   * @return {!Promise} when first pass executed.
+   */
+  whenFirstPass() {}
+
+  /**
    * Called when main AMP binary is fully initialized.
    * May never be called in Shadow Mode.
    */
@@ -436,11 +443,13 @@ export class Resources {
     /** @const @private {!Array<function()>} */
     this.passCallbacks_ = [];
 
+    /** @const @private {!Deferred} */
+    this.firstPassDone_ = new Deferred();
+
     /** @private @const {!FiniteStateMachine<!VisibilityState>} */
     this.visibilityStateMachine_ = new FiniteStateMachine(
       this.viewer_.getVisibilityState()
     );
-    this.setupVisibilityStateMachine_(this.visibilityStateMachine_);
 
     // When viewport is resized, we have to re-measure all elements.
     this.viewport_.onChanged(event => {
@@ -475,7 +484,12 @@ export class Resources {
       this.checkPendingChangeSize_(element);
     });
 
-    this.schedulePass();
+    // Schedule initial passes. This must happen in a startup task
+    // to avoid blocking body visible.
+    startupChunk(this.ampdoc, () => {
+      this.setupVisibilityStateMachine_(this.visibilityStateMachine_);
+      this.schedulePass(0);
+    });
 
     this.rebuildDomWhenReady_();
   }
@@ -2378,6 +2392,13 @@ export class Resources {
   }
 
   /**
+   * @return {!Promise} when first pass executed.
+   */
+  whenFirstPass() {
+    return this.firstPassDone_.promise;
+  }
+
+  /**
    * Calls iterator on each sub-resource
    * @param {!FiniteStateMachine<!VisibilityState>} vsm
    */
@@ -2411,6 +2432,7 @@ export class Resources {
         } else {
           dev().fine(TAG_, 'document is not visible: no scheduling');
         }
+        this.firstPassDone_.resolve();
       }
     };
     const noop = () => {};

--- a/test/unit/test-chunk.js
+++ b/test/unit/test-chunk.js
@@ -167,6 +167,13 @@ describe('chunk2', () => {
             return true;
           });
         });
+
+        it('should execute a chunk with an ampdoc', done => {
+          startupChunk(env.ampdoc, unusedIdleDeadline => {
+            done();
+          });
+        });
+
         basicTests(env);
       });
 
@@ -358,7 +365,7 @@ describe('long tasks', () => {
   describes.fakeWin(
     'long chunk tasks force a macro task between work',
     {
-      amp: true,
+      amp: false,
     },
     env => {
       let subscriptions;
@@ -386,6 +393,7 @@ describe('long tasks', () => {
         postMessageCalls = 0;
         subscriptions = {};
         clock = sandbox.useFakeTimers();
+        installDocService(env.win, /* isSingleDoc */ true);
         toggleExperiment(env.win, 'macro-after-long-task', true);
 
         env.win.addEventListener = function(type, handler) {
@@ -403,6 +411,9 @@ describe('long tasks', () => {
         };
 
         progress = '';
+        chunkInstanceForTesting(
+          env.win.document.documentElement
+        ).macroAfterLongTask_ = true;
       });
 
       it('should not run macro tasks with invisible bodys', done => {

--- a/test/unit/test-document-info.js
+++ b/test/unit/test-document-info.js
@@ -63,6 +63,7 @@ describe
         const {win} = iframe;
         installDocService(win, /* isSingleDoc */ true);
         sandbox.stub(win.Math, 'random').callsFake(() => 0.123456789);
+        win.services.documentInfo = null;
         installDocumentInfoServiceForDoc(win.document);
         return iframe.win;
       });

--- a/test/unit/test-document-info.js
+++ b/test/unit/test-document-info.js
@@ -63,7 +63,7 @@ describe
         const {win} = iframe;
         installDocService(win, /* isSingleDoc */ true);
         sandbox.stub(win.Math, 'random').callsFake(() => 0.123456789);
-        win.services.documentInfo = null;
+        win.__AMP_SERVICES.documentInfo = null;
         installDocumentInfoServiceForDoc(win.document);
         return iframe.win;
       });

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -552,6 +552,10 @@ describes.realWin('performance', {amp: true}, env => {
       )
       .returns(Promise.resolve([res1, res2]))
       .once();
+    resourcesMock
+      .expects('whenFirstPass')
+      .returns(Promise.resolve())
+      .once();
 
     return perf.whenViewportLayoutComplete_().then(() => {
       expect(res1.loadedComplete).to.be.true;
@@ -1104,6 +1108,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       });
       sandbox.stub(Services, 'resourcesForDoc').returns({
         getResourcesInRect: () => unresolvedPromise,
+        whenFirstPass: () => Promise.resolve(),
       });
       sandbox.stub(Services, 'viewportForDoc').returns({
         getSize: () => viewportSize,
@@ -1268,6 +1273,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       });
       sandbox.stub(Services, 'resourcesForDoc').returns({
         getResourcesInRect: () => unresolvedPromise,
+        whenFirstPass: () => Promise.resolve(),
       });
       sandbox.stub(Services, 'viewportForDoc').returns({
         getSize: () => viewportSize,

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -652,16 +652,17 @@ describes.fakeWin(
     it('should run a full reload pass on fonts timeout', () => {
       win.readyState = 'complete';
       win.document.eventListeners.fire({type: 'readystatechange'});
+      let basePassCount = 0;
       return resources.ampdoc
         .whenReady()
         .then(() => {
           expect(resources.relayoutAll_).to.be.false;
-          expect(schedulePassStub).to.not.be.called;
+          basePassCount = schedulePassStub.callCount;
           clock.tick(3100);
         })
         .then(() => {
           expect(resources.relayoutAll_).to.be.true;
-          expect(schedulePassStub).to.have.been.called;
+          expect(schedulePassStub).to.have.callCount(basePassCount + 1);
         });
     });
 
@@ -669,6 +670,7 @@ describes.fakeWin(
       win.readyState = 'interactive';
       win.document.eventListeners.fire({type: 'readystatechange'});
       win.document.fonts.status = 'loading';
+      let basePassCount = 0;
       return resources.ampdoc
         .whenReady()
         .then(() => {})
@@ -676,6 +678,7 @@ describes.fakeWin(
           // This is the regular remeasure on doc-ready.
           expect(resources.relayoutAll_).to.be.true;
           resources.relayoutAll_ = false;
+          basePassCount = schedulePassStub.callCount;
           return win.document.fonts.ready;
         })
         .then(() => {
@@ -685,7 +688,7 @@ describes.fakeWin(
         .then(() => {
           expect(resources.relayoutAll_).to.be.true;
           // Remeasure on doc-ready and fonts-ready.
-          expect(schedulePassStub).to.have.been.calledTwice;
+          expect(schedulePassStub).to.have.callCount(basePassCount + 1);
         });
     });
 
@@ -693,6 +696,7 @@ describes.fakeWin(
       win.readyState = 'interactive';
       win.document.eventListeners.fire({type: 'readystatechange'});
       win.document.fonts.status = 'loaded';
+      let basePassCount = 0;
       return resources.ampdoc
         .whenReady()
         .then(() => {})
@@ -700,6 +704,7 @@ describes.fakeWin(
           // This is the regular remeasure on doc-ready.
           expect(resources.relayoutAll_).to.be.true;
           resources.relayoutAll_ = false;
+          basePassCount = schedulePassStub.callCount;
           return win.document.fonts.ready;
         })
         .then(() => {
@@ -709,7 +714,7 @@ describes.fakeWin(
         .then(() => {
           expect(resources.relayoutAll_).to.be.false;
           // Only remeasure on doc-ready.
-          expect(schedulePassStub).to.have.been.calledOnce;
+          expect(schedulePassStub).to.have.callCount(basePassCount);
         });
     });
 

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -63,6 +63,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       link.setAttribute('href', 'https://pinterest.com:8080/pin1');
       link.setAttribute('rel', 'canonical');
       iframe.doc.head.appendChild(link);
+      iframe.win.services.documentInfo = null;
       installDocumentInfoServiceForDoc(iframe.ampdoc);
       resetScheduledElementForTesting(iframe.win, 'amp-analytics');
       resetScheduledElementForTesting(iframe.win, 'amp-experiment');
@@ -209,6 +210,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
     };
     installDocService(win, /* isSingleDoc */ true);
     const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
+    win.services.documentInfo = null;
     installDocumentInfoServiceForDoc(ampdoc);
     win.ampdoc = ampdoc;
     installUrlReplacementsServiceForDoc(ampdoc);

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -63,7 +63,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       link.setAttribute('href', 'https://pinterest.com:8080/pin1');
       link.setAttribute('rel', 'canonical');
       iframe.doc.head.appendChild(link);
-      iframe.win.services.documentInfo = null;
+      iframe.win.__AMP_SERVICES.documentInfo = null;
       installDocumentInfoServiceForDoc(iframe.ampdoc);
       resetScheduledElementForTesting(iframe.win, 'amp-analytics');
       resetScheduledElementForTesting(iframe.win, 'amp-experiment');
@@ -210,7 +210,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
     };
     installDocService(win, /* isSingleDoc */ true);
     const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-    win.services.documentInfo = null;
+    win.__AMP_SERVICES.documentInfo = null;
     installDocumentInfoServiceForDoc(ampdoc);
     win.ampdoc = ampdoc;
     installUrlReplacementsServiceForDoc(ampdoc);


### PR DESCRIPTION
This change allows AMP to make the body visible before the resource pipeline initializes. This results in a significant improvement in FCP. The change is, however, effectively a no-op when `macro-after-long-task` is off, because without the resource init continues to execute within the same macro as the rest of AMP's initialization.

This change may

- Regress other perf metrics, because certain JS execution and hence network requests are now delayed by a paint
- Should not improve FCP on pages that have their boilerplate removed
- May regress FID because the user may be enticed to click earlier when init code is still running.
- There is a change in how `first-viewport-ready` is calculated. Previously the code relied on resource discovery running early, now it always waits until the discovery code ran at least once.

The actual functional change is:

```js
    // Schedule initial passes. This must happen in a startup task
    // to avoid blocking body visible.
    startupChunk(this.ampdoc, () => {
      this.setupVisibilityStateMachine_(this.visibilityStateMachine_);
      this.schedulePass(0);
    });
```

Everything else are just hacks to get bad assumptions in tests fixed.

Idle-thought: Chunk.js and pass.js need to merge!!! #24109

Before
<img width="260" alt="Screen Shot 2019-08-21 at 7 46 31" src="https://user-images.githubusercontent.com/89679/63442366-d6cafe00-c3e7-11e9-98ab-6f901279e5ef.png">
After
<img width="334" alt="Screen Shot 2019-08-21 at 7 46 18" src="https://user-images.githubusercontent.com/89679/63442374-da5e8500-c3e7-11e9-8628-049fd37bd127.png">

Notice how the second screenshots shows a rendered page much earlier