### PR TITLE
✨ Adding amp-browsi extension 

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -417,6 +417,12 @@ exports.extensionBundles = [
     type: TYPES.MEDIA,
   },
   {
+    name: 'amp-browsi',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-byside-content',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/amp-browsi.amp.html
+++ b/examples/amp-browsi.amp.html
@@ -1,0 +1,694 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Browsi article test page</title>
+  <link rel="canonical" href="https://medium.com/p/cb7f223fad86">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+
+  <style amp-custom>
+    body {
+      margin: 0;
+      font-family: 'Georgia', Serif;
+      background: white;
+    }
+
+    .brand-logo {
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
+    }
+
+    .ad-container {
+      display: flex;
+      justify-content: center;
+    }
+
+    .content-container p {
+      line-height: 24px;
+    }
+
+    /* In the shadow-doc mode, the parent shell already has header and nav. */
+    .amp-shadow header {
+      display: none;
+    }
+
+    .lightbox {
+      background: #222;
+    }
+
+    .lightbox-content {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+
+      display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .lightbox-content p {
+      color: #fff;
+      padding: 15px;
+    }
+
+    .lightbox amp-img {
+      width: 100%;
+    }
+
+    figure {
+      margin: 0;
+    }
+
+    figcaption {
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
+      border-bottom: 1px solid #e2e2e2;
+      color: #6d6d6d;
+      margin-left: 20px;
+      margin-right: 20px;
+      font-size: .9em;
+      padding: 15px;
+    }
+
+    figcaption::before {
+      content: '';
+      width: 24px;
+      height: 24px;
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 5px;
+    }
+
+    figcaption.image::before {
+      background-image: url('data:image/svg+xml,<svg fill="#a9a9a9" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+    }
+
+    figcaption.video::before {
+      background-image: url('data:image/svg+xml,<svg fill="#a9a9a9" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"/></svg>');
+    }
+
+    .author {
+      display: flex;
+      align-items: center;
+
+      background: #f4f4f4;
+      padding: 0 15px;
+
+      font-size: .8em;
+
+      border: solid #dcdcdc;
+      border-width: 1px 0;
+    }
+
+    .header-time, .header-author {
+      color: #a8a3ae;
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
+      font-size: 12px;
+    }
+
+    .header-author {
+      border-right: 1px solid #d5d5d5;
+      padding-right: 10px;
+      margin-right: 10px;
+      display: inline-block;
+    }
+
+    .header-author b {
+      color: #2294dd;
+      font-weight: normal;
+    }
+
+    .author p {
+      margin: 5px;
+    }
+
+    .byline {
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
+      display: inline-block;
+    }
+
+    .byline p {
+      line-height: normal;
+    }
+
+    .byline .brand {
+      color: #6f757a;
+    }
+
+    .mailto {
+      text-decoration: none;
+    }
+
+    #author-avatar {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 5px;
+    }
+
+    h1 {
+      margin: 5px 0;
+      font-weight: normal;
+    }
+
+    footer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 226px;
+      background: #f4f4f4;
+    }
+
+    hr {
+      margin: 0;
+    }
+
+    amp-app-banner {
+      padding: 10px;
+    }
+
+    amp-app-banner .content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    amp-img {
+      background-color: #f4f4f4;
+    }
+
+    amp-app-banner amp-img {
+      background-color: transparent;
+      margin-right: 15px
+    }
+
+    amp-app-banner .description {
+      margin-right: 20px;
+    }
+
+    amp-app-banner h5 {
+      margin: 0;
+    }
+
+    amp-app-banner p {
+      font-size: 10px;
+      margin: 3px 0;
+    }
+
+    amp-app-banner .actions button {
+      padding: 5px;
+      width: 70px;
+      border: 1px solid #aaa;
+      font-size: 8px;
+      background: #fff;
+    }
+
+    amp-app-banner .actions {
+      text-align: right;
+      font-size: 14px;
+    }
+
+    amp-sidebar {
+      width: 200px;
+      background: white;
+    }
+
+    nav ul {
+      padding: 0px;
+      list-style: none;
+    }
+
+    nav li {
+      list-style: none;
+      padding: 0px;
+      padding-left: 15px;
+    }
+
+    nav li a {
+      text-decoration: none;
+      color: #666666;
+      display: block;
+      padding: 10px;
+    }
+
+    nav li.active {
+      background: #f7f7f7;
+    }
+
+    nav li.active a {
+      color: black;
+      border-right: 3px solid black;
+    }
+
+    .article-body p {
+      padding-right: 15px;
+      padding-left: 15px;
+    }
+
+    header {
+      padding: 15px;
+    }
+
+    button.menu {
+      background: transparent;
+      border: none;
+      padding: 10px;
+      padding-right: 20px;
+    }
+
+    .jump-to {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+
+    .jump-to ul a, .jump-to ol a {
+      text-decoration: none;
+      color: #2294dd;
+    }
+
+    header#top-bar {
+      background: white;
+      border-bottom: 1px solid #e2e2e2;
+    }
+
+    header#article-desc {
+      background: rgb(250, 250, 250);
+      padding: 20px;
+    }
+
+    header#article-desc h1 {
+      margin-top: 0px;
+      padding-top: 0px;
+    }
+
+    .slot-fallback {
+      padding: 16px;
+      background: #1b1b1b;
+      color: white;
+    }
+
+    #lightbox-close-btn {
+      font-family: Helvetica, sans-serif;
+      color: white;
+      position: absolute;
+      top: 0px;
+      right: 0px;
+      padding: 20px;
+    }
+  </style>
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <script async custom-element="amp-image-lightbox"
+          src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+  <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js"
+          data-amp-report-test="amp-app-banner.js"></script>
+
+  <script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js"></script>
+
+  <style amp-boilerplate>body {
+    -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+    -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+    -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+    animation: -amp-start 8s steps(1, end) 0s 1 normal both
+  }
+
+  @-webkit-keyframes -amp-start {
+    from {
+      visibility: hidden
+    }
+    to {
+      visibility: visible
+    }
+  }
+
+  @-moz-keyframes -amp-start {
+    from {
+      visibility: hidden
+    }
+    to {
+      visibility: visible
+    }
+  }
+
+  @-ms-keyframes -amp-start {
+    from {
+      visibility: hidden
+    }
+    to {
+      visibility: visible
+    }
+  }
+
+  @-o-keyframes -amp-start {
+    from {
+      visibility: hidden
+    }
+    to {
+      visibility: visible
+    }
+  }
+
+  @keyframes -amp-start {
+    from {
+      visibility: hidden
+    }
+    to {
+      visibility: visible
+    }
+  }</style>
+  <noscript>
+    <style amp-boilerplate>body {
+      -webkit-animation: none;
+      -moz-animation: none;
+      -ms-animation: none;
+      animation: none
+    }</style>
+  </noscript>
+</head>
+<body>
+<amp-browsi layout="nodisplay" pub-key="98569856" site-key="demo"></amp-browsi>
+<amp-sidebar id="sidebar" layout="nodisplay">
+  <nav>
+    <ul>
+      <li class="active">
+        <a href="#">
+          Home
+        </a>
+      </li>
+      <li><a href="#">Link 1</a></li>
+      <li><a href="#">Link 2</a></li>
+      <li><a href="#">Link 3</a></li>
+      <li><a href="#">Link 4</a></li>
+      <li><a href="#section1">Section 1</a></li>
+      <li><a href="#section2">Section 2</a></li>
+      <li><a href="#section3">Section 3</a></li>
+    </ul>
+  </nav>
+</amp-sidebar>
+<amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
+  <div class="content">
+    <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
+             width="40" height="34"></amp-img>
+    <div class="description">
+      <h5>Medium App</h5>
+      <p>Experience a richer experience on our mobile app!</p>
+    </div>
+    <div class="actions">
+      <button open-button>Open In App</button>
+    </div>
+  </div>
+</amp-app-banner>
+
+<header id="top-bar">
+  <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar">
+    ☰
+  </button>
+  <span class="brand-logo">
+      Browsi Test
+    </span>
+</header>
+
+<main role="main">
+  <article>
+    <header id="article-desc">
+      <h1 itemprop="headline">Browsi Test Article</h1>
+      <div class="header-author">
+        <amp-img src="https://picsum.photos/id/1062/20/16" id="author-avatar" placeholder
+                 height="16" width="16">
+        </amp-img>
+        by <span itemscope itemtype="http://schema.org/Person"
+                 itemprop="author"><b>Lorem Ipsum</b></span></div>
+      <time class="header-time" itemprop="datePublished"
+            datetime="2015-09-14 13:00">September 14, 2015
+      </time>
+    </header>
+    <figure>
+      <amp-img id="hero-img"
+               src="https://picsum.photos/id/1062/360/260"
+               layout="responsive" width="300" placeholder
+               alt="Picture of a dog"
+               title="Opens image in a lightbox"
+               role="button" on="tap:headline-image-lightbox"
+               height="216" tabindex="0">
+      </amp-img>
+      <figcaption class='image'>
+        Fusce pretium tempor justo, vitae.
+      </figcaption>
+    </figure>
+
+    <amp-image-lightbox id="headline-image-lightbox" layout="nodisplay"></amp-image-lightbox>
+
+    <div class="content-container">
+      <div class="jump-to">
+        <h3>Jump To</h3>
+        <ol>
+          <li><a on="tap:section1.scrollTo('position' = 'center')" href="#section1">Section 1</a></li>
+          <li><a on="tap:section2.scrollTo('position' = 'center')" href="#section2">Section 2</a></li>
+          <li><a on="tap:section3.scrollTo('position' = 'center')" href="#section3">Section 3</a></li>
+        </ol>
+      </div>
+      <div class="article-body" itemprop="articleBody">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+          luctus nunc ut elit cursus, et imperdiet diam vehicula.
+          Duis et nisi sed urna blandit bibendum et sit amet erat.
+          Suspendisse potenti. Curabitur consequat volutpat arcu nec
+          elementum. Etiam a turpis ac libero varius condimentum.
+          Maecenas sollicitudin felis aliquam tortor vulputate,
+          ac posuere velit semper.
+        </p>
+        <p>
+          Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+          ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+          et lectus. Sed tempus eget enim eget lobortis.
+          Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+          Nullam in libero nisi.
+        </p>
+
+        <div class="ad-container">
+          <!--<amp-ad width="300" height="250"-->
+          <!--type="appnexus"-->
+          <!--data-tagid="13144370">-->
+          <!--</amp-ad>-->
+          <amp-ad width="300" height="100"
+                  type="gumgum"
+                  data-zone="ggumtest"
+                  data-slot="3883">
+          </amp-ad>
+        </div>
+
+        <p>
+          Sed pharetra semper fringilla. Nulla fringilla, neque eget
+          varius suscipit, mi turpis congue odio, quis dignissim nisi
+          nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+          vel velit. Donec congue augue magna, nec eleifend dui porttitor
+          sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+          Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+          ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+          lorem ultrices nibh, in tristique mauris justo sed ante.
+          Nunc commodo purus feugiat metus bibendum consequat. Duis
+          finibus urna ut ligula auctor, sed vehicula ex aliquam.
+          Sed sed augue auctor, porta turpis ultrices, cursus diam.
+          In venenatis aliquet porta. Sed volutpat fermentum quam,
+          ac molestie nulla porttitor ac. Donec porta risus ut enim
+          pellentesque, id placerat elit ornare.
+        </p>
+
+        <figure>
+          <amp-video
+            autoplay
+            src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+            poster="https://peach.blender.org/wp-content/uploads/bbb-splash.png"
+            artwork="img/bigbuckbunny.jpg"
+            title="Big Buck Bunny"
+            album="Blender"
+            artist="Blender Foundation"
+            width="720"
+            height="405"
+            layout="responsive"
+            controls>
+          </amp-video>
+          <figcaption class='video'>
+            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          </figcaption>
+        </figure>
+
+        <p>
+          Sed pharetra semper fringilla. Nulla fringilla, neque eget
+          varius suscipit, mi turpis congue odio, quis dignissim nisi
+          nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+          vel velit. Donec congue augue magna, nec eleifend dui porttitor
+          sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+          Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+          ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+          lorem ultrices nibh, in tristique mauris justo sed ante.
+          Nunc commodo purus feugiat metus bibendum consequat. Duis
+          finibus urna ut ligula auctor, sed vehicula ex aliquam.
+          Sed sed augue auctor, porta turpis ultrices, cursus diam.
+          In venenatis aliquet porta. Sed volutpat fermentum quam,
+          ac molestie nulla porttitor ac. Donec porta risus ut enim
+          pellentesque, id placerat elit ornare.
+        </p>
+
+        <figure>
+          <amp-audio
+            src="https://www.dl-sounds.com/wp-content/uploads/edd/2017/07/The-Horizon-preview.mp3"
+            artwork="https://images.pexels.com/photos/290101/pexels-photo-290101.jpeg?w=500&h=500&auto=compress&cs=tinysrgb"
+            title="The Horizon"
+            album="Royalty Free Music"
+            artist="Dl Sounds"
+            height="50"
+            width="360"
+            controls>
+          </amp-audio>
+        </figure>
+        <amp-ad width=360 height=50
+                type="rubicon"
+                data-method="smartTag"
+                data-account="14062"
+                data-site="70608"
+                data-zone="335918"
+                data-size="43">
+        </amp-ad>
+        <p id="section1">
+          Curabitur convallis, urna quis pulvinar feugiat, purus diam
+          posuere turpis, sit amet tincidunt purus justo et mi. Donec
+          sapien urna, aliquam ut lacinia quis, varius vitae ex.
+          Maecenas efficitur iaculis lorem, at imperdiet orci viverra
+          in. Nullam eu erat eu metus ultrices viverra a sit amet leo.
+          Pellentesque est felis, pulvinar mollis sollicitudin et,
+          suscipit eget massa. Nunc bibendum non nunc et consequat.
+          Quisque auctor est vel leo faucibus, non faucibus magna ultricies.
+          Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+          posuere cubilia Curae; Vestibulum tortor lacus, bibendum et
+          enim eu, vehicula placerat erat. Nullam gravida rhoncus accumsan.
+          Integer suscipit iaculis elit nec mollis. Vestibulum eget arcu
+          nec lectus finibus rutrum vel sed orci.
+        </p>
+
+        <figure>
+          <amp-img placeholder
+                   src="https://picsum.photos/id/1015/360/260"
+                   layout="responsive" width="320"
+                   on="tap:inline-img-lightbox"
+                   alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
+                   height="180">
+          </amp-img>
+          <figcaption class='image'>
+            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          </figcaption>
+          <amp-lightbox id="inline-img-lightbox" class="lightbox"
+                        layout="nodisplay">
+
+            <div class="lightbox-content">
+              <div id="lightbox-close-btn"
+                   on="tap:inline-img-lightbox.close"
+                   role="button"
+                   tabindex="0">
+                <h1>x</h1>
+              </div>
+              <amp-img id="floating-headline-img"
+                       src="https://picsum.photos/id/1015/360/260"
+                       alt="Image of a sea"
+                       placeholder
+                       width="360" height="260" layout="responsive">
+              </amp-img>
+              <p>
+                Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+              </p>
+            </div>
+          </amp-lightbox>
+        </figure>
+
+        <p>
+          Cum sociis natoque penatibus et magnis dis parturient montes,
+          nascetur ridiculus mus. Nulla et viverra turpis. Fusce
+          viverra enim eget elit blandit, in finibus enim blandit. Integer
+          fermentum eleifend felis non posuere. In vulputate et metus at
+          aliquam. Praesent a varius est. Quisque et tincidunt nisi.
+          Nam porta urna at turpis lacinia, sit amet mattis eros elementum.
+          Etiam vel mauris mattis, dignissim tortor in, pulvinar arcu.
+          In molestie sem elit, tincidunt venenatis tortor aliquet sodales.
+          Ut elementum velit fermentum felis volutpat sodales in non libero.
+          Aliquam erat volutpat.
+        </p>
+
+        <div class="ad-container">
+          <amp-ad width=300 height=200
+                  type="adsense"
+                  data-ad-client="ca-pub-9350112648257122">
+          </amp-ad>
+        </div>
+
+        <p id="section2">
+          Morbi at velit vitae eros congue congue venenatis non dui.
+          Sed lacus sem, feugiat sed elementum sed, maximus sed lacus.
+          Integer accumsan magna in sagittis pharetra. Class aptent taciti
+          sociosqu ad litora torquent per conubia nostra, per inceptos
+          himenaeos. Suspendisse ac nisl efficitur ligula aliquam lacinia
+          eu in magna. Vestibulum non felis odio. Ut consectetur venenatis
+          felis aliquet maximus. Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos.
+        </p>
+      </div>
+      <!--
+        Slots spec is not implemented yet by any browser. Will use an older version via `<content>` tag.
+        <slot name="slot1"></slot>
+      -->
+      <div class="ad-container">
+        <amp-ad width="414" height="457"
+                type="doubleclick"
+                layout="fixed"
+                data-slot="/35096353/amptesting/badvideoad">
+        </amp-ad>s
+      </div>
+    </div>
+  </article>
+  <p id="section3">
+    Morbi at velit vitae eros congue congue venenatis non dui.
+    Sed lacus sem, feugiat sed elementum sed, maximus sed lacus.
+    Integer accumsan magna in sagittis pharetra. Class aptent taciti
+    sociosqu ad litora torquent per conubia nostra, per inceptos
+    himenaeos. Suspendisse ac nisl efficitur ligula aliquam lacinia
+    eu in magna. Vestibulum non felis odio. Ut consectetur venenatis
+    felis aliquet maximus. Class aptent taciti sociosqu ad litora
+    torquent per conubia nostra, per inceptos himenaeos.
+  </p>
+  <amp-embed width="360" height="283"
+             type=taboola
+             layout=responsive
+             heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+             data-publisher="amp-demo"
+             data-mode="thumbnails-a"
+             data-placement="Ads Example"
+             data-article="auto">
+  </amp-embed>
+
+  <div class="ad-container">
+    <amp-ad width="414" height="457"
+            type="doubleclick"
+            layout="fixed"
+            data-slot="/35096353/amptesting/badvideoad">
+    </amp-ad>
+  </div>
+</main>
+
+<footer>
+  <div class="brand-logo">
+    Footer
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/amp-browsi.amp.html
+++ b/examples/amp-browsi.amp.html
@@ -652,7 +652,7 @@
                 type="doubleclick"
                 layout="fixed"
                 data-slot="/35096353/amptesting/badvideoad">
