### PR TITLE
♻️`wg-ui-and-a11y` to own externally contributed UI related components

### DIFF
--- a/extensions/amp-apester-media/OWNERS.yaml
+++ b/extensions/amp-apester-media/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - mrsufgi
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-brid-player/OWNERS.yaml
+++ b/extensions/amp-brid-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - pedjoni8
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-brightcove/OWNERS.yaml
+++ b/extensions/amp-brightcove/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - mister-ben
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-connatix-player/OWNERS.yaml
+++ b/extensions/amp-connatix-player/OWNERS.yaml
@@ -1,5 +1,5 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- kentbrew
+- mariusszabo
 - ampproject/wg-ui-and-a11y

--- a/extensions/amp-date-display/OWNERS.yaml
+++ b/extensions/amp-date-display/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - robinpokorny
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-delight-player/OWNERS.yaml
+++ b/extensions/amp-delight-player/OWNERS.yaml
@@ -1,5 +1,5 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- kentbrew
+- xymw
 - ampproject/wg-ui-and-a11y

--- a/extensions/amp-drilldown/OWNERS.yaml
+++ b/extensions/amp-drilldown/OWNERS.yaml
@@ -1,5 +1,4 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- kentbrew
 - ampproject/wg-ui-and-a11y

--- a/extensions/amp-fx-flying-carpet/OWNERS.yaml
+++ b/extensions/amp-fx-flying-carpet/OWNERS.yaml
@@ -1,5 +1,5 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- jridgewell
+- sdbaron
 - ampproject/wg-ui-and-a11y

--- a/extensions/amp-fx-flying-carpet/OWNERS.yaml
+++ b/extensions/amp-fx-flying-carpet/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - jridgewell
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-gfycat/OWNERS.yaml
+++ b/extensions/amp-gfycat/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - koshka
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-google-vrview-image/OWNERS.yaml
+++ b/extensions/amp-google-vrview-image/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - dvoytenko
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-google-vrview-image/OWNERS.yaml
+++ b/extensions/amp-google-vrview-image/OWNERS.yaml
@@ -1,5 +1,4 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- dvoytenko
 - ampproject/wg-ui-and-a11y

--- a/extensions/amp-kaltura-player/OWNERS.yaml
+++ b/extensions/amp-kaltura-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - itaykinnrot
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-mowplayer/OWNERS.yaml
+++ b/extensions/amp-mowplayer/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - gopanisandip
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-nexxtv-player/OWNERS.yaml
+++ b/extensions/amp-nexxtv-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - neko-fire
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-o2-player/OWNERS.yaml
+++ b/extensions/amp-o2-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - yevheniiminin
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-ooyala-player/OWNERS.yaml
+++ b/extensions/amp-ooyala-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - mityaha
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-playbuzz/OWNERS.yaml
+++ b/extensions/amp-playbuzz/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - buzzdan
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-powr-player/OWNERS.yaml
+++ b/extensions/amp-powr-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - chadladensack
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-reach-player/OWNERS.yaml
+++ b/extensions/amp-reach-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - mikepmtl
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-recaptcha-input/OWNERS.yaml
+++ b/extensions/amp-recaptcha-input/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - torch2424
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-reddit/OWNERS.yaml
+++ b/extensions/amp-reddit/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - samiamorwas
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-springboard-player/OWNERS.yaml
+++ b/extensions/amp-springboard-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - Em-PredragMilosevic
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-user-notification/OWNERS.yaml
+++ b/extensions/amp-user-notification/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - erwinmombay
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-viqeo-player/OWNERS.yaml
+++ b/extensions/amp-viqeo-player/OWNERS.yaml
@@ -2,3 +2,4 @@
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
 - viqeo.tv
+- ampproject/wg-ui-and-a11y

--- a/extensions/amp-wistia-player/OWNERS.yaml
+++ b/extensions/amp-wistia-player/OWNERS.yaml
@@ -1,5 +1,5 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- kentbrew
+- chen-anders
 - ampproject/wg-ui-and-a11y


### PR DESCRIPTION
### Changes
- Adds an OWNERS file to `amp-connatix-player`, `amp-delight-player`, `amp-drilldown` and `amp-wistia-player`
- Adds `wg-ui-and-a11y` as owner to multiple UI-related components that have a single owner