### PR TITLE
Correct wg-analytics reference in owners file

### DIFF
--- a/extensions/amp-analytics/OWNERS.yaml
+++ b/extensions/amp-analytics/OWNERS.yaml
@@ -1,5 +1,5 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- wg-analytics
+- ampproject/wg-analytics
 - avimehta


### PR DESCRIPTION
In a recent PR, the `wg-analytics` team was supposed to be added as an owner of `extensions/wg-analytics`, but it was not prefixed with the `ampproject/` organization so it could not be recognized as a team. This PR corrects that team specification.