### PR TITLE
 🐛Remove erroneous timeout warning

### DIFF
--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -562,7 +562,7 @@ export class RealTimeConfigManager {
                   `using default timeout ${defaultTimeoutMillis}ms`
               );
               timeout = undefined;
-            } else if (timeout >= defaultTimeoutMillis || timeout < 0) {
+            } else if (timeout > defaultTimeoutMillis || timeout < 0) {
               user().warn(
                 TAG,
                 `Invalid RTC timeout: ${timeout}ms, ` +


### PR DESCRIPTION
When someone supplies a timeout we check whether that's >= than the default timeout, and if so warn and fall back to the default.  This means that if you set tie timeout to the default you'll get an inappropriate warning.  Change to only warning when it's > than the default.

The only behavior change here is that we're no longer emitting a warning.

Fixes #24163.