### PR TITLE
<amp-experiment> 1.0 Support mutating src attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ firebase
 .firebaserc
 firebase.json
 .firebase/
+extensions/amp-analytics/0.1/vendors/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ firebase
 .firebaserc
 firebase.json
 .firebase/
-extensions/amp-analytics/0.1/vendors/*.json

--- a/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-url.js
+++ b/extensions/amp-experiment/1.0/mutation/attribute-mutation-default-url.js
@@ -16,6 +16,7 @@
 
 import {assertAttributeMutationFormat} from './mutation';
 import {assertHttpsUrl} from '../../../../src/url';
+import {map} from '../../../../src/utils/object';
 import {user} from '../../../../src/log';
 
 const TAG = 'amp-experiment attribute-mutation-default-url';
@@ -65,10 +66,17 @@ export class AttributeMutationDefaultUrl {
   /** @override */
   mutate() {
     this.elements_.forEach(element => {
-      element.setAttribute(
-        this.mutationRecord_['attributeName'],
-        this.mutationRecord_['value']
-      );
+      // name can be href or src
+      const name = this.mutationRecord_['attributeName'];
+      const value = this.mutationRecord_['value'];
+      element.setAttribute(name, value);
+
+      // Ask AMP element to handle mutations
+      if (typeof element.mutatedAttributesCallback === 'function') {
+        const mutations = map();
+        mutations[name] = value;
+        element.mutatedAttributesCallback(mutations);
+      }
     });
   }
 

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -76,7 +76,7 @@ describes.realWin(
     }
 
     function getAttributeMutationDefaultUrl(value) {
-      elements = [doc.createElement('a')];
+      elements = elements;
       const paramsObject = getAttributeMutationParamsObject('href', value);
       return new AttributeMutationDefaultUrl(
         paramsObject.mutationRecord,
@@ -230,6 +230,7 @@ describes.realWin(
 
       describe('default url', () => {
         it('should allow valid mutations', () => {
+          elements = [document.createElement('a')];
           const attributeMutation = getAttributeMutationDefaultUrl(
             'https://amp.dev/'
           );
@@ -309,6 +310,13 @@ describes.realWin(
       });
 
       it('should mutate default url mutations', () => {
+        const element1 = document.createElement('amp-img');
+        const element2 = document.createElement('a');
+        elements = [element1, element2];
+        const mutatedAttributesCallbackSpy = sandbox.spy();
+        element1.mutatedAttributesCallback = () => {
+          mutatedAttributesCallbackSpy();
+        };
         const attributeMutation = getAttributeMutationDefaultUrl(
           'https://amp.dev/'
         );
@@ -319,6 +327,7 @@ describes.realWin(
         attributeMutation.elements_.forEach(element => {
           expect(element.getAttribute(attributeName)).to.equal(value);
         });
+        expect(mutatedAttributesCallbackSpy).to.be.calledOnce;
       });
     });
   }

--- a/test/manual/amp-experiment-1.0.html
+++ b/test/manual/amp-experiment-1.0.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-experiment</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-1.0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+    amp-user-notification {
+      padding: 5px;
+      background-color: yellow;
+      height: 50px;
+    }
+
+    .blue-class {
+      color: blue;
+    }
+  </style>
+</head>
+<body>
+  <div>
+  <h1>Title TBD</h1>
+
+  <ul>
+    <li><a href="#amp-x-background-color-test=yellow" target="_blank">#amp-x-background-color-test=yellow</a></li>
+    <li><a href="#amp-x-background-color-test=green" target="_blank">#amp-x-background-color-test=green</a></li>
+  </ul>
+  </div>
+
+  Destiny Img w/o mutation.
+  <amp-img id='test' src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width=300 height=250></amp-img>
+
+  <amp-experiment>
+    <script type="application/json">
+      {
+        "background-color-test": {
+          "variants": {
+            "yellow": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "background-color: red; color: #FFFFFF"
+                }
+              ]
+            },
+            "red": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "style",
+                  "value": "background-color: blue"
+                }
+              ]
+            }
+          }
+        },
+        "amp-img-src": {
+          "variants": {
+            "a": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "#test",
+                  "attributeName": "https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n",
+                  "value": "background-color: red; color: #FFFFFF"
+                }
+              ]
+            },
+            "b": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "#test",
+                  "attributeName": "src",
+                  "value": "https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n"
+                }
+              ]
+            }
+          }
+        },
+        "font-color-test": {
+          "variants": {
+            "blue": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "attributes",
+                  "target": "h1",
+                  "attributeName": "class",
+                  "value": "blue-class"
+                }
+              ]
+            }
+          }
+        },
+        "text-content-test": {
+          "sticky": false,
+          "variants": {
+            "firstVariant": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "characterData",
+                  "target": "h1",
+                  "value": "First characterData Variant"
+                }
+              ]
+            },
+            "secondVariant": {
+              "weight": 50,
+              "mutations": [
+                {
+                  "type": "characterData",
+                  "target": "h1",
+                  "value": "Second characterData Variant"
+                }
+              ]
+            }
+          }
+        }
+      }
+    </script>
+  </amp-experiment>
+  <amp-pixel src="https://donot.worry/?background-color-test=VARIANT(background-color-test)&font-color-test=VARIANT(font-color-test)&text-content-test=VARIANT(text-content-test)&variants=VARIANTS"></amp-pixel>
+</body>
+</html>


### PR DESCRIPTION
To fix the race condition (it happens most of the time), where the `src` attribute is changed after AMP element's `buildCallback`