### PR TITLE
Add environment variable to RTV experiment

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -4,6 +4,7 @@
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
     "expirationDateUTC": "2019-09-08",
+    "environment": "web",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"
   },
   "experimentB": {
@@ -11,6 +12,7 @@
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=_RTVEXP_INABOX_LITE",
     "issue": "https://github.com/ampproject/amphtml/issues/22867",
     "expirationDateUTC": "2019-10-10",
+    "environment": "inabox",
     "defineExperimentConstant": "_RTVEXP_INABOX_LITE"
   },
   "experimentC": {}


### PR DESCRIPTION
`environment` is used to determine whether to enable this experiment branch for inabox and/or web during promotion.

@danielrozenberg I believe the names need to be lowercase. Am I wrong?