### PR TITLE
🐛Fixes ima-video race condition and percentage played 

### DIFF
--- a/ads/google/ima-player-data.js
+++ b/ads/google/ima-player-data.js
@@ -23,7 +23,7 @@ export class ImaPlayerData {
     this.currentTime = 0;
 
     /* {!Number} */
-    this.duration = NaN;
+    this.duration = 1;
 
     /* {!Array} */
     this.playedRanges = [];

--- a/ads/google/ima-player-data.js
+++ b/ads/google/ima-player-data.js
@@ -23,7 +23,7 @@ export class ImaPlayerData {
     this.currentTime = 0;
 
     /* {!Number} */
-    this.duration = 1;
+    this.duration = NaN;
 
     /* {!Array} */
     this.playedRanges = [];

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -286,6 +286,7 @@ class AmpImaVideo extends AMP.BaseElement {
     }
     if (videoEvent == ImaPlayerData.IMA_PLAYER_DATA) {
       this.playerData_ = /** @type {!ImaPlayerData} */ (eventData['data']);
+      this.element.dispatchCustomEvent(VideoEvents.LOADEDMETADATA);
       return;
     }
     if (videoEvent == 'fullscreenchange') {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1434,7 +1434,7 @@ export class AnalyticsPercentageTracker {
     const duration = video.getDuration();
 
     // Livestreams or videos with no duration information available.
-    if (!duration || isNaN(duration) || duration <= 0) {
+    if (!duration || isNaN(duration) || duration <= 1) {
       return false;
     }
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1433,7 +1433,8 @@ export class AnalyticsPercentageTracker {
     const {video} = this.entry_;
     const duration = video.getDuration();
 
-    // Livestreams or videos with no duration information available.
+    // Livestreams or videos with no duration information available,
+    // where 1 second is the default duration for some video players
     if (!duration || isNaN(duration) || duration <= 1) {
       return false;
     }


### PR DESCRIPTION
Fixes the race condition that causes the ima-video player to freeze with slow network connection. Also added event trigger to calculate percentage played.
Closes #23356 
