### PR TITLE
Change how carousel queuing of layout visibility works for iOS.

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -241,6 +241,7 @@ exports.rules = [
       // Amp carousel (and friends) depending on base carousel
       'extensions/amp-carousel/0.2/amp-carousel.js->extensions/amp-base-carousel/0.1/action-source.js',
       'extensions/amp-carousel/0.2/amp-carousel.js->extensions/amp-base-carousel/0.1/carousel.js',
+      'extensions/amp-carousel/0.2/amp-carousel.js->extensions/amp-base-carousel/0.1/carousel-events.js',
       'extensions/amp-carousel/0.2/amp-carousel.js->extensions/amp-base-carousel/0.1/child-layout-manager.js',
 
       // Facebook components

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {INDEX_CHANGE} from './carousel-events';
 import {ActionSource} from './action-source';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-base-carousel-0.1.css';
 import {Carousel} from './carousel.js';
+import {CarouselEvents} from './carousel-events';
 import {
   ResponsiveAttributes,
   getResponsiveAttributeValue,
@@ -183,7 +183,7 @@ class AmpCarousel extends AMP.BaseElement {
 
     // Setup actions and listeners
     this.setupActions_();
-    this.element.addEventListener(INDEX_CHANGE, event => {
+    this.element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });
     this.prevArrowSlot_.addEventListener('click', event => {

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {INDEX_CHANGE} from './carousel-events';
 import {ActionSource} from './action-source';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-base-carousel-0.1.css';
@@ -182,7 +183,7 @@ class AmpCarousel extends AMP.BaseElement {
 
     // Setup actions and listeners
     this.setupActions_();
-    this.element.addEventListener('amp-carousel:indexchange', event => {
+    this.element.addEventListener(INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });
     this.prevArrowSlot_.addEventListener('click', event => {

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -182,7 +182,7 @@ class AmpCarousel extends AMP.BaseElement {
 
     // Setup actions and listeners
     this.setupActions_();
-    this.element.addEventListener('indexchange', event => {
+    this.element.addEventListener('amp-carousel:indexchange', event => {
       this.onIndexChanged_(event);
     });
     this.prevArrowSlot_.addEventListener('click', event => {

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CarouselEvents} from './carousel-events';
 import {getDetail} from '../../../src/event-helper';
 
 /**
@@ -69,7 +70,7 @@ export class CarouselAccessibility {
       },
       true
     );
-    element.addEventListener('indexchange', event => {
+    element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });
   }

--- a/extensions/amp-base-carousel/0.1/carousel-events.js
+++ b/extensions/amp-base-carousel/0.1/carousel-events.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /** @enum {string} */
+export const CarouselEvents = {
+  INDEX_CHANGE: 'amp-carousel:indexchange',
+  SCROLL_START: 'amp-carousel:scrollstart',
+  SCROLL_POSITION_CHANGED: 'amp-carousel:scrollpositionchange',
+};

--- a/extensions/amp-base-carousel/0.1/carousel-events.js
+++ b/extensions/amp-base-carousel/0.1/carousel-events.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- /** @enum {string} */
+/** @enum {string} */
 export const CarouselEvents = {
   INDEX_CHANGE: 'amp-carousel:indexchange',
   SCROLL_START: 'amp-carousel:scrollstart',

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {INDEX_CHANGE, SCROLL_POSITION_CHANGED, SCROLL_START} from './carousel-events';
 import {ActionSource} from './action-source';
 import {
   Alignment,
@@ -688,7 +689,7 @@ export class Carousel {
     this.element_.dispatchEvent(
       createCustomEvent(
         this.win_,
-        'amp-carousel:indexchange',
+        INDEX_CHANGE,
         dict({
           'index': restingIndex,
           'actionSource': this.actionSource_,
@@ -704,7 +705,7 @@ export class Carousel {
    */
   notifyScrollStart() {
     this.element_.dispatchEvent(
-      createCustomEvent(this.win_, 'amp-carousel:scrollstart', null)
+      createCustomEvent(this.win_, SCROLL_START, null)
     );
   }
 
@@ -715,7 +716,7 @@ export class Carousel {
    */
   notifyScrollPositionChanged_() {
     this.element_.dispatchEvent(
-      createCustomEvent(this.win_, 'amp-carousel:scrollpositionchange', null)
+      createCustomEvent(this.win_, SCROLL_POSITION_CHANGED, null)
     );
   }
 

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -688,7 +688,7 @@ export class Carousel {
     this.element_.dispatchEvent(
       createCustomEvent(
         this.win_,
-        'indexchange',
+        'amp-carousel:indexchange',
         dict({
           'index': restingIndex,
           'actionSource': this.actionSource_,
@@ -702,9 +702,20 @@ export class Carousel {
    * settled. In some situations, the index may not change, but you still want
    * to react to the scroll position changing.
    */
+  notifyScrollStart() {
+    this.element_.dispatchEvent(
+      createCustomEvent(this.win_, 'amp-carousel:scrollstart', null)
+    );
+  }
+
+  /**
+   * Fires an event when the scroll position has changed, once scrolling has
+   * settled. In some situations, the index may not change, but you still want
+   * to react to the scroll position changing.
+   */
   notifyScrollPositionChanged_() {
     this.element_.dispatchEvent(
-      createCustomEvent(this.win_, 'scrollpositionchange', null)
+      createCustomEvent(this.win_, 'amp-carousel:scrollpositionchange', null)
     );
   }
 
@@ -756,6 +767,7 @@ export class Carousel {
 
     this.scrolling_ = true;
     this.updateCurrent_();
+    this.notifyScrollStart();
     this.debouncedResetScrollReferencePoint_();
   }
 

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {INDEX_CHANGE, SCROLL_POSITION_CHANGED, SCROLL_START} from './carousel-events';
 import {ActionSource} from './action-source';
 import {
   Alignment,
@@ -29,6 +28,7 @@ import {
 } from './dimensions.js';
 import {AutoAdvance} from './auto-advance';
 import {CarouselAccessibility} from './carousel-accessibility';
+import {CarouselEvents} from './carousel-events';
 import {backwardWrappingDistance, forwardWrappingDistance} from './array-util';
 import {clamp, mod} from '../../../src/utils/math';
 import {createCustomEvent, listen, listenOnce} from '../../../src/event-helper';
@@ -689,7 +689,7 @@ export class Carousel {
     this.element_.dispatchEvent(
       createCustomEvent(
         this.win_,
-        INDEX_CHANGE,
+        CarouselEvents.INDEX_CHANGE,
         dict({
           'index': restingIndex,
           'actionSource': this.actionSource_,
@@ -705,7 +705,7 @@ export class Carousel {
    */
   notifyScrollStart() {
     this.element_.dispatchEvent(
-      createCustomEvent(this.win_, SCROLL_START, null)
+      createCustomEvent(this.win_, CarouselEvents.SCROLL_START, null)
     );
   }
 
@@ -716,7 +716,7 @@ export class Carousel {
    */
   notifyScrollPositionChanged_() {
     this.element_.dispatchEvent(
-      createCustomEvent(this.win_, SCROLL_POSITION_CHANGED, null)
+      createCustomEvent(this.win_, CarouselEvents.SCROLL_POSITION_CHANGED, null)
     );
   }
 

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -425,7 +425,7 @@ describes.realWin('child layout manager', {}, env => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
-        intersectionElement: el
+        intersectionElement: el,
       });
 
       clm.setQueueChanges(true);

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -150,7 +150,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -165,7 +164,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -183,7 +181,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -205,7 +202,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -228,7 +224,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -250,7 +245,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
         viewportIntersectionCallback,
       });
 
@@ -272,7 +266,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -292,7 +285,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -316,7 +308,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -341,7 +332,6 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: false,
       });
 
       clm.updateChildren(el.children);
@@ -365,9 +355,9 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: true,
       });
 
+      clm.setQueueChanges(true);
       clm.updateChildren(el.children);
       await afterRenderPromise();
 
@@ -375,79 +365,19 @@ describes.realWin('child layout manager', {}, env => {
       expect(ownersMock.scheduleLayout).to.have.not.been.called;
     });
 
-    it('should schedule layout for one extra viewport on layout', async () => {
-      const el = createHorizontalScroller(5);
-      const clm = new ChildLayoutManager({
-        ampElement: ampElementMock,
-        intersectionElement: el,
-        queueChanges: true,
-      });
-
-      clm.updateChildren(el.children);
-      clm.wasLaidOut();
-      await afterRenderPromise();
-
-      expect(ownersMock.scheduleLayout)
-        .to.have.callCount(2)
-        .to.have.been.calledWith(domElementMock, el.children[0])
-        .to.have.been.calledWith(domElementMock, el.children[1]);
-    });
-
-    it('should schedule layout when wasLaidOut is called', async () => {
-      const el = createHorizontalScroller(5);
-      const clm = new ChildLayoutManager({
-        ampElement: ampElementMock,
-        intersectionElement: el,
-        queueChanges: true,
-      });
-
-      clm.updateChildren(el.children);
-      await afterRenderPromise();
-
-      expect(ownersMock.scheduleLayout).to.have.not.been.called;
-
-      clm.wasLaidOut();
-      await afterRenderPromise();
-
-      expect(ownersMock.scheduleLayout)
-        .to.have.callCount(2)
-        .to.have.been.calledWith(domElementMock, el.children[0])
-        .to.have.been.calledWith(domElementMock, el.children[1]);
-    });
-
-    it('should update viewport visibility', async () => {
-      const el = createHorizontalScroller(5);
-      const clm = new ChildLayoutManager({
-        ampElement: ampElementMock,
-        intersectionElement: el,
-        queueChanges: true,
-      });
-
-      clm.updateChildren(el.children);
-      clm.wasLaidOut();
-      await afterRenderPromise();
-
-      expect(ownersMock.updateInViewport)
-        .to.have.callCount(5)
-        .to.have.been.calledWith(domElementMock, el.children[0], true)
-        .to.have.been.calledWith(domElementMock, el.children[1], false)
-        .to.have.been.calledWith(domElementMock, el.children[2], false)
-        .to.have.been.calledWith(domElementMock, el.children[3], false)
-        .to.have.been.calledWith(domElementMock, el.children[4], false);
-    });
-
     it('should queue layout on scroll', async () => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: true,
       });
 
+      clm.setQueueChanges(true);
       clm.updateChildren(el.children);
       clm.wasLaidOut();
       await afterRenderPromise();
 
+      clm.flushChanges();
       ownersMock.scheduleLayout.resetHistory();
       await afterScrollAndIntersectingPromise(el.children[1], el);
 
@@ -466,13 +396,14 @@ describes.realWin('child layout manager', {}, env => {
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
         intersectionElement: el,
-        queueChanges: true,
       });
 
+      clm.setQueueChanges(true);
       clm.updateChildren(el.children);
       clm.wasLaidOut();
       await afterRenderPromise();
 
+      clm.flushChanges();
       ownersMock.scheduleUnlayout.resetHistory();
       await afterScrollAndIntersectingPromise(el.children[3], el);
       await afterRenderPromise();
@@ -494,14 +425,15 @@ describes.realWin('child layout manager', {}, env => {
       const el = createHorizontalScroller(5);
       const clm = new ChildLayoutManager({
         ampElement: ampElementMock,
-        intersectionElement: el,
-        queueChanges: true,
+        intersectionElement: el
       });
 
+      clm.setQueueChanges(true);
       clm.updateChildren(el.children);
       clm.wasLaidOut();
       await afterRenderPromise();
 
+      clm.flushChanges();
       ownersMock.updateInViewport.resetHistory();
       await afterScrollAndIntersectingPromise(el.children[1], el);
       await afterRenderPromise();

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {INDEX_CHANGE, SCROLL_POSITION_CHANGED, SCROLL_START} from '../../amp-base-carousel/0.1/carousel-events';
 import {ActionSource} from '../../amp-base-carousel/0.1/action-source';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-carousel-0.2.css';
 import {Carousel} from '../../amp-base-carousel/0.1/carousel.js';
+import {CarouselEvents} from '../../amp-base-carousel/0.1/carousel-events';
 import {ChildLayoutManager} from '../../amp-base-carousel/0.1/child-layout-manager';
 import {Services} from '../../../src/services';
 import {closestAncestorElementBySelector} from '../../../src/dom';
@@ -139,15 +139,18 @@ class AmpCarousel extends AMP.BaseElement {
     // Setup actions and listeners
     this.setupActions_();
     this.stopTouchMovePropagation_();
-    this.element.addEventListener(INDEX_CHANGE, event => {
+    this.element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });
-    this.element.addEventListener(SCROLL_START, () => {
+    this.element.addEventListener(CarouselEvents.SCROLL_START, () => {
       this.onScrollStarted_();
     });
-    this.element.addEventListener(SCROLL_POSITION_CHANGED, () => {
-      this.onScrollPositionChanged_();
-    });
+    this.element.addEventListener(
+      CarouselEvents.SCROLL_POSITION_CHANGED,
+      () => {
+        this.onScrollPositionChanged_();
+      }
+    );
     this.prevButton_.addEventListener('click', () => this.interactionPrev());
     this.nextButton_.addEventListener('click', () => this.interactionNext());
 

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -66,6 +66,9 @@ class AmpCarousel extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
+    /** @private @const {boolean} */
+    this.isIos_ = Services.platformFor(this.win).isIos();
+
     /** @private {?Carousel} */
     this.carousel_ = null;
 
@@ -135,28 +138,26 @@ class AmpCarousel extends AMP.BaseElement {
     // Setup actions and listeners
     this.setupActions_();
     this.stopTouchMovePropagation_();
-    this.element.addEventListener('indexchange', event => {
+    this.element.addEventListener('amp-carousel:indexchange', event => {
       this.onIndexChanged_(event);
     });
-    this.element.addEventListener('scrollpositionchange', () => {
+    this.element.addEventListener('amp-carousel:scrollstart', () => {
+      this.onScrollStarted_();
+    });
+    this.element.addEventListener('amp-carousel:scrollpositionchange', () => {
       this.onScrollPositionChanged_();
     });
     this.prevButton_.addEventListener('click', () => this.interactionPrev());
     this.nextButton_.addEventListener('click', () => this.interactionNext());
 
     const owners = Services.ownersForDoc(element);
-    const isIos = Services.platformFor(this.win).isIos();
     this.childLayoutManager_ = new ChildLayoutManager({
       ampElement: this,
       intersectionElement: this.scrollContainer_,
-      // For iOS, we cannot trigger layout during scrolling or the UI will
-      // flicker, so tell the layout to simply queue the changes, which we
-      // flush after scrolling stops.
-      queueChanges: isIos,
       // For iOS, we queue changes until scrolling stops, which we detect
       // ~200ms after it actually stops. Load items earlier so they have time
       // to load.
-      nearbyMarginInPercent: isIos ? 200 : 100,
+      nearbyMarginInPercent: this.isIos_ ? 200 : 100,
       viewportIntersectionCallback: (child, isIntersecting) => {
         if (isIntersecting) {
           owners.scheduleResume(this.element, child);
@@ -165,6 +166,10 @@ class AmpCarousel extends AMP.BaseElement {
         }
       },
     });
+    // For iOS, we cannot trigger layout during scrolling or the UI will
+    // flicker, so tell the layout to simply queue the changes, which we
+    // flush after scrolling stops.
+    this.childLayoutManager_.setQueueChanges(this.isIos_);
 
     this.childLayoutManager_.updateChildren(this.slides_);
     this.carousel_.updateSlides(this.slides_);
@@ -578,6 +583,14 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /**
+   * Starts queuing all intersection based changes when scrolling starts, to
+   * prevent paint flickering on iOS.
+   */
+  onScrollStarted_() {
+    this.childLayoutManager_.setQueueChanges(this.isIos_);
+  }
+
+  /**
    * Update the UI (buttons) for the new scroll position. This occurs when
    * scrolling has settled.
    */
@@ -585,6 +598,8 @@ class AmpCarousel extends AMP.BaseElement {
     // Now that scrolling has settled, flush any layout changes for iOS since
     // it will not cause flickering.
     this.childLayoutManager_.flushChanges();
+    this.childLayoutManager_.setQueueChanges(false);
+
     this.updateUi_();
   }
 

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {INDEX_CHANGE, SCROLL_POSITION_CHANGED, SCROLL_START} from '../../amp-base-carousel/0.1/carousel-events';
 import {ActionSource} from '../../amp-base-carousel/0.1/action-source';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-carousel-0.2.css';
@@ -138,13 +139,13 @@ class AmpCarousel extends AMP.BaseElement {
     // Setup actions and listeners
     this.setupActions_();
     this.stopTouchMovePropagation_();
-    this.element.addEventListener('amp-carousel:indexchange', event => {
+    this.element.addEventListener(INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });
-    this.element.addEventListener('amp-carousel:scrollstart', () => {
+    this.element.addEventListener(SCROLL_START, () => {
       this.onScrollStarted_();
     });
-    this.element.addEventListener('amp-carousel:scrollpositionchange', () => {
+    this.element.addEventListener(SCROLL_POSITION_CHANGED, () => {
       this.onScrollPositionChanged_();
     });
     this.prevButton_.addEventListener('click', () => this.interactionPrev());

--- a/extensions/amp-carousel/0.2/test/test-type-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-type-slides.js
@@ -16,6 +16,7 @@
 
 import '../amp-carousel';
 import {ActionTrust} from '../../../../src/action-constants';
+import {CarouselEvents} from '../../../amp-base-carousel/0.1/carousel-events';
 import {getDetail, listenOncePromise} from '../../../../src/event-helper';
 
 /**
@@ -30,7 +31,7 @@ import {getDetail, listenOncePromise} from '../../../../src/event-helper';
  * @return {!Promise<undefined>}
  */
 async function afterIndexUpdate(el, index) {
-  const event = await listenOncePromise(el, 'indexchange');
+  const event = await listenOncePromise(el, CarouselEvents.INDEX_CHANGE);
   await el.implementation_.mutateElement(() => {});
   await el.implementation_.mutateElement(() => {});
 


### PR DESCRIPTION
- Make this more robust to when IntersectionObserver fires. While this
   is not a problem for amp-carousel, it is a problem for amp-stream-gallery,
   causing it to sometimes not detect slides to layout on the initial render.
    - Explicitly turn on/off queuing of changes during scroll rather than turning
       it off all the time and trying to catch the next IntersectionObserver
       changes after layout.
- Rename the internal carousel events to use a namespace, to avoid clashing
   with DOM events in the future.