### PR TITLE
Stop iOS 13 from elastically horizontally scrolling documents

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -78,6 +78,8 @@ html.i-amphtml-fie > body {
 
 html.i-amphtml-singledoc:not(.i-amphtml-inabox) > body,
 html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
+  overflow-x: hidden !important;
+  overflow-y: visible !important;
   position: relative !important;
 }
 

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -86,17 +86,6 @@ html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
   position: relative !important;
 }
 
-/**
- * iOS 13 with the natural viewport still applies elastic horizontal scrolling
- * with various side-effects. See b/140131460 for more details. That's why
- * `overflow-x: hidden` has to be applied (and by extension
- * `overflow-y: visible`).
- */
-html.i-amphtml-singledoc:not(.i-amphtml-inabox) > body {
-  overflow-x: hidden !important;
-  overflow-y: visible !important;
-}
-
 
 /**
  * Set `body {overflow-x: hidden}` for iOS WebView. This is b/c iOS WebView

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -76,6 +76,16 @@ html.i-amphtml-fie > body {
   overflow: visible !important;
 }
 
+/**
+ * iOS 13 with the natural viewport still applies elastic horizontal scrolling
+ * with various side-effects. See b/140131460 for more details. That's why
+ * `overflow-x: hidden` has to be applied (and by extension
+ * `overflow-y: visible`).
+ *
+ * The `position: relative` is necessary to ensure that `paddingTop` can be
+ * applied to a document to offset the header height, and it doesn't missplace
+ * `position: absolute` elements.
+ */
 html.i-amphtml-singledoc:not(.i-amphtml-inabox) > body,
 html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
   overflow-x: hidden !important;

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -77,20 +77,24 @@ html.i-amphtml-fie > body {
 }
 
 /**
- * iOS 13 with the natural viewport still applies elastic horizontal scrolling
- * with various side-effects. See b/140131460 for more details. That's why
- * `overflow-x: hidden` has to be applied (and by extension
- * `overflow-y: visible`).
- *
  * The `position: relative` is necessary to ensure that `paddingTop` can be
  * applied to a document to offset the header height, and it doesn't missplace
  * `position: absolute` elements.
  */
 html.i-amphtml-singledoc:not(.i-amphtml-inabox) > body,
 html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
