### PR TITLE
✨ Proof of concept React BaseElement

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -68,6 +68,7 @@ exports.rules = [
     whitelist: [
       'extensions/amp-date-picker/0.1/**->src/module.js',
       'extensions/amp-inputmask/0.1/**->src/module.js',
+      'extensions/amp-react-img/0.1/**->src/module.js',
     ],
   },
   {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -263,7 +263,10 @@ function appendToCompiledFile(srcFilename, destFilePath) {
   if (bundleFiles) {
     const newSource = concatFilesToString(bundleFiles.concat([destFilePath]));
     fs.writeFileSync(destFilePath, newSource, 'utf8');
-  } else if (srcFilename == 'amp-date-picker.js') {
+  } else if (
+    srcFilename == 'amp-date-picker.js' ||
+    srcFilename == 'amp-react-img.js'
+  ) {
     // For amp-date-picker, we inject the react-dates bundle after compile
     // to avoid CC from messing with browserify's module boilerplate.
     const file = fs.readFileSync(destFilePath, 'utf8');

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -752,6 +752,12 @@ exports.extensionBundles = [
     postPrepend: ['third_party/react-dates/bundle.js'],
   },
   {
+    name: 'amp-react-img',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-image-viewer',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/react-img.amp.html
+++ b/examples/react-img.amp.html
@@ -16,7 +16,7 @@
   <amp-react-img
     id="first"
     alt="preact img"
-    src="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+    srcset="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true 100w"
     width=100
     height=100
     ></amp-react-img>

--- a/examples/react-img.amp.html
+++ b/examples/react-img.amp.html
@@ -8,6 +8,7 @@
   <style amp-custom></style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async custom-element="amp-react-img" src="https://cdn.ampproject.org/v0/amp-react-img-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
@@ -19,11 +20,36 @@
     width=100
     height=100
     ></amp-react-img>
+
   <div style="height: 120vh">scroll down...</div>
+
+  <amp-state id="state">
+    <script type="application/json">
+      {
+        "alt": "bindable",
+        "src": "https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+      }
+    </script>
+  </amp-state>
+
+  <label for="alt">Mutate image's alt attribute</label>
+  <input name="alt" on="input-debounced:AMP.setState({ state: {alt: event.value} })"
+    value="bindable"
+    >
+  <br>
+
+  <label for="src">Mutate image's src attribute</label>
+  <input name="src" on="input-debounced:AMP.setState({ state: {src: event.value} })"
+    value="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+    >
+  <br>
+
   <amp-react-img
     id="second"
-    alt="preact img"
+    alt="bindable"
+    [alt]="state.alt"
     src="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+    [src]="state.src"
     width=100
     height=100
     ></amp-react-img>

--- a/examples/react-img.amp.html
+++ b/examples/react-img.amp.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP React BaseElement Example</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom></style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-react-img" src="https://cdn.ampproject.org/v0/amp-react-img-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp-react-img</h1>
+  <amp-react-img
+    id="first"
+    alt="preact img"
+    src="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+    width=100
+    height=100
+    ></amp-react-img>
+  <div style="height: 120vh">scroll down...</div>
+  <amp-react-img
+    id="second"
+    alt="preact img"
+    src="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true"
+    width=100
+    height=100
+    ></amp-react-img>
+</body>
+</html>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -286,6 +286,20 @@ function createElementRules_() {
         'alternativeName': 'src',
       },
     },
+    'AMP-REACT-IMG': {
+      'alt': null,
+      'attribution': null,
+      'src': {
+        'allowedProtocols': {
+          'data': true,
+          'http': true,
+          'https': true,
+        },
+      },
+      'srcset': {
+        'alternativeName': 'src',
+      },
+    },
     'AMP-LIGHTBOX': {
       'open': null,
     },

--- a/extensions/amp-react-img/0.1/amp-react-img.js
+++ b/extensions/amp-react-img/0.1/amp-react-img.js
@@ -139,12 +139,39 @@ AMP.extension('amp-react-img', '0.1', AMP => {
       layoutCallback() {
         const el = devAssert(this.el_);
         el.setState({prerender: false});
+        this.rerender_();
+      }
 
-        const rerender = react.createElement(Component, this.attributes_());
-        render(rerender, this.element);
+      /** @override */
+      mutatedAttributesCallback(mutations) {
+        if (!this.el_) {
+          return;
+        }
+
+        // Mutating src should override existing srcset, so remove the latter.
+        if (
+          mutations['src'] &&
+          !mutations['srcset'] &&
+          this.element.hasAttribute('srcset')
+        ) {
+          this.element.removeAttribute('srcset');
+        }
+        this.rerender_();
       }
 
       /**
+       * @private
+       */
+      rerender_() {
+        // While this "creates" a new element, React's diffing will not create
+        // a second instance of Component. Instead, the existing one already
+        // rendered into this element will be reusued.
+        const el = react.createElement(Component, this.attributes_());
+        render(el, this.element);
+      }
+
+      /**
+       * @private
        * @return {!Object<string, string>}
        */
       attributes_() {

--- a/extensions/amp-react-img/0.1/amp-react-img.js
+++ b/extensions/amp-react-img/0.1/amp-react-img.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {devAssert} from '../../../src/log';
+import {requireExternal} from '../../../src/module';
+
+/**
+ * @param {!Object<string, *>} props
+ * @param {!Array<string>} keys
+ * @return {!Object<string, *>}
+ */
+function pick(props, keys) {
+  const out = {};
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = props[key];
+    if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+
+  return out;
+}
+
+const ATTRIBUTES_TO_PROPAGATE = [
+  'alt',
+  'title',
+  'referrerpolicy',
+  'aria-label',
+  'aria-describedby',
+  'aria-labelledby',
+  'srcset',
+  'src',
+  'sizes',
+];
+
+AMP.extension('amp-react-img', '0.1', AMP => {
+  const react = requireExternal('react');
+  const {render} = requireExternal('react-dom');
+
+  /**
+   * We'll implement all our new extensions as React/Preact Components (TBD).
+   * They're true Components, not AmpElements/Amp.BaseElements.
+   */
+  class AmpImg extends react.Component {
+    /**
+     * @param {!Object} props
+     */
+    constructor(props) {
+      super(props);
+    }
+
+    /**
+     * @return {*}
+     */
+    render() {
+      const props = pick(this.props, ATTRIBUTES_TO_PROPAGATE);
+      const {
+        id,
+        'i-amphtml-ssr': ssr,
+        'i-amphtml-prerender': prerender,
+      } = this.props;
+      if (ssr) {
+        // TODO: Figure out SSR children
+      }
+
+      if (id) {
+        props['amp-img-id'] = id;
+      }
+      props['decoding'] = 'async';
+
+      // amp-img is always allowed to render, but we want to make this interesting...
+      if (prerender) {
+        delete props['src'];
+        delete props['srcset'];
+      }
+
+      return react.createElement('img', props);
+    }
+  }
+
+  /**
+   * ReactCompatibleBaseElement is a compatibility wrapper around AMP's
+   * BaseElement. It takes a Component to compose, and calls renders the
+   * component with any state necessary.
+   *
+   * This code can be shared across multiple extensions, all they need to do is
+   * supply the Component.
+   *
+   * This is only necessary in when in AMP pages. If we're in a Bento page,
+   * this code is useless. We'll supply a CustomElement factory class that will
+   * provide compatibilty between CE and React.
+   *
+   * @param {!React.Component} Component
+   * @return {Amp.BaseElement}
+   */
+  function ReactCompatibleBaseElement(Component) {
+    return class ReactBaseElement extends AMP.BaseElement {
+      /** @param {!AmpElement} element */
+      constructor(element) {
+        super(element);
+      }
+
+      /**
+       * For demo purposes.
+       * @override
+       */
+      renderOutsideViewport() {
+        return false;
+      }
+
+      /** @override */
+      isLayoutSupported() {
+        return true;
+      }
+
+      /** @override */
+      buildCallback() {
+        const el = react.createElement(
+          Component,
+          this.attributes_(/* prerender */ true)
+        );
+        render(el, this.element);
+      }
+
+      /** @override */
+      layoutCallback() {
+        const el = react.createElement(
+          Component,
+          this.attributes_(/* prerender */ false)
+        );
+        render(el, this.element);
+      }
+
+      /**
+       * @param {boolean} prerender
+       * @return {!Object<string, string>}
+       */
+      attributes_(prerender) {
+        const out = {};
+        const {attributes} = this.element;
+        for (let i = 0, l = attributes.length; i < l; i++) {
+          const attr = attributes[i];
+          out[attr.name] = attr.value;
+        }
+        out['i-amphtml-prerender'] = prerender;
+        return out;
+      }
+    };
+  }
+
+  // In AMP pages, we do the regular registration of our wrapped component.
+  const AmpReactImg = ReactCompatibleBaseElement(AmpImg);
+  AMP.registerElement('amp-react-img', AmpReactImg);
+});


### PR DESCRIPTION
This is a proof of concept to support `React`/`Preact` Components in AMP pages. Once we flesh this out, we can provide a generic class factory to create `AMP.BaseElement` classes for each wrapped Component, which can then be registered and used like regular AMP components.

A lot of the hard work was already done in `<amp-date-picker>`. 