### PR TITLE
Re-enable amp-story-consent percy tests.

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-consent.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.html
@@ -49,7 +49,7 @@
             {
               "consents": {
                 "myConsent": {
-                  "checkConsentHref": "https://ampbyexample.com/samples_templates/consent/getConsent",
+                  "checkConsentHref": "http://localhost:8000/get-consent-v1",
                   "promptUI": "consentUI"
                 }
               }

--- a/examples/visual-tests/amp-story/amp-story-consent.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.rtl.html
@@ -49,7 +49,7 @@
             {
               "consents": {
                 "myConsent": {
-                  "checkConsentHref": "https://ampbyexample.com/samples_templates/consent/getConsent",
+                  "checkConsentHref": "http://localhost:8000/get-consent-v1",
                   "promptUI": "consentUI"
                 }
               }

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -364,8 +364,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/456056607#L640
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent",
       "viewport": {"width": 320, "height": 480},
@@ -470,8 +468,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/478011222#L634
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -528,8 +524,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/456056607#L640
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -559,8 +553,6 @@
       ]
     },
     {
-      "flaky": true,
-      // See https://travis-ci.org/ampproject/amphtml/jobs/456056607#L640
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},


### PR DESCRIPTION
Re-enable `amp-story-consent` percy tests.

Let's see how that goes. I've done some testing and see no no reason why this one would flake.

Fixes #23987