### PR TITLE
🏗 Remove `--eager_build` flag from `gulp`

### DIFF
--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
@@ -60,21 +59,11 @@ async function build() {
  */
 function printDefaultTaskHelp() {
   log(green('Running the default ') + cyan('gulp ') + green('task.'));
-  const defaultTaskMessage =
-    green('⤷ JS and extensions will be ') +
+  log(
     green(
-      argv.eager_build
-        ? 'built after server startup.'
-        : 'lazily built when requested from the server.'
-    );
-  log(defaultTaskMessage);
-  if (!argv.eager_build) {
-    const eagerBuildMessage =
-      green('⤷ Use ') +
-      cyan('--eager_build ') +
-      green('to build JS and extensions after server startup.');
-    log(eagerBuildMessage);
-  }
+      '⤷ JS and extensions will be lazily built when requested from the server.'
+    )
+  );
 }
 
 /**
@@ -113,16 +102,10 @@ async function defaultTask() {
   process.env.NODE_ENV = 'development';
   printConfigHelp('gulp');
   printDefaultTaskHelp();
-  parseExtensionFlags(/* preBuild */ !argv.eager_build);
+  parseExtensionFlags(/* preBuild */ true);
   await performPrerequisiteSteps(/* watch */ true);
   await serve();
-  if (!argv.eager_build) {
-    log(green('JS and extensions will be lazily built when requested...'));
-  } else {
-    log(green('Building JS and extensions...'));
-    await compileAllUnminifiedJs(/* watch */ true);
-    await buildExtensions({watch: true});
-  }
+  log(green('JS and extensions will be lazily built when requested...'));
 }
 
 module.exports = {
@@ -153,8 +136,6 @@ watch.flags = {
 defaultTask.description =
   'Starts the dev server and lazily builds JS and extensions when requested';
 defaultTask.flags = {
-  eager_build:
-    '  Starts the dev server and builds JS and extensions after server startup',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   extensions: '  Watches and builds only the listed extensions.',
   extensions_from:

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -68,7 +68,7 @@ function getMiddleware() {
   if (argv.cache) {
     middleware.push(header({'cache-control': 'max-age=600'}));
   }
-  if (!argv._.includes('serve') && !argv.eager_build) {
+  if (!argv._.includes('serve')) {
     middleware.push(lazyBuildExtensions);
     middleware.push(lazyBuildJs);
   }
@@ -134,7 +134,7 @@ function restartServer() {
  * Initiates pre-build steps requested via command line args.
  */
 function initiatePreBuildSteps() {
-  if (!argv._.includes('serve') && !argv.eager_build) {
+  if (!argv._.includes('serve')) {
     preBuildCoreRuntime();
     if (argv.extensions || argv.extensions_from) {
       preBuildSomeExtensions();


### PR DESCRIPTION
It has been a month since the default `gulp` behavior was changed to lazy build JS files and extensions (#24386). This PR removes the stopgap `--eager_build` flag that was added at the time.

Fixes #24423