-        </amp-ad>s
+        </amp-ad>
       </div>
     </div>
   </article>

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -150,6 +150,12 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['ADSLOT_ID'],
     disableKeyAppend: true,
   },
+  browsi: {
+    url:
+      'https://amp.browsiprod.com/predict?,mt=BROWSI_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&tgt=TGT&curl=CANONICAL_URL&to=TIMEOUT&purl=HREF',
+    disableKeyAppend: true,
+    macros: ['BROWSI_ID'],
+  },
 });
 
 // DO NOT MODIFY: Setup for tests

--- a/extensions/amp-browsi/0.1/BrowsiUtils.js
+++ b/extensions/amp-browsi/0.1/BrowsiUtils.js
@@ -1,0 +1,82 @@
+import {Services} from '../../../src/services';
+
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class BrowsiUtils {
+  /**
+   * @static
+   * @return {string}
+   */
+  static getPvid() {
+    return BrowsiUtils.pvid;
+  }
+  /**
+   * @static
+   * @return {string}
+   */
+  static generateToken() {
+    let characters = 'abcdefghijklmnopqrstuvwxyz';
+    characters += characters.toUpperCase() + '_';
+    let result = '';
+    for (let i = 0; i < 10; i++) {
+      result += characters.charAt(
+        Math.floor(Math.random() * characters.length)
+      );
+    }
+    return result;
+  }
+  /**
+   * @static
+   * @param {string} url
+   */
+  static getRequest(url) {
+    const Http = new XMLHttpRequest();
+    Http.open('GET', url);
+    Http.send();
+    Http.onreadystatechange = () => {
+      return Http.responseText;
+    };
+  }
+
+  /**
+   * @static
+   * @param {!Element} ad
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {Object} additionalObj
+   * @return {Object}
+   */
+  static buildAdData(ad, ampdoc, additionalObj) {
+    const viewportService = Services.viewportForDoc(ampdoc);
+    return viewportService.getClientRectAsync(ad).then(rect => {
+      return Object.assign(
+        {},
+        {
+          adUnit: ad.getAttribute('data-slot'),
+          adType: ad.getAttribute('type'),
+          adWidth: ad.getAttribute('width'),
+          adHeight: ad.getAttribute('height'),
+          adCWidth: rect.width,
+          adCHeight: rect.height,
+          adClasses: ad.getAttribute('class'),
+        },
+        additionalObj
+      );
+    });
+  }
+}
+
+BrowsiUtils.pvid = BrowsiUtils.generateToken();

