### PR TITLE
🏗 Improve extension aliasing and allow lazy building of aliased extensions

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -33,12 +33,6 @@ const {
   toPromise,
 } = require('./helpers');
 const {
-  buildExtensions,
-  extensionAliasFilePath,
-  getExtensionsToBuild,
-  parseExtensionFlags,
-} = require('./extension-helpers');
-const {
   createModuleCompatibleES5Bundle,
 } = require('./create-module-compatible-es5-bundle');
 const {
@@ -47,6 +41,7 @@ const {
   stopNailgunServer,
 } = require('./nailgun');
 const {BABEL_SRC_GLOBS, SRC_TEMP_DIR} = require('../sources');
+const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
 const {compileJison} = require('./compile-jison');
@@ -161,7 +156,6 @@ async function dist() {
   }
 
   await stopNailgunServer(distNailgunPort);
-  await copyAliasExtensions();
   await formatExtractedMessages();
 
   if (argv.esm) {
@@ -282,29 +276,6 @@ function copyParsers() {
   return fs.copy('build/parsers', 'dist/v0').then(() => {
     endBuildStep('Copied', 'build/parsers/ to dist/v0', startTime);
   });
-}
-
-/**
- * Copy built extension to alias extension
- * @return {!Promise}
- */
-function copyAliasExtensions() {
-  if (argv.noextensions) {
-    return Promise.resolve();
-  }
-
-  const extensionsToBuild = getExtensionsToBuild();
-
-  for (const key in extensionAliasFilePath) {
-    if (extensionsToBuild.includes(extensionAliasFilePath[key].name)) {
-      fs.copySync(
-        'dist/v0/' + extensionAliasFilePath[key].file,
-        'dist/v0/' + key
-      );
-    }
-  }
-
-  return Promise.resolve();
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -20,10 +20,9 @@ const log = require('fancy-log');
 const watch = require('gulp-watch');
 const wrappers = require('../compile-wrappers');
 const {
-  aliasBundles,
+  extensionAliasBundles,
   extensionBundles,
   verifyExtensionBundles,
-  verifyExtensionAliasBundles,
 } = require('../../bundles.config');
 const {compileJs, mkdirSync} = require('./helpers');
 const {isTravisBuild} = require('../travis');
@@ -97,7 +96,6 @@ const ExtensionOption = {}; // eslint-disable-line no-unused-vars
 
 // All declared extensions.
 const extensions = {};
-const extensionAliasFilePath = {};
 
 // All extensions to build
 let extensionsToBuild = null;
@@ -162,53 +160,6 @@ function maybeInitializeExtensions(
         extensionsObject,
         includeLatest
       );
-    });
-  }
-
-  if (Object.keys(extensionAliasFilePath).length === 0) {
-    verifyExtensionAliasBundles();
-    aliasBundles.forEach(c => {
-      declareExtensionVersionAlias(
-        c.name,
-        c.version,
-        c.latestVersion,
-        c.options
-      );
-    });
-  }
-}
-
-/**
- * This function is used for declaring deprecated extensions. It simply places
- * the current version code in place of the latest versions. This has the
- * ability to break an extension version, so please be sure that this is the
- * correct one to use.
- * @param {string} name
- * @param {string} version E.g. 0.1
- * @param {string} latestVersion E.g. 0.1
- * @param {!ExtensionOption} options extension options object.
- */
-function declareExtensionVersionAlias(name, version, latestVersion, options) {
-  extensionAliasFilePath[name + '-' + version + '.js'] = {
-    'name': name,
-    'file': name + '-' + latestVersion + '.js',
-  };
-  extensionAliasFilePath[name + '-' + version + '.js.map'] = {
-    'name': name,
-    'file': name + '-' + latestVersion + '.js.map',
-  };
-  if (options.hasCss) {
-    extensionAliasFilePath[name + '-' + version + '.css'] = {
-      'name': name,
-      'file': name + '-' + latestVersion + '.css',
-    };
-  }
-  if (options.cssBinaries) {
-    options.cssBinaries.forEach(cssBinaryName => {
-      extensionAliasFilePath[cssBinaryName + '-' + version + '.css'] = {
-        'name': cssBinaryName,
-        'file': cssBinaryName + '-' + latestVersion + '.css',
-      };
     });
   }
 }
