### PR TITLE
Add handshake logic and opaque origin support to amp-viewer-messaging

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -279,6 +279,8 @@ AmpViewerMessage.prototype.data;
 AmpViewerMessage.prototype.rsvp;
 /** @public {string|undefined}  */
 AmpViewerMessage.prototype.error;
+/** @public {string|undefined}  */
+AmpViewerMessage.prototype.messagingToken;
 
 // AMP-Analytics Cross-domain iframes
 let IframeTransportEvent;

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -257,6 +257,7 @@ requirement: {
   whitelist: 'ads/mads.js'
   whitelist: 'ads/google/imaVideo.js'
   whitelist: 'ads/zen.js'
+  whitelist: 'extensions/amp-viewer-integration/0.1/messaging/messaging.js' # published as standalone library
   whitelist: 'src/json.js' # Where parseJson itself is implemented.
 }
 
@@ -277,6 +278,7 @@ requirement: {
   whitelist: 'extensions/amp-access/0.1/amp-access-iframe.js' # False-positive
   whitelist: 'extensions/amp-access/0.1/iframe-api/messenger.js' # 3p-intent
   whitelist: 'src/service/history-impl.js' # False-positive
+  whitelist: 'extensions/amp-viewer-integration/0.1/messaging/messaging.js' # published as standalone library
 }
 
 requirement: {

--- a/extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js
+++ b/extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  APP,
-  MessageType,
-  Messaging,
-  WindowPortEmulator,
-} from '../messaging/messaging';
-import {listen} from '../../../../src/event-helper';
-
-const CHANNEL_OPEN_MSG = 'channelOpen';
+import {Messaging} from '../messaging/messaging';
 
 /**
  * @fileoverview This is an example of how the viewer host can be implemented
@@ -59,87 +51,28 @@ export class AmpViewerHost {
     /** @const {string} */
     this.logsId = opt_logsId;
 
-    if (this.isWebview_ || opt_isHandshakePoll) {
-      /** @private {number} */
-      this.pollingIntervalId_ = setInterval(
-        this.initiateHandshake_.bind(this, this.intervalCtr),
-        1000
-      ); //poll every second
-    } else {
-      this.waitForHandshake_(frameOrigin);
-    }
-  }
-
-  /**
-   * @private
-   */
-  initiateHandshake_() {
-    this.log('initiateHandshake_');
-    if (this.ampIframe_) {
-      const channel = new MessageChannel();
-      let message = {
-        app: APP,
-        name: 'handshake-poll',
-      };
-      message = this.isWebview_ ? JSON.stringify(message) : message;
-      this.ampIframe_.contentWindow./*OK*/ postMessage(message, '*', [
-        channel.port2,
-      ]);
-
-      channel.port1.onmessage = function(e) {
-        const data = this.isWebview_ ? JSON.parse(e.data) : e.data;
-        if (this.isChannelOpen_(data)) {
-          this.win.clearInterval(this.pollingIntervalId_); //stop polling
-          this.log('messaging established!');
-          this.completeHandshake_(channel.port1, data.requestid);
-        } else {
-          this.messageHandler_(data.name, data.data, data.rsvp);
-        }
-      }.bind(this);
-    }
-  }
-
-  /**
-   * @param {string} targetOrigin
-   * @private
-   */
-  waitForHandshake_(targetOrigin) {
-    this.log('awaitHandshake_');
-    let unlisten = null;
     const target = this.ampIframe_.contentWindow;
-
-    const listener = function(event) {
-      if (
-        event.origin == targetOrigin &&
-        this.isChannelOpen_(event.data) &&
-        (!event.source || event.source == target)
-      ) {
-        this.log(' messaging established with ', targetOrigin);
-        unlisten();
-        const port = new WindowPortEmulator(this.win, targetOrigin, target);
-        this.completeHandshake_(port, event.data.requestid);
-      }
-    }.bind(this);
-    unlisten = listen(this.win, 'message', listener);
+    if (this.isWebview_ || opt_isHandshakePoll) {
+      Messaging.initiateHandshakeWithDocument(target).then(messaging => {
+        this.messaging_ = messaging;
+        this.completeHandshake_();
+      });
+    } else {
+      Messaging.waitForHandshakeFromDocument(
+        this.win,
+        target,
+        frameOrigin
+      ).then(messaging => {
+        this.messaging_ = messaging;
+        this.completeHandshake_();
+      });
+    }
   }
 
   /**
-   * @param {!MessagePort|!WindowPortEmulator} port
-   * @param {string} requestId
    * @private
    */
