### PR TITLE
✨Adds smoothing to amp-orientation-observer

### DIFF
--- a/examples/amp-orientation-observer-3d-parallax.amp.html
+++ b/examples/amp-orientation-observer-3d-parallax.amp.html
@@ -93,11 +93,11 @@
   </amp-animation>
   <amp-orientation-observer
     on="beta:stars.seekTo(percent=event.percent);gamma:stars.seekTo(percent=event.percent);"
-    layout="nodisplay">
+    layout="nodisplay" smoothing="5">
   </amp-orientation-observer>
   <amp-orientation-observer
     on="beta:text.seekTo(percent=event.percent);gamma:text.seekTo(percent=event.percent);"
-    layout="nodisplay">
+    layout="nodisplay" smoothing="5">
   </amp-orientation-observer>
 
   <div class="spacer"></div>

--- a/examples/amp-orientation-observer-amp-3d-gltf.amp.html
+++ b/examples/amp-orientation-observer-amp-3d-gltf.amp.html
@@ -101,7 +101,7 @@
 
   <main>
     <div>
-      <amp-orientation-observer on="gamma:model.setModelRotation(y=event.percent);" intersection-ratios="1" layout="nodisplay">
+      <amp-orientation-observer on="gamma:model.setModelRotation(y=event.percent);" intersection-ratios="1" layout="nodisplay" smoothing="5">
       </amp-orientation-observer>
       <amp-3d-gltf id="model" layout="fixed" width="320" height="240" alpha="true" antialiasing="true" autoRotate="false" enableZoom="true" src="https://webgears-3d.github.io/3d-gltf-static/m/DamagedHelmet.glb"></amp-3d-gltf>
     </div>

--- a/examples/amp-orientation-observer-panorama.amp.html
+++ b/examples/amp-orientation-observer-panorama.amp.html
@@ -44,7 +44,7 @@
     <amp-orientation-observer
         gamma-range="-90 90"
         on="gamma:gammaAnim.seekTo(percent=event.percent)" 
-        layout="nodisplay">
+        layout="nodisplay" smoothing="5">
   </amp-orientation-observer>
     <div class="panorama">
         <amp-img alt="A view of the mountains"

--- a/examples/amp-orientation-observer-scroll.amp.html
+++ b/examples/amp-orientation-observer-scroll.amp.html
@@ -47,7 +47,7 @@
       <amp-orientation-observer
         beta-range="0 180"
         on="beta:clockAnim1.seekTo(percent=event.percent)"
-        layout="nodisplay">
+        layout="nodisplay" smoothing="5">
       </amp-orientation-observer>
     </div>
     <div id="ipsum">

--- a/examples/amp-orientation-observer.amp.html
+++ b/examples/amp-orientation-observer.amp.html
@@ -121,7 +121,7 @@
       <amp-orientation-observer
         beta-range="0 180"
         on="beta:clockAnim1.seekTo(percent=event.percent)"
-        layout="nodisplay">
+        layout="nodisplay" smoothing="5">
       </amp-orientation-observer>
       <amp-img layout="responsive" width=2 height=1.5 src="./img/clock.jpg">
         <div class="clock-hand rotate-1"></div>
@@ -134,7 +134,7 @@
     <div id="clock-scene-1" class="clock-scene">
       <amp-orientation-observer
         on="gamma:clockAnim2.seekTo(percent=event.percent)"
-        layout="nodisplay">
+        layout="nodisplay" smoothing="5">
       </amp-orientation-observer>
       <amp-img layout="responsive" width=2 height=1.5 src="./img/clock.jpg">
         <div class="clock-hand rotate-2"></div>
@@ -148,7 +148,7 @@
       <amp-orientation-observer
         alpha-range="0 360"
         on="alpha:clockAnim3.seekTo(percent=event.percent)"
-        layout="nodisplay">
+        layout="nodisplay" smoothing="5">
       </amp-orientation-observer>
       <amp-img layout="responsive" width=2 height=1.5 src="./img/clock.jpg">
         <div class="clock-hand rotate-3"></div>

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -16,15 +16,17 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {Services} from '../../../src/services';
+import {clamp, sum} from '../../../src/utils/math';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {userAssert} from '../../../src/log';
 
 const TAG = 'amp-orientation-observer';
