### PR TITLE
History: Defend against bad "historyPopped" data

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -102,8 +102,8 @@ export class AmpState extends AMP.BaseElement {
       dev().error(TAG, 'Viewer must be visible before mutation.');
       return;
     }
-    const src = mutations['src'];
-    if (src !== undefined) {
+    // "src" attribute may be missing if mutated with a non-primitive.
+    if (mutations['src'] !== undefined && this.element.hasAttribute('src')) {
       this.fetchAndUpdate_(/* isInit */ false);
     }
   }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -922,7 +922,7 @@ export class HistoryBindingVirtual_ {
    * @return {boolean}
    */
   isHistoryState_(maybeHistoryState) {
-    return maybeHistoryState && maybeHistoryState['stackIndex'] !== undefined;
+    return !!maybeHistoryState && maybeHistoryState['stackIndex'] !== undefined;
   }
 
   /**

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -843,9 +843,6 @@ export class HistoryBindingNatural_ {
   }
 }
 
-/** @const {string} */
-const BAD_DATA_WARNING = 'Ignored unexpected "%s" data:';
-
 /**
  * Implementation of HistoryBindingInterface that assumes a virtual history that
  * relies on viewer's "pushHistory", "popHistory" and "historyPopped"
@@ -910,7 +907,12 @@ export class HistoryBindingVirtual_ {
     if (this.isHistoryState_(maybeHistoryState)) {
       return /** @type {!HistoryStateDef} */ (maybeHistoryState);
     } else {
-      dev().warn(TAG_, BAD_DATA_WARNING, debugId, maybeHistoryState);
+      dev().warn(
+        TAG_,
+        'Ignored unexpected "%s" data:',
+        debugId,
+        maybeHistoryState
+      );
     }
     return fallbackState;
   }
@@ -1044,7 +1046,7 @@ export class HistoryBindingVirtual_ {
     if (this.isHistoryState_(data)) {
       this.updateHistoryState_(/** @type {!HistoryStateDef} */ (data));
     } else {
-      dev().warn(TAG_, BAD_DATA_WARNING, 'historyPopped', data);
+      dev().warn(TAG_, 'Ignored unexpected "historyPopped" data:', data);
     }
   }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -843,6 +843,9 @@ export class HistoryBindingNatural_ {
   }
 }
 
+/** @const {string} */
+const BAD_DATA_WARNING = 'Ignored unexpected "%s" data:';
+
 /**
  * Implementation of HistoryBindingInterface that assumes a virtual history that
  * relies on viewer's "pushHistory", "popHistory" and "historyPopped"
@@ -899,15 +902,25 @@ export class HistoryBindingVirtual_ {
    * otherwise.
    * @param {*} maybeHistoryState
    * @param {!HistoryStateDef} fallbackState
+   * @param {string} debugId
    * @return {!HistoryStateDef}
    * @private
    */
-  toHistoryState_(maybeHistoryState, fallbackState) {
-    if (maybeHistoryState && maybeHistoryState['stackIndex']) {
+  toHistoryState_(maybeHistoryState, fallbackState, debugId) {
+    if (this.isHistoryState_(maybeHistoryState)) {
       return /** @type {!HistoryStateDef} */ (maybeHistoryState);
+    } else {
+      dev().warn(TAG_, BAD_DATA_WARNING, debugId, maybeHistoryState);
     }
-
     return fallbackState;
+  }
+
+  /**
+   * @param {*} maybeHistoryState
+   * @return {boolean}
+   */
+  isHistoryState_(maybeHistoryState) {
+    return maybeHistoryState && maybeHistoryState['stackIndex'];
   }
 
   /**
@@ -923,13 +936,12 @@ export class HistoryBindingVirtual_ {
       {'stackIndex': this.stackIndex_ + 1},
       opt_stateUpdate || {}
     ));
+    const push = 'pushHistory';
     return this.viewer_
-      .sendMessageAwaitResponse('pushHistory', message)
+      .sendMessageAwaitResponse(push, message)
       .then(response => {
-        const newState = this.toHistoryState_(
-          response,
-          /** @type {!HistoryStateDef} */ (message)
-        );
+        const fallbackState = /** @type {!HistoryStateDef} */ (message);
+        const newState = this.toHistoryState_(response, fallbackState, push);
         this.updateHistoryState_(newState);
         return newState;
       });
@@ -948,13 +960,14 @@ export class HistoryBindingVirtual_ {
       return this.get();
     }
     const message = dict({'stackIndex': this.stackIndex_});
+    const pop = 'popHistory';
     return this.viewer_
-      .sendMessageAwaitResponse('popHistory', message)
+      .sendMessageAwaitResponse(pop, message)
       .then(response => {
         const fallbackState = /** @type {!HistoryStateDef} */ (dict({
           'stackIndex': this.stackIndex_ - 1,
         }));
-        const newState = this.toHistoryState_(response, fallbackState);
+        const newState = this.toHistoryState_(response, fallbackState, pop);
         this.updateHistoryState_(newState);
         return newState;
       });
@@ -988,17 +1001,12 @@ export class HistoryBindingVirtual_ {
       {'stackIndex': this.stackIndex_},
       opt_stateUpdate || {}
     ));
+    const replace = 'replaceHistory';
     return this.viewer_
-      .sendMessageAwaitResponse(
-        'replaceHistory',
-        message,
-        /* cancelUnsent */ true
-      )
+      .sendMessageAwaitResponse(replace, message, /* cancelUnsent */ true)
       .then(response => {
-        const newState = this.toHistoryState_(
-          response,
-          /** @type {!HistoryStateDef} */ (message)
-        );
+        const fallbackState = /** @type {!HistoryStateDef} */ (message);
+        const newState = this.toHistoryState_(response, fallbackState, replace);
         this.updateHistoryState_(newState);
         return newState;
       });
@@ -1033,7 +1041,11 @@ export class HistoryBindingVirtual_ {
     if (data['newStackIndex'] !== undefined) {
       data['stackIndex'] = data['newStackIndex'];
     }
-    this.updateHistoryState_(/** @type {!HistoryStateDef} */ (data));
+    if (this.isHistoryState_(data)) {
+      this.updateHistoryState_(/** @type {!HistoryStateDef} */ (data));
+    } else {
+      dev().warn(TAG_, BAD_DATA_WARNING, 'historyPopped', data);
+    }
   }
 
   /**

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -920,7 +920,7 @@ export class HistoryBindingVirtual_ {
    * @return {boolean}
    */
   isHistoryState_(maybeHistoryState) {
-    return maybeHistoryState && maybeHistoryState['stackIndex'];
+    return maybeHistoryState && maybeHistoryState['stackIndex'] !== undefined;
   }
 
   /**

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -919,6 +919,11 @@ describes.sandboxed('HistoryBindingVirtual', {}, () => {
       expect(onStateUpdated).to.be.calledOnce;
       expect(onStateUpdated).to.be.calledWithMatch({stackIndex: 123});
     });
+
+    it('sends invalid data', () => {
+      onHistoryPopped({invalid: 'data'});
+      expect(onStateUpdated).to.not.be.called;
+    });
   });
 });
 


### PR DESCRIPTION
Also includes minor fix for runtime error due to `amp-state[src]` mutations with non-primitives.

/to @jridgewell 