### PR TITLE
Enable Saucelabs tests on Safari 11 and fix Inabox tests

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -53,6 +53,7 @@ function updateBrowsers(config) {
           'SL_Firefox',
           'SL_Edge_17',
           'SL_Safari_12',
+          'SL_Safari_11',
           'SL_IE_11',
           // TODO(amp-infra): Evaluate and add more platforms here.
           //'SL_Chrome_Android_7',

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -51,7 +51,7 @@ describe('AMPHTML ad on AMP Page', () => {
     {
       amp: true,
       extensions: ['amp-ad'],
-      frameStyle: "height: 100vh",
+      frameStyle: 'height: 100vh',
       body: `
   <div style="height: 100vh"></div>
   <amp-ad
@@ -104,7 +104,7 @@ describe('AMPHTML ad on non-AMP page (inabox)', () => {
     'BTF',
     {
       amp: false,
-      frameStyle: "height: 100vh",
+      frameStyle: 'height: 100vh',
       body: `
       <div style="height: 100vh"></div>
       <iframe

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -51,6 +51,7 @@ describe('AMPHTML ad on AMP Page', () => {
     {
       amp: true,
       extensions: ['amp-ad'],
+      frameStyle: "height: 100vh",
       body: `
   <div style="height: 100vh"></div>
   <amp-ad
@@ -65,13 +66,6 @@ describe('AMPHTML ad on AMP Page', () => {
       `,
     },
     env => {
-      beforeEach(() => {
-        // TODO: This happens after the test page is fully rendered, so there's
-        // a split second where the test iframe is not yet resized; that's
-        // enough to trigger viewability on Safari. Fix this to unskip
-        env.iframe.style.height = '100vh';
-      });
-
       it('should layout amp-img, amp-pixel, amp-analytics', () => {
         // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
         return testAmpComponentsBTF(env.win);
@@ -110,6 +104,7 @@ describe('AMPHTML ad on non-AMP page (inabox)', () => {
     'BTF',
     {
       amp: false,
+      frameStyle: "height: 100vh",
       body: `
       <div style="height: 100vh"></div>
       <iframe
@@ -121,13 +116,6 @@ describe('AMPHTML ad on non-AMP page (inabox)', () => {
       `,
     },
     env => {
-      beforeEach(() => {
-        // TODO: This happens after the test page is fully rendered, so there's
-        // a split second where the test iframe is not yet resized; that's
-        // enough to trigger viewability on Safari. Fix this to unskip
-        env.iframe.style.height = '100vh';
-      });
-
       it('should layout amp-img, amp-pixel, amp-analytics', () => {
         // See amp4test.js for creative content
         return testAmpComponentsBTF(env.win);

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -506,6 +506,7 @@ class IntegrationFixture {
         ? undefined
         : this.spec.extensions.join(',');
     const ampDocType = this.spec.ampdoc || 'single';
+    const style = this.spec.frameStyle;
 
     let url =
       this.spec.amp === false
@@ -527,7 +528,7 @@ class IntegrationFixture {
         src = addParamsToUrl('/amp4test/compose-shadow', {docUrl});
       }
 
-      env.iframe = createElementWithAttributes(document, 'iframe', {src});
+      env.iframe = createElementWithAttributes(document, 'iframe', {src, style});
       env.iframe.onload = function() {
         env.win = env.iframe.contentWindow;
         resolve();

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -528,7 +528,10 @@ class IntegrationFixture {
         src = addParamsToUrl('/amp4test/compose-shadow', {docUrl});
       }
 
-      env.iframe = createElementWithAttributes(document, 'iframe', {src, style});
+      env.iframe = createElementWithAttributes(document, 'iframe', {
+        src,
+        style,
+      });
       env.iframe.onload = function() {
         env.win = env.iframe.contentWindow;
         resolve();


### PR DESCRIPTION
Original PR is #24666. Adds test coverage to Safari 11 to test the IntersectionObserver polyfill, and fix a race condition in the test itself that would cause it to fail otherwise.