### PR TITLE
🏗🐛 Assorted fixes to vendor config generation

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -26,9 +26,9 @@ const {
   verifyExtensionAliasBundles,
 } = require('../../bundles.config');
 const {compileJs, mkdirSync} = require('./helpers');
-const {compileVendorConfigs} = require('./vendor-configs');
 const {isTravisBuild} = require('../travis');
 const {jsifyCssAsync} = require('./jsify-css');
+const {vendorConfigs} = require('./vendor-configs');
 
 const {green, red, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
@@ -435,18 +435,20 @@ function buildExtension(
     promises.push(buildCssPromise);
   }
 
-  // minify and copy vendor configs for amp-analytics component
-  if (name === 'amp-analytics') {
-    promises.push(compileVendorConfigs(options));
-  }
-
-  return Promise.all(promises).then(() => {
-    if (argv.single_pass) {
-      return Promise.resolve();
-    } else {
-      return buildExtensionJs(path, name, version, latestVersion, options);
-    }
-  });
+  return Promise.all(promises)
+    .then(() => {
+      if (argv.single_pass) {
+        return Promise.resolve();
+      } else {
+        return buildExtensionJs(path, name, version, latestVersion, options);
+      }
+    })
+    .then(() => {
+      // minify and copy vendor configs for amp-analytics component
+      if (name === 'amp-analytics') {
+        return vendorConfigs(options);
+      }
+    });
 }
 
 /**

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -16,29 +16,22 @@
 
 const minimist = require('minimist');
 const argv = minimist(process.argv.slice(2));
+const deglob = require('globs-to-files');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const gulpWatch = require('gulp-watch');
 const jsonlint = require('gulp-jsonlint');
 const jsonminify = require('gulp-jsonminify');
 const rename = require('gulp-rename');
-const {endBuildStep, printNobuildHelp, toPromise} = require('./helpers');
+const {endBuildStep, toPromise} = require('./helpers');
 
 /**
  * Entry point for 'gulp vendor-configs'
- * @return {!Promise}
- */
-async function vendorConfigs() {
-  printNobuildHelp();
-  return compileVendorConfigs();
-}
-
-/**
  * Compile all the vendor configs and drop in the dist folder
  * @param {Object=} opt_options
  * @return {!Promise}
  */
-function compileVendorConfigs(opt_options) {
+async function vendorConfigs(opt_options) {
   const options = opt_options || {};
 
   const srcPath = ['extensions/amp-analytics/0.1/vendors/*.json'];
@@ -53,7 +46,7 @@ function compileVendorConfigs(opt_options) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
     gulpWatch(srcPath, function() {
-      compileVendorConfigs(copyOptions);
+      vendorConfigs(copyOptions);
     });
   }
 
@@ -79,17 +72,18 @@ function compileVendorConfigs(opt_options) {
       )
       .pipe(gulp.dest(destPath))
   ).then(() => {
-    endBuildStep(
-      'Compiled all analytics vendor configs into ',
-      destPath,
-      startTime
-    );
+    if (deglob.sync(srcPath).length > 0) {
+      endBuildStep(
+        'Compiled all analytics vendor configs into',
+        destPath,
+        startTime
+      );
+    }
   });
 }
 
 module.exports = {
   vendorConfigs,
-  compileVendorConfigs,
 };
 
 vendorConfigs.description = 'Compile analytics vendor configs to dist';


### PR DESCRIPTION
**PR highlights:**
- Eliminates the race between `compileVendorConfigs` and `buildExtensionJs()` for `amp-analytics`. Now, the two are done one after the other, making the build logs easier to read.
- Prints the `Compiled all analytics vendor configs into dist/v0/analytics-vendors/` message only when at least one vendor config was actually generated
- Consolidates the `vendorConfigs` task by removing the call to `printNobuildHelp()` (unnecessary copy-paste)