### PR TITLE
Reenable custom-elements-v1 experiment off in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,7 @@
   "as-use-attr-for-format": 0.01,
   "blurry-placeholder": 1,
   "chunked-amp": 1,
-  "custom-elements-v1": 0,
+  "custom-elements-v1": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "fie-css-cleanup": 1,


### PR DESCRIPTION
Reverts ampproject/amphtml#24513, which turned off the experiment.

This was a safe choice for the cherry-pick to fix https://github.com/ampproject/amphtml/issues/24462. But, https://github.com/ampproject/amphtml/pull/24468 has landed so we should be ok to reenable.