--- a/extensions/amp-browsi/0.1/Prediction.js
+++ b/extensions/amp-browsi/0.1/Prediction.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {toArray} from '../../../src/types';
+import {tryParseJson} from '../../../src/json';
+
+export class Prediction {
+  /**
+   * This will set our rtc configuration.
+   * @param {Window} win our current window
+   * @param {string} pubKey
+   * @param {string} siteKey
+   */
+  constructor(win, pubKey, siteKey) {
+    this.win_ = win || window;
+    /**@private string */
+    this.browsiVendor_ = 'browsi';
+    /**@private number */
+    this.rtcTimeout_ = 750;
+    /** @private Object */
+    this.macro_ = `{"BROWSI_ID":${pubKey}_${siteKey}}`;
+  }
+
+  /**
+   * Add browsi RTC vendor to each ad on page
+   * @return {Array} amp-ads from page
+   */
+  setRtc() {
+    const ads = toArray(this.win_.document.getElementsByTagName('amp-ad'));
+    for (let i = 0; i < ads.length; i++) {
+      const ad = ads[i];
+      ad.setAttribute('rtc-config', this.getRtcTarget(ad));
+    }
+    return ads;
+  }
+
+  /**
+   * Generate rtc-config object
+   * if attribute exist - add vendor
+   * else create new object
+   * @return {string} rtc in stringed JSON
+   * @param {Element} ad the ad to getRtc from
+   */
+  getRtcTarget(ad) {
+    const curRtcString = ad.getAttribute('rtc-config');
+    if (!curRtcString) {
+      return `{"vendors": {"${this.browsiVendor_}": ${this.macro_}},"timeoutMillis": ${this.rtcTimeout_}}`;
+    }
+    const curRtc = tryParseJson(curRtcString) || {};
+    if (!curRtc['vendors']) {
+      curRtc['vendors'] = {};
+    }
+    curRtc['vendors'][this.browsiVendor_] = this.macro_;
+    if (!curRtc['timeoutMillis']) {
+      curRtc['timeoutMillis'] = this.rtcTimeout_;
+    }
+    return JSON.stringify(/** @type {JsonObject} */ (curRtc));
+  }
+}

