### PR TITLE
referrer !== '' doesn't work on Chrome 77 Windows?

### DIFF
--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -119,7 +119,7 @@ describe.configure().run('amp-ad 3P', () => {
         });
         expect(parseInt(context.pageViewId, 10)).to.be.greaterThan(0);
         // In some browsers the referrer is empty.
-        if (context.referrer !== '') {
+        if (context.referrer && context.referrer.length > 0) {
           expect(context.referrer).to.contain(
             'http://localhost:' + location.port
           );


### PR DESCRIPTION
```
DESCRIBE => amp-ad 3P
  IT => create an iframe with APIs
    ✗ AssertionError: expected '' to include 'http://localhost:9876'
        at http://localhost:9876/home/travis/build/ampproject/amphtml/test/integration/test-amp-ad-3p.js:124:39
```

https://github.com/ampproject/amphtml/blob/41441daeabef58ffc753188914644f2893a7127a/test/integration/test-amp-ad-3p.js#L121-L126

🤷‍♂ 