### PR TITLE
Enable amp-list[diffable] in other AMP specs

### DIFF
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -212,6 +212,10 @@ tags: {  # <amp-list>
     value: "no"
     value: "refresh"
   }
+  attrs: {
+    name: "diffable"
+    value: ""
+  }
   attrs: { name: "items" }
   attrs: { name: "max-items" }
   attrs: { name: "single-item" }
@@ -261,6 +265,10 @@ tags: {  # <amp-list>
   attrs: {
     name: "crossorigin"
     value: "amp-viewer-auth-token-via-post"
+  }
+  attrs: {
+    name: "diffable"
+    value: ""
   }
   attrs: { name: "items" }
   attrs: { name: "max-items" }


### PR DESCRIPTION
Meant to do this in #24467 but forgot. :p

/to @honeybadgerdontcare 