### PR TITLE
🐛Avoid carousel flickering on iOS.

### DIFF
--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -16,12 +16,36 @@
 
 import {Services} from '../../../src/services';
 
+/**
+ * Used for tracking whether or not an item is near the viewport. This is set
+ * from the IntersectionObserver and consumed by a flush.
+ */
+const NEARBY_VIEWPORT_FLAG = '__AMP_CAROUSEL_NEARBY_VIEWPORT';
+
+/**
+ * Used for tracking whether or not an item is in the viewport. This is set
+ * from the IntersectionObserver and consumed by a flush.
+ */
+const IN_VIEWPORT_FLAG = '__AMP_CAROUSEL_IN_VIEWPORT';
+
+/**
+ * The value for having no margin for intersection. That is, the item must
+ * intersect the intersection root itself.
+ */
 const NO_INTERSECTION_MARGIN = '0%';
 
 /**
- * The default margin around the scrolling element.
+ * The default margin around the scrolling element. This is a percentage of the
+ * width of the element.
  */
-const DEFAULT_NEARBY_MARGIN = '100%';
+const DEFAULT_NEARBY_MARGIN = 100;
+
+/**
+ * Additional margin before something is unlaidout. This is a percentage of the
+ * width of the element. This is used to avoid a rapid back and forth between
+ * layout and unlayout at the threshold of the nearby margin.
+ */
+const UNLAYOUT_MARGIN = 10;
 
 /**
  * What percentage of an Element must intersect before being considered as
@@ -35,6 +59,14 @@ const DEFAULT_NEARBY_MARGIN = '100%';
  * there are actual no pixels actually visible at this threshold.
  */
 const DEFAULT_INTERSECTION_THRESHOLD = 0.01;
+
+/**
+ * @enum {number}
+ */
+const ViewportChangeState = {
+  ENTER: 0,
+  LEAVE: 1,
+};
 
 /**
  * Manages scheduling layout/unlayout for children of an AMP component as they
@@ -77,12 +109,14 @@ export class ChildLayoutManager {
    *
    * Note: If the children live within a scrolling container, the
    * intersectionElement must be the scrolling container, and not an
-   * ancestor in order for `nearbyMargin` to work.
+   * ancestor in order for `nearbyMarginInPercent` to work.
    * @param {{
    *  ampElement: !AMP.BaseElement,
    *  intersectionElement: !Element,
    *  intersectionThreshold: (number|undefined),
-   *  nearbyMargin: (string|undefined),
+   *  nearbyMarginInPercent: (number|undefined),
+   *  queueChanges: (boolean|undefined),
+   *  viewportIntersectionThreshold: (number|undefined),
    *  viewportIntersectionCallback: (function(!Element, boolean)|undefined)
    * }} config
    */
