### PR TITLE
🏗 Updates existing OWNERS.yaml files with brace-set and modifier syntax1

### DIFF
--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,7 +1,7 @@
 - "?cramforce"
 - "?dvoytenko"
 - "?jridgewell"
-- "**/validator-*.{protoascii,html,out}": ampproject/wg-caching
+- "**/validator-*.{protoascii,html,out}": "#ampproject/wg-caching"
 - "*.md": ampproject/wg-outreach
 - "{.*,{{babel,bundles}.config,gulpfile}.js,renovate.json}": ampproject/wg-infra
 - "{package.json,yarn.lock}":

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -15,8 +15,11 @@
 # me on any PR that touches an owners file. This will allow me to verify
 # syntax and semantics of all updates until the syntax check API for Travis to
 # use is complete.
-#
+
 # Though this gives me the ability to approve changes to owners files, I do not
 # currently have merge access; the owners check is currently non-blocking; and 
-# I run and maintain the owners bot application. 
+# I run and maintain the owners bot application.
+
+# TODO(#24685): Remove this once most owners files have been update and/or the
+# Travis check is implemented.
 - "**/OWNERS.yaml": "#rcebulko"

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,13 +1,10 @@
 - cramforce
 - dvoytenko
 - jridgewell
-- "**/validator-*.protoascii": ampproject/wg-caching
-- "**/validator-*.html": ampproject/wg-caching
-- "**/validator-*.out": ampproject/wg-caching
+- "**/validator-*.{protoascii,html,out}": ampproject/wg-caching
 - "*.md": ampproject/wg-outreach
-- ".*, babel.config.js, bundles.config.js, gulpfile.js, renovate.json":
-  - ampproject/wg-infra
-- "package.json, yarn.lock":
+- "{.*,{{babel,bundles}.config,gulpfile}.js,renovate.json}": ampproject/wg-infra
+- "{package.json,yarn.lock}":
   - ampproject/wg-infra
   - ampproject/wg-runtime
   - ampproject/wg-performance

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,6 +1,6 @@
-- cramforce
-- dvoytenko
-- jridgewell
+- "?cramforce"
+- "?dvoytenko"
+- "?jridgewell"
 - "**/validator-*.{protoascii,html,out}": ampproject/wg-caching
 - "*.md": ampproject/wg-outreach
 - "{.*,{{babel,bundles}.config,gulpfile}.js,renovate.json}": ampproject/wg-infra

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -8,3 +8,4 @@
   - ampproject/wg-infra
   - ampproject/wg-runtime
   - ampproject/wg-performance
+- "**/OWNERS.yaml": "#rcebulko"

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -8,4 +8,15 @@
   - ampproject/wg-infra
   - ampproject/wg-runtime
   - ampproject/wg-performance
+
+# The below rule will be here only temporarily during the transition period
+# while many owners files are being updated as contributors and teams notice
+# which files are out of date. The `#` modifier means the owners bot will tag
+# me on any PR that touches an owners file. This will allow me to verify
+# syntax and semantics of all updates until the syntax check API for Travis to
+# use is complete.
+#
+# Though this gives me the ability to approve changes to owners files, I do not
+# currently have merge access; the owners check is currently non-blocking; and 
+# I run and maintain the owners bot application. 
 - "**/OWNERS.yaml": "#rcebulko"

--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,4 +1,4 @@
 - aghassemi
 - "**/*-player.{js,md}":
-  - alanorozco
-  - wassgha
+  - "#alanorozco"
+  - "#wassgha"

--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,4 +1,4 @@
 - aghassemi
-- "**/*-player.js, **/*-player.md":
+- "**/*-player.{js,md}":
   - alanorozco
   - wassgha


### PR DESCRIPTION
Upgrades to the owners bot parser include support for brace-set expansion, ie `*.{js,css}`. This PR updates currently-duplicated rules to use this syntax.