### PR TITLE
🏗 Fix Local AMP Serving CDN toggle in Chrome extension

### DIFF
--- a/testing/local-amp-chrome-extension/popup.html
+++ b/testing/local-amp-chrome-extension/popup.html
@@ -111,7 +111,7 @@
       box-sizing: border-box;
     }
 
-    label[for="base-url"], #switch-label {
+    .section-header {
       margin-bottom: 16px;
       text-align: left;
       display: block;
@@ -127,7 +127,7 @@
     <p class="desc">Switch between using a local distribution of AMP HTML or the online
     distribution hosted at https://cdn.ampproject.org/</p>
     <div id="switch-holder">
-      <label id="switch-label" for="enabled">Local AMP Serving</label>
+      <label class="section-header" for="enabled">Local AMP Serving</label>
       <div id="switch-wrapper">
         <span id="left">
           Online CDN
@@ -142,7 +142,7 @@
       </div>
     </div>
     <div id="base-url-holder">
-      <label for="base-url">Base URL</label>
+      <label for="base-url" class="section-header">Base URL</label>
       <input id="base-url" type="url">
     </div>
     <span class="notice">

--- a/testing/local-amp-chrome-extension/popup.html
+++ b/testing/local-amp-chrome-extension/popup.html
@@ -111,7 +111,7 @@
       box-sizing: border-box;
     }
 
-    label[for="base-url"], label[for="switch"] {
+    label[for="base-url"], #switch-label {
       margin-bottom: 16px;
       text-align: left;
       display: block;
@@ -123,20 +123,20 @@
     <script src="popup.js"></script>
   </head>
   <body>
-    <img id = "logo" src="logo.svg" />
+    <img id="logo" src="logo.svg" />
     <p class="desc">Switch between using a local distribution of AMP HTML or the online
     distribution hosted at https://cdn.ampproject.org/</p>
     <div id="switch-holder">
-      <label for="switch">Local AMP Serving</label>
-      <div id = "switch-wrapper">
-        <span id = "left">
+      <label id="switch-label" for="enabled">Local AMP Serving</label>
+      <div id="switch-wrapper">
+        <span id="left">
           Online CDN
         </span>
         <div id="switch-container">
-          <input type="checkbox">
-          <div id="switch"></div>
+          <input type="checkbox" id="enabled">
+          <label id="switch" for="enabled"></label>
         </div>
-        <span id = "right">
+        <span id="right">
           Local AMP
         </span>
       </div>


### PR DESCRIPTION
I noticed when trying the Local AMP Chrome extension today, that clicking on the toggle had no effect at all. I'm not sure why, but it seems a change in Chrome broke the toggle. When digging into the code, I'm not sure why the toggle worked in the first place. The toggle `div` was not seemingly connected to the checkbox. So this PR turns the `div` into a `label` with an explicit relationship so that clicks on the label will cause the `checked` state to toggle.

This PR also cleans up the formatting of the HTML a bit.