### PR TITLE
🐛Fixes bug with Safari/Edge animations not resuming

### DIFF
--- a/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
+++ b/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
@@ -137,6 +137,14 @@ export class NativeWebAnimationRunner extends AnimationRunner {
     this.setPlayState_(WebAnimationPlayState.RUNNING);
     this.runningCount_ = 0;
     this.players_.forEach(player => {
+      /**
+       * TODO(gharbiw):
+       * The playState on Safari and Edge sometimes gets stuck on
+       * the PENDING state (particularly when the animation's visibility
+       * gets toggled) so we add an exception to play even if the state
+       * is PENDING. Need to investigate why this happens, fix it and
+       * remove the exception below.
+       */
       if (
         oldRunnerPlayState != WebAnimationPlayState.PAUSED ||
         player.playState == WebAnimationPlayState.PAUSED ||

--- a/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
+++ b/extensions/amp-animation/0.1/runners/native-web-animation-runner.js
@@ -139,7 +139,8 @@ export class NativeWebAnimationRunner extends AnimationRunner {
     this.players_.forEach(player => {
       if (
         oldRunnerPlayState != WebAnimationPlayState.PAUSED ||
-        player.playState == WebAnimationPlayState.PAUSED
+        player.playState == WebAnimationPlayState.PAUSED ||
+        player.playState == WebAnimationPlayState.PENDING
       ) {
         player.play();
         this.runningCount_++;


### PR DESCRIPTION
Closes #24455

Dirty fix for a bug on Safari and Edge that prevents animations from resuming when switching tabs caused by a bug in the playState of animations (set to `pending` until the next call as opposed to `paused` or `running`).