--- a/extensions/amp-browsi/0.1/amp-browsi.js
+++ b/extensions/amp-browsi/0.1/amp-browsi.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BrowsiEngagementService} from './engagement';
+import {BrowsiUtils} from './BrowsiUtils';
+import {BrowsiViewability} from './viewability';
+import {Layout} from '../../../src/layout';
+import {Prediction} from './Prediction';
+import {sendPublisherAdFound} from './eventService';
+
+export class AmpBrowsi extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+  }
+
+  /** @override */
+  buildCallback() {
+    const ampdoc = this.getAmpDoc();
+    const pubKey = this.element.getAttribute('pub-key');
+    const siteKey = this.element.getAttribute('site-key');
+    if (!pubKey || !siteKey) {
+      return;
+    }
+    BrowsiUtils.pubKey = pubKey;
+    BrowsiUtils.siteKey = siteKey;
+    const predictionService = new Prediction(ampdoc.win, pubKey, siteKey);
+    predictionService.setRtc();
+    this.collectAndSendPublisherData(ampdoc);
+    const engagementService = new BrowsiEngagementService(ampdoc);
+    engagementService.assignEngagementReports();
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout === Layout.NODISPLAY;
+  }
+
+  /**
+   * Collect data about publisher ads on page
+   * send publisher ad found event for each ad
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+   */
+  collectAndSendPublisherData(ampDoc) {
+    this.collectPublisherData(ampDoc).then(adsData => {
+      sendPublisherAdFound(adsData);
+    });
+  }
+  /**
+   * Collect data about publisher ads on page
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+   * @return {Promise}
+   */
+  collectPublisherData(ampDoc) {
+    const adsData = [];
+    const ads = ampDoc.win.document.getElementsByTagName('amp-ad');
+    for (let i = 0; i < ads.length; i++) {
+      const ad = ads[i];
+      const additionalObj = {
+        adIndex: ad.getAttribute('data-amp-slot-index'),
+        adGoogleQuery: ad.getAttribute('data-google-query-id'),
+      };
+      const adData = BrowsiUtils.buildAdData(ad, ampDoc, additionalObj);
+      adsData.push(adData);
+      new BrowsiViewability(ad, ampDoc);
+    }
+    const embeds = ampDoc.win.document.getElementsByTagName('amp-embed');
+    for (let i = 0; i < embeds.length; i++) {
+      const embed = embeds[i];
+      const adData = BrowsiUtils.buildAdData(embed, ampDoc, {});
+      adsData.push(adData);
+    }
+    return Promise.all(adsData);
+  }
+}
+
+AMP.extension('amp-browsi', '0.1', AMP => {
+  AMP.registerElement('amp-browsi', AmpBrowsi);
+});

