### PR TITLE
Skip flaky story analytics integration tests

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -121,6 +121,7 @@ class TestConfig {
     this.runOnSafari = this.platform.isSafari.bind(this.platform);
     this.runOnIos = this.platform.isIos.bind(this.platform);
     this.runOnIe = this.platform.isIe.bind(this.platform);
+    this.runOnWindows = this.platform.isWindows.bind(this.platform);
 
     /**
      * By default, IE is skipped. Individual tests may opt in.
@@ -146,6 +147,10 @@ class TestConfig {
 
   skipIos() {
     return this.skip(this.runOnIos);
+  }
+
+  skipWindows() {
+    return this.skip(this.runOnWindows);
   }
 
   skipIfPropertiesObfuscated() {
@@ -196,6 +201,10 @@ class TestConfig {
   ifIe() {
     // It's necessary to first enable IE because we skip it by default.
     return this.enableIe().if(this.runOnIe);
+  }
+
+  ifWindows() {
+    return this.if(this.runOnWindows);
   }
 
   /**

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -121,7 +121,6 @@ class TestConfig {
     this.runOnSafari = this.platform.isSafari.bind(this.platform);
     this.runOnIos = this.platform.isIos.bind(this.platform);
     this.runOnIe = this.platform.isIe.bind(this.platform);
-    this.runOnWindows = this.platform.isWindows.bind(this.platform);
 
     /**
      * By default, IE is skipped. Individual tests may opt in.
@@ -147,10 +146,6 @@ class TestConfig {
 
   skipIos() {
     return this.skip(this.runOnIos);
-  }
-
-  skipWindows() {
-    return this.skip(this.runOnWindows);
   }
 
   skipIfPropertiesObfuscated() {
@@ -201,10 +196,6 @@ class TestConfig {
   ifIe() {
     // It's necessary to first enable IE because we skip it by default.
     return this.enableIe().if(this.runOnIe);
-  }
-
-  ifWindows() {
-    return this.if(this.runOnWindows);
   }
 
   /**

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -20,11 +20,11 @@ import {parseQueryString} from '../../src/url';
 const config = describe
   .configure()
   .skipEdge()
+  .skipWindows() // TODO(#24639): Re-enable tests.
   .ifChrome()
   .skipSinglePass();
 
-// TODO(#24639): Re-enable tests.
-config.skip('amp-story analytics', () => {
+config.run('amp-story analytics', () => {
   const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
   const body = `
         <amp-story standalone>

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -23,7 +23,7 @@ const config = describe
   .ifChrome()
   .skipSinglePass();
 
-config.run('amp-story analytics', () => {
+config.skip('amp-story analytics', () => {
   const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
   const body = `
         <amp-story standalone>

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -20,11 +20,11 @@ import {parseQueryString} from '../../src/url';
 const config = describe
   .configure()
   .skipEdge()
-  .skipWindows() // TODO(#24639): Re-enable tests.
   .ifChrome()
   .skipSinglePass();
 
-config.run('amp-story analytics', () => {
+// TODO(#24639): Re-enable tests.
+config.skip('amp-story analytics', () => {
   const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
   const body = `
         <amp-story standalone>

--- a/test/integration/test-amp-story-analytics.js
+++ b/test/integration/test-amp-story-analytics.js
@@ -23,6 +23,7 @@ const config = describe
   .ifChrome()
   .skipSinglePass();
 
+// TODO(#24639): Re-enable tests.
 config.skip('amp-story analytics', () => {
   const extensions = ['amp-story:1.0', 'amp-analytics', 'amp-social-share'];
   const body = `


### PR DESCRIPTION
They are flaking on master

https://travis-ci.org/ampproject/amphtml/jobs/587116429
```
      IT => should send analytics event when navigating
        ✗ AssertionError: expected 'page-1' to equal 'page-2'
            at _callee2$ (home/travis/build/ampproject/amphtml/test/integration/test-amp-story-analytics.js:143:35)
            at tryCatch (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:65:40)
            at Generator.invoke [as _invoke] (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:303:22)
            at Generator.prototype.<computed> [as next] (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:117:21)
            at asyncGeneratorStep (/tmp/637d6ae55d488af8c723bc9ffe1cea60.browserify.js:99961:103)
            at _next (/tmp/637d6ae55d488af8c723bc9ffe1cea60.browserify.js:99963:194)
```

https://travis-ci.org/ampproject/amphtml/jobs/587121381
```
DESCRIBE => amp-story analytics
  DESCRIBE => amp-story analytics
    DESCRIBE =>  
      IT => should send analytics event when entering bookend
        ✗ AssertionError: expected 'false' to equal 'true'
            at _callee3$ (home/travis/build/ampproject/amphtml/test/integration/test-amp-story-analytics.js:154:36)
            at tryCatch (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:65:40)
            at Generator.invoke [as _invoke] (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:303:22)
            at Generator.prototype.<computed> [as next] (home/travis/build/ampproject/amphtml/node_modules/regenerator-runtime/runtime.js:117:21)
            at asyncGeneratorStep (/tmp/d871b543b0ca58abfa25877e17f239cc.browserify.js:99961:103)
            at _next (/tmp/d871b543b0ca58abfa25877e17f239cc.browserify.js:99963:194)
```
/cc @choumx 