### PR TITLE
🏗 Increase allowed running time for sauce labs tests from 10 to 15 min

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -28,12 +28,12 @@ const COMMON_CHROME_FLAGS = [
   '--autoplay-policy=no-user-gesture-required',
 ];
 
-// Reduces the odds of Sauce labs timing out during tests. See #16135 and #24286.
+// Sauce labs timeout periods. (Increased in #16135, #24286, #24575).
 // Reference: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
 const SAUCE_TIMEOUT_CONFIG = {
-  maxDuration: 10 * 60,
-  commandTimeout: 10 * 60,
-  idleTimeout: 10 * 60,
+  maxDuration: 15 * 60,
+  commandTimeout: 15 * 60,
+  idleTimeout: 15 * 60,
 };
 
 const BABELIFY_CONFIG = Object.assign(


### PR DESCRIPTION
Mitigates #24575
