### PR TITLE
🏗 Specify owners for files in the repo's root directory

### DIFF
--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -4,3 +4,10 @@
 - "**/validator-*.protoascii": ampproject/wg-caching
 - "**/validator-*.html": ampproject/wg-caching
 - "**/validator-*.out": ampproject/wg-caching
+- "*.md": ampproject/wg-outreach
+- ".*, babel.config.js, bundles.config.js, gulpfile.js, renovate.json":
+  - ampproject/wg-infra
+- "package.json, yarn.lock":
+  - ampproject/wg-infra
+  - ampproject/wg-runtime
+  - ampproject/wg-performance


### PR DESCRIPTION
Most of the files in the repo root directory have to do with packages, infrastructure, or documentation. This PR adds owners for each category. 

- Packages: @ampproject/wg-infra, @ampproject/wg-runtime, @ampproject/wg-performance
- Infrastructure (all dot-files plus a few more): @ampproject/wg-infra 
- Documentation: @ampproject/wg-outreach 

Let me know if you think these aren't the right sets of owners. 