### PR TITLE
Add request assertion to amp-ad-exit e2e test

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {RequestBankE2E} from './request-bank';
 
 // import to install chromedriver and geckodriver
 require('chromedriver'); // eslint-disable-line no-unused-vars
@@ -44,6 +45,7 @@ const supportedBrowsers = new Set(['chrome', 'firefox', 'safari']);
  * {@link https://github.com/GoogleChrome/puppeteer/blob/master/experimental/puppeteer-firefox/README.md}
  */
 const PUPPETEER_BROWSERS = new Set(['chrome']);
+const REQUESTBANK_URL_PREFIX = 'http://localhost:8000';
 
 /**
  * @typedef {{
@@ -488,8 +490,10 @@ class EndToEndFixture {
       const config = getConfig();
       const controller = await getController(config, browserName, deviceName);
       const ampDriver = new AmpDriver(controller);
+      const requestBank = new RequestBankE2E(REQUESTBANK_URL_PREFIX, 'e2e');
       env.controller = controller;
       env.ampDriver = ampDriver;
+      env.requestBank = requestBank;
 
       const {environment} = env;
 
@@ -520,11 +524,12 @@ class EndToEndFixture {
   }
 
   async teardown(env) {
-    const {controller} = env;
+    const {controller, requestBank} = env;
     if (controller) {
       await controller.switchToParent();
       await controller.dispose();
     }
+    await requestBank.tearDown();
   }
 }
 

--- a/build-system/tasks/e2e/request-bank.js
+++ b/build-system/tasks/e2e/request-bank.js
@@ -18,9 +18,10 @@ import requestPromise from 'request-promise';
 
 /**
  * A server side temporary request storage which is useful for testing
- * browser sent HTTP requests.
+ * browser sent HTTP requests. This class is expected to be ran in NodeJS.
+ * See testing/test-helper.js for the implementation for running within Karma.
  */
-export class RequestBank {
+export class RequestBankE2E {
   /**
    * @param {string} homeUrl The URL of the dev server.
    * @param {?string} bankId The unique identifier of a specific instance to
@@ -28,7 +29,7 @@ export class RequestBank {
    */
   constructor(homeUrl, bankId) {
     /** @private {string} */
-    this.homeUrl_ = homeUrl;
+    this.homeUrl_ = homeUrl || 'http://localhost:8000';
 
     /** @private {string} */
     this.bankId_ = bankId || (Date.now() + Math.random()).toString(32);
@@ -60,11 +61,18 @@ export class RequestBank {
     return this.fetch_(url).then(body => JSON.parse(body));
   }
 
+  /**
+   * @return {Promise<JsonObject>}
+   */
   tearDown() {
     const url = `${this.homeUrl_}/amp4test/request-bank/${this.bankId_}/teardown/`;
     return this.fetch_(url);
   }
 
+  /**
+   * @param {string} url
+   * @return {Promise<JsonObject>}
+   */
   fetch_(url) {
     return requestPromise.get({
       url,

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {RequestBank} from '../../../../testing/request-bank';
 
 describes.endtoend(
   'amp-ad-exit',
@@ -23,9 +24,15 @@ describes.endtoend(
   },
   env => {
     let controller;
+    let requestBank;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
+      requestBank = new RequestBank('http://localhost:8000', 'ampadexit');
+    });
+
+    afterEach(() => {
+      return requestBank.tearDown();
     });
 
     // Setting the time explicitly to avoid test flakiness.
@@ -91,6 +98,7 @@ describes.endtoend(
       await expect(await controller.getCurrentUrl()).to.match(
         /^http:\/\/localhost:8000\/\?product2&r=0\.\d+$/
       );
+      await requestBank.withdraw('tracking');
     });
   }
 );

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RequestBankE2E} from '../../../../build-system/tasks/e2e/request-bank';
 
 describes.endtoend(
   'amp-ad-exit',
@@ -28,11 +27,7 @@ describes.endtoend(
 
     beforeEach(() => {
       controller = env.controller;
-      requestBank = new RequestBankE2E('http://localhost:8000', 'ampadexit');
-    });
-
-    afterEach(() => {
-      return requestBank.tearDown();
+      requestBank = env.requestBank;
     });
 
     // Setting the time explicitly to avoid test flakiness.

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RequestBank} from '../../../../testing/request-bank';
+import {RequestBankE2E} from '../../../../build-system/tasks/e2e/request-bank';
 
 describes.endtoend(
   'amp-ad-exit',
@@ -28,7 +28,7 @@ describes.endtoend(
 
     beforeEach(() => {
       controller = env.controller;
-      requestBank = new RequestBank('http://localhost:8000', 'ampadexit');
+      requestBank = new RequestBankE2E('http://localhost:8000', 'ampadexit');
     });
 
     afterEach(() => {

--- a/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
+++ b/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
@@ -47,7 +47,7 @@
         "target2": {
           "finalUrl": "http://localhost:8000/?product2&r=RANDOM",
           "trackingUrls": [
-            "http://localhost:8000/?tracking-url&clicked=_elem"
+            "http://localhost:8000/amp4test/request-bank/ampadexit/deposit/tracking"
           ],
           "vars": {
             "_elem": {"defaultValue": "headline"}

--- a/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
+++ b/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html
@@ -47,7 +47,7 @@
         "target2": {
           "finalUrl": "http://localhost:8000/?product2&r=RANDOM",
           "trackingUrls": [
-            "http://localhost:8000/amp4test/request-bank/ampadexit/deposit/tracking"
+            "http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking"
           ],
           "vars": {
             "_elem": {"defaultValue": "headline"}

--- a/testing/request-bank.js
+++ b/testing/request-bank.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import requestPromise from 'request-promise';
+
+/**
+ * A server side temporary request storage which is useful for testing
+ * browser sent HTTP requests.
+ */
+export class RequestBank {
+  /**
+   * @param {string} homeUrl The URL of the dev server.
+   * @param {?string} bankId The unique identifier of a specific instance to
+   * prevent interference between tests.
+   */
+  constructor(homeUrl, bankId) {
+    /** @private {string} */
+    this.homeUrl_ = homeUrl;
+
+    /** @private {string} */
+    this.bankId_ = bankId || (Date.now() + Math.random()).toString(32);
+  }
+
+  /**
+   * Returns the URL for depositing a request.
+   *
+   * @param {number|string|undefined} requestId
+   * @return {string}
+   */
+  getUrl(requestId) {
+    return `${this.homeUrl_}/amp4test/request-bank/${this.bankId_}/deposit/${requestId}/`;
+  }
+
+  /**
+   * Returns a Promise that resolves when the request of given ID is deposited.
+   * The returned promise resolves to an JsonObject contains the request info:
+   * {
+   *   url: string
+   *   headers: JsonObject
+   *   body: string
+   * }
+   * @param {number|string|undefined} requestId
+   * @return {Promise<JsonObject>}
+   */
+  withdraw(requestId) {
+    const url = `${this.homeUrl_}/amp4test/request-bank/${this.bankId_}/withdraw/${requestId}/`;
+    return this.fetch_(url).then(body => JSON.parse(body));
+  }
+
+  tearDown() {
+    const url = `${this.homeUrl_}/amp4test/request-bank/${this.bankId_}/teardown/`;
+    return this.fetch_(url);
+  }
+
+  fetch_(url) {
+    return requestPromise.get({
+      url,
+      timeout: 15000,
+    });
+  }
+}


### PR DESCRIPTION
Port the existing RequestBank to be usable on nodejs because of lack of xhr support in the current implementation. Am looking at using this for unit/integration in a separate PR.