### PR TITLE
allow specifying an amp-lightbox-gallery component within the page

### DIFF
--- a/examples/article-with-lightbox-2.0-gallery.amp.html
+++ b/examples/article-with-lightbox-2.0-gallery.amp.html
@@ -393,6 +393,7 @@
     </span>
   </header>
 
+  <amp-lightbox-gallery layout="nodisplay" id="foo"></amp-lightbox-gallery>
   <main role="main">
     <article>
       <header id="article-desc">

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -34,6 +34,9 @@
 </head>
 <body>
   <!-- Valid -->
+  <amp-lightbox-gallery layout="nodisplay" id="foo"></amp-lightbox-gallery>
+
+  <!-- Valid -->
   <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
@@ -59,6 +62,7 @@
     layout="responsive"></amp-youtube>
 
   <!-- Valid -->
+  <amp-lightbox-gallery></amp-lightbox-gallery>
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
       <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
@@ -92,7 +96,7 @@
       data-aax_src="302">
     </amp-ad>
   </amp-carousel>
- 
+
   <!-- Invalid: missing value for lightbox-thumbnail-id -->
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
   <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -35,6 +35,11 @@ FAIL
 |  </head>
 |  <body>
 |    <!-- Valid -->
+|    <amp-lightbox-gallery layout="nodisplay" id="foo"></amp-lightbox-gallery>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:37:2 The tag 'amp-lightbox-gallery' requires including the 'amp-lightbox-galley' extension JavaScript. (see https://amp.dev/documentation/components/amp-lightbox-galley) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|
+|    <!-- Valid -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
@@ -42,7 +47,7 @@ FAIL
 |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:42:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:45:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
 |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |
@@ -62,6 +67,11 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:42:2 The attri
 |      layout="responsive"></amp-youtube>
 |
 |    <!-- Valid -->
+|    <amp-lightbox-gallery></amp-lightbox-gallery>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:65:2 The implied layout 'CONTAINER' is not supported by tag 'amp-lightbox-gallery'. (see https://amp.dev/documentation/components/amp-lightbox-galley) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:65:2 The tag 'amp-lightbox-gallery' requires including the 'amp-lightbox-galley' extension JavaScript. (see https://amp.dev/documentation/components/amp-lightbox-galley) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
@@ -95,16 +105,16 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:42:2 The attri
 |        data-aax_src="302">
 |      </amp-ad>
 |    </amp-carousel>
-|   
+|
 |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:97:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:101:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
 |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |    <!-- Invalid: invalid use of lightbox-exclude -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:101:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:105:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://amp.dev/documentation/components/amp-img) [DISALLOWED_HTML]
 |  </body>
 |  </html>

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -25,6 +25,19 @@ tags: {  # amp-lightbox-gallery
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # <amp-lightbox-gallery>
+  html_format: AMP
+  tag_name: "AMP-LIGHTBOX-GALLERY"
+  requires_extension: "amp-lightbox-galley"
+  mandatory_parent: "BODY"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
+}
 attr_lists: {
   name: "lightboxable-elements"
   attrs: { name: "lightbox" }

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -29,6 +29,7 @@ tags: {  # <amp-lightbox-gallery>
   html_format: AMP
   tag_name: "AMP-LIGHTBOX-GALLERY"
   requires_extension: "amp-lightbox-galley"
+  unique: true
   mandatory_parent: "BODY"
   amp_layout: {
     supported_layouts: NODISPLAY


### PR DESCRIPTION
I noticed that we recommend people to use their own `amp-lightbox-gallery` tags, but this tag hasn't yet been allowed by the validator. 