### PR TITLE
🏗 Reorganize default `gulp` task to build extensions after launching server

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -220,8 +220,9 @@ function getExtensionsToBuild() {
  * and prints a helpful message that lets the developer know how to build the
  * runtime with a list of extensions, all the extensions used by a test file,
  * or no extensions at all.
+ * @param {boolean} defaultTask
  */
-function parseExtensionFlags() {
+function parseExtensionFlags(defaultTask) {
   if (!isTravisBuild()) {
     const noExtensionsMessage =
       green('⤷ Use ') +
@@ -246,6 +247,13 @@ function parseExtensionFlags() {
       green('⤷ Use ') +
       cyan('--extensions_from=examples/foo.amp.html ') +
       green('to build extensions from example docs.');
+    if (defaultTask) {
+      const defaultTaskMessage =
+        green('Running the default ') +
+        cyan('gulp ') +
+        green('task. (Extensions will be built after server startup.)');
+      log(defaultTaskMessage);
+    }
     if (argv.extensions) {
       if (typeof argv.extensions !== 'string') {
         log(red('ERROR:'), 'Missing list of extensions.');


### PR DESCRIPTION
Today, the default `gulp` task builds the core runtime and all extensions before starting up its webserver. As the number of extensions has increased, the wait for server startup has become several minutes long.

This PR reorganizes the default `gulp` task as follows:
1. Build the core runtime and other default targets
2. Launch the webserver
3. Build extensions

With this PR, the wait for webserver startup goes down from a few minutes to ~30 seconds. The `--watch` and `--extensions` mechanisms remain unchanged.
