### PR TITLE
Revert "🏗 Stop reporting gzipped compressed size in the bundle-size task"

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -30,6 +30,7 @@ const {
   travisPushBranch,
   travisRepoSlug,
 } = require('../travis');
+const {getStdout} = require('../exec');
 const {gitCommitHash, gitTravisMasterBaseline, shortSha} = require('../git');
 const {VERSION: internalRuntimeVersion} = require('../internal-version');
 
@@ -40,6 +41,25 @@ const expectedGitHubRepoSlug = 'ampproject/amphtml';
 const bundleSizeAppBaseUrl = 'https://amp-bundle-size-bot.appspot.com/v0/';
 
 const {red, cyan, yellow} = colors;
+
+/**
+ * Get the gzipped bundle size of the current build.
+ *
+ * @return {string} the bundle size in KB rounded to 2 decimal points.
+ */
+function getGzippedBundleSize() {
+  const cmd = `npx bundlesize -f "${runtimeFile}"`;
+  log('Running', cyan(cmd) + '...');
+  const output = getStdout(cmd).trim();
+
+  const bundleSizeOutputMatches = output.match(/PASS .*: (\d+.?\d*KB) .*/);
+  if (bundleSizeOutputMatches) {
+    const bundleSize = parseFloat(bundleSizeOutputMatches[1]);
+    log('Bundle size', cyan('(gzipped)'), 'is', cyan(`${bundleSize}KB`));
+    return bundleSize;
+  }
+  throw Error('could not infer bundle size from output.');
+}
 
 /**
  * Get the brotli bundle size of the current build.
@@ -94,6 +114,9 @@ async function storeBundleSize() {
       json: true,
       body: {
         token: process.env.BUNDLE_SIZE_TOKEN,
+        // TODO(#21275): replace the gzippedBundleSize value once the
+        // bundle-size app prefers Brotli.
+        gzippedBundleSize: getGzippedBundleSize(),
         brotliBundleSize: getBrotliBundleSize(),
       },
     });
@@ -150,6 +173,8 @@ async function skipBundleSize() {
 async function reportBundleSize() {
   if (isTravisPullRequestBuild()) {
     const baseSha = gitTravisMasterBaseline();
+    // TODO(#21275): remove gzipped reporting within ~1 month.
+    const gzippedBundleSize = getGzippedBundleSize();
     const brotliBundleSize = getBrotliBundleSize();
     const commitHash = gitCommitHash();
     try {
@@ -161,7 +186,10 @@ async function reportBundleSize() {
         json: true,
         body: {
           baseSha,
-          bundleSize: brotliBundleSize,
+          // TODO(#21275): replace the default bundleSize value from the gzipped
+          // to the brotli value, once the bundle-size app prefers those.
+          bundleSize: gzippedBundleSize,
+          gzippedBundleSize,
           brotliBundleSize,
         },
       });
@@ -199,6 +227,7 @@ function getLocalBundleSize() {
       cyan(shortSha(gitCommitHash())) + '.'
     );
   }
+  getGzippedBundleSize();
   getBrotliBundleSize();
 }
 


### PR DESCRIPTION
Reverts ampproject/amphtml#24418

Reason:

```
dist-bundle-size.js: Running gulp bundle-size --on_push_build...
514[22:55:01] Using gulpfile ~/build/ampproject/amphtml/gulpfile.js
515[22:55:01] Starting 'bundle-size'...
516[22:55:02] Bundle size (brotli) is 71.78KB
517[22:55:02] Could not store the bundle size
518[22:55:02] Error: 400 Bad Request: POST request to /store must have numeric fields "gzippedBundleSize" and "brotliBundleSize"
519[22:55:02] Finished 'bundle-size' after 640 ms
```