### PR TITLE
🐛 amp-autocomplete: Fetch remote data after first user interaction

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -354,7 +354,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.keyDownHandler_(e);
     });
     this.inputElement_.addEventListener('focus', () => {
-      this.focusHandler_();
+      this.checkFirstInteractionAndMaybeFetchData_();
       this.toggleResultsHandler_(true);
     });
     this.inputElement_.addEventListener('blur', () => {
@@ -729,12 +729,11 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /**
-   * Requests remote data source on first user interaction if one is provided.
-   * Triggers toggleResultsHandler_ to display results regardless.
+   * Requests remote data source, if provided, on first user interaction.
    * @return {!Promise}
    * @private
    */
-  focusHandler_() {
+  checkFirstInteractionAndMaybeFetchData_() {
     if (!this.interacted_ && this.element.hasAttribute('src')) {
       this.interacted_ = true;
       const remoteDataPromise = this.getRemoteData_().catch(e => {

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -354,8 +354,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.keyDownHandler_(e);
     });
     this.inputElement_.addEventListener('focus', () => {
-      this.checkFirstInteractionAndMaybeFetchData_();
-      this.toggleResultsHandler_(true);
+      this.checkFirstInteractionAndMaybeFetchData_().then(() => {
+        this.toggleResultsHandler_(true);
+      });
     });
     this.inputElement_.addEventListener('blur', () => {
       this.toggleResultsHandler_(false);
@@ -746,6 +747,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         }
       });
     }
+    return Promise.resolve();
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -51,10 +51,6 @@ describes.realWin(
         script.setAttribute('type', 'application/json');
         script.innerHTML = json;
         ampAutocomplete.appendChild(script);
-      } else {
-        sandbox
-          .stub(ampAutocomplete.implementation_, 'getRemoteData_')
-          .resolves(json.items);
       }
 
       return ampAutocomplete;
@@ -108,7 +104,7 @@ describes.realWin(
         });
     });
 
-    it('should render', () => {
+    it('should render inline data before first user interaction', () => {
       let impl, filterAndRenderSpy, clearAllSpy, filterSpy, renderSpy;
       return getAutocomplete({
         'filter': 'substring',
@@ -131,8 +127,39 @@ describes.realWin(
           expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
           expect(filterAndRenderSpy).to.have.been.calledOnce;
           expect(clearAllSpy).to.have.been.calledOnce;
-          expect(filterSpy).to.have.been.calledOnce;
-          expect(renderSpy).to.have.been.calledOnce;
+          expect(filterSpy).to.have.been.called;
+          expect(renderSpy).to.have.been.called;
+        });
+    });
+
+    it('should not render remote data before first user interaction', () => {
+      let impl, filterAndRenderSpy, clearAllSpy, filterSpy, renderSpy;
+      return getAutocomplete(
+        {
+          'filter': 'substring',
+          'min-characters': '0',
+        },
+        '{ "items" : ["apple", "banana", "orange"] }',
+        false
+      )
+        .then(ampAutocomplete => {
+          impl = ampAutocomplete.implementation_;
+          expect(impl.sourceData_).to.be.null;
+          expect(impl.inputElement_).not.to.be.null;
+          expect(impl.container_).not.to.be.null;
+          expect(impl.filter_).to.equal('substring');
+          filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
+          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
+          filterSpy = sandbox.spy(impl, 'filterData_');
+          renderSpy = sandbox.spy(impl, 'renderResults_');
+          return ampAutocomplete.layoutCallback();
+        })
+        .then(() => {
+          expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
+          expect(filterAndRenderSpy).to.have.been.calledOnce;
+          expect(clearAllSpy).to.have.been.calledOnce;
+          expect(filterSpy).not.to.have.been.called;
+          expect(renderSpy).not.to.have.been.called;
         });
     });
 
@@ -227,7 +254,7 @@ describes.realWin(
       });
     });
 
-    it('should fetch remote data when specified in src', () => {
+    it('should not fetch remote data when specified in src before first user interaction', () => {
       const data = {
         items: [
           'Albany, New York',
@@ -247,12 +274,12 @@ describes.realWin(
       ).then(ampAutocomplete => {
         ampAutocomplete.layoutCallback().then(() => {
           const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.have.ordered.members(data.items);
+          expect(impl.sourceData_).to.be.null;
         });
       });
     });
 
-    it('should fetch remote data when specified in src and using items property', () => {
+    it('should not fetch remote data when specified in src and using items property before first user interaction', () => {
       const data = {
         cities: [
           'Albany, New York',
@@ -273,12 +300,12 @@ describes.realWin(
       ).then(ampAutocomplete => {
         ampAutocomplete.layoutCallback().then(() => {
           const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.have.ordered.members(data.cities);
+          expect(impl.sourceData_).to.be.null;
         });
       });
     });
 
-    it('should fetch remote data when specified in src and using nested items property', () => {
+    it('should not fetch remote data when specified in src and using nested items property before first user interactino', () => {
       const data = {
         deeply: {
           nested: {
@@ -303,9 +330,7 @@ describes.realWin(
       ).then(ampAutocomplete => {
         ampAutocomplete.layoutCallback().then(() => {
           const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.have.ordered.members(
-            data.deeply.nested.cities
-          );
+          expect(impl.sourceData_).be.null;
         });
       });
     });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -916,12 +916,23 @@ describes.realWin(
         });
       });
 
-      it('should display fallback when provided', () => {
+      it('should not display fallback before user interaction', () => {
         sandbox.stub(impl, 'getFallback').returns(true);
         return element.layoutCallback().then(() => {
-          expect(getDataSpy).to.have.been.calledOnce;
-          expect(fallbackSpy).to.have.been.calledWith('Error for test');
-          expect(toggleFallbackSpy).to.have.been.calledWith(true);
+          expect(getDataSpy).not.to.have.been.called;
+          expect(fallbackSpy).not.to.have.been.called;
+          expect(toggleFallbackSpy).not.to.have.been.called;
+        });
+      });
+
+      it('should display fallback after user interaction if provided', () => {
+        sandbox.stub(impl, 'getFallback').returns(true);
+        return element.layoutCallback().then(() => {
+          impl.focusHandler_().then(() => {
+            expect(getDataSpy).to.have.been.calledOnce;
+            expect(fallbackSpy).to.have.been.calledWith('Error for test');
+            expect(toggleFallbackSpy).to.have.been.calledWith(true);
+          });
         });
       });
     });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -928,7 +928,7 @@ describes.realWin(
       it('should display fallback after user interaction if provided', () => {
         sandbox.stub(impl, 'getFallback').returns(true);
         return element.layoutCallback().then(() => {
-          impl.focusHandler_().then(() => {
+          impl.checkFirstInteractionAndMaybeFetchData_().then(() => {
             expect(getDataSpy).to.have.been.calledOnce;
             expect(fallbackSpy).to.have.been.calledWith('Error for test');
             expect(toggleFallbackSpy).to.have.been.calledWith(true);


### PR DESCRIPTION
Resolves #23772 

Currently amp-autocomplete will fetch remote data source on layout. This change:

- delays this initial fetch until the user first interacts with the input field contained in the component
- does not impact behavior for data provided inline