-  completeHandshake_(port, requestId) {
-    let message = {
-      app: APP,
-      requestid: requestId,
-      type: MessageType.RESPONSE,
-    };
-
-    message = this.isWebview_ ? JSON.stringify(message) : message;
-    this.log('posting Message', message);
-    port./*OK*/ postMessage(message);
-
-    this.messaging_ = new Messaging(this.win, port);
+  completeHandshake_() {
     this.messaging_.setDefaultHandler(this.messageHandler_);
 
     this.sendRequest(
@@ -150,15 +83,6 @@ export class AmpViewerHost {
       },
       true
     );
-  }
-
-  /**
-   * @param {*} eventData
-   * @return {boolean}
-   * @private
-   */
-  isChannelOpen_(eventData) {
-    return eventData.app == APP && eventData.name == CHANNEL_OPEN_MSG;
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
@@ -1,0 +1,58 @@
+export const TAG = 'amp-viewer-messaging';
+
+export const enum MessageType {
+  REQUEST = 'q',
+  RESPONSE = 's',
+}
+
+export interface Message {
+  app: string;
+  type: string;
+  requestid: number;
+  name: string;
+  data: any;
+  rsvp?: boolean;
+  error?: string;
+  messagingToken?: string;
+}
+
+export type RequestHandler = () => void;
+
+export function parseMessage(message: any): Message;
+
+export class WindowPortEmulator {
+  constructor(win: Window, origin: string, target: Window);
+  readonly win: Window;
+  addEventListener(eventType: string, handler: (...params: any[]) => any): void;
+  postMessage(data: any): void;
+  start(): void;
+}
+
+export class Messaging {
+  static initiateHandshakeWithDocument(
+    target: Window,
+    opt_token?: string,
+    opt_interval?: number
+  ): Promise<Messaging>;
+  static waitForHandshakeFromDocument(
+    source: Window,
+    target: Window,
+    origin: string,
+    opt_token?: string
+  ): Promise<Messaging>;
+  constructor(
+    win: Window,
+    port: MessagePort | WindowPortEmulator,
+    opt_isWebview?: boolean,
+    opt_token?: string
+  );
+  readonly win: Window;
+  registerHandler(messageName: string, requestHandler: RequestHandler): void;
+  unregisterHandler(messageName: string): void;
+  setDefaultHandler(requestHandler: RequestHandler): void;
+  sendRequest(
+    messageName: string,
+    messageData: any,
+    awaitResponse: boolean
+  ): Promise<any> | undefined;
+}

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
@@ -1,11 +1,4 @@
-export const TAG = 'amp-viewer-messaging';
-
-export const enum MessageType {
-  REQUEST = 'q',
-  RESPONSE = 's',
-}
-
-export interface Message {
+export interface AmpViewerMessage {
   app: string;
   type: string;
   requestid: number;
@@ -16,14 +9,13 @@ export interface Message {
   messagingToken?: string;
 }
 
-export type RequestHandler = () => void;
+export function parseMessage(message: any): AmpViewerMessage | null;
 
-export function parseMessage(message: any): Message;
+export type RequestHandler = () => void;
 
 export class WindowPortEmulator {
   constructor(win: Window, origin: string, target: Window);
-  readonly win: Window;
-  addEventListener(eventType: string, handler: (...params: any[]) => any): void;
+  addEventListener(eventType: string, handler: EventListener): void;
   postMessage(data: any): void;
   start(): void;
 }
@@ -46,7 +38,6 @@ export class Messaging {
     opt_isWebview?: boolean,
     opt_token?: string
   );
-  readonly win: Window;
   registerHandler(messageName: string, requestHandler: RequestHandler): void;
   unregisterHandler(messageName: string): void;
   setDefaultHandler(requestHandler: RequestHandler): void;

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
@@ -4,13 +4,6 @@ export type RequestHandler = (
   rsvp: boolean
 ) => Promise<any> | undefined;
 
-export class WindowPortEmulator {
-  constructor(win: Window, origin: string, target: Window);
-  addEventListener(eventType: string, handler: EventListener): void;
-  postMessage(data: any): void;
-  start(): void;
-}
-
 export class Messaging {
   static initiateHandshakeWithDocument(
     target: Window,
@@ -24,7 +17,7 @@ export class Messaging {
   ): Promise<Messaging>;
   constructor(
     win: Window,
-    port: MessagePort | WindowPortEmulator,
+    port: MessagePort,
     opt_isWebview?: boolean,
     opt_token?: string
   );

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
@@ -1,17 +1,8 @@
-export interface AmpViewerMessage {
-  app: string;
-  type: string;
-  requestid: number;
-  name: string;
-  data: any;
-  rsvp?: boolean;
-  error?: string;
-  messagingToken?: string;
-}
-
-export function parseMessage(message: any): AmpViewerMessage | null;
-
-export type RequestHandler = () => void;
+export type RequestHandler = (
+  name: string,
+  data: any,
+  rsvp: boolean
+) => Promise<any> | undefined;
 
 export class WindowPortEmulator {
   constructor(win: Window, origin: string, target: Window);

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts
@@ -23,8 +23,7 @@ export class WindowPortEmulator {
 export class Messaging {
   static initiateHandshakeWithDocument(
     target: Window,
-    opt_token?: string,
-    opt_interval?: number
+    opt_token?: string
   ): Promise<Messaging>;
   static waitForHandshakeFromDocument(
     source: Window,

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -17,40 +17,35 @@
 const TAG = 'amp-viewer-messaging';
 const CHANNEL_OPEN_MSG = 'channelOpen';
 const HANDSHAKE_POLL_MSG = 'handshake-poll';
-export const APP = '__AMPHTML__';
+const APP = '__AMPHTML__';
 
 /**
  * @enum {string}
  */
-export const MessageType = {
+const MessageType = {
   REQUEST: 'q',
   RESPONSE: 's',
 };
 
 /**
- * @typedef {!AmpViewerMessage}
- */
-export let Message;
-
-/**
  * @typedef {function(string, *, boolean):(!Promise<*>|undefined)}
  */
-export let RequestHandler;
+let RequestHandler; // eslint-disable-line no-unused-vars
 
 /**
  * @param {*} message
- * @return {?Message}
+ * @return {?AmpViewerMessage}
  */
 export function parseMessage(message) {
   if (typeof message != 'string') {
-    return /** @type {Message} */ (message);
+    return /** @type {AmpViewerMessage} */ (message);
   }
   if (message.charAt(0) != '{') {
     return null;
   }
 
   try {
-    return /** @type {?Message} */ /** @type {?} */ (JSON.parse(
+    return /** @type {?AmpViewerMessage} */ /** @type {?} */ (JSON.parse(
       /** @type {string} */ (message)
     ));
   } catch (e) {
@@ -70,20 +65,20 @@ export class WindowPortEmulator {
    * @param {!Window} target
    */
   constructor(win, origin, target) {
-    /** @const {!Window} */
-    this.win = win;
-    /** @private {string} */
+    /** @const @private {!Window} */
+    this.win_ = win;
+    /** @const @private {string} */
     this.origin_ = origin;
-    /** @private @const {!Window} */
+    /** @const @private {!Window} */
     this.target_ = target;
   }
 
   /**
    * @param {string} eventType
-   * @param {function(!Event):undefined} handler
+   * @param {function(!Event):*} handler
    */
   addEventListener(eventType, handler) {
-    this.win.addEventListener('message', event => {
+    this.win_.addEventListener('message', event => {
       if (event.origin == this.origin_ && event.source == this.target_) {
         handler(event);
       }
@@ -205,8 +200,8 @@ export class Messaging {
    * @param {boolean=} opt_verifyToken
    */
   constructor(win, port, opt_isWebview, opt_token, opt_verifyToken) {
-    /** @const {?Window} */
-    this.win = win;
+    /** @const @private {?Window} */
+    this.win_ = win;
     /** @const @private {!MessagePort|!WindowPortEmulator} */
     this.port_ = port;
     /** @const @private */
@@ -373,7 +368,7 @@ export class Messaging {
   sendResponseError_(requestId, messageName, reason) {
     const errString = this.errorToString_(reason);
     this.logError_(
-      TAG + ': sendResponseError_, Message name: ' + messageName,
+      TAG + ': sendResponseError_, message name: ' + messageName,
       errString
     );
     this.sendMessage_(
@@ -389,7 +384,7 @@ export class Messaging {
   }
 
   /**
-   * @param {Message} message
+   * @param {!AmpViewerMessage} message
    * @private
    */
   sendMessage_(message) {
@@ -408,7 +403,7 @@ export class Messaging {
    * I'm handling an incoming request from Bob. I'll either respond normally
    * (ex: "got it Bob!") or with an error (ex: "I didn't get a word of what
    * you said!").
-   * @param {Message} message
+   * @param {!AmpViewerMessage} message
    * @private
    */
   handleRequest_(message) {
@@ -449,7 +444,7 @@ export class Messaging {
   /**
    * I sent out a request to Bob. He responded. And now I'm handling that
    * response.
-   * @param {Message} message
+   * @param {!AmpViewerMessage} message
    * @private
    */
   handleResponse_(message) {
@@ -474,13 +469,13 @@ export class Messaging {
    * @private
    */
   logError_(state, opt_data) {
-    if (!this.win) {
+    if (!this.win_) {
       return;
     }
     let stateStr = 'amp-messaging-error-logger: ' + state;
     const dataStr = ' data: ' + this.errorToString_(opt_data);
     stateStr += dataStr;
-    this.win['viewerState'] = stateStr;
+    this.win_['viewerState'] = stateStr;
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -41,10 +41,10 @@ export let RequestHandler;
  * @return {?Message}
  */
 export function parseMessage(message) {
-  if (typeof message != 'string') {
+  if (typeof message !== 'string') {
     return /** @type {Message} */ (message);
   }
-  if (message.charAt(0) != '{') {
+  if (message.charAt(0) !== '{') {
     return null;
   }
 
@@ -84,9 +84,9 @@ export class WindowPortEmulator {
   addEventListener(eventType, handler) {
     this.win.addEventListener('message', e => {
       if (
-        e.origin == this.origin_ &&
-        e.source == this.target_ &&
-        e.data['app'] == APP
+        e.origin === this.origin_ &&
+        e.source === this.target_ &&
+        e.data['app'] === APP
       ) {
         handler(e);
       }
@@ -212,9 +212,9 @@ export class Messaging {
     if (!message) {
       return;
     }
-    if (message.type == MessageType.REQUEST) {
+    if (message.type === MessageType.REQUEST) {
       this.handleRequest_(message);
-    } else if (message.type == MessageType.RESPONSE) {
+    } else if (message.type === MessageType.RESPONSE) {
       this.handleResponse_(message);
     }
   }

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -41,10 +41,10 @@ export let RequestHandler;
  * @return {?Message}
  */
 export function parseMessage(message) {
-  if (typeof message !== 'string') {
+  if (typeof message != 'string') {
     return /** @type {Message} */ (message);
   }
-  if (message.charAt(0) !== '{') {
+  if (message.charAt(0) != '{') {
     return null;
   }
 
@@ -84,8 +84,8 @@ export class WindowPortEmulator {
   addEventListener(eventType, handler) {
     this.win.addEventListener('message', e => {
       if (
-        e.origin === this.origin_ &&
-        e.source === this.target_ &&
+        e.origin == this.origin_ &&
+        e.source == this.target_ &&
         e.data['app'] === APP
       ) {
         handler(e);
@@ -405,8 +405,8 @@ export function initMessaging(source, iframe, origin) {
     const listener = e => {
       const data = e.data;
       if (
-        e.origin === origin &&
-        e.source === target &&
+        e.origin == origin &&
+        e.source == target &&
         data['app'] === APP &&
         data['name'] === CHANNEL_OPEN_MSG
       ) {

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -145,12 +145,9 @@ export class Messaging {
           if (data['app'] === APP && data['name'] === CHANNEL_OPEN_MSG) {
             clearInterval(interval);
             port.removeEventListener('message', listener);
-            port./*OK*/ postMessage({
-              app: APP,
-              requestid: data['requestid'],
-              type: MessageType.RESPONSE,
-            });
-            resolve(new Messaging(source, port));
+            const messaging = new Messaging(source, port);
+            messaging.sendResponse_(data['requestid'], CHANNEL_OPEN_MSG, null);
+            resolve(messaging);
           }
         };
         port.addEventListener('message', listener);
@@ -179,14 +176,9 @@ export class Messaging {
         ) {
           source.removeEventListener('message', listener);
           const port = new WindowPortEmulator(source, origin, target);
-          port./*OK*/ postMessage(
-            /** @type {JsonObject} */ ({
-              app: APP,
-              requestid: data['requestid'],
-              type: MessageType.RESPONSE,
-            })
-          );
-          resolve(new Messaging(source, port));
+          const messaging = new Messaging(source, port);
+          messaging.sendResponse_(data['requestid'], CHANNEL_OPEN_MSG, null);
+          resolve(messaging);
         }
       };
       source.addEventListener('message', listener);

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -112,7 +112,7 @@ export class Messaging {
   /**
    * Performs a handshake and initializes messaging.
    *
-   * Requires the `handshakepoll` viewer capability.
+   * Requires the `handshakepoll` viewer capability and the `origin` viewer parameter to be specified.
    * @param {!Window} target - window containing AMP document to perform handshake with
    * @param {?string=} opt_token - message token to verify on incoming messages (must be provided as viewer parameter)
    * @return {!Promise<!Messaging>}

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -130,9 +130,9 @@ export class Messaging {
     opt_token,
     opt_interval
   ) {
-    opt_interval = opt_interval || 1000;
+    const interval = opt_interval || 1000;
     return new Promise(resolve => {
-      const interval = setInterval(() => {
+      const intervalRef = setInterval(() => {
         const channel = new MessageChannel();
         const pollMessage = /** @type {JsonObject} */ ({
           app: APP,
@@ -142,9 +142,9 @@ export class Messaging {
 
         const port = channel.port1;
         const listener = e => {
-          const data = e.data;
+          const data = {e};
           if (data['app'] === APP && data['name'] === CHANNEL_OPEN_MSG) {
-            clearInterval(interval);
+            clearInterval(intervalRef);
             port.removeEventListener('message', listener);
             const messaging = new Messaging(null, port, false, opt_token, true);
             messaging.sendResponse_(data['requestid'], CHANNEL_OPEN_MSG, null);
@@ -153,7 +153,7 @@ export class Messaging {
         };
         port.addEventListener('message', listener);
         port.start();
-      }, opt_interval);
+      }, interval);
     });
   }
 
@@ -161,7 +161,7 @@ export class Messaging {
    * Waits for handshake from iframe and initializes messaging.
    * @param {!Window} source
    * @param {!Window} target
-   * @param {!string} origin
+   * @param {string} origin
    * @param {?string=} opt_token
    * @return {!Promise<!Messaging>}
    */
@@ -384,7 +384,7 @@ export class Messaging {
   sendMessage_(message) {
     const /** Object<string, *> */ finalMessage = Object.assign(message, {});
     if (this.token_ && !this.verifyToken_) {
-      finalMessage['messagingToken'] = this.token_;
+      finalMessage.messagingToken = this.token_;
     }
     this.port_./*OK*/ postMessage(
       this.isWebview_

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -45,7 +45,7 @@ export function parseMessage(message) {
   }
 
   try {
-    return /** @type {?AmpViewerMessage} */ /** @type {?} */ (JSON.parse(
+    return /** @type {?AmpViewerMessage} */ (JSON.parse(
       /** @type {string} */ (message)
     ));
   } catch (e) {

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -137,16 +137,12 @@ export class Messaging {
 
         const port = channel.port1;
         const listener = e => {
-          const data = e.data;
-          if (
-            data['app'] === APP &&
-            data['name'] === CHANNEL_OPEN_MSG
-          ) {
+          if (e.data['app'] === APP && e.data['name'] === CHANNEL_OPEN_MSG) {
             clearInterval(interval);
             port.removeEventListener('message', listener);
             port.postMessage({
               app: APP,
-              requestid: data['requestid'],
+              requestid: e.data['requestid'],
               type: MessageType.RESPONSE,
             });
             resolve(new Messaging(source, port));
@@ -169,18 +165,17 @@ export class Messaging {
     const target = iframe.contentWindow;
     return new Promise(resolve => {
       const listener = e => {
-        const data = e.data;
         if (
           e.origin == origin &&
           (!e.source || e.source == target) &&
-          data['app'] === APP &&
-          data['name'] === CHANNEL_OPEN_MSG
+          e.data['app'] === APP &&
+          e.data['name'] === CHANNEL_OPEN_MSG
         ) {
           source.removeEventListener('message', listener);
           const port = new WindowPortEmulator(source, origin, target);
           port.postMessage({
             app: APP,
-            requestid: data['requestid'],
+            requestid: e.data['requestid'],
             type: MessageType.RESPONSE,
           });
           resolve(new Messaging(source, port));

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -133,14 +133,14 @@ export class Messaging {
           app: APP,
           name: HANDSHAKE_POLL_MSG,
         };
-        target.postMessage(message, '*', [channel.port2]);
+        target./*OK*/ postMessage(message, '*', [channel.port2]);
 
         const port = channel.port1;
         const listener = e => {
           if (e.data['app'] === APP && e.data['name'] === CHANNEL_OPEN_MSG) {
             clearInterval(interval);
             port.removeEventListener('message', listener);
-            port.postMessage({
+            port./*OK*/ postMessage({
               app: APP,
               requestid: e.data['requestid'],
               type: MessageType.RESPONSE,
@@ -173,7 +173,7 @@ export class Messaging {
         ) {
           source.removeEventListener('message', listener);
           const port = new WindowPortEmulator(source, origin, target);
-          port.postMessage({
+          port./*OK*/ postMessage({
             app: APP,
             requestid: e.data['requestid'],
             type: MessageType.RESPONSE,

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import {getData} from '../../../../src/event-helper';
-import {parseJson} from '../../../../src/json';
-
 const TAG = 'amp-viewer-messaging';
 const CHANNEL_OPEN_MSG = 'channelOpen';
 export const APP = '__AMPHTML__';
@@ -52,7 +49,7 @@ export function parseMessage(message) {
   }
 
   try {
-    return /** @type {?Message} */ /** @type {?} */ (parseJson(
+    return /** @type {?Message} */ /** @type {?} */ (JSON.parse(
       /** @type {string} */ (message)
     ));
   } catch (e) {
@@ -89,7 +86,7 @@ export class WindowPortEmulator {
       if (
         e.origin == this.origin_ &&
         e.source == this.target_ &&
-        getData(e)['app'] == APP
+        e.data['app'] == APP
       ) {
         handler(e);
       }
@@ -211,7 +208,7 @@ export class Messaging {
    * @private
    */
   handleMessage_(event) {
-    const message = parseMessage(getData(event));
+    const message = parseMessage(event.data);
     if (!message) {
       return;
     }
@@ -406,7 +403,7 @@ export function initMessaging(source, iframe, origin) {
   const target = iframe.contentWindow;
   return new Promise(resolve => {
     const listener = e => {
-      const data = getData(e);
+      const data = e.data;
       if (
         e.origin === origin &&
         e.source === target &&

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -89,7 +89,9 @@ export class WindowPortEmulator {
    * @param {JsonObject} data
    */
   postMessage(data) {
+    // Opaque (null) origin can only receive messages sent to "*"
     const targetOrigin = this.origin_ === 'null' ? '*' : this.origin_;
+
     this.target_./*OK*/ postMessage(data, targetOrigin);
   }
 
@@ -109,13 +111,13 @@ export class WindowPortEmulator {
 export class Messaging {
   /**
    * Performs a handshake and initializes messaging.
+   *
+   * Requires the `handshakepoll` viewer capability.
    * @param {!Window} target - window containing AMP document to perform handshake with
    * @param {?string=} opt_token - message token to verify on incoming messages (must be provided as viewer parameter)
-   * @param {?number=} opt_interval - how often to attempt handshake (in ms)
    * @return {!Promise<!Messaging>}
    */
-  static initiateHandshakeWithDocument(target, opt_token, opt_interval) {
-    const interval = opt_interval || 1000;
+  static initiateHandshakeWithDocument(target, opt_token) {
     return new Promise(resolve => {
       const intervalRef = setInterval(() => {
         const channel = new MessageChannel();
@@ -147,14 +149,14 @@ export class Messaging {
         };
         port.addEventListener('message', listener);
         port.start();
-      }, interval);
+      }, 1000);
     });
   }
 
   /**
    * Waits for handshake from iframe and initializes messaging.
    *
-   * Requires the `handshakepoll` viewer capability.
+   * Requires the `origin` viewer parameter to be specified.
    * @param {!Window} source - the source window containing the viewer
    * @param {!Window} target - window containing AMP document to perform handshake with (usually contentWindow of iframe)
    * @param {string} origin - origin of target window (use "null" if opaque)

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -6,9 +6,7 @@
   "license": "Apache-2.0",
   "main": "messaging.js",
   "types": "messaging.d.ts",
-  "keywords": [
-    "amp"
-  ],
+  "keywords": ["amp"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ampproject/amp-toolbox.git"

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -1,11 +1,17 @@
 {
-  "name": "amp-viewer-messaging",
-  "version": "1.0.2",
+  "name": "@ampproject/viewer-messaging",
+  "version": "1.1.0",
   "description": "Messaging between an AMP Doc and a Viewer",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
+  "main": "messaging.js",
+  "types": "messaging.d.ts",
+  "keywords": [
+    "amp"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ampproject/amphtml/tree/master/extensions/amp-viewer-integration/0.1/messaging/"
-  }
+    "url": "git+https://github.com/ampproject/amp-toolbox.git"
+  },
+  "homepage": "https://github.com/ampproject/amphtml/tree/master/extensions/amp-viewer-integration/0.1/messaging"
 }

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -9,7 +9,7 @@
   "keywords": ["amp"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ampproject/amp-toolbox.git",
+    "url": "https://github.com/ampproject/amphtml.git",
     "directory": "extensions/amp-viewer-integration/0.1/messaging"
   },
   "homepage": "https://github.com/ampproject/amphtml/tree/master/extensions/amp-viewer-integration/0.1/messaging"

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -9,7 +9,8 @@
   "keywords": ["amp"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ampproject/amp-toolbox.git"
+    "url": "https://github.com/ampproject/amp-toolbox.git",
+    "directory": "extensions/amp-viewer-integration/0.1/messaging"
   },
   "homepage": "https://github.com/ampproject/amphtml/tree/master/extensions/amp-viewer-integration/0.1/messaging"
 }

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -456,7 +456,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
 
           expect(logErrorSpy).to.have.been.calledOnce;
           const state =
-            'amp-viewer-messaging: sendResponseError_, Message name: name';
+            'amp-viewer-messaging: sendResponseError_, message name: name';
           expect(logErrorSpy).to.have.been.calledWith(state, errString);
         });
       });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -20,110 +20,115 @@ import {getWinOrigin, serializeQueryString} from '../../../../../src/url';
 describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
 
-  describe.configure().run('Handshake', () => {
-    let viewerIframe;
-    let iframeOrigin;
+  describe
+    .configure()
+    .ifChrome()
+    .run('Handshake', () => {
+      let viewerIframe;
+      let iframeOrigin;
 
-    beforeEach(() => {
-      const loc = window.location;
-      viewerIframe = document.createElement('iframe');
-      iframeOrigin = `${loc.protocol}//iframe.${loc.hostname}:${loc.port}`;
-      document.body.appendChild(viewerIframe);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(viewerIframe);
-    });
-
-    it('should wait for the handshake', () => {
-      const params = serializeQueryString({
-        origin: getWinOrigin(window),
+      beforeEach(() => {
+        const loc = window.location;
+        viewerIframe = document.createElement('iframe');
+        iframeOrigin = `http://iframe.localhost:${loc.port}`;
+        document.body.appendChild(viewerIframe);
       });
-      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
-      viewerIframe.setAttribute('src', ampDocUrl);
 
-      return Messaging.waitForHandshakeFromDocument(
-        window,
-        viewerIframe.contentWindow,
-        iframeOrigin
-      )
-        .then(messaging => {
-          messaging.setDefaultHandler(() => {});
-          return new Promise(resolve =>
-            messaging.registerHandler('documentLoaded', resolve)
-          );
-        })
-        .then(name => {
-          expect(name).to.equal('documentLoaded');
+      afterEach(() => {
+        document.body.removeChild(viewerIframe);
+      });
+
+      it('should wait for the handshake', () => {
+        const params = serializeQueryString({
+          origin: getWinOrigin(window),
         });
-    });
+        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+        viewerIframe.setAttribute('src', ampDocUrl);
 
-    it('should work on opaque origin with messaging token', () => {
-      const params = serializeQueryString({
-        origin: getWinOrigin(window),
-        messagingToken: 'test-token',
+        return Messaging.waitForHandshakeFromDocument(
+          window,
+          viewerIframe.contentWindow,
+          iframeOrigin
+        )
+          .then(messaging => {
+            messaging.setDefaultHandler(() => Promise.resolve());
+            return new Promise(resolve =>
+              messaging.registerHandler('documentLoaded', resolve)
+            );
+          })
+          .then(name => {
+            expect(name).to.equal('documentLoaded');
+          });
       });
-      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
-      viewerIframe.setAttribute('sandbox', 'allow-scripts');
-      viewerIframe.setAttribute('src', ampDocUrl);
 
-      return Messaging.waitForHandshakeFromDocument(
-        window,
-        viewerIframe.contentWindow,
-        'null',
-        'test-token'
-      )
-        .then(messaging => {
-          messaging.setDefaultHandler(() => {});
-          return new Promise(resolve =>
-            messaging.registerHandler('documentLoaded', resolve)
-          );
-        })
-        .then(name => {
-          expect(name).to.equal('documentLoaded');
+      it('should work on opaque origin with messaging token', () => {
+        const params = serializeQueryString({
+          origin: getWinOrigin(window),
+          messagingToken: 'test-token',
         });
-    });
+        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+        viewerIframe.setAttribute('sandbox', 'allow-scripts');
+        viewerIframe.setAttribute('src', ampDocUrl);
 
-    it('should fail if messaging token is wrong', () => {
-      const params = serializeQueryString({
-        origin: getWinOrigin(window),
-        messagingToken: 'foo',
+        return Messaging.waitForHandshakeFromDocument(
+          window,
+          viewerIframe.contentWindow,
+          'null',
+          'test-token'
+        )
+          .then(messaging => {
+            messaging.setDefaultHandler(() => Promise.resolve());
+            return new Promise(resolve =>
+              messaging.registerHandler('documentLoaded', resolve)
+            );
+          })
+          .then(name => {
+            expect(name).to.equal('documentLoaded');
+          });
       });
-      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
-      viewerIframe.setAttribute('src', ampDocUrl);
 
-      return Messaging.waitForHandshakeFromDocument(
-        window,
-        viewerIframe.contentWindow,
-        iframeOrigin,
-        'bar'
-      ).then(messaging => {
-        const handlerStub = sandbox.stub();
-        messaging.setDefaultHandler(handlerStub);
-        expect(handlerStub).to.not.have.been.called;
-      });
-    });
-
-    it('should perform polling handshake', function() {
-      this.timeout(5000);
-
-      const params = serializeQueryString({
-        origin: getWinOrigin(window),
-        cap: 'handshakepoll',
-      });
-      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
-      viewerIframe.setAttribute('src', ampDocUrl);
-
-      return Messaging.initiateHandshakeWithDocument(viewerIframe.contentWindow)
-        .then(messaging => {
-          messaging.setDefaultHandler(() => {});
-          return new Promise(resolve =>
-            messaging.registerHandler('documentLoaded', resolve)
-          );
-        })
-        .then(name => {
-          expect(name).to.equal('documentLoaded');
+      it('should fail if messaging token is wrong', () => {
+        const params = serializeQueryString({
+          origin: getWinOrigin(window),
+          messagingToken: 'foo',
         });
+        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+        viewerIframe.setAttribute('src', ampDocUrl);
+
+        return Messaging.waitForHandshakeFromDocument(
+          window,
+          viewerIframe.contentWindow,
+          iframeOrigin,
+          'bar'
+        ).then(messaging => {
+          const handlerStub = sandbox.stub();
+          messaging.setDefaultHandler(handlerStub);
+          expect(handlerStub).to.not.have.been.called;
+        });
+      });
+
+      it('should perform polling handshake', function() {
+        this.timeout(5000);
+
+        const params = serializeQueryString({
+          origin: getWinOrigin(window),
+          cap: 'handshakepoll',
+        });
+        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+        viewerIframe.setAttribute('src', ampDocUrl);
+
+        return Messaging.initiateHandshakeWithDocument(
+          viewerIframe.contentWindow
+        )
+          .then(messaging => {
+            messaging.setDefaultHandler(() => Promise.resolve());
+            return new Promise(resolve =>
+              messaging.registerHandler('documentLoaded', resolve)
+            );
+          })
+          .then(name => {
+            expect(name).to.equal('documentLoaded');
+          });
+      });
     });
-  });
 });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Messaging} from '../../messaging/messaging';
+import {getWinOrigin, serializeQueryString} from '../../../../../src/url';
+
+describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
+  const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
+
+  describe.configure().run('Handshake', () => {
+    let viewerIframe;
+    let iframeOrigin;
+
+    beforeEach(() => {
+      const loc = window.location;
+      viewerIframe = document.createElement('iframe');
+      iframeOrigin = `${loc.protocol}//iframe.${loc.hostname}:${loc.port}`;
+      document.body.appendChild(viewerIframe);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(viewerIframe);
+    });
+
+    it('should wait for the handshake', () => {
+      const params = serializeQueryString({
+        origin: getWinOrigin(window),
+      });
+      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+      viewerIframe.setAttribute('src', ampDocUrl);
+
+      return Messaging.waitForHandshakeFromDocument(
+        window,
+        viewerIframe.contentWindow,
+        iframeOrigin
+      )
+        .then(messaging => {
+          messaging.setDefaultHandler(() => {});
+          return new Promise(resolve =>
+            messaging.registerHandler('documentLoaded', resolve)
+          );
+        })
+        .then(name => {
+          expect(name).to.equal('documentLoaded');
+        });
+    });
+
+    it('should work on opaque origin with messaging token', () => {
+      const params = serializeQueryString({
+        origin: getWinOrigin(window),
+        messagingToken: 'test-token',
+      });
+      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+      viewerIframe.setAttribute('sandbox', 'allow-scripts');
+      viewerIframe.setAttribute('src', ampDocUrl);
+
+      return Messaging.waitForHandshakeFromDocument(
+        window,
+        viewerIframe.contentWindow,
+        'null',
+        'test-token'
+      )
+        .then(messaging => {
+          messaging.setDefaultHandler(() => {});
+          return new Promise(resolve =>
+            messaging.registerHandler('documentLoaded', resolve)
+          );
+        })
+        .then(name => {
+          expect(name).to.equal('documentLoaded');
+        });
+    });
+
+    it('should fail if messaging token is wrong', () => {
+      const params = serializeQueryString({
+        origin: getWinOrigin(window),
+        messagingToken: 'foo',
+      });
+      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+      viewerIframe.setAttribute('src', ampDocUrl);
+
+      return Messaging.waitForHandshakeFromDocument(
+        window,
+        viewerIframe.contentWindow,
+        iframeOrigin,
+        'bar'
+      ).then(messaging => {
+        const handlerStub = sandbox.stub();
+        messaging.setDefaultHandler(handlerStub);
+        expect(handlerStub).to.not.have.been.called;
+      });
+    });
+
+    it('should perform polling handshake', function() {
+      this.timeout(5000);
+
+      const params = serializeQueryString({
+        origin: getWinOrigin(window),
+        cap: 'handshakepoll',
+      });
+      const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+      viewerIframe.setAttribute('src', ampDocUrl);
+
+      return Messaging.initiateHandshakeWithDocument(viewerIframe.contentWindow)
+        .then(messaging => {
+          messaging.setDefaultHandler(() => {});
+          return new Promise(resolve =>
+            messaging.registerHandler('documentLoaded', resolve)
+          );
+        })
+        .then(name => {
+          expect(name).to.equal('documentLoaded');
+        });
+    });
+  });
+});

--- a/test/fixtures/served/ampdoc-with-messaging.html
+++ b/test/fixtures/served/ampdoc-with-messaging.html
@@ -20,8 +20,9 @@
   <meta charset="utf-8">
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1">
-  <script async src="../../../dist/amp.js"></script>
-  <script async src="../../../dist/v0/amp-viewer-integration-0.1.max.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>
   <script>
   console.log("===> AMP Doc is loaded and ready for messaging! <===");
   </script>


### PR DESCRIPTION
*   Removes dependencies on `getData` and `parseJson` to make it easier to publish on NPM.
*   Adds support for opaque origins (`postMessage` must use `*` as `targetOrigin` when origin is `"null"`).
*   Adds `initMessaging` helper function ([most of this logic is from here](https://github.com/ampproject/amp-viewer/blob/cbf0ae384cbd1b31a4b953ddaecbf1eaf3b9ce61/mobile-web/src/viewer-messaging.js#L100-L119)).
*   Changes uses of `==` to `===`.

I'll make a second PR to update version in package.json and publish when this is merged.