### PR TITLE
Fix Document.referrer tests in Chrome 77

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -624,6 +624,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('returns the right URL', () => {
+      const viewer = Services.viewerForDoc(element);
+      // inabox-viewer.getReferrerUrl() returns Promise<string>.
+      sandbox
+        .stub(viewer, 'getReferrerUrl')
+        .returns(Promise.resolve('http://fake.example/?foo=bar'));
+
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       const impl2 = new AmpAdNetworkDoubleclickImpl(element);
       impl.setPageviewStateToken('abc');
@@ -664,7 +670,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           /(\?|&)eid=([^&]+%2C)*12345678(%2C[^&]+)*(&|$)/,
           /(\?|&)url=https?%3A%2F%2F[a-zA-Z0-9.:%-]+(&|$)/,
           /(\?|&)top=localhost(&|$)/,
-          /(\?|&)ref=https?%3A%2F%2Flocalhost%3A9876%2F[a-zA-Z0-9.:%-]+(&|$)/,
+          /(\?|&)ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar/,
           /(\?|&)dtd=[0-9]+(&|$)/,
           /(\?|&)vis=[0-5]+(&|$)/,
           /(\?|&)psts=([^&]+%2C)*def(%2C[^&]+)*(&|$)/,

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -534,6 +534,9 @@ describes.realWin(
       });
 
       it('expands platform vars', () => {
+        sandbox
+          .stub(viewer, 'getReferrerUrl')
+          .returns('http://fake.example/?foo=bar');
         const analytics = getAnalyticsTag({
           'requests': {
             'pageview':
@@ -543,7 +546,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /https:\/\/example.com\/title=Test%20Title&ref=http%3A%2F%2Flocalhost%3A9876%2F(context|debug).html/
+            /https:\/\/example.com\/title=Test%20Title&ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar/
           );
         });
       });
@@ -679,6 +682,9 @@ describes.realWin(
       });
 
       it('expands url-replacements vars', () => {
+        sandbox
+          .stub(viewer, 'getReferrerUrl')
+          .returns('http://fake.example/?foo=bar');
         const analytics = getAnalyticsTag({
           'requests': {
             'pageview':
@@ -697,7 +703,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /https:\/\/example.com\/test1=x&test2=http%3A%2F%2Flocalhost%3A9876%2F(context|debug).html&title=Test%20Title/
+            /https:\/\/example.com\/test1=x&test2=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar&title=Test%20Title/
           );
         });
       });

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -276,15 +276,14 @@ describes.sandboxed('UrlReplacements', {}, () => {
       });
     });
 
-  it.configure()
-    .skipFirefox()
-    .run('should replace DOCUMENT_REFERRER', () => {
-      return expandUrlAsync('?ref=DOCUMENT_REFERRER').then(res => {
-        expect(res).to.equal(
-          '?ref=http%3A%2F%2Flocalhost%3A9876%2Fcontext.html'
-        );
-      });
-    });
+  it('should replace DOCUMENT_REFERRER', async () => {
+    const replacements = await getReplacements();
+    sandbox
+      .stub(viewerService, 'getReferrerUrl')
+      .returns('http://fake.example/?foo=bar');
+    const res = await replacements.expandUrlAsync('?ref=DOCUMENT_REFERRER');
+    expect(res).to.equal('?ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar');
+  });
 
   it('should replace EXTERNAL_REFERRER', () => {
     const windowInterface = mockWindowInterface(sandbox);


### PR DESCRIPTION
In Chrome 77 `Document.referrer` is now empty string in test iframes.

Fixes 4 broken tests on master: https://travis-ci.org/ampproject/amphtml/jobs/583391139

And wow our "unit tests" are something else. :)