### PR TITLE
🏗 Add support for pre-building some extensions during `gulp --lazy_build`

### DIFF
--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -93,20 +93,21 @@ exports.lazyBuildJs = async function(req, res, next) {
 };
 
 /**
- * Pre-builds some extensions (and the core runtime) if requested via command
- * line flags. Note: We do not await the calls to build() so that the user can
- * start using the webserver immediately.
+ * Pre-builds the core runtime and returns immediately so that the user can
+ * start using the webserver.
+ */
+exports.preBuildCoreRuntime = function() {
+  build(jsBundles, 'amp.js', doBuildJs);
+};
+
+/**
+ * Pre-builds some extensions (requested via command line flags) and returns
+ * immediately so that the user can start using the webserver.
  * @param {!Object} argv
  */
 exports.preBuildSomeExtensions = function(argv) {
   const extensions = getExtensionsToBuild(argv);
-  log(
-    green('Pre-building'),
-    cyan(`amp.js`),
-    green('and extensions:'),
-    cyan(extensions.join(', '))
-  );
-  build(jsBundles, 'amp.js', doBuildJs);
+  log(green('Pre-building extensions:'), cyan(extensions.join(', ')));
   for (const extensionBundle in extensionBundles) {
     const extension = extensionBundles[extensionBundle].name;
     if (extensions.includes(extension) && !extensionBundle.endsWith('latest')) {

--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -100,7 +100,13 @@ exports.lazyBuildJs = async function(req, res, next) {
  */
 exports.preBuildSomeExtensions = function(argv) {
   const extensions = getExtensionsToBuild(argv);
-  log(green('Pre-building extensions:'), cyan(extensions.join(', ')));
+  log(
+    green('Pre-building'),
+    cyan(`amp.js`),
+    green('and extensions:'),
+    cyan(extensions.join(', '))
+  );
+  build(jsBundles, 'amp.js', doBuildJs);
   for (const extensionBundle in extensionBundles) {
     const extension = extensionBundles[extensionBundle].name;
     if (extensions.includes(extension) && !extensionBundle.endsWith('latest')) {

--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -70,16 +70,34 @@ async function build(bundles, bundle, buildFunc) {
   bundles[bundle].watched = true;
 }
 
+/**
+ * Lazy builds the correct version of an extension when requested.
+ * @param {!Object} req
+ * @param {!Object} res
+ * @param {function()} next
+ */
 exports.lazyBuildExtensions = async function(req, res, next) {
   const matcher = /\/dist\/v0\/([^\/]*)\.max\.js/;
   await lazyBuild(req.url, matcher, extensionBundles, doBuildExtension, next);
 };
 
+/**
+ * Lazy builds a non-extension JS file when requested.
+ * @param {!Object} req
+ * @param {!Object} res
+ * @param {function()} next
+ */
 exports.lazyBuildJs = async function(req, res, next) {
   const matcher = /\/.*\/([^\/]*\.js)/;
   await lazyBuild(req.url, matcher, jsBundles, doBuildJs, next);
 };
 
+/**
+ * Pre-builds some extensions (and the core runtime) if requested via command
+ * line flags. Note: We do not await the calls to build() so that the user can
+ * start using the webserver immediately.
+ * @param {!Object} argv
+ */
 exports.preBuildSomeExtensions = function(argv) {
   const extensions = getExtensionsToBuild(argv);
   log(green('Pre-building extensions:'), cyan(extensions.join(', ')));

--- a/build-system/lazy-build.js
+++ b/build-system/lazy-build.js
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const log = require('fancy-log');
 const {
   doBuildExtension,
   maybeInitializeExtensions,
+  getExtensionsToBuild,
 } = require('./tasks/extension-helpers');
+const {cyan, green} = require('ansi-colors');
 const {doBuildJs} = require('./tasks/helpers');
 const {jsBundles} = require('../bundles.config');
 
@@ -75,4 +78,15 @@ exports.lazyBuildExtensions = async function(req, res, next) {
 exports.lazyBuildJs = async function(req, res, next) {
   const matcher = /\/.*\/([^\/]*\.js)/;
   await lazyBuild(req.url, matcher, jsBundles, doBuildJs, next);
+};
+
+exports.preBuildSomeExtensions = function(argv) {
+  const extensions = getExtensionsToBuild(argv);
+  log(green('Pre-building extensions:'), cyan(extensions.join(', ')));
+  for (const extensionBundle in extensionBundles) {
+    const extension = extensionBundles[extensionBundle].name;
+    if (extensions.includes(extension) && !extensionBundle.endsWith('latest')) {
+      build(extensionBundles, extensionBundle, doBuildExtension);
+    }
+  }
 };

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -31,6 +31,7 @@ const webserver = require('gulp-webserver');
 const {
   lazyBuildExtensions,
   lazyBuildJs,
+  preBuildCoreRuntime,
   preBuildSomeExtensions,
 } = require('./lazy-build');
 
@@ -96,6 +97,7 @@ if (noCachingExtensions) {
 if (lazyBuild) {
   middleware.push(lazyBuildExtensions);
   middleware.push(lazyBuildJs);
+  preBuildCoreRuntime();
   if (argv.extensions || argv.extensions_from) {
     preBuildSomeExtensions(argv);
   }

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -20,13 +20,19 @@
  * files and list directories for use with the gulp live server
  */
 const app = require('./app');
+const argv = require('minimist')(process.env.ARGV.split(',').slice(2));
 const colors = require('ansi-colors');
 const gulp = require('gulp');
+const header = require('connect-header');
 const isRunning = require('is-running');
 const log = require('fancy-log');
 const morgan = require('morgan');
 const webserver = require('gulp-webserver');
-const {lazyBuildExtensions, lazyBuildJs} = require('./lazy-build');
+const {
+  lazyBuildExtensions,
+  lazyBuildJs,
+  preBuildSomeExtensions,
+} = require('./lazy-build');
 
 const {
   SERVE_HOST: host,
@@ -40,7 +46,6 @@ const sendCachingHeaders = process.env.SERVE_CACHING_HEADERS == 'true';
 const noCachingExtensions =
   process.env.SERVE_EXTENSIONS_WITHOUT_CACHING == 'true';
 const lazyBuild = process.env.LAZY_BUILD == 'true';
-const header = require('connect-header');
 
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
@@ -91,6 +96,9 @@ if (noCachingExtensions) {
 if (lazyBuild) {
   middleware.push(lazyBuildExtensions);
   middleware.push(lazyBuildJs);
+  if (argv.extensions || argv.extensions_from) {
+    preBuildSomeExtensions(argv);
+  }
 }
 
 // Start gulp webserver

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -90,7 +90,7 @@ async function performBuild(watch, defaultTask) {
   if (defaultTask) {
     printDefaultTaskHelp();
   }
-  if (!argv.lazy_build) {
+  if (!argv.lazy_build || argv.extensions || argv.extensions_from) {
     parseExtensionFlags();
   }
   await Promise.all([
@@ -116,6 +116,9 @@ async function defaultTask() {
   serve(argv.lazy_build);
   log(green('Started ') + cyan('gulp ') + green('server. '));
   if (argv.lazy_build) {
+    if (argv.extensions || argv.extensions_from) {
+      await buildExtensions({watch: true});
+    }
     log(green('JS and extensions will be lazily built when requested...'));
   } else {
     log(green('Building JS and extensions...'));

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -80,7 +80,9 @@ function printDefaultTaskHelp() {
       cyan('--extensions ') +
       green('or ') +
       cyan('--extensions_from ') +
-      green('to pre-build some extensions.');
+      green('to pre-build ') +
+      cyan('amp.js ') +
+      green('and some extensions.');
     log(extensionsMessage);
   }
 }

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -74,6 +74,14 @@ function printDefaultTaskHelp() {
       green('to lazily build JS and extensions ') +
       green('when requested from the server.');
     log(lazyBuildMessage);
+  } else {
+    const extensionsMessage =
+      green('⤷ Use ') +
+      cyan('--extensions ') +
+      green('or ') +
+      cyan('--extensions_from ') +
+      green('to pre-build some extensions.');
+    log(extensionsMessage);
   }
 }
 

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -80,9 +80,7 @@ function printDefaultTaskHelp() {
       cyan('--extensions ') +
       green('or ') +
       cyan('--extensions_from ') +
-      green('to pre-build ') +
-      cyan('amp.js ') +
-      green('and some extensions.');
+      green('to pre-build some extensions.');
     log(extensionsMessage);
   }
 }

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -19,7 +19,6 @@ const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
   compileAllUnminifiedJs,
-  compileCoreRuntime,
   printConfigHelp,
   printNobuildHelp,
 } = require('./helpers');
@@ -99,9 +98,6 @@ async function performBuild(watch, defaultTask) {
     compileJison(),
     bootstrapThirdPartyFrames(watch),
   ]);
-  if (!argv.lazy_build) {
-    await compileCoreRuntime(watch);
-  }
   if (!defaultTask) {
     await compileAllUnminifiedJs(watch);
     await buildExtensions({watch});

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -74,7 +74,7 @@ function printDefaultTaskHelp() {
       green('to lazily build JS and extensions ') +
       green('when requested from the server.');
     log(lazyBuildMessage);
-  } else {
+  } else if (!argv.extensions && !argv.extensions_from) {
     const extensionsMessage =
       green('⤷ Use ') +
       cyan('--extensions ') +
@@ -98,7 +98,7 @@ async function performBuild(watch, defaultTask) {
   if (defaultTask) {
     printDefaultTaskHelp();
   }
-  if (!argv.lazy_build || argv.extensions || argv.extensions_from) {
+  if (!argv.lazy_build) {
     parseExtensionFlags();
   }
   await Promise.all([
@@ -124,9 +124,6 @@ async function defaultTask() {
   serve(argv.lazy_build);
   log(green('Started ') + cyan('gulp ') + green('server. '));
   if (argv.lazy_build) {
-    if (argv.extensions || argv.extensions_from) {
-      await buildExtensions({watch: true});
-    }
     log(green('JS and extensions will be lazily built when requested...'));
   } else {
     log(green('Building JS and extensions...'));

--- a/build-system/tasks/compile-jison.js
+++ b/build-system/tasks/compile-jison.js
@@ -41,30 +41,23 @@ const imports = new Map([
  * For example, css-expr-impl.jison creates `cssParser`.
  * @return {!Promise<void>}
  */
-function compileJison() {
+async function compileJison() {
   fs.mkdirSync('build/parsers', {recursive: true});
+  const startTime = Date.now();
   const promises = [];
   jisonPaths.forEach(jisonPath => {
     glob.sync(jisonPath).forEach(jisonFile => {
-      const startTime = Date.now();
       const jsFile = path.basename(jisonFile, '.jison');
       const extension = jsFile.replace('-expr-impl', '');
       const parser = extension + 'Parser';
       const newFilePath = `build/parsers/${jsFile}.js`;
-      promises.push(
-        compileExpr(jisonFile, parser, newFilePath).then(() => {
-          endBuildStep(
-            'Compiled',
-            `${jsFile}.jison → ${newFilePath} as ${parser}`,
-            startTime
-          );
-        })
-      );
+      promises.push(compileExpr(jisonFile, parser, newFilePath));
     });
   });
-
-  return Promise.all(promises);
+  await Promise.all(promises);
+  endBuildStep('Compiled Jison parsers into', 'build/parsers/', startTime);
 }
+
 /**
  * Helper function that uses jison to generate a parser for the input file.
  * @param {string} jisonFilePath

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -23,7 +23,6 @@ const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
   compileAllMinifiedJs,
-  compileCoreRuntime,
   compileJs,
   endBuildStep,
   hostname,
@@ -148,7 +147,6 @@ async function dist() {
     copyCss(),
     copyParsers(),
   ]);
-  await compileCoreRuntime(/* watch */ false, /* minify */ true);
 
   if (isTravisBuild()) {
     // New line after all the compilation progress dots on Travis.

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -167,27 +167,32 @@ function maybeInitializeExtensions(
 /**
  * Process the command line arguments --noextensions, --extensions, and
  * --extensions_from and return a list of the referenced extensions.
+ * @param {!Object=} argvObject
  * @return {!Array<string>}
  */
-function getExtensionsToBuild() {
+function getExtensionsToBuild(argvObject = argv) {
   if (extensionsToBuild) {
     return extensionsToBuild;
   }
   extensionsToBuild = DEFAULT_EXTENSION_SET;
-  if (argv.extensions) {
-    if (argv.extensions === 'minimal_set') {
-      argv.extensions = MINIMAL_EXTENSION_SET.join(',');
-    } else if (argv.extensions === 'inabox') {
-      argv.extensions = INABOX_EXTENSION_SET.join(',');
+  if (argvObject.extensions) {
+    if (argvObject.extensions === 'minimal_set') {
+      argvObject.extensions = MINIMAL_EXTENSION_SET.join(',');
+    } else if (argvObject.extensions === 'inabox') {
+      argvObject.extensions = INABOX_EXTENSION_SET.join(',');
     }
-    const explicitExtensions = argv.extensions.split(',');
+    const explicitExtensions = argvObject.extensions.split(',');
     extensionsToBuild = dedupe(extensionsToBuild.concat(explicitExtensions));
   }
-  if (argv.extensions_from) {
-    const extensionsFrom = getExtensionsFromArg(argv.extensions_from);
+  if (argvObject.extensions_from) {
+    const extensionsFrom = getExtensionsFromArg(argvObject.extensions_from);
     extensionsToBuild = dedupe(extensionsToBuild.concat(extensionsFrom));
   }
-  if (!argv.noextensions && !argv.extensions && !argv.extensions_from) {
+  if (
+    !argvObject.noextensions &&
+    !argvObject.extensions &&
+    !argvObject.extensions_from
+  ) {
     const allExtensions = [];
     for (const extension in extensions) {
       allExtensions.push(extensions[extension].name);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -174,26 +174,6 @@ function bootstrapThirdPartyFrames(watch, minify) {
 }
 
 /**
- * Compiles the core runtime binary
- * @param {boolean} watch
- * @param {boolean} minify
- * @return {!Promise}
- */
-function compileCoreRuntime(watch, minify) {
-  return compileJs('./src/', 'amp.js', './dist', {
-    toName: 'amp.js',
-    minifiedName: 'v0.js',
-    includePolyfills: true,
-    watch,
-    minify,
-    wrapper: wrappers.mainBinary,
-    singlePassCompilation: argv.single_pass,
-    esmPassCompilation: argv.esm,
-    includeOnlyESMLevelPolyfills: argv.esm,
-  });
-}
-
-/**
  * Compile and optionally minify the stylesheets and the scripts for the runtime
  * and drop them in the dist folder
  * @param {boolean} watch
@@ -203,6 +183,14 @@ function compileCoreRuntime(watch, minify) {
 function compileAllJs(watch, minify) {
   return Promise.all([
     minify ? Promise.resolve() : doBuildJs(jsBundles, 'polyfills.js', {watch}),
+    doBuildJs(jsBundles, 'amp.js', {
+      watch,
+      minify,
+      wrapper: wrappers.mainBinary,
+      singlePassCompilation: argv.single_pass,
+      esmPassCompilation: argv.esm,
+      includeOnlyESMLevelPolyfills: argv.esm,
+    }),
     doBuildJs(jsBundles, 'alp.max.js', {watch, minify}),
     doBuildJs(jsBundles, 'examiner.max.js', {watch, minify}),
     doBuildJs(jsBundles, 'ww.max.js', {watch, minify}),
@@ -678,7 +666,6 @@ module.exports = {
   bootstrapThirdPartyFrames,
   compileAllMinifiedJs,
   compileAllUnminifiedJs,
-  compileCoreRuntime,
   compileJs,
   compileTs,
   devDependencies,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -156,7 +156,8 @@ function doBuildJs(jsBundles, name, extraOptions) {
  * @param {boolean} minify
  * @return {!Promise}
  */
-function bootstrapThirdPartyFrames(watch, minify) {
+async function bootstrapThirdPartyFrames(watch, minify) {
+  const startTime = Date.now();
   const promises = [];
   thirdPartyFrames.forEach(frameObject => {
     promises.push(
@@ -170,7 +171,12 @@ function bootstrapThirdPartyFrames(watch, minify) {
       });
     });
   }
-  return Promise.all(promises);
+  await Promise.all(promises);
+  endBuildStep(
+    'Bootstrapped 3p frames into',
+    `dist.3p/${minify ? internalRuntimeVersion : 'current'}/`,
+    startTime
+  );
 }
 
 /**
@@ -594,13 +600,8 @@ function concatFilesToString(files) {
  * @return {!Promise}
  */
 function thirdPartyBootstrap(input, outputName, minify) {
-  const startTime = Date.now();
   if (!minify) {
-    return toPromise(gulp.src(input).pipe(gulp.dest('dist.3p/current'))).then(
-      () => {
-        endBuildStep('Processed', input, startTime);
-      }
-    );
+    return toPromise(gulp.src(input).pipe(gulp.dest('dist.3p/current')));
   }
 
   // By default we use an absolute URL, that is independent of the
@@ -628,9 +629,7 @@ function thirdPartyBootstrap(input, outputName, minify) {
           'dir'
         );
       })
-  ).then(() => {
-    endBuildStep('Processed', input, startTime);
-  });
+  );
 }
 
 /**

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -70,6 +70,7 @@ function serve(lazyBuild) {
       path.dirname(require.resolve('../app-index')),
     ],
     env: {
+      // TODO(rsimha): Improve the cross-process message passing being done here
       'NODE_ENV': 'development',
       'SERVE_PORT': port,
       'SERVE_HOST': host,
@@ -79,6 +80,7 @@ function serve(lazyBuild) {
       'SERVE_CACHING_HEADERS': sendCachingHeaders,
       'SERVE_EXTENSIONS_WITHOUT_CACHING': noCachingExtensions,
       'LAZY_BUILD': lazyBuild,
+      'ARGV': process.argv,
     },
     stdout: !quiet,
   };


### PR DESCRIPTION
When `gulp --lazy_build` is run, all extensions are lazily built by default. This can pose a problem when a test page requests several extensions, causing the page to timeout while the extensions are being lazily built.

This PR mitigates the problem by letting developers pre-build some extensions and lazy-build the rest.

**Highlights:**
- Added support for the use of `--extensions` and / or `--extensions_from` with `gulp --lazy_build`
- Cleaned up logging for `compileJison()` and `bootstrapThirdPartyFrames()` (logs are now less chatty)
- Removed `compileCoreRuntime()` (addresses https://github.com/ampproject/amphtml/pull/24244#discussion_r318384400)

**Usage:**
```js
// Lazy build all JS and extensions
gulp --lazy_build

//  Eagerly build amp-foo and amp-bar, lazily build the rest
gulp --lazy_build --extensions=amp-foo,amp-bar

//  Eagerly build extensions used by examples/foo.amp.html, lazily build the rest
gulp --lazy_build --extensions_from=examples/foo.amp.html
```
Partial fix for #24141
Follow up to #24138, #24152, #24199, #24214, #24258, #24244