### PR TITLE
amp-bind: Increase equality check depth to 20

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1134,7 +1134,7 @@ export class Bind {
       // Useful for rendering amp-list with amp-bind state via [src].
       if (
         newValue === undefined ||
-        deepEquals(newValue, previousResult, /* depth */ 10)
+        deepEquals(newValue, previousResult, /* depth */ 20)
       ) {
       } else {
         boundProperty.previousResult = newValue;


### PR DESCRIPTION
Causes surprising `amp-list` re-render on some complex pages e.g. `b/141334021`.

/to @jridgewell 