### PR TITLE
🏗 Use `config.lintGlobs` instead of a hard-coded list of globs

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -170,7 +170,9 @@ function lintableFilesChanged() {
   return gitDiffNameOnlyMaster().filter(function(file) {
     return (
       fs.existsSync(file) &&
-      (path.extname(file) == '.js' || path.basename(file) == 'OWNERS')
+      deglob
+        .sync(config.lintGlobs)
+        .some(lintableFile => lintableFile.endsWith(file))
     );
   });
 }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -167,12 +167,11 @@ function runLinter(stream, options) {
  * @return {!Array<string>}
  */
 function lintableFilesChanged() {
+  const lintableFiles = deglob.sync(config.lintGlobs);
   return gitDiffNameOnlyMaster().filter(function(file) {
     return (
       fs.existsSync(file) &&
-      deglob
-        .sync(config.lintGlobs)
-        .some(lintableFile => lintableFile.endsWith(file))
+      lintableFiles.some(lintableFile => lintableFile.endsWith(file))
     );
   });
 }


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/pull/24943#pullrequestreview-298421382

Follow up to #24943