@@ -90,7 +124,9 @@ export class ChildLayoutManager {
     ampElement,
     intersectionElement,
     intersectionThreshold = DEFAULT_INTERSECTION_THRESHOLD,
-    nearbyMargin = DEFAULT_NEARBY_MARGIN,
+    nearbyMarginInPercent = DEFAULT_NEARBY_MARGIN,
+    queueChanges = false,
+    viewportIntersectionThreshold = intersectionThreshold,
     viewportIntersectionCallback = () => {},
   }) {
     /** @private @const */
@@ -106,7 +142,13 @@ export class ChildLayoutManager {
     this.intersectionThreshold_ = intersectionThreshold;
 
     /** @private @const */
-    this.nearbyMargin_ = nearbyMargin;
+    this.nearbyMarginInPercent_ = nearbyMarginInPercent;
+
+    /** @private @const */
+    this.queueChanges_ = queueChanges;
+
+    /** @private @const */
+    this.viewportIntersectionThreshold_ = viewportIntersectionThreshold;
 
     /** @private @const */
     this.viewportIntersectionCallback_ = viewportIntersectionCallback;
@@ -114,34 +156,26 @@ export class ChildLayoutManager {
     /** @private {!IArrayLike<!Element>} */
     this.children_ = [];
 
-    /** @private {?IntersectionObserver}] */
-    this.nearbyObserver_ = null;
+    /** @private {?IntersectionObserver} */
+    this.nearingViewportObserver_ = null;
 
-    /** @private {?IntersectionObserver}] */
-    this.visibleObserver_ = null;
+    /** @private {?IntersectionObserver} */
+    this.backingAwayViewportObserver_ = null;
+
+    /** @private {?IntersectionObserver} */
+    this.inViewportObserver_ = null;
 
     /** @private {boolean} */
     this.laidOut_ = false;
-  }
 
-  /**
-   * @param {string} margin
-   * @param {function(!Element, boolean)} intersectionCallback
-   * @return {!IntersectionObserver}
-   */
-  createObserver_(margin, intersectionCallback) {
-    return new this.ampElement_.win.IntersectionObserver(
-      entries => {
-        entries.forEach(({target, isIntersecting}) => {
-          intersectionCallback(target, isIntersecting);
-        });
-      },
-      {
-        root: this.intersectionElement_,
-        rootMargin: margin,
-        threshold: this.intersectionThreshold_,
-      }
-    );
+    /** @private {boolean} */
+    this.flushNextNearingViewportChanges_ = false;
+
+    /** @private {boolean} */
+    this.flushNextBackingAwayViewportChanges_ = false;
+
+    /** @private {boolean} */
+    this.flushNextInViewportChanges_ = false;
   }
 
   /**
@@ -173,26 +207,158 @@ export class ChildLayoutManager {
 
   /**
    * Sets up for intersection monitoring, creating IntersectionObserver
-   * instances for nearby Eelements as well as those that are actually visible.
+   * instances for doing layout  as well as those that are actually visible.
+   *
+   * We set up separate observers for layout and unlayout. When the element is
+   * near to the viewport, we trigger layout. However, we have some extra
+   * buffer space before triggering unlayout, to prevent cycling between the
+   * two on the threshold, which can cause problems in Safari.
    */
   setup_() {
-    if (this.nearbyObserver_ && this.visibleObserver_) {
+    if (
+      this.nearingViewportObserver_ &&
+      this.backingAwayViewportObserver_ &&
+      this.inViewportObserver_
+    ) {
       return;
     }
 
-    this.nearbyObserver_ = this.createObserver_(
-      this.nearbyMargin_,
-      (target, isIntersecting) => {
-        this.triggerLayout_(target, isIntersecting);
+    const {win} = this.ampElement_;
+
+    this.nearingViewportObserver_ = new win.IntersectionObserver(
+      entries => this.processNearingChanges_(entries),
+      {
+        root: this.intersectionElement_,
+        rootMargin: `${this.nearbyMarginInPercent_}%`,
+        threshold: this.intersectionThreshold_,
       }
     );
 
-    this.visibleObserver_ = this.createObserver_(
-      NO_INTERSECTION_MARGIN,
-      (target, isIntersecting) => {
-        this.triggerVisibility_(target, isIntersecting);
+    this.backingAwayViewportObserver_ = new win.IntersectionObserver(
+      entries => this.processBackingAwayChanges_(entries),
+      {
+        root: this.intersectionElement_,
+        rootMargin: `${this.nearbyMarginInPercent_ + UNLAYOUT_MARGIN}%`,
+        threshold: this.intersectionThreshold_,
       }
     );
+
+    this.inViewportObserver_ = new win.IntersectionObserver(
+      entries => this.processInViewportChanges_(entries),
+      {
+        root: this.intersectionElement_,
+        rootMargin: NO_INTERSECTION_MARGIN,
+        threshold: this.viewportIntersectionThreshold_,
+      }
+    );
+  }
+
+  /**
+   * Processes the intersection entries for things nearing the viewport,
+   * marking them applying the changes if needed.
+   * @param {!Array<!IntersectionObserverEntry>} entries
+   */
+  processNearingChanges_(entries) {
+    entries
+      .filter(({isIntersecting}) => isIntersecting)
+      .forEach(({target}) => {
+        target[NEARBY_VIEWPORT_FLAG] = ViewportChangeState.ENTER;
+      });
+
+    if (!this.queueChanges_ || this.flushNextNearingViewportChanges_) {
+      this.flushNearingViewportChanges_();
+      this.flushNextNearingViewportChanges_ = false;
+    }
+  }
+
+  /**
+   * Processes the intersection entries for things backing away from viewport,
+   * marking them applying the changes if needed.
+   * @param {!Array<!IntersectionObserverEntry>} entries
+   */
+  processBackingAwayChanges_(entries) {
+    entries
+      .filter(({isIntersecting}) => !isIntersecting)
+      .forEach(({target}) => {
+        target[NEARBY_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
+      });
+
+    if (!this.queueChanges_ || this.flushNextBackingAwayViewportChanges_) {
+      this.flushBackingAwayViewportChanges_();
+      this.flushNextBackingAwayViewportChanges_ = false;
+    }
+  }
+
+  /**
+   * Processes the intersection entries for things in the viewport,
+   * marking them applying the changes if needed.
+   * @param {!Array<!IntersectionObserverEntry>} entries
+   */
+  processInViewportChanges_(entries) {
+    entries.forEach(({target, isIntersecting}) => {
+      target[IN_VIEWPORT_FLAG] = isIntersecting
+        ? ViewportChangeState.ENTER
+        : ViewportChangeState.LEAVE;
+    });
+
+    if (!this.queueChanges_ || this.flushNextInViewportChanges_) {
+      this.flushInViewportChanges_();
+      this.flushNextInViewportChanges_ = false;
+    }
+  }
+
+  /**
+   * Flush all intersection changes previously picked up.
+   */
+  flushChanges() {
+    this.flushNearingViewportChanges_();
+    this.flushBackingAwayViewportChanges_();
+    this.flushInViewportChanges_();
+  }
+
+  /**
+   * Flush changes for things nearing the viewport.
+   */
+  flushNearingViewportChanges_() {
+    for (let i = 0; i < this.children_.length; i++) {
+      const child = this.children_[i];
+
+      if (child[NEARBY_VIEWPORT_FLAG] == ViewportChangeState.ENTER) {
+        this.triggerLayout_(child, true);
+        child[NEARBY_VIEWPORT_FLAG] = null;
+      }
+    }
+  }
+
+  /**
+   * Flush changes for things backing away from the viewport.
+   */
+  flushBackingAwayViewportChanges_() {
+    for (let i = 0; i < this.children_.length; i++) {
+      const child = this.children_[i];
+
+      if (child[NEARBY_VIEWPORT_FLAG] == ViewportChangeState.LEAVE) {
+        this.triggerLayout_(child, false);
+        child[NEARBY_VIEWPORT_FLAG] = null;
+      }
+    }
+  }
+
+  /**
+   * Flush changes for things in the viewport.
+   */
+  flushInViewportChanges_() {
+    for (let i = 0; i < this.children_.length; i++) {
+      const child = this.children_[i];
+
+      if (child[IN_VIEWPORT_FLAG] == ViewportChangeState.ENTER) {
+        this.triggerVisibility_(child, true);
+      } else if (child[IN_VIEWPORT_FLAG] == ViewportChangeState.LEAVE) {
+        this.triggerVisibility_(child, false);
+      }
+
+      child[IN_VIEWPORT_FLAG] = null;
+    }
   }
 
   /**
@@ -212,14 +378,16 @@ export class ChildLayoutManager {
     // Simply disconnect, in case the children have changed, we can make sure
     // everything is detached.
     if (!observe) {
-      this.nearbyObserver_.disconnect();
-      this.visibleObserver_.disconnect();
+      this.nearingViewportObserver_.disconnect();
+      this.backingAwayViewportObserver_.disconnect();
+      this.inViewportObserver_.disconnect();
       return;
     }
 
     for (let i = 0; i < this.children_.length; i++) {
-      this.nearbyObserver_.observe(this.children_[i]);
-      this.visibleObserver_.observe(this.children_[i]);
+      this.nearingViewportObserver_.observe(this.children_[i]);
+      this.backingAwayViewportObserver_.observe(this.children_[i]);
+      this.inViewportObserver_.observe(this.children_[i]);
     }
   }
 
@@ -252,6 +420,12 @@ export class ChildLayoutManager {
   wasLaidOut() {
     this.laidOut_ = true;
     this.monitorChildren_(this.laidOut_);
+
+    // Make sure we flush the next changes from the IntersectionObservers,
+    // regardless if queuing was requested, since things were just laid out.
+    this.flushNextNearingViewportChanges_ = true;
+    this.flushNextBackingAwayViewportChanges_ = true;
+    this.flushNextInViewportChanges_ = true;
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -20,7 +20,7 @@ import {Services} from '../../../src/services';
  * Used for tracking whether or not an item is near the viewport. This is set
  * from the IntersectionObserver and consumed by a flush.
  */
-const NEARBY_VIEWPORT_FLAG = '__AMP_CAROUSEL_NEARBY_VIEWPORT';
+const NEAR_VIEWPORT_FLAG = '__AMP_CAROUSEL_NEAR_VIEWPORT';
 
 /**
  * Used for tracking whether or not an item is in the viewport. This is set
@@ -262,7 +262,7 @@ export class ChildLayoutManager {
     entries
       .filter(({isIntersecting}) => isIntersecting)
       .forEach(({target}) => {
-        target[NEARBY_VIEWPORT_FLAG] = ViewportChangeState.ENTER;
+        target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.ENTER;
       });
 
     if (!this.queueChanges_ || this.flushNextNearingViewportChanges_) {
@@ -280,7 +280,7 @@ export class ChildLayoutManager {
     entries
       .filter(({isIntersecting}) => !isIntersecting)
       .forEach(({target}) => {
-        target[NEARBY_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
+        target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
       });
 
     if (!this.queueChanges_ || this.flushNextBackingAwayViewportChanges_) {
@@ -323,9 +323,9 @@ export class ChildLayoutManager {
     for (let i = 0; i < this.children_.length; i++) {
       const child = this.children_[i];
 
-      if (child[NEARBY_VIEWPORT_FLAG] == ViewportChangeState.ENTER) {
+      if (child[NEAR_VIEWPORT_FLAG] == ViewportChangeState.ENTER) {
         this.triggerLayout_(child, true);
-        child[NEARBY_VIEWPORT_FLAG] = null;
+        child[NEAR_VIEWPORT_FLAG] = null;
       }
     }
   }
@@ -337,9 +337,9 @@ export class ChildLayoutManager {
     for (let i = 0; i < this.children_.length; i++) {
       const child = this.children_[i];
 
-      if (child[NEARBY_VIEWPORT_FLAG] == ViewportChangeState.LEAVE) {
+      if (child[NEAR_VIEWPORT_FLAG] == ViewportChangeState.LEAVE) {
         this.triggerLayout_(child, false);
-        child[NEARBY_VIEWPORT_FLAG] = null;
+        child[NEAR_VIEWPORT_FLAG] = null;
       }
     }
   }

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -393,7 +393,6 @@ describes.realWin('child layout manager', {}, env => {
         .to.have.been.calledWith(domElementMock, el.children[1]);
     });
 
-
     it('should schedule layout when wasLaidOut is called', async () => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({
@@ -437,7 +436,6 @@ describes.realWin('child layout manager', {}, env => {
         .to.have.been.calledWith(domElementMock, el.children[4], false);
     });
 
-
     it('should queue layout on scroll', async () => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({
@@ -462,7 +460,6 @@ describes.realWin('child layout manager', {}, env => {
         .to.have.callCount(1)
         .to.have.been.calledWith(domElementMock, el.children[2]);
     });
-
 
     it('should queue scheduleUnlayout on scroll', async () => {
       const el = createHorizontalScroller(5);
@@ -493,7 +490,6 @@ describes.realWin('child layout manager', {}, env => {
         .to.have.been.calledWith(domElementMock, el.children[0]);
     });
 
-    
     it('should queue updateInViewport on scroll', async () => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -144,200 +144,381 @@ describes.realWin('child layout manager', {}, env => {
     return el.children;
   }
 
-  it('should just setOwner when not laid out', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+  describe('when not queuing changes', () => {
+    it('should just setOwner when not laid out', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      await afterRenderPromise();
+
+      expect(ownersMock.setOwner).to.have.callCount(5);
+      expect(ownersMock.scheduleLayout).to.have.not.been.called;
     });
 
-    clm.updateChildren(el.children);
-    await afterRenderPromise();
+    it('should schedule layout for one extra viewport on layout', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
 
-    expect(ownersMock.setOwner).to.have.callCount(5);
-    expect(ownersMock.scheduleLayout).to.have.not.been.called;
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0])
+        .to.have.been.calledWith(domElementMock, el.children[1]);
+    });
+
+    it('should schedule layout when wasLaidOut is called', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout).to.have.not.been.called;
+
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0])
+        .to.have.been.calledWith(domElementMock, el.children[1]);
+    });
+
+    it('should schedule layout when children change', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleLayout.resetHistory();
+      const newChildren = replaceChildren(el, 3);
+      clm.updateChildren(newChildren);
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, newChildren[0])
+        .to.have.been.calledWith(domElementMock, newChildren[1]);
+    });
+
+    it('should update viewport visibility', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      expect(ownersMock.updateInViewport)
+        .to.have.callCount(5)
+        .to.have.been.calledWith(domElementMock, el.children[0], true)
+        .to.have.been.calledWith(domElementMock, el.children[1], false)
+        .to.have.been.calledWith(domElementMock, el.children[2], false)
+        .to.have.been.calledWith(domElementMock, el.children[3], false)
+        .to.have.been.calledWith(domElementMock, el.children[4], false);
+    });
+
+    it('should call the viewportIntersectionCallback', async () => {
+      const viewportIntersectionCallback = env.sandbox.spy();
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+        viewportIntersectionCallback,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      expect(viewportIntersectionCallback)
+        .to.have.callCount(5)
+        .to.have.been.calledWith(el.children[0], true)
+        .to.have.been.calledWith(el.children[1], false)
+        .to.have.been.calledWith(el.children[2], false)
+        .to.have.been.calledWith(el.children[3], false)
+        .to.have.been.calledWith(el.children[4], false);
+    });
+
+    it('should scheduleLayout on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleLayout.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[1], el);
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(1)
+        .to.have.been.calledWith(domElementMock, el.children[2]);
+    });
+
+    it('should scheduleUnlayout on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleUnlayout.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[3], el);
+      await afterRenderPromise();
+
+      // Note, el.children[1] was not unlaidout, even though it is more than one
+      // viewport away. The unlayout has an extra buffer space to avoid switching
+      // between layout and unlayout at the edge.
+      expect(ownersMock.scheduleUnlayout)
+        .to.have.callCount(1)
+        .to.have.been.calledWith(domElementMock, el.children[0]);
+    });
+
+    it('should scheduleUnlayout on wasUnlaidOut', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleUnlayout.resetHistory();
+      clm.wasUnlaidOut();
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleUnlayout)
+        .to.have.callCount(5)
+        .to.have.been.calledWith(domElementMock, el.children[0])
+        .to.have.been.calledWith(domElementMock, el.children[1])
+        .to.have.been.calledWith(domElementMock, el.children[2])
+        .to.have.been.calledWith(domElementMock, el.children[3])
+        .to.have.been.calledWith(domElementMock, el.children[4]);
+    });
+
+    it('should updateInViewport on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: false,
+      });
+
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.updateInViewport.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[1], el);
+      await afterRenderPromise();
+
+      expect(ownersMock.updateInViewport)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0], false)
+        .to.have.been.calledWith(domElementMock, el.children[1], true);
+    });
   });
 
-  it('should schedule layout for one extra viewport', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+  describe('queuing changes', () => {
+    it('should just setOwner when not laid out', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
+
+      clm.updateChildren(el.children);
+      await afterRenderPromise();
+
+      expect(ownersMock.setOwner).to.have.callCount(5);
+      expect(ownersMock.scheduleLayout).to.have.not.been.called;
     });
 
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
+    it('should schedule layout for one extra viewport on layout', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-    expect(ownersMock.scheduleLayout)
-      .to.have.callCount(2)
-      .to.have.been.calledWith(domElementMock, el.children[0])
-      .to.have.been.calledWith(domElementMock, el.children[1]);
-  });
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
 
-  it('should schedule layout when wasLaidOut is called', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0])
+        .to.have.been.calledWith(domElementMock, el.children[1]);
     });
 
-    clm.updateChildren(el.children);
-    await afterRenderPromise();
-    clm.wasLaidOut();
-    await afterRenderPromise();
 
-    expect(ownersMock.scheduleLayout)
-      .to.have.callCount(2)
-      .to.have.been.calledWith(domElementMock, el.children[0])
-      .to.have.been.calledWith(domElementMock, el.children[1]);
-  });
+    it('should schedule layout when wasLaidOut is called', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-  it('should schedule layout when children change', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+      clm.updateChildren(el.children);
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout).to.have.not.been.called;
+
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0])
+        .to.have.been.calledWith(domElementMock, el.children[1]);
     });
 
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
+    it('should update viewport visibility', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-    ownersMock.scheduleLayout.resetHistory();
-    const newChildren = replaceChildren(el, 3);
-    clm.updateChildren(newChildren);
-    await afterRenderPromise();
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
 
-    expect(ownersMock.scheduleLayout)
-      .to.have.callCount(2)
-      .to.have.been.calledWith(domElementMock, newChildren[0])
-      .to.have.been.calledWith(domElementMock, newChildren[1]);
-  });
-
-  it('should update viewport visibility', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+      expect(ownersMock.updateInViewport)
+        .to.have.callCount(5)
+        .to.have.been.calledWith(domElementMock, el.children[0], true)
+        .to.have.been.calledWith(domElementMock, el.children[1], false)
+        .to.have.been.calledWith(domElementMock, el.children[2], false)
+        .to.have.been.calledWith(domElementMock, el.children[3], false)
+        .to.have.been.calledWith(domElementMock, el.children[4], false);
     });
 
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
 
-    expect(ownersMock.updateInViewport)
-      .to.have.callCount(5)
-      .to.have.been.calledWith(domElementMock, el.children[0], true)
-      .to.have.been.calledWith(domElementMock, el.children[1], false)
-      .to.have.been.calledWith(domElementMock, el.children[2], false)
-      .to.have.been.calledWith(domElementMock, el.children[3], false)
-      .to.have.been.calledWith(domElementMock, el.children[4], false);
-  });
+    it('should queue layout on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-  it('should call the viewportIntersectionCallback', async () => {
-    const viewportIntersectionCallback = env.sandbox.spy();
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
-      viewportIntersectionCallback,
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleLayout.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[1], el);
+
+      // Make sure changes are not applied yet.
+      expect(ownersMock.scheduleLayout).to.have.not.been.called;
+      // Now flush the changes and check that they are applied.
+      clm.flushChanges();
+
+      expect(ownersMock.scheduleLayout)
+        .to.have.callCount(1)
+        .to.have.been.calledWith(domElementMock, el.children[2]);
     });
 
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
 
-    expect(viewportIntersectionCallback)
-      .to.have.callCount(5)
-      .to.have.been.calledWith(el.children[0], true)
-      .to.have.been.calledWith(el.children[1], false)
-      .to.have.been.calledWith(el.children[2], false)
-      .to.have.been.calledWith(el.children[3], false)
-      .to.have.been.calledWith(el.children[4], false);
-  });
+    it('should queue scheduleUnlayout on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-  it('should scheduleLayout on scroll', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
+
+      ownersMock.scheduleUnlayout.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[3], el);
+      await afterRenderPromise();
+
+      // Make sure changes are not applied yet.
+      expect(ownersMock.scheduleUnlayout).to.have.not.been.called;
+      // Now flush the changes and check that they are applied.
+      clm.flushChanges();
+
+      // Note, el.children[1] was not unlaidout, even though it is more than one
+      // viewport away. The unlayout has an extra buffer space to avoid switching
+      // between layout and unlayout at the edge.
+      expect(ownersMock.scheduleUnlayout)
+        .to.have.callCount(1)
+        .to.have.been.calledWith(domElementMock, el.children[0]);
     });
 
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
+    
+    it('should queue updateInViewport on scroll', async () => {
+      const el = createHorizontalScroller(5);
+      const clm = new ChildLayoutManager({
+        ampElement: ampElementMock,
+        intersectionElement: el,
+        queueChanges: true,
+      });
 
-    ownersMock.scheduleLayout.resetHistory();
-    await afterScrollAndIntersectingPromise(el.children[1], el);
+      clm.updateChildren(el.children);
+      clm.wasLaidOut();
+      await afterRenderPromise();
 
-    expect(ownersMock.scheduleLayout)
-      .to.have.callCount(1)
-      .to.have.been.calledWith(domElementMock, el.children[2]);
-  });
+      ownersMock.updateInViewport.resetHistory();
+      await afterScrollAndIntersectingPromise(el.children[1], el);
+      await afterRenderPromise();
 
-  it('should scheduleUnlayout on scroll', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
+      // Make sure changes are not applied yet.
+      expect(ownersMock.updateInViewport).to.have.not.been.called;
+      // Now flush the changes and check that they are applied.
+      clm.flushChanges();
+
+      expect(ownersMock.updateInViewport)
+        .to.have.callCount(2)
+        .to.have.been.calledWith(domElementMock, el.children[0], false)
+        .to.have.been.calledWith(domElementMock, el.children[1], true);
     });
-
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
-
-    ownersMock.scheduleUnlayout.resetHistory();
-    await afterScrollAndIntersectingPromise(el.children[2], el);
-    await afterRenderPromise();
-
-    expect(ownersMock.scheduleUnlayout)
-      .to.have.callCount(1)
-      .to.have.been.calledWith(domElementMock, el.children[0]);
-  });
-
-  it('should scheduleUnlayout on wasUnlaidOut', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
-    });
-
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
-
-    ownersMock.scheduleUnlayout.resetHistory();
-    clm.wasUnlaidOut();
-    await afterRenderPromise();
-
-    expect(ownersMock.scheduleUnlayout)
-      .to.have.callCount(5)
-      .to.have.been.calledWith(domElementMock, el.children[0])
-      .to.have.been.calledWith(domElementMock, el.children[1])
-      .to.have.been.calledWith(domElementMock, el.children[2])
-      .to.have.been.calledWith(domElementMock, el.children[3])
-      .to.have.been.calledWith(domElementMock, el.children[4]);
-  });
-
-  it('should updateInViewport on scroll', async () => {
-    const el = createHorizontalScroller(5);
-    const clm = new ChildLayoutManager({
-      ampElement: ampElementMock,
-      intersectionElement: el,
-    });
-
-    clm.updateChildren(el.children);
-    clm.wasLaidOut();
-    await afterRenderPromise();
-
-    ownersMock.updateInViewport.resetHistory();
-    await afterScrollAndIntersectingPromise(el.children[1], el);
-    await afterRenderPromise();
-
-    expect(ownersMock.updateInViewport)
-      .to.have.callCount(2)
-      .to.have.been.calledWith(domElementMock, el.children[0], false)
-      .to.have.been.calledWith(domElementMock, el.children[1], true);
   });
 });


### PR DESCRIPTION
On iOS (but not desktop Safari), the carousel slides will sometimes flicker if we attempt to do layout while the user is scrolling the carousel, which can be distracting. To avoid this, wait until scrolling has stopped before requesting layout.

- Change logic to avoid layout of children until scrolling stops for iOS
  * This may result in the user hitting blank slides if scrolling quickly more
    often, but avoids a distracting flicker in the general case
  * Note: there may still be a flicker if the user starts scrolling again before one of the nearby finishes layout
- Avoid trashing at the threshold for layout/unlayout in Safari by giving the
  unlayout an extra buffer area