-const DEVICE_REST_ORIENTATION_ALPHA_VALUE = 180;
-const DEVICE_REST_ORIENTATION_BETA_VALUE = 0;
-const DEVICE_REST_ORIENTATION_GAMMA_VALUE = 0;
+const DEFAULT_REST_ALPHA = 180;
+const DEFAULT_REST_BETA = 0;
+const DEFAULT_REST_GAMMA = 0;
 const DELTA_CONST = 0.1;
+const DEFAULT_SMOOTHING_PTS = 4;
 
 export class AmpOrientationObserver extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -47,13 +49,36 @@ export class AmpOrientationObserver extends AMP.BaseElement {
     this.gammaRange_ = [-90, 90];
 
     /** @private {number} */
-    this.alphaValue_ = DEVICE_REST_ORIENTATION_ALPHA_VALUE;
+    this.alphaValue_ = DEFAULT_REST_ALPHA;
 
     /** @private {number} */
-    this.betaValue_ = DEVICE_REST_ORIENTATION_BETA_VALUE;
+    this.betaValue_ = DEFAULT_REST_BETA;
 
     /** @private {number} */
-    this.gammaValue_ = DEVICE_REST_ORIENTATION_GAMMA_VALUE;
+    this.gammaValue_ = DEFAULT_REST_GAMMA;
+
+    /** @private {number} */
+    this.restAlphaValue_ = DEFAULT_REST_ALPHA;
+
+    /** @private {number} */
+    this.restBetaValue_ = DEFAULT_REST_BETA;
+
+    /** @private {number} */
+    this.restGammaValue_ = DEFAULT_REST_GAMMA;
+
+    /** @private {Array} */
+    this.alphaSmoothingPoints_ = [];
+
+    /** @private {Array} */
+    this.betaSmoothingPoints_ = [];
+
+    /** @private {Array} */
+    this.gammaSmoothingPoints_ = [];
+
+    /** @private {?number} */
+    this.smoothing_ = this.element.hasAttribute('smoothing')
+      ? this.element.getAttribute('smoothing') || DEFAULT_SMOOTHING_PTS
+      : null;
   }
 
   /** @override */
