### PR TITLE
allow script tag for non-transformed AMP with amp-script

### DIFF
--- a/extensions/amp-script/0.1/test/validator-amp-script.html
+++ b/extensions/amp-script/0.1/test/validator-amp-script.html
@@ -50,6 +50,14 @@
     <canvas id="myCanvas" width="100px" height="100px"></canvas>
   </amp-script>
 
+  <!-- Valid: script tag with target of amp-script -->
+  <script id="hello-world" type="text/plain" target="amp-script">
+    const btn = document.querySelector('button');
+    btn.addEventListener('click', () => {
+      document.body.textContent += 'Hello World!';
+    });
+  </script>
+
   <!-- Invalid: <canvas> element outside of amp-script tag. -->
   <canvas id="myCanvas" width="100px" height="100px"></canvas>
 

--- a/extensions/amp-script/0.1/test/validator-amp-script.html
+++ b/extensions/amp-script/0.1/test/validator-amp-script.html
@@ -28,10 +28,13 @@
   <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
 </head>
 <body>
-  <!-- Valid: With 'script' attribute. -->
+  <!-- Valid: With 'script' tag and target. -->
   <amp-script layout=container script=hello></amp-script>
   <script type=text/plain target=amp-script id=hello>
-    document.body.textContent = "Hello world!";
+    const btn = document.querySelector('button');
+    btn.addEventListener('click', () => {
+      document.body.textContent += 'Hello World!';
+    });
   </script>
 
   <!-- Valid: With 'src' attribute. -->
@@ -49,14 +52,6 @@
   <amp-script layout=container src="https://example.com/foo.js">
     <canvas id="myCanvas" width="100px" height="100px"></canvas>
   </amp-script>
-
-  <!-- Valid: script tag with target of amp-script -->
-  <script id="hello-world" type="text/plain" target="amp-script">
-    const btn = document.querySelector('button');
-    btn.addEventListener('click', () => {
-      document.body.textContent += 'Hello World!';
-    });
-  </script>
 
   <!-- Invalid: <canvas> element outside of amp-script tag. -->
   <canvas id="myCanvas" width="100px" height="100px"></canvas>

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -29,10 +29,13 @@ FAIL
 |    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
 |  </head>
 |  <body>
-|    <!-- Valid: With 'script' attribute. -->
+|    <!-- Valid: With 'script' tag and target. -->
 |    <amp-script layout=container script=hello></amp-script>
 |    <script type=text/plain target=amp-script id=hello>
-|      document.body.textContent = "Hello world!";
+|      const btn = document.querySelector('button');
+|      btn.addEventListener('click', () => {
+|        document.body.textContent += 'Hello World!';
+|      });
 |    </script>
 |
 |    <!-- Valid: With 'src' attribute. -->
@@ -51,71 +54,63 @@ FAIL
 |      <canvas id="myCanvas" width="100px" height="100px"></canvas>
 |    </amp-script>
 |
-|    <!-- Valid: script tag with target of amp-script -->
-|    <script id="hello-world" type="text/plain" target="amp-script">
-|      const btn = document.querySelector('button');
-|      btn.addEventListener('click', () => {
-|        document.body.textContent += 'Hello World!';
-|      });
-|    </script>
-|
 |    <!-- Invalid: <canvas> element outside of amp-script tag. -->
 |    <canvas id="myCanvas" width="100px" height="100px"></canvas>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:62:2 The tag 'canvas' may only appear as a descendant of tag 'amp-script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:57:2 The tag 'canvas' may only appear as a descendant of tag 'amp-script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: With neither 'script' or 'src' attributes. -->
 |    <amp-script layout=container></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:65:2 The tag 'amp-script' is missing a mandatory attribute - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:60:2 The tag 'amp-script' is missing a mandatory attribute - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Both 'script' and 'src' attributes. -->
 |    <amp-script layout=container src="https://example.com/foo.js" script=hello></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:68:2 Mutually exclusive attributes encountered in tag 'amp-script' - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:63:2 Mutually exclusive attributes encountered in tag 'amp-script' - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Relative URL. -->
 |    <amp-script layout=container src="/foo.js"></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:71:2 The relative URL '/foo.js' for attribute 'src' in tag 'amp-script' is disallowed. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:66:2 The relative URL '/foo.js' for attribute 'src' in tag 'amp-script' is disallowed. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Non-https 'src' attribute. -->
 |    <amp-script layout=container src="http://not.https.url"></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:74:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:69:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
 |    <script type=text/plain>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:77:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:72:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'type'. -->
 |    <script type=text/amp-script target=amp-script id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:82:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script) [DISALLOWED_HTML]
