### PR TITLE
Do not trigger slideChange on the initial render.

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -680,13 +680,18 @@ export class Carousel {
   }
 
   /**
-   * Updates the resting index as well as firing an event.
+   * Updates the resting index as well as firing an event, if it actually
+   * changed.
    * @param {number} restingIndex The new resting index.
    * @param {ActionSource=} actionSource The actionSource associated with this
    *    change.
    * @private
    */
   updateRestingIndex_(restingIndex, actionSource) {
+    if (this.restingIndex_ == restingIndex) {
+      return;
+    }
+
     this.restingIndex_ = restingIndex;
     this.element_.dispatchEvent(
       createCustomEvent(

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -106,6 +106,13 @@ class AmpCarousel extends AMP.BaseElement {
 
     /** @private {?ChildLayoutManager} */
     this.childLayoutManager_ = null;
+
+    /**
+     * Whether or not to skip a slideChange when the index changes. Used to
+     * avoid triggering a slideChange on the initial render.
+     * @private {boolean}
+     */
+    this.skipNextSlideChange_ = true;
   }
 
   /** @override */
@@ -618,6 +625,16 @@ class AmpCarousel extends AMP.BaseElement {
     const detail = getDetail(event);
     const index = detail['index'];
     const actionSource = detail['actionSource'];
+
+    this.hadTouch_ = this.hadTouch_ || actionSource == ActionSource.TOUCH;
+    this.updateCurrentIndex_(index);
+    this.updateUi_();
+
+    if (this.skipNextSlideChange_) {
+      this.skipNextSlideChange_ = false;
+      return;
+    }
+
     const data = dict({'index': index});
     const name = 'slideChange';
     const isHighTrust = this.isHighTrustActionSource_(actionSource);
@@ -626,9 +643,6 @@ class AmpCarousel extends AMP.BaseElement {
     const action = createCustomEvent(this.win, `slidescroll.${name}`, data);
     this.action_.trigger(this.element, name, action, trust);
     this.element.dispatchCustomEvent(name, data);
-    this.hadTouch_ = this.hadTouch_ || actionSource == ActionSource.TOUCH;
-    this.updateCurrentIndex_(index);
-    this.updateUi_();
   }
 }
 

--- a/extensions/amp-carousel/0.2/test/test-type-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-type-slides.js
@@ -201,6 +201,27 @@ describes.realWin(
       });
     });
 
+    describe('slideChange event', () => {
+      it('should not dispatch on initial render', async () => {
+        const eventSpy = sandbox.spy();
+        container.addEventListener('slideChange', eventSpy);
+        await getCarousel({loop: false});
+
+        expect(eventSpy).to.have.not.been.called;
+      });
+
+      it('should dispatch when changing slides', async () => {
+        const eventSpy = sandbox.spy();
+        container.addEventListener('slideChange', eventSpy);
+        const carousel = await getCarousel({loop: false});
+
+        carousel.implementation_.interactionNext();
+        await afterIndexUpdate(carousel);
+
+        expect(eventSpy).to.have.been.calledOnce;
+      });
+    });
+
     describe('goToSlide action', () => {
       it('should propagate high trust', async () => {
         const carousel = await getCarousel({loop: false});


### PR DESCRIPTION
- Change the carousel implementation to stop notifying when the internal index did not actually change. Note that the initial change is from `NaN` to an actual index, so that will still notify.
- Change the carousel 0.2 code to only fire the slideChange event/action after the first one (from the initial render).

Closes #24706
Fixes #24701