### PR TITLE
gulp integration build command consistency

### DIFF
--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -37,7 +37,11 @@ class Runner extends RuntimeTestRunner {
       return;
     }
     execOrDie('gulp clean');
-    execOrDie(`gulp dist --fortesting --config ${argv.config}`);
+    if (argv.compiled) {
+      execOrDie(`gulp dist --fortesting --config ${argv.config}`);
+    } else {
+      execOrDie(`gulp build --config ${argv.config}`);
+    }
   }
 }
 


### PR DESCRIPTION
We need to run `gulp build` if we want to use unminimized bundle (amp.js vs v0.js). This PR fixes the problem that `gulp integration` by default does not build the right bundle it requires.