### PR TITLE
🏗 Remove unnecessary `process.env` references in `build-system/`

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -148,7 +148,6 @@ VideoAnalyticsDetailsDef.prototype.width;
 var process = {};
 process.env;
 process.env.NODE_ENV;
-process.env.SERVE_MODE;
 
 /** @type {boolean|undefined} */
 window.IS_AMP_ALT;

--- a/build-system/server/amp4test.js
+++ b/build-system/server/amp4test.js
@@ -18,20 +18,15 @@
 const app = require('express').Router();
 const cors = require('./amp-cors');
 const minimist = require('minimist');
-const argv = minimist(process.argv.slice(2), {
-  boolean: ['strictBabelTransform'],
-});
-const multer = require('multer');
+const argv = minimist(process.argv.slice(2));
 const path = require('path');
+const upload = require('multer')();
 const {renderShadowViewer} = require('./shadow-viewer');
-const {replaceUrls} = require('./app-utils');
-const upload = multer();
-
-/* eslint-disable max-len */
+const {replaceUrls, getServeMode} = require('./app-utils');
 
 const KARMA_SERVER_PORT = 9876;
-const {SERVE_MODE} = process.env;
 const CUSTOM_TEMPLATES = ['amp-mustache'];
+const SERVE_MODE = getServeMode();
 
 /**
  * Logs the given messages to the console when --verbose is specified.
@@ -48,10 +43,10 @@ app.use('/compose-doc', function(req, res) {
 
   const {body, css, experiments, extensions, spec} = req.query;
 
-  const compiled = process.env.SERVE_MODE == 'compiled';
-  const frameHtml = compiled
-    ? 'dist.3p/current-min/frame.html'
-    : 'dist.3p/current/frame.max.html';
+  const frameHtml =
+    SERVE_MODE == 'compiled'
+      ? 'dist.3p/current-min/frame.html'
+      : 'dist.3p/current/frame.max.html';
 
   let experimentsBlock = '';
   if (experiments) {
@@ -244,7 +239,7 @@ app.get('/a4a/:bid', (req, res) => {
 function composeDocument(config) {
   const {body, css, extensions, head, spec, mode} = config;
 
-  const m = mode || process.env.SERVE_MODE;
+  const m = mode || SERVE_MODE;
   const cdn = m === 'cdn';
   const compiled = m === 'compiled';
 

--- a/build-system/server/app-index/index.js
+++ b/build-system/server/app-index/index.js
@@ -25,10 +25,9 @@ const {
   isMainPageFromUrl,
   formatBasepath,
 } = require('./util/listing');
+const {getServeMode} = require('../app-utils');
 const {join} = require('path');
 const {renderTemplate} = require('./template');
-
-const pc = process;
 
 // Sitting on /build-system/server/app-index, so we go back thrice for the repo root.
 const root = path.join(__dirname, '../../../');
@@ -51,7 +50,7 @@ async function serveIndex({url}, res, next) {
     selectModePrefix: '/',
     isMainPage: isMainPageFromUrl(url),
     basepath: formatBasepath(mappedPath),
-    serveMode: pc.env.SERVE_MODE || 'default',
+    serveMode: getServeMode(),
     css,
   });
 

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -14,6 +14,33 @@
  * limitations under the License.
  */
 
