### PR TITLE
Make JS URLs more robust in local testing

### DIFF
--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -1319,7 +1319,7 @@ function addViewerIntegrationScript(ampJsVersion, file) {
 }
 
 function getUrlPrefix(req) {
-  return '//' + req.headers.host;
+  return req.protocol + '://' + req.headers.host;
 }
 
 function generateInfo(filePath) {


### PR DESCRIPTION
Previously the protocol-relative URLs could get confused if the doc has a base URL.