### PR TITLE
🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery.

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -146,7 +146,7 @@ class AmpCarousel extends AMP.BaseElement {
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
 
-    this.setupCarouselDom_();
+    this.buildCarouselDom_();
 
     this.carousel_ = new Carousel({
       win: this.win,
@@ -162,9 +162,9 @@ class AmpCarousel extends AMP.BaseElement {
     });
 
     this.carousel_.updateSlides(this.slides_);
-    this.setupChildVisibilityTracking_();
-    this.setupActions_();
-    this.setupListeners_();
+    this.initializeChildLayoutManagement_();
+    this.initializeActions_();
+    this.initializeListeners_();
     this.updateUi_();
   }
 
@@ -232,7 +232,7 @@ class AmpCarousel extends AMP.BaseElement {
    * Creates the DOM for the carousel, placing the children into their correct
    * spot.
    */
-  setupCarouselDom_() {
+  buildCarouselDom_() {
     const {element} = this;
     const children = toArray(element.children);
     let prevArrow;
@@ -330,7 +330,7 @@ class AmpCarousel extends AMP.BaseElement {
    * Setups up visibility tracking for the child elements, laying them out
    * when needed.
    */
-  setupChildVisibilityTracking_() {
+  initializeChildLayoutManagement_() {
     // Set up management of layout for the child slides.
     const owners = Services.ownersForDoc(this.element);
     this.childLayoutManager_ = new ChildLayoutManager({
@@ -368,7 +368,7 @@ class AmpCarousel extends AMP.BaseElement {
   /**
    * @private
    */
-  setupActions_() {
+  initializeActions_() {
     this.registerAction(
       'prev',
       ({trust}) => {
@@ -397,7 +397,7 @@ class AmpCarousel extends AMP.BaseElement {
   /**
    * @private
    */
-  setupListeners_() {
+  initializeListeners_() {
     this.element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
       this.onIndexChanged_(event);
     });

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -53,6 +53,12 @@ class AmpCarousel extends AMP.BaseElement {
     /** @private @const */
     this.responsiveAttributes_ = this.getAttributeConfig_();
 
+    /** @private @const {boolean} */
+    this.isIos_ = Services.platformFor(this.win).isIos();
+
+    /** @private {?Element} */
+    this.scrollContainer_ = null;
+
     /** @private {?Carousel} */
     this.carousel_ = null;
 
@@ -188,6 +194,7 @@ class AmpCarousel extends AMP.BaseElement {
   /** @override */
   unlayoutCallback() {
     this.childLayoutManager_.wasUnlaidOut();
+    return true;
   }
 
   /** @override */
@@ -202,7 +209,6 @@ class AmpCarousel extends AMP.BaseElement {
   /**
    * Moves the Carousel to a given index.
    * @param {number} index
-   * @return {!Promise<undefined>}
    */
   goToSlide(index) {
     this.carousel_.goToSlide(index, {smoothScroll: false});
@@ -247,11 +253,6 @@ class AmpCarousel extends AMP.BaseElement {
     // Create the DOM, get references to elements.
     element.appendChild(this.renderContainerDom_());
     this.scrollContainer_ = element.querySelector('.i-amphtml-carousel-scroll');
-    this.slidesContainer_ = element.querySelector(
-      '.i-amphtml-stream-gallery-slides'
-    );
-
-    this.content_ = element.querySelector('.i-amphtml-carousel-content');
     this.prevArrowSlot_ = this.element.querySelector(
       '.i-amphtml-base-carousel-arrow-prev-slot'
     );
@@ -334,7 +335,7 @@ class AmpCarousel extends AMP.BaseElement {
     const owners = Services.ownersForDoc(this.element);
     this.childLayoutManager_ = new ChildLayoutManager({
       ampElement: this,
-      intersectionElement: this.scrollContainer_,
+      intersectionElement: dev().assertElement(this.scrollContainer_),
       // For iOS, we queue changes until scrolling stops, which we detect
       // ~200ms after it actually stops. Load items earlier so they have time
       // to load.

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -19,22 +19,22 @@ import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-base-carousel-0.1.css';
 import {Carousel} from './carousel.js';
 import {CarouselEvents} from './carousel-events';
+import {ChildLayoutManager} from './child-layout-manager';
 import {
   ResponsiveAttributes,
   getResponsiveAttributeValue,
 } from './responsive-attributes';
 import {Services} from '../../../src/services';
-import {
-  closestAncestorElementBySelector,
-  iterateCursor,
-  toggleAttribute,
-} from '../../../src/dom';
 import {createCustomEvent, getDetail} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
-import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {
+  iterateCursor,
+  scopedQuerySelectorAll,
+  toggleAttribute,
+} from '../../../src/dom';
 import {toArray} from '../../../src/types';
 
 /**
@@ -50,8 +50,8 @@ class AmpCarousel extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @protected {number} */
-    this.advanceCount_ = 1;
+    /** @private @const */
+    this.responsiveAttributes_ = this.getAttributeConfig_();
 
     /** @private {?Carousel} */
     this.carousel_ = null;
@@ -75,8 +75,17 @@ class AmpCarousel extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private @const */
-    this.responsiveAttributes_ = new ResponsiveAttributes({
+    /** @private {?ChildLayoutManager} */
+    this.childLayoutManager_ = null;
+  }
+
+  /**
+   * The configuration for handling attributes on this element.
+   * @return {!Object<string, function(string)>}
+   * @private
+   */
+  getAttributeConfig_() {
+    return new ResponsiveAttributes({
       'advance-count': newValue => {
         this.carousel_.updateAdvanceCount(Number(newValue) || 0);
       },
@@ -131,76 +140,26 @@ class AmpCarousel extends AMP.BaseElement {
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
 
-    const {element, win} = this;
-    const children = toArray(element.children);
-    let prevArrow;
-    let nextArrow;
-    // Figure out which slot the children go into.
-    children.forEach(c => {
-      const slot = c.getAttribute('slot');
-      if (slot == 'prev-arrow') {
-        prevArrow = c;
-      } else if (slot == 'next-arrow') {
-        nextArrow = c;
-      } else if (!isSizer(c)) {
-        this.slides_.push(c);
-      }
-    });
-    // Create the carousel's inner DOM.
-    element.appendChild(this.renderContainerDom_());
-
-    const scrollContainer = dev().assertElement(
-      this.element.querySelector('.i-amphtml-carousel-scroll')
-    );
+    this.setupCarouselDom_();
 
     this.carousel_ = new Carousel({
-      win,
-      element,
-      scrollContainer,
+      win: this.win,
+      element: this.element,
+      scrollContainer: dev().assertElement(this.scrollContainer_),
       initialIndex: this.getInitialIndex_(),
       runMutate: cb => this.mutateElement(cb),
     });
-
-    // Do some manual "slot" distribution
-    this.slides_.forEach(slide => {
-      slide.classList.add('i-amphtml-carousel-slotted');
-      scrollContainer.appendChild(slide);
-    });
-    this.prevArrowSlot_ = this.element.querySelector(
-      '.i-amphtml-base-carousel-arrow-prev-slot'
-    );
-    this.nextArrowSlot_ = this.element.querySelector(
-      '.i-amphtml-base-carousel-arrow-next-slot'
-    );
-    // Slot the arrows, with defaults
-    this.prevArrowSlot_.appendChild(prevArrow || this.createPrevArrow_());
-    this.nextArrowSlot_.appendChild(nextArrow || this.createNextArrow_());
 
     // Handle the initial set of attributes
     toArray(this.element.attributes).forEach(attr => {
       this.attributeMutated_(attr.name, attr.value);
     });
 
-    // Setup actions and listeners
-    this.setupActions_();
-    this.element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
-      this.onIndexChanged_(event);
-    });
-    this.prevArrowSlot_.addEventListener('click', event => {
-      if (event.target != event.currentTarget) {
-        this.carousel_.prev(ActionSource.GENERIC_HIGH_TRUST);
-      }
-    });
-    this.nextArrowSlot_.addEventListener('click', event => {
-      if (event.target != event.currentTarget) {
-        this.carousel_.next(ActionSource.GENERIC_HIGH_TRUST);
-      }
-    });
-
     this.carousel_.updateSlides(this.slides_);
+    this.setupChildVisibilityTracking_();
+    this.setupActions_();
+    this.setupListeners_();
     this.updateUi_();
-    // Signal for runtime to check children for layout.
-    return this.mutateElement(() => {});
   }
 
   /** @override */
@@ -209,29 +168,26 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /** @override */
-  layoutCallback() {
-    // TODO(sparhami) #19259 Tracks a more generic way to do this. Remove once
-    // we have something better.
-    const isScaled = closestAncestorElementBySelector(
-      this.element,
-      '[i-amphtml-scale-animation]'
-    );
-    if (isScaled) {
-      return Promise.resolve();
-    }
-
-    this.carousel_.updateUi();
-    return Promise.resolve();
-  }
-
-  /** @override */
   pauseCallback() {
-    this.carousel_.pauseAutoAdvance();
+    this.carousel_.pauseLayout();
   }
 
   /** @override */
   resumeCallback() {
-    this.carousel_.resumeAutoAdvance();
+    this.carousel_.resumeLayout();
+  }
+
+  /** @override */
+  layoutCallback() {
+    this.carousel_.updateUi();
+    this.childLayoutManager_.wasLaidOut();
+
+    return Promise.resolve();
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    this.childLayoutManager_.wasUnlaidOut();
   }
 
   /** @override */
@@ -246,6 +202,7 @@ class AmpCarousel extends AMP.BaseElement {
   /**
    * Moves the Carousel to a given index.
    * @param {number} index
+   * @return {!Promise<undefined>}
    */
   goToSlide(index) {
     this.carousel_.goToSlide(index, {smoothScroll: false});
@@ -263,6 +220,53 @@ class AmpCarousel extends AMP.BaseElement {
    */
   interactionPrev() {
     this.carousel_.prev(ActionSource.GENERIC_HIGH_TRUST);
+  }
+
+  /**
+   * Creates the DOM for the carousel, placing the children into their correct
+   * spot.
+   */
+  setupCarouselDom_() {
+    const {element} = this;
+    const children = toArray(element.children);
+    let prevArrow;
+    let nextArrow;
+
+    // Figure out which "slot" the children go into.
+    children.forEach(c => {
+      const slot = c.getAttribute('slot');
+      if (slot == 'prev-arrow') {
+        prevArrow = c;
+      } else if (slot == 'next-arrow') {
+        nextArrow = c;
+      } else if (!isSizer(c)) {
+        this.slides_.push(c);
+      }
+    });
+
+    // Create the DOM, get references to elements.
+    element.appendChild(this.renderContainerDom_());
+    this.scrollContainer_ = element.querySelector('.i-amphtml-carousel-scroll');
+    this.slidesContainer_ = element.querySelector(
+      '.i-amphtml-stream-gallery-slides'
+    );
+
+    this.content_ = element.querySelector('.i-amphtml-carousel-content');
+    this.prevArrowSlot_ = this.element.querySelector(
+      '.i-amphtml-base-carousel-arrow-prev-slot'
+    );
+    this.nextArrowSlot_ = this.element.querySelector(
+      '.i-amphtml-base-carousel-arrow-next-slot'
+    );
+
+    // Do some manual "slot" distribution
+    this.slides_.forEach(slide => {
+      slide.classList.add('i-amphtml-carousel-slotted');
+      this.scrollContainer_.appendChild(slide);
+    });
+
+    this.prevArrowSlot_.appendChild(prevArrow || this.createPrevArrow_());
+    this.nextArrowSlot_.appendChild(nextArrow || this.createNextArrow_());
   }
 
   /**
@@ -322,6 +326,45 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /**
+   * Setups up visibility tracking for the child elements, laying them out
+   * when needed.
+   */
+  setupChildVisibilityTracking_() {
+    // Set up management of layout for the child slides.
+    const owners = Services.ownersForDoc(this.element);
+    this.childLayoutManager_ = new ChildLayoutManager({
+      ampElement: this,
+      intersectionElement: this.scrollContainer_,
+      // For iOS, we queue changes until scrolling stops, which we detect
+      // ~200ms after it actually stops. Load items earlier so they have time
+      // to load.
+      nearbyMarginInPercent: this.isIos_ ? 200 : 100,
+      viewportIntersectionCallback: (child, isIntersecting) => {
+        if (isIntersecting) {
+          owners.scheduleResume(this.element, child);
+        } else {
+          owners.schedulePause(this.element, child);
+        }
+      },
+    });
+    // For iOS, we cannot trigger layout during scrolling or the UI will
+    // flicker, so tell the layout to simply queue the changes, which we
+    // flush after scrolling stops.
+    this.childLayoutManager_.setQueueChanges(this.isIos_);
+
+    // For amp-inline-gallery-slide, we need to actually monitor the content,
+    // which is transformed instead of the slide.
+    const monitoredDescendants = this.slides_
+      .map(slide => {
+        return slide.localName === 'amp-inline-gallery-slide'
+          ? toArray(scopedQuerySelectorAll(slide, '> :not([slot])'))
+          : slide;
+      })
+      .reduce((arr, children) => arr.concat(children), []);
+    this.childLayoutManager_.updateChildren(monitoredDescendants);
+  }
+
+  /**
    * @private
    */
   setupActions_() {
@@ -351,6 +394,42 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /**
+   * @private
+   */
+  setupListeners_() {
+    this.element.addEventListener(CarouselEvents.INDEX_CHANGE, event => {
+      this.onIndexChanged_(event);
+    });
+    this.element.addEventListener(CarouselEvents.SCROLL_START, () => {
+      this.onScrollStarted_();
+    });
+    this.element.addEventListener(
+      CarouselEvents.SCROLL_POSITION_CHANGED,
+      () => {
+        this.onScrollPositionChanged_();
+      }
+    );
+    this.element.addEventListener('goToSlide', event => {
+      const detail = getDetail(event);
+      this.carousel_.goToSlide(detail['index']);
+    });
+    this.prevArrowSlot_.addEventListener('click', event => {
+      // Make sure the slot itself was not clicked, since that fills the
+      // entire height of the gallery.
+      if (event.target != event.currentTarget) {
+        this.carousel_.prev(ActionSource.GENERIC_HIGH_TRUST);
+      }
+    });
+    this.nextArrowSlot_.addEventListener('click', event => {
+      // Make sure the slot itself was not clicked, since that fills the
+      // entire height of the gallery.
+      if (event.target != event.currentTarget) {
+        this.carousel_.next(ActionSource.GENERIC_HIGH_TRUST);
+      }
+    });
+  }
+
+  /**
    * Updates the UI of the <amp-base-carousel> itself, but not the internal
    * implementation.
    * @private
@@ -373,6 +452,27 @@ class AmpCarousel extends AMP.BaseElement {
       'i-amphtml-base-carousel-hide-buttons',
       this.hadTouch_
     );
+  }
+
+  /**
+   * Starts queuing all intersection based changes when scrolling starts, to
+   * prevent paint flickering on iOS.
+   */
+  onScrollStarted_() {
+    this.childLayoutManager_.setQueueChanges(this.isIos_);
+  }
+
+  /**
+   * Update the UI (buttons) for the new scroll position. This occurs when
+   * scrolling has settled.
+   */
+  onScrollPositionChanged_() {
+    // Now that scrolling has settled, flush any layout changes for iOS since
+    // it will not cause flickering.
+    this.childLayoutManager_.flushChanges();
+    this.childLayoutManager_.setQueueChanges(false);
+
+    this.updateUi_();
   }
 
   /**
@@ -428,12 +528,5 @@ class AmpCarousel extends AMP.BaseElement {
 }
 
 AMP.extension('amp-base-carousel', '0.1', AMP => {
-  if (
-    !isExperimentOn(AMP.win, 'amp-base-carousel') &&
-    !isExperimentOn(AMP.win, 'amp-lightbox-gallery-base-carousel')
-  ) {
-    return;
-  }
-
   AMP.registerElement('amp-base-carousel', AmpCarousel, CSS);
 });

--- a/extensions/amp-base-carousel/0.1/carousel-events.js
+++ b/extensions/amp-base-carousel/0.1/carousel-events.js
@@ -16,6 +16,7 @@
 
 /** @enum {string} */
 export const CarouselEvents = {
+  OFFSET_CHANGE: 'amp-carousel:offsetchange',
   INDEX_CHANGE: 'amp-carousel:indexchange',
   SCROLL_START: 'amp-carousel:scrollstart',
   SCROLL_POSITION_CHANGED: 'amp-carousel:scrollpositionchange',

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -20,11 +20,11 @@ import {
   Axis,
   findOverlappingIndex,
   getDimension,
-  getScrollPosition,
+  getPercentageOffsetFromAlignment,
   scrollContainerToElement,
-  setScrollPosition,
   setTransformTranslateStyle,
   updateLengthStyle,
+  updateScrollPosition,
 } from './dimensions.js';
 import {AutoAdvance} from './auto-advance';
 import {CarouselAccessibility} from './carousel-accessibility';
@@ -218,6 +218,11 @@ export class Carousel {
     this.allSpacers_ = [];
 
     /**
+     * @private {boolean}
+     */
+    this.layoutPaused_ = false;
+
+    /**
      * Set from sources of programmatic scrolls to avoid doing work associated
      * with regular scrolling.
      * @private {boolean}
@@ -225,10 +230,11 @@ export class Carousel {
     this.ignoreNextScroll_ = false;
 
     /**
-     * The offset from the start edge for the element at the current index.
-     * This is used to preserve relative scroll position when updating the UI
-     * after things have moved (e.g. on rotate).
-     * @protected {number}
+     * The offset for the current element, based on the alignment and axis. This
+     * is a percentage of the Element's length along the current axis. This is
+     * used to preserve relative scroll position when updating the UI after
+     * things have moved (e.g. on rotate).
+     * @private {number}
      */
     this.currentElementOffset_ = 0;
 
@@ -389,11 +395,11 @@ export class Carousel {
     // If we have a requested index, use that as the reference point. The
     // current index may not be updated yet.This allows calling `advance`
     // multiple times in a row and ending on the correct slide.
-    const index = requestedIndex_ != null ? requestedIndex_ : currentIndex_;
+    const index = requestedIndex_ !== null ? requestedIndex_ : currentIndex_;
     const newIndex = index + delta;
     const endIndex = slides_.length - 1;
-    const atStart = index == 0;
-    const atEnd = index == endIndex;
+    const atStart = index === 0;
+    const atEnd = index === endIndex;
     const passingStart = newIndex < 0;
     const passingEnd = newIndex > endIndex;
 
@@ -420,20 +426,21 @@ export class Carousel {
   }
 
   /**
-   * Pauses the auto advance temporarily. This can be resumed by calling
-   * resumeAutoAdvance. This should only be used internally for the carousel
-   * implementation and not exposed.
+   * Pauses the layout temporarily. This can be resumed by calling
+   * `resumseLayout`.
    */
-  pauseAutoAdvance() {
+  pauseLayout() {
+    this.layoutPaused_ = true;
     this.autoAdvance_.pause();
   }
 
   /**
-   * Resumes auto advance when paused by pauseAutoAdvance. Note that if the
-   * autoadvance has been stopped, this has no effect. This should only be used
-   * internally for the carousel implementation and not exposed.
+   * Resumes layout of the component. This will update the UI to the correct
+   * state if there were changes since pausing layout.
    */
-  resumeAutoAdvance() {
+  resumeLayout() {
+    this.layoutPaused_ = false;
+    this.updateUi();
     this.autoAdvance_.resume();
   }
 
@@ -474,7 +481,7 @@ export class Carousel {
       return;
     }
 
-    if (index == this.currentIndex_) {
+    if (index === this.currentIndex_) {
       return;
     }
 
@@ -505,7 +512,8 @@ export class Carousel {
    *    either "start" or "cemter".
    */
   updateAlignment(alignment) {
-    this.alignment_ = alignment == 'start' ? Alignment.START : Alignment.CENTER;
+    this.alignment_ =
+      alignment === 'start' ? Alignment.START : Alignment.CENTER;
     this.updateUi();
   }
 
@@ -597,7 +605,6 @@ export class Carousel {
   updateSlides(slides) {
     this.slides_ = slides;
     this.carouselAccessibility_.updateSlides(slides);
-    this.updateUi();
   }
 
   /**
@@ -634,7 +641,7 @@ export class Carousel {
    * slide is at the start / center of the scrollable, depending on alignment).
    */
   updateUi() {
-    if (this.updating_) {
+    if (this.updating_ || this.layoutPaused_) {
       return;
     }
 
@@ -647,7 +654,7 @@ export class Carousel {
         this.userScrollable_
       );
       this.scrollContainer_.setAttribute('hide-scrollbar', this.hideScrollbar_);
-      this.scrollContainer_.setAttribute('horizontal', this.axis_ == Axis.X);
+      this.scrollContainer_.setAttribute('horizontal', this.axis_ === Axis.X);
       this.scrollContainer_.setAttribute('loop', this.isLooping());
       this.scrollContainer_.setAttribute('snap', this.snap_);
       // TODO(sparhami) Do not use CSS custom property
@@ -688,7 +695,7 @@ export class Carousel {
    * @private
    */
   updateRestingIndex_(restingIndex, actionSource) {
-    if (this.restingIndex_ == restingIndex) {
+    if (this.restingIndex_ === restingIndex) {
       return;
     }
 
@@ -699,8 +706,39 @@ export class Carousel {
         CarouselEvents.INDEX_CHANGE,
         dict({
           'index': restingIndex,
+          'total': this.slides_.length,
           'actionSource': actionSource,
-        })
+          'slides': this.slides_,
+        }),
+        {
+          bubbles: true,
+        }
+      )
+    );
+  }
+
+  /**
+   * Updates the current offset within the current Element as well as firing an
+   * event.
+   * @param {number} index The index of the Element.
+   * @param {number} offset The offset, as a percentage of the Element's width.
+   */
+  updateCurrentElementOffset_(index, offset) {
+    this.currentIndex_ = index;
+    this.currentElementOffset_ = offset;
+    this.element_.dispatchEvent(
+      createCustomEvent(
+        this.win_,
+        CarouselEvents.OFFSET_CHANGE,
+        dict({
+          'index': index,
+          'total': this.slides_.length,
+          'offset': offset,
+          'slides': this.slides_,
+        }),
+        {
+          bubbles: true,
+        }
       )
     );
   }
@@ -795,8 +833,8 @@ export class Carousel {
   isUserScrolling_() {
     return (
       this.scrolling_ &&
-      (this.actionSource_ == ActionSource.TOUCH ||
-        this.actionSource_ == ActionSource.WHEEL)
+      (this.actionSource_ === ActionSource.TOUCH ||
+        this.actionSource_ === ActionSource.WHEEL)
     );
   }
 
@@ -957,8 +995,8 @@ export class Carousel {
    */
   setChildrenSnapAlign_() {
     const slideCount = this.slides_.length;
-    const startAligned = this.alignment_ == Alignment.START;
-    const oddVisibleCount = mod(this.visibleCount_, 2) == 1;
+    const startAligned = this.alignment_ === Alignment.START;
+    const oddVisibleCount = mod(this.visibleCount_, 2) === 1;
     // For the legacy scroll-snap-coordinate, when center aligning with an odd
     // count, actually use a start coordinate. Otherwise it will snap to the
     // center of the slides near the edge of the container. That is
@@ -974,7 +1012,7 @@ export class Carousel {
       // to do the mapping.
       const slideIndex = mod(index, slideCount);
       // If an item is at the start of the group, it gets an aligned.
-      const shouldSnap = mod(slideIndex, this.snapBy_) == 0;
+      const shouldSnap = mod(slideIndex, this.snapBy_) === 0;
 
       setStyles(child, {
         'scroll-snap-align': shouldSnap ? this.alignment_ : 'none',
@@ -1056,24 +1094,29 @@ export class Carousel {
       return;
     }
 
+    // The overlapping element, may be a spacer.
+    const overlappingElement = items[overlappingIndex];
     // Since we are potentially looking accross all spacers, we need to convert
     // to a slide index.
     const newIndex = overlappingIndex % slides_.length;
-    // Update the current offset on each scroll so that we have it up to date
-    // in case of a resize.
-    const currentElement = slides_[newIndex];
-    const {start: elementStart} = getDimension(axis_, currentElement);
-    const {start: containerStart} = getDimension(axis_, scrollContainer_);
 
-    this.currentElementOffset_ = elementStart - containerStart;
+    // Update the current offset on each scroll so that we have it up to date
+    // in case of a resize. Also notifies interested parties about where we are
+    // within the current index.
+    const offset = getPercentageOffsetFromAlignment(
+      axis_,
+      alignment_,
+      scrollContainer_,
+      overlappingElement
+    );
+    this.updateCurrentElementOffset_(newIndex, offset);
 
     // We did not move at all.
-    if (newIndex == currentIndex_) {
+    if (newIndex === currentIndex_) {
       return;
     }
 
     this.runMutate_(() => {
-      this.currentIndex_ = newIndex;
       this.moveSlides_(totalLength);
     });
   }
@@ -1108,8 +1151,8 @@ export class Carousel {
     // event. If we have a programmatic scroll request, we still need to move
     // to that index.
     if (
-      this.restingIndex_ == this.currentIndex_ &&
-      this.requestedIndex_ == null &&
+      this.restingIndex_ === this.currentIndex_ &&
+      this.requestedIndex_ === null &&
       !force
     ) {
       return;
@@ -1117,7 +1160,7 @@ export class Carousel {
 
     // We are updating during a programmatic scroll, so go to the correct
     // index.
-    if (this.requestedIndex_ != null) {
+    if (this.requestedIndex_ !== null) {
       this.currentIndex_ = this.requestedIndex_;
       this.requestedIndex_ = null;
     }
@@ -1126,12 +1169,19 @@ export class Carousel {
 
     this.runMutate_(() => {
       this.updateRestingIndex_(this.currentIndex_, actionSource_);
-
+      this.updateCurrentElementOffset_(
+        this.currentIndex_,
+        this.currentElementOffset_
+      );
       this.resetSlideTransforms_(totalLength);
       this.hideSpacersAndSlides_();
       this.moveSlides_(totalLength);
       this.restoreScrollStart_();
     });
+
+    this.element_.dispatchEvent(
+      createCustomEvent(this.win_, 'reset-reference-point')
+    );
   }
 
   /**
@@ -1143,6 +1193,7 @@ export class Carousel {
    */
   restoreScrollStart_() {
     const {
+      alignment_,
       axis_,
       currentElementOffset_,
       currentIndex_,
@@ -1150,21 +1201,28 @@ export class Carousel {
       slides_,
     } = this;
     const currentElement = slides_[currentIndex_];
-    const {length: containerLength, start: containerStart} = getDimension(
+    // Figure out what is the difference between where the Element is, and
+    // where it should be as a percentage of its length.
+    const actualOffset = getPercentageOffsetFromAlignment(
       axis_,
-      scrollContainer_
+      alignment_,
+      scrollContainer_,
+      currentElement
     );
-    const {start: elementStart} = getDimension(axis_, currentElement);
-    const scrollPos = getScrollPosition(axis_, scrollContainer_);
-    const offset =
-      Math.abs(currentElementOffset_) <= containerLength
-        ? currentElementOffset_
-        : 0;
-    const pos = elementStart - offset - containerStart + scrollPos;
+    const deltaOffset = actualOffset - currentElementOffset_;
+    // Now convert the offset into pixels.
+    const {length} = getDimension(axis_, currentElement);
+    const deltaInPixels = deltaOffset * length;
+
+    // No scroll will happen, make sure the `ignoreNextScroll_` flag is not
+    // set.
+    if (!deltaInPixels) {
+      return;
+    }
 
     this.ignoreNextScroll_ = true;
     runDisablingSmoothScroll(scrollContainer_, () => {
-      setScrollPosition(axis_, scrollContainer_, pos);
+      updateScrollPosition(axis_, scrollContainer_, deltaInPixels);
     });
   }
 
@@ -1180,10 +1238,10 @@ export class Carousel {
     const runner = smoothScroll ? (el, cb) => cb() : runDisablingSmoothScroll;
     runner(this.scrollContainer_, () => {
       scrollContainerToElement(
-        slide,
-        this.scrollContainer_,
         this.axis_,
-        this.alignment_
+        this.alignment_,
+        this.scrollContainer_,
+        slide
       );
     });
   }
@@ -1238,7 +1296,7 @@ export class Carousel {
     // TODO(sparhami) The current approach of moving a set number of slides
     // does not work well for the mixed length use case.
     const {alignment_, slides_, visibleCount_} = this;
-    const isStartAligned = alignment_ == Alignment.START;
+    const isStartAligned = alignment_ === Alignment.START;
     // How many slides fit into the current "window" of slides. When center
     // aligning, we can ignore this as we want to have the same amount on both
     // sides.
@@ -1260,7 +1318,7 @@ export class Carousel {
    */
   inLastWindow_(index) {
     const {alignment_, slides_, visibleCount_} = this;
-    const startAligned = alignment_ == Alignment.START;
+    const startAligned = alignment_ === Alignment.START;
     const lastWindowSize = startAligned ? visibleCount_ : visibleCount_ / 2;
 
     return index >= slides_.length - lastWindowSize;

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -1178,10 +1178,6 @@ export class Carousel {
       this.moveSlides_(totalLength);
       this.restoreScrollStart_();
     });
-
-    this.element_.dispatchEvent(
-      createCustomEvent(this.win_, 'reset-reference-point')
-    );
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/dimensions.js
+++ b/extensions/amp-base-carousel/0.1/dimensions.js
@@ -85,6 +85,19 @@ export function getStart(axis, el) {
 }
 
 /**
+ * @param {!Axis} axis The Axis to get the position for.
+ * @param {!Alignment} alignment The Alignment to get the position for.
+ * @param {!Element} el The Element to get the position for.
+ * @return {number} The position for the given Element along the given axis for
+ *    the given alignment.
+ */
+export function getPosition(axis, alignment, el) {
+  return alignment == Alignment.START
+    ? getStart(axis, el)
+    : getCenter(axis, el);
+}
+
+/**
  * @param {!Axis} axis The axis along which to set the length.
  * @param {!Element} el The Element to set the length for.
  * @param {number} length The length value, in pixels, to set.
@@ -122,7 +135,27 @@ export function setTransformTranslateStyle(axis, el, delta) {
  */
 export function overlaps(axis, el, position) {
   const {start, end} = getDimension(axis, el);
-  return start <= position && position <= end;
+  // Ignore the end point, since that is shared with the adjacent Element.
+  return start <= position && position < end;
+}
+
+/**
+ * @param {!Axis} axis The axis to align on.
+ * @param {!Alignment} alignment The desired alignment.
+ * @param {!Element} container The container to align against.
+ * @param {!Element} el The Element get the offset for.
+ * @return {number} How far el is from alignment, as a percentage of its length.
+ */
+export function getPercentageOffsetFromAlignment(
+  axis,
+  alignment,
+  container,
+  el
+) {
+  const elPos = getPosition(axis, alignment, el);
+  const containerPos = getPosition(axis, alignment, container);
+  const {length: elLength} = getDimension(axis, el);
+  return (elPos - containerPos) / elLength;
 }
 
 /**
@@ -144,10 +177,7 @@ export function findOverlappingIndex(
   children,
   startIndex
 ) {
-  const pos =
-    alignment == Alignment.START
-      ? getStart(axis, container) + 1
-      : getCenter(axis, container);
+  const pos = getPosition(axis, alignment, container);
 
   // First look at the start index, since is the most likely to overlap.
   if (overlaps(axis, children[startIndex], pos)) {
@@ -155,7 +185,7 @@ export function findOverlappingIndex(
   }
 
   // Move outwards, since the closer indicies are more likely to overlap.
-  for (let i = 1; i < children.length / 2; i++) {
+  for (let i = 1; i <= children.length / 2; i++) {
     const nextIndex = mod(startIndex + i, children.length);
     const prevIndex = mod(startIndex - i, children.length);
 
@@ -211,18 +241,26 @@ export function updateScrollPosition(axis, el, delta) {
  * Scrolls the position within a scrolling container to an Element. Unlike
  * `scrollIntoView`, this function does not scroll the container itself into
  * view.
- * @param {!Element} el The Element to scroll to.
- * @param {!Element} container The scrolling container.
  * @param {!Axis} axis The axis to scroll along.
  * @param {!Alignment} alignment How to align the element within the container.
+ * @param {!Element} container The scrolling container.
+ * @param {!Element} el The Element to scroll to.
+ * @param {number} offset A percentage offset within the element to scroll to.
  */
-export function scrollContainerToElement(el, container, axis, alignment) {
+export function scrollContainerToElement(
+  axis,
+  alignment,
+  container,
+  el,
+  offset = 0
+) {
   const startAligned = alignment == Alignment.START;
+  const {length} = getDimension(axis, el);
   const snapOffset = startAligned ? getStart(axis, el) : getCenter(axis, el);
   const scrollOffset = startAligned
     ? getStart(axis, container)
     : getCenter(axis, container);
-  const delta = snapOffset - scrollOffset;
+  const delta = snapOffset - scrollOffset - offset * length;
 
   updateScrollPosition(axis, container, delta);
 }

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -212,12 +212,12 @@ class AmpCarousel extends AMP.BaseElement {
 
   /** @override */
   pauseCallback() {
-    this.carousel_.pauseAutoAdvance();
+    this.carousel_.pauseLayout();
   }
 
   /** @override */
   resumeCallback() {
-    this.carousel_.resumeAutoAdvance();
+    this.carousel_.resumeLayout();
   }
 
   /** @override */


### PR DESCRIPTION
The changes are in preparation for amp-inline-gallery, and move some of the code to more closely match #24388.

- Refactor amp-base-carousel to more closely match amp-stream-gallery's
code patterns.
- Track the current offset in the slide as a percentage rather than a
pixel offset, which will restore scroll position more accurately when
resizing.
- Fire events notifying what the current slide is and how much progress
been made for the gallery (e.g. to show indicator dots).
- Use intersection observer for visibility tracking of child slides for
amp-base-carousel.
- Fix a couple of edge cases (`<=` vs `<`).