### PR TITLE
🏗 Always build amp-loader and amp-auto-lightbox (adapted from #24137)

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -18,13 +18,8 @@ const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
 const gulpWatch = require('gulp-watch');
-const {
-  endBuildStep,
-  mkdirSync,
-  printNobuildHelp,
-  toPromise,
-} = require('./helpers');
 const {buildExtensions, extensions} = require('./extension-helpers');
+const {endBuildStep, mkdirSync, toPromise} = require('./helpers');
 const {jsifyCssAsync} = require('./jsify-css');
 const {maybeUpdatePackages} = require('./update-packages');
 
@@ -34,7 +29,6 @@ const {maybeUpdatePackages} = require('./update-packages');
  */
 async function css() {
   maybeUpdatePackages();
-  printNobuildHelp();
   return compileCss();
 }
 
@@ -65,10 +59,9 @@ const cssEntryPoints = [
 /**
  * Compile all the css and drop in the build folder
  * @param {boolean} watch
- * @param {boolean=} opt_compileAll
  * @return {!Promise}
  */
-function compileCss(watch, opt_compileAll) {
+function compileCss(watch) {
   if (watch) {
     gulpWatch('css/**/*.css', function() {
       compileCss();
@@ -134,12 +127,7 @@ function compileCss(watch, opt_compileAll) {
   });
 
   return promise
-    .then(() =>
-      buildExtensions({
-        compileOnlyCss: true,
-        compileAll: opt_compileAll,
-      })
-    )
+    .then(() => buildExtensions({compileOnlyCss: true}))
     .then(() => {
       endBuildStep('Recompiled all CSS files into', 'build/', startTime);
     });

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -125,7 +125,7 @@ async function dist() {
   } else {
     parseExtensionFlags();
   }
-  await compileCss(/* watch */ undefined, /* opt_compileAll */ true);
+  await compileCss();
   await compileJison();
   await startNailgunServer(distNailgunPort, /* detached */ false);
 
@@ -296,16 +296,12 @@ function copyAliasExtensions() {
   const extensionsToBuild = getExtensionsToBuild();
 
   for (const key in extensionAliasFilePath) {
-    if (
-      extensionsToBuild.length > 0 &&
-      extensionsToBuild.indexOf(extensionAliasFilePath[key]['name']) == -1
-    ) {
-      continue;
+    if (extensionsToBuild.includes(extensionAliasFilePath[key].name)) {
+      fs.copySync(
+        'dist/v0/' + extensionAliasFilePath[key].file,
+        'dist/v0/' + key
+      );
     }
-    fs.copySync(
-      'dist/v0/' + extensionAliasFilePath[key]['file'],
-      'dist/v0/' + key
-    );
   }
 
   return Promise.resolve();


### PR DESCRIPTION
This PR picks up where #24137 left off. 

**Highlights:**
- Always include `amp-loader` and `amp-auto-lightbox` in the list of extensions to be built
- Refactor `getExtensionsToBuild()` and `buildExtensions()`
- Remove the defunct `options.CompileAll`
- Use `options.compileOnlyCss` to determine if `buildExtensions()` should build just CSS (for all extensions)
- Minor clean up

Addresses https://github.com/ampproject/amphtml/pull/24137#pullrequestreview-279234713
Closes #24137 