### PR TITLE
♿Add alert role to toast for screen reader support

### DIFF
--- a/extensions/amp-story/1.0/toast.js
+++ b/extensions/amp-story/1.0/toast.js
@@ -47,8 +47,10 @@ export class Toast {
     const toast = createElementWithAttributes(
       win.document,
       'div',
-      /** @type {!JsonObject} */ ({'class': TOAST_CLASSNAME}),
-      /** @type {!JsonObject} */ ({'role': TOAST_ROLE})
+      /** @type {!JsonObject} */ ({
+        'class': TOAST_CLASSNAME,
+        'role': TOAST_ROLE,
+      })
     );
 
     if (typeof childNodeOrText == 'string') {

--- a/extensions/amp-story/1.0/toast.js
+++ b/extensions/amp-story/1.0/toast.js
@@ -21,10 +21,10 @@ import {toWin} from '../../../src/types';
 const TOAST_CLASSNAME = 'i-amphtml-story-toast';
 
 /**
- * The 'status' role politely announces toast content to screen readers.
+ * The 'alert' role assertively announces toast content to screen readers.
  * @private @const {string}
  * */
-const TOAST_ROLE = 'status';
+const TOAST_ROLE = 'alert';
 
 /**
  * Should be higher than total animation time.

--- a/extensions/amp-story/1.0/toast.js
+++ b/extensions/amp-story/1.0/toast.js
@@ -21,6 +21,12 @@ import {toWin} from '../../../src/types';
 const TOAST_CLASSNAME = 'i-amphtml-story-toast';
 
 /**
+ * The 'status' role politely announces toast content to screen readers.
+ * @private @const {string}
+ * */
+const TOAST_ROLE = 'status';
+
+/**
  * Should be higher than total animation time.
  * @private @const {number}
  */
@@ -41,7 +47,8 @@ export class Toast {
     const toast = createElementWithAttributes(
       win.document,
       'div',
-      /** @type {!JsonObject} */ ({'class': TOAST_CLASSNAME})
+      /** @type {!JsonObject} */ ({'class': TOAST_CLASSNAME}),
+      /** @type {!JsonObject} */ ({'role': TOAST_ROLE})
     );
 
     if (typeof childNodeOrText == 'string') {


### PR DESCRIPTION
Adds the `alert` role to toasts so screen readers assertively announce the content when the toast is displayed.
Resolves #24805 

