### PR TITLE
♿Add alert role to sound announcements for screen reader support

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -129,6 +129,7 @@ const TEMPLATE = {
             {
               tag: 'div',
               attrs: dict({
+                'role': 'alert',
                 'class': 'i-amphtml-message-container',
               }),
               children: [


### PR DESCRIPTION
Adds the `alert` role to sound announcements (e.g. "Sound on", "Sound off", or "This page has no sound") to assertively announce the content to screen readers.
Resolves #24807 