### PR TITLE
🏗 Follow up changes to integration tests on sauce labs

### DIFF
--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -49,7 +49,10 @@ async function main() {
 
     await startSauceConnect(FILENAME);
     timedExecOrDie('gulp unit --nobuild --saucelabs');
-    timedExecOrDie('gulp integration --nobuild --compiled --saucelabs');
+    timedExecOrDie(
+      'gulp integration --nobuild --compiled --saucelabs --stable'
+    );
+    timedExec('gulp integration --nobuild --compiled --saucelabs --beta');
 
     stopSauceConnect(FILENAME);
   } else {

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -29,7 +29,6 @@ const {
   stopTimer,
   startSauceConnect,
   stopSauceConnect,
-  timedExec: timedExecBase,
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
@@ -37,7 +36,6 @@ const {isTravisPullRequestBuild} = require('../travis');
 
 const FILENAME = 'remote-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExec = cmd => timedExecBase(cmd, FILENAME);
 const timedExecOrDie = cmd => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
@@ -52,7 +50,7 @@ async function main() {
     timedExecOrDie(
       'gulp integration --nobuild --compiled --saucelabs --stable'
     );
-    timedExec('gulp integration --nobuild --compiled --saucelabs --beta');
+    timedExecOrDie('gulp integration --nobuild --compiled --saucelabs --beta');
 
     stopSauceConnect(FILENAME);
   } else {
@@ -89,7 +87,9 @@ async function main() {
       timedExecOrDie(
         'gulp integration --nobuild --compiled --saucelabs --stable'
       );
-      timedExec('gulp integration --nobuild --compiled --saucelabs --beta');
+      timedExecOrDie(
+        'gulp integration --nobuild --compiled --saucelabs --beta'
+      );
     }
     stopSauceConnect(FILENAME);
   }

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -29,7 +29,7 @@ const {
   stopTimer,
   startSauceConnect,
   stopSauceConnect,
-  timedExec,
+  timedExec: timedExecBase,
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
@@ -37,8 +37,8 @@ const {isTravisPullRequestBuild} = require('../travis');
 
 const FILENAME = 'remote-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExec = cmd => timedExecBase(cmd, FILENAME);
+const timedExecOrDie = cmd => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -29,6 +29,7 @@ const IS_GULP_UNIT = argv._[0] === 'unit';
 const IS_GULP_E2E = argv._[0] === 'e2e';
 
 const IS_LOCAL_CHANGES = !!argv.local_changes;
+const IS_SAUCELABS = !!argv.saucelabs;
 const IS_SAUCELABS_STABLE = !!argv.saucelabs && !!argv.stable;
 const IS_SAUCELABS_BETA = !!argv.saucelabs && !!argv.beta;
 const IS_SINGLE_PASS = !!argv.single_pass;
@@ -67,10 +68,10 @@ function inferTestType() {
 
   if (IS_SAUCELABS_BETA) {
     return `${type}/saucelabs-beta`;
-  }
-
-  if (IS_SAUCELABS_STABLE) {
+  } else if (IS_SAUCELABS_STABLE) {
     return `${type}/saucelabs-stable`;
+  } else if (IS_SAUCELABS) {
+    return `${type}/saucelabs`;
   }
 
   if (IS_SINGLE_PASS) {

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -29,11 +29,15 @@ const IS_GULP_UNIT = argv._[0] === 'unit';
 const IS_GULP_E2E = argv._[0] === 'e2e';
 
 const IS_LOCAL_CHANGES = !!argv.local_changes;
-const IS_SAUCELABS = !!argv.saucelabs;
+const IS_SAUCELABS_STABLE = !!argv.saucelabs && !!argv.stable;
+const IS_SAUCELABS_BETA = !!argv.saucelabs && !!argv.beta;
 const IS_SINGLE_PASS = !!argv.single_pass;
 
 const TEST_TYPE_SUBTYPES = new Map([
-  ['integration', ['local', 'single-pass', 'saucelabs']],
+  [
+    'integration',
+    ['local', 'single-pass', 'saucelabs-beta', 'saucelabs-stable'],
+  ],
   ['unit', ['local', 'local-changes', 'saucelabs']],
   ['e2e', ['local']],
 ]);
@@ -61,8 +65,12 @@ function inferTestType() {
     return `${type}/local-changes`;
   }
 
-  if (IS_SAUCELABS) {
-    return `${type}/saucelabs`;
+  if (IS_SAUCELABS_BETA) {
+    return `${type}/saucelabs-beta`;
+  }
+
+  if (IS_SAUCELABS_STABLE) {
+    return `${type}/saucelabs-stable`;
   }
 
   if (IS_SINGLE_PASS) {

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -20,7 +20,6 @@ const fs = require('fs');
 const log = require('fancy-log');
 const opn = require('opn');
 const path = require('path');
-
 const {
   reportTestErrored,
   reportTestFinished,

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -266,7 +266,7 @@ async function runTestInSauceLabs(config) {
 
   if (argv.beta) {
     config.browsers = browsers.beta;
-    const betaExitCode = await createKarmaServer(config, () => {});
+    const betaExitCode = await createKarmaServer(config, reportTestRunComplete);
     if (betaExitCode != 0) {
       log(
         yellow('Some tests have failed on'),
@@ -311,13 +311,6 @@ async function runTestInBatches_(config, browsers) {
       totalStableFailed += results.failed;
     }
   };
-  const betaRunCompleteFn = async (browsers, results) => {
-    if (results.error) {
-      await reportTestErrored();
-    } else {
-      await reportTestFinished(results.success, results.failed);
-    }
-  };
 
   if (browsers.stable.length) {
     const allBatchesExitCodes = await runTestInBatchesWithBrowsers_(
@@ -348,7 +341,7 @@ async function runTestInBatches_(config, browsers) {
       'beta',
       browsers.beta,
       config,
-      betaRunCompleteFn
+      reportTestRunComplete
     );
     if (allBatchesExitCodes) {
       log(

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -309,6 +309,13 @@ async function runTestInBatches_(config, browsers) {
       totalStableFailed += results.failed;
     }
   };
+  const betaRunCompleteFn = async (browsers, results) => {
+    if (results.error) {
+      await reportTestErrored();
+    } else {
+      await reportTestFinished(results.success, results.failed);
+    }
+  };
 
   if (browsers.stable.length) {
     const allBatchesExitCodes = await runTestInBatchesWithBrowsers_(
@@ -339,7 +346,7 @@ async function runTestInBatches_(config, browsers) {
       'beta',
       browsers.beta,
       config,
-      /* runCompleteFn */ () => {}
+      betaRunCompleteFn
     );
     if (allBatchesExitCodes) {
       log(


### PR DESCRIPTION
**Highlights:**
- Separate duplicate `integration/saucelabs` test status into `integration/saucelabs-stable` and `integration/saucelabs-beta`
- Split up execution into stable and beta for push builds too
- Report results / totals / errors for beta runs
- Set an "error" status when zero tests are detected, but don't exit (allows recovery in cases like [this](https://travis-ci.org/ampproject/amphtml/jobs/586766065#L2161-L2166))
- Fix logging

**Fixes [this](https://github.com/ampproject/amphtml/pull/24619/checks?check_run_id=227541301) error:**
![image](https://user-images.githubusercontent.com/26553114/65192788-62b36280-da46-11e9-8976-0194e9e308dd.png)

Follow up to #24613
