### PR TITLE
fix(amp-yotpo):restore child iframe in layoutCallback

### DIFF
--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -52,24 +52,6 @@ export class AmpYotpo extends AMP.BaseElement {
       'The data-widget-type attribute is required for <amp-yotpo> %s',
       this.element
     );
-    const iframe = getIframe(this.win, this.element, 'yotpo');
-    this.applyFillContent(iframe);
-
-    const unlisten = listenFor(
-      iframe,
-      'embed-size',
-      data => {
-        this.attemptChangeHeight(data['height']).catch(() => {
-          /* do nothing */
-        });
-      },
-      /* opt_is3P */ true
-    );
-    this.unlisteners_.push(unlisten);
-
-    this.element.appendChild(iframe);
-    this.iframe_ = iframe;
-    return this.loadPromise(iframe);
   }
 
   /** @override */
@@ -92,6 +74,28 @@ export class AmpYotpo extends AMP.BaseElement {
       this.iframe_ = null;
     }
     return true;
+  }
+
+  /** @override */
+  layoutCallback() {
+    const iframe = getIframe(this.win, this.element, 'yotpo');
+    this.applyFillContent(iframe);
+
+    const unlisten = listenFor(
+      iframe,
+      'embed-size',
+      data => {
+        this.attemptChangeHeight(data['height']).catch(() => {
+          /* do nothing */
+        });
+      },
+      /* opt_is3P */ true
+    );
+    this.unlisteners_.push(unlisten);
+
+    this.element.appendChild(iframe);
+    this.iframe_ = iframe;
+    return this.loadPromise(iframe);
   }
 }
 


### PR DESCRIPTION
corresponding to issue  #20559: Child iframe removed in unlayoutCallback but never restored. b/123308595

added layoutCallback to load child iframe 