### PR TITLE
Allow amp-experiment to prerender and bypass maximum build limit

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -707,7 +707,7 @@ const forbiddenTerms = {
       'src/inabox/amp-inabox.js',
     ],
   },
-  'isRenderBlocking': {
+  'isBuildRenderBlocking': {
     message:
       'This is a protected API. Please only override it the element is ' +
       'render blocking',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -707,6 +707,19 @@ const forbiddenTerms = {
       'src/inabox/amp-inabox.js',
     ],
   },
+  'isRenderBlocking': {
+    message:
+      'This is a protected API. Please only override it the element is ' +
+      'render blocking',
+    whitelist: [
+      'src/service/resources-impl.js',
+      'src/service/resource.js',
+      'src/custom-element.js',
+      'src/base-element.js',
+      'extensions/amp-experiment/0.1/amp-experiment.js',
+      'extensions/amp-experiment/1.0/amp-experiment.js',
+    ],
+  },
   '^describe[\\.|\\(|$]': {
     message:
       'Top-level "describe" blocks in test files have been deprecated. ' +

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -30,6 +30,23 @@ export class AmpExperiment extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    /*
+     * Prerender is allowed because the client_id is only used to calculate
+     * the variant bucket.
+     * In the case where a client_id is first generated
+     * during prerender, the base cid will be stored in the AMP viewer domain.
+     */
+    return true;
+  }
+
+  /** @override */
+  isRenderBlocking() {
+    // variantService is render blocking
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     return getServicePromiseForDoc(this.getAmpDoc(), 'variant').then(
       variantsService => {

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -41,7 +41,7 @@ export class AmpExperiment extends AMP.BaseElement {
   }
 
   /** @override */
-  isRenderBlocking() {
+  isBuildRenderBlocking() {
     // variantService is render blocking
     return true;
   }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -48,7 +48,7 @@ export class AmpExperiment extends AMP.BaseElement {
   }
 
   /** @override */
-  isRenderBlocking() {
+  isBuildRenderBlocking() {
     // variantService is render blocking
     return true;
   }

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -37,6 +37,23 @@ export class AmpExperiment extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    /*
+     * Prerender is allowed because the client_id is only used to calculate
+     * the variant bucket.
+     * In the case where a client_id is first generated
+     * during prerender, the base cid will be stored in the AMP viewer domain.
+     */
+    return true;
+  }
+
+  /** @override */
+  isRenderBlocking() {
+    // variantService is render blocking
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     const buildCallbackPromises = [
       getServicePromiseForDoc(this.getAmpDoc(), 'variant'),

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -406,7 +406,7 @@ export class BaseElement {
    * built _and_ laid out will be prioritized.
    * @return {boolean}
    */
-  isRenderBlocking() {
+  isBuildRenderBlocking() {
     return false;
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -399,6 +399,18 @@ export class BaseElement {
   }
 
   /**
+   * Subclasses can override this method to indicate that it is has
+   * render-blocking service.
+   *
+   * The return value of this function is used to determine if the element
+   * built _and_ laid out will be prioritized.
+   * @return {boolean}
+   */
+  isRenderBlocking() {
+    return false;
+  }
+
+  /**
    * Subclasses can override this method to create a dynamic placeholder
    * element and return it to be appended to the element. This will only
    * be called if the element doesn't already have a placeholder.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1018,8 +1018,8 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      * @final
      */
-    isRenderBlocking() {
-      return this.implementation_.isRenderBlocking();
+    isBuildRenderBlocking() {
+      return this.implementation_.isBuildRenderBlocking();
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1014,6 +1014,15 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Whether the element has render-blocking service.
+     * @return {boolean}
+     * @final
+     */
+    isRenderBlocking() {
+      return this.implementation_.isRenderBlocking();
+    }
+
+    /**
      * Creates a placeholder for the element.
      * @return {?Element}
      * @final

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -656,8 +656,8 @@ export class Resource {
    * Whether this element has render-blocking service.
    * @return {boolean}
    */
-  isRenderBlocking() {
-    return this.element.isRenderBlocking();
+  isBuildRenderBlocking() {
+    return this.element.isBuildRenderBlocking();
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -653,6 +653,14 @@ export class Resource {
   }
 
   /**
+   * Whether this element has render-blocking service.
+   * @return {boolean}
+   */
+  isRenderBlocking() {
+    return this.element.isRenderBlocking();
+  }
+
+  /**
    * @param {number|boolean} viewport derived from renderOutsideViewport.
    * @return {!Promise} resolves when underlying element is built and within the
    *    viewport range given.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -478,7 +478,7 @@ export class ResourcesImpl {
    * @private
    */
   buildResourceUnsafe_(resource, schedulePass, force = false) {
-    if (!this.isUnderBuildQuota_() && !force) {
+    if (!this.isUnderBuildQuota_() && !force && !resource.isRenderBlocking()) {
       return null;
     }
     const promise = resource.build();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -478,7 +478,11 @@ export class ResourcesImpl {
    * @private
    */
   buildResourceUnsafe_(resource, schedulePass, force = false) {
-    if (!this.isUnderBuildQuota_() && !force && !resource.isRenderBlocking()) {
+    if (
+      !this.isUnderBuildQuota_() &&
+      !force &&
+      !resource.isBuildRenderBlocking()
+    ) {
       return null;
     }
     const promise = resource.build();

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1110,7 +1110,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.element.isBuilt = () => false;
     resource1.element.idleRenderOutsideViewport = () => true;
     resource1.prerenderAllowed = () => true;
-    resource1.isRenderBlocking = () => false;
+    resource1.isBuildRenderBlocking = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
     resource1.build = sandbox.spy();
 
@@ -1127,7 +1127,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.element.isBuilt = () => false;
     resource1.element.idleRenderOutsideViewport = () => true;
     resource1.prerenderAllowed = () => true;
-    resource1.isRenderBlocking = () => true;
+    resource1.isBuildRenderBlocking = () => true;
     resource1.state_ = ResourceState.NOT_BUILT;
     resource1.build = sandbox.spy();
 

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1110,11 +1110,29 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.element.isBuilt = () => false;
     resource1.element.idleRenderOutsideViewport = () => true;
     resource1.prerenderAllowed = () => true;
+    resource1.isRenderBlocking = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
     resource1.build = sandbox.spy();
 
     resources.buildOrScheduleBuildForResource_(resource1);
     expect(resource1.build).to.not.be.called;
+  });
+
+  it('should build render blocking resource even if quota is reached', () => {
+    sandbox.stub(resources.ampdoc, 'hasBeenVisible').callsFake(() => false);
+    sandbox.stub(resources, 'schedule_');
+    resources.documentReady_ = true;
+    resources.buildAttemptsCount_ = 21; // quota is 20
+
+    resource1.element.isBuilt = () => false;
+    resource1.element.idleRenderOutsideViewport = () => true;
+    resource1.prerenderAllowed = () => true;
+    resource1.isRenderBlocking = () => true;
+    resource1.state_ = ResourceState.NOT_BUILT;
+    resource1.build = sandbox.spy();
+
+    resources.buildOrScheduleBuildForResource_(resource1);
+    expect(resource1.build).to.be.called;
   });
 
   it('should layout resource if outside viewport but idle', () => {


### PR DESCRIPTION
As we agreed offline, this PR 
1. Allow `<amp-experiment>` component to prerender
2. Introduce restricted `isBuildRenderBlocking()` method to bypass the 20 maximum build count

