### PR TITLE
Turn custom-elements-v1 experiment off in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,7 @@
   "as-use-attr-for-format": 0.01,
   "blurry-placeholder": 1,
   "chunked-amp": 1,
-  "custom-elements-v1": 1,
+  "custom-elements-v1": 0,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "fie-css-cleanup": 1,


### PR DESCRIPTION
Temporary fix for https://github.com/ampproject/amphtml/issues/24470. 