### PR TITLE
🐛Story Ads: Don't require outlink meta tag

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1795,7 +1795,9 @@ export class AmpA4A extends AMP.BaseElement {
         metaData.images = metaDataObj['images'].splice(0, 5);
       }
       if (this.isSinglePageStoryAd) {
-        if (!metaDataObj['ctaUrl'] || !metaDataObj['ctaType']) {
+        // CTA Type is a required meta tag. CTA Url can come from meta tag, or
+        // (temporarily) amp-ad-exit config.
+        if (!metaDataObj['ctaType']) {
           throw new Error(INVALID_SPSA_RESPONSE);
         }
         this.element.setAttribute('data-vars-ctatype', metaDataObj['ctaType']);

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1797,6 +1797,7 @@ export class AmpA4A extends AMP.BaseElement {
       if (this.isSinglePageStoryAd) {
         // CTA Type is a required meta tag. CTA Url can come from meta tag, or
         // (temporarily) amp-ad-exit config.
+        // TODO(#24080): maybe rerequire cta url?
         if (!metaDataObj['ctaType']) {
           throw new Error(INVALID_SPSA_RESPONSE);
         }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1937,12 +1937,19 @@ describe('amp-a4a', () => {
       ).to.throw(new RegExp(INVALID_SPSA_RESPONSE));
     });
 
-    it('should throw due to missing outlink', () => {
+    it('should not throw due to missing outlink', () => {
       metaData.ctaType = '0';
       a4a.isSinglePageStoryAd = true;
-      expect(() =>
-        a4a.getAmpAdMetadata(buildCreativeString(metaData))
-      ).to.throw(new RegExp(INVALID_SPSA_RESPONSE));
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
+      const expected = Object.assign(
+        {
+          minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
+        },
+        metaData
+      );
+      delete expected.ctaType;
+      expect(actual).to.deep.equal(expected);
+      expect(a4a.element.dataset.varsCtatype).to.equal('0');
     });
 
     it('should set appropriate attributes and return metadata object', () => {


### PR DESCRIPTION
In #24044 I introduced some code that would allow the outlink url to come from amp-ad-exit. This allows some partner teams to use this option while waiting on full story ad integration. 

Because the outlink can now be in the amp ad exit we should no longer throw when no `cta-url` meta tag is present.

This should probably be reinstated as part of work in #24080