### PR TITLE
🏗 Update ownership rules for extensions/**/*-player.js

### DIFF
--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,1 +1,2 @@
 - aghassemi
+- "**/*-player.js": alanorozco

--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,2 +1,4 @@
 - aghassemi
-- "**/*-player.js, **/*-player.md": alanorozco
+- "**/*-player.js, **/*-player.md":
+  - alanorozco
+  - wassgha

--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,2 +1,2 @@
 - aghassemi
-- "**/*-player.js": alanorozco
+- "**/*-player.js, **/*-player.md": alanorozco

--- a/extensions/amp-3q-player/OWNERS.yaml
+++ b/extensions/amp-3q-player/OWNERS.yaml
@@ -1,2 +1,1 @@
 - cvializ
-- alanorozco

--- a/extensions/amp-brid-player/OWNERS.yaml
+++ b/extensions/amp-brid-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - pedjoni8

--- a/extensions/amp-delight-player/OWNERS.yaml
+++ b/extensions/amp-delight-player/OWNERS.yaml
@@ -1,2 +1,0 @@
-- aghassemi
-- alanorozco

--- a/extensions/amp-kaltura-player/OWNERS.yaml
+++ b/extensions/amp-kaltura-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - itaykinnrot

--- a/extensions/amp-nexxtv-player/OWNERS.yaml
+++ b/extensions/amp-nexxtv-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - neko-fire

--- a/extensions/amp-o2-player/OWNERS.yaml
+++ b/extensions/amp-o2-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - yevheniiminin

--- a/extensions/amp-ooyala-player/OWNERS.yaml
+++ b/extensions/amp-ooyala-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - mityaha

--- a/extensions/amp-reach-player/OWNERS.yaml
+++ b/extensions/amp-reach-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - mikepmtl

--- a/extensions/amp-springboard-player/OWNERS.yaml
+++ b/extensions/amp-springboard-player/OWNERS.yaml
@@ -1,2 +1,1 @@
-- aghassemi
 - Em-PredragMilosevic

--- a/extensions/amp-wistia-player/OWNERS.yaml
+++ b/extensions/amp-wistia-player/OWNERS.yaml
@@ -1,2 +1,0 @@
-- aghassemi
-- alanorozco


### PR DESCRIPTION
All extensions ending in `-player` by convention are video players and are owned by @alanorozco and @wassgha . This PR:
- Adds `alanorozco` and `wassgha` as owners for all files `extensions/**/*-player.(js|md)`
- Removes duplicate ownership declarations in individual extension OWNERS files for @alanorozco (who owns all `*-player.(js|md)`) and @aghassemi (who is an owner of the full `extensions` directory
- Deletes empty OWNERS files