### PR TITLE
✨Add `img-sizes` attribute to `amp-img`.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -87,7 +87,7 @@ export class AmpImg extends BaseElement {
   propagateSizes() {
     const sizes = this.getSizesValueToUse_();
     if (sizes === null) {
-      this.img_.removeAttribute('sizes', sizes);
+      this.img_.removeAttribute('sizes');
     } else {
       this.img_.setAttribute('sizes', sizes);
     }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -121,7 +121,7 @@ export class AmpImg extends BaseElement {
         this.img_,
         /* opt_removeMissingAttrs */ true
       );
-      if (mutations['img-sizes'] || mutations['sizes']) {
+      if (mutations['sizes']) {
         this.propagateSizes();
       }
       guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -125,6 +125,10 @@ For the `<img>` tag in `HTML`, the `sizes` attribute is used in conjunction with
 
 See [Responsive images with srcset, sizes & heights](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction) for usage of `sizes` and `srcset`.
 
+**img-sizes**
+
+Like the `sizes` attribute, the value is applied to the underlying `<img>` as `sizes`. In contrast, this does not affect the width of the `<amp-img>` element and is only used to select one of the sources from the `srcset`.
+
 **alt**
 
 A string of alternate text, similar to the `alt` attribute on `img`.

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -127,7 +127,7 @@ See [Responsive images with srcset, sizes & heights](https://amp.dev/documentati
 
 **img-sizes**
 
-Like the `sizes` attribute, the value is applied to the underlying `<img>` as `sizes`. In contrast, this does not affect the width of the `<amp-img>` element and is only used to select one of the sources from the `srcset`.
+Like `sizes` above, sets the [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute on the underlying `img`. Unlike `sizes`, this does not change the width of the `amp-img` and is only used by the browser for picking which source to use from the `srcset`.
 
 **alt**
 

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -233,22 +233,6 @@ describe('amp-img', () => {
     expect(impl.img_.getAttribute('sizes')).to.equal('50vw');
   });
 
-  it('should update sizes on img-sizes mutation', async () => {
-    const ampImg = await getImg({
-      src: '/examples/img/sample.jpg',
-      srcset: SRCSET_STRING,
-      'img-sizes': '640px',
-      width: 300,
-      height: 200,
-    });
-    const impl = ampImg.implementation_;
-
-    ampImg.setAttribute('img-sizes', '50vw');
-    impl.mutatedAttributesCallback({'img-sizes': '50vw'});
-
-    expect(impl.img_.getAttribute('sizes')).to.equal('50vw');
-  });
-
   it('should ignore sizes mutations when img-sizes is used', async () => {
     const ampImg = await getImg({
       src: '/examples/img/sample.jpg',

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5210,6 +5210,8 @@ tags: {  # <amp-img>
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
+  # Used to set sizes on the <img> without AMP's sizes behavior
+  attrs: { name: "img-sizes" }
   # <amp-bind>
   attrs: { name: "[alt]" }
   attrs: { name: "[attribution]" }


### PR DESCRIPTION
This allows specifying the `sizes` to use for an `<img>`, without getting
the sizing behavior of `sizes` in AMP (which adds a width based on which media query matches).

For #21736
