### PR TITLE
Soft DNS rewrite for various dev envelops

### DIFF
--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -26,6 +26,7 @@ const BBPromise = require('bluebird');
 const bodyParser = require('body-parser');
 const cors = require('./amp-cors');
 const devDashboard = require('./app-index/index');
+const evilDns = require('evil-dns');
 const formidable = require('formidable');
 const fs = BBPromise.promisifyAll(require('fs'));
 const jsdom = require('jsdom');
@@ -44,6 +45,9 @@ const {replaceUrls, isRtvMode} = require('./app-utils');
 
 const TEST_SERVER_PORT = argv.port || 8000;
 let SERVE_MODE = getServeMode();
+
+// Envelopes require rewriting these DNS records
+evilDns.add('*.localhost', '127.0.0.1');
 
 app.use(bodyParser.text());
 app.use(require('./routes/a4a-envelopes'));

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-sort-imports-es6-autofix": "0.4.0",
     "eslint-plugin-sort-requires": "2.1.0",
     "event-stream": "4.0.1",
+    "evil-dns": "0.2.0",
     "express": "4.17.1",
     "fancy-log": "1.3.3",
     "fetch-mock": "7.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,6 +5652,11 @@ events@^2.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
   integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
 
+evil-dns@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/evil-dns/-/evil-dns-0.2.0.tgz#6ff64bf9c99a18df465458e6878ac570ea15d9b9"
+  integrity sha1-b/ZL+cmaGN9GVFjmh4rFcOoV2bk=
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"


### PR DESCRIPTION
We have been depending on https://github.com/ampproject/amphtml/blob/master/.travis.yml#L34 to override DNS for *.localhost on Travis, but it does not exist on local dev environment. I find this evil-dns module that would inject into DNS module and overwrite DNS for the current nodejs instance only, so we do not have to depend on travis /etc/hosts.