--- a/extensions/amp-browsi/0.1/engagement.js
+++ b/extensions/amp-browsi/0.1/engagement.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../../src/services';
+import {sendEngagement} from './eventService';
+
+export class BrowsiEngagementService {
+  /**
+   * Engagement Service Constructor
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /**
+     * Max running time in seconds
+     * @const {number}
+     */
+    this.runTime = 120;
+    /**
+     * Sample time in seconds
+     * @const {number}
+     */
+    this.sampleTime = 1;
+    /**
+     * Min engagement event amount to send
+     * @const {number}
+     */
+    this.minBatchLength = 5;
+    /**
+     * @private {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+     */
+    this.ampdoc_ = ampdoc;
+
+    /**
+     * @private @const {!../../../src/service/viewport/viewport-interface.ViewportInterface}
+     */
+    this.viewport_ = Services.viewportForDoc(this.ampdoc_);
+
+    /**
+     * @private {Array}
+     */
+    this.engagementBatch_ = [];
+
+    /**
+     * @private {number}
+     */
+    this.startTime_ = Date.now();
+
+    /**
+     * @private {number}
+     */
+    this.lastScrollTop_ = 1;
+
+    /**
+     * @private {number}
+     */
+    this.lastEngagementReportTime_ = this.startTime_;
+  }
+
+  /**
+   * Samples engagement metrics for the current time
+   * @return {Object} An object that includes Engagement data for the current time
+   */
+  buildEngagementData() {
+    const screenHeight = window.screen.availHeight;
+    const bodyHeight = this.ampdoc_.getBody()./*OK*/ clientHeight;
+    const scrollTop = this.viewport_.getScrollTop();
+    const pixelsDiff = scrollTop - this.lastScrollTop_;
+    const now = Date.now();
+    const timeDelta = (now - this.lastEngagementReportTime_) / 1000;
+
+    return {
+      scrollTop,
+      timeOnPage: (now - this.startTime_) / 1000,
+      screenHeight,
+      now,
+      scrollDistance: scrollTop + screenHeight,
+      scrollDepth: (scrollTop / bodyHeight) * 100,
+      pageHeight: bodyHeight,
+      timeDelta,
+      pixelDelta: pixelsDiff,
+      velocity: Math.round(Math.abs(pixelsDiff / timeDelta)),
+    };
+  }
+
+  /**
+   * Initiates the Engagement reports:
+   * - Every 1 second, engagement data is sampled
+   * - The data is batched and each time 5 engagement samples are collected, 5 matching engagement events are sent.
+   * - This behavior is defined to work for 2 minutes (120 seconds)
+   */
+  assignEngagementReports() {
+    const interval = setInterval(() => {
+      const engagementEvent = this.buildEngagementData();
+      this.lastScrollTop_ = engagementEvent./*OK*/ scrollTop;
+      this.lastEngagementReportTime_ = engagementEvent.now;
+
+      this.engagementBatch_.push(engagementEvent);
+      if (this.engagementBatch_.length >= this.minBatchLength) {
+        this.sendAndEmptyEngagementBatch();
+      }
+    }, this.sampleTime * 1000);
+
+    setTimeout(() => {
+      clearInterval(interval);
+    }, this.runTime * 1000);
+  }
+
+  /**
+   * Sends engagement events, that match the engagement data objects that were collected.
+   */
+  sendAndEmptyEngagementBatch() {
+    sendEngagement(this.engagementBatch_);
+    this.engagementBatch_ = [];
+  }
+  /**
+   * Checks if the lastEngagement date was reset, indicates that we sent the engagement at least once.
+   * @return {boolean}
+   */
+  isSentAtLeastOnce() {
+    return this.startTime_ !== this.lastEngagementReportTime_;
+  }
+}

--- a/extensions/amp-browsi/0.1/enums.js
+++ b/extensions/amp-browsi/0.1/enums.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EventTopic = {
+  AMP: 'amp',
+};
+
+export const EventType = {
+  PUBLISHER_AD_VIEWED: 'publisher ad viewed',
+  PUBLISHER_AD_FOUND: 'publisher ad found',
+  ENGAGEMENT: 'engagement',
+};

