### PR TITLE
🏗 Increase duration for which Sauce VMs are allowed to run tests

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -28,12 +28,12 @@ const COMMON_CHROME_FLAGS = [
   '--autoplay-policy=no-user-gesture-required',
 ];
 
-// Reduces the odds of Sauce labs timing out during tests. See #16135.
+// Reduces the odds of Sauce labs timing out during tests. See #16135 and #24286.
 // Reference: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
 const SAUCE_TIMEOUT_CONFIG = {
   maxDuration: 10 * 60,
   commandTimeout: 10 * 60,
-  idleTimeout: 5 * 60,
+  idleTimeout: 10 * 60,
 };
 
 const BABELIFY_CONFIG = Object.assign(


### PR DESCRIPTION
Recently, there have been a spate of Travis timeouts due to tests taking too long on Sauce labs. This is correlated to the fact that we've recently started running more tests on Chrome, and they sometimes take > 5 mins total.

For example, here's info from the Sauce Labs failure corresponding to [this](https://travis-ci.org/ampproject/amphtml/jobs/581290688) build:

![image](https://user-images.githubusercontent.com/26553114/64370843-43034f80-cfed-11e9-9225-6cee3b552b9a.png)

This PR increases the `idleTimeout` value to 10 mins, to allow tests to run for that long before timing out.

Possible fix for #24286