### PR TITLE
🐛Add layout attribute to amp-story-consent test element

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -545,6 +545,7 @@ describes.realWin(
 
         const consentEl = win.document.createElement('amp-consent');
         const storyConsentEl = win.document.createElement('amp-story-consent');
+        storyConsentEl.setAttribute('layout', 'nodisplay');
         consentEl.appendChild(storyConsentEl);
         element.appendChild(consentEl);
 


### PR DESCRIPTION
Removes error message in `amp-story consent` test by adding a `nodisplay` layout attribute.
Resolves #24762 