### PR TITLE
🐛 Ensure amp-mustache is version locked to v0.js

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -20,7 +20,6 @@ import {CommonSignals} from './common-signals';
 import {
   LogLevel, // eslint-disable-line no-unused-vars
   dev,
-  devAssert,
   initLogConstructor,
   overrideLogLevel,
   setReportError,
@@ -878,22 +877,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
   if (internalRuntimeVersion() == v) {
     return false;
   }
-  // The :not is an extra prevention of recursion because it will be
-  // added to script tags that go into the code path below.
-  const scriptInHead = win.document.head./*OK*/ querySelector(
-    `[custom-element="${fnOrStruct.n}"]:not([i-amphtml-inserted])`
-  );
-  devAssert(
-    scriptInHead,
-    'Expected to find script for extension: %s',
-    fnOrStruct.n
-  );
-  if (!scriptInHead) {
-    return false;
-  }
-  // Mark the element as being replaced, so that the installExtension code
-  // assumes it as not-present.
-  Services.extensionsFor(win).reloadExtension(fnOrStruct.n, scriptInHead);
+  Services.extensionsFor(win).reloadExtension(fnOrStruct.n);
   return true;
 }
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -239,17 +239,30 @@ export class Extensions {
   /**
    * Reloads the new version of the extension.
    * @param {string} extensionId
-   * @param {!Element} oldScriptElement
    * @return {!Promise<!ExtensionDef>}
    */
-  reloadExtension(extensionId, oldScriptElement) {
+  reloadExtension(extensionId) {
+    const attribute = isTemplateExtension(extensionId)
+      ? 'custom-element'
+      : 'custom-template';
+    // The :not is an extra prevention of recursion because it will be
+    // added to script tags that go into the code path below.
+    const oldScriptElement = this.win.document.head./*OK*/ querySelector(
+      `[${attribute}="${extensionId}"]:not([i-amphtml-inserted])`
+    );
+    devAssert(
+      oldScriptElement,
+      'Expected to find script for extension: %s',
+      extensionId
+    );
+
     // "Disconnect" the old script element and extension record.
     const holder = this.extensions_[extensionId];
     if (holder) {
       devAssert(!holder.loaded && !holder.error);
       delete this.extensions_[extensionId];
     }
-    oldScriptElement.removeAttribute('custom-element');
+    oldScriptElement.removeAttribute(attribute);
     oldScriptElement.setAttribute('i-amphtml-loaded-new-version', extensionId);
     const urlParts = parseExtensionUrl(oldScriptElement.src);
     return this.preloadExtension(extensionId, urlParts.extensionVersion);
@@ -511,8 +524,11 @@ export class Extensions {
       return false;
     }
     if (holder.scriptPresent === undefined) {
+      const attribute = isTemplateExtension(extensionId)
+        ? 'custom-element'
+        : 'custom-template';
       const scriptInHead = this.win.document.head./*OK*/ querySelector(
-        `[custom-element="${extensionId}"]`
+        `[${attribute}="${extensionId}"]`
       );
       holder.scriptPresent = !!scriptInHead;
     }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -243,8 +243,8 @@ export class Extensions {
    */
   reloadExtension(extensionId) {
     const attribute = isTemplateExtension(extensionId)
-      ? 'custom-element'
-      : 'custom-template';
+      ? 'custom-template'
+      : 'custom-element';
     // The :not is an extra prevention of recursion because it will be
     // added to script tags that go into the code path below.
     const oldScriptElement = this.win.document.head./*OK*/ querySelector(
@@ -525,8 +525,8 @@ export class Extensions {
     }
     if (holder.scriptPresent === undefined) {
       const attribute = isTemplateExtension(extensionId)
-        ? 'custom-element'
-        : 'custom-template';
+        ? 'custom-template'
+        : 'custom-element';
       const scriptInHead = this.win.document.head./*OK*/ querySelector(
         `[${attribute}="${extensionId}"]`
       );


### PR DESCRIPTION
Because `amp-mustache` is registered as `<script custom-template="amp-mustache">`, we failed to find the currently-loaded-but-incorrect-version script in `maybeLoadCorrectVersion`. Now, we defer that responsibility to the extension loader service.