### PR TITLE
🏗 Remove alanorozo as explicit owner (present in team)

### DIFF
--- a/extensions/amp-auto-lightbox/OWNERS.yaml
+++ b/extensions/amp-auto-lightbox/OWNERS.yaml
@@ -1,5 +1,4 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- alanorozco
 - ampproject/wg-ui-and-a11y


### PR DESCRIPTION
This PR is part of a general owners cleanup effort.

PR #24743 added `ampproject/wg-ui-and-a11y` as an owner of `extensions/amp-auto-lightbox`, which previously just had `alanorozco`. Since he's a member of that team already, the rule is unnecessary, so this PR cleans that up.