### PR TITLE
🐛 exclude amp- prefixes from reserved class

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -52,11 +52,10 @@ export function getAutofocusElementForShowAction(element) {
 const TAG = 'STANDARD-ACTIONS';
 
 /**
- * Regular expression that identifies AMP CSS classes.
- * Includes 'i-amphtml-', '-amp-', and 'amp-' prefixes.
+ * Regular expression that identifies AMP CSS classes with 'i-amphtml-' prefixes.
  * @type {!RegExp}
  */
-const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
+const AMP_CSS_RE = /^i-amphtml-/;
 
 /**
  * This service contains implementations of some of the most typical actions,

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -395,8 +395,7 @@ describes.sandboxed('StandardActions', {}, () => {
   });
 
   describe('"toggleClass" action', () => {
-    const dummyClass = 'amp-test-class-toggle';
-    const dummyInternalClass = 'i-amphtml-test-class-toggle';
+    const dummyClass = 'test-class-toggle';
 
     it('should add class when not in classList', () => {
       const element = createElement();
@@ -425,31 +424,79 @@ describes.sandboxed('StandardActions', {}, () => {
       expectElementToDropClass(element, dummyClass);
     });
 
+    it('should add classes with amp- and -amp- prefixes', () => {
+      const element = createElement();
+      const invocation1 = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': 'amp-test-class-toggle',
+        },
+      };
+      standardActions.handleToggleClass_(invocation1);
+      expect(element.classList.contains('amp-test-class-toggle')).to.be.true;
+      const invocation2 = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': '-amp-test-class-toggle',
+        },
+      };
+      standardActions.handleToggleClass_(invocation2);
+      expect(element.classList.contains('-amp-test-class-toggle')).to.be.true;
+    });
+
+    it('should delete classes with amp- and -amp- prefixes', () => {
+      const element = createElement();
+      element.classList.add('amp-test-class-toggle');
+      const invocation1 = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': 'amp-test-class-toggle',
+        },
+      };
+      standardActions.handleToggleClass_(invocation1);
+      expect(element.classList.contains('amp-test-class-toggle')).to.be.false;
+      element.classList.add('-amp-test-class-toggle');
+      const invocation2 = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': '-amp-test-class-toggle',
+        },
+      };
+      standardActions.handleToggleClass_(invocation2);
+      expect(element.classList.contains('amp-test-class-toggle')).to.be.false;
+    });
+
     it('should not add amp internal classes', () => {
       const element = createElement();
       const invocation = {
         node: element,
         satisfiesTrust: () => true,
         args: {
-          'class': dummyInternalClass,
+          'class': 'i-amphtml-test-class-toggle',
         },
       };
       standardActions.handleToggleClass_(invocation);
-      expect(element.classList.contains(dummyInternalClass)).to.be.false;
+      expect(element.classList.contains('i-amphtml-test-class-toggle')).to.be
+        .false;
     });
 
     it('should not delete amp internal classes', () => {
       const element = createElement();
-      element.classList.add(dummyInternalClass);
+      element.classList.add('i-amphtml-test-class-toggle');
       const invocation = {
         node: element,
         satisfiesTrust: () => true,
         args: {
-          'class': dummyInternalClass,
+          'class': 'i-amphtml-test-class-toggle',
         },
       };
       standardActions.handleToggleClass_(invocation);
-      expect(element.classList.contains(dummyInternalClass)).to.be.true;
+      expect(element.classList.contains('i-amphtml-test-class-toggle')).to.be
+        .true;
     });
 
     it('should add class when not in classList, when force=true', () => {

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -395,12 +395,8 @@ describes.sandboxed('StandardActions', {}, () => {
   });
 
   describe('"toggleClass" action', () => {
-    const dummyClass = 'test-class-toggle';
-    const dummyInternalClasses = [
-      'i-amphtml-test-class-toggle',
-      '-amp-test-class-toggle',
-      'amp-test-class-toggle',
-    ];
+    const dummyClass = 'amp-test-class-toggle';
+    const dummyInternalClass = 'i-amphtml-test-class-toggle';
 
     it('should add class when not in classList', () => {
       const element = createElement();
@@ -431,33 +427,29 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should not add amp internal classes', () => {
       const element = createElement();
-      dummyInternalClasses.forEach(dummyInternalClass => {
-        const invocation = {
-          node: element,
-          satisfiesTrust: () => true,
-          args: {
-            'class': dummyInternalClass,
-          },
-        };
-        standardActions.handleToggleClass_(invocation);
-        expect(element.classList.contains(dummyInternalClass)).to.be.false;
-      });
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': dummyInternalClass,
+        },
+      };
+      standardActions.handleToggleClass_(invocation);
+      expect(element.classList.contains(dummyInternalClass)).to.be.false;
     });
 
     it('should not delete amp internal classes', () => {
       const element = createElement();
-      dummyInternalClasses.forEach(dummyInternalClass => {
-        element.classList.add(dummyInternalClass);
-        const invocation = {
-          node: element,
-          satisfiesTrust: () => true,
-          args: {
-            'class': dummyInternalClass,
-          },
-        };
-        standardActions.handleToggleClass_(invocation);
-        expect(element.classList.contains(dummyInternalClass)).to.be.true;
-      });
+      element.classList.add(dummyInternalClass);
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'class': dummyInternalClass,
+        },
+      };
+      standardActions.handleToggleClass_(invocation);
+      expect(element.classList.contains(dummyInternalClass)).to.be.true;
     });
 
     it('should add class when not in classList, when force=true', () => {


### PR DESCRIPTION
Fixes #24457 

toggleClass action should be applicable to all classes (including `amp-*` and `-amp-*`) except those with `i-amphtml-` prefixes.

@cathyxz @choumx 