### PR TITLE
Log karma browser errors as a warning

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -218,7 +218,7 @@ function karmaBrowsersReady() {
 }
 
 function karmaBrowserError(browser, error) {
-  console.log('\n');
+  console./*OK*/ log('\n');
   log(yellow(`WARNING: Error detected with ${browser}`));
   log(yellow(JSON.stringify(error)));
 }

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -217,6 +217,12 @@ function karmaBrowsersReady() {
   log(green('Done. Running tests...'));
 }
 
+function karmaBrowserError(browser, error) {
+  console.log('\n');
+  log(yellow(`WARNING: Error detected with ${browser}`));
+  log(yellow(JSON.stringify(error)));
+}
+
 function karmaRunStart() {
   if (!argv.saucelabs) {
     log(green('Running tests locally...'));
@@ -377,6 +383,7 @@ async function createKarmaServer(
     .on('browsers_ready', () => karmaBrowsersReady())
     .on('browser_start', browser => karmaBrowserStart(browser))
     .on('browser_complete', browser => karmaBrowserComplete(browser))
+    .on('browser_error', (browser, error) => karmaBrowserError(browser, error))
     .on('run_complete', runCompleteFn);
 
   karmaServer.start();


### PR DESCRIPTION
Follow up to https://github.com/ampproject/amphtml/pull/24323 where we're still seeing Travis VMs time out. This PR just adds logging to when a browser error occurs with karma.