### PR TITLE
Temporary fix: Disable custom element experiment check because it happens too early

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -46,7 +46,11 @@ if (self.document) {
   // isExperimentOn() must be called after Object.assign polyfill is installed.
   // TODO(jridgewell, estherkim): Find out why CE isn't being polyfilled for IE.
   if (
-    isExperimentOn(self, 'custom-elements-v1') ||
+    // NOTE: isExperimentOn cannot be called this early due to
+    // a dependency of logging having been initialized.
+    // This is just a minimal revert of
+    // https://github.com/ampproject/amphtml/pull/24215
+    (false && isExperimentOn(self, 'custom-elements-v1')) ||
     (getMode().test && !getMode().testIe)
   ) {
     installCustomElements(self);


### PR DESCRIPTION
There is an init order conflict between experiment framework and logging infra. Disable the call for quick cherry-pick before we do a better fix.

This is a partial rollback of #24215

Fixes #24499 