### PR TITLE
🏗 Temporarily duplicate `-player.{js,md}` rules for syntax change

### DIFF
--- a/extensions/OWNERS.yaml
+++ b/extensions/OWNERS.yaml
@@ -1,4 +1,7 @@
 - aghassemi
-- "**/*-player.js, **/*-player.md":
+- "**/*-player.js":
+  - alanorozco
+  - wassgha
+- "**/*-player.md":
   - alanorozco
   - wassgha


### PR DESCRIPTION
After several cases where glob brace-expansion would have been useful, it's being added to the supported owners glob pattern syntax. It must replace the current comma-separated pattern approach, and is not backwards-compatible. This PR temporarily replaces the comma-separated rule with two separate rules for the two file extensions.

This ensures that there is no period of time between the new owners parser rolling out and the comma-separated rules being updated, which would otherwise potentially cause a disruption in ownership for @alanorozco and @wassgha .

Once this PR is merged, the new owners syntax can be rolled out. After that, PR #24599 contains updates to this and another OWNERS file using the new brace-set syntax.