### PR TITLE
🐛 Logging message toString() blunder fix

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -124,7 +124,7 @@ const externalMessagesSimpleTableUrl = () =>
  * @return {string}
  */
 const messageArgToEncodedComponent = arg =>
-  encodeURIComponent(elementStringOrPassthru(arg).toString());
+  encodeURIComponent(String(elementStringOrPassthru(arg)));
 
 /**
  * Logging class. Use of sentinel string instead of a boolean to check user/dev


### PR DESCRIPTION
The `toString()` method won't be able to serialize `null` or `undefined`, but `String()` will.