### PR TITLE
♻️ Redefine custom-elements-v1 as an RTV experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,6 @@
   "as-use-attr-for-format": 0.01,
   "blurry-placeholder": 1,
   "chunked-amp": 1,
-  "custom-elements-v1": 0,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "fie-css-cleanup": 1,

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -16,11 +16,11 @@
     "defineExperimentConstant": "_RTVEXP_INABOX_LITE"
   },
   "experimentC": {
-    "name": "CEv1",
+    "name": "Custom Elements V1",
     "environment": "AMP",
     "command": "gulp dist --defineExperimentConstant=CUSTOM_ELEMENTS_V1",
     "issue": "https://github.com/ampproject/amphtml/issues/17243",
-    "expirationDateUTC": "2020-12-31",
+    "expirationDateUTC": "2020-01-01",
     "defineExperimentConstant": "CUSTOM_ELEMENTS_V1"
   }
 }

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -15,5 +15,12 @@
     "expirationDateUTC": "2019-10-10",
     "defineExperimentConstant": "_RTVEXP_INABOX_LITE"
   },
-  "experimentC": {}
+  "experimentC": {
+    "name": "CEv1",
+    "environment": "AMP",
+    "command": "gulp dist --defineExperimentConstant=CUSTOM_ELEMENTS_V1",
+    "issue": "https://github.com/ampproject/amphtml/issues/17243",
+    "expirationDateUTC": "2020-12-31",
+    "defineExperimentConstant": "CUSTOM_ELEMENTS_V1"
+  }
 }

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -857,7 +857,11 @@ export class FriendlyIframeEmbed {
 function installPolyfillsInChildWindow(parentWin, childWin) {
   installDocContains(childWin);
   installDOMTokenList(childWin);
-  if (isExperimentOn(parentWin, 'custom-elements-v1') || getMode().test) {
+  if (
+    // eslint-disable-next-line no-undef
+    CUSTOM_ELEMENTS_V1 ||
+    getMode().test
+  ) {
     installCustomElements(childWin);
   } else {
     installRegisterElement(childWin, 'auto');

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -46,11 +46,8 @@ if (self.document) {
   // isExperimentOn() must be called after Object.assign polyfill is installed.
   // TODO(jridgewell, estherkim): Find out why CE isn't being polyfilled for IE.
   if (
-    // NOTE: isExperimentOn cannot be called this early due to
-    // a dependency of logging having been initialized.
-    // This is just a minimal revert of
-    // https://github.com/ampproject/amphtml/pull/24215
-    (false && isExperimentOn(self, 'custom-elements-v1')) ||
+    // eslint-disable-next-line no-undef
+    CUSTOM_ELEMENTS_V1 ||
     (getMode().test && !getMode().testIe)
   ) {
     installCustomElements(self);

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -28,7 +28,6 @@ import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installObjectValues} from './polyfills/object-values';
 import {install as installPromise} from './polyfills/promise';
 import {installCustomElements as installRegisterElement} from 'document-register-element/build/document-register-element.patched';
-import {isExperimentOn} from './experiments';
 
 installFetch(self);
 installMathSign(self);
@@ -43,7 +42,6 @@ if (self.document) {
   installDocContains(self);
   installGetBoundingClientRect(self);
 
-  // isExperimentOn() must be called after Object.assign polyfill is installed.
   // TODO(jridgewell, estherkim): Find out why CE isn't being polyfilled for IE.
   if (
     // eslint-disable-next-line no-undef

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -276,12 +276,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17107',
   },
   {
-    id: 'custom-elements-v1',
-    name: 'Enable a new custom elements v1 polyfill',
-    spec: 'https://github.com/ampproject/amphtml/pull/17205',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17243',
-  },
-  {
     id: 'amp-carousel-chrome-scroll-snap',
     name: 'Enables scroll snap on carousel on Chrome browsers',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16508',


### PR DESCRIPTION
This sidesteps https://github.com/ampproject/amphtml/issues/24499 by using an RTV experiment instead of a local experiment.

Also, it'll show the performance benefits, since we'll be able to DCE the old polyfill code. 😃