### PR TITLE
🏗 Lazily build JS during default `gulp` task

### DIFF
--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 const fs = require('fs-extra');
-const log = require('fancy-log');
-const {cyan} = require('colors');
+const {endBuildStep} = require('../tasks/helpers');
 
 const pathPrefix = 'dist/log-messages';
 
@@ -42,13 +41,13 @@ const extractedItems = () => fs.readJson(extractedPath).then(Object.values);
  */
 async function formatExtractedMessages() {
   const items = await extractedItems();
-  log('Formatting log messages from', cyan(extractedPath));
   return Promise.all(
     Object.entries(formats).map(async ([path, format]) => {
+      const startTime = Date.now();
       const formatted = {};
       items.forEach(item => (formatted[item.id] = format(item)));
       await fs.outputJson(path, formatted);
-      log('Formatted', cyan(path));
+      endBuildStep('Formatted', path, startTime);
     })
   );
 }

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -690,10 +690,7 @@ function cleanupWeakModuleFiles() {
 
 function compile(flagsArray) {
   if (isTravisBuild()) {
-    log(
-      'Minifying single-pass runtime targets with',
-      colors.cyan('closure-compiler')
-    );
+    log('Minifying single-pass JS with', colors.cyan('closure-compiler'));
   }
   // TODO(@cramforce): Run the post processing step
   return new Promise(function(resolve, reject) {

--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -17,8 +17,8 @@ const {
   doBuildExtension,
   maybeInitializeExtensions,
 } = require('./tasks/extension-helpers');
-const {doBuildRuntimeTarget} = require('./tasks/helpers');
-const {runtimeBundles} = require('../bundles.config');
+const {doBuildJs} = require('./tasks/helpers');
+const {jsBundles} = require('../bundles.config');
 
 const extensions = {};
 maybeInitializeExtensions(extensions, /* includeLatest */ true);
@@ -38,14 +38,14 @@ exports.lazyBuildExtensions = function(req, res, next) {
   next();
 };
 
-exports.lazyBuildRuntimeTargets = function(req, res, next) {
-  const jsTargetUrlMatcher = /\/.*\/([^\/]*\.js)/;
-  const jsTargetMatch = req.url.match(jsTargetUrlMatcher);
-  if (jsTargetMatch && jsTargetMatch.length == 2) {
-    const jsTarget = jsTargetMatch[1];
-    if (runtimeBundles[jsTarget] && !runtimeBundles[jsTarget].watched) {
-      return doBuildRuntimeTarget(jsTarget, {watch: true}).then(() => {
-        runtimeBundles[jsTarget].watched = true;
+exports.lazyBuildJs = function(req, res, next) {
+  const jsUrlMatcher = /\/.*\/([^\/]*\.js)/;
+  const jsMatch = req.url.match(jsUrlMatcher);
+  if (jsMatch && jsMatch.length == 2) {
+    const jsBundle = jsMatch[1];
+    if (jsBundles[jsBundle] && !jsBundles[jsBundle].watched) {
+      return doBuildJs(jsBundle, {watch: true}).then(() => {
+        jsBundles[jsBundle].watched = true;
         next();
       });
     }

--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const {
+  doBuildExtension,
+  maybeInitializeExtensions,
+} = require('./tasks/extension-helpers');
+const {doBuildRuntimeTarget} = require('./tasks/helpers');
+const {runtimeBundles} = require('../bundles.config');
+
+const extensions = {};
+maybeInitializeExtensions(extensions, /* includeLatest */ true);
+
+exports.lazyBuildExtensions = function(req, res, next) {
+  const extensionUrlMatcher = /\/dist\/v0\/([^\/]*)\.max\.js/;
+  const extensionMatch = req.url.match(extensionUrlMatcher);
+  if (extensionMatch && extensionMatch.length == 2) {
+    const extension = extensionMatch[1];
+    if (extensions[extension] && !extensions[extension].watched) {
+      return doBuildExtension(extensions, extension, {watch: true}).then(() => {
+        extensions[extension].watched = true;
+        next();
+      });
+    }
+  }
+  next();
+};
+
+exports.lazyBuildRuntimeTargets = function(req, res, next) {
+  const jsTargetUrlMatcher = /\/.*\/([^\/]*\.js)/;
+  const jsTargetMatch = req.url.match(jsTargetUrlMatcher);
+  if (jsTargetMatch && jsTargetMatch.length == 2) {
+    const jsTarget = jsTargetMatch[1];
+    if (runtimeBundles[jsTarget] && !runtimeBundles[jsTarget].watched) {
+      return doBuildRuntimeTarget(jsTarget, {watch: true}).then(() => {
+        runtimeBundles[jsTarget].watched = true;
+        next();
+      });
+    }
+  }
+  next();
+};

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -26,10 +26,7 @@ const isRunning = require('is-running');
 const log = require('fancy-log');
 const morgan = require('morgan');
 const webserver = require('gulp-webserver');
-const {
-  doBuildExtension,
-  maybeInitializeExtensions,
-} = require('./tasks/extension-helpers');
+const {lazyBuildExtensions, lazyBuildRuntimeTargets} = require('./lazy-build');
 
 const {
   SERVE_HOST: host,
@@ -42,10 +39,8 @@ const quiet = process.env.SERVE_QUIET == 'true';
 const sendCachingHeaders = process.env.SERVE_CACHING_HEADERS == 'true';
 const noCachingExtensions =
   process.env.SERVE_EXTENSIONS_WITHOUT_CACHING == 'true';
-const lazyBuildExtensions = process.env.LAZY_BUILD_EXTENSIONS == 'true';
+const lazyBuild = process.env.LAZY_BUILD == 'true';
 const header = require('connect-header');
-
-const extensions = {};
 
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
@@ -93,24 +88,9 @@ if (noCachingExtensions) {
   });
 }
 
-if (lazyBuildExtensions) {
-  maybeInitializeExtensions(extensions, /* includeLatest */ true);
-  middleware.push(function(req, res, next) {
-    const extensionUrlMatcher = /\/dist\/v0\/(.*)\.max\.js/;
-    const extensionMatch = req.url.match(extensionUrlMatcher);
-    if (extensionMatch && extensionMatch.length == 2) {
-      const extension = extensionMatch[1];
-      if (extensions[extension] && !extensions[extension].watched) {
-        return doBuildExtension(extensions, extension, {watch: true}).then(
-          () => {
-            extensions[extension].watched = true;
-            next();
-          }
-        );
-      }
-    }
-    next();
-  });
+if (lazyBuild) {
+  middleware.push(lazyBuildExtensions);
+  middleware.push(lazyBuildRuntimeTargets);
 }
 
 // Start gulp webserver

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -26,7 +26,7 @@ const isRunning = require('is-running');
 const log = require('fancy-log');
 const morgan = require('morgan');
 const webserver = require('gulp-webserver');
-const {lazyBuildExtensions, lazyBuildRuntimeTargets} = require('./lazy-build');
+const {lazyBuildExtensions, lazyBuildJs} = require('./lazy-build');
 
 const {
   SERVE_HOST: host,
@@ -90,7 +90,7 @@ if (noCachingExtensions) {
 
 if (lazyBuild) {
   middleware.push(lazyBuildExtensions);
-  middleware.push(lazyBuildRuntimeTargets);
+  middleware.push(lazyBuildJs);
 }
 
 // Start gulp webserver

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -18,7 +18,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
-  compileUnminifiedRuntimeTargets,
+  compileAllUnminifiedJs,
   compileCoreRuntime,
   printConfigHelp,
   printNobuildHelp,
@@ -61,7 +61,7 @@ async function build() {
 function printDefaultTaskHelp() {
   log(green('Running the default ') + cyan('gulp ') + green('task.'));
   const defaultTaskMessage =
-    green('⤷ Runtime targets and extensions will be ') +
+    green('⤷ JS and extensions will be ') +
     green(
       argv.lazy_build
         ? 'lazily built when requested from the server.'
@@ -72,7 +72,7 @@ function printDefaultTaskHelp() {
     const lazyBuildMessage =
       green('⤷ Use ') +
       cyan('--lazy_build ') +
-      green('to lazily build runtime targets and extensions ') +
+      green('to lazily build JS and extensions ') +
       green('when requested from the server.');
     log(lazyBuildMessage);
   }
@@ -100,7 +100,7 @@ async function performBuild(watch, defaultTask) {
     compileCoreRuntime(watch),
   ]);
   if (!defaultTask) {
-    await compileUnminifiedRuntimeTargets(watch);
+    await compileAllUnminifiedJs(watch);
     await buildExtensions({watch});
   }
   if (isTravisBuild()) {
@@ -117,14 +117,10 @@ async function defaultTask() {
   serve(argv.lazy_build);
   log(green('Started ') + cyan('gulp ') + green('server. '));
   if (argv.lazy_build) {
-    log(
-      green(
-        'Runtime targets and extensions will be lazily built when requested...'
-      )
-    );
+    log(green('JS and extensions will be lazily built when requested...'));
   } else {
-    log(green('Building runtime targets and extensions...'));
-    await compileUnminifiedRuntimeTargets(watch);
+    log(green('Building JS and extensions...'));
+    await compileAllUnminifiedJs(watch);
     await buildExtensions({watch: true});
   }
 }
@@ -157,7 +153,7 @@ watch.flags = {
 defaultTask.description = 'Runs "watch" and then "serve"';
 defaultTask.flags = {
   lazy_build:
-    '  Lazily builds runtime targets and extensions when they are requested from the server',
+    '  Lazily builds JS and extensions when they are requested from the server',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -17,11 +17,9 @@
 const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const {
-  buildAlp,
-  buildExaminer,
-  buildWebWorker,
-  compileAllUnminifiedTargets,
-  compileJs,
+  bootstrapThirdPartyFrames,
+  compileUnminifiedRuntimeTargets,
+  compileCoreRuntime,
   printConfigHelp,
   printNobuildHelp,
 } = require('./helpers');
@@ -58,6 +56,29 @@ async function build() {
 }
 
 /**
+ * Prints a useful help message prior to the default gulp task
+ */
+function printDefaultTaskHelp() {
+  log(green('Running the default ') + cyan('gulp ') + green('task.'));
+  const defaultTaskMessage =
+    green('⤷ Runtime targets and extensions will be ') +
+    green(
+      argv.lazy_build
+        ? 'lazily built when requested from the server.'
+        : 'built after server startup.'
+    );
+  log(defaultTaskMessage);
+  if (!argv.lazy_build) {
+    const lazyBuildMessage =
+      green('⤷ Use ') +
+      cyan('--lazy_build ') +
+      green('to lazily build runtime targets and extensions ') +
+      green('when requested from the server.');
+    log(lazyBuildMessage);
+  }
+}
+
+/**
  * Performs the build steps for gulp, gulp build, and gulp watch
  * @param {boolean} watch
  * @param {boolean} defaultTask
@@ -67,32 +88,25 @@ async function performBuild(watch, defaultTask) {
   process.env.NODE_ENV = 'development';
   printNobuildHelp();
   printConfigHelp(defaultTask ? 'gulp' : watch ? 'gulp watch' : 'gulp build');
-  parseExtensionFlags(defaultTask);
-  return Promise.all([compileCss(watch), compileJison()])
-    .then(() => {
-      return Promise.all([
-        polyfillsForTests(),
-        buildAlp({watch}),
-        buildExaminer({watch}),
-        buildWebWorker({watch}),
-        defaultTask ? Promise.resolve() : buildExtensions({watch}),
-        compileAllUnminifiedTargets(watch),
-      ]);
-    })
-    .then(() => {
-      if (isTravisBuild()) {
-        // New line after all the compilation progress dots on Travis.
-        console.log('\n');
-      }
-    });
-}
-
-/**
- * Compile the polyfills script and drop it in the build folder
- * @return {!Promise}
- */
-function polyfillsForTests() {
-  return compileJs('./src/', 'polyfills.js', './build/');
+  if (defaultTask) {
+    printDefaultTaskHelp();
+  }
+  if (!argv.lazy_build) {
+    parseExtensionFlags();
+  }
+  await Promise.all([compileCss(watch), compileJison()]);
+  await Promise.all([
+    bootstrapThirdPartyFrames(watch),
+    compileCoreRuntime(watch),
+  ]);
+  if (!defaultTask) {
+    await compileUnminifiedRuntimeTargets(watch);
+    await buildExtensions({watch});
+  }
+  if (isTravisBuild()) {
+    // New line after all the compilation progress dots on Travis.
+    console.log('\n');
+  }
 }
 
 /**
@@ -100,17 +114,17 @@ function polyfillsForTests() {
  */
 async function defaultTask() {
   await watch(/* defaultTask */ true);
-  serve(argv.lazy_build_extensions);
-  const startedMessage = green('Started ') + cyan('gulp ') + green('server. ');
-  if (argv.lazy_build_extensions) {
+  serve(argv.lazy_build);
+  log(green('Started ') + cyan('gulp ') + green('server. '));
+  if (argv.lazy_build) {
     log(
-      startedMessage +
-        green(
-          'Extensions will be lazily built when requested from the server...'
-        )
+      green(
+        'Runtime targets and extensions will be lazily built when requested...'
+      )
     );
   } else {
-    log(startedMessage + green('Building extensions...'));
+    log(green('Building runtime targets and extensions...'));
+    await compileUnminifiedRuntimeTargets(watch);
     await buildExtensions({watch: true});
   }
 }
@@ -133,6 +147,7 @@ build.flags = {
 
 watch.description = 'Watches for changes in files, re-builds when detected';
 watch.flags = {
+  config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:
     '  Watches and builds only the extensions from the listed AMP(s).',
@@ -141,8 +156,9 @@ watch.flags = {
 
 defaultTask.description = 'Runs "watch" and then "serve"';
 defaultTask.flags = {
-  lazy_build_extensions:
-    '  Lazily builds extensions when they are requested from the server',
+  lazy_build:
+    '  Lazily builds runtime targets and extensions when they are requested from the server',
+  config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:
     '  Watches and builds only the extensions from the listed AMP(s).',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -21,6 +21,18 @@ const fs = require('fs-extra');
 const gulp = require('gulp');
 const log = require('fancy-log');
 const {
+  bootstrapThirdPartyFrames,
+  compileCoreRuntime,
+  compileJs,
+  compileMinifiedRuntimeTargets,
+  endBuildStep,
+  hostname,
+  mkdirSync,
+  printConfigHelp,
+  printNobuildHelp,
+  toPromise,
+} = require('./helpers');
+const {
   buildExtensions,
   extensionAliasFilePath,
   getExtensionsToBuild,
@@ -34,21 +46,6 @@ const {
   startNailgunServer,
   stopNailgunServer,
 } = require('./nailgun');
-const {
-  WEB_PUSH_PUBLISHER_FILES,
-  WEB_PUSH_PUBLISHER_VERSIONS,
-  buildAlp,
-  buildExaminer,
-  buildWebWorker,
-  compileJs,
-  compileAllMinifiedTargets,
-  endBuildStep,
-  hostname,
-  mkdirSync,
-  printConfigHelp,
-  printNobuildHelp,
-  toPromise,
-} = require('./helpers');
 const {BABEL_SRC_GLOBS, SRC_TEMP_DIR} = require('../sources');
 const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
@@ -64,6 +61,13 @@ const argv = require('minimist')(process.argv.slice(2));
 
 const babel = require('@babel/core');
 const deglob = require('globs-to-files');
+
+const WEB_PUSH_PUBLISHER_FILES = [
+  'amp-web-push-helper-frame',
+  'amp-web-push-permission-dialog',
+];
+
+const WEB_PUSH_PUBLISHER_VERSIONS = ['0.1'];
 
 function transferSrcsToTempDir() {
   log(
@@ -138,13 +142,8 @@ async function dist() {
   }
 
   await Promise.all([
-    compileAllMinifiedTargets(),
-    // NOTE: When adding a line here,
-    // consider whether you need to include polyfills
-    // and whether you need to init logging (initLogConstructor).
-    buildAlp({minify: true, watch: false}),
-    buildExaminer({minify: true, watch: false}),
-    buildWebWorker({minify: true, watch: false}),
+    compileMinifiedRuntimeTargets(),
+    bootstrapThirdPartyFrames(/* watch */ false, /* minify */ true),
     buildExtensions({minify: true, watch: false}),
     buildExperiments({minify: true, watch: false}),
     buildLoginDone('0.1', {minify: true, watch: false}),
@@ -154,6 +153,7 @@ async function dist() {
     copyCss(),
     copyParsers(),
   ]);
+  await compileCoreRuntime(/* watch */ false, /* minify */ true);
 
   if (isTravisBuild()) {
     // New line after all the compilation progress dots on Travis.

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -22,9 +22,9 @@ const gulp = require('gulp');
 const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
+  compileAllMinifiedJs,
   compileCoreRuntime,
   compileJs,
-  compileMinifiedRuntimeTargets,
   endBuildStep,
   hostname,
   mkdirSync,
@@ -142,7 +142,7 @@ async function dist() {
   }
 
   await Promise.all([
-    compileMinifiedRuntimeTargets(),
+    compileAllMinifiedJs(),
     bootstrapThirdPartyFrames(/* watch */ false, /* minify */ true),
     buildExtensions({minify: true, watch: false}),
     buildExperiments({minify: true, watch: false}),

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -252,9 +252,8 @@ function getExtensionsToBuild() {
  * and prints a helpful message that lets the developer know how to build the
  * runtime with a list of extensions, all the extensions used by a test file,
  * or no extensions at all.
- * @param {boolean} defaultTask
  */
-function parseExtensionFlags(defaultTask) {
+function parseExtensionFlags() {
   if (!isTravisBuild()) {
     const noExtensionsMessage =
       green('⤷ Use ') +
@@ -279,23 +278,6 @@ function parseExtensionFlags(defaultTask) {
       green('⤷ Use ') +
       cyan('--extensions_from=examples/foo.amp.html ') +
       green('to build extensions from example docs.');
-    const defaultTaskMessage =
-      green('Running the default ') +
-      cyan('gulp ') +
-      green('task. (Extensions will be ') +
-      green(
-        argv.lazy_build_extensions
-          ? 'lazily built when requested from the server.)'
-          : 'built after server startup.)'
-      );
-    const lazyBuildExtensionsMessage =
-      green('⤷ Use ') +
-      cyan('--lazy_build_extensions ') +
-      green('to lazily build extensions when requested from the server.');
-    if (defaultTask) {
-      log(defaultTaskMessage);
-      log(lazyBuildExtensionsMessage);
-    }
     if (argv.extensions) {
       if (typeof argv.extensions !== 'string') {
         log(red('ERROR:'), 'Missing list of extensions.');

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -32,7 +32,7 @@ const source = require('vinyl-source-stream');
 const sourcemaps = require('gulp-sourcemaps');
 const watchify = require('watchify');
 const wrappers = require('../compile-wrappers');
-const {altMainBundles, runtimeBundles} = require('../../bundles.config');
+const {altMainBundles, jsBundles} = require('../../bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
 const {isTravisBuild} = require('../travis');
@@ -108,26 +108,26 @@ const hostname = argv.hostname || 'cdn.ampproject.org';
 const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
- * Compile runtime targets in minified mode and drop them in dist/.
+ * Compile JS in minified mode and drop them in dist/.
  * @return {!Promise}
  */
-function compileMinifiedRuntimeTargets() {
+function compileAllMinifiedJs() {
   if (isTravisBuild()) {
-    log('Minifying multi-pass runtime targets with', cyan('closure-compiler'));
+    log('Minifying multi-pass JS with', cyan('closure-compiler'));
   }
-  return compileRuntimeTargets(/* watch */ false, /* minify */ true);
+  return compileAllJs(/* watch */ false, /* minify */ true);
 }
 
 /**
- * Compile runtime targets in unminified mode and drop them in dist/.
+ * Compile JS in unminified mode and drop them in dist/.
  * @param {boolean} watch
  * @return {!Promise}
  */
-function compileUnminifiedRuntimeTargets(watch) {
+function compileAllUnminifiedJs(watch) {
   if (isTravisBuild()) {
-    log('Compiling runtime with', cyan('browserify'));
+    log('Compiling JS with', cyan('browserify'));
   }
-  return compileRuntimeTargets(/* watch */ watch);
+  return compileAllJs(/* watch */ watch);
 }
 
 /**
@@ -135,8 +135,8 @@ function compileUnminifiedRuntimeTargets(watch) {
  * @param {?Object} extraOptions
  * @return {!Promise}
  */
-function doBuildRuntimeTarget(name, extraOptions) {
-  const target = runtimeBundles[name];
+function doBuildJs(name, extraOptions) {
+  const target = jsBundles[name];
   if (target) {
     return compileJs(
       target.srcDir,
@@ -145,11 +145,7 @@ function doBuildRuntimeTarget(name, extraOptions) {
       Object.assign({}, target.options, extraOptions)
     );
   } else {
-    return Promise.reject(
-      red('Error:'),
-      'Could not find runtime target',
-      cyan(name)
-    );
+    return Promise.reject(red('Error:'), 'Could not find', cyan(name));
   }
 }
 
@@ -198,26 +194,26 @@ function compileCoreRuntime(watch, minify) {
 
 /**
  * Compile and optionally minify the stylesheets and the scripts for the runtime
- * targets and drop them in the dist folder
+ * and drop them in the dist folder
  * @param {boolean} watch
  * @param {boolean} minify
  * @return {!Promise}
  */
-function compileRuntimeTargets(watch, minify) {
+function compileAllJs(watch, minify) {
   return Promise.all([
-    minify ? Promise.resolve() : doBuildRuntimeTarget('polyfills.js', {watch}),
-    doBuildRuntimeTarget('alp.max.js', {watch, minify}),
-    doBuildRuntimeTarget('examiner.max.js', {watch, minify}),
-    doBuildRuntimeTarget('ww.max.js', {watch, minify}),
-    doBuildRuntimeTarget('integration.js', {watch, minify}),
-    doBuildRuntimeTarget('ampcontext-lib.js', {watch, minify}),
-    doBuildRuntimeTarget('iframe-transport-client-lib.js', {watch, minify}),
-    doBuildRuntimeTarget('recaptcha.js', {watch, minify}),
-    doBuildRuntimeTarget('amp-viewer-host.max.js', {watch, minify}),
-    doBuildRuntimeTarget('video-iframe-integration.js', {watch, minify}),
-    doBuildRuntimeTarget('amp-inabox-host.js', {watch, minify}),
-    doBuildRuntimeTarget('amp-shadow.js', {watch, minify}),
-    doBuildRuntimeTarget('amp-inabox.js', {watch, minify}),
+    minify ? Promise.resolve() : doBuildJs('polyfills.js', {watch}),
+    doBuildJs('alp.max.js', {watch, minify}),
+    doBuildJs('examiner.max.js', {watch, minify}),
+    doBuildJs('ww.max.js', {watch, minify}),
+    doBuildJs('integration.js', {watch, minify}),
+    doBuildJs('ampcontext-lib.js', {watch, minify}),
+    doBuildJs('iframe-transport-client-lib.js', {watch, minify}),
+    doBuildJs('recaptcha.js', {watch, minify}),
+    doBuildJs('amp-viewer-host.max.js', {watch, minify}),
+    doBuildJs('video-iframe-integration.js', {watch, minify}),
+    doBuildJs('amp-inabox-host.js', {watch, minify}),
+    doBuildJs('amp-shadow.js', {watch, minify}),
+    doBuildJs('amp-inabox.js', {watch, minify}),
   ]);
 }
 
@@ -674,13 +670,13 @@ module.exports = {
   BABELIFY_GLOBAL_TRANSFORM,
   BABELIFY_PLUGINS,
   bootstrapThirdPartyFrames,
-  compileMinifiedRuntimeTargets,
-  compileUnminifiedRuntimeTargets,
+  compileAllMinifiedJs,
+  compileAllUnminifiedJs,
   compileCoreRuntime,
   compileJs,
   compileTs,
   devDependencies,
-  doBuildRuntimeTarget,
+  doBuildJs,
   enableLocalTesting,
   endBuildStep,
   hostname,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -32,7 +32,7 @@ const source = require('vinyl-source-stream');
 const sourcemaps = require('gulp-sourcemaps');
 const watchify = require('watchify');
 const wrappers = require('../compile-wrappers');
-const {altMainBundles} = require('../../bundles.config');
+const {altMainBundles, runtimeBundles} = require('../../bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
 const {isTravisBuild} = require('../travis');
@@ -49,7 +49,14 @@ const argv = require('minimist')(process.argv.slice(2));
  */
 const NOBUILD_HELP_TASKS = new Set(['e2e', 'integration', 'visual-diff']);
 
+/**
+ * Used during minification to concatenate modules
+ */
 const MODULE_SEPARATOR = ';';
+
+/**
+ * Used during minification to concatenate extension bundles
+ */
 const EXTENSION_BUNDLE_MAP = {
   'amp-viz-vega.js': [
     'third_party/d3/d3.js',
@@ -59,6 +66,9 @@ const EXTENSION_BUNDLE_MAP = {
   'amp-inputmask.js': ['third_party/inputmask/bundle.js'],
 };
 
+/**
+ * List of unminified targets to which AMP_CONFIG should be written
+ */
 const UNMINIFIED_TARGETS = [
   'amp.js',
   'amp-esm.js',
@@ -68,6 +78,9 @@ const UNMINIFIED_TARGETS = [
   'integration.js',
 ];
 
+/**
+ * List of minified targets to which AMP_CONFIG should be written
+ */
 const MINIFIED_TARGETS = [
   'v0.js',
   'shadow-v0.js',
@@ -76,18 +89,17 @@ const MINIFIED_TARGETS = [
   'f.js',
 ];
 
-const WEB_PUSH_PUBLISHER_FILES = [
-  'amp-web-push-helper-frame',
-  'amp-web-push-permission-dialog',
-];
-
-const WEB_PUSH_PUBLISHER_VERSIONS = ['0.1'];
-
+/**
+ * Settings for the global Babelify transform while compiling unminified code
+ */
 const BABELIFY_GLOBAL_TRANSFORM = {
   global: true, // Transform node_modules
   ignore: devDependencies(), // Ignore devDependencies
 };
 
+/**
+ * Plugins used by Babelify while compiling unminified code
+ */
 const BABELIFY_PLUGINS = {
   plugins: [conf.getReplacePlugin(), conf.getJsonConfigurationPlugin()],
 };
@@ -96,160 +108,117 @@ const hostname = argv.hostname || 'cdn.ampproject.org';
 const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
- * Compile all runtime targets in minified mode and drop them in dist/.
+ * Compile runtime targets in minified mode and drop them in dist/.
  * @return {!Promise}
  */
-function compileAllMinifiedTargets() {
+function compileMinifiedRuntimeTargets() {
   if (isTravisBuild()) {
     log('Minifying multi-pass runtime targets with', cyan('closure-compiler'));
   }
-  return compile(/* watch */ false, /* shouldMinify */ true);
+  return compileRuntimeTargets(/* watch */ false, /* minify */ true);
 }
 
 /**
- * Compile all runtime targets in unminified mode and drop them in dist/.
+ * Compile runtime targets in unminified mode and drop them in dist/.
  * @param {boolean} watch
  * @return {!Promise}
  */
-function compileAllUnminifiedTargets(watch) {
+function compileUnminifiedRuntimeTargets(watch) {
   if (isTravisBuild()) {
     log('Compiling runtime with', cyan('browserify'));
   }
-  return compile(/* watch */ watch);
+  return compileRuntimeTargets(/* watch */ watch);
 }
 
 /**
- * Compile and optionally minify the stylesheets and the scripts
- * and drop them in the dist folder
- *
- * @param {boolean} watch
- * @param {boolean} shouldMinify
+ * @param {string} name
+ * @param {?Object} extraOptions
  * @return {!Promise}
  */
-function compile(watch, shouldMinify) {
-  const promises = [
-    compileJs(
-      './3p/',
-      'integration.js',
-      './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'),
-      {
-        minifiedName: 'f.js',
-        watch,
-        minify: shouldMinify,
-        externs: ['./ads/ads.extern.js'],
-        include3pDirectories: true,
-        includePolyfills: true,
-      }
-    ),
-    compileJs(
-      './3p/',
-      'ampcontext-lib.js',
-      './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'),
-      {
-        minifiedName: 'ampcontext-v0.js',
-        watch,
-        minify: shouldMinify,
-        externs: ['./ads/ads.extern.js'],
-        include3pDirectories: true,
-        includePolyfills: false,
-      }
-    ),
-    compileJs(
-      './3p/',
-      'iframe-transport-client-lib.js',
-      './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'),
-      {
-        minifiedName: 'iframe-transport-client-v0.js',
-        watch,
-        minify: shouldMinify,
-        externs: ['./ads/ads.extern.js'],
-        include3pDirectories: true,
-        includePolyfills: false,
-      }
-    ),
-    compileJs(
-      './3p/',
-      'recaptcha.js',
-      './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'),
-      {
-        minifiedName: 'recaptcha.js',
-        watch,
-        minify: shouldMinify,
-        externs: [],
-        include3pDirectories: true,
-        includePolyfills: true,
-      }
-    ),
-    compileJs(
-      './extensions/amp-viewer-integration/0.1/examples/',
-      'amp-viewer-host.js',
-      './dist/v0/examples',
-      {
-        toName: 'amp-viewer-host.max.js',
-        minifiedName: 'amp-viewer-host.js',
-        incudePolyfills: true,
-        watch,
-        extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-        compilationLevel: 'WHITESPACE_ONLY',
-        minify: shouldMinify,
-      }
-    ),
-    compileJs('./src/', 'video-iframe-integration.js', './dist', {
-      minifiedName: 'video-iframe-integration-v0.js',
-      includePolyfills: false,
-      watch,
-      minify: shouldMinify,
-    }),
-    compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-      toName: 'amp-inabox-host.js',
-      minifiedName: 'amp4ads-host-v0.js',
-      includePolyfills: false,
-      watch,
-      minify: shouldMinify,
-    }),
-    compileJs('./src/', 'amp-shadow.js', './dist', {
-      minifiedName: 'shadow-v0.js',
-      includePolyfills: true,
-      watch,
-      minify: shouldMinify,
-    }),
-    compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-      toName: 'amp-inabox.js',
-      minifiedName: 'amp4ads-v0.js',
-      includePolyfills: true,
-      extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-      watch,
-      minify: shouldMinify,
-    }),
-  ];
+function doBuildRuntimeTarget(name, extraOptions) {
+  const target = runtimeBundles[name];
+  if (target) {
+    return compileJs(
+      target.srcDir,
+      target.srcFilename,
+      extraOptions.minify ? target.minifiedDestDir : target.destDir,
+      Object.assign({}, target.options, extraOptions)
+    );
+  } else {
+    return Promise.reject(
+      red('Error:'),
+      'Could not find runtime target',
+      cyan(name)
+    );
+  }
+}
 
+/**
+ * Generates frames.html
+ * @param {boolean} watch
+ * @param {boolean} minify
+ * @return {!Promise}
+ */
+function bootstrapThirdPartyFrames(watch, minify) {
+  const promises = [];
   thirdPartyFrames.forEach(frameObject => {
     promises.push(
-      thirdPartyBootstrap(frameObject.max, frameObject.min, shouldMinify)
+      thirdPartyBootstrap(frameObject.max, frameObject.min, minify)
     );
   });
-
   if (watch) {
     thirdPartyFrames.forEach(frameObject => {
       gulpWatch(frameObject.max, function() {
-        thirdPartyBootstrap(frameObject.max, frameObject.min, shouldMinify);
+        thirdPartyBootstrap(frameObject.max, frameObject.min, minify);
       });
     });
   }
+  return Promise.all(promises);
+}
 
-  return Promise.all(promises).then(() => {
-    return compileJs('./src/', 'amp.js', './dist', {
-      toName: 'amp.js',
-      minifiedName: 'v0.js',
-      includePolyfills: true,
-      watch,
-      minify: shouldMinify,
-      wrapper: wrappers.mainBinary,
-      singlePassCompilation: argv.single_pass,
-      esmPassCompilation: argv.esm,
-      includeOnlyESMLevelPolyfills: argv.esm,
-    });
+/**
+ * Compiles the core runtime binary
+ * @param {boolean} watch
+ * @param {boolean} minify
+ * @return {!Promise}
+ */
+function compileCoreRuntime(watch, minify) {
+  return compileJs('./src/', 'amp.js', './dist', {
+    toName: 'amp.js',
+    minifiedName: 'v0.js',
+    includePolyfills: true,
+    watch,
+    minify,
+    wrapper: wrappers.mainBinary,
+    singlePassCompilation: argv.single_pass,
+    esmPassCompilation: argv.esm,
+    includeOnlyESMLevelPolyfills: argv.esm,
   });
+}
+
+/**
+ * Compile and optionally minify the stylesheets and the scripts for the runtime
+ * targets and drop them in the dist folder
+ * @param {boolean} watch
+ * @param {boolean} minify
+ * @return {!Promise}
+ */
+function compileRuntimeTargets(watch, minify) {
+  return Promise.all([
+    minify ? Promise.resolve() : doBuildRuntimeTarget('polyfills.js', {watch}),
+    doBuildRuntimeTarget('alp.max.js', {watch, minify}),
+    doBuildRuntimeTarget('examiner.max.js', {watch, minify}),
+    doBuildRuntimeTarget('ww.max.js', {watch, minify}),
+    doBuildRuntimeTarget('integration.js', {watch, minify}),
+    doBuildRuntimeTarget('ampcontext-lib.js', {watch, minify}),
+    doBuildRuntimeTarget('iframe-transport-client-lib.js', {watch, minify}),
+    doBuildRuntimeTarget('recaptcha.js', {watch, minify}),
+    doBuildRuntimeTarget('amp-viewer-host.max.js', {watch, minify}),
+    doBuildRuntimeTarget('video-iframe-integration.js', {watch, minify}),
+    doBuildRuntimeTarget('amp-inabox-host.js', {watch, minify}),
+    doBuildRuntimeTarget('amp-shadow.js', {watch, minify}),
+    doBuildRuntimeTarget('amp-inabox.js', {watch, minify}),
+  ]);
 }
 
 /**
@@ -631,12 +600,12 @@ function concatFilesToString(files) {
  *
  * @param {string} input
  * @param {string} outputName
- * @param {boolean} shouldMinify
+ * @param {boolean} minify
  * @return {!Promise}
  */
-function thirdPartyBootstrap(input, outputName, shouldMinify) {
+function thirdPartyBootstrap(input, outputName, minify) {
   const startTime = Date.now();
-  if (!shouldMinify) {
+  if (!minify) {
     return toPromise(gulp.src(input).pipe(gulp.dest('dist.3p/current'))).then(
       () => {
         endBuildStep('Processed', input, startTime);
@@ -675,55 +644,6 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
 }
 
 /**
- * Build ALP JS.
- *
- * @param {!Object} options
- * @return {!Promise}
- */
-function buildAlp(options) {
-  options = options || {};
-  return compileJs('./ads/alp/', 'install-alp.js', './dist/', {
-    toName: 'alp.max.js',
-    watch: options.watch,
-    minify: options.minify || argv.minify,
-    includePolyfills: true,
-    minifiedName: 'alp.js',
-  });
-}
-
-/**
- * Build Examiner JS.
- *
- * @param {!Object} options
- * @return {!Promise}
- */
-function buildExaminer(options) {
-  return compileJs('./src/examiner/', 'examiner.js', './dist/', {
-    toName: 'examiner.max.js',
-    watch: options.watch,
-    minify: options.minify || argv.minify,
-    includePolyfills: true,
-    minifiedName: 'examiner.js',
-  });
-}
-
-/**
- * Build web worker JS.
- *
- * @param {!Object} options
- * @return {!Promise}
- */
-function buildWebWorker(options) {
-  return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
-    toName: 'ww.max.js',
-    minifiedName: 'ww.js',
-    includePolyfills: true,
-    watch: options.watch,
-    minify: options.minify || argv.minify,
-  });
-}
-
-/**
  *Creates directory in sync manner
  *
  * @param {string} path
@@ -753,16 +673,14 @@ function toPromise(readable) {
 module.exports = {
   BABELIFY_GLOBAL_TRANSFORM,
   BABELIFY_PLUGINS,
-  WEB_PUSH_PUBLISHER_FILES,
-  WEB_PUSH_PUBLISHER_VERSIONS,
-  buildAlp,
-  buildExaminer,
-  buildWebWorker,
-  compileAllMinifiedTargets,
-  compileAllUnminifiedTargets,
+  bootstrapThirdPartyFrames,
+  compileMinifiedRuntimeTargets,
+  compileUnminifiedRuntimeTargets,
+  compileCoreRuntime,
   compileJs,
   compileTs,
   devDependencies,
+  doBuildRuntimeTarget,
   enableLocalTesting,
   endBuildStep,
   hostname,

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -34,9 +34,9 @@ const noCachingExtensions = argv.noCachingExtensions != undefined;
 
 /**
  * Starts a simple http server at the repository root
- * @param {boolean} lazyBuildExtensions
+ * @param {boolean} lazyBuild
  */
-function serve(lazyBuildExtensions) {
+function serve(lazyBuild) {
   createCtrlcHandler('serve');
 
   // Get the serve mode
@@ -78,7 +78,7 @@ function serve(lazyBuildExtensions) {
       'SERVE_QUIET': quiet,
       'SERVE_CACHING_HEADERS': sendCachingHeaders,
       'SERVE_EXTENSIONS_WITHOUT_CACHING': noCachingExtensions,
-      'LAZY_BUILD_EXTENSIONS': lazyBuildExtensions,
+      'LAZY_BUILD': lazyBuild,
     },
     stdout: !quiet,
   };

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -33,9 +33,9 @@ const TYPES = (exports.TYPES = {
 });
 
 /**
- * Used to generate top-level runtime build targets
+ * Used to generate top-level JS build targets
  */
-exports.runtimeBundles = {
+exports.jsBundles = {
   'polyfills.js': {
     srcDir: './src/',
     srcFilename: 'polyfills.js',
@@ -1120,7 +1120,7 @@ exports.aliasBundles = [
 ];
 
 /**
- * Used to generate alternative runtime build targets
+ * Used to generate alternative JS build targets
  */
 exports.altMainBundles = [
   {

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -19,6 +19,10 @@
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 
+const {
+  VERSION: internalRuntimeVersion,
+} = require('./build-system/internal-version');
+
 /**
  * @enum {string}
  */
@@ -28,6 +32,158 @@ const TYPES = (exports.TYPES = {
   MISC: '_base_misc',
 });
 
+/**
+ * Used to generate top-level runtime build targets
+ */
+exports.runtimeBundles = {
+  'polyfills.js': {
+    srcDir: './src/',
+    srcFilename: 'polyfills.js',
+    destDir: './build/',
+    minifiedDestDir: './build/',
+  },
+  'alp.max.js': {
+    srcDir: './ads/alp/',
+    srcFilename: 'install-alp.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      toName: 'alp.max.js',
+      includePolyfills: true,
+      minifiedName: 'alp.js',
+    },
+  },
+  'examiner.max.js': {
+    srcDir: './src/examiner/',
+    srcFilename: 'examiner.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      toName: 'examiner.max.js',
+      includePolyfills: true,
+      minifiedName: 'examiner.js',
+    },
+  },
+  'ww.max.js': {
+    srcDir: './src/web-worker/',
+    srcFilename: 'web-worker.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      toName: 'ww.max.js',
+      minifiedName: 'ww.js',
+      includePolyfills: true,
+    },
+  },
+  'integration.js': {
+    srcDir: './3p/',
+    srcFilename: 'integration.js',
+    destDir: './dist.3p/current',
+    minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
+    options: {
+      minifiedName: 'f.js',
+      externs: ['./ads/ads.extern.js'],
+      include3pDirectories: true,
+      includePolyfills: true,
+    },
+  },
+  'ampcontext-lib.js': {
+    srcDir: './3p/',
+    srcFilename: 'ampcontext-lib.js',
+    destDir: './dist.3p/current',
+    minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
+    options: {
+      minifiedName: 'ampcontext-v0.js',
+      externs: ['./ads/ads.extern.js'],
+      include3pDirectories: true,
+      includePolyfills: false,
+    },
+  },
+  'iframe-transport-client-lib.js': {
+    srcDir: './3p/',
+    srcFilename: 'iframe-transport-client-lib.js',
+    destDir: './dist.3p/current',
+    minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
+    options: {
+      minifiedName: 'iframe-transport-client-v0.js',
+      externs: ['./ads/ads.extern.js'],
+      include3pDirectories: true,
+      includePolyfills: false,
+    },
+  },
+  'recaptcha.js': {
+    srcDir: './3p/',
+    srcFilename: 'recaptcha.js',
+    destDir: './dist.3p/current',
+    minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
+    options: {
+      minifiedName: 'recaptcha.js',
+      externs: [],
+      include3pDirectories: true,
+      includePolyfills: true,
+    },
+  },
+  'amp-viewer-host.max.js': {
+    srcDir: './extensions/amp-viewer-integration/0.1/examples/',
+    srcFilename: 'amp-viewer-host.js',
+    destDir: './dist/v0/examples',
+    minifiedDestDir: './dist/v0/examples',
+    options: {
+      toName: 'amp-viewer-host.max.js',
+      minifiedName: 'amp-viewer-host.js',
+      incudePolyfills: true,
+      extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
+      compilationLevel: 'WHITESPACE_ONLY',
+    },
+  },
+  'video-iframe-integration.js': {
+    srcDir: './src/',
+    srcFilename: 'video-iframe-integration.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      minifiedName: 'video-iframe-integration-v0.js',
+      includePolyfills: false,
+    },
+  },
+  'amp-inabox-host.js': {
+    srcDir: './ads/inabox/',
+    srcFilename: 'inabox-host.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      toName: 'amp-inabox-host.js',
+      minifiedName: 'amp4ads-host-v0.js',
+      includePolyfills: false,
+    },
+  },
+  'amp-shadow.js': {
+    srcDir: './src/',
+    srcFilename: 'amp-shadow.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      minifiedName: 'shadow-v0.js',
+      includePolyfills: true,
+    },
+  },
+  'amp-inabox.js': {
+    srcDir: './src/inabox/',
+    srcFilename: 'amp-inabox.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      toName: 'amp-inabox.js',
+      minifiedName: 'amp4ads-v0.js',
+      includePolyfills: true,
+      extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+    },
+  },
+};
+
+/**
+ * Used to generate extension build targets
+ */
 exports.extensionBundles = [
   {
     name: 'amp-3d-gltf',
@@ -950,6 +1106,9 @@ exports.extensionBundles = [
   },
 ];
 
+/**
+ * Used to generate extension alias build targets
+ */
 exports.aliasBundles = [
   {
     name: 'amp-sticky-ad',
@@ -960,6 +1119,9 @@ exports.aliasBundles = [
   },
 ];
 
+/**
+ * Used to generate alternative runtime build targets
+ */
 exports.altMainBundles = [
   {
     path: 'src/amp-shadow.js',


### PR DESCRIPTION
#24152 added a way to lazily build extensions during the default `gulp` task. This PR goes a step further, and lazily builds all JS (except for the core runtime `amp.js`, which is eagerly built).

**Usage:**
```
gulp --lazy_build
```

**Highlights:**
- Removed all hardcoded `compileJs` calls in `build-system/tasks/helpers.js`
- Added several js target definitions to `bundles.config.js`
- Refactored JS building into a new function called `doBuildJs()`
- Added a new server module `build-system/lazy-build.js` to build JS and extensions
- Refactored `performBuild()` in `build-system/tasks/build.js`
- Refactored `dist()` in `build-system/tasks/dist.js`
- Assorted documentation / logging / clean up

**Coming up:**
- Refactor `serve.js` and `server.js` to eliminate the separate binary problem mentioned in https://github.com/ampproject/amphtml/pull/24152#discussion_r317148476
- Implement the "luxury" version mentioned in https://github.com/ampproject/amphtml/pull/24138#pullrequestreview-278442430, where the server waits when a build is in progress

Partially addresses https://github.com/ampproject/amphtml/pull/24152#pullrequestreview-279247356
Partial fix for #24141 
Follow up to #24138 and #24152