### PR TITLE
Temporary fix: Don't use rIC for post-startup scheduled tasks

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -230,8 +230,8 @@ class Task {
    * @protected
    */
   useRequestIdleCallback_() {
-    // By default, always use requestIdleCallback.
-    return true;
+    // By default, never use requestIdleCallback.
+    return false;
   }
 }
 


### PR DESCRIPTION
... because the current use of rIC is optimized for the pre-rendering and not configurable to work well while the doc is visible, leading to very high latency is some cases.

Alternative to #24189
Related to #24109