--- a/extensions/amp-browsi/0.1/eventService.js
+++ b/extensions/amp-browsi/0.1/eventService.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BrowsiUtils} from './BrowsiUtils';
+import {EventTopic, EventType} from './enums';
+import {getMode} from '../../../src/mode';
+
+const serverUrl = 'https://amp.browsiprod.com/events';
+const pvid = BrowsiUtils.getPvid();
+
+/**
+ * @param {string} topic
+ * @param {string} type
+ * @param {Array} events
+ */
+function send(topic, type, events) {
+  if (!getMode().test) {
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('POST', `${serverUrl}?p=${pvid}`, true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send(JSON.stringify(events));
+  }
+  if (getMode().localDev) {
+    console /*OK*/
+      .log(
+        `%c ${topic}/${type}`,
+        'background: #AAFF7F; color: black; font-weight: bold; text-decoration:underline; font-size: 18px;',
+        events
+      );
+  }
+}
+/**
+ * @param {Array} events
+ * */
+export function sendEngagement(events) {
+  const allEvents = events.map(event =>
+    Object.assign({}, event, {et: EventType.ENGAGEMENT})
+  );
+  send(EventTopic.AMP, EventType.ENGAGEMENT, allEvents);
+}
+
+/**
+ * @param {Object | null} ad
+ * */
+export function sendPublisherAdViewed(ad) {
+  const publisherAdViewed = getPublisherAdViewedEvent(ad);
+  send(EventTopic.AMP, EventType.PUBLISHER_AD_VIEWED, [publisherAdViewed]);
+}
+
+/**
+ * @param {Array} ads
+ * @return {Array}
+ * */
+export function sendPublisherAdFound(ads) {
+  const publisherAdsFound = ads.map(ad => {
+    return Object.assign({}, getPublisherAdFoundEvent(ad), {});
+  });
+  send(EventTopic.AMP, EventType.PUBLISHER_AD_FOUND, publisherAdsFound);
+  return publisherAdsFound;
+}
+
+/**
+ * @param {!Object} ad
+ * @return {Object}
+ * */
+function getPublisherAdFoundEvent(ad) {
+  return Object.assign({}, ad, {
+    et: EventType.PUBLISHER_AD_FOUND,
+  });
+}
+
+/**
+ * @param {Object | null} ad
+ * @return {Object}
+ * */
+function getPublisherAdViewedEvent(ad) {
+  return Object.assign({}, ad, {
+    et: EventType.PUBLISHER_AD_VIEWED,
+    amp: 'amp',
+  });
+}

--- a/extensions/amp-browsi/0.1/test/test-amp-browsi.js
+++ b/extensions/amp-browsi/0.1/test/test-amp-browsi.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-browsi';
+import {AmpBrowsi} from '../amp-browsi';
+import {BrowsiEngagementService} from '../engagement';
+import {Prediction} from '../Prediction';
+import {createElementWithAttributes} from '../../../../src/dom';
+
+describes.realWin(
+  'amp-browsi',
+  {
+    amp: {
+      extensions: ['amp-browsi', 'amp-ad'],
+    },
+  },
+  env => {
+    let win, doc;
+
+    // const ads = []; //, amp1, amp2
+    let element;
+    let browsiAmpElement;
+    let ampDoc;
+
+    const pubKey = '98569856';
+    const siteKey = 'demo';
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      browsiAmpElement = createBrowsiAmp(doc);
+      ampDoc = browsiAmpElement.getAmpDoc();
+      const ad = createAmpAd(doc, 'ad1');
+      doc.body.appendChild(ad);
+    });
+    function createAmpAd(doc, id) {
+      element = createElementWithAttributes(env.win.document, 'amp-ad', {
+        'id': id,
+        'width': '200',
+        'height': '50',
+        'type': 'doubleclick',
+        'data-slot': 'demoSlot',
+        'layout': 'fixed',
+      });
+      return element;
+    }
+    function createBrowsiAmp(doc) {
+      const element = doc.createElement('amp-browsi');
+      element.setAttribute('pub-key', pubKey);
+      element.setAttribute('site-key', siteKey);
+      doc.body.appendChild(element);
+      browsiAmpElement = new AmpBrowsi(element);
+      return browsiAmpElement;
+    }
+
+    it('should Get correct publisher ad data', function() {
+      browsiAmpElement.collectPublisherData(ampDoc).then(adsData => {
+        expect(adsData.length).to.equal(1);
+        expect(adsData[0].adUnit).to.equal('demoSlot');
+        expect(adsData[0].adType).to.equal('doubleclick');
+        expect(adsData[0].adWidth).to.equal('200');
+        expect(adsData[0].adHeight).to.equal('50');
+        expect(adsData[0].adClasses).to.equal('');
+      });
+    });
+
+    it('should set browsi rtc-config', function() {
+      const predictionService = new Prediction(env.win, pubKey, siteKey);
+      const ads = Array.from(predictionService.setRtc());
+      expect(ads.length).to.equal(1);
+      ads.forEach(ad => {
+        const rtcConfig = ad.getAttribute('rtc-config');
+        expect(rtcConfig).to.equal(
+          `{"vendors": {"browsi": {"BROWSI_ID":${pubKey}_${siteKey}}},"timeoutMillis": 750}`
+        );
+      });
+    });
+
+    it('should send at least one engagement batch event', function() {
+      const engagementService = new BrowsiEngagementService(ampDoc);
+      engagementService.assignEngagementReports();
+      const timeout =
+        engagementService.minBatchLength * engagementService.sampleTime + 1;
+      setTimeout(function() {
+        expect(engagementService.isSentAtLeastOnce()).to.equal(true);
+      }, timeout * 1000);
+    });
+  }
+);

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
@@ -5,44 +5,6 @@
   <title>amp-browsi example</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>
