### PR TITLE
Add e2e test for amp-ad-exit

### DIFF
--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -88,6 +88,15 @@ class FunctionalTestController {
   async getTitle() {}
 
   /**
+   * Select the given window.
+   * {@link https://www.w3.org/TR/webdriver1/#dfn-switch-to-window}
+   *
+   * @param {!ElementHandle} unusedHandle
+   * @return {!Promise}
+   */
+  async switchToWindow(unusedHandle) {}
+
+  /**
    * Selects the current top-level browsing context or a child browsing context
    * of the current browsing context to use as the current browsing context for
    * subsequent commands.
@@ -314,6 +323,15 @@ class FunctionalTestController {
    * @return {!ControllerPromise<boolean>}
    */
   async isElementEnabled(unusedHandle) {}
+
+  /**
+   * Return an array of handles consisting of all windows in the browser
+   * session.
+   * {@link https://www.w3.org/TR/webdriver1/#get-window-handles}
+   *
+   * @return {!Promise<!ElementHandle>}
+   */
+  async getAllWindows() {}
 
   /**
    * The Set Window Rect command alters the size and the position of the

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -91,10 +91,10 @@ class FunctionalTestController {
    * Select the given window.
    * {@link https://www.w3.org/TR/webdriver1/#dfn-switch-to-window}
    *
-   * @param {!ElementHandle} unusedHandle
+   * @param {string} unusedString
    * @return {!Promise}
    */
-  async switchToWindow(unusedHandle) {}
+  async switchToWindow(unusedString) {}
 
   /**
    * Selects the current top-level browsing context or a child browsing context
@@ -329,7 +329,7 @@ class FunctionalTestController {
    * session.
    * {@link https://www.w3.org/TR/webdriver1/#get-window-handles}
    *
-   * @return {!Promise<!ElementHandle>}
+   * @return {!Promise<string>}
    */
   async getAllWindows() {}
 

--- a/build-system/tasks/e2e/functional-test-controller.js
+++ b/build-system/tasks/e2e/functional-test-controller.js
@@ -329,7 +329,7 @@ class FunctionalTestController {
    * session.
    * {@link https://www.w3.org/TR/webdriver1/#get-window-handles}
    *
-   * @return {!Promise<string>}
+   * @return {!Promise<Array<string>>}
    */
   async getAllWindows() {}
 

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -420,7 +420,7 @@ class SeleniumWebDriverController {
     );
   }
   /**
-   * @return {!Promise<string>}
+   * @return {!Promise<Array<string>>}
    * @override
    */
   async getAllWindows() {

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -420,12 +420,11 @@ class SeleniumWebDriverController {
     );
   }
   /**
-   * @return {!Promise<!ElementHandle>}
+   * @return {!Promise<string>}
    * @override
    */
   async getAllWindows() {
-    const handles = await this.driver.getAllWindowHandles();
-    return handles.map(handle => new ElementHandle(handle, this));
+    return await this.driver.getAllWindowHandles();
   }
 
   /**
@@ -610,12 +609,12 @@ class SeleniumWebDriverController {
   }
 
   /**
-   * @param {!ElementHandle} handle
+   * @param {string} handle
    * @return {!Promise}
    * @override
    */
   async switchToWindow(handle) {
-    await this.driver.switchTo().window(handle.getElement());
+    await this.driver.switchTo().window(handle);
   }
 
   /**

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -261,6 +261,17 @@ class SeleniumWebDriverController {
   }
 
   /**
+   * @return {!ControllerPromise<string>}
+   * @override
+   */
+  getCurrentUrl() {
+    return new ControllerPromise(
+      this.driver.getCurrentUrl(),
+      this.getWaitFn_(() => this.driver.getCurrentUrl())
+    );
+  }
+
+  /**
    * @param {string} location
    * @return {!Promise}
    * @override
@@ -407,6 +418,14 @@ class SeleniumWebDriverController {
       webElement.isEnabled(),
       this.getWaitFn_(() => webElement.isEnabled())
     );
+  }
+  /**
+   * @return {!Promise<!ElementHandle>}
+   * @override
+   */
+  async getAllWindows() {
+    const handles = await this.driver.getAllWindowHandles();
+    return handles.map(handle => new ElementHandle(handle, this));
   }
 
   /**
@@ -588,6 +607,15 @@ class SeleniumWebDriverController {
     const webElement = handle.getElement();
     const imageString = await webElement.takeScreenshot();
     fs.writeFile(path, imageString, 'base64', function() {});
+  }
+
+  /**
+   * @param {!ElementHandle} handle
+   * @return {!Promise}
+   * @override
+   */
+  async switchToWindow(handle) {
+    await this.driver.switchTo().window(handle.getElement());
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -74,8 +74,8 @@ describes.endtoend(
       await expect(windows.length).to.equal(2);
 
       await controller.switchToWindow(windows[1]);
-      await expect(await controller.getCurrentUrl()).to.equal(
-        'http://localhost:8000/?product1&x=71&y=98&e=Product%201&shouldNotBeReplaced=AMP_VERSION'
+      await expect(await controller.getCurrentUrl()).to.match(
+        /^http:\/\/localhost:8000\/\?product1&x=71&y=9[78]&e=Product%201&shouldNotBeReplaced=AMP_VERSION$/
       );
     });
 

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'amp-ad-exit',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html',
+    environments: 'amp4ads-preset',
+  },
+  env => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    // Setting the time explicitly to avoid test flakiness.
+    async function setTime(epochTime) {
+      await controller.evaluate(time => {
+        window.Date = {
+          now: () => time,
+        };
+        if (window.parent) {
+          try {
+            window.parent.Date = window.Date;
+          } catch (e) {}
+        }
+      }, epochTime);
+    }
+
+    it('product1 clicked without delay', async () => {
+      const adDiv = await controller.findElement('#product1');
+      await controller.click(adDiv);
+
+      const windows = await controller.getAllWindows();
+      await expect(windows.length).to.equal(1);
+    });
+
+    it('product1 clicked near the border', async () => {
+      const adDiv = await controller.findElement('#product1');
+      await setTime(Number.MAX_VALUE);
+
+      await controller.driver
+        .actions()
+        .move({x: -55, y: -55, origin: adDiv.getElement()})
+        .press()
+        .release()
+        .perform();
+
+      const windows = await controller.getAllWindows();
+      await expect(windows.length).to.equal(1);
+    });
+
+    it('product1 ad opened', async () => {
+      const adDiv = await controller.findElement('#product1');
+      await setTime(Number.MAX_VALUE);
+      await controller.click(adDiv);
+
+      const windows = await controller.getAllWindows();
+      await expect(windows.length).to.equal(2);
+
+      await controller.switchToWindow(windows[1]);
+      await expect(await controller.getCurrentUrl()).to.equal(
+        'http://localhost:8000/?product1&x=71&y=98&e=Product%201&shouldNotBeReplaced=AMP_VERSION'
+      );
+    });
+
+    it('product2 ad opened', async () => {
+      const adDiv = await controller.findElement('#product2');
+      await setTime(Number.MAX_VALUE);
+      await controller.click(adDiv);
+
+      const windows = await controller.getAllWindows();
+      await expect(windows.length).to.equal(2);
+
+      await controller.switchToWindow(windows[1]);
+      await expect(await controller.getCurrentUrl()).to.match(
+        /^http:\/\/localhost:8000\/\?product2&r=0\.\d+$/
+      );
+    });
+  }
+);