@@ -363,7 +314,7 @@ function dedupe(arr) {
  * @param {!Object} options
  * @return {!Promise}
  */
-function buildExtensions(options) {
+async function buildExtensions(options) {
   maybeInitializeExtensions(extensions, /* includeLatest */ false);
   const extensionsToBuild = getExtensionsToBuild();
   const results = [];
@@ -375,7 +326,7 @@ function buildExtensions(options) {
       results.push(doBuildExtension(extensions, extension, options));
     }
   }
-  return Promise.all(results);
+  await Promise.all(results);
 }
 
 /**
@@ -385,11 +336,11 @@ function buildExtensions(options) {
  * @param {!Object} options
  * @return {!Promise}
  */
-function doBuildExtension(extensions, extension, options) {
+async function doBuildExtension(extensions, extension, options) {
   const e = extensions[extension];
   let o = Object.assign({}, options);
   o = Object.assign(o, e);
-  return buildExtension(
+  await buildExtension(
     e.name,
     e.version,
     e.latestVersion,
@@ -416,21 +367,21 @@ function doBuildExtension(extensions, extension, options) {
  * @param {string} latestVersion Latest version of the extension.
  * @param {boolean} hasCss Whether there is a CSS file for this extension.
  * @param {?Object} options
- * @param {!Array=} opt_extraGlobs
+ * @param {!Array=} extraGlobs
  * @return {!Promise}
  */
-function buildExtension(
+async function buildExtension(
   name,
   version,
   latestVersion,
   hasCss,
   options,
-  opt_extraGlobs
+  extraGlobs
 ) {
   options = options || {};
-  options.extraGlobs = opt_extraGlobs;
+  options.extraGlobs = extraGlobs;
   if (options.compileOnlyCss && !hasCss) {
-    return Promise.resolve();
+    return;
   }
   const path = 'extensions/' + name + '/' + version;
 
@@ -452,32 +403,22 @@ function buildExtension(
       }
     });
   }
-  const promises = [];
   if (hasCss) {
     mkdirSync('build');
     mkdirSync('build/css');
-    const buildCssPromise = buildExtensionCss(path, name, version, options);
+    await buildExtensionCss(path, name, version, options);
     if (options.compileOnlyCss) {
-      return buildCssPromise;
+      return;
     }
-
-    promises.push(buildCssPromise);
   }
-
-  return Promise.all(promises)
-    .then(() => {
-      if (argv.single_pass) {
-        return Promise.resolve();
-      } else {
-        return buildExtensionJs(path, name, version, latestVersion, options);
-      }
-    })
-    .then(() => {
-      // minify and copy vendor configs for amp-analytics component
-      if (name === 'amp-analytics') {
-        return vendorConfigs(options);
-      }
-    });
+  if (argv.single_pass) {
+    return;
+  } else {
+    await buildExtensionJs(path, name, version, latestVersion, options);
+  }
+  if (name === 'amp-analytics') {
+    await vendorConfigs(options);
+  }
 }
 
 /**
@@ -487,7 +428,7 @@ function buildExtension(
  * @param {!Object} options
  * @return {!Promise}
  */
-function buildExtensionCss(path, name, version, options) {
+async function buildExtensionCss(path, name, version, options) {
   /**
    * Writes CSS binaries
    *
@@ -501,23 +442,22 @@ function buildExtensionCss(path, name, version, options) {
     fs.writeFileSync(jsName, jsCss, 'utf-8');
     fs.writeFileSync(cssName, css, 'utf-8');
   }
-  const promises = [];
-  const mainCssBinary = jsifyCssAsync(path + '/' + name + '.css').then(
-    writeCssBinaries.bind(null, `${name}-${version}.css`)
-  );
-
-  if (Array.isArray(options.cssBinaries)) {
-    promises.push.apply(
-      promises,
-      options.cssBinaries.map(function(name) {
-        return jsifyCssAsync(`${path}/${name}.css`).then(css =>
-          writeCssBinaries(`${name}-${version}.css`, css)
-        );
-      })
-    );
+  const mainCss = await jsifyCssAsync(path + '/' + name + '.css');
+  writeCssBinaries(`${name}-${version}.css`, mainCss);
+  const aliasBundle = extensionAliasBundles[name];
+  const isAliased = aliasBundle && aliasBundle.version == version;
+  if (isAliased) {
+    writeCssBinaries(`${name}-${aliasBundle.aliasedVersion}.css`, mainCss);
   }
-  promises.push(mainCssBinary);
-  return Promise.all(promises);
+  if (Array.isArray(options.cssBinaries)) {
+    options.cssBinaries.map(async function(name) {
+      const css = await jsifyCssAsync(`${path}/${name}.css`);
+      writeCssBinaries(`${name}-${version}.css`, css);
+      if (isAliased) {
+        writeCssBinaries(`${name}-${aliasBundle.aliasedVersion}.css`, css);
+      }
+    });
+  }
 }
 
 /**
@@ -532,9 +472,9 @@ function buildExtensionCss(path, name, version, options) {
  * @param {!Object} options
  * @return {!Promise}
  */
-function buildExtensionJs(path, name, version, latestVersion, options) {
+async function buildExtensionJs(path, name, version, latestVersion, options) {
   const filename = options.filename || name + '.js';
-  return compileJs(
+  await compileJs(
     path + '/',
     filename,
     './dist/v0',
@@ -551,24 +491,34 @@ function buildExtensionJs(path, name, version, latestVersion, options) {
         ? ''
         : wrappers.extension(name, options.loadPriority),
     })
-  ).then(() => {
+  );
+
+  const aliasBundle = extensionAliasBundles[name];
+  const isAliased = aliasBundle && aliasBundle.version == version;
+  if (isAliased) {
+    const src = `${name}-${version}${options.minify ? '' : '.max'}.js`;
+    const dest = `${name}-${aliasBundle.aliasedVersion}${
+      options.minify ? '' : '.max'
+    }.js`;
+    fs.copySync(`dist/v0/${src}`, `dist/v0/${dest}`);
+    fs.copySync(`dist/v0/${src}.map`, `dist/v0/${dest}.map`);
+  }
+
+  if (name === 'amp-script') {
     // Copy @ampproject/worker-dom/dist/amp/worker/worker.js to dist/ folder.
-    if (name === 'amp-script') {
-      const dir = 'node_modules/@ampproject/worker-dom/dist/amp/worker/';
-      const file = `dist/v0/amp-script-worker-${version}`;
-      // The "js" output is minified and transpiled to ES5.
-      fs.copyFileSync(dir + 'worker.js', `${file}.js`);
-      // The "mjs" output is unminified ES6 and has debugging flags enabled.
-      fs.copyFileSync(dir + 'worker.mjs', `${file}.max.js`);
-    }
-  });
+    const dir = 'node_modules/@ampproject/worker-dom/dist/amp/worker/';
+    const file = `dist/v0/amp-script-worker-${version}`;
+    // The "js" output is minified and transpiled to ES5.
+    fs.copyFileSync(dir + 'worker.js', `${file}.js`);
+    // The "mjs" output is unminified ES6 and has debugging flags enabled.
+    fs.copyFileSync(dir + 'worker.mjs', `${file}.max.js`);
+  }
 }
 
 module.exports = {
   buildExtensions,
   doBuildExtension,
   extensions,
-  extensionAliasFilePath,
   getExtensionsToBuild,
   maybeInitializeExtensions,
   parseExtensionFlags,

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -1124,17 +1124,14 @@ exports.extensionBundles = [
 ];
 
 /**
- * Used to generate extension alias build targets
+ * Used to alias a version of an extension to an older deprecated version.
  */
-exports.aliasBundles = [
-  {
-    name: 'amp-sticky-ad',
-    version: '0.1',
-    latestVersion: '1.0',
-    options: {hasCss: true},
-    type: 'ads',
+exports.extensionAliasBundles = {
+  'amp-sticky-ad': {
+    version: '1.0',
+    aliasedVersion: '0.1',
   },
-];
+};
 
 /**
  * Used to generate alternative JS build targets
@@ -1222,33 +1219,6 @@ exports.verifyExtensionBundles = function() {
       validTypes.some(validType => validType === bundle.type),
       'type',
       `is not one of ${validTypes.join(',')} in`,
-      bundle.name,
-      bundleString
-    );
-  });
-};
-
-exports.verifyExtensionAliasBundles = function() {
-  exports.aliasBundles.forEach(bundle => {
-    const bundleString = JSON.stringify(bundle, null, 2);
-    verifyBundle_(
-      'name' in bundle,
-      'name',
-      'is missing from',
-      '',
-      bundleString
-    );
-    verifyBundle_(
-      'version' in bundle,
-      'version',
-      'is missing from',
-      bundle.name,
-      bundleString
-    );
-    verifyBundle_(
-      'latestVersion' in bundle,
-      'latestVersion',
-      'is missing from',
       bundle.name,
       bundleString
     );


### PR DESCRIPTION
This PR changes the way extension aliasing is done, and paves the way for lazy building of aliased extensions.

**Highlights:**
- Deleted `declareExtensionVersionAlias()`, `copyAliasExtensions()`, and `verifyExtensionAliasBundles()`
- Changed format of `extensionAliasBundles` to include just the current version and the aliased (deprecated) version
    - Other options are inferred from the current version
- Moved extension aliasing to happen just after the building of CSS / JS (so it can happen during lazy builds)
- Assorted clean up, use of `async` / `await`

**Coming up:** Modify the path switching code in `app.js` to handle the case where an aliased extension is requested

Partial fix for #24141 and #24226