### PR TITLE
🐛Add CSS rule to hide amp-loaders from stories

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -299,8 +299,8 @@ amp-story-page {
   background-color: #757575;
 }
 
-amp-story .i-amphtml-loader {
-  display: none !important;
+amp-story .amp-active > div {
+  display: none;
 }
 
 /**

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -300,7 +300,7 @@ amp-story-page {
 }
 
 amp-story .amp-active > div {
-  display: none;
+  display: none !important;
 }
 
 /**


### PR DESCRIPTION
Added a rule to ignore amp-active divs on amp-stories to prevent the outdated loader from displaying.
Resolves #24609 