### PR TITLE
Adding support for time/duration (amp-brid-player extension)

### DIFF
--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -55,6 +55,12 @@ class AmpBridPlayer extends AMP.BaseElement {
     /** @private {string} */
     this.playerID_ = '';
 
+    /** @private {?number}  */
+    this.currentTime_ = 0;
+
+    /** @private {?number}  */
+    this.duration_ = 0;
+
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
 
@@ -279,13 +285,19 @@ class AmpBridPlayer extends AMP.BaseElement {
         'play': VideoEvents.PLAYING,
         'pause': VideoEvents.PAUSE,
       });
-      return;
     }
 
     if (params[2] == 'volume') {
       this.volume_ = parseFloat(params[3]);
       element.dispatchCustomEvent(mutedOrUnmutedEvent(this.volume_ <= 0));
-      return;
+    }
+
+    if (params[2] == 'currentTime') {
+      this.currentTime_ = parseFloat(params[3]);
+    }
+
+    if (params[2] == 'duration') {
+      this.duration_ = parseFloat(params[3]);
     }
   }
 
@@ -376,14 +388,12 @@ class AmpBridPlayer extends AMP.BaseElement {
 
   /** @override */
   getCurrentTime() {
-    // Not supported.
-    return 0;
+    return /** @type {number} */ (this.currentTime_);
   }
 
   /** @override */
   getDuration() {
-    // Not supported.
-    return 1;
+    return /** @type {number} */ (this.duration_);
   }
 
   /** @override */


### PR DESCRIPTION
This is a fix for current behavior where getCurrentTime() always returns 0, while getDuration() always returns 1.