+amp-script/0.1/test/validator-amp-script.html:77:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script) [DISALLOWED_HTML]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'target'. -->
 |    <script type=text/plain target=amp-js id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:87:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:82:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'target' attribute. -->
 |    <script type=text/plain id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:92:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:87:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'id' attribute. -->
 |    <script type=text/plain target=amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:97:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:92:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |  </body>

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -32,8 +32,6 @@ FAIL
 |    <!-- Valid: With 'script' attribute. -->
 |    <amp-script layout=container script=hello></amp-script>
 |    <script type=text/plain target=amp-script id=hello>
->>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:33:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello world!";
 |    </script>
 |
@@ -53,63 +51,71 @@ amp-script/0.1/test/validator-amp-script.html:33:2 Custom JavaScript is not allo
 |      <canvas id="myCanvas" width="100px" height="100px"></canvas>
 |    </amp-script>
 |
+|    <!-- Valid: script tag with target of amp-script -->
+|    <script id="hello-world" type="text/plain" target="amp-script">
+|      const btn = document.querySelector('button');
+|      btn.addEventListener('click', () => {
+|        document.body.textContent += 'Hello World!';
+|      });
+|    </script>
+|
 |    <!-- Invalid: <canvas> element outside of amp-script tag. -->
 |    <canvas id="myCanvas" width="100px" height="100px"></canvas>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:54:2 The tag 'canvas' may only appear as a descendant of tag 'amp-script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:62:2 The tag 'canvas' may only appear as a descendant of tag 'amp-script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: With neither 'script' or 'src' attributes. -->
 |    <amp-script layout=container></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:57:2 The tag 'amp-script' is missing a mandatory attribute - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:65:2 The tag 'amp-script' is missing a mandatory attribute - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Both 'script' and 'src' attributes. -->
 |    <amp-script layout=container src="https://example.com/foo.js" script=hello></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:60:2 Mutually exclusive attributes encountered in tag 'amp-script' - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:68:2 Mutually exclusive attributes encountered in tag 'amp-script' - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Relative URL. -->
 |    <amp-script layout=container src="/foo.js"></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:63:2 The relative URL '/foo.js' for attribute 'src' in tag 'amp-script' is disallowed. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:71:2 The relative URL '/foo.js' for attribute 'src' in tag 'amp-script' is disallowed. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Non-https 'src' attribute. -->
 |    <amp-script layout=container src="http://not.https.url"></amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:66:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+amp-script/0.1/test/validator-amp-script.html:74:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |
 |    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
 |    <script type=text/plain>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:69:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:77:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'type'. -->
 |    <script type=text/amp-script target=amp-script id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:74:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:82:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script) [DISALLOWED_HTML]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'target'. -->
 |    <script type=text/plain target=amp-js id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:79:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:87:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'target' attribute. -->
 |    <script type=text/plain id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:84:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:92:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'id' attribute. -->
 |    <script type=text/plain target=amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:89:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+amp-script/0.1/test/validator-amp-script.html:97:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
 |      document.body.textContent = "Hello World!";
 |    </script>
 |  </body>

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -25,35 +25,36 @@ tags: {
   attr_lists: "common-extension-attrs"
 }
 # Temporarily disable until interaction of amp-script and signed exchanges has
