### PR TITLE
🐛Story Ads: update amp-ad-exit config

### DIFF
--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -101,13 +101,23 @@
   </div>
   <amp-ad-exit id="exit-api">
     <script type="application/json">
-    {
-      "targets": {
-        "url_0": {
-          "finalUrl": "https://www.amp.dev"
+      {
+        "filters": {},
+        "options": {},
+        "targets": {
+          "exit1": {
+            "filters": [],
+            "finalUrl": "https://www.amp.dev",
+            "trackingUrls": [],
+            "vars": {
+              "_rm_eid": {
+                "defaultValue": "5645519",
+                "iframeTransportSignal": ""
+              }
+            }
+          }
         }
       }
-    }
     </script>
   </amp-ad-exit>
 </body>


### PR DESCRIPTION
This config more closely matches output from partner ad networks and should be used in e2e/ manual testing. 