### PR TITLE
🏗 Reorganize `dist()`

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -497,7 +497,7 @@ function printConfigHelp(command) {
   log(
     green('Building version'),
     cyan(internalRuntimeVersion),
-    green('of the runtime for local testing with the'),
+    green('of the runtime with the'),
     cyan(argv.config === 'canary' ? 'canary' : 'prod'),
     green('AMP config.')
   );


### PR DESCRIPTION
This PR reorganizes `dist()` to eliminate unnecessary parallelism, while maintaining the advantage of building runtime JS files and extensions respectively in parallel.

Implements the idea in https://github.com/ampproject/amphtml/issues/24487#issuecomment-532411620

Potential fix for #24487