@@ -110,24 +135,119 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    */
   deviceOrientationHandler_(event) {
     if (event instanceof DeviceOrientationEvent) {
-      if (Math.abs(event.alpha - this.alphaValue_) > DELTA_CONST) {
-        this.alphaValue_ = /** @type {number} */ (event.alpha);
+      const {screen} = this.win;
+
+      const {alpha} = event;
+      let {gamma, beta} = event;
+
+      // Detect the implementation of orientation angle
+      const angle =
+        'orientation' in screen ? screen.orientation.angle : screen.orientation;
+
+      // Reverse gamma/beta if the device is in landscape
+      if (this.win.orientation == 90 || this.win.orientation == -90) {
+        const tmp = gamma;
+        gamma = beta;
+        beta = tmp;
+      }
+
+      // Flip signs of the angles if the phone is in 'reverse landscape' or
+      // 'reverse portrait'
+      if (angle < 0) {
+        gamma = -gamma;
+        beta = -beta;
+      }
+
+      if (Math.abs(alpha - this.alphaValue_) > DELTA_CONST) {
+        if (this.smoothing_) {
+          this.alphaValue_ = this.smoothedAlphaValue_(alpha);
+        } else {
+          this.alphaValue_ = /** @type {number} */ (alpha);
+        }
         this.triggerEvent_('alpha', this.alphaValue_, this.alphaRange_);
       }
-      if (Math.abs(event.beta - this.betaValue_) > DELTA_CONST) {
-        this.betaValue_ = /** @type {number} */ (event.beta);
+      if (Math.abs(beta - this.betaValue_) > DELTA_CONST) {
+        if (this.smoothing_) {
+          this.betaValue_ = this.smoothedBetaValue_(beta);
+        } else {
+          this.betaValue_ = /** @type {number} */ (beta);
+        }
         this.triggerEvent_('beta', this.betaValue_, this.betaRange_);
       }
-      if (Math.abs(event.gamma - this.gammaValue_) > DELTA_CONST) {
-        this.gammaValue_ = /** @type {number} */ (event.gamma);
+      if (Math.abs(gamma - this.gammaValue_) > DELTA_CONST) {
+        if (this.smoothing_) {
+          this.gammaValue_ = this.smoothedGammaValue_(gamma);
+        } else {
+          this.gammaValue_ = /** @type {number} */ (gamma);
+        }
         this.triggerEvent_('gamma', this.gammaValue_, this.gammaRange_);
       }
     }
   }
 
   /**
+   * Calculates a moving average over previous values of the alpha value
+   * @param {number} alpha
+   * @return {number}
+   */
+  smoothedAlphaValue_(alpha) {
+    if (this.alphaSmoothingPoints_.length > this.smoothing_) {
+      this.alphaSmoothingPoints_.shift();
+    }
+    this.alphaSmoothingPoints_.push(alpha);
+    const avgAlpha = sum(this.alphaSmoothingPoints_) / this.smoothing_;
+    if (
+      this.alphaSmoothingPoints_.length > this.smoothing_ &&
+      this.restAlphaValue_ == DEFAULT_REST_ALPHA
+    ) {
+      this.restAlphaValue_ = avgAlpha;
+    }
+    return avgAlpha - this.restAlphaValue_;
+  }
+
+  /**
+   * Calculates a moving average over previous values of the beta value
+   * @param {number} beta
+   * @return {number}
+   */
+  smoothedBetaValue_(beta) {
+    if (this.betaSmoothingPoints_.length > this.smoothing_) {
+      this.betaSmoothingPoints_.shift();
+    }
+    this.betaSmoothingPoints_.push(beta);
+    const avgBeta = sum(this.betaSmoothingPoints_) / this.smoothing_;
+    if (
+      this.betaSmoothingPoints_.length > this.smoothing_ &&
+      this.restBetaValue_ == DEFAULT_REST_BETA
+    ) {
+      this.restBetaValue_ = avgBeta;
+    }
+    return avgBeta - this.restBetaValue_;
+  }
+
+  /**
+   * Calculates a moving average over previous values of the gamma value
+   * @param {number} gamma
+   * @return {number}
+   */
+  smoothedGammaValue_(gamma) {
+    if (this.gammaSmoothingPoints_.length > this.smoothing_) {
+      this.gammaSmoothingPoints_.shift();
+    }
+    this.gammaSmoothingPoints_.push(gamma);
+    const avgGamma = sum(this.betaSmoothingPoints_) / this.smoothing_;
+    if (
+      this.gammaSmoothingPoints_.length > this.smoothing_ &&
+      this.restGammaValue_ == DEFAULT_REST_BETA
+    ) {
+      this.restGammaValue_ = avgGamma;
+    }
+    return avgGamma - this.restGammaValue_;
+  }
+
+  /**
    * Dispatches the event to signify change in the device orientation
-   * along alpha axis.
+   * along a certain axis.
    * @param {string} eventName
    * @param {?number} eventValue
    * @param {Array} eventRange
@@ -142,7 +262,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
       this.win,
       `${TAG}.${eventName}`,
       dict({
-        'angle': eventValue.toFixed(),
+        'angle': clamp(eventValue.toFixed(), eventRange[0], eventRange[1]),
         'percent': percentValue / (eventRange[1] - eventRange[0]),
       })
     );

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -77,7 +77,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
 
     /** @private {?number} */
     this.smoothing_ = this.element.hasAttribute('smoothing')
-      ? this.element.getAttribute('smoothing') || DEFAULT_SMOOTHING_PTS
+      ? Number(this.element.getAttribute('smoothing')) || DEFAULT_SMOOTHING_PTS
       : null;
   }
 
@@ -160,7 +160,9 @@ export class AmpOrientationObserver extends AMP.BaseElement {
 
       if (Math.abs(alpha - this.alphaValue_) > DELTA_CONST) {
         if (this.smoothing_) {
-          this.alphaValue_ = this.smoothedAlphaValue_(alpha);
+          this.alphaValue_ = this.smoothedAlphaValue_(
+            /** @type {number} */ (alpha)
+          );
         } else {
           this.alphaValue_ = /** @type {number} */ (alpha);
         }
@@ -168,7 +170,9 @@ export class AmpOrientationObserver extends AMP.BaseElement {
       }
       if (Math.abs(beta - this.betaValue_) > DELTA_CONST) {
         if (this.smoothing_) {
-          this.betaValue_ = this.smoothedBetaValue_(beta);
+          this.betaValue_ = this.smoothedBetaValue_(
+            /** @type {number} */ (beta)
+          );
         } else {
           this.betaValue_ = /** @type {number} */ (beta);
         }
@@ -176,7 +180,9 @@ export class AmpOrientationObserver extends AMP.BaseElement {
       }
       if (Math.abs(gamma - this.gammaValue_) > DELTA_CONST) {
         if (this.smoothing_) {
-          this.gammaValue_ = this.smoothedGammaValue_(gamma);
+          this.gammaValue_ = this.smoothedGammaValue_(
+            /** @type {number} */ (gamma)
+          );
         } else {
           this.gammaValue_ = /** @type {number} */ (gamma);
         }
@@ -249,7 +255,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * Dispatches the event to signify change in the device orientation
    * along a certain axis.
    * @param {string} eventName
-   * @param {?number} eventValue
+   * @param {number} eventValue
    * @param {Array} eventRange
    * @private
    */
@@ -262,7 +268,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
       this.win,
       `${TAG}.${eventName}`,
       dict({
-        'angle': clamp(eventValue.toFixed(), eventRange[0], eventRange[1]),
+        'angle': clamp(eventValue, eventRange[0], eventRange[1]).toFixed(),
         'percent': percentValue / (eventRange[1] - eventRange[0]),
       })
     );

--- a/extensions/amp-orientation-observer/0.1/test/test-amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/test/test-amp-orientation-observer.js
@@ -41,6 +41,11 @@ describes.realWin(
             return '-90 90';
           }
         },
+        hasAttribute(attr) {
+          if (attr == 'smoothing') {
+            return false;
+          }
+        },
       };
       elem.ownerDocument = {
         defaultView: env.win,

--- a/extensions/amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html
+++ b/extensions/amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html
@@ -42,6 +42,8 @@
   <amp-orientation-observer layout="nodisplay" alpha-range="0 90" on="alpha:foo(angle=event.angle);beta:bar;gamma:baz"></amp-orientation-observer>
   <amp-orientation-observer layout="nodisplay" beta-range="0 90" on="alpha:foo;beta:bar(percent=event.percent);gamma:baz"></amp-orientation-observer>
   <amp-orientation-observer layout="nodisplay" beta-range="0 90" on="alpha:foo;beta:bar(angle=event.angle);gamma:baz"></amp-orientation-observer>
+  <amp-orientation-observer layout="nodisplay" smoothing="5"></amp-orientation-observer>
+  <amp-orientation-observer layout="nodisplay" smoothing></amp-orientation-observer>
 
   <!-- Invalid: missing required layout value -->
   <amp-orientation-observer></amp-orientation-observer>
@@ -70,5 +72,11 @@
   <amp-orientation-observer gamma-range="100 100 100" layout="nodisplay"></amp-orientation-observer>
   <amp-orientation-observer gamma-range="a 100" layout="nodisplay"></amp-orientation-observer>
   <amp-orientation-observer gamma-range="a b" layout="nodisplay"></amp-orientation-observer>
+
+  <!-- Invalid: smoothing value not valid -->
+  <amp-orientation-observer smoothing="b" layout="nodisplay"></amp-orientation-observer>
+  <amp-orientation-observer smoothing="2.5" layout="nodisplay"></amp-orientation-observer>
+  <amp-orientation-observer smoothing="0.5" layout="nodisplay"></amp-orientation-observer>
+  <amp-orientation-observer smoothing="-5" layout="nodisplay"></amp-orientation-observer>
 </body>
 </html>

--- a/extensions/amp-orientation-observer/0.1/test/validator-amp-orientation-observer.out
+++ b/extensions/amp-orientation-observer/0.1/test/validator-amp-orientation-observer.out
@@ -43,77 +43,93 @@ FAIL
 |    <amp-orientation-observer layout="nodisplay" alpha-range="0 90" on="alpha:foo(angle=event.angle);beta:bar;gamma:baz"></amp-orientation-observer>
 |    <amp-orientation-observer layout="nodisplay" beta-range="0 90" on="alpha:foo;beta:bar(percent=event.percent);gamma:baz"></amp-orientation-observer>
 |    <amp-orientation-observer layout="nodisplay" beta-range="0 90" on="alpha:foo;beta:bar(angle=event.angle);gamma:baz"></amp-orientation-observer>
+|    <amp-orientation-observer layout="nodisplay" smoothing="5"></amp-orientation-observer>
+|    <amp-orientation-observer layout="nodisplay" smoothing></amp-orientation-observer>
 |
 |    <!-- Invalid: missing required layout value -->
 |    <amp-orientation-observer></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:47:2 The implied layout 'CONTAINER' is not supported by tag 'amp-orientation-observer'. (see https://amp.dev/documentation/components/amp-orientation-observer) [AMP_LAYOUT_PROBLEM]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:49:2 The implied layout 'CONTAINER' is not supported by tag 'amp-orientation-observer'. (see https://amp.dev/documentation/components/amp-orientation-observer) [AMP_LAYOUT_PROBLEM]
 |
 |    <!-- Invalid: alpha-range, beta-range & gamma-range not valid entries -->
 |    <amp-orientation-observer alpha-range="" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:50:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:52:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="foo" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:51:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:53:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="100fx" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:52:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:54:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="100 a" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:53:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:55:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="100 100 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:54:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:56:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="a 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:55:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:57:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer alpha-range="a b" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:56:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:58:2 The attribute 'alpha-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |
 |    <amp-orientation-observer beta-range="" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:58:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:60:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="foo" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:59:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:61:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="100fx" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:60:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:62:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="100 a" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:61:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:63:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="100 100 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:62:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:64:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="a 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:63:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:65:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer beta-range="a b" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:64:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:66:2 The attribute 'beta-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |
 |    <amp-orientation-observer gamma-range="" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:66:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:68:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="foo" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:67:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:69:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="100fx" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:68:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:70:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100fx'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="100 a" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:69:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:71:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100 a'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="100 100 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:70:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:72:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value '100 100 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="a 100" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:71:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:73:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'a 100'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |    <amp-orientation-observer gamma-range="a b" layout="nodisplay"></amp-orientation-observer>
 >>   ^~~~~~~~~
-amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:72:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:74:2 The attribute 'gamma-range' in tag 'amp-orientation-observer' is set to the invalid value 'a b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+|
+|    <!-- Invalid: smoothing value not valid -->
+|    <amp-orientation-observer smoothing="b" layout="nodisplay"></amp-orientation-observer>
+>>   ^~~~~~~~~
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:77:2 The attribute 'smoothing' in tag 'amp-orientation-observer' is set to the invalid value 'b'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+|    <amp-orientation-observer smoothing="2.5" layout="nodisplay"></amp-orientation-observer>
+>>   ^~~~~~~~~
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:78:2 The attribute 'smoothing' in tag 'amp-orientation-observer' is set to the invalid value '2.5'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+|    <amp-orientation-observer smoothing="0.5" layout="nodisplay"></amp-orientation-observer>
+>>   ^~~~~~~~~
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:79:2 The attribute 'smoothing' in tag 'amp-orientation-observer' is set to the invalid value '0.5'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
+|    <amp-orientation-observer smoothing="-5" layout="nodisplay"></amp-orientation-observer>
+>>   ^~~~~~~~~
+amp-orientation-observer/0.1/test/validator-amp-orientation-observer.html:80:2 The attribute 'smoothing' in tag 'amp-orientation-observer' is set to the invalid value '-5'. (see https://amp.dev/documentation/components/amp-orientation-observer) [DISALLOWED_HTML]
 |  </body>
 |  </html>

--- a/extensions/amp-orientation-observer/amp-orientation-observer.md
+++ b/extensions/amp-orientation-observer/amp-orientation-observer.md
@@ -141,6 +141,10 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
 
 Specifies that the associated action should only take place for changes between the specified range along the y axis. Specified as a space separated list of 2 values (e.g., `gamma-range="0 90"`. By default the related action is triggered for all changes between `0` and `360 degrees`.
 
+##### smoothing (optional)
+
+When enabled, outputs a moving average of the last `n` values instead of the raw value read from the sensor. By default smoothing is enabled and set to 4.
+
 ## Validation
 
 See [amp-orientation-observer rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii) in the AMP validator specification.

--- a/extensions/amp-orientation-observer/amp-orientation-observer.md
+++ b/extensions/amp-orientation-observer/amp-orientation-observer.md
@@ -5,6 +5,7 @@ formats:
 teaser:
   text: Monitors the orientation of an element within the viewport as a user scrolls, and dispatches events that can be used with other AMP components.
 ---
+
 <!---
 Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
@@ -46,24 +47,21 @@ other AMP components.
 
 ## Overview
 
-The `amp-orientation-observer` component monitors the orientation of a device, and dispatches low-trust level events (`alpha`, `beta`, `gamma`) that report changes in the device's orientation along the `alpha`, `beta` and `gamma` axises in terms of `angle` and `percent`. These can be used to trigger actions (*Only Low Trust Actions*) on other components (e.g., [amp-animation](https://amp.dev/documentation/components/amp-animation)).
+The `amp-orientation-observer` component monitors the orientation of a device, and dispatches low-trust level events (`alpha`, `beta`, `gamma`) that report changes in the device's orientation along the `alpha`, `beta` and `gamma` axises in terms of `angle` and `percent`. These can be used to trigger actions (_Only Low Trust Actions_) on other components (e.g., [amp-animation](https://amp.dev/documentation/components/amp-animation)).
 
 {% call callout('Note', type='note') %}
 The `amp-orientation-observer` component is only useful when used with other components and does not do anything on its own.
 {% endcall %}
 
-
 #### Events
 
 These are the low-trust level events that the `amp-orientation-observer` component dispatches:
 
-
-| Event    | Description                                            |
-| ---------| -------------------------------------------------------|
-| `alpha`  | Represents the motion of the device around the z axis. |
-| `beta`   | Represents the motion of the device around the x axis. |
-| `gamma`  | Represents the motion of the device around the y axis. This represents a left to right motion of the device. |
-
+| Event   | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| `alpha` | Represents the motion of the device around the z axis.                                                       |
+| `beta`  | Represents the motion of the device around the x axis.                                                       |
+| `gamma` | Represents the motion of the device around the y axis. This represents a left to right motion of the device. |
 
 ## What can I do with amp-orientation-observer?
 
@@ -81,20 +79,20 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
 -->
 <amp-animation id="clockAnim" layout="nodisplay">
   <script type="application/json">
-    {
-    "duration": "3s",
-    "fill": "both",
-    "direction": "alternate",
-    "animations": [
       {
-        "selector": "#clock-scene .clock-hand",
-        "keyframes": [
-          { "transform": "rotate(-180deg)" },
-          { "transform": "rotate(0deg)" }
-        ]
-      }
-    ]
-  }
+      "duration": "3s",
+      "fill": "both",
+      "direction": "alternate",
+      "animations": [
+        {
+          "selector": "#clock-scene .clock-hand",
+          "keyframes": [
+            { "transform": "rotate(-180deg)" },
+            { "transform": "rotate(0deg)" }
+          ]
+        }
+      ]
+    }
   </script>
 </amp-animation>
 
@@ -106,13 +104,13 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
   -->
   <amp-orientation-observer
     on="beta:clockAnim1.seekTo(percent=event.percent)"
-    layout="nodisplay">
+    layout="nodisplay"
+  >
   </amp-orientation-observer>
-  <amp-img layout="responsive" width=2 height=1.5 src="./img/clock.jpg">
+  <amp-img layout="responsive" width="2" height="1.5" src="./img/clock.jpg">
     <div class="clock-hand"></div>
   </amp-img>
 </div>
-
 ```
 
 ## Attributes
@@ -125,7 +123,7 @@ Specifies that the associated action should only take place for changes between 
 
 Specifies that the associated action should only take place for changes between the specified range along the x axis. Specified as a space separated list of 2 values (e.g., `beta-range="0 180"`). By default, the related action is triggered for all changes between `0` and `360 degrees`.
 
-*Example: Using beta-range to limit the range of degrees to watch along the x axis*
+_Example: Using beta-range to limit the range of degrees to watch along the x axis_
 
 Imagine an animation where the hour hand of a clock rotates as the user scrolls the page.
 
@@ -133,7 +131,8 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
 <amp-orientation-observer
   beta-range="0 180"
   on="beta:clockAnim1.seekTo(percent=event.percent)"
-  layout="nodisplay">
+  layout="nodisplay"
+>
 </amp-orientation-observer>
 ```
 
@@ -143,7 +142,7 @@ Specifies that the associated action should only take place for changes between 
 
 ##### smoothing (optional)
 
-When enabled, outputs a moving average of the last `n` values instead of the raw value read from the sensor. By default smoothing is enabled and set to 4.
+When enabled, outputs a moving average of the last `n` values instead of the raw value read from the sensor. By default, when activated, smoothing will be set to 4 points.
 
 ## Validation
 

--- a/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
+++ b/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
@@ -49,6 +49,10 @@ tags: {  # <amp-orientation-observer>
     # Values such as: "100 100", "0 100", etc..
     value_regex: "(\\d+)\\s{1}(\\d+)"
   }
+  attrs: {
+    name: "smoothing"
+    value_regex: "([0-9]+)?"
+  }
   amp_layout {
     supported_layouts: NODISPLAY
   }

--- a/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
+++ b/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
@@ -51,7 +51,7 @@ tags: {  # <amp-orientation-observer>
   }
   attrs: {
     name: "smoothing"
-    value_regex: "([0-9]+)?"
+    value_regex: "[0-9]+|"
   }
   amp_layout {
     supported_layouts: NODISPLAY

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -153,3 +153,14 @@ export function polarToCartesian(centerX, centerY, radius, angleInDegrees) {
     y: centerY + radius * Math.sin(angleInRadians),
   };
 }
+
+/**
+ * Sums up the values of the given array and returns the result
+ * @param {Array<number>} values
+ * @return {number}
+ */
+export function sum(values) {
+  return values.reduce(function(a, b) {
+    return a + b;
+  });
+}

--- a/test/unit/utils/test-math.js
+++ b/test/unit/utils/test-math.js
@@ -21,6 +21,7 @@ import {
   magnitude,
   mapRange,
   mod,
+  sum,
 } from '../../../src/utils/math';
 
 describes.sandboxed('utils/math', {}, () => {
@@ -239,6 +240,13 @@ describes.sandboxed('utils/math', {}, () => {
       expect(distance(-1.5, -3, 1.5, 1)).to.equal(5);
       expect(distance(4, 6, -1, -6)).to.equal(13);
       expect(distance(-0.5, -0.5, 1, 2)).be.closeTo(2.915, 0.001);
+    });
+  });
+
+  describe('sum', () => {
+    it('should sum up an array of numbers', () => {
+      expect(sum([2, 10, 100])).to.equal(112);
+      expect(sum([-3, 2, 44])).to.equal(43);
     });
   });
 });


### PR DESCRIPTION
Closes #19326 , Closes #24400 

### Changes
- Adds a configurable smoothing of the `alpha`/`beta`/`gamma` values (the configurable value is the subset size used to generate the moving average)
- Dynamically reads the rest values of `alpha`/`beta`/`gamma` instead of defaulting to `0`
- Clamps the values to the provided ranges
- Adds the required validator tests