### PR TITLE
Enable Saucelabs tests on Safari 11

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -53,6 +53,7 @@ function updateBrowsers(config) {
           'SL_Firefox',
           'SL_Edge_17',
           'SL_Safari_12',
+          'SL_Safari_11',
           'SL_IE_11',
           // TODO(amp-infra): Evaluate and add more platforms here.
           //'SL_Chrome_Android_7',

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -157,7 +157,7 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   overrideGlobalScrollTo() {
-    return true;
+    return false;
   }
 
   /** @override */

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -295,7 +295,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   });
 
   it('should require override of the global scrollTo', () => {
-    expect(binding.overrideGlobalScrollTo()).to.be.true;
+    expect(binding.overrideGlobalScrollTo()).to.be.false;
   });
 
   // TODO(#22220): Remove when "ios-fixed-no-transfer" experiment is cleaned up.


### PR DESCRIPTION
To test our code that uses IntersectionObserverPolyfill. Safari 11 does not have native InOb support