### PR TITLE
🏗 Change Attribute Name in SwG Encrypted Scripts

### DIFF
--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -73,7 +73,7 @@ export class CryptoHandler {
     this.decryptionPromise_ = this.ampdoc_.whenReady().then(() => {
       const encryptedSections = this.ampdoc_
         .getRootNode()
-        .querySelectorAll('script[encrypted]');
+        .querySelectorAll('script[ciphertext]');
       const promises = [];
       iterateCursor(encryptedSections, encryptedSection => {
         promises.push(

--- a/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
@@ -73,21 +73,23 @@ describes.realWin(
 
       // Create encrypted content in the document body.
       const crypt1 = win.document.createElement('script');
-      crypt1.setAttribute('encrypted', '');
+      crypt1.setAttribute('ciphertext', '');
       crypt1.setAttribute('type', 'application/octet-stream');
       crypt1.textContent = encryptedContent;
       cryptoSection1 = win.document.createElement('section');
       cryptoSection1.setAttribute('subscriptions-section', 'content');
+      cryptoSection1.setAttribute('encrypted', '');
       cryptoSection1.appendChild(crypt1);
       win.document.body.appendChild(cryptoSection1);
 
       // Create encrypted content in the document body.
       const crypt2 = win.document.createElement('script');
-      crypt2.setAttribute('encrypted', '');
+      crypt2.setAttribute('ciphertext', '');
       crypt2.setAttribute('type', 'application/octet-stream');
       crypt2.textContent = encryptedContent;
       cryptoSection2 = win.document.createElement('section');
       cryptoSection2.setAttribute('subscriptions-section', 'content');
+      cryptoSection2.setAttribute('encrypted', '');
       cryptoSection2.appendChild(crypt2);
       win.document.body.appendChild(cryptoSection2);
 


### PR DESCRIPTION
Changes the attribute name in SwG encrypted scripts from "encrypted" to "ciphertext" to avoid attribute duplication between the script tag and the surrounding section tag.