### PR TITLE
🏗 Add `OWNERS` files for all `build-system/` sub-directories

### DIFF
--- a/build-system/babel-plugins/OWNERS
+++ b/build-system/babel-plugins/OWNERS
@@ -1,0 +1,16 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'ampproject/wg-runtime' },
+        { name: 'ampproject/wg-performance' },
+        { name: 'erwinmombay', notify: true },
+        { name: 'jridgewell', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/common/OWNERS
+++ b/build-system/common/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: 'ampproject/wg-infra' }]
+    }
+  ]
+}

--- a/build-system/compile/OWNERS
+++ b/build-system/compile/OWNERS
@@ -1,0 +1,33 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: 'ampproject/wg-infra' }]
+    },
+    {
+      pattern: '{build.conf,bundles.config,sources}.js',
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'ampproject/wg-runtime' },
+        { name: 'ampproject/wg-performance' }
+      ]
+    },
+    {
+      pattern: '{closure-compile,compile}.js',
+      owners: [{ name: 'rsimha', notify: true }]
+    },
+    {
+      pattern: 'single-pass.js',
+      owners: [
+        { name: 'erwinmombay', notify: true },
+        { name: 'rsimha', notify: true }
+      ]
+    },
+    {
+      pattern: 'internal-version.js',
+      owners: [{ name: 'danielrozenberg', notify: true }]
+    }
+  ]
+}

--- a/build-system/eslint-rules/OWNERS
+++ b/build-system/eslint-rules/OWNERS
@@ -1,0 +1,16 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'ampproject/wg-runtime' },
+        { name: 'ampproject/wg-performance' },
+        { name: 'erwinmombay', notify: true },
+        { name: 'jridgewell', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/externs/OWNERS
+++ b/build-system/externs/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: '*' }]
+    }
+  ]
+}

--- a/build-system/pr-check/OWNERS
+++ b/build-system/pr-check/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'estherkim', notify: true },
+        { name: 'rsimha', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/runner/OWNERS
+++ b/build-system/runner/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'erwinmombay', notify: true },
+        { name: 'rsimha', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/sauce_connect/OWNERS
+++ b/build-system/sauce_connect/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'rsimha', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/server/OWNERS
+++ b/build-system/server/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: 'ampproject/wg-infra' }]
+    },
+    {
+      pattern: 'lazy-build.js',
+      owners: [{ name: 'rsimha', notify: true }]
+    }
+  ]
+}

--- a/build-system/server/app-index/OWNERS
+++ b/build-system/server/app-index/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'alanorozco', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/tasks/OWNERS
+++ b/build-system/tasks/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: 'ampproject/wg-infra' }]
+    }
+  ]
+}

--- a/build-system/tasks/e2e/OWNERS
+++ b/build-system/tasks/e2e/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'estherkim', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/tasks/runtime-test/OWNERS
+++ b/build-system/tasks/runtime-test/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'estherkim', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/tasks/visual-diff/OWNERS
+++ b/build-system/tasks/visual-diff/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'danielrozenberg', notify: true }
+      ]
+    }
+  ]
+}

--- a/build-system/test-configs/OWNERS
+++ b/build-system/test-configs/OWNERS
@@ -1,0 +1,18 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-infra' },
+        { name: 'ampproject/wg-runtime' },
+        { name: 'ampproject/wg-performance' }
+      ]
+    },
+    {
+      pattern: 'dep-check-config.js',
+      owners: [{ name: '*' }]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds `OWNERS` files across `build-system/`.

/cc @ampproject/wg-infra @ampproject/wg-runtime @ampproject/wg-performance since there's some common code that everyone must be able to edit.