### PR TITLE
Upgrade DOMPurify to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ampproject/animations": "0.2.0",
     "@ampproject/worker-dom": "0.19.0",
     "document-register-element": "1.5.0",
-    "dompurify": "1.0.11",
+    "dompurify": "2.0.2",
     "moment": "2.24.0",
     "preact": "8.4.2",
     "preact-compat": "3.18.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4927,10 +4927,10 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-dompurify@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-1.0.11.tgz#fe0f4a40d147f7cebbe31a50a1357539cfc1eb4d"
-  integrity sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ==
+dompurify@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.2.tgz#42d709484aad6732db053f7db6ededea37376a8f"
+  integrity sha512-ehPzk0IiRtJQkrKqENyGHy/+jJoAmXi50fEb0bsdxzEytdb2mob5QjyQjMAXBGeBCRE+k0/MDD1caBg5X/JLBA==
 
 domutils@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Upgrade past 2.0.1 for this:

> Fixed a bypass affecting latest Chrome, caused by a newly discovered Chrome mXSS vulnerability

Not sure why renovate-bot didn't generate the PRs for 2.x.x. 

https://github.com/cure53/DOMPurify/releases 