### PR TITLE
✅ Remove skipWindows() as a test config

### DIFF
--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -16,10 +16,7 @@
 
 import {createPointerEvent} from '../../../../../testing/test-helper';
 
-const t = describe
-  .configure()
-  .ifChrome()
-  .skipWindows(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
+const t = describe.configure().ifChrome();
 
 t.run('amp-image-slider', function() {
   this.timeout(20000);

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -30,7 +30,6 @@ describe
   .configure()
   .skipSafari()
   .skipSinglePass()
-  .skipWindows()
   .skip('amp-script', function() {
     this.timeout(TIMEOUT);
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -160,10 +160,6 @@ class TestConfig {
     });
   }
 
-  skipWindows() {
-    return this.skip(() => this.platform.isWindows());
-  }
-
   enableIe() {
     this.skipMatchers.splice(this.skipMatchers.indexOf(this.runOnIe), 1);
     return this;

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -19,8 +19,7 @@ import {whenUpgradedToCustomElement} from '../../src/dom';
 const t = describe
   .configure()
   .ifChrome()
-  .skipSinglePass()
-  .skipWindows(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
+  .skipSinglePass(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
 
 t.run('amp-carousel', function() {
   this.timeout(10000);

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -27,8 +27,7 @@ const t = describe
   .configure()
   .retryOnSaucelabs()
   // TODO(@cramforce): Find out why it does not work with obfuscated props.
-  .skipIfPropertiesObfuscated()
-  .skipWindows(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
+  .skipIfPropertiesObfuscated();
 
 t.run('error page', function() {
   this.timeout(TIMEOUT);

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -19,8 +19,7 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 const t = describe
   .configure()
   .skipSafari() // TODO(zhouyx, #11459): Unskip the test on safari.
-  .skipEdge()
-  .skipWindows(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
+  .skipEdge();
 
 t.run('user-error', function() {
   describes.integration(

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -145,7 +145,6 @@ export function runVideoPlayerIntegrationTests(
     .configure()
     .skipIfPropertiesObfuscated()
     .ifChrome()
-    .skipWindows() // TODO(#19647): Flaky on Chrome 71 on Windows 10.
     .run('Analytics Triggers', function() {
       this.timeout(TIMEOUT);
       let video;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -23,8 +23,7 @@ import {whenUpgradedToCustomElement} from '../../src/dom';
 const t = describe
   .configure()
   .skipIfPropertiesObfuscated()
-  .ifChrome()
-  .skipWindows(); // TODO(#19647): Flaky on Chrome 71 on Windows 10.
+  .ifChrome();
 
 t.run('Viewer Visibility State', () => {
   function noop() {}


### PR DESCRIPTION
`skipWindows()` was used to skip flaky tests, but introduced a side effect where tests were being skipped for all browsers (excluding those opted into Safari) in Sauce Labs. This is because we run integration tests for Chrome, Firefox, Edge and IE on Windows.

Skipping tests should be allowed at the browser level, not OS.

related to #24124