### PR TITLE
📖 Update amp-autocomplete documentation

### DIFF
--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -79,10 +79,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><strong>src (optional)</strong></td>
-    <td><p>The URL of the remote endpoint that returns the JSON that will be filtered and rendered within this <code>amp-autocomplete</code>. This must be a CORS HTTP service and the URL's protocol must be HTTPS. The endpoint must implement the requirements specified in the <a href="https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests?referrer=ampproject.org">CORS Requests in AMP</a> spec. If fetching the data at the src URL fails, the <code>amp-autocomplete</code> triggers a fallback.</p>
-    <p>
-    The src attribute may be omitted if the <code>[src]</code> attribute exists.
-    </p>
+    <td>The URL of the remote endpoint that returns the JSON that will be filtered and rendered within this <code>amp-autocomplete</code>. This must be a CORS HTTP service and the URL's protocol must be HTTPS. The endpoint must implement the requirements specified in the <a href="https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests?referrer=ampproject.org">CORS Requests in AMP</a> spec. If fetching the data at the src URL fails, the <code>amp-autocomplete</code> triggers a fallback. The src attribute may be omitted if the <code>[src]</code> attribute exists.
     </td>
   </tr>
   <tr>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -79,11 +79,11 @@ Example:
   </tr>
   <tr>
     <td width="40%"><strong>src (optional)</strong></td>
-    <td>The URL of the remote endpoint that returns the JSON that will be filtered and rendered within this <code>amp-autocomplete</code>. This must be a CORS HTTP service and the URL's protocol must be HTTPS. The endpoint must implement the requirements specified in the <a href="https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests?referrer=ampproject.org">CORS Requests in AMP</a> spec.
-
+    <td><p>The URL of the remote endpoint that returns the JSON that will be filtered and rendered within this <code>amp-autocomplete</code>. This must be a CORS HTTP service and the URL's protocol must be HTTPS. The endpoint must implement the requirements specified in the <a href="https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests?referrer=ampproject.org">CORS Requests in AMP</a> spec. If fetching the data at the src URL fails, the <code>amp-autocomplete</code> triggers a fallback.</p>
+    <p>
     The src attribute may be omitted if the <code>[src]</code> attribute exists.
-
-    If fetching the data at the src URL fails, the <code><amp-autocomplete></code> triggers a fallback.</td>
+    </p>
+    </td>
   </tr>
   <tr>
     <td width="40%"><strong>filter-expr (optional)</strong></td>


### PR DESCRIPTION
Resolves #24684 

The `<` and `>` tags around `<amp-autocomplete>` in the documentation render the component on its documentation page instead of displays it as the desired text literal. This causes the section to end mid-sentence on the [amp.dev](https://amp.dev/documentation/components/amp-autocomplete/#attributes):
<img width="782" alt="Screen Shot 2019-09-23 at 11 15 17 AM" src="https://user-images.githubusercontent.com/10456171/65445275-d5825c00-ddff-11e9-9e85-b4feca957494.png">
