### PR TITLE
Fix test-amp-ad-3p.js in Chrome 77

### DIFF
--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -118,9 +118,8 @@ describe.configure().run('amp-ad 3P', () => {
           search: '',
         });
         expect(parseInt(context.pageViewId, 10)).to.be.greaterThan(0);
-        // In some browsers the referrer is empty. But in Chrome it works, so
-        // we always check there.
-        if (context.referrer !== '' || platform.isChrome()) {
+        // In some browsers the referrer is empty.
+        if (context.referrer !== '') {
           expect(context.referrer).to.contain(
             'http://localhost:' + location.port
           );


### PR DESCRIPTION
Looks like `Referer` is no longer available in Chrome 77 (went to stable today).

```
DESCRIBE => amp-ad 3P
  IT => create an iframe with APIs
    ✗ AssertionError: expected '' to include 'http://localhost:9876'
        at http://localhost:9876/home/travis/build/ampproject/amphtml/test/integration/test-amp-ad-3p.js:124:39

[19:13:05] HeadlessChrome 77.0.3865 (Linux 0.0.0): Executed 262 of 440 (Skipped 178) 1 FAILED
```

https://travis-ci.org/ampproject/amphtml/jobs/583312743

/to @lannka 