### PR TITLE
Document setState/getState in amp-script

### DIFF
--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -147,7 +147,7 @@ Under the hood, `amp-script` uses [@ampproject/worker-dom](https://github.com/am
 This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings).
 
 [tip type="default"]
-`AMP.setState()` requires the [`amp-bind`](https://amp.dev/documentation/components/amp-bind) extension to be installed.
+`AMP.setState()` requires the [`amp-bind`](https://amp.dev/documentation/components/amp-bind) extension script to be included in the document head.
 [/tip]
 
 ```js
@@ -168,7 +168,7 @@ AMP.getState(expr) {}
 ##### Example with WebSocket and AMP.setState()
 
 ```html
-<amp-script width=1 height=1 script="webSocketDemo" development>
+<amp-script width=1 height=1 script="webSocketDemo">
 </amp-script>
 
 <!--

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -138,13 +138,11 @@ Will be reflected on the page as a new child of the `amp-script` element:
 
 Under the hood, `amp-script` uses [@ampproject/worker-dom](https://github.com/ampproject/worker-dom/). For design details, see the ["Intent to Implement" issue](https://github.com/ampproject/amphtml/issues/13471).
 
-### Advanced usages
-
-#### Passing data between amp-script and the page
+### State manipulation
 
 `amp-script` supports getting and setting [`amp-state`](https://amp.dev/documentation/components/amp-bind/#initializing-state-with-amp-state) JSON via JavaScript.
 
-This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings).
+This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings). These elements can be inside (descendants) or outside (non-descendants) of the `amp-script` element.
 
 [tip type="default"]
 `AMP.setState()` requires the [`amp-bind`](https://amp.dev/documentation/components/amp-bind) extension script to be included in the document head.

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -142,7 +142,13 @@ Under the hood, `amp-script` uses [@ampproject/worker-dom](https://github.com/am
 
 #### Passing data between amp-script and the page
 
-`amp-script` supports getting and setting `amp-state` JSON via JavaScript.
+`amp-script` supports getting and setting [`amp-state`](https://amp.dev/documentation/components/amp-bind/#initializing-state-with-amp-state) JSON via JavaScript.
+
+This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings).
+
+[tip type="default"]
+`AMP.setState()` requires the [`amp-bind`](https://amp.dev/documentation/components/amp-bind) extension to be installed.
+[/tip]
 
 ```js
 /**
@@ -159,7 +165,7 @@ AMP.setState(json) {}
 AMP.getState(expr) {}
 ```
 
-For example:
+##### Example with WebSocket and AMP.setState()
 
 ```html
 <amp-script width=1 height=1 script="webSocketDemo" development>

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -138,6 +138,45 @@ Will be reflected on the page as a new child of the `amp-script` element:
 
 Under the hood, `amp-script` uses [@ampproject/worker-dom](https://github.com/ampproject/worker-dom/). For design details, see the ["Intent to Implement" issue](https://github.com/ampproject/amphtml/issues/13471).
 
+### Advanced usages
+
+#### Passing data between amp-script and the page
+
+`amp-script` supports getting and setting `amp-state` JSON via JavaScript.
+
+```js
+/**
+ * Deep-merges `json` into the current amp-state.
+ * @param {!Object} json A JSON object e.g. must not contain circular references.
+ */
+AMP.setState(json) {}
+
+/**
+ * Asynchronously returns amp-state.
+ * @param {string=} expr An optional JSON expression string e.g. "foo.bar".
+ * @return {!Promise<!Object>}
+ */
+AMP.getState(expr) {}
+```
+
+For example:
+
+```html
+<amp-script width=1 height=1 script="webSocketDemo" development>
+</amp-script>
+
+<!--
+  <amp-state> doesn't support WebSocket URLs in its "src" attribute,
+  but we can use <amp-script> to work around it. :)
+-->
+<script type="text/plain" target="amp-script" id="webSocketDemo">
+  const socket = new WebSocket('wss://websocket.example');
+  socket.onmessage = e => {
+    AMP.setState({socketData: event.data});
+  };
+</script>
+```
+
 ### Restrictions
 
 #### Allowed APIs


### PR DESCRIPTION
Add "Advanced usages" section that explains how to use `AMP.setState` and `AMP.getState` in amp-script.