### PR TITLE
🏗 Fail the visual test when tests threw

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -778,11 +778,8 @@ async function visualDiff() {
     argv.grep = RegExp(argv.grep);
   }
 
-  try {
-    await performVisualTests();
-  } finally {
-    return await cleanup_();
-  }
+  await performVisualTests();
+  return await cleanup_();
 }
 
 /**


### PR DESCRIPTION
Nowadays, the visual test will succeed even if something was thrown from `performVisualTests()`. This PR changes so it'll throw. `cleanup_()` will still be executed because we have https://github.com/powerivq/amphtml/blob/651278b3037a7a668a3170fcdbabba42da0dc12d/build-system/tasks/visual-diff/index.js#L864

Fixes https://github.com/ampproject/amphtml/issues/24185