### PR TITLE
🏗 Lazy build by default during `gulp` and replace `--lazy_build` with `--eager_build`

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const log = require('fancy-log');
 const {
   doBuildExtension,
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
-const {cyan, green} = require('ansi-colors');
 const {doBuildJs} = require('../tasks/helpers');
 const {jsBundles} = require('../../bundles.config');
 
@@ -103,11 +101,9 @@ exports.preBuildCoreRuntime = function() {
 /**
  * Pre-builds some extensions (requested via command line flags) and returns
  * immediately so that the user can start using the webserver.
- * @param {!Object} argv
  */
-exports.preBuildSomeExtensions = function(argv) {
-  const extensions = getExtensionsToBuild(argv);
-  log(green('Pre-building extensions:'), cyan(extensions.join(', ')));
+exports.preBuildSomeExtensions = function() {
+  const extensions = getExtensionsToBuild();
   for (const extensionBundle in extensionBundles) {
     const extension = extensionBundles[extensionBundle].name;
     if (extensions.includes(extension) && !extensionBundle.endsWith('latest')) {

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -76,7 +76,7 @@ function printDefaultTaskHelp() {
 }
 
 /**
- * Performs pre-requisite build steps
+ * Performs the pre-requisite build steps for gulp, gulp build, and gulp watch
  * @param {boolean} watch
  * @return {!Promise}
  */

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -34,13 +34,12 @@ const {serve} = require('./serve');
 
 /**
  * Enables watching for file changes in css, extensions.
- * @param {boolean} defaultTask
  * @return {!Promise}
  */
-async function watch(defaultTask) {
+async function watch() {
   maybeUpdatePackages();
   createCtrlcHandler('watch');
-  return performBuild(/* watch */ true, defaultTask);
+  return performBuild(/* watch */ true);
 }
 
 /**
@@ -62,54 +61,44 @@ function printDefaultTaskHelp() {
   const defaultTaskMessage =
     green('⤷ JS and extensions will be ') +
     green(
-      argv.lazy_build
-        ? 'lazily built when requested from the server.'
-        : 'built after server startup.'
+      argv.eager_build
+        ? 'built after server startup.'
+        : 'lazily built when requested from the server.'
     );
   log(defaultTaskMessage);
-  if (!argv.lazy_build) {
-    const lazyBuildMessage =
+  if (!argv.eager_build) {
+    const eagerBuildMessage =
       green('⤷ Use ') +
-      cyan('--lazy_build ') +
-      green('to lazily build JS and extensions ') +
-      green('when requested from the server.');
-    log(lazyBuildMessage);
-  } else if (!argv.extensions && !argv.extensions_from) {
-    const extensionsMessage =
-      green('⤷ Use ') +
-      cyan('--extensions ') +
-      green('or ') +
-      cyan('--extensions_from ') +
-      green('to pre-build some extensions.');
-    log(extensionsMessage);
+      cyan('--eager_build ') +
+      green('to build JS and extensions after server startup.');
+    log(eagerBuildMessage);
   }
 }
 
 /**
- * Performs the build steps for gulp, gulp build, and gulp watch
+ * Performs pre-requisite build steps
  * @param {boolean} watch
- * @param {boolean} defaultTask
  * @return {!Promise}
  */
-async function performBuild(watch, defaultTask) {
+async function performPrerequisiteSteps(watch) {
+  await compileCss(watch);
+  await compileJison();
+  await bootstrapThirdPartyFrames(watch);
+}
+
+/**
+ * Performs the build steps for gulp build and gulp watch
+ * @param {boolean} watch
+ * @return {!Promise}
+ */
+async function performBuild(watch) {
   process.env.NODE_ENV = 'development';
   printNobuildHelp();
-  printConfigHelp(defaultTask ? 'gulp' : watch ? 'gulp watch' : 'gulp build');
-  if (defaultTask) {
-    printDefaultTaskHelp();
-  }
-  if (!argv.lazy_build) {
-    parseExtensionFlags();
-  }
-  await Promise.all([
-    compileCss(watch),
-    compileJison(),
-    bootstrapThirdPartyFrames(watch),
-  ]);
-  if (!defaultTask) {
-    await compileAllUnminifiedJs(watch);
-    await buildExtensions({watch});
-  }
+  printConfigHelp(watch ? 'gulp watch' : 'gulp build');
+  parseExtensionFlags();
+  await performPrerequisiteSteps(watch);
+  await compileAllUnminifiedJs(watch);
+  await buildExtensions({watch});
   if (isTravisBuild()) {
     // New line after all the compilation progress dots on Travis.
     console.log('\n');
@@ -118,15 +107,22 @@ async function performBuild(watch, defaultTask) {
 
 /**
  * The default task run when `gulp` is executed
+ * @return {!Promise}
  */
 async function defaultTask() {
-  await watch(/* defaultTask */ true);
+  maybeUpdatePackages();
+  createCtrlcHandler('gulp');
+  process.env.NODE_ENV = 'development';
+  printConfigHelp('gulp');
+  printDefaultTaskHelp();
+  parseExtensionFlags(/* preBuild */ !argv.eager_build);
+  await performPrerequisiteSteps(/* watch */ true);
   await serve();
-  if (argv.lazy_build) {
+  if (!argv.eager_build) {
     log(green('JS and extensions will be lazily built when requested...'));
   } else {
     log(green('Building JS and extensions...'));
-    await compileAllUnminifiedJs(watch);
+    await compileAllUnminifiedJs(/* watch */ true);
     await buildExtensions({watch: true});
   }
 }
@@ -156,10 +152,11 @@ watch.flags = {
   noextensions: '  Watches and builds with no extensions.',
 };
 
-defaultTask.description = 'Runs "watch" and then "serve"';
+defaultTask.description =
+  'Starts the dev server and lazily builds JS and extensions when requested';
 defaultTask.flags = {
-  lazy_build:
-    '  Lazily builds JS and extensions when they are requested from the server',
+  eager_build:
+    '  Starts the dev server and builds JS and extensions after server startup',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -68,7 +68,7 @@ function getMiddleware() {
   if (argv.cache) {
     middleware.push(header({'cache-control': 'max-age=600'}));
   }
-  if (!argv.eager_build) {
+  if (!argv._.includes('serve') && !argv.eager_build) {
     middleware.push(lazyBuildExtensions);
     middleware.push(lazyBuildJs);
   }
@@ -134,7 +134,7 @@ function restartServer() {
  * Initiates pre-build steps requested via command line args.
  */
 function initiatePreBuildSteps() {
-  if (!argv.eager_build) {
+  if (!argv._.includes('serve') && !argv.eager_build) {
     preBuildCoreRuntime();
     if (argv.extensions || argv.extensions_from) {
       preBuildSomeExtensions();

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -68,7 +68,7 @@ function getMiddleware() {
   if (argv.cache) {
     middleware.push(header({'cache-control': 'max-age=600'}));
   }
-  if (argv.lazy_build) {
+  if (!argv.eager_build) {
     middleware.push(lazyBuildExtensions);
     middleware.push(lazyBuildJs);
   }
@@ -134,10 +134,10 @@ function restartServer() {
  * Initiates pre-build steps requested via command line args.
  */
 function initiatePreBuildSteps() {
-  if (argv.lazy_build) {
+  if (!argv.eager_build) {
     preBuildCoreRuntime();
     if (argv.extensions || argv.extensions_from) {
-      preBuildSomeExtensions(argv);
+      preBuildSomeExtensions();
     }
   }
 }

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -205,9 +205,9 @@ Now whenever you're ready to build amphtml and start up your local server, simpl
 gulp
 ```
 
-Running the `gulp` command will compile the code and start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000)
+Running the `gulp` command will start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000).
 
-You can browse the [http://localhost:8000/examples](http://localhost:8000/examples) directory to see some demo pages for various AMP components and combination of components.
+You can browse the [http://localhost:8000/examples](http://localhost:8000/examples) directory to see some demo pages for various AMP components and combination of components. When a page is visited, the JS files and extensions used by the page will get lazily built and served.
 
 Note that by default each of the pages in the /examples directory uses the unminified AMP JavaScript from your local server. You can also change which JS to load from local server by hitting the `/serve_mode=<mode>` endpoint:
 


### PR DESCRIPTION
**PR Highlights:**
- Makes lazy building the default behavior of `gulp`
- Adds the `--eager_build` flag which eagerly builds all JS files and extensions after server startup
- Cleans up code that passed `argv` to `preBuildSomeExtensions()` (unnecessary after #24325)
- Moves the `if (lazyBuild)` blocks in `performBuild()` to `defaultTask()`
- Updates `parseExtensionFlags()` to distinguish between lazy and eager building
- Removes the outdated `--extensions=minimal_set` in favor of the always up to date `--extensions_from=examples/article.amp.html`
- Updates developer docs to describe the new behavior of `gulp`

**Usage:**

```js
// Lazily build all JS and extensions
gulp

//  Eagerly build amp-foo and amp-bar, lazily build the rest
gulp --extensions=amp-foo,amp-bar

//  Eagerly build extensions used by examples/foo.amp.html, lazily build the rest
gulp --extensions_from=examples/foo.amp.html

// Eagerly build all JS and extensions
gulp --eager_build
```

Fixes #24141

