### PR TITLE
🐛Fix progress bar bug with more comprehensive advancement checks

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1645,4 +1645,12 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.element.setAttribute('aria-labelledby', descriptionElId);
     }
   }
+
+  /**
+   * Returns AdvancementType for the page
+   * @return {AdvancementType}
+   */
+  getAdvancementType() {
+    return this.advancement_.getType();
+  }
 }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1648,7 +1648,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Returns AdvancementType for the page
-   * @return {AdvancementType}
+   * @return {./page-advancement.AdvancementType}
    */
   getAdvancementType() {
     return this.advancement_.getType();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1647,10 +1647,10 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Returns AdvancementType for the page
-   * @return {./page-advancement.AdvancementType}
+   * Returns whether the page will automatically advance
+   * @return {boolean}
    */
-  getAdvancementType() {
-    return this.advancement_.getType();
+  isAutoAdvance() {
+    return this.advancement_.isAutoAdvance();
   }
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -36,11 +36,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
-import {
-  AdvancementConfig,
-  AdvancementType,
-  TapNavigationDirection,
-} from './page-advancement';
+import {AdvancementConfig, TapNavigationDirection} from './page-advancement';
 import {
   AdvancementMode,
   AnalyticsEvent,
@@ -1442,10 +1438,7 @@ export class AmpStory extends AMP.BaseElement {
 
           // Start progress bar update for pages that are not ads or auto-
           // advance.
-          if (
-            targetPage.getAdvancementType() !== AdvancementType.MEDIA_BASED &&
-            targetPage.getAdvancementType() !== AdvancementType.TIME_BASED
-          ) {
+          if (!targetPage.isAutoAdvance()) {
             this.systemLayer_.updateProgress(
               targetPageId,
               this.advancement_.getProgress()

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -36,7 +36,11 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
-import {AdvancementConfig, TapNavigationDirection} from './page-advancement';
+import {
+  AdvancementConfig,
+  AdvancementType,
+  TapNavigationDirection,
+} from './page-advancement';
 import {
   AdvancementMode,
   AnalyticsEvent,
@@ -1436,12 +1440,10 @@ export class AmpStory extends AMP.BaseElement {
           this.storeService_.dispatch(Action.TOGGLE_AD, false);
           removeAttributeInMutate(this, Attributes.AD_SHOWING);
 
-          // Start progress bar update for pages that are not ads or auto-
-          // advance.
-          const isAutoAdvance = targetPage.element.hasAttribute(
-            Attributes.AUTO_ADVANCE_AFTER
-          );
-          if (!isAutoAdvance) {
+          if (
+            targetPage.getAdvancementType() !== AdvancementType.MEDIA_BASED &&
+            targetPage.getAdvancementType() !== AdvancementType.TIME_BASED
+          ) {
             this.systemLayer_.updateProgress(
               targetPageId,
               this.advancement_.getProgress()

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1440,6 +1440,8 @@ export class AmpStory extends AMP.BaseElement {
           this.storeService_.dispatch(Action.TOGGLE_AD, false);
           removeAttributeInMutate(this, Attributes.AD_SHOWING);
 
+          // Start progress bar update for pages that are not ads or auto-
+          // advance.
           if (
             targetPage.getAdvancementType() !== AdvancementType.MEDIA_BASED &&
             targetPage.getAdvancementType() !== AdvancementType.TIME_BASED

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -1049,6 +1049,13 @@ class MediaBasedAdvancement extends AdvancementConfig {
           #${escapeCssSelectorIdent(autoAdvanceStr)}`
       );
       if (!elements.length) {
+        if (autoAdvanceStr) {
+          user().warn(
+            'AMP-STORY-PAGE',
+            `Element with ID ${rootEl.id} has no media element ` +
+              'supported for automatic advancement.'
+          );
+        }
         return null;
       }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -64,15 +64,6 @@ export const TapNavigationDirection = {
   'PREVIOUS': 2,
 };
 
-/** @const @enum */
-export const AdvancementType = {
-  'BASE': 1,
-  'MANUAL': 2,
-  'TIME_BASED': 3,
-  'MEDIA_BASED': 4,
-  'MULTIPLE': 5,
-};
-
 /**
  * Base class for the AdvancementConfig.  By default, does nothing other than
  * tracking its internal state when started/stopped, and listeners will never be
@@ -149,11 +140,11 @@ export class AdvancementConfig {
   }
 
   /**
-   * Returns advancement type
-   * @return {AdvancementType}
+   * Returns whether the advancement configuration will automatically advance
+   * @return {boolean}
    */
-  getType() {
-    return AdvancementType.BASE;
+  isAutoAdvance() {
+    return false;
   }
 
   /**
@@ -239,13 +230,6 @@ export class AdvancementConfig {
     }
 
     return new AdvancementConfig();
-  }
-
-  /**
-   * @override
-   */
-  getType() {
-    return AdvancementType.MULTIPLE;
   }
 }
 
@@ -334,8 +318,8 @@ class ManualAdvancement extends AdvancementConfig {
   /**
    * @override
    */
-  getType() {
-    return AdvancementType.MANUAL;
+  isAutoAdvance() {
+    return false;
   }
 
   /**
@@ -749,8 +733,8 @@ class TimeBasedAdvancement extends AdvancementConfig {
   /**
    * @override
    */
-  getType() {
-    return AdvancementType.TIME_BASED;
+  isAutoAdvance() {
+    return true;
   }
 
   /** @override */
@@ -1010,8 +994,8 @@ class MediaBasedAdvancement extends AdvancementConfig {
   /**
    * @override
    */
-  getType() {
-    return AdvancementType.MEDIA_BASED;
+  isAutoAdvance() {
+    return true;
   }
 
   /** @override */
@@ -1052,7 +1036,7 @@ class MediaBasedAdvancement extends AdvancementConfig {
         if (autoAdvanceStr) {
           user().warn(
             'AMP-STORY-PAGE',
-            `Element with ID ${rootEl.id} has no media element ` +
+            `Element with ID ${element.id} has no media element ` +
               'supported for automatic advancement.'
           );
         }

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -64,6 +64,15 @@ export const TapNavigationDirection = {
   'PREVIOUS': 2,
 };
 
+/** @const @enum */
+export const AdvancementType = {
+  'BASE': 1,
+  'MANUAL': 2,
+  'TIME_BASED': 3,
+  'MEDIA_BASED': 4,
+  'MULTIPLE': 5,
+};
+
 /**
  * Base class for the AdvancementConfig.  By default, does nothing other than
  * tracking its internal state when started/stopped, and listeners will never be
@@ -137,6 +146,14 @@ export class AdvancementConfig {
    */
   stop(unusedCanResume) {
     this.isRunning_ = false;
+  }
+
+  /**
+   * Returns advancement type
+   * @return {AdvancementType}
+   */
+  getType() {
+    return AdvancementType.BASE;
   }
 
   /**
@@ -223,6 +240,13 @@ export class AdvancementConfig {
 
     return new AdvancementConfig();
   }
+
+  /**
+   * @override
+   */
+  getType() {
+    return AdvancementType.MULTIPLE;
+  }
 }
 
 /**
@@ -305,6 +329,13 @@ class ManualAdvancement extends AdvancementConfig {
       this.maybePerformNavigation_.bind(this),
       true
     );
+  }
+
+  /**
+   * @override
+   */
+  getType() {
+    return AdvancementType.MANUAL;
   }
 
   /**
@@ -715,6 +746,13 @@ class TimeBasedAdvancement extends AdvancementConfig {
       : null;
   }
 
+  /**
+   * @override
+   */
+  getType() {
+    return AdvancementType.TIME_BASED;
+  }
+
   /** @override */
   getProgress() {
     if (this.startTimeMs_ === null) {
@@ -967,6 +1005,13 @@ class MediaBasedAdvancement extends AdvancementConfig {
   stop() {
     super.stop();
     this.unlistenFns_.forEach(fn => fn());
+  }
+
+  /**
+   * @override
+   */
+  getType() {
+    return AdvancementType.MEDIA_BASED;
   }
 
   /** @override */


### PR DESCRIPTION
Fixes a bug where the progress bar would work improperly with a mismatch between the id supplied in `auto-advance-after` and the id of the media elements. Additionally, refactors the check for advancement types for updating the progress on non-auto-advanced pages.
Resolves #24940 