### PR TITLE
🏗 Copy aliased extensions after single pass compilation

### DIFF
--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -37,6 +37,7 @@ const tempy = require('tempy');
 const terser = require('terser');
 const through = require('through2');
 const {
+  extensionAliasBundles,
   extensionBundles,
   altMainBundles,
   TYPES,
@@ -565,6 +566,7 @@ exports.singlePassCompile = async function(entryModule, options) {
     .then(eliminateIntermediateBundles)
     .then(thirdPartyConcat)
     .then(cleanupWeakModuleFiles)
+    .then(copyAliasedExtensions)
     .catch(err => {
       err.showStack = false; // Useless node_modules stack
       throw err;
@@ -675,6 +677,19 @@ function postPrepend(extension, prependContents) {
     const remapped = resorcery(map, loadSourceMap, !argv.full_sourcemaps);
     fs.writeFileSync(path, bundle.toString(), 'utf8');
     fs.writeFileSync(`${path}.map`, remapped.toString(), 'utf8');
+  });
+}
+
+/**
+ * Copies JS for aliased extensions. (CSS is already dropped in place.)
+ */
+function copyAliasedExtensions() {
+  Object.keys(extensionAliasBundles).forEach(aliasedExtension => {
+    const {version, aliasedVersion} = extensionAliasBundles[aliasedExtension];
+    const src = `${aliasedExtension}-${version}.js`;
+    const dest = `${aliasedExtension}-${aliasedVersion}.js`;
+    fs.copySync(`dist/v0/${src}`, `dist/v0/${dest}`);
+    fs.copySync(`dist/v0/${src}.map`, `dist/v0/${dest}.map`);
   });
 }
 


### PR DESCRIPTION
#24258 changed the way aliased extensions are copied, and moved the copy step into the extension building step in order to support lazy building of extensions one at a time. As a result, aliased extensions are no longer copied during single pass compilation.

This PR adds an additional step to single pass compilation to copy all aliased extensions.

Follow up to #24258