-    body {
-      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
-      animation: -amp-start 8s steps(1, end) 0s 1 normal both
-    }
-    @-webkit-keyframes -amp-start {
-      from {visibility: hidden}
-      to {visibility: visible}
-    }
-
-    @-moz-keyframes -amp-start {
-      from {visibility: hidden}
-      to {visibility: visible}
-    }
-
-    @-ms-keyframes -amp-start {
-      from {visibility: hidden}
-      to {visibility: visible}
-    }
-
-    @-o-keyframes -amp-start {
-      from {visibility: hidden}
-      to {visibility: visible}
-    }
-
-    @keyframes -amp-start {
-      from {visibility: hidden}
-      to {visibility: visible}
-    }</style>
-  <noscript>
-    <style amp-boilerplate>body {
-      -webkit-animation: none;
-      -moz-animation: none;
-      -ms-animation: none;
-      animation: none
-    }</style>
   </noscript>
   <style amp-custom>
     amp-browsi {
@@ -53,7 +15,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-<amp-browsi layout="responsive" width="150" height="80"></amp-browsi>
+<amp-browsi layout="nolayout" pub-key="98569856" site-key="demo"></amp-browsi>
 <amp-ad></amp-ad>
 </body>
 </html>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
@@ -21,6 +21,65 @@
   <title>amp-browsi example</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>
+    body {
+      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      animation: -amp-start 8s steps(1, end) 0s 1 normal both
+    }
+
+    @-webkit-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+      to {
+        visibility: visible
+      }
+    }
+
+    @-moz-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+      to {
+        visibility: visible
+      }
+    }
+
+    @-ms-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+      to {
+        visibility: visible
+      }
+    }
+
+    @-o-keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+      to {
+        visibility: visible
+      }
+    }
+
+    @keyframes -amp-start {
+      from {
+        visibility: hidden
+      }
+      to {
+        visibility: visible
+      }
+    }</style>
+  <noscript>
+    <style amp-boilerplate>body {
+      -webkit-animation: none;
+      -moz-animation: none;
+      -ms-animation: none;
+      animation: none
+    }</style>
   </noscript>
   <style amp-custom>
     amp-browsi {
@@ -32,7 +91,6 @@
 </head>
 <body>
 <!-- Valid --->
-<amp-browsi layout="nolayout" pub-key="98569856" site-key="demo"></amp-browsi>
-<amp-ad></amp-ad>
+<amp-browsi layout="nodisplay" pub-key="98569856" site-key="demo"></amp-browsi>
 </body>
 </html>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
@@ -1,3 +1,19 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests is testing a valid usage of this extension.
+-->
 <!doctype html>
 <html ⚡>
 <head>
@@ -15,6 +31,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+<!-- Valid --->
 <amp-browsi layout="nolayout" pub-key="98569856" site-key="demo"></amp-browsi>
 <amp-ad></amp-ad>
 </body>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-browsi example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>
+    body {
+      -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+      animation: -amp-start 8s steps(1, end) 0s 1 normal both
+    }
+    @-webkit-keyframes -amp-start {
+      from {visibility: hidden}
+      to {visibility: visible}
+    }
+
+    @-moz-keyframes -amp-start {
+      from {visibility: hidden}
+      to {visibility: visible}
+    }
+
+    @-ms-keyframes -amp-start {
+      from {visibility: hidden}
+      to {visibility: visible}
+    }
+
+    @-o-keyframes -amp-start {
+      from {visibility: hidden}
+      to {visibility: visible}
+    }
+
+    @keyframes -amp-start {
+      from {visibility: hidden}
+      to {visibility: visible}
+    }</style>
+  <noscript>
+    <style amp-boilerplate>body {
+      -webkit-animation: none;
+      -moz-animation: none;
+      -ms-animation: none;
+      animation: none
+    }</style>
+  </noscript>
+  <style amp-custom>
+    amp-browsi {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<amp-browsi layout="responsive" width="150" height="80"></amp-browsi>
+<amp-ad></amp-ad>
+</body>
+</html>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
@@ -1,4 +1,20 @@
 PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests is testing a valid usage of this extension.
+|  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>
@@ -6,11 +22,76 @@ PASS
 |    <title>amp-browsi example</title>
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-boilerplate>
+|      body {
+|        -webkit-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -moz-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        -ms-animation: -amp-start 8s steps(1, end) 0s 1 normal both;
+|        animation: -amp-start 8s steps(1, end) 0s 1 normal both
+|      }
+|
+|      @-webkit-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-moz-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-ms-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @-o-keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|        to {
+|          visibility: visible
+|        }
+|      }
+|
+|      @keyframes -amp-start {
+|        from {
+|          visibility: hidden
+|        }
+|        to {
+|          visibility: visible
+|        }
+|      }</style>
+|    <noscript>
+|      <style amp-boilerplate>body {
+|        -webkit-animation: none;
+|        -moz-animation: none;
+|        -ms-animation: none;
+|        animation: none
+|      }</style>
+|    </noscript>
+|    <style amp-custom>
+|      amp-browsi {
+|        color: red;
+|      }
+|    </style>
 |    <script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|    <amp-browsi layout="nodisplay" pub-key="98569856" site-key="demo"></amp-browsi>
+|  <!-- Valid --->
+|  <amp-browsi layout="nodisplay" pub-key="98569856" site-key="demo"></amp-browsi>
 |  </body>
 |  </html>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
@@ -1,0 +1,21 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-browsi example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-browsi {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-browsi layout="responsive" width="150" height="80"></amp-browsi>
+|  </body>
+|  </html>

--- a/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
+++ b/extensions/amp-browsi/0.1/test/validator-amp-browsi.out
@@ -7,15 +7,10 @@ PASS
 |    <link rel="canonical" href="amps.html">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      amp-browsi {
-|        color: red;
-|      }
-|    </style>
 |    <script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js"></script>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|    <amp-browsi layout="responsive" width="150" height="80"></amp-browsi>
+|    <amp-browsi layout="nodisplay" pub-key="98569856" site-key="demo"></amp-browsi>
 |  </body>
 |  </html>

--- a/extensions/amp-browsi/0.1/viewability.js
+++ b/extensions/amp-browsi/0.1/viewability.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BrowsiUtils} from './BrowsiUtils';
+import {sendPublisherAdViewed} from './eventService';
+
+export class BrowsiViewability {
+  /**
+   * @param {!Element} ad
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+   * **/
+  constructor(ad, ampDoc) {
+    /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampDoc_ = ampDoc;
+    /** @private {IntersectionObserver} */
+    this.observer_ = null;
+    /** @private number*/
+    this.viewableTime_ = 1000;
+    /** @private null|Date*/
+    this.startTime_ = null;
+    /** @private Element*/
+    this.ad_ = ad;
+    /** @private null|Timer*/
+    this.viewabilityInterval_ = null;
+    // /** @private boolean */
+    // this.viewed_ = false;
+    /** @private Object*/
+    this.options_ = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.5,
+    };
+
+    this.observe();
+  }
+
+  /**
+   * Start observing element
+   */
+  observe() {
+    this.observer_ = new IntersectionObserver(
+      this.handleObserveChange.bind(this),
+      this.options_
+    );
+    this.observer_.observe(this.ad_);
+  }
+
+  /**
+   * Triggered each time the element (ad) is in or out of view according to configurations
+   * also fires once when initialized
+   * @param {Array} entries
+   * */
+  handleObserveChange(entries) {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        if (!this.startTime_) {
+          this.startTime_ = Date.now();
+        }
+        this.countForViewability();
+      } else {
+        this.handleNotInView();
+      }
+    });
+  }
+
+  /**
+   * Report ad viewed
+   */
+  reportViewed() {
+    this.resetInterval();
+    this.observer_.disconnect();
+    // this.viewed_ = true;
+    const adData = BrowsiUtils.buildAdData(this.ad_, this.ampDoc_, {});
+    sendPublisherAdViewed(adData);
+  }
+
+  /**
+   * Get viewd duration ms
+   * @return {number}
+   */
+  getViewedDuration() {
+    return this.startTime_ ? Date.now() - this.startTime_ : -1;
+  }
+
+  /**
+   * Fired when ad goes out of view
+   */
+  handleNotInView() {
+    this.resetInterval();
+    this.startTime_ = null;
+  }
+
+  /**
+   * Count time in view
+   * Fires when ad is in view
+   * If view time > 1s => report viewed
+   */
+  countForViewability() {
+    if (!this.viewabilityInterval_) {
+      this.viewabilityInterval_ = setInterval(() => {
+        if (this.getViewedDuration() > this.viewableTime_) {
+          this.reportViewed();
+        }
+      }, 50);
+    }
+  }
+
+  /**
+   * Reset in view counter
+   */
+  resetInterval() {
+    clearInterval(this.viewabilityInterval_);
+    this.viewabilityInterval_ = null;
+  }
+}

