### PR TITLE
Remove amp-youtube a4a deprecation notice

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -147,12 +147,6 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    if (this.element.isInA4A()) {
-      this.user().error(
-        TAG,
-        'amp-youtube is deprecated in AMPHTML ads. See https://github.com/ampproject/amphtml/issues/21340'
-      );
-    }
     this.videoid_ = this.getVideoId_();
     this.liveChannelid_ = this.getLiveChannelId_();
     this.assertDatasourceExists_();


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/21340

Make sure all validation changes on https://github.com/ampproject/amphtml/pull/24864 are deployed on ampproject.org before merging this.

