### PR TITLE
Ramp up experiment for AdSense ad size optimization to 1% of AMP traffic

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -19,6 +19,7 @@
   "canary": 1,
 
   "a4aProfilingRate": 0.01,
+  "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,6 +19,7 @@
   "canary": 0,
 
   "a4aProfilingRate": 0.01,
+  "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/issues/23568.
