### PR TITLE
Use tagname for creating story embeds

### DIFF
--- a/examples/amp-story/embed.html
+++ b/examples/amp-story/embed.html
@@ -39,7 +39,7 @@
   </head>
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
-    <article class="medium amp-story-embed">
+    <amp-story-embed>
       <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
           data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
           class="story">
@@ -60,6 +60,6 @@
           class="story">
         <span class="title">A local’s guide to what to eat and do in Rome</span>
       </a>
-    </article>
+    </amp-story-embed>
   </body>
 </html>

--- a/src/amp-story-embed.js
+++ b/src/amp-story-embed.js
@@ -119,7 +119,7 @@ export class AmpStoryEmbed {
 }
 
 const doc = self.document;
-const embeds = doc.getElementsByClassName('amp-story-embed');
+const embeds = doc.getElementsByTagName('amp-story-embed');
 for (let i = 0; i < embeds.length; i++) {
   const embed = embeds[i];
   const embedImpl = new AmpStoryEmbed(doc, embed);


### PR DESCRIPTION
Basing this on a tag name will help to unify the AMP and non-AMP APIs, but keeping the implementation will avoid having to include the custom element polyfill.

WDYT?