### PR TITLE
Move ANALYTICS_VENDOR_SPLIT expiry back one month

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -4,7 +4,7 @@
     "environment": "AMP",
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
-    "expirationDateUTC": "2019-09-08",
+    "expirationDateUTC": "2019-10-08",
     "environment": "web",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"
   },


### PR DESCRIPTION
Fixes master.

```
/home/travis/build/ampproject/amphtml/build-system/build.conf.js:94
        throw new Error(
        ^
Error: experimentA has expired on Sun, 08 Sep 2019 00:00:00 GMT. Please remove from experiments-config.json and cleanup relevant code.
```
https://travis-ci.org/ampproject/amphtml/jobs/582527777

This was last broken a month ago in #23809. @zhouyx Are these expiry dates arbitrary? If so, we should pick a further date that doesn't break next month.