### PR TITLE
🏗 Remove nainar as explicit owner (present in team)

### DIFF
--- a/extensions/amp-twitter/0.1/OWNERS.yaml
+++ b/extensions/amp-twitter/0.1/OWNERS.yaml
@@ -1,4 +1,0 @@
-# For an explanation of the OWNERS.yaml rules and syntax, see:
-# https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
-
-- nainar


### PR DESCRIPTION
This PR is part of a general owners cleanup effort.

PR #24743 added `ampproject/wg-ui-and-a11y` as an owner of `extensions/amp-twitter`. Since `nainar` is a member of that team, the rule in `extensions/amp-twitter/0.1/OWNERS.yaml`, which just has `nainar`, would unnecessarily assign `nainar` higher relevance. This PR removes the unneeded OWNERS.yaml file.