### PR TITLE
Story Ads: propagate visible attr to transformed body.

### DIFF
--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -9,7 +9,7 @@
 
   <meta name="amp-cta-type" content="INSTALL">
   <meta name="amp-cta-url" content="https://www.amp.dev">
-  <meta name="amp4ads-vars-attribution-icon" content="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png">
+  <meta name="amp4ads-vars-attribution-icon" content="/test/fixtures/e2e/amphtml-ads/resource/icon.png">
   <meta name="amp4ads-vars-attribution-url" content="https://www.google.com">
 
   <style amp-custom>

--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -8,9 +8,9 @@
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 
   <meta name="amp-cta-type" content="INSTALL">
-  <meta name="amp-cta-url" content="https://www.example.com">
+  <meta name="amp-cta-url" content="https://www.amp.dev">
   <meta name="amp4ads-vars-attribution-icon" content="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png">
-  <meta name="amp4ads-vars-attribution-url" content="https://www.amp.dev">
+  <meta name="amp4ads-vars-attribution-url" content="https://www.google.com">
 
   <style amp-custom>
     @font-face {
@@ -99,26 +99,5 @@
       </amp-img>
     </div>
   </div>
-  <amp-ad-exit id="exit-api">
-    <script type="application/json">
-      {
-        "filters": {},
-        "options": {},
-        "targets": {
-          "exit1": {
-            "filters": [],
-            "finalUrl": "https://www.amp.dev",
-            "trackingUrls": [],
-            "vars": {
-              "_rm_eid": {
-                "defaultValue": "5645519",
-                "iframeTransportSignal": ""
-              }
-            }
-          }
-        }
-      }
-    </script>
-  </amp-ad-exit>
 </body>
 </html>

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -700,7 +700,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     const frameDoc = getFrameDoc(friendlyIframeEmbed);
     const {body} = frameDoc;
-    // TODO(#24080) Remove alternate body when we have full ad network support.
+    // TODO(#24829) Remove alternate body when we have full ad network support.
     const alternateBody = body.querySelector('#x-a4a-former-body');
     this.mutateElement(() => {
       body.setAttribute(Attributes.IFRAME_BODY_VISIBLE, '');
@@ -716,7 +716,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   removeVisibleAttribute_() {
     this.mutateElement(() => {
       if (this.visibleAdBody_) {
-        // TODO(#24080) Remove alternate body when we have full ad network support.
+        // TODO(#24829) Remove alternate body when we have full ad network support.
         const alternateBody = this.visibleAdBody_.querySelector(
           '#x-a4a-former-body'
         );

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -700,8 +700,12 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     const frameDoc = getFrameDoc(friendlyIframeEmbed);
     const {body} = frameDoc;
+    // TODO(#24080) Remove alternate body when we have full ad network support.
+    const alternateBody = body.querySelector('#x-a4a-former-body');
     this.mutateElement(() => {
       body.setAttribute(Attributes.IFRAME_BODY_VISIBLE, '');
+      alternateBody &&
+        alternateBody.setAttribute(Attributes.IFRAME_BODY_VISIBLE, '');
       this.visibleAdBody_ = body;
     });
   }
@@ -712,6 +716,12 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   removeVisibleAttribute_() {
     this.mutateElement(() => {
       if (this.visibleAdBody_) {
+        // TODO(#24080) Remove alternate body when we have full ad network support.
+        const alternateBody = this.visibleAdBody_.querySelector(
+          '#x-a4a-former-body'
+        );
+        alternateBody &&
+          alternateBody.removeAttribute(Attributes.IFRAME_BODY_VISIBLE);
         this.visibleAdBody_.removeAttribute(Attributes.IFRAME_BODY_VISIBLE);
         this.visibleAdBody_ = null;
       }

--- a/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
@@ -20,7 +20,7 @@ const viewport = {
 };
 
 describes.endtoend(
-  'amp-story-auto-ads',
+  'amp-story-auto-ads:basic',
   {
     testUrl:
       'http://localhost:8000/test/fixtures/e2e/amp-story-auto-ads/basic.html',
@@ -41,12 +41,62 @@ describes.endtoend(
       const activePage = await controller.findElement('[active]');
       await expect(controller.getElementAttribute(activePage, 'ad')).to.exist;
       await validateAdOverlay(controller);
-      await validateAdAttribution(controller);
-      await validateCta(controller);
+      await validateAdAttribution(
+        controller,
+        'https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png' // iconUrl
+      );
+      await validateCta(
+        controller,
+        'https://www.amp.dev' // ctaUrl
+      );
+
+      await switchToAdFrame(controller);
+      const body = await controller.findElement('body');
+      await expect(controller.getElementAttribute(body, 'amp-story-visible')).to
+        .exist;
+      await controller.switchToParent();
     });
 
     // TODO(ccordry): write test that checks attribution click -- will
     // require additional changes to controller interface.
+  }
+);
+
+describes.endtoend(
+  'amp-story-auto-ads:dv3',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-story-auto-ads/dv3-request.html',
+    initialRect: {width: viewport.WIDTH, height: viewport.HEIGHT},
+    environments: ['single', 'viewer-demo'],
+  },
+  env => {
+    let controller;
+
+    beforeEach(() => {
+      controller = env.controller;
+    });
+
+    it('should render correctly', async () => {
+      await clickThroughPages(controller, /* numPages */ 7);
+      const activePage = await controller.findElement('[active]');
+      await expect(controller.getElementAttribute(activePage, 'ad')).to.exist;
+      await validateAdOverlay(controller);
+      await validateAdAttribution(
+        controller,
+        'https://googleads.g.doubleclick.net/pagead/images/mtad/ad_choices_blue.png' // iconUrl
+      );
+      await validateCta(
+        controller,
+        'https://adclick.g.doubleclick.net/pcs/123'
+      );
+
+      switchToAdFrame(controller);
+      const movedBody = await controller.findElement('#x-a4a-former-body');
+      await expect(
+        controller.getElementAttribute(movedBody, 'amp-story-visible')
+      ).to.exist;
+    });
   }
 );
 
@@ -83,7 +133,7 @@ async function validateAdOverlay(controller) {
   await controller.switchToLight();
 }
 
-async function validateCta(controller) {
+async function validateCta(controller, ctaUrl) {
   const ctaButton = await controller.findElement('.i-amphtml-story-ad-link');
   await expect(controller.getElementCssValue(ctaButton, 'visibility')).to.equal(
     'visible'
@@ -92,7 +142,7 @@ async function validateCta(controller) {
     '_blank'
   );
   await expect(controller.getElementAttribute(ctaButton, 'href')).to.equal(
-    'https://www.amp.dev'
+    ctaUrl
   );
   await expect(controller.getElementAttribute(ctaButton, 'role')).to.equal(
     'link'
@@ -109,7 +159,7 @@ async function validateCta(controller) {
   );
 }
 
-async function validateAdAttribution(controller) {
+async function validateAdAttribution(controller, iconUrl) {
   const attributionHost = await controller.findElement(
     '.i-amphtml-attribution-host'
   );
@@ -119,7 +169,7 @@ async function validateAdAttribution(controller) {
     '.i-amphtml-story-ad-attribution'
   );
   await expect(controller.getElementAttribute(attribution, 'src')).to.equal(
-    'https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png'
+    iconUrl
   );
   await expect(
     controller.getElementCssValue(attribution, 'visibility')
@@ -136,4 +186,9 @@ async function validateAdAttribution(controller) {
   });
 
   await controller.switchToLight();
+}
+
+async function switchToAdFrame(controller) {
+  const frame = await controller.findElement('#i-amphtml-ad-page-1 iframe');
+  await controller.switchToFrame(frame);
 }

--- a/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
@@ -43,7 +43,7 @@ describes.endtoend(
       await validateAdOverlay(controller);
       await validateAdAttribution(
         controller,
-        'https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png' // iconUrl
+        '/test/fixtures/e2e/amphtml-ads/resource/icon.png' // iconUrl
       );
       await validateCta(
         controller,

--- a/test/fixtures/e2e/amp-story-auto-ads/dv3-request.html
+++ b/test/fixtures/e2e/amp-story-auto-ads/dv3-request.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-0.1.js"></script>
+    <title>Amp Story Auto Ads DV3</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="canonical" href="helloworld.html">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+
+  <body>
+    <amp-story
+      title="amp-story-auto-ads-basic"
+      publisher="The AMP Team"
+      publisher-logo-src="https://placekitten.com/10/10"
+      poster-portrait-src="https://placekitten.com/300/400"
+      poster-square-src="https://placekitten.com/10/10"
+      poster-landscape-src="https://placekitten.com/400/300"
+      standalone>
+
+      <amp-story-auto-ads id="i-amphtml-demo-1">
+        <script type="application/json">
+          {
+            "ad-attributes": {
+              "type": "fake",
+              "src": "/test/fixtures/e2e/amp-story-auto-ads/dv3-transformed-creative.html",
+              "a4a-conversion": true
+            }
+          }
+        </script>
+      </amp-story-auto-ads>
+
+      <amp-story-page id="cover">
+        <amp-story-grid-layer template="vertical">
+          <h1>Fake ads served locally</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="two">
+        <amp-story-grid-layer template="vertical">
+          <h1>page two</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <<amp-story-page id="three">
+        <amp-story-grid-layer template="vertical">
+          <h1>page three</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="four">
+        <amp-story-grid-layer template="vertical">
+          <h1>page four</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="five">
+        <amp-story-grid-layer template="vertical">
+          <h1>page five</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="six">
+        <amp-story-grid-layer template="vertical">
+          <h1>page six</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="seven">
+        <amp-story-grid-layer template="vertical">
+          <h1>page seven</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="eight">
+        <amp-story-grid-layer template="vertical">
+          <h1>page eight</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="nine">
+        <amp-story-grid-layer template="vertical">
+          <h1>page nine</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="ten">
+        <amp-story-grid-layer template="vertical">
+          <h1>page ten</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="eleven">
+        <amp-story-grid-layer template="vertical">
+          <h1>page eleven</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="twelve">
+        <amp-story-grid-layer template="vertical">
+          <h1>page twelve</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="thirteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page thirteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="fourteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page fourteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="fifteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page fifteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="sixteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page sixteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="seventeen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page seventeen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="eighteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page eighteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="nineteen">
+        <amp-story-grid-layer template="vertical">
+          <h1>page nineteen</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="twenty">
+        <amp-story-grid-layer template="vertical">
+          <h1>page twenty</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-bookend src="../../examples/amp-story/bookendv1.json" layout="nodisplay">
+      </amp-story-bookend>
+    </amp-story>
+  </body>
+</html>

--- a/test/fixtures/e2e/amp-story-auto-ads/dv3-transformed-creative.html
+++ b/test/fixtures/e2e/amp-story-auto-ads/dv3-transformed-creative.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html amp4ads>
+  <head>
+    <meta charset=utf-8>
+    <meta content="width=device-width,minimum-scale=1,initial-scale=1" name=viewport>
+    <meta content="vendor=doubleclick,type=impression-id,value=CJ7Qouup-eQCFRjTWwodQaUNng" name=amp4ads-id>
+    <meta content=https://www.dummy.com name=amp-cta-url>
+    <meta content=LEARN_MORE name=amp-cta-type>
+    <meta content=https://www.google.com/url%3Fct%3Dabg%26q%3Dhttps://www.google.com/adsense/support/bin/request.py%253Fcontact%253Dabg_afc%2526url%253D%2526gl%253DUS%2526hl%253Den%2526ai0%253D%26usg%3DAFQjCNF5SlI_RscgVMh7GqStmahOa0n4VA name=amp4ads-vars-attribution-url>
+    <meta content=https://googleads.g.doubleclick.net/pagead/images/mtad/ad_choices_blue.png name=amp4ads-vars-attribution-icon>
+    <script async src=https://cdn.ampproject.org/amp4ads-v0.js></script>
+    <script async custom-element=amp-ad-exit src=https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js></script><script async custom-element=amp-analytics src=https://cdn.ampproject.org/v0/amp-analytics-0.1.js></script><script async custom-element=amp-fit-text src=https://cdn.ampproject.org/v0/amp-fit-text-0.1.js></script><script async custom-element=amp-form src=https://cdn.ampproject.org/v0/amp-form-0.1.js></script>
+    <style amp-custom>
+      #google_uploaded_a4a {
+        position:absolute;
+        left:0;
+        top:0;
+        z-index:9000;
+      }
+      #google_uploaded_a4a {
+        width:100%;
+        height:100%;
+      }
+      #google_uploaded_a4a .a4a-wrap {
+        height:100vh;
+        display:flex;
+        flex-direction:column;
+        justify-content:center;
+        align-items:center;
+      }
+      #google_uploaded_a4a .a4a-container {
+        height:100px;
+        width:100px;
+      }
+    </style>
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  </head>
+   <body class=amp-animate>
+      <amp-ad-exit id=exit-api>
+         <script type=application/json>{"filters":{},"options":{"startTimingEvent":"navigationStart"},"targets":{"exit1":{"filters":[],"finalUrl":"https://adclick.g.doubleclick.net/pcs/123","trackingUrls":[],"vars":{"_rm_eid":{"defaultValue":"5645519","iframeTransportSignal":""}}}}}</script>
+      </amp-ad-exit>
+      <div id=google_uploaded_a4a>
+         <div id=x-a4a-former-body on="tap:exit-api.exit(target=redirectUrl)" role=link tabindex=0>
+            <div class=a4a-wrap>
+               <div class=a4a-container>
+                  <svg id=a4a-logo viewbox="0 0 30 30" xmlns=http://www.w3.org/2000/svg>
+                     <g fill=none fill-rule=evenodd>
+                        <path d="M0 15c0 8.284 6.716 15 15 15 8.285 0 15-6.716 15-15 0-8.284-6.715-15-15-15C6.716 0 0 6.716 0 15z" fill=#FFF></path>
+                        <path d="M13.85 24.098h-1.14l1.128-6.823-3.49.005h-.05a.57.57 0 0 1-.568-.569c0-.135.125-.363.125-.363l6.272-10.46 1.16.005-1.156 6.834 3.508-.004h.056c.314 0 .569.254.569.568 0 .128-.05.24-.121.335L13.85 24.098zM15 0C6.716 0 0 6.716 0 15c0 8.284 6.716 15 15 15 8.285 0 15-6.716 15-15 0-8.284-6.715-15-15-15z" fill=#005AF0 fill-rule=nonzero></path>
+                     </g>
+                  </svg>
+               </div>
+            </div>
+         </div>
+      </div>
+      <amp-pixel src="https://googleads4.g.doubleclick.net/pcs/view?xai=AKAOjstT45EE_36qeQjnWGk88U_B9wDtFEECF0_9bw2UUWy9xJEuJDn_-vyrFgf5FvV9UNyFFvbfE6CC1y1IrJ9ssDf3wtNMz87MygTB9F_3EafrvyjsjmndLf9LuazdruzlVMHK-Dn2JTnQnDL8a2i31R-rVk4WELnEuoKUgYZ0zzNZcRQz1V6xCLKYAGrfBV_EU-WtKywgxdbnuyBRGUfMjCgFknBtWbpvappq_jOfg2QUzg0NVsWsj8dWE4VBMUN1cte3Co-sqfNAq0JCnLKr43DqJXWTBU-Y7wa04aXk-RTKKlwLdf2ko9F4GFXckP6ZYRrzrEZMHOt0TVaj8y26cARTJRmr0WczhTbMF--pa8Yxt8yVyXabzGPoeGRN1cPDU0IEr2PV-V4IR3rZtVGwLEFbw84SHTyCgPClZjsY2SAP4xwiaEo3E9s2IdmMiiW-_LV-rnaY_7zXv-kWjcOdJvcRpcuNhWL0UTjotWp87dxayRwZ55UhOMVMRWZDOtebJg0nKnYWN5Cp9Ju3wop5thNWl4jXiy2GXWwzKG98ENDC00rvADGqDIWnrHQ8guw0W42aKFCUxknIBdqbPrM_NnrfgbQDdGncR5cJgJ0iEnFqrcrpFshGqFkDaA46lPOAJ7heQE_f4hikTkXagQ2laXAkUTGAKoCRcrWuNUkVHGQevXfcVGD3moIFPZow_GmgYdp269ARMLoETY2dBBnizZO37rextV_n9n4ebxvmzYtmiR1r8OehIKEiyV2dWX482O-V4SuV1s8IisBja8nR4NVgi21LCervs7PGrsO94wxSC9XnqwjztSdAMMUJWiqsO507BqKMxVOEk15TyE33Ns1ALYD7qMPTFYgd6rxrDAEUZv6vBVDb394ej0wlk5jWhQunnLYeHEfzysStwXa-pWW43rMZRy9xxHAY3bg5JTiP83O_3CbIej3aIQ5jKAXkTkKwQi7v8tr3twa1y1B1pJc7FDCotuSlj95Cdzjq28DoS-8&amp;sai=AMfl-YSUqbF93ywk3xaJfoBWfprDY5aBXDKSyUhKNxS6-1KK1wCBU3Pz8WspW2_SXNIBVhYDl2MI8pAXfoPoMpRBsbCjSGwL6sqEH6r04gg7vQ5szr-deMQrx5zZOHxDIPcCdNzzoopYQ6Az4R4v1zxKfLvdgV6tp9DWSJvYNK9EeUfFS4NRzZxSXYUIlV16rNG7drmvbYOqanPnqPFOEOXVTJww0A&amp;sig=Cg0ArKJSzNVX088WcMyUEAE&amp;pr=39:%%WINNING_PRICE%%&amp;urlfix=1&amp;adurl=;TIMESTAMP"></amp-pixel>
+      <amp-analytics>
+         <script type=application/json>{"transport": {"beacon": false, "xhrpost": false},"requests": {"visibility1": "//pagead2.googlesyndication.com/activeview?avi=BQchDpV2SXd7pBpim7wLByrbwCQAAAAAQATgBiAEB4AQCiAWxhK0FoAZH&id=ampim&o=${elementX},${elementY}&d=${elementWidth},${elementHeight}&ss=${screenWidth},${screenHeight}&bs=${viewportWidth},${viewportHeight}&mcvt=${maxContinuousVisibleTime}&mtos=0,0,${maxContinuousVisibleTime},${maxContinuousVisibleTime},${maxContinuousVisibleTime}&tos=0,0,${totalVisibleTime},0,0&tfs=${firstSeenTime}&tls=${lastSeenTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&pt=${pageLoadTime}&tt=${totalTime}&rpt=${navTiming(navigationStart,loadEventStart)}&rst=${navTiming(navigationStart)}&r=v&adk=0&avms=ampa"},"triggers": {"continuousVisible": {"on": "visible","request": ["visibility1"],"visibilitySpec": {"selector": ":root","visiblePercentageMin": 50,"continuousTimeMin": 1000}}}}</script>
+      </amp-analytics>
+      <amp-analytics>
+         <script type=application/json>{"transport": {"beacon": true, "xhrpost": false},"requests": {"ampeos": "//pagead2.googlesyndication.com/activeview?avi=BQchDpV2SXd7pBpim7wLByrbwCQAAAAAQATgBiAEB4AQCiAWxhK0FoAZH&id=ampeos&o=${elementX},${elementY}&d=${elementWidth},${elementHeight}&ss=${screenWidth},${screenHeight}&bs=${viewportWidth},${viewportHeight}&mcvt=${maxContinuousVisibleTime}&mtos=0,0,${maxContinuousVisibleTime},${maxContinuousVisibleTime},${maxContinuousVisibleTime}&tos=0,0,${totalVisibleTime},0,0&tfs=${firstSeenTime}&tls=${lastSeenTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&pt=${pageLoadTime}&tt=${totalTime}&rpt=${navTiming(navigationStart,loadEventStart)}&rst=${navTiming(navigationStart)}&r=de&isd=${initialScrollDepth}&msd=${maxScrollDepth}"},"triggers": {"endOfSession": {"on": "visible","request": "ampeos","visibilitySpec": {"reportWhen": "documentExit","selector": ":root","visiblePercentageMin": 50}}}}</script>
+      </amp-analytics>
+      <amp-pixel src="https://pagead2.googlesyndication.com/pagead/gen_204?id=xbid&amp;dbm_b=AKAmf-Aob-OhUeVKt9tXoQeZJtajK4BAtThqUH6pdUMZzBdR33pwsUkm1uvZN7_XrIU9BORNz5IEb98-Nl8pGQsdsSvwwwoHo5APJv5V2HyAgVvKZUkOoxo"></amp-pixel>
+      <amp-analytics>
+         <script type=application/json>{"transport": {"beacon": true, "xhrpost": false},"requests": {"ampeos": "//pagead2.googlesyndication.com/activeview?avi=Bv2sxpV2SXd7pBpim7wLByrbwCQDCgYaSpQoAABABOAGIAQHIAQngBAOIBdPP96YYoAY90ggFCIABEAE&cid=CAASEuRofdiA2ENk01QwphbjtClMyA&id=ampeos&o=${elementX},${elementY}&d=${elementWidth},${elementHeight}&ss=${screenWidth},${screenHeight}&bs=${viewportWidth},${viewportHeight}&mcvt=${maxContinuousVisibleTime}&mtos=0,0,${maxContinuousVisibleTime},${maxContinuousVisibleTime},${maxContinuousVisibleTime}&tos=0,0,${totalVisibleTime},0,0&tfs=${firstSeenTime}&tls=${lastSeenTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&pt=${pageLoadTime}&tt=${totalTime}&rpt=${navTiming(navigationStart,loadEventStart)}&rst=${navTiming(navigationStart)}&r=de&isd=${initialScrollDepth}&msd=${maxScrollDepth}"},"triggers": {"endOfSession": {"on": "visible","request": "ampeos","visibilitySpec": {"reportWhen": "documentExit","selector": ":root","visiblePercentageMin": 50}}}}</script>
+      </amp-analytics>
+      <amp-pixel allow-ssr-img src="//www.google.com/ads/measurement/l?ebcid=ALh7CaQZK_guz0omkhNohjeKilFUKhNiWS2rAw6O8F0LQPWyAHUdttVEZdMXz4OzM3cttv2U5cQ4486Rd5Buugcgr1SmalcM4A"></amp-pixel>
+      <amp-pixel allow-ssr-img src=https://googleads.g.doubleclick.net/pagead/ide_cookie></amp-pixel>
+      <div style="bottom:0;right:0;width:100px;height:100px;background:initial;position:absolute;max-width:100%;max-height:100%;pointer-events:none;image-rendering:pixelated;z-index:2147483647;background-image:url(&#39;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACsAAAAWBAMAAACrl3iAAAAABlBMVEUAAAD+AciWmZzWAAAAAnRSTlMAApidrBQAAAB+SURBVBjTbZEBDoAwCAO7H/T/r9XRUjCRzSnZAQWBfzuy9+PueGDd8r7JeEU0Ot7liqK2vbnXMzQSM17X9oqSMfFLN3ZApYYRlgLl5+KlI5rcYqftkBPqpNjWAaRbLN0zT6y+jLduT+G0lE/pzM5KNu2Ggc8EWzPXvxQNnXgAY9UFzZ1ZCnQAAAAASUVORK5CYII=&#39;);"></div>
+      <amp-analytics>
+         <script type=application/json>{"triggers": {"1": {"on": "render-start","parentPostMessage": "{\"adClient\":\"ca-pub-3285741363974337\",\"enableAutoAdSize\":\"0\",\"googMsgType\":\"adsense-settings\"}"}}}</script>
+      </amp-analytics>
+      <script amp-ad-metadata type=application/json>
+         {
+            "ampRuntimeUtf16CharOffsets" : [ 726, 1206 ],
+            "ctaType" : "LEARN_MORE",
+            "ctaUrl" : "https://www.dummy.com",
+            "customElementExtensions" : [ "amp-ad-exit", "amp-analytics", "amp-fit-text", "amp-form" ],
+            "extensions" : [
+               {
+                  "custom-element" : "amp-ad-exit",
+                  "src" : "https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js"
+               },
+               {
+                  "custom-element" : "amp-analytics",
+                  "src" : "https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
+               },
+               {
+                  "custom-element" : "amp-fit-text",
+                  "src" : "https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"
+               },
+               {
+                  "custom-element" : "amp-form",
+                  "src" : "https://cdn.ampproject.org/v0/amp-form-0.1.js"
+               }
+            ],
+            "jsonUtf16CharOffsets" : {
+               "amp-analytics" : [ 5615, 6544, 6575, 7523, 7774, 8780, 9627, 9839 ]
+            }
+         }
+      </script>
+   </body>
+</html>


### PR DESCRIPTION
Some ad network partners will transform a creative after upload, including moving content that was previously in the `<body>` into a separate `<div>`.

This is a temporary solution until we have full ad network support or finalize a proper API, see #24829

Also introduces an e2e test with a transformed dv3 creative and removes some dv3 specific html from the base e2e test.