### PR TITLE
🏗🐛 Remove imports from `log-messages.js` that break custom babel plugin tests

### DIFF
--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 const fs = require('fs-extra');
-const {endBuildStep} = require('../tasks/helpers');
+const log = require('fancy-log');
+const {cyan} = require('colors');
 
 const pathPrefix = 'dist/log-messages';
 
@@ -43,11 +44,10 @@ async function formatExtractedMessages() {
   const items = await extractedItems();
   return Promise.all(
     Object.entries(formats).map(async ([path, format]) => {
-      const startTime = Date.now();
       const formatted = {};
       items.forEach(item => (formatted[item.id] = format(item)));
       await fs.outputJson(path, formatted);
-      endBuildStep('Formatted', path, startTime);
+      log('Formatted', cyan(path));
     })
   );
 }

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -45,6 +45,10 @@ const targetMatchers = [
     targets: ['BABEL_PLUGIN', 'RUNTIME'], // Test the runtime for babel plugin changes.
     func: file => {
       return (
+        file == 'build-system/internal-version.js' ||
+        file == 'build-system/log-module-metadata.js' ||
+        file == 'build-system/static-template-metadata.js' ||
+        file == 'build-system/compile/log-messages.js' ||
         file == 'build-system/tasks/babel-plugin-tests.js' ||
         file.startsWith('build-system/babel-plugins/')
       );


### PR DESCRIPTION
The tests for AMP's custom babel plugins are [broken](https://travis-ci.org/ampproject/amphtml/jobs/576577805#L360) on `master` because of code that was imported by `log-messages.js`

PR highlights:

- Remove `require` statement that leads to the babel transformation of more code than intended
- Make sure babel plugin tests are run for changes to any files that affect the plugins