### PR TITLE
Revert "amp-bind: Rate-limit history operations"

### DIFF
--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -828,8 +828,8 @@ describe
 
         describe('history', () => {
           beforeEach(() => {
-            sandbox.stub(history, 'replace');
-            sandbox.stub(history, 'push');
+            sandbox.spy(history, 'replace');
+            sandbox.spy(history, 'push');
             sandbox.stub(viewer, 'isEmbedded').returns(true);
           });
 
@@ -842,9 +842,6 @@ describe
                 {one: 1}
               );
               return promise.then(() => {
-                // History.replace has a 1s debounce.
-                clock.tick(1000);
-
                 // Shouldn't call replace() with null `data`.
                 expect(history.replace).to.not.be.called;
               });
@@ -858,10 +855,7 @@ describe
               return promise.then(() => {
                 expect(history.push).to.be.called;
                 // `data` param should be null on untrusted viewers.
-                expect(history.push).to.be.calledWith(
-                  sinon.match.func,
-                  undefined
-                );
+                expect(history.push).to.be.calledWith(sinon.match.func, null);
               });
             });
           });
@@ -881,11 +875,6 @@ describe
                 {one: 1}
               );
               return promise.then(() => {
-                expect(history.replace).to.not.be.called;
-
-                // History.replace has a 1s debounce.
-                clock.tick(1000);
-
                 expect(history.replace).calledOnce;
                 // `data` param should exist on trusted viewers.
                 expect(history.replace).calledWith({
@@ -907,39 +896,6 @@ describe
                   data: {'amp-bind': {foo: 'bar'}},
                   title: '',
                 });
-              });
-            });
-
-            it('should collapse consecutive replaces', async () => {
-              await bind.setStateWithExpression('{foo: 1}', {});
-              await bind.setStateWithExpression('{foo: 2}', {});
-
-              expect(history.replace).to.not.be.called;
-
-              clock.tick(1000);
-
-              expect(history.replace).calledOnce;
-              expect(history.replace).calledWith({
-                data: {'amp-bind': {foo: 2}},
-                title: '',
-              });
-            });
-
-            it('should flush history immediately after push', async () => {
-              await bind.setStateWithExpression('{foo: 1}', {});
-
-              expect(history.replace).to.not.be.called;
-              expect(history.push).to.not.be.called;
-
-              await bind.pushStateWithExpression('{bar: 2}', {});
-
-              expect(history.replace).calledWith({
-                data: {'amp-bind': {foo: 1}},
-                title: '',
-              });
-              expect(history.push).calledWith(sinon.match.func, {
-                data: {'amp-bind': {foo: 1, bar: 2}},
-                title: '',
               });
             });
           });


### PR DESCRIPTION
Reverts ampproject/amphtml#23938.

Rate-limiting should happen at the `History` service level to avoid breaking history change ordering between extensions e.g. when `amp-lightbox.open` is chained after a `AMP.setState` action. 

May be related to an AoG bug. Rolling back first and will roll forward with the correct fix soon.