### PR TITLE
🐛Story Ads: fix dependency

### DIFF
--- a/build-system/sources.js
+++ b/build-system/sources.js
@@ -84,7 +84,7 @@ const CLOSURE_SRC_GLOBS = [
   'extensions/amp-a4a/**/*.js',
   // TODO(#24080) Remove this when story ads have full ad network support.
   // Needed for amp-story-auto-ads to validate amp-ad-exit config.
-  'extensions/amp-ad-exit/0.1/config.js',
+  'extensions/amp-ad-exit/**/*.js',
   // Currently needed for crypto.js and visibility.js.
   // Should consider refactoring.
   'extensions/amp-analytics/**/*.js',


### PR DESCRIPTION
amp-story-auto-ads is importing a function from amp-ad-exit to validate config. In PR #24044 I added this specific file, but should have been a glob. 

This showed up as `FilterType$$module$extensions$amp_ad_exit$0_1$filters$filter is not defined` in canary

Side note: this worked when testing with `gulp dist --fortesting && gulp serve --compiled` not sure why it wasn't broken. @erwinmombay Do you know of a better way I can test?