### PR TITLE
Fix bookend momentum scrolling on iOS.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.css
@@ -45,6 +45,7 @@
   height: calc(100% - 40px) !important;
   background: rgba(255, 255, 255, 1) !important;
   overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch !important;
   transition: background 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
 }
 


### PR DESCRIPTION
Fix bookend momentum scrolling on iOS.

I deleted it from the bookend code [here](https://github.com/ampproject/amphtml/pull/23761/files#diff-67e8c7c25bbfaceb818b48a574a0edbaL41) and forgot to add it to the draggable drawer code.