### PR TITLE
🏗 Lazily build extensions during the default `gulp` task

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -100,10 +100,13 @@ if (lazyBuildExtensions) {
     const extensionMatch = req.url.match(extensionUrlMatcher);
     if (extensionMatch && extensionMatch.length == 2) {
       const extension = extensionMatch[1];
-      if (extensions[extension]) {
-        return doBuildExtension(extensions, extension).then(() => {
-          next();
-        });
+      if (extensions[extension] && !extensions[extension].watched) {
+        return doBuildExtension(extensions, extension, {watch: true}).then(
+          () => {
+            extensions[extension].watched = true;
+            next();
+          }
+        );
       }
     }
     next();

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -96,11 +96,11 @@ if (noCachingExtensions) {
 if (lazyBuildExtensions) {
   maybeInitializeExtensions(extensions, /* includeLatest */ true);
   middleware.push(function(req, res, next) {
-    const extensionUrlMatcher = /\/dist\/v0\/(amp-.*)\.max\.js/;
+    const extensionUrlMatcher = /\/dist\/v0\/(.*)\.max\.js/;
     const extensionMatch = req.url.match(extensionUrlMatcher);
     if (extensionMatch && extensionMatch.length == 2) {
       const extension = extensionMatch[1];
-      if (!extension.startsWith('amp-script-worker')) {
+      if (extensions[extension]) {
         return doBuildExtension(extensions, extension).then(() => {
           next();
         });

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -26,6 +26,10 @@ const isRunning = require('is-running');
 const log = require('fancy-log');
 const morgan = require('morgan');
 const webserver = require('gulp-webserver');
+const {
+  doBuildExtension,
+  maybeInitializeExtensions,
+} = require('./tasks/extension-helpers');
 
 const {
   SERVE_HOST: host,
@@ -38,7 +42,10 @@ const quiet = process.env.SERVE_QUIET == 'true';
 const sendCachingHeaders = process.env.SERVE_CACHING_HEADERS == 'true';
 const noCachingExtensions =
   process.env.SERVE_EXTENSIONS_WITHOUT_CACHING == 'true';
+const lazyBuildExtensions = process.env.LAZY_BUILD_EXTENSIONS == 'true';
 const header = require('connect-header');
+
+const extensions = {};
 
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
@@ -81,6 +88,23 @@ if (noCachingExtensions) {
     if (req.url.startsWith('/dist/v0/amp-')) {
       log('Skipping caching for ', req.url);
       res.header('Cache-Control', 'no-store');
+    }
+    next();
+  });
+}
+
+if (lazyBuildExtensions) {
+  maybeInitializeExtensions(extensions, /* includeLatest */ true);
+  middleware.push(function(req, res, next) {
+    const extensionUrlMatcher = /\/dist\/v0\/(amp-.*)\.max\.js/;
+    const extensionMatch = req.url.match(extensionUrlMatcher);
+    if (extensionMatch && extensionMatch.length == 2) {
+      const extension = extensionMatch[1];
+      if (!extension.startsWith('amp-script-worker')) {
+        return doBuildExtension(extensions, extension).then(() => {
+          next();
+        });
+      }
     }
     next();
   });

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const {
   buildAlp,
@@ -42,7 +43,7 @@ const {serve} = require('./serve');
 async function watch(defaultTask) {
   maybeUpdatePackages();
   createCtrlcHandler('watch');
-  return performBuild(/** watch */ true, /** defaultTask */ defaultTask);
+  return performBuild(/* watch */ true, defaultTask);
 }
 
 /**
@@ -98,10 +99,20 @@ function polyfillsForTests() {
  * The default task run when `gulp` is executed
  */
 async function defaultTask() {
-  await watch(/** defaultTask */ true);
-  serve();
-  log(green('Started'), cyan('gulp'), green('server. Building extensions...'));
-  await buildExtensions({watch: true});
+  await watch(/* defaultTask */ true);
+  serve(argv.lazy_build_extensions);
+  const startedMessage = green('Started ') + cyan('gulp ') + green('server. ');
+  if (argv.lazy_build_extensions) {
+    log(
+      startedMessage +
+        green(
+          'Extensions will be lazily built when requested from the server...'
+        )
+    );
+  } else {
+    log(startedMessage + green('Building extensions...'));
+    await buildExtensions({watch: true});
+  }
 }
 
 module.exports = {
@@ -138,6 +149,8 @@ defaultTask.flags = {
   with_shadow: '  Also watch and build the amp-shadow.js binary.',
   with_video_iframe_integration:
     '  Also watch and build the video-iframe-integration.js binary.',
+  lazy_build_extensions:
+    '  Lazily builds extensions when they are requested from the server',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:
     '  Watches and builds only the extensions from the listed AMP(s).',

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -34,8 +34,9 @@ const noCachingExtensions = argv.noCachingExtensions != undefined;
 
 /**
  * Starts a simple http server at the repository root
+ * @param {boolean} lazyBuildExtensions
  */
-function serve() {
+function serve(lazyBuildExtensions) {
   createCtrlcHandler('serve');
 
   // Get the serve mode
@@ -77,6 +78,7 @@ function serve() {
       'SERVE_QUIET': quiet,
       'SERVE_CACHING_HEADERS': sendCachingHeaders,
       'SERVE_EXTENSIONS_WITHOUT_CACHING': noCachingExtensions,
+      'LAZY_BUILD_EXTENSIONS': lazyBuildExtensions,
     },
     stdout: !quiet,
   };


### PR DESCRIPTION
**Background:** Until recently, the default `gulp` task would build the core runtime and all extensions before starting up its webserver. With #24138, the flow was reorganized to:

1. Build the core runtime and other default targets
2. Launch the webserver
3. Build extensions

**PR highlights:** A new flag `--lazy_build_extensions` is introduced for the default `gulp` task. It further reorganizes the flow as follows:

1. Build the core runtime and other default targets (unchanged)
2. Launch the webserver (unchanged)
3. The first time an extension is requested from the server, lazily build it (with watch enabled) and serve a fresh version
    - After this, the normal `watch` mechanism applies, and the extension gets rebuilt on edit 
    - Subsequent requests for the extension will instantly serve it without yet another rebuild

**Notes:** `--lazy_build_extensions` changes the `watch` mechanism during the default `gulp` task.
- Initially, all extensions are built only when first requested from the server.
- Once an extension is requested, the normal `watch` mechanism applies, and the extension is rebuilt on edit.
- Meanwhile, the core runtime will continue to be rebuilt on file edit. (Initial-build-on-request is slightly more complicated since `buildExtension` cannot be called.)

**Example:** Here's what it will look like when you run `gulp --lazy_build_extensions` from a clean state and open `article.amp.html` in a browser. Initial page load time depends on how many extensions need to be built. Subsequent page loads are instant.

![Screenshot from 2019-08-22 18-48-38](https://user-images.githubusercontent.com/26553114/63555139-c90f9880-c50d-11e9-93a3-053a3f8cd037.png)


Follow up to #24138
Partial fix for #24141