### PR TITLE
🏗 Reduce `gulp dist` parallelism on Travis, add some logging

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -30,6 +30,7 @@ const {
 } = require('./closure-compile');
 const {checkTypesNailgunPort, distNailgunPort} = require('../tasks/nailgun');
 const {CLOSURE_SRC_GLOBS, SRC_TEMP_DIR} = require('../sources');
+const {isTravisBuild} = require('../travis');
 const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {singlePassCompile} = require('./single-pass');
 const {VERSION: internalRuntimeVersion} = require('../internal-version');
@@ -41,7 +42,8 @@ let inProgress = 0;
 // There's a race in the gulp plugin of closure compiler that gets exposed
 // during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
-const MAX_PARALLEL_CLOSURE_INVOCATIONS = 1;
+const MAX_PARALLEL_CLOSURE_INVOCATIONS =
+  isTravisBuild() && argv.single_pass ? 4 : 1;
 
 /**
  * Prefixes the the tmp directory if we need to shadow files that have been

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -163,7 +163,11 @@ function compile(
 
     console /*OK*/
       .assert(typeof entryModuleFilenames == 'string');
-    return singlePassCompile(entryModuleFilenames, compilationOptions);
+    return singlePassCompile(
+      entryModuleFilenames,
+      compilationOptions,
+      timeInfo
+    );
   }
 
   return new Promise(function(resolve, reject) {

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -61,14 +61,21 @@ exports.closureCompile = async function(
   entryModuleFilename,
   outputDir,
   outputFilename,
-  options
+  options,
+  timeInfo
 ) {
   // Rate limit closure compilation to MAX_PARALLEL_CLOSURE_INVOCATIONS
   // concurrent processes.
   return new Promise(function(resolve, reject) {
     function start() {
       inProgress++;
-      compile(entryModuleFilename, outputDir, outputFilename, options).then(
+      compile(
+        entryModuleFilename,
+        outputDir,
+        outputFilename,
+        options,
+        timeInfo
+      ).then(
         function() {
           inProgress--;
           next();
@@ -101,7 +108,13 @@ function cleanupBuildDir() {
 }
 exports.cleanupBuildDir = cleanupBuildDir;
 
-function compile(entryModuleFilenames, outputDir, outputFilename, options) {
+function compile(
+  entryModuleFilenames,
+  outputDir,
+  outputFilename,
+  options,
+  timeInfo
+) {
   const hideWarningsFor = [
     'third_party/amp-toolbox-cache-url/',
     'third_party/caja/',
@@ -360,6 +373,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     } else {
       const gulpSrcs = argv.single_pass ? srcs : convertPathsToTmpRoot(srcs);
       const gulpBase = argv.single_pass ? '.' : SRC_TEMP_DIR;
+      timeInfo.startTime = Date.now();
       return gulp
         .src(gulpSrcs, {base: gulpBase})
         .pipe(gulpIf(shouldShortenLicense, shortenLicense()))

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -30,7 +30,6 @@ const {
 } = require('./closure-compile');
 const {checkTypesNailgunPort, distNailgunPort} = require('../tasks/nailgun');
 const {CLOSURE_SRC_GLOBS, SRC_TEMP_DIR} = require('../sources');
-const {isTravisBuild} = require('../travis');
 const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {singlePassCompile} = require('./single-pass');
 const {VERSION: internalRuntimeVersion} = require('../internal-version');
@@ -42,7 +41,7 @@ let inProgress = 0;
 // There's a race in the gulp plugin of closure compiler that gets exposed
 // during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
-const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild() ? 4 : 1;
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = 1;
 
 /**
  * Prefixes the the tmp directory if we need to shadow files that have been

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -548,7 +548,8 @@ function isAltMainBundle(name) {
   });
 }
 
-exports.singlePassCompile = async function(entryModule, options) {
+exports.singlePassCompile = async function(entryModule, options, timeInfo) {
+  timeInfo.startTime = Date.now();
   return exports
     .getFlags({
       modules: [entryModule].concat(extensions),

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -316,7 +316,7 @@ async function buildExtensions(options) {
     }
   }
   await Promise.all(results);
-  if (!options.compileOnlyCss) {
+  if (!options.compileOnlyCss && !argv.single_pass) {
     endBuildStep(
       options.minify ? 'Minified all' : 'Compiled all',
       'extensions',

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -25,6 +25,7 @@ const {
   verifyExtensionBundles,
 } = require('../../bundles.config');
 const {compileJs, mkdirSync} = require('./helpers');
+const {endBuildStep} = require('./helpers');
 const {isTravisBuild} = require('../travis');
 const {jsifyCssAsync} = require('./jsify-css');
 const {vendorConfigs} = require('./vendor-configs');
@@ -302,6 +303,7 @@ function dedupe(arr) {
  * @return {!Promise}
  */
 async function buildExtensions(options) {
+  const startTime = Date.now();
   maybeInitializeExtensions(extensions, /* includeLatest */ false);
   const extensionsToBuild = getExtensionsToBuild();
   const results = [];
@@ -314,6 +316,13 @@ async function buildExtensions(options) {
     }
   }
   await Promise.all(results);
+  if (!options.compileOnlyCss) {
+    endBuildStep(
+      options.minify ? 'Minified all' : 'Compiled all',
+      'extensions',
+      startTime
+    );
+  }
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -102,21 +102,19 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
  * Compile JS in minified mode and drop them in dist/.
- * @return {!Promise}
  */
-function compileAllMinifiedJs() {
+async function compileAllMinifiedJs() {
   log('Minifying multi-pass JS with', cyan('closure-compiler') + '...');
-  return compileAllJs(/* watch */ false, /* minify */ true);
+  await compileAllJs(/* watch */ false, /* minify */ true);
 }
 
 /**
  * Compile JS in unminified mode and drop them in dist/.
  * @param {boolean} watch
- * @return {!Promise}
  */
-function compileAllUnminifiedJs(watch) {
+async function compileAllUnminifiedJs(watch) {
   log('Compiling JS with', cyan('browserify') + '...');
-  return compileAllJs(/* watch */ watch);
+  await compileAllJs(/* watch */ watch);
 }
 
 /**
@@ -173,10 +171,10 @@ async function bootstrapThirdPartyFrames(watch, minify) {
  * and drop them in the dist folder
  * @param {boolean} watch
  * @param {boolean} minify
- * @return {!Promise}
  */
-function compileAllJs(watch, minify) {
-  return Promise.all([
+async function compileAllJs(watch, minify) {
+  const startTime = Date.now();
+  await Promise.all([
     minify ? Promise.resolve() : doBuildJs(jsBundles, 'polyfills.js', {watch}),
     doBuildJs(jsBundles, 'amp.js', {
       watch,
@@ -200,6 +198,11 @@ function compileAllJs(watch, minify) {
     doBuildJs(jsBundles, 'amp-shadow.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-inabox.js', {watch, minify}),
   ]);
+  endBuildStep(
+    minify ? 'Minified all' : 'Compiled all',
+    'runtime JS files',
+    startTime
+  );
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -102,19 +102,21 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 /**
  * Compile JS in minified mode and drop them in dist/.
+ * @return {!Promise}
  */
-async function compileAllMinifiedJs() {
+function compileAllMinifiedJs() {
   log('Minifying multi-pass JS with', cyan('closure-compiler') + '...');
-  await compileAllJs(/* watch */ false, /* minify */ true);
+  return compileAllJs(/* watch */ false, /* minify */ true);
 }
 
 /**
  * Compile JS in unminified mode and drop them in dist/.
  * @param {boolean} watch
+ * @return {!Promise}
  */
-async function compileAllUnminifiedJs(watch) {
+function compileAllUnminifiedJs(watch) {
   log('Compiling JS with', cyan('browserify') + '...');
-  await compileAllJs(/* watch */ watch);
+  return compileAllJs(/* watch */ watch);
 }
 
 /**
@@ -171,10 +173,11 @@ async function bootstrapThirdPartyFrames(watch, minify) {
  * and drop them in the dist folder
  * @param {boolean} watch
  * @param {boolean} minify
+ * @return {!Promise}
  */
-async function compileAllJs(watch, minify) {
+function compileAllJs(watch, minify) {
   const startTime = Date.now();
-  await Promise.all([
+  return Promise.all([
     minify ? Promise.resolve() : doBuildJs(jsBundles, 'polyfills.js', {watch}),
     doBuildJs(jsBundles, 'amp.js', {
       watch,
@@ -197,12 +200,13 @@ async function compileAllJs(watch, minify) {
     doBuildJs(jsBundles, 'amp-inabox-host.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-shadow.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-inabox.js', {watch, minify}),
-  ]);
-  endBuildStep(
-    minify ? 'Minified all' : 'Compiled all',
-    'runtime JS files',
-    startTime
-  );
+  ]).then(() => {
+    endBuildStep(
+      minify ? 'Minified all' : 'Compiled all',
+      'runtime JS files',
+      startTime
+    );
+  });
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -249,10 +249,10 @@ function appendToCompiledFile(srcFilename, destFilePath) {
  * @return {!Promise}
  */
 function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
-  const startTime = Date.now();
+  const timeInfo = {};
   const entryPoint = path.join(srcDir, srcFilename);
   const {minifiedName} = options;
-  return closureCompile(entryPoint, destDir, minifiedName, options)
+  return closureCompile(entryPoint, destDir, minifiedName, options, timeInfo)
     .then(function() {
       const destPath = path.join(destDir, minifiedName);
       appendToCompiledFile(srcFilename, destPath);
@@ -275,7 +275,7 @@ function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         });
         name += ', and all extensions';
       }
-      endBuildStep('Minified', name, startTime);
+      endBuildStep('Minified', name, timeInfo.startTime);
     })
     .then(() => {
       if (argv.fortesting && MINIFIED_TARGETS.includes(minifiedName)) {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -481,10 +481,13 @@ function compileJs(srcDir, srcFilename, destDir, options) {
 function endBuildStep(stepName, targetName, startTime) {
   const endTime = Date.now();
   const executionTime = new Date(endTime - startTime);
+  const mins = executionTime.getMinutes();
   const secs = executionTime.getSeconds();
   const ms = ('000' + executionTime.getMilliseconds().toString()).slice(-3);
   let timeString = '(';
-  if (secs === 0) {
+  if (mins > 0) {
+    timeString += mins + ' m ' + secs + '.' + ms + ' s)';
+  } else if (secs === 0) {
     timeString += ms + ' ms)';
   } else {
     timeString += secs + '.' + ms + ' s)';


### PR DESCRIPTION
Still trying to figure out why `gulp dist` occasionally stalls on Travis. Tried a few things listed in #24487.

**Next steps in this PR:**

- Reduce parallelism for multi-pass `gulp dist` to 1 (doesn't make a substantial difference to running time)
- Add logging + timing for `buildExtensions()` and `compileAllJs()` (so we know when all promises have resolved)
- Fix bug in timing each minification step (we were counting queued time instead of running time, and weren't including the minutes value for longer tasks)

See https://github.com/ampproject/amphtml/issues/24487#issuecomment-533691728

Potential fix for #24487