+const minimist = require('minimist');
+
+/**
+ * Determines the server's mode based on command line arguments.
+ * @return {string}
+ */
+function getServeMode() {
+  const argv = minimist(process.argv.slice(2), {string: ['rtv']});
+  if (argv.compiled) {
+    return 'compiled';
+  }
+  if (argv.cdn) {
+    return 'cdn';
+  }
+  if (argv.rtv != undefined) {
+    const {rtv} = argv;
+    if (isRtvMode(rtv)) {
+      return 'rtv';
+    } else {
+      const err = new Error(`Invalid rtv: ${rtv}. (Must be 15 digits long.)`);
+      err.showStack = false;
+      throw err;
+    }
+  }
+  return 'default';
+}
+
 /**
  * @param {string} serveMode
  * @return {boolean}
@@ -117,4 +144,8 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
   return file;
 };
 
-module.exports = {replaceUrls, isRtvMode};
+module.exports = {
+  isRtvMode,
+  replaceUrls,
+  getServeMode,
+};

--- a/build-system/server/app-video-testbench.js
+++ b/build-system/server/app-video-testbench.js
@@ -20,6 +20,7 @@ const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));
 const {JSDOM} = require('jsdom');
 const {replaceUrls} = require('./app-utils');
+const {getServeMode} = require('./app-utils');
 
 const sourceFile = 'test/manual/amp-video.amp.html';
 
@@ -366,7 +367,6 @@ function isValidExtension(extension) {
 
 
 function runVideoTestBench(req, res, next) {
-  const mode = process.env.SERVE_MODE;
   fs.readFileAsync(sourceFile).then(contents => {
     const dom = new JSDOM(contents);
     const {window} = dom;
@@ -394,7 +394,7 @@ function runVideoTestBench(req, res, next) {
 
     appendClientScript(doc);
 
-    return res.end(replaceUrls(mode, dom.serialize()));
+    return res.end(replaceUrls(getServeMode(), dom.serialize()));
   }).error(() => {
     next();
   });

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -18,8 +18,7 @@ const app = require('express').Router();
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));
 const request = require('request');
-const {getServeMode} = require('../app-utils');
-const {replaceUrls} = require('../app-utils');
+const {getServeMode, replaceUrls} = require('../app-utils');
 
 // In-a-box envelope.
 // Examples:

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -18,8 +18,8 @@ const app = require('express').Router();
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs'));
 const request = require('request');
+const {getServeMode} = require('../app-utils');
 const {replaceUrls} = require('../app-utils');
-const {SERVE_MODE} = process.env;
 
 // In-a-box envelope.
 // Examples:
@@ -78,7 +78,7 @@ app.use('/a4a(|-3p)/', (req, res) => {
     const content = fillTemplate(template, url.href, req.query)
       .replace(/CHECKSIG/g, force3p || '')
       .replace(/DISABLE3PFALLBACK/g, !force3p);
-    res.end(replaceUrls(SERVE_MODE, content));
+    res.end(replaceUrls(getServeMode(), content));
   });
 });
 

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -216,10 +216,7 @@ function lint() {
   }
   if (argv.files) {
     setFilesToLint(argv.files.split(','));
-  } else if (
-    !eslintRulesChanged() &&
-    (process.env.LOCAL_PR_CHECK || argv.local_changes)
-  ) {
+  } else if (!eslintRulesChanged() && argv.local_changes) {
     const jsFiles = jsFilesChanged();
     if (jsFiles.length == 0) {
       log(colors.green('INFO: ') + 'No JS files in this PR');

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -254,11 +254,6 @@ class RuntimeTestRunner {
   }
 
   async setup() {
-    // Run tests against compiled code when explicitly specified via --compiled,
-    // or when the minified runtime is automatically built.
-    process.env.SERVE_MODE =
-      argv.compiled || !argv.nobuild ? 'compiled' : 'default';
-
     await this.maybeBuild();
     await startServer({
       name: 'AMP Test Server',

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -38,7 +38,7 @@ let url = '';
 const serverFiles = deglob.sync(['build-system/server/**']);
 
 /**
- * Determines the server's mode based on command line arguments.
+ * Logs the server's mode (based on command line arguments).
  */
 function logServeMode() {
   switch (getServeMode()) {

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -30,7 +30,7 @@ const {
 } = require('../server/lazy-build');
 const {createCtrlcHandler} = require('../ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
-const {isRtvMode} = require('../server/app-utils');
+const {getServeMode} = require('../server/app-utils');
 
 // Used for logging during server start / stop.
 let url = '';
@@ -40,24 +40,19 @@ const serverFiles = deglob.sync(['build-system/server/**']);
 /**
  * Determines the server's mode based on command line arguments.
  */
-function setServeMode() {
-  if (argv.compiled) {
-    process.env.SERVE_MODE = 'compiled';
-    log(green('Serving'), cyan('minified JS'));
-  } else if (argv.cdn) {
-    process.env.SERVE_MODE = 'cdn';
-    log(green('Serving'), cyan('current prod JS'));
-  } else if (argv.rtv_serve_mode) {
-    const rtv = argv.rtv_serve_mode;
-    if (isRtvMode(rtv)) {
-      process.env.SERVE_MODE = rtv;
-      log(green('Serving'), cyan(`RTV ${rtv} JS`));
-    } else {
-      throw new Error(`Invalid rtv_serve_mode: ${rtv}`);
-    }
-  } else {
-    process.env.SERVE_MODE = 'default';
-    log(green('Serving'), cyan('unminified JS'));
+function logServeMode() {
+  switch (getServeMode()) {
+    case 'compiled':
+      log(green('Serving'), cyan('minified'), green('JS'));
+      break;
+    case 'cdn':
+      log(green('Serving'), cyan('current prod'), green('JS'));
+      break;
+    case 'rtv':
+      log(green('Serving JS from RTV'), cyan(`${argv.rtv}`));
+      break;
+    default:
+      log(green('Serving'), cyan('unminified'), green('JS'));
   }
 }
 
@@ -152,7 +147,7 @@ function initiatePreBuildSteps() {
  */
 async function serve() {
   createCtrlcHandler('serve');
-  setServeMode();
+  logServeMode();
   watch(serverFiles, restartServer);
   await startServer();
   initiatePreBuildSteps();
@@ -172,4 +167,7 @@ serve.flags = {
   'quiet': "  Run in quiet mode and don't log HTTP requests",
   'cache': '  Make local resources cacheable by the browser',
   'no_caching_extensions': '  Disable caching for extensions',
+  'compiled': '  Serve minified JS',
+  'cdn': '  Serve current prod JS',
+  'rtv': '  Serve JS from the RTV provided',
 };

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -134,14 +134,12 @@ function setPercyTargetCommit() {
  *     and reachable.
  */
 async function launchWebServer() {
+  const stdio = argv.webserver_debug
+    ? ['ignore', process.stdout, process.stderr]
+    : 'ignore';
   webServerProcess_ = execScriptAsync(
-    `gulp serve --compiled --host ${HOST} --port ${PORT} ` +
-      `${process.env.WEBSERVER_QUIET}`,
-    {
-      stdio: argv.webserver_debug
-        ? ['ignore', process.stdout, process.stderr]
-        : 'ignore',
-    }
+    `gulp serve --compiled --host ${HOST} --port ${PORT}`,
+    {stdio}
   );
 
   webServerProcess_.on('close', code => {
@@ -722,14 +720,9 @@ async function snapshotWebpages(percy, browser, webpages) {
  * Enables debugging if requested via command line.
  */
 function setDebuggingLevel() {
-  process.env.WEBSERVER_QUIET = '--quiet';
-
   if (argv.debug) {
     argv['chrome_debug'] = true;
     argv['webserver_debug'] = true;
-  }
-  if (argv.webserver_debug) {
-    process.env.WEBSERVER_QUIET = '';
   }
 }
 
@@ -885,11 +878,11 @@ visualDiff.description = 'Runs the AMP visual diff tests.';
 visualDiff.flags = {
   'master': '  Includes a blank snapshot (baseline for skipped builds)',
   'empty': '  Creates a dummy Percy build with only a blank snapshot',
-  'chrome_debug': '  Prints debug info from Chrome',
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
+  'chrome_debug': '  Prints debug info from Chrome',
   'webserver_debug': '  Prints debug info from the local gulp webserver',
-  'debug': '  Prints all the above debug info',
+  'debug': '  Prints debug info from Chrome and the local gulp webserver',
   'grep': '  Runs tests that match the pattern',
   'percy_project': '  Override the PERCY_PROJECT environment variable',
   'percy_token': '  Override the PERCY_TOKEN environment variable',


### PR DESCRIPTION
With #24325, `gulp serve` was re-implemented as an in-process server. As a result, the following instances of cross-process message passing via `process.env` in `build-system/` can be removed:

- `process.env.LOCAL_PR_CHECK` (not used anywhere)
- `process.env.WEBSERVER_QUIET` (replaced by `webserver_debug`)
- `process.env.SERVE_MODE` (replaced by `getServeMode()`)

Follow up to #24325
Related to #24141