### PR TITLE
🐛Work around a Chrome layout bug introduced in Chrome 77.

### DIFF
--- a/extensions/amp-loader/0.1/amp-loader.css
+++ b/extensions/amp-loader/0.1/amp-loader.css
@@ -116,7 +116,7 @@
 }
 
 /* Positioning for various parts */
-.i-amphtml-new-loader-spinner,
+.i-amphtml-new-loader-spinner-wrapper,
 .i-amphtml-new-loader-logo,
 .i-amphtml-new-loader-shim {
   position: absolute;
@@ -127,10 +127,13 @@
 }
 
 /* The spinner itself */
+.i-amphtml-new-loader-spinner-wrapper {
+  margin: 12px;
+}
+
 .i-amphtml-new-loader-spinner {
   stroke: currentColor;
   stroke-width: 1.5px;
-  margin: 12px;
   opacity: 0;
   animation: i-amphtml-new-loader-fade-in 0.8s ease-in forwards;
   animation-delay: 1.8s;

--- a/extensions/amp-loader/0.1/spinner.js
+++ b/extensions/amp-loader/0.1/spinner.js
@@ -135,10 +135,14 @@ function getSpinnerPath() {
  * @return {!Element}
  */
 export function createSpinnerDom(html) {
+  // Extra wrapping div here is to workaround:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1002748
   const content = html`
-    <svg class="i-amphtml-new-loader-spinner" viewbox="0 0 48 48">
-      <path class="i-amphtml-new-loader-spinner-path" fill="none"></path>
-    </svg>
+    <div class="i-amphtml-new-loader-spinner-wrapper">
+      <svg class="i-amphtml-new-loader-spinner" viewbox="0 0 48 48">
+        <path class="i-amphtml-new-loader-spinner-path" fill="none"></path>
+      </svg>
+    </div>
   `;
 
   // We create the path with code, rather than inline it above, as it is


### PR DESCRIPTION
The new Chrome layout engine has a bug with SVGs and position: absolute.
Since this has already launched, workaround the issue using a wrapping
element.

See: https://bugs.chromium.org/p/chromium/issues/detail?id=1002748

Note: Chrome 77 is launching today, unclear if this meets the cherry-pick criteria, but we may want to consider unlaunching the loaders or cherry-picking this.

Fixes #24393

/cc @nainar
