### PR TITLE
Deduplicates amp-story-page ids.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -527,7 +527,10 @@ export class AmpStory extends AMP.BaseElement {
    */
   initializePageIds_() {
     const pageEls = this.element.querySelectorAll('amp-story-page');
-    const pageIds = Array.prototype.map.call(pageEls, el => el.id || 'default');
+    const pageIds = Array.prototype.map.call(
+      pageEls,
+      el => el.id || 'default-page'
+    );
     for (let i = 0; i < pageIds.length; i++) {
       let counter = 0;
       let index;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -415,6 +415,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeStyles_();
     this.initializeListeners_();
     this.initializeListenersForDev_();
+    this.initializePageIds_();
 
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
@@ -521,6 +522,25 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
+   * Initializes page ids by deduplicating them.
+   * @private
+   */
+  initializePageIds_() {
+    const pageEls = this.element.querySelectorAll('amp-story-page');
+    const pageIds = Array.prototype.map.call(pageEls, el => el.id || 'default');
+    for (let i = 0; i < pageIds.length; i++) {
+      let counter = 0;
+      let index;
+      while ((index = pageIds.indexOf(pageIds[i], i + 1)) !== -1) {
+        user().error(TAG, `Duplicate amp-story-page ID ${pageIds[index]}`);
+        const newId = `${pageIds[index]}__${++counter}`;
+        pageEls[index].id = newId;
+        pageIds[index] = newId;
+      }
+    }
+  }
+
+  /**
    * @param {!Element} styleEl
    * @private
    */
@@ -607,6 +627,9 @@ export class AmpStory extends AMP.BaseElement {
   buildSystemLayer_(initialPageId) {
     this.updateAudioIcon_();
 
+    // TODO(gmajoulet): cache the page ids in the store from the
+    // initializePageIds_ method to remove this block. Requires refactoring in
+    // test-amp-story to avoid console.errors.
     let pageIds;
     if (this.pages_.length) {
       pageIds = this.pages_.map(page => page.element.id);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -102,7 +102,7 @@ import {
 import {createPseudoLocale} from '../../../src/localized-strings';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev, devAssert, user} from '../../../src/log';
-import {dict} from '../../../src/utils/object';
+import {dict, map} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {findIndex} from '../../../src/utils/array';
 import {getConsentPolicyState} from '../../../src/consent';
@@ -531,15 +531,16 @@ export class AmpStory extends AMP.BaseElement {
       pageEls,
       el => el.id || 'default-page'
     );
+    const idsMap = map();
     for (let i = 0; i < pageIds.length; i++) {
-      let counter = 0;
-      let index;
-      while ((index = pageIds.indexOf(pageIds[i], i + 1)) !== -1) {
-        user().error(TAG, `Duplicate amp-story-page ID ${pageIds[index]}`);
-        const newId = `${pageIds[index]}__${++counter}`;
-        pageEls[index].id = newId;
-        pageIds[index] = newId;
+      if (idsMap[pageIds[i]] === undefined) {
+        idsMap[pageIds[i]] = 0;
+        continue;
       }
+      user().error(TAG, `Duplicate amp-story-page ID ${pageIds[i]}`);
+      const newId = `${pageIds[i]}__${++idsMap[pageIds[i]]}`;
+      pageEls[i].id = newId;
+      pageIds[i] = newId;
     }
   }
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -540,6 +540,54 @@ describes.realWin(
         });
     });
 
+    it('should deduplicate amp-story-page ids', async () => {
+      createPages(story.element, 6, [
+        'cover',
+        'page-1',
+        'cover',
+        'page-1',
+        'page-1',
+        'page-2',
+      ]);
+
+      allowConsoleError(() => story.buildCallback());
+      await story.layoutCallback();
+
+      const pages = story.element.querySelectorAll('amp-story-page');
+      const pageIds = Array.prototype.map.call(pages, page => page.id);
+      expect(pageIds).to.deep.equal([
+        'cover',
+        'page-1',
+        'cover__1',
+        'page-1__1',
+        'page-1__2',
+        'page-2',
+      ]);
+    });
+
+    it('should deduplicate amp-story-page ids and cache them', async () => {
+      createPages(story.element, 6, [
+        'cover',
+        'page-1',
+        'cover',
+        'page-1',
+        'page-1',
+        'page-2',
+      ]);
+
+      allowConsoleError(() => story.buildCallback());
+      await story.layoutCallback();
+
+      expect(story.storeService_.get(StateProperty.PAGE_IDS)).to.deep.equal([
+        'cover',
+        'page-1',
+        'cover__1',
+        'page-1__1',
+        'page-1__2',
+        'page-2',
+      ]);
+    });
+
     describe('amp-story consent', () => {
       it('should pause the story if there is a consent', () => {
         sandbox


### PR DESCRIPTION
Deduplicates `amp-story-page` ids and triggers a user error, so the story doesn't fail on load.
Having duplicated IDs completely fails navigation or the progress bar.

```
<amp-story-page id="cover">
<amp-story-page id="cover">
```

becomes

```
<amp-story-page id="cover">
<amp-story-page id="cover__1">
```