### PR TITLE
🐛 Set a destination scope to hasAction method to prevent checking tap presence on parents elements on amp-accordion

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -188,7 +188,7 @@ class AmpAccordion extends AMP.BaseElement {
       this.headers_.push(header);
 
       userAssert(
-        this.action_.hasAction(header, 'tap', header.parentElement) == false,
+        this.action_.hasAction(header, 'tap', section) == false,
         'amp-accordion headings should not have tap actions registered.'
       );
 

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -188,7 +188,7 @@ class AmpAccordion extends AMP.BaseElement {
       this.headers_.push(header);
 
       userAssert(
-        this.action_.hasAction(header, 'tap') == false,
+        this.action_.hasAction(header, 'tap', header.parentElement) == false,
         'amp-accordion headings should not have tap actions registered.'
       );
 


### PR DESCRIPTION
Closes #24118 
Fix bug introduced in #23720, resolve issue #24118 