### PR TITLE
🐛 Fix regression for analytics with custom event name

### DIFF
--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -311,7 +311,6 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     if (eventReceived == 'analytics') {
       const spec = devAssert(data['analytics']);
-
       this.dispatchCustomAnalyticsEvent_(spec['eventType'], spec['vars']);
       return;
     }

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -16,7 +16,6 @@
 import {Deferred} from '../../../src/utils/promise';
 import {
   MIN_VISIBILITY_RATIO_FOR_AUTOPLAY,
-  VideoAnalyticsEvents,
   VideoEvents,
 } from '../../../src/video-interface';
 import {
@@ -336,10 +335,13 @@ class AmpVideoIframe extends AMP.BaseElement {
       ANALYTICS_EVENT_TYPE_PREFIX
     );
 
-    this.element.dispatchCustomEvent(VideoAnalyticsEvents.CUSTOM, {
-      eventType,
-      vars,
-    });
+    this.element.dispatchCustomEvent(
+      VideoEvents.CUSTOM_TICK,
+      dict({
+        'eventType': eventType,
+        'vars': vars,
+      })
+    );
   }
 
   /**

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -16,10 +16,7 @@
 
 import '../amp-video-iframe';
 import {Services} from '../../../../src/services';
-import {
-  VideoAnalyticsEvents,
-  VideoEvents,
-} from '../../../../src/video-interface';
+import {VideoEvents} from '../../../../src/video-interface';
 import {
   addAttributesToElement,
   whenUpgradedToCustomElement,
@@ -353,7 +350,7 @@ describes.realWin(
           if (accept) {
             const expectedEventVars = {eventType, vars: vars || {}};
             const expectedDispatch = dispatch.withArgs(
-              VideoAnalyticsEvents.CUSTOM,
+              VideoEvents.CUSTOM_TICK,
               expectedEventVars
             );
             implementation_.onMessage_({data});
@@ -362,8 +359,8 @@ describes.realWin(
             allowConsoleError(() => {
               expect(() => implementation_.onMessage_({data})).to.throw();
             });
-            expect(dispatch.withArgs(VideoAnalyticsEvents.CUSTOM, any)).to.not
-              .have.been.called;
+            expect(dispatch.withArgs(VideoEvents.CUSTOM_TICK, any)).to.not.have
+              .been.called;
           }
         });
       });

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -30,6 +30,7 @@ import {
   VideoEvents,
   VideoServiceSignals,
   userInteractedWith,
+  videoAnalyticsCustomEventTypeKey,
 } from '../video-interface';
 import {Services} from '../services';
 import {VideoSessionManager} from './video-session-manager';
@@ -522,7 +523,7 @@ class VideoEntry {
    * @param {!Object<string, string>} vars
    */
   logCustomAnalytics_(eventType, vars) {
-    const prefixedVars = dict({'customEventType': eventType});
+    const prefixedVars = {[videoAnalyticsCustomEventTypeKey]: eventType};
 
     Object.keys(vars).forEach(key => {
       prefixedVars[`custom_${key}`] = vars[key];

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -475,14 +475,16 @@ class VideoEntry {
       analyticsEvent(this, VideoAnalyticsEvents.AD_END)
     );
 
-    listen(video.element, VideoAnalyticsEvents.CUSTOM, e => {
+    listen(video.element, VideoEvents.CUSTOM_TICK, e => {
       const data = getData(e);
       const eventType = data['eventType'];
-      const vars = data['vars'];
-      this.logCustomAnalytics_(
-        dev().assertString(eventType, '`eventType` missing'),
-        vars
-      );
+      if (!eventType) {
+        // CUSTOM_TICK is a generic event for 3p players whose semantics
+        // don't fit with other video events.
+        // If `eventType` is unset, it's not meant for analytics.
+        return;
+      }
+      this.logCustomAnalytics_(eventType, data['vars']);
     });
 
     video
@@ -520,13 +522,13 @@ class VideoEntry {
    * @param {!Object<string, string>} vars
    */
   logCustomAnalytics_(eventType, vars) {
-    const prefixedVars = {};
+    const prefixedVars = dict({'customEventType': eventType});
 
     Object.keys(vars).forEach(key => {
       prefixedVars[`custom_${key}`] = vars[key];
     });
 
-    analyticsEvent(this, eventType, prefixedVars);
+    analyticsEvent(this, VideoAnalyticsEvents.CUSTOM, prefixedVars);
   }
 
   /** Listens for signals to delegate autoplay to a different module. */
@@ -1528,7 +1530,7 @@ export class AnalyticsPercentageTracker {
 
 /**
  * @param {!VideoEntry} entry
- * @param {!VideoAnalyticsEvents|string} eventType
+ * @param {!VideoAnalyticsEvents} eventType
  * @param {!Object<string, string>=} opt_vars A map of vars and their values.
  * @private
  */

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -497,6 +497,13 @@ export const VideoAnalyticsEvents = {
 };
 
 /**
+ * This key can't predictably collide with custom var names as defined in
+ * analytics user configuration.
+ * @type {string}
+ */
+export const videoAnalyticsCustomEventTypeKey = '__amp:eventType';
+
+/**
  * Helper union type to be used internally, so that the compiler treats
  * `VideoInterface` objects as `BaseElement`s, which they should be anyway.
  *

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -350,6 +350,15 @@ export const VideoEvents = {
    * @event ad_end
    */
   AD_END: 'ad_end',
+
+  /**
+   * A 3p video player can send signals for analytics whose meaning doesn't
+   * fit for other events. In this case, a `tick` event is sent with additional
+   * information in its data property.
+   *
+   * @event amp:video:tick
+   */
+  CUSTOM_TICK: 'amp:video:tick',
 };
 
 /** @typedef {string} */

--- a/test/manual/amp-video.amp.html
+++ b/test/manual/amp-video.amp.html
@@ -246,7 +246,7 @@
             "request": "event",
             "selector": "#my-video",
             "vars": {
-              "eventType": "video-custom"
+              "eventType": "video-custom-foo"
             }
           }
         }


### PR DESCRIPTION
Borked this feature during review for #18869, as custom event names were introduced per request.

Fixes by introducing an intermediate signal rather than overriding the event dispatched.

`VideoEventTracker` for analytics only knows how to listen to a finite set of signals, so it's simpler to "redefine" the event type for user configuration on the analytics end.

Fixes #22665