### PR TITLE
🐛Fix localization for locales containing uppercase chars.

### DIFF
--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -125,12 +125,13 @@ export class LocalizationService {
    * @return {!LocalizationService} For chaining.
    */
   registerLocalizedStringBundle(languageCode, localizedStringBundle) {
-    if (!this.localizedStringBundles_[languageCode]) {
-      this.localizedStringBundles_[languageCode] = {};
+    const normalizedLangCode = languageCode.toLowerCase();
+    if (!this.localizedStringBundles_[normalizedLangCode]) {
+      this.localizedStringBundles_[normalizedLangCode] = {};
     }
 
     Object.assign(
-      this.localizedStringBundles_[languageCode],
+      this.localizedStringBundles_[normalizedLangCode],
       localizedStringBundle
     );
     return this;

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -73,6 +73,18 @@ describes.fakeWin('localization', {}, env => {
       );
     });
 
+    it('should handle registration of uppercase locales', () => {
+      env.win.document.documentElement.setAttribute('lang', 'zh-CN');
+      const localizationService = new LocalizationService(env.win);
+      localizationService.registerLocalizedStringBundle('zh-CN', {
+        '123': {
+          string: '买票',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('123')).to.equal('买票');
+    });
+
     it('should utilize fallback if string is missing', () => {
       const localizationService = new LocalizationService(env.win);
       localizationService.registerLocalizedStringBundle('en', {


### PR DESCRIPTION
Stories (and story ads) are registering many string bundles in the following way https://github.com/ampproject/amphtml/blob/8f2e2f849fbdd933a3718e8f74d5b8830cbc7c28/extensions/amp-story/1.0/amp-story.js#L359-L381

The variants that have uppercase letters are not correctly being retrieved. This is because in `registerLocalizedStringBundle ` the registration is keyed on the uppercase version 
```js
this.localizedStringBundles_ = { 'en-GB' : { ...some bundle...} }
```

But in `getLanguageCodesFromString` when we generate potential keys we are lowercasing them https://github.com/ampproject/amphtml/blob/8f2e2f849fbdd933a3718e8f74d5b8830cbc7c28/src/service/localization.js#L76-L79
Therefore it tries to find `this.localizedStringBundles_['en-gb']` which does not exist :(

This PR changes the logic to also lowercase upon registration of the bundle.