### PR TITLE
Pass experiment channel via the AmpRuntimeTypeParam

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -282,6 +282,14 @@ describe('Google A4A utils', () => {
         })
       ).to.equal('1');
     });
+    it('should specify that this is experimentA', () => {
+      expect(
+        getAmpRuntimeTypeParameter({
+          AMP_CONFIG: {type: 'experimentA'},
+          location: {origin: 'https://www-example-com.cdn.ampproject.org'},
+        })
+      ).to.equal('10');
+    });
     it('should not have `art` parameter when AMP_CONFIG is undefined', () => {
       expect(
         getAmpRuntimeTypeParameter({

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -849,6 +849,8 @@ export function getBinaryTypeNumericalCode(type) {
       'experimentA': '10',
       'experimentB': '11',
       'experimentC': '12',
+      'nomod': '42',
+      'mod': '43',
     }[type] || null
   );
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -846,6 +846,9 @@ export function getBinaryTypeNumericalCode(type) {
       'control': '1',
       'canary': '2',
       'rc': '3',
+      'experimentA': '10',
+      'experimentB': '11',
+      'experimentC': '12',
     }[type] || null
   );
 }


### PR DESCRIPTION
I named the param same as the experiment prefix. 

One thing I found is that the param is only used for A4A, not related to inabox. So I left the `experimentX-control` alone. 

We should also document all the new AMP_CONFIG.type somewhere. 

to @erwinmombay @jeffkaufman 