### PR TITLE
Fix wildcard owners in `test` and `examples`

### DIFF
--- a/examples/OWNERS.yaml
+++ b/examples/OWNERS.yaml
@@ -1,4 +1,4 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- *
+- "*"

--- a/test/OWNERS.yaml
+++ b/test/OWNERS.yaml
@@ -1,4 +1,4 @@
 # For an explanation of the OWNERS.yaml rules and syntax, see:
 # https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml
 
-- *
+- "*"


### PR DESCRIPTION
YAML treats `*` as a special character, so it requires quotes to parse properly.