### PR TITLE
🐛Fix carousel 0.2 arrows not hiding until two swipes.

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -610,6 +610,7 @@ class AmpCarousel extends AMP.BaseElement {
     this.element.dispatchCustomEvent(name, data);
     this.hadTouch_ = this.hadTouch_ || actionSource == ActionSource.TOUCH;
     this.updateCurrentIndex_(index);
+    this.updateUi_();
   }
 
   /**


### PR DESCRIPTION
After the first swipe has finished (the index has changed), also update the arrow buttons UI state, after updating `this.hadTouch_`, letting the buttons know they should hide.

For https://github.com/ampproject/amphtml/issues/24481#issuecomment-530935624