### PR TITLE
🐛Update Ooyala player version from Sandbox to Prod

### DIFF
--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -109,7 +109,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     const playerVersion = el.getAttribute('data-playerversion') || '';
     if (playerVersion.toLowerCase() == 'v4') {
       src =
-        'https://player.ooyala.com/static/v4/production/' +
+        'https://player.ooyala.com/static/v4/production/latest/' +
         'skin-plugin/amp_iframe.html?pcode=' +
         encodeURIComponent(this.pCode_);
       const configUrl = el.getAttribute('data-config');

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -109,7 +109,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     const playerVersion = el.getAttribute('data-playerversion') || '';
     if (playerVersion.toLowerCase() == 'v4') {
       src =
-        'https://player.ooyala.com/static/v4/sandbox/amp_iframe/' +
+        'https://player.ooyala.com/static/v4/production/' +
         'skin-plugin/amp_iframe.html?pcode=' +
         encodeURIComponent(this.pCode_);
       const configUrl = el.getAttribute('data-config');

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -95,8 +95,8 @@ describes.realWin(
         const playerIframe = player.querySelector('iframe');
         expect(playerIframe).to.not.be.null;
         expect(playerIframe.src).to.equal(
-          'https://player.ooyala.com/static/v4/sandbox/' +
-            'amp_iframe/skin-plugin/amp_iframe.html' +
+          'https://player.ooyala.com/static/v4/production/latest/' +
+            'skin-plugin/amp_iframe.html' +
             '?pcode=5zb2wxOlZcNCe_HVT3a6cawW298X' +
             '&ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ' +
             '&pbid=6440813504804d76ba35c8c787a4b33c'

--- a/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.html
+++ b/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.html
@@ -32,9 +32,9 @@
     <amp-ooyala-player
       height=400
       width=400
-      data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-      data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-      data-playerid="26e2e3c1049c4e70ae08a242638b5c40"
+      data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+      data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+      data-playerid="a19658a7198f4cffb745bf2062551f9b"
       data-playerversion="v4">
     </amp-ooyala-player>
 
@@ -42,33 +42,33 @@
     <amp-ooyala-player
       height=400
       width=400
-      data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-      data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-      data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+      data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+      data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+      data-playerid="a19658a7198f4cffb745bf2062551f9b">
     </amp-ooyala-player>
 
     <!-- invalid, needs data-pcode -->
     <amp-ooyala-player
       height=400
       width=400
-      data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-      data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+      data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+      data-playerid="a19658a7198f4cffb745bf2062551f9b">
     </amp-ooyala-player>
 
     <!-- invalid, needs data-embedcode -->
     <amp-ooyala-player
       height=400
       width=400
-      data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-      data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+      data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+      data-playerid="a19658a7198f4cffb745bf2062551f9b">
     </amp-ooyala-player>
 
     <!-- invalid, needs data-playerid -->
     <amp-ooyala-player
       height=400
       width=400
-      data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-      data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X">
+      data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+      data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz">
     </amp-ooyala-player>
   </body>
 </html>

--- a/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.out
+++ b/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.out
@@ -33,9 +33,9 @@ FAIL
 |      <amp-ooyala-player
 |        height=400
 |        width=400
-|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40"
+|        data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+|        data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+|        data-playerid="a19658a7198f4cffb745bf2062551f9b"
 |        data-playerversion="v4">
 |      </amp-ooyala-player>
 |
@@ -43,9 +43,9 @@ FAIL
 |      <amp-ooyala-player
 |        height=400
 |        width=400
-|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|        data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+|        data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+|        data-playerid="a19658a7198f4cffb745bf2062551f9b">
 |      </amp-ooyala-player>
 |
 |      <!-- invalid, needs data-pcode -->
@@ -54,8 +54,8 @@ FAIL
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:51:4 The mandatory attribute 'data-pcode' is missing in tag 'amp-ooyala-player'. (see https://amp.dev/documentation/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
 |        height=400
 |        width=400
-|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|        data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+|        data-playerid="a19658a7198f4cffb745bf2062551f9b">
 |      </amp-ooyala-player>
 |
 |      <!-- invalid, needs data-embedcode -->
@@ -64,8 +64,8 @@ amp-ooyala-player/0.1/test/validator-amp-ooyala.html:51:4 The mandatory attribut
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:59:4 The mandatory attribute 'data-embedcode' is missing in tag 'amp-ooyala-player'. (see https://amp.dev/documentation/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
 |        height=400
 |        width=400
-|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
-|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|        data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz"
+|        data-playerid="a19658a7198f4cffb745bf2062551f9b">
 |      </amp-ooyala-player>
 |
 |      <!-- invalid, needs data-playerid -->
@@ -74,8 +74,8 @@ amp-ooyala-player/0.1/test/validator-amp-ooyala.html:59:4 The mandatory attribut
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:67:4 The mandatory attribute 'data-playerid' is missing in tag 'amp-ooyala-player'. (see https://amp.dev/documentation/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
 |        height=400
 |        width=400
-|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
-|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X">
+|        data-embedcode="93eGs5MDE6dQ-pp527TpHmaFz4zuU9aX"
+|        data-pcode="p0cW46sbRY1PxXueRVL2a_4BfdFz">
 |      </amp-ooyala-player>
 |    </body>
 |  </html>


### PR DESCRIPTION
The Ooyala player iframe version currently used is at https://player.ooyala.com/static/v4/sandbox/amp_iframe/skin-plugin/amp_iframe.html which is using the player version 4.10.6

Our current production version is at v4.32.8. This update will solve some customer issues with analytics and provide them with a more recent and stable player.
