### PR TITLE
🏗 Lando: Install dependencies needed for building validator

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -30,6 +30,7 @@ services:
     install_dependencies_as_root:
       - curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
       - apt-get update && apt-get install -y openjdk-8-jdk && apt-get install -y ant && apt-get clean
+      - apt-get install -y openjdk-7-jre protobuf-compiler python2.7 python-protobuf
     build:
       - yarn global add gulp-cli
       - yarn


### PR DESCRIPTION
This is a follow-up on #23213 which adds a Lando environment for AMP core development. When attempting to [build the validator](https://github.com/ampproject/amphtml/tree/master/validator#usage), I found that the required dependencies were missing. This PR adds them.