### PR TITLE
Use SameSite=None for canary cookie.

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Services} from './services';
 import {endsWith} from './string';
 import {
   getSourceOrigin,
@@ -211,21 +210,19 @@ function trySetCookie(win, name, value, expirationTime, domain, sameSite) {
 }
 
 /**
- * Gets the cookie string to use for SameSite. This works around an issue where
- * Safari treats an unknown value ("None") as "Strict".
+ * Gets the cookie string to use for SameSite. This only sets the SameSite
+ * value if specified, falling back to the browser default. The default value
+ * is equivalent to SameSite.NONE, but is planned to be set to SameSite.LAX in
+ * Chrome 80.
+ *
+ * Note: In Safari 12, if the value is set to SameSite.NONE, it is treated by
+ * the browser as SameSite.STRICT.
  * @param {Window} win
  * @param {!SameSite|undefined} sameSite
  * @return {string} The string to use when setting the cookie.
  */
 function getSameSiteString(win, sameSite) {
   if (!sameSite) {
-    return '';
-  }
-
-  const platform = Services.platformFor(win);
-  const isWebkit = platform.isIos() || platform.isSafari();
-
-  if (isWebkit && sameSite == SameSite.NONE) {
     return '';
   }
 

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -180,7 +180,7 @@ export function getHighestAvailableDomain(win) {
  * @param {string} value
  * @param {time} expirationTime
  * @param {string|undefined} domain
- * @param {!SameSite|undefined} sameSite
+ * @param {!SameSite=} sameSite
  */
 function trySetCookie(win, name, value, expirationTime, domain, sameSite) {
   // We do not allow setting cookies on the domain that contains both

--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -5,13 +5,7 @@
   <title>AMP Experiments</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="robots" content="noindex">
-  <!--
-    TODO(sparhami) Can we make these async? We currently depend on
-    execution order so that the AMP_CONFIG from v0.js does not interfere
-    with the one from the cache-busted v0.js loaded via experiments.js.
-  -->
-  <script defer src="https://cdn.ampproject.org/v0.js"></script>
-  <script defer src="/dist.tools/experiments/experiments.js"></script>
+  <script async src="/dist.tools/experiments/experiments.js"></script>
   <style>
     body {
       max-width: 600px;

--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -5,7 +5,13 @@
   <title>AMP Experiments</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="robots" content="noindex">
-  <script async src="/dist.tools/experiments/experiments.js"></script>
+  <!--
+    TODO(sparhami) Can we make these async? We currently depend on
+    execution order so that the AMP_CONFIG from v0.js does not interfere
+    with the one from the cache-busted v0.js loaded via experiments.js.
+  -->
+  <script defer src="https://cdn.ampproject.org/v0.js"></script>
+  <script defer src="/dist.tools/experiments/experiments.js"></script>
   <style>
     body {
       max-width: 600px;

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -17,8 +17,8 @@
 import '../../src/polyfills';
 import '../../src/service/timer-impl';
 import {Deferred} from '../../src/utils/promise';
+import {SameSite, getCookie, setCookie} from '../../src/cookies';
 import {devAssert, initLogConstructor, setReportError} from '../../src/log';
-import {getCookie, setCookie} from '../../src/cookies';
 import {getMode} from '../../src/mode';
 import {isExperimentOn, toggleExperiment} from '../../src/experiments';
 import {listenOnce} from '../../src/event-helper';
@@ -564,6 +564,10 @@ function setAmpCanaryCookie_(cookieState) {
     // Set explicit domain, so the cookie gets sent to sub domains.
     domain: location.hostname,
     allowOnProxyOrigin: true,
+    // Make sure the cookie is available for the script loads coming from
+    // other domains. Chrome's default of LAX would otherwise prevent it
+    // from being sent.
+    sameSite: SameSite.NONE,
   };
   setCookie(window, 'AMP_CANARY', cookieState, validUntil, cookieOptions);
   // Reflect default experiment state.


### PR DESCRIPTION
With Chrome 78 (beta) and Chrome 80 (stable), cookies will be set with `SameSite=Lax` by default. This prevents the canary/rc cookie from being sent when the page is not on the cdn.ampproject.org domain when requesting v0.js.

Fixes #24643

/cc @jridgewell 