### PR TITLE
🏗 Fix karma sauce timeouts on Travis

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -305,7 +305,7 @@ module.exports = {
   // karma-sauce-launcher.
   // See https://github.com/karma-runner/karma-sauce-launcher/pull/161.
   browserDisconnectTimeout: 15 * 60 * 1000,
-  browserNoActivityTimeout: 15 * 60 * 1000,
+  browserNoActivityTimeout: 30 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -305,7 +305,7 @@ module.exports = {
   // karma-sauce-launcher.
   // See https://github.com/karma-runner/karma-sauce-launcher/pull/161.
   browserDisconnectTimeout: 15 * 60 * 1000,
-  browserNoActivityTimeout: 30 * 1000,
+  browserNoActivityTimeout: 2 * 60 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,


### PR DESCRIPTION
Attempt to fix_ https://github.com/ampproject/amphtml/issues/24286 by setting karma's `browserNoActivityTimeout` to 30s.

Right now `browserNoActivityTimeout` is set to 15 min. Which means if a browser stopped sending messaged to karma, karma would wait 15 minutes before disconnecting itself and retrying.
Travis VMs will time out after 10 minutes so we're not actually letting karma disconnect and reconnect.

Also `browserDisconnectTimeout` is set to 15 min but I'm not sure this is the issue.