### PR TITLE
🐛 CEv1: Only upgrade nodes if ownerDocument matches registry doc

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -662,7 +662,7 @@ function installPatches(win, registry) {
     // Only upgrade elements if the cloned node belonged to _this_ document.
     // Eg, when cloning a <template>'s content, the cloned document fragment
     // does not belong to this document.
-    if (this.ownerDocument === document) {
+    if (cloned.ownerDocument === document) {
       registry.upgradeSelf(cloned);
       registry.upgrade(cloned);
     }

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -585,7 +585,7 @@ class Registry {
  * @param {!Registry} registry
  */
 function installPatches(win, registry) {
-  const {Document, Element, Node, Object} = win;
+  const {Document, Element, Node, Object, document} = win;
   const docProto = Document.prototype;
   const elProto = Element.prototype;
   const nodeProto = Node.prototype;
@@ -613,7 +613,14 @@ function installPatches(win, registry) {
   // TODO(jridgewell): Can fire adoptedCallback for cross doc imports.
   docProto.importNode = function() {
     const imported = importNode.apply(this, arguments);
-    if (imported) {
+
+    // Only upgrade elements if the document that the nodes were imported into
+    // is _this_ document. If it's another document, then that document's
+    // element registry must do the upgrade.
+    // Eg, when importing from a <template>, the cloned document fragment
+    // should be upgraded. But importing from document into the <template>
+    // should not.
+    if (imported && this === document) {
       registry.upgradeSelf(imported);
       registry.upgrade(imported);
     }
@@ -651,8 +658,14 @@ function installPatches(win, registry) {
   // Patch cloneNode to immediately upgrade custom elements.
   nodeProto.cloneNode = function() {
     const cloned = cloneNode.apply(this, arguments);
-    registry.upgradeSelf(cloned);
-    registry.upgrade(cloned);
+
+    // Only upgrade elements if the cloned node belonged to _this_ document.
+    // Eg, when cloning a <template>'s content, the cloned document fragment
+    // does not belong to this document.
+    if (this.ownerDocument === document) {
+      registry.upgradeSelf(cloned);
+      registry.upgrade(cloned);
+    }
     return cloned;
   };
 


### PR DESCRIPTION
There was a bug where cloning in/out of a `<template>` would upgrade the custom element nodes even if the tree belonged to the template's document (which is distinct from the page's document).

Fixes https://github.com/ampproject/amphtml/issues/24462