-# been security reviewed.
-#tags: {  # <amp-script> (local script)
-#  html_format: AMP
-#  tag_name: "SCRIPT"
-#  spec_name: "amp-script extension local script"
-#  requires_extension: "amp-script"
-#  attrs: {
-#    name: "target"
-#    mandatory: true
-#    value: "amp-script"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  attrs: {
-#    name: "type"
-#    mandatory: true
-#    value_casei: "text/plain"
-#  }
-#  attr_lists: "mandatory-id-attr"
-#  attr_lists: "nonce-attr"
-#  cdata: {
-#    max_bytes: 10000
-#    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
-#    blacklisted_cdata_regex: {
-#      regex: "<!--"
-#      error_message: "html comments"
-#    }
-#  }
-#  spec_url: "https://amp.dev/documentation/components/amp-script"
-#}
+# been security reviewed, this is gated by disabled_by: "transformed".
+tags: {  # <amp-script> (local script)
+  html_format: AMP
+  disabled_by: "transformed"
+  tag_name: "SCRIPT"
+  spec_name: "amp-script extension local script"
+  requires_extension: "amp-script"
+  attrs: {
+    name: "target"
+    mandatory: true
+    value: "amp-script"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "text/plain"
+  }
+  attr_lists: "mandatory-id-attr"
+  attr_lists: "nonce-attr"
+  cdata: {
+    max_bytes: 10000
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-script"
+}
 tags: {  # <amp-script>
   html_format: AMP
   tag_name: "AMP-SCRIPT"

--- a/validator/testdata/transformed_feature_tests/amp_script.html
+++ b/validator/testdata/transformed_feature_tests/amp_script.html
@@ -18,7 +18,7 @@
   Tests amp-script as part of Transformed AMP.
 -->
 <!doctype html>
-<html ⚡ transformed=self>
+<html ⚡ transformed="google;v=1">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/transformed_feature_tests/amp_script.html
+++ b/validator/testdata/transformed_feature_tests/amp_script.html
@@ -1,0 +1,95 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests amp-script as part of Transformed AMP.
+-->
+<!doctype html>
+<html ⚡ transformed=self>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+</head>
+<body>
+  <!-- Invalid: With 'script' tag and target (becomes valid after review). -->
+  <amp-script layout=container script=hello></amp-script>
+  <script type=text/plain target=amp-script id=hello>
+    const btn = document.querySelector('button');
+    btn.addEventListener('click', () => {
+      document.body.textContent += 'Hello World!';
+    });
+  </script>
+
+  <!-- Valid: With 'src' attribute. -->
+  <amp-script layout=container src="https://example.com/foo.js">
+    <div class="root">
+      <p>Some text to hydrate.</p>
+    </div>
+  </amp-script>
+
+  <!-- Valid: 'sandbox' attribute. -->
+  <amp-script layout=container src="https://example.com/foo.js" sandbox="allow-forms">
+  </amp-script>
+
+  <!-- Valid: With <canvas> element. -->
+  <amp-script layout=container src="https://example.com/foo.js">
+    <canvas id="myCanvas" width="100px" height="100px"></canvas>
+  </amp-script>
+
+  <!-- Invalid: <canvas> element outside of amp-script tag. -->
+  <canvas id="myCanvas" width="100px" height="100px"></canvas>
+
+  <!-- Invalid: With neither 'script' or 'src' attributes. -->
+  <amp-script layout=container></amp-script>
+
+  <!-- Invalid: Both 'script' and 'src' attributes. -->
+  <amp-script layout=container src="https://example.com/foo.js" script=hello></amp-script>
+
+  <!-- Invalid: Relative URL. -->
+  <amp-script layout=container src="/foo.js"></amp-script>
+
+  <!-- Invalid: Non-https 'src' attribute. -->
+  <amp-script layout=container src="http://not.https.url"></amp-script>
+
+  <!-- Invalid: Local script without 'target' or 'id' attributes. -->
+  <script type=text/plain>
+    document.body.textContent = "Hello World!";
+  </script>
+
+  <!-- Invalid: Local script with invalid 'type'. -->
+  <script type=text/amp-script target=amp-script id=hello>
+    document.body.textContent = "Hello World!";
+  </script>
+
+  <!-- Invalid: Local script with invalid 'target'. -->
+  <script type=text/plain target=amp-js id=hello>
+    document.body.textContent = "Hello World!";
+  </script>
+
+  <!-- Invalid: Local script without 'target' attribute. -->
+  <script type=text/plain id=hello>
+    document.body.textContent = "Hello World!";
+  </script>
+
+  <!-- Invalid: Local script without 'id' attribute. -->
+  <script type=text/plain target=amp-script>
+    document.body.textContent = "Hello World!";
+  </script>
+</body>

--- a/validator/testdata/transformed_feature_tests/amp_script.out
+++ b/validator/testdata/transformed_feature_tests/amp_script.out
@@ -19,9 +19,7 @@ FAIL
 |    Tests amp-script as part of Transformed AMP.
 |  -->
 |  <!doctype html>
-|  <html ⚡ transformed=self>
->> ^~~~~~~~~
-transformed_feature_tests/amp_script.html:21:0 The attribute 'transformed' in tag 'html' is set to the invalid value 'self'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup) [DISALLOWED_HTML]
+|  <html ⚡ transformed="google;v=1">
 |  <head>
 |    <meta charset="utf-8">
 |    <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/transformed_feature_tests/amp_script.out
+++ b/validator/testdata/transformed_feature_tests/amp_script.out
@@ -1,0 +1,122 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-script as part of Transformed AMP.
+|  -->
+|  <!doctype html>
+|  <html ⚡ transformed=self>
+>> ^~~~~~~~~
+transformed_feature_tests/amp_script.html:21:0 The attribute 'transformed' in tag 'html' is set to the invalid value 'self'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup) [DISALLOWED_HTML]
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: With 'script' tag and target (becomes valid after review). -->
+|    <amp-script layout=container script=hello></amp-script>
+|    <script type=text/plain target=amp-script id=hello>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:33:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      const btn = document.querySelector('button');
+|      btn.addEventListener('click', () => {
+|        document.body.textContent += 'Hello World!';
+|      });
+|    </script>
+|
+|    <!-- Valid: With 'src' attribute. -->
+|    <amp-script layout=container src="https://example.com/foo.js">
+|      <div class="root">
+|        <p>Some text to hydrate.</p>
+|      </div>
+|    </amp-script>
+|
+|    <!-- Valid: 'sandbox' attribute. -->
+|    <amp-script layout=container src="https://example.com/foo.js" sandbox="allow-forms">
+|    </amp-script>
+|
+|    <!-- Valid: With <canvas> element. -->
+|    <amp-script layout=container src="https://example.com/foo.js">
+|      <canvas id="myCanvas" width="100px" height="100px"></canvas>
+|    </amp-script>
+|
+|    <!-- Invalid: <canvas> element outside of amp-script tag. -->
+|    <canvas id="myCanvas" width="100px" height="100px"></canvas>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:57:2 The tag 'canvas' may only appear as a descendant of tag 'amp-script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags) [AMP_TAG_PROBLEM]
+|
+|    <!-- Invalid: With neither 'script' or 'src' attributes. -->
+|    <amp-script layout=container></amp-script>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:60:2 The tag 'amp-script' is missing a mandatory attribute - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+|
+|    <!-- Invalid: Both 'script' and 'src' attributes. -->
+|    <amp-script layout=container src="https://example.com/foo.js" script=hello></amp-script>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:63:2 Mutually exclusive attributes encountered in tag 'amp-script' - pick one of ['script', 'src']. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+|
+|    <!-- Invalid: Relative URL. -->
+|    <amp-script layout=container src="/foo.js"></amp-script>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:66:2 The relative URL '/foo.js' for attribute 'src' in tag 'amp-script' is disallowed. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+|
+|    <!-- Invalid: Non-https 'src' attribute. -->
+|    <amp-script layout=container src="http://not.https.url"></amp-script>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:69:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script) [AMP_TAG_PROBLEM]
+|
+|    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
+|    <script type=text/plain>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:72:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      document.body.textContent = "Hello World!";
+|    </script>
+|
+|    <!-- Invalid: Local script with invalid 'type'. -->
+|    <script type=text/amp-script target=amp-script id=hello>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:77:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      document.body.textContent = "Hello World!";
+|    </script>
+|
+|    <!-- Invalid: Local script with invalid 'target'. -->
+|    <script type=text/plain target=amp-js id=hello>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:82:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      document.body.textContent = "Hello World!";
+|    </script>
+|
+|    <!-- Invalid: Local script without 'target' attribute. -->
+|    <script type=text/plain id=hello>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:87:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      document.body.textContent = "Hello World!";
+|    </script>
+|
+|    <!-- Invalid: Local script without 'id' attribute. -->
+|    <script type=text/plain target=amp-script>
+>>   ^~~~~~~~~
+transformed_feature_tests/amp_script.html:92:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|      document.body.textContent = "Hello World!";
+|    </script>
+|  </body>
+>>       ^~~~~~~~~
+transformed_feature_tests/amp_script.html:95:6 The mandatory tag 'style[amp-runtime] (transformed)' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]


### PR DESCRIPTION
Partially fixes #24171 by allowing the script tag for non-Transformed AMP when `<script>` has attribute/value `target=amp-script`.