### PR TITLE
Remove conflicting experiments-config

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -5,7 +5,6 @@
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=ANALYTICS_VENDOR_SPLIT",
     "issue": "",
     "expirationDateUTC": "2019-10-08",
-    "environment": "web",
     "defineExperimentConstant": "ANALYTICS_VENDOR_SPLIT"
   },
   "experimentB": {
@@ -14,7 +13,6 @@
     "command": "gulp generate-vendor-jsons && gulp dist --defineExperimentConstant=_RTVEXP_INABOX_LITE",
     "issue": "https://github.com/ampproject/amphtml/issues/22867",
     "expirationDateUTC": "2019-10-10",
-    "environment": "inabox",
     "defineExperimentConstant": "_RTVEXP_INABOX_LITE"
   },
   "experimentC": {}


### PR DESCRIPTION
I did not notice the existing key when I added the lowercase `environment`s.

cc @zhouyx 