### PR TITLE
Carve out flex slot expansion for multi-size responses.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1252,9 +1252,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.attemptChangeSize(newHeight, newWidth).catch(() => {});
       if (
         newWidth > width &&
-        // If 'fluid' was the primary requested size, ensure we do not trigger
-        // slot adjustment if the returned size is one of the requested multi
-        // -sizes. Slot adjustment should only be triggered when the creative 
+        // If 'fluid' were the primary requested size, ensure we do not trigger
+        // slot adjustment if the returned size is one of the requested multi-
+        // sizes. Slot adjustment should only be triggered when the creative 
         // size is not one of the requested sizes.
         (!this.isFluidPrimaryRequest_ ||
           (this.parameterSize &&

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1252,9 +1252,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.attemptChangeSize(newHeight, newWidth).catch(() => {});
       if (
         newWidth > width &&
-        // Nothing to adjust if the returned size was one that was requested.
-        this.parameterSize &&
-        this.parameterSize.indexOf(`${newWidth}x${newHeight}`) == -1
+        // If 'fluid' was the primary requested size, ensure we do not trigger
+        // slot adjustment if the returned size is one of the requested multi
+        // -sizes. Slot adjustment should only be triggered when the creative 
+        // size is not one of the requested sizes.
+        (!this.isFluidPrimaryRequest_ ||
+          (this.parameterSize &&
+            this.parameterSize.indexOf(`${newWidth}x${newHeight}`) == -1))
       ) {
         this.adjustSlotPostExpansion_(newWidth);
       }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1254,7 +1254,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         newWidth > width &&
         // If 'fluid' were the primary requested size, ensure we do not trigger
         // slot adjustment if the returned size is one of the requested multi-
-        // sizes. Slot adjustment should only be triggered when the creative 
+        // sizes. Slot adjustment should only be triggered when the creative
         // size is not one of the requested sizes.
         (!this.isFluidPrimaryRequest_ ||
           (this.parameterSize &&

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1250,7 +1250,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       (returnedSizeDifferent && heightNotIncreased)
     ) {
       this.attemptChangeSize(newHeight, newWidth).catch(() => {});
-      if (newWidth > width) {
+      if (
+        newWidth > width &&
+        // Nothing to adjust if the returned size was one that was requested.
+        this.parameterSize &&
+        this.parameterSize.indexOf(`${newWidth}x${newHeight}`) == -1
+      ) {
         this.adjustSlotPostExpansion_(newWidth);
       }
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -355,8 +355,18 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         newWidth: 400,
         margin: '-375px',
       },
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 200,
+        margin: '',
+        isMultiSizeResponse: true,
+      },
     ].forEach((testCase, testNum) => {
       it(`should adjust slot CSS after expanding width #${testNum}`, () => {
+        impl.parameterSize = testCase.isMultiSizeResponse
+          ? '320x50,200x50'
+          : '200x50';
         sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
           impl.element.style.width = `${width}px`;
           return {
@@ -390,8 +400,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         });
         expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
-        // We use a fixed '11' value for z-index.
-        expect(impl.element.style.zIndex).to.equal('11');
+        if (!testCase.isMultiSizeResponse) {
+          // We use a fixed '30' value for z-index.
+          expect(impl.element.style.zIndex).to.equal('11');
+        }
       });
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -401,7 +401,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         });
         expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
         if (!testCase.isMultiSizeResponse) {
-          // We use a fixed '30' value for z-index.
+          // We use a fixed '11' value for z-index.
           expect(impl.element.style.zIndex).to.equal('11');
         }
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -364,9 +364,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       },
     ].forEach((testCase, testNum) => {
       it(`should adjust slot CSS after expanding width #${testNum}`, () => {
-        impl.parameterSize = testCase.isMultiSizeResponse
-          ? '320x50,200x50'
-          : '200x50';
+        if (testCase.isMultiSizeResponse) {
+          impl.parameterSize = '320x50,200x50';
+          impl.isFluidPrimaryRequest_ = true;
+        } else {
+          impl.paramterSize = '200x50';
+        }
         sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
           impl.element.style.width = `${width}px`;
           return {


### PR DESCRIPTION
If the returned creative has a size that matches one that was requested, we don't need to adjust the slot in any way.