### PR TITLE
🐛Fix facebook loader for comments, page.

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -246,7 +246,6 @@ exports.rules = [
       // Facebook components
       'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/0.1/facebook-loader.js',
       'extensions/amp-facebook-comments/0.1/amp-facebook-comments.js->extensions/amp-facebook/0.1/facebook-loader.js',
-      'extensions/amp-facebook-page/0.1/amp-facebook-page.js->extensions/amp-facebook/0.1/facebook-loader.js',
 
       // Amp geo in group enum
       'extensions/amp-consent/0.1/amp-consent.js->extensions/amp-geo/0.1/amp-geo-in-group.js',

--- a/build-system/sources.js
+++ b/build-system/sources.js
@@ -98,6 +98,8 @@ const CLOSURE_SRC_GLOBS = [
   'extensions/amp-experiment/**/*.js',
   // Needed to access form impl from other extensions
   'extensions/amp-form/**/*.js',
+  // Needed by amp-facebook-* for the loader logo
+  'extensions/amp-facebook/0.1/facebook-loader.js',
   // Needed to access inputmask impl from other extensions
   'extensions/amp-inputmask/**/*.js',
   // Needed for AccessService


### PR DESCRIPTION
- Add facebook loader as a source since it is needed by
amp-facebook-page and amp-facebook-comments.
- Remove duplicate dep-check-config entry.

Fixes #24253

