### PR TITLE
📖 Add copyright notice to license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015–2019 The AMP HTML Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This help GitHub properly identify the license and surface it correctly in its UI and API.

A Google copyright notice was removed in #22944 by @Gregable, and the change approved by @cramforce, but there weren't any explanations as to why.

/cc @mrjoro 
