### PR TITLE
Media rebuffer rate metric as integer and not float.

### DIFF
--- a/extensions/amp-story/1.0/media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/media-performance-metrics-service.js
@@ -212,11 +212,9 @@ export class MediaPerformanceMetricsService {
       return;
     }
 
-    const rebufferRate =
-      Math.round(
-        (metrics.rebufferTime / (metrics.rebufferTime + metrics.watchTime)) *
-          1000
-      ) / 1000;
+    const rebufferRate = Math.round(
+      (metrics.rebufferTime / (metrics.rebufferTime + metrics.watchTime)) * 100
+    );
 
     this.performanceService_.tickDelta('vjl', metrics.jointLatency);
     this.performanceService_.tickDelta('vwt', metrics.watchTime);

--- a/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
@@ -245,8 +245,8 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
       service.stopMeasuring(video);
 
       // playing: 600; waiting: 800
-      // 800 / (600 + 800) ~= 0.571
-      expect(tickStub).to.have.been.calledWithExactly('vrbr', 0.571);
+      // (800 / (600 + 800)) * 100 ~= 57
+      expect(tickStub).to.have.been.calledWithExactly('vrbr', 57);
     });
 
     it('should record mean time between rebuffers', () => {


### PR DESCRIPTION
Updating the media rebuffer rate metric from float to integer, as the current CSI pipeline doesn't support floats.