### PR TITLE
🏗✨ Add Mac OS support for the Sauce Labs Proxy launcher script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ yarn-error.log
 PERCY_BUILD_ID
 chromedriver.log
 sc-*-linux*
+sc-*-osx*
+sauce_connect_*
 EXTENSIONS_CSS_MAP
 deps.txt
 firebase

--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -127,6 +127,7 @@ do
     END_TIME=$( date +%s )
     TOTAL_TIME=$(( END_TIME - START_TIME ))
     echo "$LOG_PREFIX Done running $(CYAN "start_sauce_connect.sh") Total time: $(CYAN "$TOTAL_TIME"s)"
+    echo "$LOG_PREFIX To stop the proxy, run $(CYAN "stop_sauce_connect.sh") from the same directory"
     break
   else
     # Continue waiting.

--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -33,6 +33,11 @@ READY_FILE="sauce_connect_ready"
 READY_DELAY_SECS=120
 LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
 
+if [[ -z "$SAUCE_USERNAME" || -z "$SAUCE_ACCESS_KEY" ]]; then
+  echo "$LOG_PREFIX The $(CYAN "SAUCE_USERNAME") and $(CYAN "SAUCE_ACCESS_KEY") environment variables must be set."
+  exit 1
+fi
+
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION-linux.tar.gz"
   ARCHIVE_FILE="$DOWNLOAD_DIR/$SC_VERSION-linux.tar.gz"

--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -15,26 +15,36 @@
 # limitations under the license.
 #
 # This script starts the sauce connect proxy, and waits for a successful
-# connection.
+# connection. Works on Linux and Mac OS.
 
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 
-SC_VERSION="sc-4.5.1-linux"
+SC_VERSION="sc-4.5.1"
 AUTHENTICATED_STATUS_URL="https://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@saucelabs.com/rest/v1/info/status"
 STATUS_URL="https://saucelabs.com/rest/v1/info/status"
-DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"
 DOWNLOAD_DIR="sauce_connect"
-TAR_FILE="$DOWNLOAD_DIR/$SC_VERSION.tar.gz"
-BINARY_FILE="$SC_VERSION/bin/sc"
 PID_FILE="sauce_connect_pid"
 LOG_FILE="sauce_connect_log"
 OUTPUT_FILE="sauce_connect_output"
 READY_FILE="sauce_connect_ready"
 READY_DELAY_SECS=120
-LOG_PREFIX=$(YELLOW "start_sauce_connect.sh:")
+LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION-linux.tar.gz"
+  ARCHIVE_FILE="$DOWNLOAD_DIR/$SC_VERSION-linux.tar.gz"
+  BINARY_FILE="$SC_VERSION-linux/bin/sc"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION-osx.zip"
+  ARCHIVE_FILE="$DOWNLOAD_DIR/$SC_VERSION-osx.zip"
+  BINARY_FILE="$SC_VERSION-osx/bin/sc"
+else
+  echo "$LOG_PREFIX Sauce Connect Proxy launcher script does not support the $(CYAN "$OSTYPE") platform."
+  exit 1
+fi
 
 # Start a timer to track how long setup took
 START_TIME=$( date +%s )
@@ -59,14 +69,22 @@ else
 fi
 
 # Download the sauce connect proxy binary (if needed) and unpack it.
-if [[ -f $TAR_FILE ]]; then
-  echo "$LOG_PREFIX Using cached Sauce Connect binary $(CYAN "$TAR_FILE")"
+if [[ -f $ARCHIVE_FILE ]]; then
+  echo "$LOG_PREFIX Using cached Sauce Connect binary $(CYAN "$ARCHIVE_FILE")"
 else
   echo "$LOG_PREFIX Downloading $(CYAN "$DOWNLOAD_URL")"
-  wget -q "$DOWNLOAD_URL" -P "$DOWNLOAD_DIR"
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    wget -q "$DOWNLOAD_URL" -P "$DOWNLOAD_DIR"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    curl -s --create-dirs -o "$ARCHIVE_FILE" -O "$DOWNLOAD_URL"
+  fi
 fi
