### PR TITLE
Fix reloadExtension for amp-viewer-integration

### DIFF
--- a/src/element-service.js
+++ b/src/element-service.js
@@ -196,21 +196,29 @@ function assertService(service, id, extension) {
 }
 
 /**
- * Get list of all the extension JS files
+ * Get list of all the extension JS files.
  * @param {HTMLHeadElement|Element|ShadowRoot} head
  * @return {!Array<string>}
  */
 export function extensionScriptsInNode(head) {
-  // ampdoc.getHeadNode() can return null
+  // ampdoc.getHeadNode() can return null.
   if (!head) {
     return [];
   }
-  const scripts = [];
-  const list = head.querySelectorAll('script[custom-element]');
+  const scripts = {};
+  // Note: Some extensions don't have [custom-element] or [custom-template]
+  // e.g. amp-viewer-integration.
+  const list = head.querySelectorAll(
+    'script[custom-element],script[custom-template]'
+  );
   for (let i = 0; i < list.length; i++) {
-    scripts.push(list[i].getAttribute('custom-element'));
+    const script = list[i];
+    const name =
+      script.getAttribute('custom-element') ||
+      script.getAttribute('custom-template');
+    scripts[name] = true;
   }
-  return scripts;
+  return Object.keys(scripts);
 }
 
 /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -727,6 +727,8 @@ export class MultidocManager {
               const src = n.getAttribute('src');
               const isRuntime =
                 src.indexOf('/amp.js') != -1 || src.indexOf('/v0.js') != -1;
+              // Note: Some extensions don't have [custom-element] or
+              // [custom-template] e.g. amp-viewer-integration.
               const customElement = n.getAttribute('custom-element');
               const customTemplate = n.getAttribute('custom-template');
               const versionRe = /-(\d+.\d+)(.max)?\.js$/;

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -269,17 +269,13 @@ export class Extensions {
    * @private
    */
   getExtensionScript_(extensionId, includeInserted = true) {
-    const attr = this.attributeForExtension_(extensionId);
     // Always ignore <script> elements that have a mismatched RTV.
     const modifier =
       ':not([i-amphtml-loaded-new-version])' +
       (includeInserted ? '' : ':not([i-amphtml-inserted])');
-    const {head} = this.win.document;
-    const selectors = [
-      `script[${attr}="${extensionId}"]` + modifier,
-      `script[src*="/${extensionId}-"]` + modifier,
-    ];
-    return head./*OK*/ querySelector(selectors.join(','));
+    return this.win.document.head./*OK*/ querySelector(
+      `script[src*="/${extensionId}-"]` + modifier
+    );
   }
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -285,7 +285,9 @@ export class Extensions {
       return {el, attr};
     }
     // Some extensions don't have an attribute e.g. amp-viewer-integration.
-    el = head./*OK*/ querySelector(`script[src*="/${extensionId}-"]` + modifier);
+    el = head./*OK*/ querySelector(
+      `script[src*="/${extensionId}-"]` + modifier
+    );
     if (el) {
       return {el};
     }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -278,7 +278,7 @@ export class Extensions {
     const modifier = includeInserted ? '' : ':not([i-amphtml-inserted])';
     const {head} = this.win.document;
     const el = head./*OK*/ querySelector(
-      `[${attr}="${extensionId}"]` + modifier
+      `script[${attr}="${extensionId}"]` + modifier
     );
     if (el) {
       const urlParts = parseExtensionUrl(el.src);
@@ -286,10 +286,10 @@ export class Extensions {
     }
     // Some extensions don't have an attribute e.g. amp-viewer-integration.
     const elements = head./*OK*/ querySelectorAll(
-      ':not([custom-template]):not([custom-element])' + modifier
+      'script:not([custom-template]):not([custom-element])' + modifier
     );
     for (let i = 0; i < elements.length; i++) {
-      const el = elements[i];
+      const el = elements.item(i);
       const urlParts = parseExtensionUrl(el.src);
       if (urlParts.extensionId === extensionId) {
         return {el, version: urlParts.extensionVersion};

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -285,7 +285,7 @@ export class Extensions {
       return {el, attr};
     }
     // Some extensions don't have an attribute e.g. amp-viewer-integration.
-    el = head./*OK*/ querySelector(`script[src*="${extensionId}-"]` + modifier);
+    el = head./*OK*/ querySelector(`script[src*="/${extensionId}-"]` + modifier);
     if (el) {
       return {el};
     }

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -177,7 +177,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
         head: {
           nodeType: /* ELEMENT */ 1,
           querySelectorAll: selector => {
-            if (selector == 'script[custom-element]') {
+            if (selector == 'script[custom-element],script[custom-template]') {
               return elements;
             }
             return [];

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -637,7 +637,6 @@ describes.sandboxed('Extensions', {}, () => {
         extensions.reloadExtension('amp-list');
       }).to.throw('Cannot find script for extension: amp-list');
 
-      expect(list.hasAttribute('custom-element')).to.be.true;
       expect(list.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
       expect(extensions.preloadExtension).to.not.be.called;
     });
@@ -650,7 +649,6 @@ describes.sandboxed('Extensions', {}, () => {
 
       extensions.reloadExtension('amp-list');
 
-      expect(list.hasAttribute('custom-element')).to.be.false;
       expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
         'amp-list'
       );
@@ -668,7 +666,6 @@ describes.sandboxed('Extensions', {}, () => {
 
       extensions.reloadExtension('amp-mustache');
 
-      expect(mustache.hasAttribute('custom-template')).to.be.false;
       expect(mustache.getAttribute('i-amphtml-loaded-new-version')).to.equal(
         'amp-mustache'
       );
@@ -790,6 +787,7 @@ describes.sandboxed('Extensions', {}, () => {
       it('should not insert when script exists in head', () => {
         const ampTestScript = doc.createElement('script');
         ampTestScript.setAttribute('custom-element', 'amp-test');
+        ampTestScript.setAttribute('i-amphtml-loaded-new-version', 'amp-test');
         expect(
           doc.head.querySelectorAll('[custom-element="amp-test"]')
         ).to.have.length(0);
@@ -802,6 +800,13 @@ describes.sandboxed('Extensions', {}, () => {
         extensions.preloadExtension('amp-test');
         expect(
           doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(2);
+        expect(
+          doc.head.querySelectorAll(
+            '[custom-element="amp-test"]' +
+              ':not([i-amphtml-loaded-new-version])' +
+              '[i-amphtml-inserted]'
+          )
         ).to.have.length(1);
         expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
         expect(win.customElements.elements['amp-test']).to.not.exist;

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -25,7 +25,7 @@ import {installTimerService} from '../../src/service/timer-impl';
 class AmpTest extends BaseElement {}
 class AmpTestSub extends BaseElement {}
 
-describes.sandboxed('Extensions', {}, () => {
+describe('Extensions', () => {
   describes.fakeWin('registerExtension', {}, env => {
     let win;
     let extensions;
@@ -602,6 +602,99 @@ describes.sandboxed('Extensions', {}, () => {
       return extensions.loadElementClass('amp-ext').then(elementClass => {
         expect(elementClass).to.equal(ctor);
       });
+    });
+  });
+
+  describes.fakeWin('reloadExtension', {}, env => {
+    let win;
+    let extensions;
+
+    beforeEach(() => {
+      win = env.win;
+      sandbox = env.sandbox;
+
+      sandbox.stub(Services, 'ampdocServiceFor').returns(null);
+      extensions = new Extensions(win);
+      sandbox.stub(extensions, 'preloadExtension');
+    });
+
+    it('should devAssert if script cannot be found', () => {
+      expect(() => {
+        extensions.reloadExtension('amp-list');
+      }).to.throw('Cannot find script for extension: amp-list');
+
+      expect(extensions.preloadExtension).to.not.be.called;
+    });
+
+    it('should ignore inserted scripts', () => {
+      const list = document.createElement('script');
+      list.setAttribute('custom-element', 'amp-list');
+      list.setAttribute('src', 'https://cdn.ampproject.org/v0/amp-list-0.1.js');
+      list.setAttribute('i-amphtml-inserted', '');
+      win.document.head.appendChild(list);
+
+      expect(() => {
+        extensions.reloadExtension('amp-list');
+      }).to.throw('Cannot find script for extension: amp-list');
+
+      expect(list.hasAttribute('custom-element')).to.be.true;
+      expect(list.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
+      expect(extensions.preloadExtension).to.not.be.called;
+    });
+
+    it('should support [custom-element] scripts', () => {
+      const list = document.createElement('script');
+      list.setAttribute('custom-element', 'amp-list');
+      list.setAttribute('src', 'https://cdn.ampproject.org/v0/amp-list-0.1.js');
+      win.document.head.appendChild(list);
+
+      extensions.reloadExtension('amp-list');
+
+      expect(list.hasAttribute('custom-element')).to.be.false;
+      expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+        'amp-list'
+      );
+      expect(extensions.preloadExtension).to.be.calledWith('amp-list', '0.1');
+    });
+
+    it('should support [custom-template] scripts', () => {
+      const mustache = document.createElement('script');
+      mustache.setAttribute('custom-template', 'amp-mustache');
+      mustache.setAttribute(
+        'src',
+        'https://cdn.ampproject.org/v0/amp-mustache-0.2.js'
+      );
+      win.document.head.appendChild(mustache);
+
+      extensions.reloadExtension('amp-mustache');
+
+      expect(mustache.hasAttribute('custom-template')).to.be.false;
+      expect(mustache.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+        'amp-mustache'
+      );
+      expect(extensions.preloadExtension).to.be.calledWith(
+        'amp-mustache',
+        '0.2'
+      );
+    });
+
+    it('should support no-attribute scripts', () => {
+      const viewer = document.createElement('script');
+      viewer.setAttribute(
+        'src',
+        'https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js'
+      );
+      win.document.head.appendChild(viewer);
+
+      extensions.reloadExtension('amp-viewer-integration');
+
+      expect(viewer.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+        'amp-viewer-integration'
+      );
+      expect(extensions.preloadExtension).to.be.calledWith(
+        'amp-viewer-integration',
+        '0.1'
+      );
     });
   });
 

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -25,7 +25,7 @@ import {installTimerService} from '../../src/service/timer-impl';
 class AmpTest extends BaseElement {}
 class AmpTestSub extends BaseElement {}
 
-describe('Extensions', () => {
+describes.sandboxed('Extensions', {}, () => {
   describes.fakeWin('registerExtension', {}, env => {
     let win;
     let extensions;

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -540,7 +540,9 @@ describes.fakeWin(
       toggleExperiment(win, 'version-locking', true);
       function addExisting(index) {
         const s = document.createElement('script');
-        s.setAttribute('custom-element', 'amp-test-element' + index);
+        const name = 'amp-test-element' + index;
+        s.setAttribute('custom-element', name);
+        s.setAttribute('src', `/${name}-0.1.js`);
         win.document.head.appendChild(s);
         return s;
       }
@@ -621,9 +623,6 @@ describes.fakeWin(
       yield waitNext(promise);
       expect(progress).to.equal('134');
       expect(queueExtensions).to.have.length(0);
-      expect(s1.getAttribute('custom-element')).to.be.null;
-      expect(s2.getAttribute('custom-element')).to.be.null;
-      expect(s3.getAttribute('custom-element')).to.be.null;
       expect(s1.getAttribute('i-amphtml-loaded-new-version')).to.equal(
         'amp-test-element1'
       );


### PR DESCRIPTION
Fixes runtime error on pages that use `amp-viewer-integration` with a mismatched RTV vs. v0.js.

```
extensions-impl.js:265 Uncaught (in promise) TypeError: Cannot read property 'removeAttribute' of null
    at gn.f.reloadExtension (extensions-impl.js:265)
    at sn (runtime.js:880)
    at pn (runtime.js:207)
    at un (runtime.js:324)
    at wj.kd (amp.js:118)
    at vj (chunk.js:192)
    at rj.Se (chunk.js:420)
    at chunk.js:471
```

`b/141559641`