### PR TITLE
🏗 Make `nailgun` server stoppage a time-bound operation and log errors if any

### DIFF
--- a/build-system/tasks/nailgun.js
+++ b/build-system/tasks/nailgun.js
@@ -35,6 +35,7 @@ const DEFAULT_NAILGUN_PORT = '2113';
 const CHECK_TYPES_NAILGUN_PORT = '2114';
 const DIST_NAILGUN_PORT = '2115';
 const NAILGUN_STARTUP_TIMEOUT_MS = 5 * 1000;
+const NAILGUN_STOP_TIMEOUT_MS = 5 * 1000;
 
 /**
  * Replaces the default compiler binary with nailgun on linux and macos
@@ -142,16 +143,21 @@ async function stopNailgunServer(port) {
   }
   if (process.platform == 'darwin' || process.platform == 'linux') {
     const stopNailgunServerCmd = `${nailgunRunner} --nailgun-port ${port} ng-stop`;
-    if (exec(stopNailgunServerCmd, {stdio: 'pipe'}).status == 0) {
+    const stopped = exec(stopNailgunServerCmd, {
+      stdio: 'pipe',
+      timeout: NAILGUN_STOP_TIMEOUT_MS,
+    });
+    if (stopped.status == 0) {
       log('Stopped', cyan('nailgun-server.jar'), 'on port', cyan(port));
     } else {
       log(
         yellow('WARNING:'),
-        'Could not find a running instance of',
+        'Could not stop',
         cyan('nailgun-server.jar'),
         'on port',
         cyan(port)
       );
+      log(red(stopped.stderr));
     }
   }
 }


### PR DESCRIPTION
It's possible that the operation to stop the nailgun server after `gulp dist` occasionally causes Travis builds to stall. Since this is a non-essential cleanup step, it makes sense to make the operation time-bound and non-blocking.

This PR implements the idea in https://github.com/ampproject/amphtml/issues/24487#issuecomment-533321019 and gives the process 5 seconds to execute before printing a warning and continuing.

**Reference:** See the `timeout` option of [`child_process.spawnSync()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)

Potential fix for #24487