### PR TITLE
fix compatibility of load-more with reset-on-refresh

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -486,6 +486,9 @@ export class AmpList extends AMP.BaseElement {
           });
         }
         removeChildren(dev().assertElement(this.container_));
+        if (this.loadMoreEnabled_) {
+          this.getLoadMoreService_().hideAllLoadMoreElements();
+        }
       });
     }
   }

--- a/extensions/amp-list/0.1/service/load-more-service.js
+++ b/extensions/amp-list/0.1/service/load-more-service.js
@@ -254,4 +254,16 @@ export class LoadMoreService {
     loadMoreButton.classList.toggle('amp-visible', false);
     this.getLoadMoreLoadingElement().classList.toggle('amp-visible', false);
   }
+
+  /**
+   * Hide all load-more elements during reset.
+   */
+  hideAllLoadMoreElements() {
+    this.getLoadMoreButton().classList.toggle('amp-visible', false);
+    this.getLoadMoreLoadingElement().classList.toggle('amp-visible', false);
+    this.getLoadMoreFailedElement().classList.toggle('amp-visible', false);
+    if (this.getLoadMoreEndElement()) {
+      this.getLoadMoreEndElement().classList.toggle('amp-visible', false);
+    }
+  }
 }

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -123,7 +123,7 @@
     layout="fixed-height"
     src="/list/infinite-scroll?items=4&left=8"
     [src]="data.url"
-    load-more="manual"
+    load-more="auto"
     reset-on-refresh
     load-more-bookmark="next">
     <template type="amp-mustache">

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -117,12 +117,14 @@
 
   <h1>AMP List</h1>
   <p>This is a flexbox amp-list with tiles, something like an infinite image gallery.</p>
-
+  <button on="tap:list.refresh">Click to Refresh</button>
   <amp-list width="auto" height="200"
+    id="list"
     layout="fixed-height"
-    src="/list/infinite-scroll?items=10&left=50"
+    src="/list/infinite-scroll?items=4&left=8"
     [src]="data.url"
-    load-more="auto"
+    load-more="manual"
+    reset-on-refresh
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">
@@ -133,12 +135,7 @@
         </div>
       </div>
     </template>
-    <div fallback>
-      FALLBACK
-    </div>
-    <div placeholder>
-      PLACEHOLDER
-    </div>
+
     <amp-list-load-more load-more-failed>
     </amp-list-load-more>
     <amp-list-load-more load-more-end>

--- a/test/manual/amp-list/load-more-refresh.amp.html
+++ b/test/manual/amp-list/load-more-refresh.amp.html
@@ -117,12 +117,14 @@
 
   <h1>AMP List</h1>
   <p>This is a flexbox amp-list with tiles, something like an infinite image gallery.</p>
+  <button on="tap:list.refresh">Click to Refresh</button>
   <amp-list width="auto" height="200"
     id="list"
     layout="fixed-height"
-    src="/list/infinite-scroll?items=10&left=50"
+    src="/list/infinite-scroll?items=4&left=8"
     [src]="data.url"
     load-more="auto"
+    reset-on-refresh
     load-more-bookmark="next">
     <template type="amp-mustache">
       <div class="pin-container">
@@ -133,12 +135,7 @@
         </div>
       </div>
     </template>
-    <div fallback>
-      FALLBACK
-   </div>
-   <div placeholder>
-     PLACEHOLDER
-   </div>
+
     <amp-list-load-more load-more-failed>
     </amp-list-load-more>
     <amp-list-load-more load-more-end>


### PR DESCRIPTION
Closes #24034. 

The reset-on-refresh feature basically nukes the existing contents of `amp-list` and shows the placeholder while loading. If load-more is applied, the relevant elements like load-more-loading, load-more-ended, load-more-button, and load-more-failed should all be hidden during the refresh. 