-echo "$LOG_PREFIX Unpacking $(CYAN "$TAR_FILE")"
-tar -xzf "$TAR_FILE"
+echo "$LOG_PREFIX Unpacking $(CYAN "$ARCHIVE_FILE")"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  tar -xzf "$ARCHIVE_FILE"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  unzip -qu "$ARCHIVE_FILE"
+fi
 
 # Clean up old files, if any.
 if [[ -f "$LOG_FILE" ]]; then
@@ -91,7 +109,7 @@ fi
 
 
 # Launch proxy and wait for a tunnel to be created.
-echo "$LOG_PREFIX Launching $(CYAN "$BINARY_FILE")"
+echo "$LOG_PREFIX Launching $(CYAN "$BINARY_FILE")..."
 "$BINARY_FILE" --verbose --tunnel-identifier "$TUNNEL_IDENTIFIER" --readyfile "$READY_FILE" --pidfile "$PID_FILE" --logfile "$LOG_FILE" 1>"$OUTPUT_FILE" 2>&1 &
 count=0
 while [ $count -lt $READY_DELAY_SECS ]
@@ -100,7 +118,11 @@ do
   then
     # Print confirmation.
     PID="$(cat "$PID_FILE")"
-    TUNNEL_ID="$(grep -oP "Tunnel ID: \K.*$" "$OUTPUT_FILE")"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+      TUNNEL_ID="$(grep -oP "Tunnel ID: \K.*$" "$OUTPUT_FILE")"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      TUNNEL_ID="$(grep -o "Tunnel ID: .*$" "$OUTPUT_FILE" | cut -d' ' -f3)"
+    fi
     echo "$LOG_PREFIX Sauce Connect Proxy with tunnel ID $(CYAN "$TUNNEL_ID") and identifier $(CYAN "$TUNNEL_IDENTIFIER") is now running as pid $(CYAN "$PID")"
     END_TIME=$( date +%s )
     TOTAL_TIME=$(( END_TIME - START_TIME ))

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -216,22 +216,25 @@ To run the tests on Sauce Labs:
 * Create a Sauce Labs account.  If you are only going to use your account for open source projects like this one you can sign up for a free [Open Sauce](https://saucelabs.com/solutions/open-source) account.  (If you create an account through the normal account creation mechanism you'll be signing up for a free trial that expires; you can contact Sauce Labs customer service to switch your account to Open Sauce if you did this accidentally.)
 * Set the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables.  On Linux add this to your `.bashrc`:
 
-   ```
+   ```sh
    export SAUCE_USERNAME=<Sauce Labs username>
    export SAUCE_ACCESS_KEY=<Sauce Labs access key>
    ```
 
   You can find your Sauce Labs access key on the [User Settings](https://saucelabs.com/beta/user-settings) page.
-* Install the [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect+Proxy).
 * Run the proxy and then run the tests:
-   ```
-   # start the proxy
-   sc
+   ```sh
+   # Start the proxy
+   ./build-system/sauce_connect/start_sauce_connect.sh
 
-   # after seeing the "Sauce Connect is up" msg, run the tests
+   # Run tests
    gulp [unit|integration] --saucelabs
+
+   # Stop the proxy
+   ./build-system/sauce_connect/stop_sauce_connect.sh
    ```
-* It may take a few minutes for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard.
+* It may take several seconds for the proxy to start and for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard.
+* The tunnel ID used during local development is the email address of the author of the latest commit on the local branch.
 
 ## Visual Diff Tests
 


### PR DESCRIPTION
**Start proxy:**
```sh
export SAUCE_USERNAME=<username>
export SAUCE_ACCESS_KEY=<access key>
./build-system/sauce_connect/start_sauce_connect.sh
```

**Stop proxy:**
```sh
./build-system/sauce_connect/stop_sauce_connect.sh
```

<img width="1306" alt="" src="https://user-images.githubusercontent.com/26553114/64999458-deca7080-d8b5-11e9-879f-3842ae131987.png">