--- a/extensions/amp-browsi/amp-browsi.md
+++ b/extensions/amp-browsi/amp-browsi.md
@@ -1,0 +1,79 @@
+---
+$category@: ads-analytics
+formats:
+  - ads: 
+teaser:
+  text: Provides viewability prediction to ads.
+---
+<!--
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-browsi
+
+Provides realtime viewability prediction to ads on AMP pages using Browsi Prediction Service.  
+
+<table>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-browsi" src="https://cdn.ampproject.org/v0/amp-browsi-0.1.js">&lt;/script></code></td>
+  </tr>
+   <tr>
+      <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+      <td>nodisplay</td>
+    </tr>
+  <!--
+    <tr>
+      <td class="col-fourty"><strong>Examples</strong></td>
+      <td><a href="https://ampbyexample.com/components/amp-browsi/">Annotated code example for amp-browsi</a></td>
+    </tr>
+  -->
+</table>
+
+## Behavior
+
+The `amp-browsi` extension scans all ads on page and uses `rtc-config` attribute to call **Browsi Viewability Predictor**
+server which will return a targeting object that will be sent to the adServer 
+
+`amp-browsi` is collecting user behaviour and ads data to allow **Browsi Viewability Predictor** to provide accurate predictions   
+
+## Example
+
+```html
+<amp-browsi
+    pub-key="98569856"
+    site-key="1234"
+    layout="nodisplay">
+</amp-browsi>
+```
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><strong>pub-id</strong></td>
+    <td>The `pub-key` attribute identify the publisher's id so Browsi could return the correct prediction</td>
+  </tr>
+  <tr>
+      <td width="40%"><strong>site-key</strong></td>
+      <td>The `site-key` attribute identify the publisher's site id so Browsi could return the correct prediction</td>
+    </tr>
+</table>
+
+
+<!--
+## Validation
+See [amp-browsi rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-browsi/validator-amp-browsi.protoascii) in the AMP validator specification.
+-->

--- a/extensions/amp-browsi/amp-browsi.md
+++ b/extensions/amp-browsi/amp-browsi.md
@@ -63,7 +63,7 @@ service which will return a targeting object that will be sent to the adServer.
 
 <table>
   <tr>
-    <td width="40%"><strong>pub-id</strong></td>
+    <td width="40%"><strong>pub-key</strong></td>
     <td>The `pub-key` attribute identify the publisher's id so Browsi could return the correct prediction</td>
   </tr>
   <tr>

--- a/extensions/amp-browsi/amp-browsi.md
+++ b/extensions/amp-browsi/amp-browsi.md
@@ -44,10 +44,10 @@ Provides realtime viewability prediction to ads on AMP pages using Browsi Predic
 
 ## Behavior
 
-The `amp-browsi` extension scans all ads on page and uses `rtc-config` attribute to call **Browsi Viewability Predictor**
-server which will return a targeting object that will be sent to the adServer 
+The `amp-browsi` extension detects all ads on page and uses `rtc-config` attribute to call **Browsi Viewability Predictor**
+service which will return a targeting object that will be sent to the adServer.
 
-`amp-browsi` is collecting user behaviour and ads data to allow **Browsi Viewability Predictor** to provide accurate predictions   
+`amp-browsi` collects data to allow **Browsi Viewability Predictor Service** to provide accurate predictions.   
 
 ## Example
 

--- a/extensions/amp-browsi/validator-amp-browsi.protoascii
+++ b/extensions/amp-browsi/validator-amp-browsi.protoascii
@@ -22,15 +22,22 @@ tags: {  # amp-browsi
     version: "0.1"
     version: "latest"
   }
-  attr_lists: "pub-id"
+  attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-browsi>
   html_format: AMP
   tag_name: "AMP-BROWSI"
   requires_extension: "amp-browsi"
-  attr_lists: "pub-id"
-  # spec_url: "https://amp.dev/documentation/components/amp-browsi"
+  spec_url: "https://amp.dev/documentation/components/amp-browsi"
   amp_layout: {
     supported_layouts: NODISPLAY
   }
+  attrs: {
+    name: "pub-key"
+    value: "98569856"
+  }
+  attrs: {
+      name: "site-key"
+      value: "demo"
+    }
 }

--- a/extensions/amp-browsi/validator-amp-browsi.protoascii
+++ b/extensions/amp-browsi/validator-amp-browsi.protoascii
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-browsi
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-browsi"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "pub-id"
+}
+tags: {  # <amp-browsi>
+  html_format: AMP
+  tag_name: "AMP-BROWSI"
+  requires_extension: "amp-browsi"
+  attr_lists: "pub-id"
+  # spec_url: "https://amp.dev/documentation/components/amp-browsi"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}

--- a/extensions/amp-browsi/validator-amp-browsi.protoascii
+++ b/extensions/amp-browsi/validator-amp-browsi.protoascii
@@ -35,9 +35,11 @@ tags: {  # <amp-browsi>
   attrs: {
     name: "pub-key"
     value: "98569856"
+    mandatory: true
   }
   attrs: {
       name: "site-key"
       value: "demo"
+      mandatory: true
     }
 }


### PR DESCRIPTION
# Description
- Provides realtime viewability prediction to ads on AMP pages using Browsi Prediction Service.

## Behavior

The `amp-browsi` extension detects all ads on page and uses `rtc-config` attribute to call **Browsi Viewability Predictor Service** which will return a targeting object that will be sent to the adServer.

`amp-browsi` collects data to allow **Browsi Viewability Predictor Service** to provide accurate predictions.   