### PR TITLE
🏗 Prevent corrupt Travis caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ jobs:
       name: 'Visual Diff Tests'
       script:
         - unbuffer node build-system/pr-check/visual-diff-tests.js
+      env:
+        - CACHE_NAME=VISUALDIFFJOB
     - stage: test
       name: 'Local Tests'
       script:
@@ -85,6 +87,8 @@ jobs:
       name: 'End to End Tests'
       script:
         - unbuffer node build-system/pr-check/e2e-tests.js
+      env:
+        - CACHE_NAME=E2EJOB
     - stage: experiment
       name: "Experiment A Tests"
       script:
@@ -97,9 +101,9 @@ jobs:
       name: "Experiment C Tests"
       script:
         - unbuffer node build-system/pr-check/experiment-tests.js --experiment=experimentC
-before_cache:
+# before_cache:
   # do not store cache for pr builds
-  - if [[ $TRAVIS_EVENT_TYPE == pull_request ]]; then exit $TRAVIS_TEST_RESULT ; fi
+  # - if [[ $TRAVIS_EVENT_TYPE == pull_request ]]; then exit $TRAVIS_TEST_RESULT ; fi
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,5 +113,4 @@ cache:
     - validator/node_modules
     - validator/nodejs/node_modules
     - validator/webui/node_modules
-    - $HOME/Library/Caches/Homebrew
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,9 @@ jobs:
       name: "Experiment C Tests"
       script:
         - unbuffer node build-system/pr-check/experiment-tests.js --experiment=experimentC
-# before_cache:
+before_cache:
   # do not store cache for pr builds
-  # - if [[ $TRAVIS_EVENT_TYPE == pull_request ]]; then exit $TRAVIS_TEST_RESULT ; fi
+  - if [[ $TRAVIS_EVENT_TYPE == pull_request ]]; then exit $TRAVIS_TEST_RESULT ; fi
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
All jobs on push builds share the same cache. However, the visual diff and e2e jobs require extra npm packages, which aren't always present in the cache. This results in an error where the only fix is to manually delete the cache and restart the job.

This creates separate caches for the visual diff and e2e jobs.