### PR TITLE
🐛 Use __proto__ instead of setPrototypeOf

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -770,7 +770,7 @@ function polyfill(win) {
       el = createElement.call(document, def.name);
     }
 
-    // Finally, if the node was already constructed, we need to reset it's
+    // Finally, if the node was already constructed, we need to reset its
     // prototype to the custom element prototype. And if it wasn't already
     // constructed, we created a new node via native createElement, and we need
     // to reset its prototype. Basically always reset the prototype.

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -773,8 +773,8 @@ function polyfill(win) {
     // Finally, if the node was already constructed, we need to reset it's
     // prototype to the custom element prototype. And if it wasn't already
     // constructed, we created a new node via native createElement, and we need
-    // to reset it's prototype. Basically always reset the prototype.
-    Object.setPrototypeOf(el, constructor.prototype);
+    // to reset its prototype. Basically always reset the prototype.
+    el.__proto__ = constructor.prototype;
     return el;
   }
   subClass(Object, HTMLElement, HTMLElementPolyfill);
@@ -830,6 +830,7 @@ function subClass(Object, superClass, subClass) {
       value: subClass,
     },
   });
+  subClass.__proto__ = superClass;
 }
 
 /**


### PR DESCRIPTION
We're getting an error from `setPrototypeOf` somehow not being a method on `Object`.