### PR TITLE
🏗 Allow retries for e2e test setup and set retries to 1

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -410,7 +410,8 @@ function describeEnv(factory) {
       this.timeout(TEST_TIMEOUT);
       beforeEach(async function() {
         this.timeout(SETUP_TIMEOUT);
-        await fixture.setup(env, browserName);
+        const retries = 1;
+        await fixture.setup(env, browserName, retries);
 
         // don't install for CI
         if (!isTravisBuild()) {
@@ -479,34 +480,43 @@ class EndToEndFixture {
   /**
    * @param {!Object} env
    * @param {string} browserName
+   * @param {number} retries
    */
-  async setup(env, browserName) {
-    const {testUrl, experiments = [], initialRect, deviceName} = this.spec;
-    const config = getConfig();
-    const controller = await getController(config, browserName, deviceName);
-    const ampDriver = new AmpDriver(controller);
-    env.controller = controller;
-    env.ampDriver = ampDriver;
+  async setup(env, browserName, retries = 0) {
+    try {
+      const {testUrl, experiments = [], initialRect, deviceName} = this.spec;
+      const config = getConfig();
+      const controller = await getController(config, browserName, deviceName);
+      const ampDriver = new AmpDriver(controller);
+      env.controller = controller;
+      env.ampDriver = ampDriver;
 
-    const {environment} = env;
+      const {environment} = env;
 
-    const url = new URL(testUrl);
-    if (experiments.length > 0) {
-      if (environment.includes('inabox')) {
-        // inabox experiments are toggled at server side using <meta> tag
-        url.searchParams.set('exp', experiments.join(','));
+      const url = new URL(testUrl);
+      if (experiments.length > 0) {
+        if (environment.includes('inabox')) {
+          // inabox experiments are toggled at server side using <meta> tag
+          url.searchParams.set('exp', experiments.join(','));
+        } else {
+          // AMP doc experiments are toggled via cookies
+          await toggleExperiments(ampDriver, url.href, experiments);
+        }
+      }
+
+      if (initialRect) {
+        const {width, height} = initialRect;
+        await controller.setWindowRect({width, height});
+      }
+
+      await ampDriver.navigateToEnvironment(environment, url.href);
+    } catch (ex) {
+      if (retries > 0) {
+        await this.setup(env, browserName, --retries);
       } else {
-        // AMP doc experiments are toggled via cookies
-        await toggleExperiments(ampDriver, url.href, experiments);
+        throw ex;
       }
     }
-
-    if (initialRect) {
-      const {width, height} = initialRect;
-      await controller.setWindowRect({width, height});
-    }
-
-    await ampDriver.navigateToEnvironment(environment, url.href);
   }
 
   async teardown(env) {

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -35,6 +35,7 @@ const {PuppeteerController} = require('./puppeteer-controller');
 const SUB = ' ';
 const TEST_TIMEOUT = 40000;
 const SETUP_TIMEOUT = 30000;
+const SETUP_RETRIES = 1;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const supportedBrowsers = new Set(['chrome', 'firefox', 'safari']);
 /**
@@ -410,8 +411,7 @@ function describeEnv(factory) {
       this.timeout(TEST_TIMEOUT);
       beforeEach(async function() {
         this.timeout(SETUP_TIMEOUT);
-        const retries = 1;
-        await fixture.setup(env, browserName, retries);
+        await fixture.setup(env, browserName, SETUP_RETRIES);
 
         // don't install for CI
         if (!isTravisBuild()) {


### PR DESCRIPTION
Sometimes in Travis, chromedriver fails to start up.
```
 1) amp-bind with <amp-video>
       chrome
          AMPHTML ads inabox environment 
           "before each" hook for "should NOT change src when new value uses an invalid protocol":
     WebDriverError: unknown error: Chrome failed to start: exited abnormally
  (chrome not reachable)
  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```
So I added a retry mechanism. Note that this is different than `this.retries()` in mocha, because mocha retries only work for tests themselves, not hooks.