### PR TITLE
🐛 Fix existing syntax errors in OWNERS.yaml files

### DIFF
--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,5 +1,4 @@
 - cramforce
 - dvoytenko
 - jridgewell
-- ampproject/validator:
-  - "*.protoascii"
+- "**/validator-*.protoascii": ampproject/validator

--- a/css/OWNERS.yaml
+++ b/css/OWNERS.yaml
@@ -1,2 +1,2 @@
-- @aghassemi
-- @camelburrito
+- aghassemi
+- camelburrito

--- a/test/OWNERS.yaml
+++ b/test/OWNERS.yaml
@@ -1,2 +1,2 @@
-- @ampproject/runtime
-- @ampproject/validator
+- ampproject/runtime
+- ampproject/validator


### PR DESCRIPTION
Some existing OWNERS files have errors. This PR:
- removes empty OWNERS.yaml files
- removes unnecessary `@` prefix before teams/usernames
- fixes protoascii glob pattern in root owners file