### PR TITLE
Add a link to analytics blogpost on amp.dev

### DIFF
--- a/extensions/amp-story/amp-story-analytics.md
+++ b/extensions/amp-story/amp-story-analytics.md
@@ -16,6 +16,8 @@ limitations under the License.
 
 # AMP Story and Analytics
 
+This document details triggers associated with AMP Stories. If you're looking for a guide to setting up analytics for your AMP pages, see [this blog post](https://blog.amp.dev/2019/08/28/analytics-for-your-amp-stories/)
+
 ## Story triggers
 
 `amp-story` issues events for changes of state. These events can be reported through the analytics configuration by using triggers.


### PR DESCRIPTION
This doc shows up as the first result on SERP for [amp story analytics]. Adding a link to the user-friendly blogpost.