### PR TITLE
amp-selector: "select" event should have variable trust

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -453,7 +453,7 @@ export class AmpSelector extends AMP.BaseElement {
       })
     );
     // TODO(wg-ui-and-a11y): Remove this in Q1 2020.
-    if (trust <= ActionTrust.HIGH) {
+    if (trust < ActionTrust.HIGH) {
       user().warn(
         TAG,
         '"select" event now has the same trust as the originating action. ' +

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -452,6 +452,14 @@ export class AmpSelector extends AMP.BaseElement {
         'selectedOptions': this.selectedOptions_(),
       })
     );
+    // TODO(wg-ui-and-a11y): Remove this in Q1 2020.
+    if (trust <= ActionTrust.HIGH) {
+      user().warn(
+        TAG,
+        '"select" event now has the same trust as the originating action. ' +
+          'See https://github.com/ampproject/amphtml/issues/24443 for details.'
+      );
+    }
     this.action_.trigger(this.element, name, selectEvent, trust);
   }
 

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -363,7 +363,8 @@ export class AmpSelector extends AMP.BaseElement {
       }
       // Newly picked option should always have focus.
       this.updateFocus_(el);
-      this.fireSelectEvent_(el);
+      // User gesture trigger is "high" trust.
+      this.fireSelectEvent_(el, ActionTrust.HIGH);
     });
   }
 
@@ -428,8 +429,8 @@ export class AmpSelector extends AMP.BaseElement {
       } else {
         this.clearSelection_(el);
       }
-
-      this.fireSelectEvent_(el);
+      // "toggle" action only requires "low" trust.
+      this.fireSelectEvent_(el, ActionTrust.LOW);
     });
   }
 
@@ -438,9 +439,10 @@ export class AmpSelector extends AMP.BaseElement {
    * 'targetOption' - option value of the selected or deselected element.
    * 'selectedOptions' - array of option values of selected elements.
    * @param {!Element} el The element that was selected or deslected.
+   * @param {!ActionTrust} trust
    * @private
    */
-  fireSelectEvent_(el) {
+  fireSelectEvent_(el, trust) {
     const name = 'select';
     const selectEvent = createCustomEvent(
       this.win,
@@ -450,7 +452,7 @@ export class AmpSelector extends AMP.BaseElement {
         'selectedOptions': this.selectedOptions_(),
       })
     );
-    this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
+    this.action_.trigger(this.element, name, selectEvent, trust);
   }
 
   /**
@@ -479,7 +481,8 @@ export class AmpSelector extends AMP.BaseElement {
     }
 
     this.setInputs_();
-    this.fireSelectEvent_(el);
+    // "selectUp" and "selectDown" actions only require "low" trust.
+    this.fireSelectEvent_(el, ActionTrust.LOW);
   }
 
   /**

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -15,6 +15,7 @@
  */
 
 import '../amp-selector';
+import {ActionTrust} from '../../../../src/action-constants';
 import {AmpEvents} from '../../../../src/amp-events';
 import {Keys} from '../../../../src/utils/key-codes';
 
@@ -845,6 +846,9 @@ describes.realWin(
         expect(event).to.have.property('detail');
         expect(event.detail).to.have.property('targetOption', '3');
         expect(event.detail).to.have.deep.property('selectedOptions', ['3']);
+
+        const trust = triggerSpy.firstCall.args[3];
+        expect(trust).to.equal(ActionTrust.HIGH);
       });
 
       it('should trigger "select" event when an item is toggled', async () => {
@@ -873,6 +877,9 @@ describes.realWin(
         expect(event).to.have.property('detail');
         expect(event.detail).to.have.property('targetOption', '3');
         expect(event.detail).to.have.deep.property('selectedOptions', ['3']);
+
+        const trust = triggerSpy.firstCall.args[3];
+        expect(trust).to.equal(ActionTrust.LOW);
       });
 
       it('should trigger "select" event for multiple selections', function*() {
@@ -906,6 +913,9 @@ describes.realWin(
           '1',
           '2',
         ]);
+
+        const trust = triggerSpy.firstCall.args[3];
+        expect(trust).to.equal(ActionTrust.HIGH);
       });
 
       it(
@@ -942,6 +952,9 @@ describes.realWin(
           expect(event).to.have.property('detail');
           expect(event.detail).to.have.property('targetOption', '1');
           expect(event.detail).to.have.deep.property('selectedOptions', ['1']);
+
+          const trust = triggerSpy.firstCall.args[3];
+          expect(trust).to.equal(ActionTrust.LOW);
         }
       );
 
@@ -977,6 +990,9 @@ describes.realWin(
           expect(event).to.have.property('detail');
           expect(event.detail).to.have.property('targetOption', '5');
           expect(event.detail).to.have.deep.property('selectedOptions', ['5']);
+
+          const trust = triggerSpy.firstCall.args[3];
+          expect(trust).to.equal(ActionTrust.LOW);
         }
       );
 

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -868,6 +868,7 @@ describes.realWin(
           method: 'toggle',
           args,
           satisfiesTrust: () => true,
+          trust: 789,
         });
 
         expect(triggerSpy).to.be.calledOnce;
@@ -879,7 +880,7 @@ describes.realWin(
         expect(event.detail).to.have.deep.property('selectedOptions', ['3']);
 
         const trust = triggerSpy.firstCall.args[3];
-        expect(trust).to.equal(ActionTrust.LOW);
+        expect(trust).to.equal(789);
       });
 
       it('should trigger "select" event for multiple selections', function*() {
@@ -941,6 +942,7 @@ describes.realWin(
           impl.executeAction({
             method: 'selectDown',
             satisfiesTrust: () => true,
+            trust: 789,
           });
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
           expect(ampSelector.children[1].hasAttribute('selected')).to.be.true;
@@ -954,7 +956,7 @@ describes.realWin(
           expect(event.detail).to.have.deep.property('selectedOptions', ['1']);
 
           const trust = triggerSpy.firstCall.args[3];
-          expect(trust).to.equal(ActionTrust.LOW);
+          expect(trust).to.equal(789);
         }
       );
 
@@ -978,7 +980,11 @@ describes.realWin(
           expect(ampSelector.hasAttribute('multiple')).to.be.false;
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
 
-          impl.executeAction({method: 'selectUp', satisfiesTrust: () => true});
+          impl.executeAction({
+            method: 'selectUp',
+            satisfiesTrust: () => true,
+            trust: 789,
+          });
 
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
           expect(ampSelector.children[5].hasAttribute('selected')).to.be.true;
@@ -992,7 +998,7 @@ describes.realWin(
           expect(event.detail).to.have.deep.property('selectedOptions', ['5']);
 
           const trust = triggerSpy.firstCall.args[3];
-          expect(trust).to.equal(ActionTrust.LOW);
+          expect(trust).to.equal(789);
         }
       );
 


### PR DESCRIPTION
Fixes #24425 and closes #24443.

Note: do not submit until deprecation notice period is over in mid-October.

/to @sparhami 