### PR TITLE
Add warn and info to removable dev log messages.

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -26,6 +26,8 @@ const REMOVABLE = {
   dev: [
     'assert',
     'fine',
+    'info',
+    'warn',
     'assertElement',
     'assertString',
     'assertNumber',

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -46,6 +46,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
   ImmutableSet<String> suffixTypes = ImmutableSet.of(
       "dev$$module$src$log().assert()",
       "dev$$module$src$log().fine()",
+      "dev$$module$src$log().info()",
+      "dev$$module$src$log().warn()",
       "dev$$module$src$log().assertElement()",
       "dev$$module$src$log().assertString()",
       "dev$$module$src$log().assertNumber()",


### PR DESCRIPTION
Folks may feel that this change shouldn't be made. But I never turn these on in optimized code.

On the upside: This should be a small performance and code size win.