### PR TITLE
🐛 Update Ooyala player version from Sandbox to Prod Latest

### DIFF
--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -95,8 +95,8 @@ describes.realWin(
         const playerIframe = player.querySelector('iframe');
         expect(playerIframe).to.not.be.null;
         expect(playerIframe.src).to.equal(
-          'https://player.ooyala.com/static/v4/sandbox/' +
-            'amp_iframe/skin-plugin/amp_iframe.html' +
+          'https://player.ooyala.com/static/v4/production/latest/' +
+            'skin-plugin/amp_iframe.html' +
             '?pcode=5zb2wxOlZcNCe_HVT3a6cawW298X' +
             '&ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ' +
             '&pbid=6440813504804d76ba35c8c787a4b33c'


### PR DESCRIPTION
The Ooyala player iframe version currently used is at https://player.ooyala.com/static/v4/sandbox/amp_iframe/skin-plugin/amp_iframe.html which is using the player version 4.10.6

Our current production latest version is at v4.35.5. This update will solve some customer issues with analytics and provide them with a more recent and stable player


