### PR TITLE
Remove __amp_source_origin from the documentation

### DIFF
--- a/build-system/server/amp-cors.js
+++ b/build-system/server/amp-cors.js
@@ -21,25 +21,14 @@
  * @type {RegExp}
  */
 const ORIGIN_REGEX = new RegExp(
-  '^https?://localhost:8000|^https?://.+.localhost:8000'
-);
-
-/**
- * In practice this would be the publishers origin.
- * Please see AMP CORS docs for more details:
- *    https://goo.gl/F6uCAY
- * @type {RegExp}
- */
-const SOURCE_ORIGIN_REGEX = new RegExp(
-  '^https?://localhost:8000|^https?://.+.localhost:8000'
+  '^https?://localhost:8000|^https?://.+\\.localhost:8000'
 );
 
 function assertCors(
   req,
   res,
   opt_validMethods,
-  opt_exposeHeaders,
-  opt_ignoreMissingSourceOrigin
+  opt_exposeHeaders
 ) {
   // Allow disable CORS check (iframe fixtures have origin 'about:srcdoc').
   if (req.query.cors == '0') {
@@ -49,7 +38,6 @@ function assertCors(
   const validMethods = opt_validMethods || ['GET', 'POST', 'OPTIONS'];
   const invalidMethod = req.method + ' method is not allowed. Use POST.';
   const invalidOrigin = 'Origin header is invalid.';
-  const invalidSourceOrigin = '__amp_source_origin parameter is invalid.';
   const unauthorized = 'Unauthorized Request';
   let origin;
 
@@ -62,23 +50,14 @@ function assertCors(
   if (req.headers.origin) {
     origin = req.headers.origin;
     if (!ORIGIN_REGEX.test(req.headers.origin)) {
-      res.statusCode = 500;
+      res.statusCode = 403;
       res.end(JSON.stringify({message: invalidOrigin}));
       throw invalidOrigin;
-    }
-
-    if (
-      !opt_ignoreMissingSourceOrigin &&
-      !SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)
-    ) {
-      res.statusCode = 500;
-      res.end(JSON.stringify({message: invalidSourceOrigin}));
-      throw invalidSourceOrigin;
     }
   } else if (req.headers['amp-same-origin'] == 'true') {
     origin = getUrlPrefix(req);
   } else {
-    res.statusCode = 401;
+    res.statusCode = 403;
     res.end(JSON.stringify({message: unauthorized}));
     throw unauthorized;
   }

--- a/build-system/server/amp-cors.js
+++ b/build-system/server/amp-cors.js
@@ -24,12 +24,7 @@ const ORIGIN_REGEX = new RegExp(
   '^https?://localhost:8000|^https?://.+\\.localhost:8000'
 );
 
-function assertCors(
-  req,
-  res,
-  opt_validMethods,
-  opt_exposeHeaders
-) {
+function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
   // Allow disable CORS check (iframe fixtures have origin 'about:srcdoc').
   if (req.query.cors == '0') {
     return;

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -778,7 +778,7 @@ app.get('/iframe/*', (req, res) => {
 });
 
 app.get('/a4a_template/*', (req, res) => {
-  cors.assertCors(req, res, ['GET'], undefined, true);
+  cors.assertCors(req, res, ['GET']);
   const match = /^\/a4a_template\/([a-z-]+)\/(\d+)$/.exec(req.path);
   if (!match) {
     res.status(404);
@@ -870,7 +870,7 @@ app.get(
         }
         file = file.replace(/__TEST_SERVER_PORT__/g, TEST_SERVER_PORT);
 
-        if (inabox && req.headers.origin && req.query.__amp_source_origin) {
+        if (inabox && req.headers.origin) {
           // Allow CORS requests for A4A.
           cors.enableCors(req, res, req.headers.origin);
         } else {


### PR DESCRIPTION
I cannot figure out what purpose the `__amp_source_origin` serves now. I believe I left it behind in the last PR (#22648) due to oversight.

Let me know if you'd like to add a "__amp_source_origin is deprecated" section.

Closes #22136.
Followup on #22648.