--- a/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
+++ b/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html amp4ads>
+<head>
+  <title>amp-ad-exit</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  <script async custom-element="amp-ad-exit" src="https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js"></script>
+  <style amp-custom>
+    .ad {
+      border: 1px solid black;
+      width: 280px;
+      height: 230px;
+      background: #fff;
+    }
+
+    h1, .product {
+      cursor: pointer;
+    }
+
+    h1 {
+      font-size: 150%;
+      margin: 0;
+      color: #4285f4;
+      text-decoration: underline;
+    }
+
+    .product {
+      width: 100px;
+      height: 100px;
+      margin: 10px;
+      padding: 10px;
+      background: #0f9d58;
+      float: left;
+    }
+
+    amp-carousel .content {
+      width: 80%;
+      height: 80%;
+      margin: 10% 10%;
+      text-align: center;
+    }
+    .content pre { display: inline; }
+  </style>
+</head>
+<body>
+<amp-ad-exit id="exit-api" layout="nodisplay">
+  <script type="application/json">
+    {
+      "targets": {
+        "target1": {
+          "finalUrl": "http://localhost:8000/?product1&x=CLICK_X&y=CLICK_Y&e=_elem&shouldNotBeReplaced=AMP_VERSION",
+          "vars": {
+            "_elem": {"defaultValue": "headline"}
+          },
+          "filters": ["longDelay", "borderProtection"]
+        },
+        "target2": {
+          "finalUrl": "http://localhost:8000/?product2&r=RANDOM",
+          "trackingUrls": [
+            "http://localhost:8000/?tracking-url&clicked=_elem"
+          ],
+          "vars": {
+            "_elem": {"defaultValue": "headline"}
+          },
+          "filters": ["longDelay"]
+        }
+      },
+      "filters": {
+        "longDelay": {
+          "type": "clickDelay",
+          "delay": 10000
+        },
+        "borderProtection": {
+          "type": "clickLocation",
+          "bottom": 10,
+          "left": 10,
+          "right": 10,
+          "relativeTo": "#product1"
+        }
+      },
+      "transport": {
+        "beacon": true,
+        "image": true
+      }
+    }
+  </script>
+</amp-ad-exit>
+<div class="ad">
+  <h1 on="tap:exit-api.exit(target='target1')" role="button" tabindex="1">amp-ad-exit e2e test</h1>
+  <div class="product" id="product1" on="tap:exit-api.exit(target='target1', _elem='Product 1')" role="button" tabindex="1">
+    <p>product 1</p>
+  </div>
+  <div class="product" id="product2" on="tap:exit-api.exit(target='target2', _elem='Product 2')" role="button" tabindex="1">
+    <p>product 2</p>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
There is no convenient way to intercept beacon calls right now, so I'll defer that part. This PR adds a few e2e tests for amp4ads amp-ad-exit.

I added two new interfaces into `functional-test-controller.js`.