### PR TITLE
🏗 Wait on pending builds during `gulp --lazy_build`

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -131,11 +131,12 @@ function compileAllUnminifiedJs(watch) {
 }
 
 /**
+ * @param {!Object} jsBundles
  * @param {string} name
  * @param {?Object} extraOptions
  * @return {!Promise}
  */
-function doBuildJs(name, extraOptions) {
+function doBuildJs(jsBundles, name, extraOptions) {
   const target = jsBundles[name];
   if (target) {
     return compileJs(
@@ -201,19 +202,19 @@ function compileCoreRuntime(watch, minify) {
  */
 function compileAllJs(watch, minify) {
   return Promise.all([
-    minify ? Promise.resolve() : doBuildJs('polyfills.js', {watch}),
-    doBuildJs('alp.max.js', {watch, minify}),
-    doBuildJs('examiner.max.js', {watch, minify}),
-    doBuildJs('ww.max.js', {watch, minify}),
-    doBuildJs('integration.js', {watch, minify}),
-    doBuildJs('ampcontext-lib.js', {watch, minify}),
-    doBuildJs('iframe-transport-client-lib.js', {watch, minify}),
-    doBuildJs('recaptcha.js', {watch, minify}),
-    doBuildJs('amp-viewer-host.max.js', {watch, minify}),
-    doBuildJs('video-iframe-integration.js', {watch, minify}),
-    doBuildJs('amp-inabox-host.js', {watch, minify}),
-    doBuildJs('amp-shadow.js', {watch, minify}),
-    doBuildJs('amp-inabox.js', {watch, minify}),
+    minify ? Promise.resolve() : doBuildJs(jsBundles, 'polyfills.js', {watch}),
+    doBuildJs(jsBundles, 'alp.max.js', {watch, minify}),
+    doBuildJs(jsBundles, 'examiner.max.js', {watch, minify}),
+    doBuildJs(jsBundles, 'ww.max.js', {watch, minify}),
+    doBuildJs(jsBundles, 'integration.js', {watch, minify}),
+    doBuildJs(jsBundles, 'ampcontext-lib.js', {watch, minify}),
+    doBuildJs(jsBundles, 'iframe-transport-client-lib.js', {watch, minify}),
+    doBuildJs(jsBundles, 'recaptcha.js', {watch, minify}),
+    doBuildJs(jsBundles, 'amp-viewer-host.max.js', {watch, minify}),
+    doBuildJs(jsBundles, 'video-iframe-integration.js', {watch, minify}),
+    doBuildJs(jsBundles, 'amp-inabox-host.js', {watch, minify}),
+    doBuildJs(jsBundles, 'amp-shadow.js', {watch, minify}),
+    doBuildJs(jsBundles, 'amp-inabox.js', {watch, minify}),
   ]);
 }
 


### PR DESCRIPTION
Today, if a test webpage requests a JS file more than once during `gulp --lazy_build`, concurrent builds are triggered for the same file, leading to a race.

This PR eliminates the race as follows:
- Changes the function signature of `doBuildJs()` to match that of `doBuildExtension()`
- Refactors repeated code in `lazyBuildExtensions()` and `lazyBuildJs()` into a helper function `lazyBuild()` that calls the correct build function if necessary
- Adds a mechanism to `lazyBuild()` to keep track of and wait for pending builds before serving 

This implements the "luxury" version of lazy building mentioned in https://github.com/ampproject/amphtml/pull/24138#pullrequestreview-278442430


Addresses https://github.com/ampproject/amphtml/issues/24141#issuecomment-524878844
Partial fix for #24141
Follow up to #24138, #24152, and #24199