+  position: relative !important;
+}
+
+/**
+ * iOS 13 with the natural viewport still applies elastic horizontal scrolling
+ * with various side-effects. See b/140131460 for more details. That's why
+ * `overflow-x: hidden` has to be applied (and by extension
+ * `overflow-y: visible`).
+ */
+html.i-amphtml-singledoc:not(.i-amphtml-inabox) > body {
   overflow-x: hidden !important;
   overflow-y: visible !important;
-  position: relative !important;
 }
 
 

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -60,7 +60,7 @@ export class ViewportBindingNatural_ {
      * See `handleScrollEvent_` for details.
      * @private @const {boolean}
      */
-    this.resetScrollX_ = this.platform_.isIos() && this.win.top != this.win;
+    this.resetScrollX_ = this.platform_.isIos() && this.win.parent !== this.win;
 
     /** @const {function()} */
     this.boundScrollEventListener_ = this.handleScrollEvent_.bind(this);
@@ -74,8 +74,10 @@ export class ViewportBindingNatural_ {
 
   /** @private */
   handleScrollEvent_() {
-    if (this.resetScrollX_ &&
-        this.getScrollingElement()./*OK*/ scrollLeft > 0) {
+    if (
+      this.resetScrollX_ &&
+      this.getScrollingElement()./*OK*/ scrollLeft > 0
+    ) {
       // In the iframed iOS Safari case the `touch-action` and
       // `overscroll-behavior` are not observed which leads to the overscroll
       // bugs on the horizontal axis. The solution is to reset the horizontal

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -56,16 +56,33 @@ export class ViewportBindingNatural_ {
     /** @private @const {!Observable} */
     this.resizeObservable_ = new Observable();
 
+    /**
+     * See `handleScrollEvent_` for details.
+     * @private @const {boolean}
+     */
+    this.resetScrollX_ = this.platform_.isIos() && this.win.top != this.win;
+
     /** @const {function()} */
-    this.boundScrollEventListener_ = () => {
-      this.scrollObservable_.fire();
-    };
+    this.boundScrollEventListener_ = this.handleScrollEvent_.bind(this);
 
     // eslint-disable-next-line jsdoc/require-returns
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
     dev().fine(TAG_, 'initialized natural viewport');
+  }
+
+  /** @private */
+  handleScrollEvent_() {
+    if (this.resetScrollX_ &&
+        this.getScrollingElement()./*OK*/ scrollLeft > 0) {
+      // In the iframed iOS Safari case the `touch-action` and
+      // `overscroll-behavior` are not observed which leads to the overscroll
+      // bugs on the horizontal axis. The solution is to reset the horizontal
+      // scrolling in this case. See b/140131460 for more details.
+      this.getScrollingElement()./*OK*/ scrollLeft = 0;
+    }
+    this.scrollObservable_.fire();
   }
 
   /** @override */

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -29,7 +29,6 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   let binding;
   let win;
   let ampdoc;
-  let viewer;
   let child;
   let sandbox;
 
@@ -46,14 +45,12 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
     child.style.height = '300px';
     win.document.body.appendChild(child);
 
-    viewer = {};
-
     installPlatformService(win);
     installVsyncService(win);
     installDocService(win, /* isSingleDoc */ true);
     installGlobalDocumentStateService(win);
     ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-    binding = new ViewportBindingNatural_(ampdoc, viewer);
+    binding = new ViewportBindingNatural_(ampdoc);
     binding.connect();
   });
 
@@ -64,7 +61,7 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   });
 
   it('should configure body as relative', () => {
-    binding = new ViewportBindingNatural_(ampdoc, viewer);
+    binding = new ViewportBindingNatural_(ampdoc);
     expect(win.document.body.style.display).to.not.be.ok;
     const bodyStyles = win.getComputedStyle(win.document.body);
     expect(bodyStyles.position).to.equal('relative');
@@ -75,7 +72,7 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
 
   it('should override body overflow for iOS webview', () => {
     win.document.documentElement.classList.add('i-amphtml-webview');
-    binding = new ViewportBindingNatural_(ampdoc, viewer);
+    binding = new ViewportBindingNatural_(ampdoc);
     const bodyStyles = win.getComputedStyle(win.document.body);
     expect(bodyStyles.position).to.equal('relative');
     expect(bodyStyles.overflowX).to.equal('hidden');
@@ -222,6 +219,49 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
     htmlCss = win.getComputedStyle(win.document.documentElement);
     expect(htmlCss.overflowX).to.equal('hidden');
     expect(htmlCss.overflowY).to.equal('auto');
+  });
+});
+
+describes.realWin.only('ViewportBindingNatural on iOS', {ampCss: true}, env => {
+  let binding;
+  let win;
+  let ampdoc;
+  let child;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+
+    env.iframe.style.width = '100px';
+    env.iframe.style.height = '200px';
+    win = env.win;
+    win.document.documentElement.classList.add('i-amphtml-singledoc');
+
+    child = win.document.createElement('div');
+    child.style.width = '200px';
+    child.style.height = '300px';
+    win.document.body.appendChild(child);
+
+    installPlatformService(win);
+    installVsyncService(win);
+    installDocService(win, /* isSingleDoc */ true);
+    installGlobalDocumentStateService(win);
+    ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
+    sandbox.stub(Services.platformFor(win), 'isIos').returns(true);
+    binding = new ViewportBindingNatural_(ampdoc);
+    binding.connect();
+  });
+
+  it('should reset overscroll on X-axis', () => {
+    win.scrollTo(1, 0);
+    expect(win.pageXOffset).to.equal(1);
+    return new Promise(resolve => {
+      win.addEventListener('scroll', () => {
+        if (win.pageXOffset == 0) {
+          resolve();
+        }
+      });
+    });
   });
 });
 

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -222,7 +222,7 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   });
 });
 
-describes.realWin.only('ViewportBindingNatural on iOS', {ampCss: true}, env => {
+describes.realWin('ViewportBindingNatural on iOS', {ampCss: true}, env => {
   let binding;
   let win;
   let ampdoc;


### PR DESCRIPTION
Partial for #23379.
Fix for b/140131460.