### PR TITLE
🏗 Update ownership rules for validator files

### DIFF
--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,4 +1,4 @@
 - cramforce
 - dvoytenko
 - jridgewell
-- "**/validator-*.protoascii": ampproject/validator
+- "**/validator-*.protoascii": ampproject/wg-caching

--- a/validator/OWNERS.yaml
+++ b/validator/OWNERS.yaml
@@ -1,4 +1,1 @@
-- gregable
-- honeybadgerdontcare
-- alin04
-- twifkak
+- ampproject/wg-caching


### PR DESCRIPTION
This PR:
- adds @ampproject/wg-caching as an owner of the `validator` directory
- removes the individual owners from the list (as they are all team members)
- adds @ampproject/wg-caching as an owner of all `validator-*.protoascii` files

@honeybadgerdontcare I noticed there are also files of the form `validator-*.html` and `validator-*.out`; are these also under your purview?