### PR TITLE
Add environment type to experiment config

### DIFF
--- a/build-system/global-configs/README.md
+++ b/build-system/global-configs/README.md
@@ -8,6 +8,7 @@ besides 1 or 0.
 # experiments-config.json
 
 - `name`: Experiment name
+- `environment`: Specify the type of environment the experiment runs. Only support `AMP` and `INABOX`.
 - `command`: Command used to build the experiment
 - `issue`: The issue tracker URL for this experiment
 - `expirationDateUTC`: The experiment expiration date in YYYY-MM-DD format, in UTC. If an experiment is expired, it will fail the build process. This expiration date is only read during the build. As a result, the experiment will actually end on the following release date after the expiration.

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,6 +1,7 @@
 {
   "experimentA": {
     "name": "ANALYTICS_VENDOR_SPLIT",
+    "environment": "AMP",
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
     "expirationDateUTC": "2019-09-08",
@@ -8,6 +9,7 @@
   },
   "experimentB": {
     "name": "INABOX_LITE",
+    "environment": "INABOX",
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=_RTVEXP_INABOX_LITE",
     "issue": "https://github.com/ampproject/amphtml/issues/22867",
     "expirationDateUTC": "2019-10-10",


### PR DESCRIPTION
As we agreed added two types of experiment environment. Or maybe `type` is a better name?

@estherkim I don't know if it matters. But do you think we should run integration test for experiment that's only built for inabox?  

Thanks.