### PR TITLE
✨Add amp-iframe support for Pym.js width and height resize messages

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -525,7 +525,7 @@ export class AmpIframe extends AMP.BaseElement {
     } else if ('width' === args[0]) {
       this.updateSize_(undefined, parseInt(args[1], 10));
     } else {
-      user().warn(`Unsupported Pym.js message: ${data}`);
+      user().warn(TAG_, `Unsupported Pym.js message: ${data}`);
     }
   }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -475,7 +475,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     // Listen for resize messages sent by Pym.js.
     this.unlistenPym_ = listen(
-      window,
+      this.win,
       'message',
       this.listenForPymMessage_.bind(this)
     );

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -22,7 +22,7 @@ import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {createCustomEvent, getData, listen} from '../../../src/event-helper';
 import {devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {endsWith} from '../../../src/string';
+import {endsWith, startsWith} from '../../../src/string';
 import {
   isAdLike,
   isPausable,
@@ -510,7 +510,7 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
     const data = getData(event);
-    if (typeof data !== 'string' || 'pym' !== data.substr(0, 3)) {
+    if (typeof data !== 'string' || !startsWith(data, 'pym')) {
       return;
     }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -514,16 +514,16 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
 
-    // The format of the message takes the form of `pym${id}xPYMx${type}xPYMx${message}`.
+    // The format of the message takes the form of `pymxPYMx${id}xPYMx${type}xPYMx${message}`.
     // The id is unnecessary for integration with amp-iframe; the possible types include
     // 'height', 'width', 'parentPositionInfo', 'navigateTo', and  'scrollToChildPos'.
     // Only the 'height' and 'width' messages are currently supported.
     // See <https://github.com/nprapps/pym.js/blob/57feb68/src/pym.js#L85-L102>
-    const args = data.split(/xPYMx/).splice(2);
-    if ('height' === args[0]) {
-      this.updateSize_(parseInt(args[1], 10), undefined);
-    } else if ('width' === args[0]) {
-      this.updateSize_(undefined, parseInt(args[1], 10));
+    const args = data.split(/xPYMx/);
+    if ('height' === args[2]) {
+      this.updateSize_(parseInt(args[3], 10), undefined);
+    } else if ('width' === args[2]) {
+      this.updateSize_(undefined, parseInt(args[3], 10));
     } else {
       user().warn(TAG_, `Unsupported Pym.js message: ${data}`);
     }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -104,7 +104,7 @@ export class AmpIframe extends AMP.BaseElement {
     this.sandbox_ = '';
 
     /** @private {Function} */
-    this.unlisten_ = null;
+    this.unlistenPym_ = null;
 
     /**
      * The source of the iframe. May change to null for tracking iframes
@@ -474,7 +474,7 @@ export class AmpIframe extends AMP.BaseElement {
     );
 
     // Listen for resize messages sent by Pym.js.
-    this.unlisten_ = listen(
+    this.unlistenPym_ = listen(
       window,
       'message',
       this.listenForPymMessage_.bind(this)
@@ -568,9 +568,9 @@ export class AmpIframe extends AMP.BaseElement {
    * @override
    **/
   unlayoutCallback() {
-    if (this.unlisten_) {
-      this.unlisten_();
-      this.unlisten_ = null;
+    if (this.unlistenPym_) {
+      this.unlistenPym_();
+      this.unlistenPym_ = null;
     }
     if (this.iframe_) {
       removeElement(this.iframe_);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -504,7 +504,7 @@ export class AmpIframe extends AMP.BaseElement {
    * Listen for Pym.js messages for 'height' and 'width'.
    *
    * @see http://blog.apps.npr.org/pym.js/
-   * @param {MessageEvent} event
+   * @param {!MessageEvent} event
    * @private
    */
   listenForPymMessage_(event) {

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -474,11 +474,9 @@ export class AmpIframe extends AMP.BaseElement {
     );
 
     // Listen for resize messages sent by Pym.js.
-    this.unlistenPym_ = listen(
-      this.win,
-      'message',
-      this.listenForPymMessage_.bind(this)
-    );
+    this.unlistenPym_ = listen(this.win, 'message', event => {
+      return this.listenForPymMessage_(/** @type {!MessageEvent} */ (event));
+    });
 
     if (this.isClickToPlay_) {
       listenFor(iframe, 'embed-ready', this.activateIframe_.bind(this));

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -508,12 +508,11 @@ export class AmpIframe extends AMP.BaseElement {
    * @private
    */
   listenForPymMessage_(event) {
-    if (
-      !this.iframe_ ||
-      event.source !== this.iframe_.contentWindow ||
-      typeof event.data !== 'string' ||
-      'pym' !== event.data.substr(0, 3)
-    ) {
+    if (!this.iframe_ || event.source !== this.iframe_.contentWindow) {
+      return;
+    }
+    const data = getData(event);
+    if (typeof data !== 'string' || 'pym' !== data.substr(0, 3)) {
       return;
     }
 
@@ -522,7 +521,7 @@ export class AmpIframe extends AMP.BaseElement {
     // 'height', 'width', 'parentPositionInfo', 'navigateTo', and  'scrollToChildPos'.
     // Only the 'height' and 'width' messages are currently supported.
     // See <https://github.com/nprapps/pym.js/blob/57feb68/src/pym.js#L85-L102>
-    const args = event.data.split(/xPYMx/).splice(2);
+    const args = data.split(/xPYMx/).splice(2);
     if ('height' === args[0]) {
       this.updateSize_(parseInt(args[1], 10), undefined);
     } else if ('width' === args[0]) {

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -526,6 +526,8 @@ export class AmpIframe extends AMP.BaseElement {
       this.updateSize_(parseInt(args[1], 10), undefined);
     } else if ('width' === args[0]) {
       this.updateSize_(undefined, parseInt(args[1], 10));
+    } else {
+      user().warn(`Unsupported Pym.js message: ${data}`);
     }
   }
 

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1059,6 +1059,64 @@ describes.realWin(
             ActionTrust.HIGH
           );
         });
+
+        it('should listen for Pym.js height event', function*() {
+          const ampIframe = createAmpIframe(env, {
+            src: iframeSrc,
+            sandbox: 'allow-scripts allow-same-origin',
+            width: 200,
+            height: 200,
+            resizable: '',
+          });
+          yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+          const impl = ampIframe.implementation_;
+          return new Promise((resolve, unusedReject) => {
+            impl.updateSize_ = (height, width) => {
+              resolve({height, width});
+            };
+            const iframe = ampIframe.querySelector('iframe');
+            iframe.contentWindow.postMessage(
+              {
+                sentinel: 'amp-test',
+                type: 'requestPymjsHeight',
+                height: 234,
+              },
+              '*'
+            );
+          }).then(res => {
+            expect(res.height).to.equal(234);
+            expect(res.width).to.be.an('undefined');
+          });
+        });
+
+        it('should listen for Pym.js width event', function*() {
+          const ampIframe = createAmpIframe(env, {
+            src: iframeSrc,
+            sandbox: 'allow-scripts allow-same-origin',
+            width: 200,
+            height: 200,
+            resizable: '',
+          });
+          yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+          const impl = ampIframe.implementation_;
+          return new Promise((resolve, unusedReject) => {
+            impl.updateSize_ = (height, width) => {
+              resolve({height, width});
+            };
+            const iframe = ampIframe.querySelector('iframe');
+            iframe.contentWindow.postMessage(
+              {
+                sentinel: 'amp-test',
+                type: 'requestPymjsWidth',
+                width: 345,
+              },
+              '*'
+            );
+          }).then(res => {
+            expect(res.width).to.equal(345);
+            expect(res.height).to.be.an('undefined');
+          });
+        });
       });
 
       describe('pause/resume', () => {

--- a/test/fixtures/served/iframe.html
+++ b/test/fixtures/served/iframe.html
@@ -53,10 +53,10 @@ window.addEventListener('message', function(event) {
             type: 'send-embed-state',
           }, '*');
     } else if (event.data.type === 'requestPymjsHeight') {
-      var msg = [ 'pym', 'height', event.data.height ].join( 'xPYMx' );
+      var msg = [ 'pym', 'example', 'height', event.data.height ].join( 'xPYMx' );
       getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
     } else if (event.data.type === 'requestPymjsWidth') {
-      var msg = [ 'pym', 'width', event.data.height ].join( 'xPYMx' );
+      var msg = [ 'pym', 'example', 'width', event.data.height ].join( 'xPYMx' );
       getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
     }
   }

--- a/test/fixtures/served/iframe.html
+++ b/test/fixtures/served/iframe.html
@@ -52,6 +52,12 @@ window.addEventListener('message', function(event) {
             sentinel: sentinel,
             type: 'send-embed-state',
           }, '*');
+    } else if (event.data.type === 'requestPymjsHeight') {
+      var msg = [ 'pym', 'height', event.data.height ].join( 'xPYMx' );
+      getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
+    } else if (event.data.type === 'requestPymjsWidth') {
+      var msg = [ 'pym', 'width', event.data.height ].join( 'xPYMx' );
+      getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
     }
   }
 });

--- a/test/fixtures/served/iframe.html
+++ b/test/fixtures/served/iframe.html
@@ -25,9 +25,9 @@ function getAmpWindow(sentinel) {
 }
 
 window.addEventListener('message', function(event) {
+  var sentinel, msg;
   if (event.data) {
-    if (event.data.type == 'requestHeight') {
-      var sentinel;
+    if (event.data.type === 'requestHeight') {
       if (event.data.is3p) {
         sentinel = event.data.sentinel;
       } else {
@@ -40,8 +40,7 @@ window.addEventListener('message', function(event) {
             height: event.data.height,
             width: event.data.width,
           }, '*');
-    } else if (event.data.type == 'subscribeToEmbedState') {
-      var sentinel;
+    } else if (event.data.type === 'subscribeToEmbedState') {
       if (event.data.is3p) {
         sentinel = event.data.sentinel;
       } else {
@@ -53,10 +52,20 @@ window.addEventListener('message', function(event) {
             type: 'send-embed-state',
           }, '*');
     } else if (event.data.type === 'requestPymjsHeight') {
-      var msg = [ 'pym', 'example', 'height', event.data.height ].join( 'xPYMx' );
+      msg = [ 'pym', 'example', 'height', event.data.height ].join( 'xPYMx' );
+      if (event.data.is3p) {
+        sentinel = event.data.sentinel;
+      } else {
+        sentinel = 'amp';
+      }
       getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
-    } else if (event.data.type === 'requestPymjsWidth') {
-      var msg = [ 'pym', 'example', 'width', event.data.height ].join( 'xPYMx' );
+    } else if (event.data.type === 'requestPymjsWidth' || 1) {
+      msg = [ 'pym', 'example', 'width', event.data.width ].join( 'xPYMx' );
+      if (event.data.is3p) {
+        sentinel = event.data.sentinel;
+      } else {
+        sentinel = 'amp';
+      }
       getAmpWindow(sentinel)./*OK*/postMessage( msg, '*');
     }
   }


### PR DESCRIPTION
Fixes #22714.

Pym.js supports the client window sending several types of messages, including:

* `height`
* `width`
* `parentPositionInfo`
* `navigateTo`
* `scrollToChildPos`

The only two messages that seem relevant in an AMP context are `width` and `height`, as they map to the [`embed-size` message](https://amp.dev/documentation/components/amp-iframe/?format=websites#iframe-resizing) that AMP is currently looking for.

[Demo video](https://youtu.be/sL7sdsBjNIQ) (YouTube): 

> [![Demo video](http://i.ytimg.com/vi/sL7sdsBjNIQ/maxresdefault.jpg)](https://youtu.be/sL7sdsBjNIQ)

The code can be tested using this Glitch: https://amp-iframe-pymjs-resizable.glitch.me/