### PR TITLE
✨amp-form: Initialize form from URL

### DIFF
--- a/examples/amp-form-initialization-test.html
+++ b/examples/amp-form-initialization-test.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html ⚡>
+
+<head>
+  <title>amp-form initialization test</title>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <link rel="canonical" href="amp-form-initialization-test.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}
+  </style>
+  <noscript>
+    <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
+  </noscript>
+  <style amp-custom>
+    body {
+      padding: 1em;
+      margin: 0;
+      font-family: sans-serif;
+    }
+    input:not([type="checkbox"]):not([type="radio"]),
+    select,
+    textarea {
+      width: 90%;
+    }
+    th {
+      text-align: left;
+      padding-top: 1em;
+    }
+    td {
+      padding: 0.25em;
+    }
+    td:first-child {
+      font-family: monospace;
+    }
+    .msg {
+      font-family: sans-serif;
+      border: 1px solid #ccc;
+      padding: 0.5em;
+    }
+
+    input[name="layout-checked"]~p:after {
+      content: " not checked";
+    }
+    input[name="layout-checked"]:checked~p:after {
+      content: " checked";
+    }
+    input[name="layout-checked"]:checked~p {
+      height: 4em;
+      background-color: lightgreen;
+      line-height: 4em;
+      text-align: center;
+    }
+
+    input[name="layout-invalid"]~p:after {
+      content: " valid";
+    }
+    input[name="layout-invalid"]:invalid~p:after {
+      content: " invalid";
+    }
+    input[name="layout-invalid"]:invalid~p {
+      height: 4em;
+      background-color: orange;
+      line-height: 4em;
+      text-align: center;
+    }
+
+    input[name="layout-hidden"][type="hidden"][value="0"]~p:after {
+      content: " 0";
+    }
+    input[name="layout-hidden"][type="hidden"]~p:after {
+      content: " ?";
+    }
+    input[name="layout-hidden"][type="hidden"][value="0"]~p {
+      height: 4em;
+      background-color: lightblue;
+      line-height: 4em;
+      text-align: center;
+    }
+  </style>
+</head>
+
+<body>
+  <p><a href="amp-form-initialization-test.html?input-color=%23ffffff&input-datetime-local=2019-01-01T00%3A00&input-email=test%40test.com&input-month=2019-01&input-number=100&input-range=6&input-search=some+search&input-tel=%2B1-555-555-5555&input-text=some+text&input-time=01%3A00&input-url=https%3A%2F%2Famp.dev%2Fs%3Fq%3D3%23e&input-week=2019-W01&input-hidden=some+hidden&input-checkbox-1=1&input-checkbox-2=2&input-radio=2&select=2&textarea=some+textarea&nofill-input-text=other+text&nofill-input-checkbox-1=1&nofill-input-checkbox-2=2&nofill-input-radio=2&nofill-select=2&nofill-textarea=other+textarea&layout-checked=on&layout-invalid=.&layout-hidden=0">Test URL</a> (or populate form manually and submit with button below)</p>
+  <form id="form2" method="GET" action="amp-form-initialization-test.html" target="_top" data-initialize-from-url>
+    <table>
+      <tr>
+        <td colspan="3" class="msg">The following form fields have attribute <code>data-allow-initialization</code>, so their values should be set from the URL on page load.</td>
+      </tr>
+      <tr>
+        <th>Type</th>
+        <th>Field</th>
+        <th>Default value</th>
+      </tr>
+      <tr>
+        <td>&lt;input type="color"&gt;</td>
+        <td><input type="color" name="input-color" data-allow-initialization></td>
+        <td><input type="color"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="datetime-local"&gt;</td>
+        <td><input type="datetime-local" name="input-datetime-local" data-allow-initialization></td>
+        <td><input type="datetime-local"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="email"&gt;</td>
+        <td><input type="email" name="input-email" data-allow-initialization></td>
+        <td><input type="email"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="month"&gt;</td>
+        <td><input type="month" name="input-month" data-allow-initialization></td>
+        <td><input type="month"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="number"&gt;</td>
+        <td><input type="number" name="input-number" data-allow-initialization></td>
+        <td><input type="number"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="range"&gt;</td>
+        <td><input type="range" name="input-range" data-allow-initialization></td>
+        <td><input type="range"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="search"&gt;</td>
+        <td><input type="search" name="input-search" data-allow-initialization></td>
+        <td><input type="search"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="tel"&gt;</td>
+        <td><input type="tel" name="input-tel" data-allow-initialization></td>
+        <td><input type="tel"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="text"&gt;</td>
+        <td><input type="text" name="input-text" data-allow-initialization></td>
+        <td><input type="text"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="time"&gt;</td>
+        <td><input type="time" name="input-time" data-allow-initialization></td>
+        <td><input type="time"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="url"&gt;</td>
+        <td><input type="url" name="input-url" data-allow-initialization></td>
+        <td><input type="url"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="week"&gt;</td>
+        <td><input type="week" name="input-week" data-allow-initialization></td>
+        <td><input type="week"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="hidden"&gt;</td>
+        <td><input type="hidden" name="input-hidden" data-allow-initialization></td>
+        <td><input type="hidden"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="checkbox"&gt;</td>
+        <td>
+          <label><input type="checkbox" name="input-checkbox-1" value="1" data-allow-initialization> 1</label>
+          <label><input type="checkbox" name="input-checkbox-2" value="2" data-allow-initialization> 2</label>
+        </td>
+        <td>
+          <label><input type="checkbox" value="1"> 1</label>
+          <label><input type="checkbox" value="2"> 2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;input type="radio"&gt;</td>
+        <td>
+          <label><input type="radio" name="input-radio" value="1" data-allow-initialization> 1</label>
+          <label><input type="radio" name="input-radio" value="2" data-allow-initialization> 2</label>
+        </td>
+        <td>
+          <label><input type="radio" name="default-input-radio" value="1"> 1</label>
+          <label><input type="radio" name="default-input-radio" value="2"> 2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;select&gt;</td>
+        <td>
+          <select name="select" data-allow-initialization>
+            <option value="1">1</option>
+            <option value="2">2</option>
+          </select>
+        </td>
+        <td>
+          <select>
+            <option value="1">1</option>
+            <option value="2">2</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;textarea&gt;</td>
+        <td><textarea name="textarea" data-allow-initialization></textarea></td>
+        <td><textarea></textarea></td>
+      </tr>
+      <tr>
+        <td colspan="3" class="msg">The following form fields <em>do not</em> have attribute <code>data-allow-initialization</code>, so their values should <em>not</em> be set from the URL on page load.</td>
+      </tr>
+      <tr>
+        <th>Type</th>
+        <th>Field</th>
+        <th>Default value</th>
+      </tr>
+      <tr>
+        <td>&lt;input type="text"&gt;</td>
+        <td><input type="text" name="nofill-input-text"></td>
+        <td><input type="text"></td>
+      </tr>
+      <tr>
+        <td>&lt;input type="checkbox"&gt;</td>
+        <td>
+          <label><input type="checkbox" name="nofill-input-checkbox-1" value="1"> 1</label>
+          <label><input type="checkbox" name="nofill-input-checkbox-2" value="2"> 2</label>
+        </td>
+        <td>
+          <label><input type="checkbox" value="1"> 1</label>
+          <label><input type="checkbox" value="2"> 2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;input type="radio"&gt;</td>
+        <td>
+          <label><input type="radio" name="nofill-input-radio" value="1"> 1</label>
+          <label><input type="radio" name="nofill-input-radio" value="2"> 2</label>
+        </td>
+        <td>
+          <label><input type="radio" name="nofill-default-input-radio" value="1"> 1</label>
+          <label><input type="radio" name="nofill-default-input-radio" value="2"> 2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;select&gt;</td>
+        <td>
+          <select name="nofill-select">
+            <option value="1">1</option>
+            <option value="2">2</option>
+          </select>
+        </td>
+        <td>
+          <select>
+            <option value="1">1</option>
+            <option value="2">2</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>&lt;textarea&gt;</td>
+        <td><textarea name="nofill-textarea"></textarea></td>
+        <td><textarea></textarea></td>
+      </tr>
+      <tr>
+        <td colspan="3" class="msg">Sample layout hacking</td>
+      </tr>
+      <tr>
+        <td>:checked</td>
+        <td colspan="2">
+          <input type="checkbox" name="layout-checked" id="layout-checked" data-allow-initialization>
+          <label for="layout-checked">checkbox</label>
+          <p>This checkbox is </p>
+        </td>
+      </tr>
+      <tr>
+        <td>:invalid</td>
+        <td colspan="2">
+          <input type="email" name="layout-invalid" id="layout-invalid" placeholder="email" data-allow-initialization>
+          <p>This input is </p>
+        </td>
+      </tr>
+      <tr>
+        <td>[type="hidden"][value="0"]</td>
+        <td colspan="2">
+          <input type="hidden" name="layout-hidden" id="layout-hidden" data-allow-initialization>
+          <p>Input value is </p>
+        </td>
+      </tr>
+    </table>
+    <button>Submit</button>
+  </form>
+</body>
+
+</html>

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1288,11 +1288,7 @@ export class AmpForm {
         valueTags.includes(tag)
       ) {
         if (field.value !== value) {
-          try {
-            field.value = value;
-          } catch (e) {
-            dev().error(TAG, 'unable to initialize form element', e);
-          }
+          field.value = value;
         }
       } else if (tag === 'INPUT' && checkedInputTypes.includes(type)) {
         const inputs = this.form_./*OK*/ querySelectorAll(
@@ -1300,11 +1296,7 @@ export class AmpForm {
         );
         iterateCursor(inputs, input => {
           if (input.checked !== (input.value === value)) {
-            try {
-              input.checked = input.value === value;
-            } catch (e) {
-              dev().error(TAG, 'unable to initialize form element', e);
-            }
+            input.checked = input.value === value;
           }
         });
       }

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -3170,9 +3170,8 @@ describes.repeated(
       'Initialize from URL',
       {
         amp: {
-          runtimeOn: true,
           ampdoc: variant.ampdoc,
-          extensions: ['amp-form', 'amp-selector'], // amp-form is installed as service.
+          extensions: ['amp-form'],
         },
         win: {
           location:
@@ -3190,15 +3189,7 @@ describes.repeated(
           doc = env.ampdoc.getRootNode();
           const ownerDoc = doc.ownerDocument || doc;
           createElement = ownerDoc.createElement.bind(ownerDoc);
-          Services.resourcesForDoc(env.ampdoc);
         });
-
-        function getAmpForm(form, canonical = 'https://example.com/amps.html') {
-          new AmpFormService(env.ampdoc);
-          Services.documentInfoForDoc(env.ampdoc).canonicalUrl = canonical;
-          env.ampdoc.getBody().appendChild(form);
-          return Promise.resolve(new AmpForm(form, 'amp-form-test-id'));
-        }
 
         function getAmpFormWithInitialization(initFromUrl) {
           const form = createElement('form');
@@ -3269,20 +3260,20 @@ describes.repeated(
           textarea.innerHTML = '0';
           form.appendChild(textarea);
 
-          return getAmpForm(form).then(ampForm => {
-            return {
-              ampForm,
-              fields: {
-                textNoInit,
-                hiddenAmpReplace,
-                text,
-                radio0,
-                radio1,
-                checkbox,
-                select,
-                textarea,
-              },
-            };
+          env.ampdoc.getBody().appendChild(form);
+          const ampForm = new AmpForm(form, 'amp-form-test-id');
+          return Promise.resolve({
+            ampForm,
+            fields: {
+              textNoInit,
+              hiddenAmpReplace,
+              text,
+              radio0,
+              radio1,
+              checkbox,
+              select,
+              textarea,
+            },
           });
         }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -3165,5 +3165,172 @@ describes.repeated(
         });
       }
     );
+
+    describes.fakeWin(
+      'Initialize from URL',
+      {
+        amp: {
+          runtimeOn: true,
+          ampdoc: variant.ampdoc,
+          extensions: ['amp-form', 'amp-selector'], // amp-form is installed as service.
+        },
+        win: {
+          location:
+            'https://example.com/amps.html?textNoInit=1&hiddenAmpReplace=1&text=1&radio=1&checkbox=on&select=1&textarea=1',
+          top: {
+            location: 'https://example-top.com',
+          },
+        },
+      },
+      env => {
+        let doc;
+        let createElement;
+
+        beforeEach(() => {
+          doc = env.ampdoc.getRootNode();
+          const ownerDoc = doc.ownerDocument || doc;
+          createElement = ownerDoc.createElement.bind(ownerDoc);
+          Services.resourcesForDoc(env.ampdoc);
+        });
+
+        function getAmpForm(form, canonical = 'https://example.com/amps.html') {
+          new AmpFormService(env.ampdoc);
+          Services.documentInfoForDoc(env.ampdoc).canonicalUrl = canonical;
+          env.ampdoc.getBody().appendChild(form);
+          return Promise.resolve(new AmpForm(form, 'amp-form-test-id'));
+        }
+
+        function getAmpFormWithInitialization(initFromUrl) {
+          const form = createElement('form');
+          form.setAttribute('method', 'GET');
+          if (initFromUrl) {
+            form.setAttribute('data-initialize-from-url', '');
+          }
+
+          // Create inputs that do not support initialization from URL
+          const textNoInit = createElement('input');
+          textNoInit.setAttribute('type', 'text');
+          textNoInit.setAttribute('name', 'textNoInit');
+          textNoInit.setAttribute('value', '0');
+          form.appendChild(textNoInit);
+
+          const hiddenAmpReplace = createElement('input');
+          hiddenAmpReplace.setAttribute('type', 'hidden');
+          hiddenAmpReplace.setAttribute('name', 'hiddenAmpReplace');
+          hiddenAmpReplace.setAttribute('value', '0');
+          hiddenAmpReplace.setAttribute('data-amp-replace', '');
+          hiddenAmpReplace.setAttribute('data-allow-initialization', '');
+          form.appendChild(hiddenAmpReplace);
+
+          // Create inputs that support initialization from URL
+          const text = createElement('input');
+          text.setAttribute('type', 'text');
+          text.setAttribute('name', 'text');
+          text.setAttribute('value', '0');
+          text.setAttribute('data-allow-initialization', '');
+          form.appendChild(text);
+
+          const radio0 = createElement('input');
+          radio0.setAttribute('type', 'radio');
+          radio0.setAttribute('name', 'radio');
+          radio0.setAttribute('checked', '');
+          radio0.setAttribute('value', '0');
+          radio0.setAttribute('data-allow-initialization', '');
+          form.appendChild(radio0);
+
+          const radio1 = createElement('input');
+          radio1.setAttribute('type', 'radio');
+          radio1.setAttribute('name', 'radio');
+          radio1.setAttribute('value', '1');
+          radio1.setAttribute('data-allow-initialization', '');
+          form.appendChild(radio1);
+
+          const checkbox = createElement('input');
+          checkbox.setAttribute('type', 'checkbox');
+          checkbox.setAttribute('name', 'checkbox');
+          checkbox.setAttribute('data-allow-initialization', '');
+          form.appendChild(checkbox);
+
+          const select = createElement('select');
+          select.setAttribute('name', 'select');
+          select.setAttribute('data-allow-initialization', '');
+          const option1 = createElement('option');
+          option1.setAttribute('value', '0');
+          option1.setAttribute('selected', '');
+          const option2 = createElement('option');
+          option2.setAttribute('value', '1');
+          select.appendChild(option1);
+          select.appendChild(option2);
+          form.appendChild(select);
+
+          const textarea = createElement('textarea');
+          textarea.setAttribute('name', 'textarea');
+          textarea.setAttribute('data-allow-initialization', '');
+          textarea.innerHTML = '0';
+          form.appendChild(textarea);
+
+          return getAmpForm(form).then(ampForm => {
+            return {
+              ampForm,
+              fields: {
+                textNoInit,
+                hiddenAmpReplace,
+                text,
+                radio0,
+                radio1,
+                checkbox,
+                select,
+                textarea,
+              },
+            };
+          });
+        }
+
+        it('should not be dirty', () => {
+          return getAmpFormWithInitialization(true).then(response => {
+            const {ampForm} = response;
+            const form = ampForm.form_;
+
+            expect(form).to.not.have.class(DIRTINESS_INDICATOR_CLASS);
+          });
+        });
+
+        it('should selectively initialize fields', () => {
+          return getAmpFormWithInitialization(true).then(response => {
+            const {fields} = response;
+
+            // URL: ?textNoInit=1&hiddenAmpReplace=1&text=1&radio=1&checkbox=on&select=1&textarea=1
+
+            // field value/checked should not change
+            expect(fields['textNoInit'].value).to.equal('0');
+            expect(fields['hiddenAmpReplace'].value).to.equal('0');
+
+            // field value/checked should change
+            expect(fields['text'].value).to.equal('1');
+            expect(fields['radio0'].checked).to.be.false;
+            expect(fields['radio1'].checked).to.be.true;
+            expect(fields['checkbox'].checked).to.be.true;
+            expect(fields['select'].value).to.equal('1');
+            expect(fields['textarea'].value).to.equal('1');
+          });
+        });
+
+        it('should not initialize fields in unsupported form', () => {
+          return getAmpFormWithInitialization(false).then(response => {
+            const {fields} = response;
+
+            // field value/checked should not change
+            expect(fields['textNoInit'].value).to.equal('0');
+            expect(fields['hiddenAmpReplace'].value).to.equal('0');
+            expect(fields['text'].value).to.equal('0');
+            expect(fields['radio0'].checked).to.be.true;
+            expect(fields['radio1'].checked).to.be.false;
+            expect(fields['checkbox'].checked).to.be.false;
+            expect(fields['select'].value).to.equal('0');
+            expect(fields['textarea'].value).to.equal('0');
+          });
+        });
+      }
+    );
   }
 );

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -131,7 +131,7 @@ To learn about redirecting the user after successfully submitting the form, see 
 
 ##### data-initialize-from-url
 
-Initializes supported form fields from the URL. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields under the form can optionally be initialized from URL query parameter values.
+Initializes form fields from the window URL's search string, where the query parameter name matches the field's name. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields can optionally be initialized.
 
 Individual fields are opted-in if they contain attribute `data-allow-initialization`. On page load, if the URL contains a query parameter with name matching an opted-in field's `name` attribute, the value or checked-state of that field will be updated based on the value of that query parameter. For example, `<input type="search" name="q" data-allow-initialization>` would display "my search" if the AMP page is visited with URL `https://example.com/search?q=my+search`.
 

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -131,14 +131,15 @@ To learn about redirecting the user after successfully submitting the form, see 
 
 ##### data-initialize-from-url
 
-Initializes supported form fields from the URL. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields under the form can optionally be initialized from URL query parameter values. Individual fields are opted-in if they contain attribute `data-allow-initialization`.
+Initializes supported form fields from the URL. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields under the form can optionally be initialized from URL query parameter values.
 
-Example: an AMP page can be used to display search results, where the search input echoes the search term.
+Individual fields are opted-in if they contain attribute `data-allow-initialization`. On page load, if the URL contains a query parameter with name matching an opted-in field's `name` attribute, the value or checked-state of that field will be updated based on the value of that query parameter. For example, `<input type="search" name="q" data-allow-initialization>` would display "my search" if the AMP page is visited with URL `https://example.com/search?q=my+search`.
+
+Sample:
 
 ```html
-<form id="myform"
+<form data-initialize-from-url
     method="get"
-    data-initialize-from-url
     action="https://example.com/search"{% if not format=='email'%}
     target="_top"{% endif %}>
   <label>Search: <input type="search" name="q" data-allow-initialization></label>
@@ -150,7 +151,7 @@ Limitations:
 
 - Supported `<input>` types include `color`, `date`, `datetime-local`, `email`, `hidden`, `month`, `number`, `range`, `search`, `tel`, `text`, `time`, `url`, and `week`.
 - Fields that take advantage of [variable substitutions](#variable-substitutions) (fields with attribute `data-amp-replace`) are not supported.
-- AMP pages delivered from an [AMP cache](https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/) ignore this attribute. Forms with this attribute are valid, but fields will not initialize from URL query parameter values.
+- This feature is not supported on AMP pages delivered by an [AMP cache](https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/). The `data-initialize-from-url` and `data-allow-initialization` attributes will not cause AMP validation failures, but the form fields will not be initialized from the URL.
 
 ##### Other form attributes
 

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -129,6 +129,29 @@ The value for `action-xhr` can be the same or a different endpoint than `action`
 
 To learn about redirecting the user after successfully submitting the form, see the [Redirecting after a submission](#redirecting-after-a-submission) section below.
 
+##### data-initialize-from-url
+
+Initializes supported form fields from the URL. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields under the form can optionally be initialized from URL query parameter values. Individual fields are opted-in if they contain attribute `data-allow-initialization`.
+
+Example: an AMP page can be used to display search results, where the search input echoes the search term.
+
+```html
+<form id="myform"
+    method="get"
+    data-initialize-from-url
+    action="https://example.com/search"{% if not format=='email'%}
+    target="_top"{% endif %}>
+  <label>Search: <input type="search" name="q" data-allow-initialization></label>
+</form>
+<!-- display search results using amp-list -->
+```
+
+Limitations:
+
+- Supported `<input>` types include `color`, `date`, `datetime-local`, `email`, `hidden`, `month`, `number`, `range`, `search`, `tel`, `text`, `time`, `url`, and `week`.
+- Fields that take advantage of [variable substitutions](#variable-substitutions) (fields with attribute `data-amp-replace`) are not supported.
+- AMP pages delivered from an [AMP cache](https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/) ignore this attribute. Forms with this attribute are valid, but fields will not initialize from URL query parameter values.
+
 ##### Other form attributes
 
 All other [form attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) are optional.

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -149,7 +149,7 @@ Sample:
 
 Limitations:
 
-- Supported `<input>` types include `color`, `date`, `datetime-local`, `email`, `hidden`, `month`, `number`, `range`, `search`, `tel`, `text`, `time`, `url`, and `week`.
+- Supported `<input>` types include `checkbox`, `color`, `date`, `datetime-local`, `email`, `hidden`, `month`, `number`, `radio`, `range`, `search`, `tel`, `text`, `time`, `url`, and `week`.
 - Fields that take advantage of [variable substitutions](#variable-substitutions) (fields with attribute `data-amp-replace`) are not supported.
 - This feature is not supported on AMP pages delivered by an [AMP cache](https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/). The `data-initialize-from-url` and `data-allow-initialization` attributes will not cause AMP validation failures, but the form fields will not be initialized from the URL.
 


### PR DESCRIPTION
Introduce amp-form attribute `data-initialize-from-url` and form field
attribute `data-allow-initialization` to selectively populate form
fields from URL query parameter values on page load.

Fixes #24533
Fixes #24876