### PR TITLE
📈 AmpStoryEventTracker & Integration tests

### DIFF
--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -201,7 +201,7 @@ export class AnalyticsRoot {
    * has not been requested before, it will be created.
    *
    * @param {string} name
-   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.ScrollEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)} klass
+   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.ScrollEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)|function(new:./events.AmpStoryEventTracker, !AnalyticsRoot)} klass
    * @return {!./events.EventTracker}
    */
   getTracker(name, klass) {

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -449,7 +449,7 @@ export class AmpStoryEventTracker extends CustomEventTracker {
    * @param {function(!AnalyticsEvent)} listener
    */
   fireListener_(event, rootTarget, config, listener) {
-    const {type} = event;
+    const type = event['type'];
     const on = config['on'];
 
     if (type !== on) {

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -405,6 +405,8 @@ export class CustomEventTracker extends EventTracker {
   }
 }
 
+// TODO(Enriqe): If needed, add support for sandbox story event.
+// (e.g. sandbox-story-xxx).
 export class AmpStoryEventTracker extends CustomEventTracker {
   /**
    * @param {!./analytics-root.AnalyticsRoot} root
@@ -415,7 +417,7 @@ export class AmpStoryEventTracker extends CustomEventTracker {
 
   /** @override */
   add(context, eventType, config, listener) {
-    // TODO(artezan): add support for storySpec.
+    // TODO(Enriqe): add support for storySpec.
     const rootTarget = this.root.getRootElement();
 
     // Fire buffered events if any.

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -44,9 +44,9 @@ const TAG = 'amp-analytics/events';
  * @enum {string}
  */
 export const AnalyticsEventType = {
-  AMP_STORY: 'amp-story',
   CLICK: 'click',
   CUSTOM: 'custom',
+  AMP_STORY: 'amp-story',
   HIDDEN: 'hidden',
   INI_LOAD: 'ini-load',
   RENDER_START: 'render-start',

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -46,11 +46,11 @@ const TAG = 'amp-analytics/events';
 export const AnalyticsEventType = {
   CLICK: 'click',
   CUSTOM: 'custom',
-  AMP_STORY: 'amp-story',
   HIDDEN: 'hidden',
   INI_LOAD: 'ini-load',
   RENDER_START: 'render-start',
   SCROLL: 'scroll',
+  STORY: 'story',
   TIMER: 'timer',
   VIDEO: 'video',
   VISIBLE: 'visible',
@@ -82,13 +82,6 @@ const TRACKER_TYPE = Object.freeze({
       return new CustomEventTracker(root);
     },
   },
-  [AnalyticsEventType.AMP_STORY]: {
-    name: AnalyticsEventType.AMP_STORY,
-    allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
-    klass: function(root) {
-      return new AmpStoryEventTracker(root);
-    },
-  },
   [AnalyticsEventType.HIDDEN]: {
     name: AnalyticsEventType.VISIBLE, // Reuse tracker with visibility
     allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
@@ -115,6 +108,13 @@ const TRACKER_TYPE = Object.freeze({
     allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
     klass: function(root) {
       return new ScrollEventTracker(root);
+    },
+  },
+  [AnalyticsEventType.STORY]: {
+    name: AnalyticsEventType.STORY,
+    allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES,
+    klass: function(root) {
+      return new AmpStoryEventTracker(root);
     },
   },
   [AnalyticsEventType.TIMER]: {
@@ -176,7 +176,7 @@ export function getTrackerKeyName(eventType) {
     return AnalyticsEventType.VIDEO;
   }
   if (isAmpStoryTriggerType(eventType)) {
-    return AnalyticsEventType.AMP_STORY;
+    return AnalyticsEventType.STORY;
   }
   if (!isReservedTriggerType(eventType)) {
     return AnalyticsEventType.CUSTOM;
@@ -450,12 +450,6 @@ export class AmpStoryEventTracker extends CustomEventTracker {
    */
   fireListener_(event, rootTarget, config, listener) {
     const type = event['type'];
-    const on = config['on'];
-
-    if (type !== on) {
-      return;
-    }
-
     const vars = event['vars'];
 
     listener(new AnalyticsEvent(rootTarget, type, vars));

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -79,7 +79,7 @@ export class InstrumentationService {
    */
   getTrackerClass_(trackerName) {
     switch (trackerName) {
-      case AnalyticsEventType.AMP_STORY:
+      case AnalyticsEventType.STORY:
         return AmpStoryEventTracker;
       default:
         return CustomEventTracker;

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import {
+  AmpStoryEventTracker,
+  AnalyticsEvent,
+  AnalyticsEventType,
+  CustomEventTracker,
+  getTrackerKeyName,
+} from './events';
 import {AmpdocAnalyticsRoot, EmbedAnalyticsRoot} from './analytics-root';
-import {AnalyticsEvent, AnalyticsEventType, CustomEventTracker} from './events';
 import {AnalyticsGroup} from './analytics-group';
 import {Services} from '../../../src/services';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
@@ -68,6 +74,19 @@ export class InstrumentationService {
   }
 
   /**
+   * @param {string} trackerName
+   * @private
+   */
+  getTrackerClass_(trackerName) {
+    switch (trackerName) {
+      case AnalyticsEventType.AMP_STORY:
+        return AmpStoryEventTracker;
+      default:
+        return CustomEventTracker;
+    }
+  }
+
+  /**
    * Triggers the analytics event with the specified type.
    *
    * @param {!Element} target
@@ -77,10 +96,11 @@ export class InstrumentationService {
   triggerEventForTarget(target, eventType, opt_vars) {
     const event = new AnalyticsEvent(target, eventType, opt_vars);
     const root = this.findRoot_(target);
-    const tracker = /** @type {!CustomEventTracker} */ (root.getTracker(
-      AnalyticsEventType.CUSTOM,
-      CustomEventTracker
-    ));
+    const trackerName = getTrackerKeyName(eventType);
+    const tracker = root.getTracker(
+      trackerName,
+      this.getTrackerClass_(trackerName)
+    );
     tracker.trigger(event);
   }
 

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -97,10 +97,10 @@ export class InstrumentationService {
     const event = new AnalyticsEvent(target, eventType, opt_vars);
     const root = this.findRoot_(target);
     const trackerName = getTrackerKeyName(eventType);
-    const tracker = root.getTracker(
+    const tracker = /** @type {!CustomEventTracker|!AmpStoryEventTracker} */ (root.getTracker(
       trackerName,
       this.getTrackerClass_(trackerName)
-    );
+    ));
     tracker.trigger(event);
   }
 

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -666,15 +666,12 @@ describes.realWin('Events', {amp: 1}, env => {
 
     beforeEach(() => {
       clock = sandbox.useFakeTimers();
-      tracker = root.getTracker(
-        AnalyticsEventType.AMP_STORY,
-        AmpStoryEventTracker
-      );
+      tracker = root.getTracker(AnalyticsEventType.STORY, AmpStoryEventTracker);
       rootTarget = root.getRootElement();
       getRootElementSpy = sandbox.spy(root, 'getRootElement');
     });
 
-    it('should initalize, add listeners and dispose', () => {
+    it('should initalize, add listeners, and dispose', () => {
       expect(tracker.root).to.equal(root);
       expect(tracker.buffer_).to.exist;
 
@@ -684,18 +681,8 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should listen on story events', () => {
       const handler2 = sandbox.spy();
-      tracker.add(
-        analyticsElement,
-        'story-event-1',
-        {on: 'story-event-1'},
-        handler
-      );
-      tracker.add(
-        analyticsElement,
-        'story-event-2',
-        {on: 'story-event-2'},
-        handler2
-      );
+      tracker.add(analyticsElement, 'story-event-1', {}, handler);
+      tracker.add(analyticsElement, 'story-event-2', {}, handler2);
       tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
       expect(getRootElementSpy).to.be.calledTwice;
 
@@ -711,7 +698,7 @@ describes.realWin('Events', {amp: 1}, env => {
       expect(handler2).to.be.calledOnce;
     });
 
-    it('should buffer custom events early on', () => {
+    it('should buffer story events early on', () => {
       // Events before listeners added.
       tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
       tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
@@ -722,18 +709,8 @@ describes.realWin('Events', {amp: 1}, env => {
       // Listeners added: immediate events fired.
       const handler2 = sandbox.spy();
       const handler3 = sandbox.spy();
-      tracker.add(
-        analyticsElement,
-        'story-event-1',
-        {on: 'story-event-1'},
-        handler
-      );
-      tracker.add(
-        analyticsElement,
-        'story-event-2',
-        {on: 'story-event-2'},
-        handler2
-      );
+      tracker.add(analyticsElement, 'story-event-1', {}, handler);
+      tracker.add(analyticsElement, 'story-event-2', {}, handler2);
       tracker.add(
         analyticsElement,
         'story-event-3',
@@ -776,11 +753,11 @@ describes.realWin('Events', {amp: 1}, env => {
       expect(tracker.buffer_).to.be.undefined;
     });
 
-    it('should not fire twice from observerable and buffer', () => {
+    it('should not fire twice from observable and buffer', () => {
       tracker.trigger(
         new AnalyticsEvent(target, 'story-event-1', {'order': '1'})
       );
-      tracker.add(target, 'story-event-1', {on: 'story-event-1'}, handler);
+      tracker.add(target, 'story-event-1', {}, handler);
 
       tracker.trigger(
         new AnalyticsEvent(target, 'story-event-1', {'order': '2'})
@@ -802,12 +779,7 @@ describes.realWin('Events', {amp: 1}, env => {
       tracker.trigger(
         new AnalyticsEvent(target, 'story-event-1', {'order': '2'})
       );
-      tracker.add(
-        analyticsElement,
-        'story-event-1',
-        {on: 'story-event-1'},
-        handler
-      );
+      tracker.add(analyticsElement, 'story-event-1', {}, handler);
 
       tracker.trigger(
         new AnalyticsEvent(target, 'story-event-1', {'order': '3'})

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -15,8 +15,8 @@
  */
 
 import * as lolex from 'lolex';
-import {AmpdocAnalyticsRoot} from '../analytics-root';
 import {
+  AmpStoryEventTracker,
   AnalyticsEvent,
   AnalyticsEventType,
   ClickEventTracker,
@@ -28,6 +28,7 @@ import {
   VisibilityTracker,
   trackerTypeForTesting,
 } from '../events';
+import {AmpdocAnalyticsRoot} from '../analytics-root';
 import {Deferred} from '../../../../src/utils/promise';
 import {Signals} from '../../../../src/utils/signals';
 import {macroTask} from '../../../../testing/yield';
@@ -653,6 +654,180 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(handler.lastCall).to.be.calledWith(
         new AnalyticsEvent(target, 'sandbox-1-event-1', {'order': '4'})
+      );
+    });
+  });
+
+  describe('AmpStoryEventTracker', () => {
+    let tracker;
+    let clock;
+    let getRootElementSpy;
+    let rootTarget;
+
+    beforeEach(() => {
+      clock = sandbox.useFakeTimers();
+      tracker = root.getTracker(
+        AnalyticsEventType.AMP_STORY,
+        AmpStoryEventTracker
+      );
+      rootTarget = root.getRootElement();
+      getRootElementSpy = sandbox.spy(root, 'getRootElement');
+    });
+
+    it('should initalize, add listeners and dispose', () => {
+      expect(tracker.root).to.equal(root);
+      expect(tracker.buffer_).to.exist;
+
+      tracker.dispose();
+      expect(tracker.buffer_).to.not.exist;
+    });
+
+    it('should listen on story events', () => {
+      const handler2 = sandbox.spy();
+      tracker.add(
+        analyticsElement,
+        'story-event-1',
+        {on: 'story-event-1'},
+        handler
+      );
+      tracker.add(
+        analyticsElement,
+        'story-event-2',
+        {on: 'story-event-2'},
+        handler2
+      );
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
+      expect(getRootElementSpy).to.be.calledTwice;
+
+      expect(handler).to.be.calledOnce;
+      expect(handler2).to.have.not.been.called;
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
+
+      expect(handler).to.be.calledOnce;
+      expect(handler2).to.be.calledOnce;
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
+
+      expect(handler).to.have.callCount(2);
+      expect(handler2).to.be.calledOnce;
+    });
+
+    it('should buffer custom events early on', () => {
+      // Events before listeners added.
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
+      expect(tracker.buffer_['story-event-1']).to.have.length(1);
+      expect(tracker.buffer_['story-event-2']).to.have.length(2);
+
+      // Listeners added: immediate events fired.
+      const handler2 = sandbox.spy();
+      const handler3 = sandbox.spy();
+      tracker.add(
+        analyticsElement,
+        'story-event-1',
+        {on: 'story-event-1'},
+        handler
+      );
+      tracker.add(
+        analyticsElement,
+        'story-event-2',
+        {on: 'story-event-2'},
+        handler2
+      );
+      tracker.add(
+        analyticsElement,
+        'story-event-3',
+        {on: 'story-event-3'},
+        handler3
+      );
+
+      expect(handler).to.be.calledOnce;
+      expect(handler2).to.have.callCount(2);
+      expect(handler3).to.have.not.been.called;
+      expect(tracker.buffer_['story-event-1']).to.have.length(1);
+      expect(tracker.buffer_['story-event-2']).to.have.length(2);
+      expect(tracker.buffer_['story-event-3']).to.be.undefined;
+
+      // Second round of events.
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-3'));
+      expect(getRootElementSpy).to.have.callCount(3);
+
+      expect(handler).to.have.callCount(2);
+      expect(handler2).to.have.callCount(3);
+      expect(handler3).to.be.calledOnce;
+      expect(tracker.buffer_['story-event-1']).to.have.length(2);
+      expect(tracker.buffer_['story-event-2']).to.have.length(3);
+      expect(tracker.buffer_['story-event-3']).to.have.length(1);
+
+      // Buffering time expires.
+      clock.tick(10001);
+      expect(tracker.buffer_).to.be.undefined;
+
+      // Post-buffering round of events.
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-2'));
+      tracker.trigger(new AnalyticsEvent(target, 'story-event-3'));
+
+      expect(handler).to.have.callCount(3);
+      expect(handler2).to.have.callCount(4);
+      expect(handler3).to.have.callCount(2);
+      expect(tracker.buffer_).to.be.undefined;
+    });
+
+    it('should not fire twice from observerable and buffer', () => {
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '1'})
+      );
+      tracker.add(target, 'story-event-1', {on: 'story-event-1'}, handler);
+
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '2'})
+      );
+
+      expect(handler).to.have.callCount(2);
+      expect(handler.firstCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '1'})
+      );
+      expect(handler.secondCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '2'})
+      );
+    });
+
+    it('should handle all events without duplicate trigger', () => {
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '1'})
+      );
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '2'})
+      );
+      tracker.add(
+        analyticsElement,
+        'story-event-1',
+        {on: 'story-event-1'},
+        handler
+      );
+
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '3'})
+      );
+      tracker.trigger(
+        new AnalyticsEvent(target, 'story-event-1', {'order': '4'})
+      );
+
+      expect(handler).to.have.callCount(4);
+      expect(handler.firstCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '1'})
+      );
+      expect(handler.secondCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '2'})
+      );
+      expect(handler.thirdCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '3'})
+      );
+      expect(handler.lastCall).to.be.calledWith(
+        new AnalyticsEvent(rootTarget, 'story-event-1', {'order': '4'})
       );
     });
   });

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -117,7 +117,7 @@ describe('amp-story analytics', function() {
       browser = new BrowserController(env.win);
       env.iframe.style.height = '732px';
       env.iframe.style.width = '412px';
-      return browser.waitForElementLayout('amp-story');
+      return browser.waitForElementLayout('amp-story', 20000);
     });
 
     it('should send analytics event when landing on a page', async () => {

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BrowserController, RequestBank} from '../../testing/test-helper';
+import {parseQueryString} from '../../src/url';
+
+describe
+  .configure()
+  .skipEdge()
+  .run('amp-story analytics', function() {
+    const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
+    const body = `
+
+      <amp-story standalone>
+        <amp-analytics>
+          <script type="application/json">
+          {
+            "requests": {
+              "endpoint": "${RequestBank.getUrl()}"
+            },
+            "triggers": {
+              "trackPageview": {
+                "on": "story-page-visible",
+                "request": "endpoint",
+                "extraUrlParams": {
+                  "pageVisible": "\${storyPageId}"
+                }
+              },
+              "trackBookendEnter": {
+                "on": "story-bookend-enter",
+                "request": "endpoint",
+                "extraUrlParams": {
+                  "bookendEnter": true
+                }
+              },
+              "trackBookendExit": {
+                "on": "story-bookend-exit",
+                "request": "endpoint",
+                "extraUrlParams": {
+                  "bookendExit": true
+                }
+              }
+            },
+            "extraUrlParams": {
+              "pageVisible": "\${storyPageId}",
+              "bookendEnter": false,
+              "bookendExit": false,
+              "muted": false,
+              "unmuted": false
+            }
+          }
+          </script>
+        </amp-analytics>
+        <amp-story-page id="page-1">
+          <amp-story-grid-layer template="vertical">
+            <h1>First page</h1>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="page-2">
+          <amp-story-grid-layer template="vertical">
+            <h1>Second page</h1>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-bookend layout="nodisplay">
+          <script type="application/json">
+          {
+            "bookendVersion": "v1.0",
+            "shareProviders": [
+              {
+                "provider": "facebook",
+                "data-param-app_id": "1682114265451337",
+                "data-param-href": "https://fr-fr.facebook.com/LaRochePosayFrance/"
+              },
+              {
+                "provider": "twitter",
+                "data-param-url": "https://twitter.com/larocheposayfr?lang=fr"
+              }
+            ],
+            "components": [
+              {
+                "type": "heading",
+                "text": "Learn more about our 0% formulation charter"
+              },
+              {
+                "type": "cta-link",
+                "links": [
+                  {
+                    "text": "Click here",
+                    "url": "https://www.laroche-posay.fr/produits-soins/anthelios/peaux-sensibles-ou-allergiques-au-soleil-r93.aspx"
+                  }
+                ]
+              },
+              {
+                "type": "landscape",
+                "title": "TRAPPIST-1 Planets May Still Be Wet Enough for Life",
+                "url": "http://example.com/article.html",
+                "category": "astronomy",
+                "image": "http://placehold.it/360x760"
+              }
+            ]
+          }
+          </script>
+        </amp-story-bookend>
+      </amp-story>`;
+    describes.integration('amp-story analytics', {body, extensions}, env => {
+      let browser;
+      beforeEach(() => {
+        browser = new BrowserController(env.win);
+      });
+
+      it('should send analytics event when landing on a page', async () => {
+        await browser.waitForElementLayout('#page-1');
+        await RequestBank.withdraw().then(req => {
+          const q = parseQueryString(req.url.substr(1));
+          expect(q['pageVisible']).to.equal('page-1');
+        });
+      });
+
+      it('should send analytics event when navigating', async () => {
+        browser.click('#page-1');
+        await browser.waitForElementLayout('#page-2');
+        await RequestBank.withdraw().then(req => {
+          const q = parseQueryString(req.url.substr(1));
+          expect(q['pageVisible']).to.equal('page-2');
+        });
+      });
+
+      it('should send analytics event when entering bookend', async () => {
+        browser.click('#page-1');
+        await browser.waitForElementLayout('#page-2');
+        browser.click('#page-2');
+        await browser.wait(100);
+        await RequestBank.withdraw().then(req => {
+          const q = parseQueryString(req.url.substr(1));
+          expect(q['bookendEnter']).to.equal('true');
+        });
+      });
+
+      it('should send analytics event when exiting bookend', async () => {
+        browser.click('#page-1');
+        await browser.waitForElementLayout('#page-2');
+        browser.click('#page-2');
+        await browser.wait(100);
+        browser.click('amp-story-bookend');
+        await browser.wait(100);
+        await RequestBank.withdraw().then(req => {
+          const q = parseQueryString(req.url.substr(1));
+          expect(q['bookendExit']).to.equal('true');
+        });
+      });
+    });
+  });

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -17,9 +17,8 @@
 import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {parseQueryString} from '../../src/url';
 
-describe('amp-story analytics', function() {
-  const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
-  const body = `
+const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
+const body = `
       <amp-story standalone>
         <amp-analytics>
           <script type="application/json">
@@ -111,54 +110,53 @@ describe('amp-story analytics', function() {
           </script>
         </amp-story-bookend>
       </amp-story>`;
-  describes.integration('amp-story analytics', {body, extensions}, env => {
-    let browser;
-    beforeEach(() => {
-      browser = new BrowserController(env.win);
-      env.iframe.style.height = '732px';
-      env.iframe.style.width = '412px';
-      return browser.waitForElementLayout('amp-story', 20000);
-    });
+describes.integration('amp-story analytics', {body, extensions}, env => {
+  let browser;
+  beforeEach(() => {
+    browser = new BrowserController(env.win);
+    env.iframe.style.height = '732px';
+    env.iframe.style.width = '412px';
+    return browser.waitForElementLayout('amp-story', 20000);
+  });
 
-    it('should send analytics event when landing on a page', async () => {
-      await browser.waitForElementLayout('#page-1', 20000);
+  it('should send analytics event when landing on a page', async () => {
+    await browser.waitForElementLayout('#page-1', 20000);
 
-      const req = await RequestBank.withdraw();
-      const q = parseQueryString(req.url.substr(1));
-      expect(q['pageVisible']).to.equal('page-1');
-    });
+    const req = await RequestBank.withdraw();
+    const q = parseQueryString(req.url.substr(1));
+    expect(q['pageVisible']).to.equal('page-1');
+  });
 
-    it('should send analytics event when navigating', async () => {
-      browser.click('#page-1');
-      await browser.waitForElementLayout('#page-2', 20000);
+  it('should send analytics event when navigating', async () => {
+    browser.click('#page-1');
+    await browser.waitForElementLayout('#page-2', 20000);
 
-      const req = await RequestBank.withdraw();
-      const q = parseQueryString(req.url.substr(1));
-      expect(q['pageVisible']).to.equal('page-2');
-    });
+    const req = await RequestBank.withdraw();
+    const q = parseQueryString(req.url.substr(1));
+    expect(q['pageVisible']).to.equal('page-2');
+  });
 
-    it('should send analytics event when entering bookend', async () => {
-      browser.click('#page-1');
-      await browser.waitForElementLayout('#page-2', 20000);
-      browser.click('#page-2');
-      await browser.wait(100);
+  it('should send analytics event when entering bookend', async () => {
+    browser.click('#page-1');
+    await browser.waitForElementLayout('#page-2', 20000);
+    browser.click('#page-2');
+    await browser.wait(100);
 
-      const req = await RequestBank.withdraw();
-      const q = parseQueryString(req.url.substr(1));
-      expect(q['bookendEnter']).to.equal('true');
-    });
+    const req = await RequestBank.withdraw();
+    const q = parseQueryString(req.url.substr(1));
+    expect(q['bookendEnter']).to.equal('true');
+  });
 
-    it('should send analytics event when exiting bookend', async () => {
-      browser.click('#page-1');
-      await browser.waitForElementLayout('#page-2', 20000);
-      browser.click('#page-2');
-      await browser.wait(100);
-      browser.click('amp-story-bookend');
-      await browser.wait(100);
+  it('should send analytics event when exiting bookend', async () => {
+    browser.click('#page-1');
+    await browser.waitForElementLayout('#page-2', 20000);
+    browser.click('#page-2');
+    await browser.wait(100);
+    browser.click('amp-story-bookend');
+    await browser.wait(100);
 
-      const req = await RequestBank.withdraw();
-      const q = parseQueryString(req.url.substr(1));
-      expect(q['bookendExit']).to.equal('true');
-    });
+    const req = await RequestBank.withdraw();
+    const q = parseQueryString(req.url.substr(1));
+    expect(q['bookendExit']).to.equal('true');
   });
 });

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -17,12 +17,9 @@
 import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {parseQueryString} from '../../src/url';
 
-describe
-  .configure()
-  .skipEdge()
-  .run('amp-story analytics', function() {
-    const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
-    const body = `
+describe('amp-story analytics', function() {
+  const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
+  const body = `
       <amp-story standalone>
         <amp-analytics>
           <script type="application/json">
@@ -114,51 +111,54 @@ describe
           </script>
         </amp-story-bookend>
       </amp-story>`;
-    describes.integration('amp-story analytics', {body, extensions}, env => {
-      let browser;
-      beforeEach(() => {
-        browser = new BrowserController(env.win);
-      });
+  describes.integration('amp-story analytics', {body, extensions}, env => {
+    let browser;
+    beforeEach(() => {
+      browser = new BrowserController(env.win);
+      env.iframe.style.height = '732px';
+      env.iframe.style.width = '412px';
+      return browser.waitForElementLayout('amp-story');
+    });
 
-      it('should send analytics event when landing on a page', async () => {
-        await browser.waitForElementLayout('#page-1', 20000);
+    it('should send analytics event when landing on a page', async () => {
+      await browser.waitForElementLayout('#page-1', 20000);
 
-        const req = await RequestBank.withdraw();
-        const q = parseQueryString(req.url.substr(1));
-        expect(q['pageVisible']).to.equal('page-1');
-      });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['pageVisible']).to.equal('page-1');
+    });
 
-      it('should send analytics event when navigating', async () => {
-        browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 20000);
+    it('should send analytics event when navigating', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
 
-        const req = await RequestBank.withdraw();
-        const q = parseQueryString(req.url.substr(1));
-        expect(q['pageVisible']).to.equal('page-2');
-      });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['pageVisible']).to.equal('page-2');
+    });
 
-      it('should send analytics event when entering bookend', async () => {
-        browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 20000);
-        browser.click('#page-2');
-        await browser.wait(100);
+    it('should send analytics event when entering bookend', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
+      browser.click('#page-2');
+      await browser.wait(100);
 
-        const req = await RequestBank.withdraw();
-        const q = parseQueryString(req.url.substr(1));
-        expect(q['bookendEnter']).to.equal('true');
-      });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['bookendEnter']).to.equal('true');
+    });
 
-      it('should send analytics event when exiting bookend', async () => {
-        browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 20000);
-        browser.click('#page-2');
-        await browser.wait(100);
-        browser.click('amp-story-bookend');
-        await browser.wait(100);
+    it('should send analytics event when exiting bookend', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
+      browser.click('#page-2');
+      await browser.wait(100);
+      browser.click('amp-story-bookend');
+      await browser.wait(100);
 
-        const req = await RequestBank.withdraw();
-        const q = parseQueryString(req.url.substr(1));
-        expect(q['bookendExit']).to.equal('true');
-      });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['bookendExit']).to.equal('true');
     });
   });
+});

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -23,7 +23,6 @@ describe
   .run('amp-story analytics', function() {
     const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
     const body = `
-
       <amp-story standalone>
         <amp-analytics>
           <script type="application/json">
@@ -123,19 +122,19 @@ describe
 
       it('should send analytics event when landing on a page', async () => {
         await browser.waitForElementLayout('#page-1');
-        await RequestBank.withdraw().then(req => {
-          const q = parseQueryString(req.url.substr(1));
-          expect(q['pageVisible']).to.equal('page-1');
-        });
+
+        const req = await RequestBank.withdraw();
+        const q = parseQueryString(req.url.substr(1));
+        expect(q['pageVisible']).to.equal('page-1');
       });
 
       it('should send analytics event when navigating', async () => {
         browser.click('#page-1');
         await browser.waitForElementLayout('#page-2');
-        await RequestBank.withdraw().then(req => {
-          const q = parseQueryString(req.url.substr(1));
-          expect(q['pageVisible']).to.equal('page-2');
-        });
+
+        const req = await RequestBank.withdraw();
+        const q = parseQueryString(req.url.substr(1));
+        expect(q['pageVisible']).to.equal('page-2');
       });
 
       it('should send analytics event when entering bookend', async () => {
@@ -143,10 +142,10 @@ describe
         await browser.waitForElementLayout('#page-2');
         browser.click('#page-2');
         await browser.wait(100);
-        await RequestBank.withdraw().then(req => {
-          const q = parseQueryString(req.url.substr(1));
-          expect(q['bookendEnter']).to.equal('true');
-        });
+
+        const req = await RequestBank.withdraw();
+        const q = parseQueryString(req.url.substr(1));
+        expect(q['bookendEnter']).to.equal('true');
       });
 
       it('should send analytics event when exiting bookend', async () => {
@@ -156,10 +155,10 @@ describe
         await browser.wait(100);
         browser.click('amp-story-bookend');
         await browser.wait(100);
-        await RequestBank.withdraw().then(req => {
-          const q = parseQueryString(req.url.substr(1));
-          expect(q['bookendExit']).to.equal('true');
-        });
+
+        const req = await RequestBank.withdraw();
+        const q = parseQueryString(req.url.substr(1));
+        expect(q['bookendExit']).to.equal('true');
       });
     });
   });

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -17,146 +17,154 @@
 import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {parseQueryString} from '../../src/url';
 
-const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
-const body = `
-      <amp-story standalone>
-        <amp-analytics>
-          <script type="application/json">
-          {
-            "requests": {
-              "endpoint": "${RequestBank.getUrl()}"
-            },
-            "triggers": {
-              "trackPageview": {
-                "on": "story-page-visible",
-                "request": "endpoint",
-                "extraUrlParams": {
-                  "pageVisible": "\${storyPageId}"
-                }
+const config = describe
+  .configure()
+  .skipEdge()
+  .ifChrome()
+  .skipSinglePass();
+
+config.run('amp-story analytics', () => {
+  const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
+  const body = `
+        <amp-story standalone>
+          <amp-analytics>
+            <script type="application/json">
+            {
+              "requests": {
+                "endpoint": "${RequestBank.getUrl()}"
               },
-              "trackBookendEnter": {
-                "on": "story-bookend-enter",
-                "request": "endpoint",
-                "extraUrlParams": {
-                  "bookendEnter": true
-                }
-              },
-              "trackBookendExit": {
-                "on": "story-bookend-exit",
-                "request": "endpoint",
-                "extraUrlParams": {
-                  "bookendExit": true
-                }
-              }
-            },
-            "extraUrlParams": {
-              "pageVisible": "\${storyPageId}",
-              "bookendEnter": false,
-              "bookendExit": false,
-              "muted": false,
-              "unmuted": false
-            }
-          }
-          </script>
-        </amp-analytics>
-        <amp-story-page id="page-1">
-          <amp-story-grid-layer template="vertical">
-            <h1>First page</h1>
-          </amp-story-grid-layer>
-        </amp-story-page>
-        <amp-story-page id="page-2">
-          <amp-story-grid-layer template="vertical">
-            <h1>Second page</h1>
-          </amp-story-grid-layer>
-        </amp-story-page>
-        <amp-story-bookend layout="nodisplay">
-          <script type="application/json">
-          {
-            "bookendVersion": "v1.0",
-            "shareProviders": [
-              {
-                "provider": "facebook",
-                "data-param-app_id": "1682114265451337",
-                "data-param-href": "https://fr-fr.facebook.com/LaRochePosayFrance/"
-              },
-              {
-                "provider": "twitter",
-                "data-param-url": "https://twitter.com/larocheposayfr?lang=fr"
-              }
-            ],
-            "components": [
-              {
-                "type": "heading",
-                "text": "Learn more about our 0% formulation charter"
-              },
-              {
-                "type": "cta-link",
-                "links": [
-                  {
-                    "text": "Click here",
-                    "url": "https://www.laroche-posay.fr/produits-soins/anthelios/peaux-sensibles-ou-allergiques-au-soleil-r93.aspx"
+              "triggers": {
+                "trackPageview": {
+                  "on": "story-page-visible",
+                  "request": "endpoint",
+                  "extraUrlParams": {
+                    "pageVisible": "\${storyPageId}"
                   }
-                ]
+                },
+                "trackBookendEnter": {
+                  "on": "story-bookend-enter",
+                  "request": "endpoint",
+                  "extraUrlParams": {
+                    "bookendEnter": true
+                  }
+                },
+                "trackBookendExit": {
+                  "on": "story-bookend-exit",
+                  "request": "endpoint",
+                  "extraUrlParams": {
+                    "bookendExit": true
+                  }
+                }
               },
-              {
-                "type": "landscape",
-                "title": "TRAPPIST-1 Planets May Still Be Wet Enough for Life",
-                "url": "http://example.com/article.html",
-                "category": "astronomy",
-                "image": "http://placehold.it/360x760"
+              "extraUrlParams": {
+                "pageVisible": "\${storyPageId}",
+                "bookendEnter": false,
+                "bookendExit": false,
+                "muted": false,
+                "unmuted": false
               }
-            ]
-          }
-          </script>
-        </amp-story-bookend>
-      </amp-story>`;
-describes.integration('amp-story analytics', {body, extensions}, env => {
-  let browser;
-  beforeEach(() => {
-    browser = new BrowserController(env.win);
-    env.iframe.style.height = '732px';
-    env.iframe.style.width = '412px';
-    return browser.waitForElementLayout('amp-story', 20000);
-  });
+            }
+            </script>
+          </amp-analytics>
+          <amp-story-page id="page-1">
+            <amp-story-grid-layer template="vertical">
+              <h1>First page</h1>
+            </amp-story-grid-layer>
+          </amp-story-page>
+          <amp-story-page id="page-2">
+            <amp-story-grid-layer template="vertical">
+              <h1>Second page</h1>
+            </amp-story-grid-layer>
+          </amp-story-page>
+          <amp-story-bookend layout="nodisplay">
+            <script type="application/json">
+            {
+              "bookendVersion": "v1.0",
+              "shareProviders": [
+                {
+                  "provider": "facebook",
+                  "data-param-app_id": "1682114265451337",
+                  "data-param-href": "https://fr-fr.facebook.com/LaRochePosayFrance/"
+                },
+                {
+                  "provider": "twitter",
+                  "data-param-url": "https://twitter.com/larocheposayfr?lang=fr"
+                }
+              ],
+              "components": [
+                {
+                  "type": "heading",
+                  "text": "Learn more about our 0% formulation charter"
+                },
+                {
+                  "type": "cta-link",
+                  "links": [
+                    {
+                      "text": "Click here",
+                      "url": "https://www.laroche-posay.fr/produits-soins/anthelios/peaux-sensibles-ou-allergiques-au-soleil-r93.aspx"
+                    }
+                  ]
+                },
+                {
+                  "type": "landscape",
+                  "title": "TRAPPIST-1 Planets May Still Be Wet Enough for Life",
+                  "url": "http://example.com/article.html",
+                  "category": "astronomy",
+                  "image": "http://placehold.it/360x760"
+                }
+              ]
+            }
+            </script>
+          </amp-story-bookend>
+        </amp-story>`;
+  describes.integration('amp-story analytics', {body, extensions}, env => {
+    let browser;
+    beforeEach(() => {
+      browser = new BrowserController(env.win);
+      env.iframe.style.height = '732px';
+      env.iframe.style.width = '412px';
+      return browser.waitForElementLayout('amp-story', 20000);
+    });
 
-  it('should send analytics event when landing on a page', async () => {
-    await browser.waitForElementLayout('#page-1', 20000);
+    it('should send analytics event when landing on a page', async () => {
+      await browser.waitForElementLayout('#page-1', 20000);
 
-    const req = await RequestBank.withdraw();
-    const q = parseQueryString(req.url.substr(1));
-    expect(q['pageVisible']).to.equal('page-1');
-  });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['pageVisible']).to.equal('page-1');
+    });
 
-  it('should send analytics event when navigating', async () => {
-    browser.click('#page-1');
-    await browser.waitForElementLayout('#page-2', 20000);
+    it('should send analytics event when navigating', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
 
-    const req = await RequestBank.withdraw();
-    const q = parseQueryString(req.url.substr(1));
-    expect(q['pageVisible']).to.equal('page-2');
-  });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['pageVisible']).to.equal('page-2');
+    });
 
-  it('should send analytics event when entering bookend', async () => {
-    browser.click('#page-1');
-    await browser.waitForElementLayout('#page-2', 20000);
-    browser.click('#page-2');
-    await browser.wait(100);
+    it('should send analytics event when entering bookend', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
+      browser.click('#page-2');
+      await browser.wait(100);
 
-    const req = await RequestBank.withdraw();
-    const q = parseQueryString(req.url.substr(1));
-    expect(q['bookendEnter']).to.equal('true');
-  });
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['bookendEnter']).to.equal('true');
+    });
 
-  it('should send analytics event when exiting bookend', async () => {
-    browser.click('#page-1');
-    await browser.waitForElementLayout('#page-2', 20000);
-    browser.click('#page-2');
-    await browser.wait(100);
-    browser.click('amp-story-bookend');
-    await browser.wait(100);
+    it('should send analytics event when exiting bookend', async () => {
+      browser.click('#page-1');
+      await browser.waitForElementLayout('#page-2', 20000);
+      browser.click('#page-2');
+      await browser.wait(100);
+      browser.click('amp-story-bookend');
+      await browser.wait(100);
 
-    const req = await RequestBank.withdraw();
-    const q = parseQueryString(req.url.substr(1));
-    expect(q['bookendExit']).to.equal('true');
+      const req = await RequestBank.withdraw();
+      const q = parseQueryString(req.url.substr(1));
+      expect(q['bookendExit']).to.equal('true');
+    });
   });
 });

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -121,7 +121,7 @@ describe
       });
 
       it('should send analytics event when landing on a page', async () => {
-        await browser.waitForElementLayout('#page-1', 15000);
+        await browser.waitForElementLayout('#page-1', 20000);
 
         const req = await RequestBank.withdraw();
         const q = parseQueryString(req.url.substr(1));
@@ -130,7 +130,7 @@ describe
 
       it('should send analytics event when navigating', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 15000);
+        await browser.waitForElementLayout('#page-2', 20000);
 
         const req = await RequestBank.withdraw();
         const q = parseQueryString(req.url.substr(1));
@@ -139,7 +139,7 @@ describe
 
       it('should send analytics event when entering bookend', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 15000);
+        await browser.waitForElementLayout('#page-2', 20000);
         browser.click('#page-2');
         await browser.wait(100);
 
@@ -150,7 +150,7 @@ describe
 
       it('should send analytics event when exiting bookend', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2', 15000);
+        await browser.waitForElementLayout('#page-2', 20000);
         browser.click('#page-2');
         await browser.wait(100);
         browser.click('amp-story-bookend');

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -121,7 +121,7 @@ describe
       });
 
       it('should send analytics event when landing on a page', async () => {
-        await browser.waitForElementLayout('#page-1');
+        await browser.waitForElementLayout('#page-1', 15000);
 
         const req = await RequestBank.withdraw();
         const q = parseQueryString(req.url.substr(1));
@@ -130,7 +130,7 @@ describe
 
       it('should send analytics event when navigating', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2');
+        await browser.waitForElementLayout('#page-2', 15000);
 
         const req = await RequestBank.withdraw();
         const q = parseQueryString(req.url.substr(1));
@@ -139,7 +139,7 @@ describe
 
       it('should send analytics event when entering bookend', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2');
+        await browser.waitForElementLayout('#page-2', 15000);
         browser.click('#page-2');
         await browser.wait(100);
 
@@ -150,7 +150,7 @@ describe
 
       it('should send analytics event when exiting bookend', async () => {
         browser.click('#page-1');
-        await browser.waitForElementLayout('#page-2');
+        await browser.waitForElementLayout('#page-2', 15000);
         browser.click('#page-2');
         await browser.wait(100);
         browser.click('amp-story-bookend');


### PR DESCRIPTION
Partial rollforward of #23030

### Doesn't include:
* Configurable options (StorySpec) e.g. `repeat: false` option. This will come in a follow up

### Does include:
* Integration tests
* New tracker `AmpStoryEventTracker` which inherits from `CustomEventTracker`. This will make it possible for us to build story-specific features in analytics (e.g. `storySpec`).