### PR TITLE
✨ Add amp-wordpress-embed component

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -919,6 +919,12 @@ exports.extensionBundles = [
     type: TYPES.MEDIA,
   },
   {
+    name: 'amp-wordpress-embed',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-position-observer',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/amp-wordpress-embed.amp.html
+++ b/examples/amp-wordpress-embed.amp.html
@@ -19,7 +19,7 @@
   <amp-wordpress-embed
     data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
     layout="fixed-height"
-    height="100">
+    height="200">
     <blockquote class="wp-embedded-content" placeholder>
       <a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a>
     </blockquote>

--- a/examples/amp-wordpress-embed.amp.html
+++ b/examples/amp-wordpress-embed.amp.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-wordpress-embed example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    h1, h2 {font-family: Verdana,Geneva,sans-serif}
+  </style>
+  <script async custom-element="amp-wordpress-embed" src="https://cdn.ampproject.org/v0/amp-wordpress-embed-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>AMP-WORDPRESS-EMBED Examples</h1>
+
+  <h2>Embed without Featured Image</h2>
+  <amp-wordpress-embed
+    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+    layout="fixed-height"
+    height="100">
+  </amp-wordpress-embed>
+
+  <h2>Embed with Featured Image</h2>
+  <amp-wordpress-embed
+    data-url="https://wordpress.org/news/2017/11/tipton/"
+    layout="fixed-height"
+    height="200">
+  </amp-wordpress-embed>
+</body>
+</html>

--- a/examples/amp-wordpress-embed.amp.html
+++ b/examples/amp-wordpress-embed.amp.html
@@ -20,6 +20,9 @@
     data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
     layout="fixed-height"
     height="100">
+    <blockquote class="wp-embedded-content" placeholder>
+      <a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a>
+    </blockquote>
   </amp-wordpress-embed>
 
   <h2>Embed with Featured Image</h2>

--- a/examples/amp-wordpress-embed.amp.html
+++ b/examples/amp-wordpress-embed.amp.html
@@ -19,17 +19,25 @@
   <amp-wordpress-embed
     data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
     layout="fixed-height"
-    height="200">
+    height="200"
+  >
     <blockquote class="wp-embedded-content" placeholder>
       <a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a>
     </blockquote>
+    <button overflow>Expand</button>
   </amp-wordpress-embed>
 
   <h2>Embed with Featured Image</h2>
   <amp-wordpress-embed
-    data-url="https://wordpress.org/news/2017/11/tipton/"
     layout="fixed-height"
-    height="200">
+    height="200"
+    title="“WordPress 4.9 “Tipton”” — WordPress News"
+    data-url="https://wordpress.org/news/2017/11/tipton/"
+  >
+    <blockquote class="wp-embedded-content" placeholder>
+      <a href="https://wordpress.org/news/2017/11/tipton/">WordPress 4.9 “Tipton”</a>
+    </blockquote>
+    <button overflow>Expand</button>
   </amp-wordpress-embed>
 </body>
 </html>

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -31,6 +31,7 @@ import {Layout} from '../../../src/layout';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
+import {user} from '../../../src/log';
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
 
@@ -40,14 +41,27 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
+
+    /** @private {?string} */
+    this.url_ = null;
+  }
+
+  buildCallback() {
+    // @todo Need to support placeholder.
+
+    const {element: el} = this;
+
+    this.url_ = user().assert(
+        el.getAttribute('data-url'),
+        'The data-url attribute is required for %s', el);
   }
 
   /**
-  * @param {boolean=} opt_onLayout
-  * @override
-  */
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://gist.github.com/', opt_onLayout);
+    this.preconnect.url(this.url_, opt_onLayout);
   }
 
   /** @override */
@@ -58,7 +72,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     /* the third parameter 'github' ties it to the 3p/github.js */
-    const iframe = getIframe(this.win, this.element, 'github');
+    const iframe = getIframe(this.win, this.element, 'github'); // @todo Change.
     this.applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(iframe, 'embed-size', data => {

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -21,8 +21,8 @@
  * <code>
  * <amp-wordpress-embed
  *   layout="fixed-height"
- *   data-gistid="a19e811dcd7df10c4da0931641538497"
- *   height="1613">
+ *   data-url="https://example.com/2018/05/17/awesome-post/"
+ *   height="240">
  * </amp-wordpress-embed>
  * </code>
  */

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -55,8 +55,6 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // @todo Need to support placeholder.
-
     const {element: el} = this;
 
     this.placeholder_ = this.getPlaceholder();
@@ -124,6 +122,21 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
   }
 
   /**
+   * Makes the iframe visible.
+   * @private
+   */
+  activateIframe_() {
+    if (this.placeholder_) {
+      this.getVsync().mutate(() => {
+        if (this.iframe_) {
+          setStyle(this.iframe_, 'zIndex', 0);
+          this.togglePlaceholder(false);
+        }
+      });
+    }
+  }
+
+  /**
    * Handle message event.
    *
    * @param {MessageEvent} event
@@ -178,21 +191,6 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
       this.iframe_ = null;
     }
     return true;
-  }
-
-  /**
-   * Makes the iframe visible.
-   * @private
-   */
-  activateIframe_() {
-    if (this.placeholder_) {
-      this.getVsync().mutate(() => {
-        if (this.iframe_) {
-          setStyle(this.iframe_, 'zIndex', 0);
-          this.togglePlaceholder(false);
-        }
-      });
-    }
   }
 }
 

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -21,7 +21,7 @@
  * <code>
  * <amp-wordpress-embed
  *   layout="fixed-height"
- *   data-url="https://example.com/2018/05/17/awesome-post/"
+ *   data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
  *   height="240">
  * </amp-wordpress-embed>
  * </code>

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -35,7 +35,7 @@ import {addParamToUrl} from '../../../src/url';
 // import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
-import {user, userAssert} from '../../../src/log';
+import {userAssert} from '../../../src/log';
 
 /** @type {number}  */
 let count = 0;
@@ -89,6 +89,12 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const {element: el} = this;
+
+    userAssert(
+      this.getOverflowElement(),
+      'Overflow element must be defined for amp-wordpress-embed: %s',
+      this.element
+    );
 
     const url = addParamToUrl(this.url_, 'embed', 'true');
 
@@ -153,7 +159,13 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     switch (event.data.message) {
       case 'height':
         if (typeof event.data.value === 'number') {
-          this./*OK*/ changeHeight(event.data.value);
+          const newHeight = event.data.value;
+          this.attemptChangeSize(newHeight).then(
+            () => {
+              this./*OK*/ changeHeight(newHeight);
+            },
+            () => {}
+          );
         }
         break;
       case 'link':

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -30,18 +30,13 @@
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
-// import {createFrameFor} from '../../../src/iframe-video';
-// import {htmlFor} from '../../../src/static-template';
-// import {listenFor} from '../../../src/iframe-helper';
+import {getData} from '../../../src/event-helper';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {userAssert} from '../../../src/log';
 
 /** @type {number}  */
 let count = 0;
-
-/** @type {number}  */
-const trackingIframeTimeout = 5000;
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -113,27 +108,10 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
       // Chrome does not reflect the iframe readystate.
       frame.readyState = 'complete';
       this.activateIframe_();
-
-      if (this.isTrackingFrame_) {
-        // Prevent this iframe from ever being recreated.
-        this.iframeSrc = null;
-
-        Services.timerFor(this.win)
-          .promise(trackingIframeTimeout)
-          .then(() => {
-            removeElement(frame);
-            this.element.setAttribute('amp-removed', '');
-            this.iframe_ = null;
-          });
-      }
     };
 
-    // @todo Figure out right way to do this with listenFor or whatever is the right way to do it.
     // Triggered by sendEmbedMessage inside the iframe.
     addEventListener('message', this.handleMessageEvent_);
-    // listenFor(frame, 'height', data => {
-    //   this./*OK*/changeHeight(data['value']);
-    // }, /* opt_is3P */true);
 
     this.element.appendChild(frame);
 

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -35,7 +35,7 @@ import {addParamToUrl} from '../../../src/url';
 // import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
-import {user} from '../../../src/log';
+import {user, userAssert} from '../../../src/log';
 
 /** @type {number}  */
 let count = 0;
@@ -68,11 +68,9 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
     this.handleMessageEvent_ = this.handleMessageEvent_.bind(this);
 
-    this.url_ = user().assert(
-      el.getAttribute('data-url'),
-      'The data-url attribute is required for %s',
-      el
-    );
+    this.url_ = el.getAttribute('data-url');
+
+    userAssert(this.url_, 'The data-url attribute is required for %s', el);
   }
 
   /**

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -17,6 +17,29 @@
 /**
  * @fileoverview Embeds a WordPress Post
  *
+ * The messages being sent by WordPress have event data consisting of an object with keys for 'message' and 'value'.
+ * The 'message' can be either 'height' or 'link'.
+ *
+ * The 'height' message event data looks like this:
+ *
+ * <code>
+ * {"message":"height", "value":356}
+ * </code>
+ *
+ * WordPress enforces a minimum height of 200px and a maximum height of 1000px.
+ *
+ * The 'link' message event data looks like this:
+ *
+ * <code>
+ * {"message":"link", "value":"https://wordpress.org/news/2017/11/tipton/"}
+ * </code>
+ *
+ * WordPress will only navigate the user to the URL in such a message if it is the same origin as the URL of the
+ * WordPress post being embedded and if the iframe is currently active.
+ *
+ * @see https://core.trac.wordpress.org/browser/tags/5.2.3/src/js/_enqueues/lib/embed-template.js
+ * @see https://core.trac.wordpress.org/browser/tags/5.2.3/src/js/_enqueues/wp/embed.js
+ *
  * Example:
  * <code>
  * <amp-wordpress-embed

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Embeds a Github gist
+ *
+ * Example:
+ * <code>
+ * <amp-wordpress-embed
+ *   layout="fixed-height"
+ *   data-gistid="a19e811dcd7df10c4da0931641538497"
+ *   height="1613">
+ * </amp-wordpress-embed>
+ * </code>
+ */
+
+import {Layout} from '../../../src/layout';
+import {getIframe} from '../../../src/3p-frame';
+import {listenFor} from '../../../src/iframe-helper';
+import {removeElement} from '../../../src/dom';
+
+export class AmpWordPressEmbed extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?HTMLIFrameElement} */
+    this.iframe_ = null;
+  }
+
+  /**
+  * @param {boolean=} opt_onLayout
+  * @override
+  */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url('https://gist.github.com/', opt_onLayout);
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.FIXED_HEIGHT;
+  }
+
+  /** @override */
+  layoutCallback() {
+    /* the third parameter 'github' ties it to the 3p/github.js */
+    const iframe = getIframe(this.win, this.element, 'github');
+    this.applyFillContent(iframe);
+    // Triggered by window.context.requestResize() inside the iframe.
+    listenFor(iframe, 'embed-size', data => {
+      this./*OK*/changeHeight(data['height']);
+    }, /* opt_is3P */true);
+
+    this.element.appendChild(iframe);
+    this.iframe_ = iframe;
+    return this.loadPromise(iframe);
+  }
+
+  /**
+   * @override
+   */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+}
+
+
+AMP.extension('amp-wordpress-embed', '0.1', AMP => {
+  AMP.registerElement('amp-wordpress-embed', AmpWordPressEmbed);
+});

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -28,10 +28,10 @@
  */
 
 import {Layout} from '../../../src/layout';
+import {createFrameFor} from '../../../src/iframe-video';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
-import {createFrameFor} from '../../../src/iframe-video';
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
 
@@ -46,6 +46,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     this.url_ = null;
   }
 
+  /** @override */
   buildCallback() {
     // @todo Need to support placeholder.
 
@@ -71,8 +72,8 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const url = new URL( this.url_ );
-    url.searchParams.set( 'embed', 'true' );
+    const url = new URL(this.url_);
+    url.searchParams.set('embed', 'true');
 
     const iframe = createFrameFor(this, url.toString());
     this.applyFillContent(iframe);

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,6 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
     const frame = this.element.ownerDocument.createElement('iframe');
     frame.setAttribute('frameborder', 0);
-    frame.setAttribute('allowfullscreen', '');
     frame.setAttribute('scrolling', 'no');
     // Note that allow-same-origin cannot be used for sake of same-origin post embeds.
     frame.setAttribute('sandbox', 'allow-scripts');

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -22,7 +22,7 @@
  * <amp-wordpress-embed
  *   layout="fixed-height"
  *   data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
- *   height="240">
+ *   height="200">
  * </amp-wordpress-embed>
  * </code>
  */

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -96,7 +96,8 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     frame.setAttribute('frameborder', 0);
     frame.setAttribute('allowfullscreen', '');
     frame.setAttribute('scrolling', 'no');
-    frame.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+    // Note that allow-same-origin cannot be used for sake of same-origin post embeds.
+    frame.setAttribute('sandbox', 'allow-scripts');
     this.iframe_ = frame;
     this.applyFillContent(frame);
 

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @fileoverview Embeds a Github gist
+ * @fileoverview Embeds a WordPress Post
  *
  * Example:
  * <code>
@@ -99,7 +99,6 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     return true;
   }
 }
-
 
 AMP.extension('amp-wordpress-embed', '0.1', AMP => {
   AMP.registerElement('amp-wordpress-embed', AmpWordPressEmbed);

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -28,10 +28,10 @@
  */
 
 import {Layout} from '../../../src/layout';
-import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
+import {createFrameFor} from '../../../src/iframe-video';
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
 
@@ -71,12 +71,15 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    /* the third parameter 'github' ties it to the 3p/github.js */
-    const iframe = getIframe(this.win, this.element, 'github'); // @todo Change.
+    const url = new URL( this.url_ );
+    url.searchParams.set( 'embed', 'true' );
+
+    const iframe = createFrameFor(this, url.toString());
     this.applyFillContent(iframe);
-    // Triggered by window.context.requestResize() inside the iframe.
-    listenFor(iframe, 'embed-size', data => {
-      this./*OK*/changeHeight(data['height']);
+
+    // Triggered by sendEmbedMessage inside the iframe.
+    listenFor(iframe, 'height', data => {
+      this./*OK*/changeHeight(data['value']);
     }, /* opt_is3P */true);
 
     this.element.appendChild(iframe);

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -123,16 +123,25 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     };
 
     // @todo Figure out right way to do this with listenFor or whatever is the right way to do it.
-    // @todo Add link message.
     // Triggered by sendEmbedMessage inside the iframe.
     window.addEventListener('message', event => {
       if (
-        event.source === frame.contentWindow &&
-        'height' === event.data.message &&
-        event.data.value &&
-        typeof event.data.value === 'number'
+        event.source !== frame.contentWindow ||
+        'undefined' === typeof event.data.message ||
+        'undefined' === typeof event.data.value
       ) {
-        this./*OK*/ changeHeight(event.data.value);
+        return;
+      }
+
+      switch (event.data.message) {
+        case 'height':
+          if (typeof event.data.value === 'number') {
+            this./*OK*/ changeHeight(event.data.value);
+          }
+          break;
+        case 'link':
+          window.location.href = event.data.value;
+          break;
       }
     });
     // listenFor(frame, 'height', data => {

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -28,23 +28,22 @@
  */
 
 import {Layout} from '../../../src/layout';
-import {addParamToUrl} from '../../../src/url';
-import {createFrameFor} from '../../../src/iframe-video';
-import {listenFor} from '../../../src/iframe-helper';
-import {removeElement} from '../../../src/dom';
-import {user} from '../../../src/log';
-import {htmlFor} from '../../../src/static-template';
 import {Services} from '../../../src/services';
+import {addParamToUrl} from '../../../src/url';
+// import {createFrameFor} from '../../../src/iframe-video';
+// import {htmlFor} from '../../../src/static-template';
+// import {listenFor} from '../../../src/iframe-helper';
+import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
+import {user} from '../../../src/log';
 
 /** @type {number}  */
 let count = 0;
 
 /** @type {number}  */
-let trackingIframeTimeout = 5000;
+const trackingIframeTimeout = 5000;
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
-
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -68,8 +67,10 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     this.placeholder_ = this.getPlaceholder();
 
     this.url_ = user().assert(
-        el.getAttribute('data-url'),
-        'The data-url attribute is required for %s', el);
+      el.getAttribute('data-url'),
+      'The data-url attribute is required for %s',
+      el
+    );
   }
 
   /**
@@ -82,7 +83,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    return layout == Layout.FIXED_HEIGHT;
+    return layout === Layout.FIXED_HEIGHT;
   }
 
   /** @override */
@@ -111,11 +112,13 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
         // Prevent this iframe from ever being recreated.
         this.iframeSrc = null;
 
-        Services.timerFor(this.win).promise(trackingIframeTimeout).then(() => {
-          removeElement(frame);
-          this.element.setAttribute('amp-removed', '');
-          this.iframe_ = null;
-        });
+        Services.timerFor(this.win)
+          .promise(trackingIframeTimeout)
+          .then(() => {
+            removeElement(frame);
+            this.element.setAttribute('amp-removed', '');
+            this.iframe_ = null;
+          });
       }
     };
 
@@ -123,10 +126,13 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
     // @todo Add link message.
     // Triggered by sendEmbedMessage inside the iframe.
     window.addEventListener('message', event => {
-      if (event.source === frame.contentWindow &&
+      if (
+        event.source === frame.contentWindow &&
         'height' === event.data.message &&
-        event.data.value && typeof event.data.value === 'number') {
-        this./*OK*/changeHeight(event.data.value);
+        event.data.value &&
+        typeof event.data.value === 'number'
+      ) {
+        this./*OK*/ changeHeight(event.data.value);
       }
     });
     // listenFor(frame, 'height', data => {

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -22,7 +22,14 @@
  * <amp-wordpress-embed
  *   layout="fixed-height"
  *   data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
- *   height="200">
+ *   height="200"
+ * >
+ *   <blockquote placeholder>
+ *     <a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">
+ *       New Embeds Feature in WordPress 4.4
+ *     </a>
+ *   </blockquote>
+ *   <button overflow>Expand</button>
  * </amp-wordpress-embed>
  * </code>
  */

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -65,7 +65,7 @@ import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {userAssert} from '../../../src/log';
 
-/** @type {number}  */
+/** @type {number} */
 let count = 0;
 
 export class AmpWordPressEmbed extends AMP.BaseElement {
@@ -174,7 +174,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
   /**
    * Handle message event.
    *
-   * @param {MessageEvent} event
+   * @param {Event|MessageEvent} event
    * @private
    */
   handleMessageEvent_(event) {
@@ -213,11 +213,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
           typeof data['value'] === 'string' &&
           this.hasSameOrigin_(data['value'])
         ) {
-          const embeddedUrl = new URL(this.url_);
-          const requestedUrl = new URL(data['value']);
-          if (embeddedUrl.origin === requestedUrl.origin) {
-            window.top.location.href = requestedUrl.href;
-          }
+          window.top.location.href = data['value'];
         }
         break;
     }
@@ -231,7 +227,7 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
    * @private
    */
   hasSameOrigin_(url) {
-    const embeddedUrl = new URL(this.url_);
+    const embeddedUrl = new URL(/** @type {string} */ (this.url_));
     const checkedUrl = new URL(url);
     return embeddedUrl.origin === checkedUrl.origin;
   }

--- a/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/amp-wordpress-embed.js
@@ -140,7 +140,12 @@ export class AmpWordPressEmbed extends AMP.BaseElement {
           }
           break;
         case 'link':
-          window.location.href = event.data.value;
+          if (
+            document.activeElement &&
+            document.activeElement.contentWindow === event.source
+          ) {
+            window.location.href = event.data.value;
+          }
           break;
       }
     });

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -16,37 +16,44 @@
 
 import '../amp-wordpress-embed';
 
-
-describes.realWin('amp-wordpress-embed', {
-  amp: {
-    extensions: ['amp-wordpress-embed'],
+describes.realWin(
+  'amp-wordpress-embed',
+  {
+    amp: {
+      extensions: ['amp-wordpress-embed'],
+    },
   },
-}, env => {
-  let win, doc;
+  env => {
+    let win, doc;
 
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-  });
-
-  function getIns(url) {
-    const ins = doc.createElement('amp-wordpress-embed');
-    ins.setAttribute('data-url', url);
-    ins.setAttribute('height', '241');
-    doc.body.appendChild(ins);
-    return ins.build().then(() => ins.layoutCallback()).then(() => ins);
-  }
-
-  it('renders responsively', () => {
-    return getIns('https://wordpress.example.com/post').then(ins => {
-      const iframe = ins.querySelector('iframe');
-      expect(iframe).to.not.be.null;
-      expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
     });
-  });
 
-  it('Rejects because data-url is missing', () => {
-    expect(getIns('')).to.be.rejectedWith(
-        /The data-url attribute is required for/);
-  });
-});
+    function getIns(url) {
+      const ins = doc.createElement('amp-wordpress-embed');
+      ins.setAttribute('data-url', url);
+      ins.setAttribute('height', '241');
+      doc.body.appendChild(ins);
+      return ins
+        .build()
+        .then(() => ins.layoutCallback())
+        .then(() => ins);
+    }
+
+    it('renders responsively', () => {
+      return getIns('https://wordpress.example.com/post').then(ins => {
+        const iframe = ins.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.className).to.match(/i-amphtml-fill-content/);
+      });
+    });
+
+    it('Rejects because data-url is missing', () => {
+      expect(getIns('')).to.be.rejectedWith(
+        /The data-url attribute is required for/
+      );
+    });
+  }
+);

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -29,36 +29,24 @@ describes.realWin('amp-wordpress-embed', {
     doc = win.document;
   });
 
-  function getIns(gistid, file) {
+  function getIns(url) {
     const ins = doc.createElement('amp-wordpress-embed');
-    ins.setAttribute('data-gistid', gistid);
-    ins.setAttribute('height', '237');
-    if (file) {
-      ins.setAttribute('data-file', file);
-    }
+    ins.setAttribute('data-url', url);
+    ins.setAttribute('height', '241');
     doc.body.appendChild(ins);
     return ins.build().then(() => ins.layoutCallback()).then(() => ins);
   }
 
   it('renders responsively', () => {
-    return getIns('b9bb35bc68df68259af94430f012425f').then(ins => {
+    return getIns('https://wordpress.example.com/post').then(ins => {
       const iframe = ins.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.className).to.match(/i-amphtml-fill-content/);
     });
   });
 
-  it('renders responsively with specific file', () => {
-    return getIns('b9bb35bc68df68259af94430f012425f', 'hello-world.html')
-        .then(ins => {
-          const iframe = ins.querySelector('iframe');
-          expect(iframe).to.not.be.null;
-          expect(iframe.className).to.match(/i-amphtml-fill-content/);
-        });
-  });
-
-  it('Rejects because data-gistid is missing', () => {
+  it('Rejects because data-url is missing', () => {
     expect(getIns('')).to.be.rejectedWith(
-        /The data-gistid attribute is required for/);
+        /The data-url attribute is required for/);
   });
 });

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -33,6 +33,9 @@ describes.realWin(
 
     function getIns(url) {
       const ins = doc.createElement('amp-wordpress-embed');
+      const overflowEl = doc.createElement('button');
+      overflowEl.setAttribute('overflow', '');
+      ins.appendChild(overflowEl);
       ins.setAttribute('data-url', url);
       ins.setAttribute('height', '241');
       doc.body.appendChild(ins);

--- a/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/0.1/test/test-amp-wordpress-embed.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-wordpress-embed';
+
+
+describes.realWin('amp-wordpress-embed', {
+  amp: {
+    extensions: ['amp-wordpress-embed'],
+  },
+}, env => {
+  let win, doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+
+  function getIns(gistid, file) {
+    const ins = doc.createElement('amp-wordpress-embed');
+    ins.setAttribute('data-gistid', gistid);
+    ins.setAttribute('height', '237');
+    if (file) {
+      ins.setAttribute('data-file', file);
+    }
+    doc.body.appendChild(ins);
+    return ins.build().then(() => ins.layoutCallback()).then(() => ins);
+  }
+
+  it('renders responsively', () => {
+    return getIns('b9bb35bc68df68259af94430f012425f').then(ins => {
+      const iframe = ins.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    });
+  });
+
+  it('renders responsively with specific file', () => {
+    return getIns('b9bb35bc68df68259af94430f012425f', 'hello-world.html')
+        .then(ins => {
+          const iframe = ins.querySelector('iframe');
+          expect(iframe).to.not.be.null;
+          expect(iframe.className).to.match(/i-amphtml-fill-content/);
+        });
+  });
+
+  it('Rejects because data-gistid is missing', () => {
+    expect(getIns('')).to.be.rejectedWith(
+        /The data-gistid attribute is required for/);
+  });
+});

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -31,11 +31,11 @@
   <!-- Valid: Embeds a WordPress post. -->
   <amp-wordpress-embed
     layout="fixed-height"
-    height="240"
+    height="200"
     data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
   >
     <button overflow>Expand</button>
-    <blockquote fallback><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
+    <blockquote placeholder><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
   </amp-wordpress-embed>
 </body>
 </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -1,0 +1,59 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-wordpress-embed tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-wordpress-embed" src="https://cdn.ampproject.org/v0/amp-wordpress-embed-latest.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- Valid: Embeds an entire gist from GitHub. -->
+  <amp-wordpress-embed
+    layout="fixed-height"
+    height="241"
+    data-gistid="b9bb35bc68df68259af94430f012425f">
+  </amp-wordpress-embed>
+
+  <!-- Valid: Embeds one file out of a gist from GitHub. -->
+  <amp-wordpress-embed
+    layout="fixed-height"
+    height="197"
+    data-gistid="a19e811dcd7df10c4da0931641538497"
+    data-file="hi.c">
+  </amp-wordpress-embed>
+
+  <!-- Invalid: missing data-gistid attribute. -->
+  <amp-wordpress-embed
+    layout="fixed-height"
+    height="241">
+  </amp-wordpress-embed>
+
+  <!-- Invalid: illegal layout. -->
+  <amp-wordpress-embed
+    layout="responsive"
+    height="241"
+    data-gistid="b9bb35bc68df68259af94430f012425f">
+  </amp-wordpress-embed>
+</body>
+</html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -32,7 +32,10 @@
   <amp-wordpress-embed
     layout="fixed-height"
     height="240"
-    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">
+    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+  >
+    <button overflow>Expand</button>
+    <blockquote fallback><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
   </amp-wordpress-embed>
 </body>
 </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -31,8 +31,8 @@
   <!-- Valid: Embeds a WordPress post. -->
   <amp-wordpress-embed
     layout="fixed-height"
-    height="241"
-    data-url="b9bb35bc68df68259af94430f012425f">
+    height="240"
+    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">
   </amp-wordpress-embed>
 </body>
 </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html
@@ -28,32 +28,11 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <!-- Valid: Embeds an entire gist from GitHub. -->
+  <!-- Valid: Embeds a WordPress post. -->
   <amp-wordpress-embed
     layout="fixed-height"
     height="241"
-    data-gistid="b9bb35bc68df68259af94430f012425f">
-  </amp-wordpress-embed>
-
-  <!-- Valid: Embeds one file out of a gist from GitHub. -->
-  <amp-wordpress-embed
-    layout="fixed-height"
-    height="197"
-    data-gistid="a19e811dcd7df10c4da0931641538497"
-    data-file="hi.c">
-  </amp-wordpress-embed>
-
-  <!-- Invalid: missing data-gistid attribute. -->
-  <amp-wordpress-embed
-    layout="fixed-height"
-    height="241">
-  </amp-wordpress-embed>
-
-  <!-- Invalid: illegal layout. -->
-  <amp-wordpress-embed
-    layout="responsive"
-    height="241"
-    data-gistid="b9bb35bc68df68259af94430f012425f">
+    data-url="b9bb35bc68df68259af94430f012425f">
   </amp-wordpress-embed>
 </body>
 </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
@@ -1,6 +1,6 @@
 PASS
 |  <!--
-|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |
@@ -29,36 +29,11 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|    <!-- Valid: Embeds an entire gist from GitHub. -->
+|    <!-- Valid: Embeds a WordPress post. -->
 |    <amp-wordpress-embed
 |      layout="fixed-height"
-|      height="241"
-|      data-gistid="b9bb35bc68df68259af94430f012425f">
-|    </amp-wordpress-embed>
-|
-|    <!-- Valid: Embeds one file out of a gist from GitHub. -->
-|    <amp-wordpress-embed
-|      layout="fixed-height"
-|      height="197"
-|      data-gistid="a19e811dcd7df10c4da0931641538497"
-|      data-file="hi.c">
-|    </amp-wordpress-embed>
-|
-|    <!-- Invalid: missing data-gistid attribute. -->
-|    <amp-wordpress-embed
->>   ^~~~~~~~~
-amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html:47:2 The mandatory attribute 'data-gistid' is missing in tag 'amp-wordpress-embed'. (see https://www.ampproject.org/docs/reference/components/amp-wordpress-embed) [AMP_TAG_PROBLEM]
-|      layout="fixed-height"
-|      height="241">
-|    </amp-wordpress-embed>
-|
-|    <!-- Invalid: illegal layout. -->
-|    <amp-wordpress-embed
->>   ^~~~~~~~~
-amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html:53:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-wordpress-embed'. (see https://www.ampproject.org/docs/reference/components/amp-wordpress-embed) [AMP_LAYOUT_PROBLEM]
-|      layout="responsive"
-|      height="241"
-|      data-gistid="b9bb35bc68df68259af94430f012425f">
+|      height="240"
+|      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">
 |    </amp-wordpress-embed>
 |  </body>
 |  </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
@@ -1,0 +1,64 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-wordpress-embed tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-wordpress-embed" src="https://cdn.ampproject.org/v0/amp-wordpress-embed-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Embeds an entire gist from GitHub. -->
+|    <amp-wordpress-embed
+|      layout="fixed-height"
+|      height="241"
+|      data-gistid="b9bb35bc68df68259af94430f012425f">
+|    </amp-wordpress-embed>
+|
+|    <!-- Valid: Embeds one file out of a gist from GitHub. -->
+|    <amp-wordpress-embed
+|      layout="fixed-height"
+|      height="197"
+|      data-gistid="a19e811dcd7df10c4da0931641538497"
+|      data-file="hi.c">
+|    </amp-wordpress-embed>
+|
+|    <!-- Invalid: missing data-gistid attribute. -->
+|    <amp-wordpress-embed
+>>   ^~~~~~~~~
+amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html:47:2 The mandatory attribute 'data-gistid' is missing in tag 'amp-wordpress-embed'. (see https://www.ampproject.org/docs/reference/components/amp-wordpress-embed) [AMP_TAG_PROBLEM]
+|      layout="fixed-height"
+|      height="241">
+|    </amp-wordpress-embed>
+|
+|    <!-- Invalid: illegal layout. -->
+|    <amp-wordpress-embed
+>>   ^~~~~~~~~
+amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.html:53:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-wordpress-embed'. (see https://www.ampproject.org/docs/reference/components/amp-wordpress-embed) [AMP_LAYOUT_PROBLEM]
+|      layout="responsive"
+|      height="241"
+|      data-gistid="b9bb35bc68df68259af94430f012425f">
+|    </amp-wordpress-embed>
+|  </body>
+|  </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
@@ -33,7 +33,10 @@ PASS
 |    <amp-wordpress-embed
 |      layout="fixed-height"
 |      height="240"
-|      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">
+|      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+|    >
+|      <button overflow>Expand</button>
+|      <blockquote fallback><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
 |    </amp-wordpress-embed>
 |  </body>
 |  </html>

--- a/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
+++ b/extensions/amp-wordpress-embed/0.1/test/validator-amp-wordpress-embed.out
@@ -32,11 +32,11 @@ PASS
 |    <!-- Valid: Embeds a WordPress post. -->
 |    <amp-wordpress-embed
 |      layout="fixed-height"
-|      height="240"
+|      height="200"
 |      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
 |    >
 |      <button overflow>Expand</button>
-|      <blockquote fallback><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
+|      <blockquote placeholder><a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a></blockquote>
 |    </amp-wordpress-embed>
 |  </body>
 |  </html>

--- a/extensions/amp-wordpress-embed/OWNERS
+++ b/extensions/amp-wordpress-embed/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'westonruter' },
+        { name: 'amedina' },
+        { name: 'ampproject/wg-ui-and-a11y' }
+      ]
+    }
+  ]
+}

--- a/extensions/amp-wordpress-embed/OWNERS.yaml
+++ b/extensions/amp-wordpress-embed/OWNERS.yaml
@@ -1,0 +1,2 @@
+- westonruter
+- amedina

--- a/extensions/amp-wordpress-embed/OWNERS.yaml
+++ b/extensions/amp-wordpress-embed/OWNERS.yaml
@@ -1,2 +1,0 @@
-- westonruter
-- amedina

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -26,7 +26,7 @@ limitations under the License.
     <td><code>&lt;script async custom-element="amp-wordpress-embed" src="https://cdn.ampproject.org/v0/amp-wordpress-embed-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout/">Supported Layouts</a></strong></td>
     <td>fixed-height</td>
   </tr>
   <!-- <tr>
@@ -65,7 +65,7 @@ You should also provide a placeholder `blockquote` that contains a link to the o
 
 ##### data-url (required)
 
-The URL of the post to embed.
+The URL (permalink) of the WordPress post to embed. The component will automatically add `?embed=true` to the URL.
 
 ##### layout (required)
 

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a <a href="https://gist.github.com/">GitHub Gist</a>.</td>
+    <td>Embeds a <a href="https://wordpress.org/">WordPress post</a>.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -29,44 +29,33 @@ limitations under the License.
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
     <td>fixed-height</td>
   </tr>
-  <tr>
+  <!-- <tr>
     <td width="40%"><strong>Examples</strong></td>
     <td><a href="https://ampbyexample.com/components/amp-wordpress-embed/">Annotated code example for amp-wordpress-embed</a></td>
-  </tr>
+  </tr> -->
 </table>
 
 [TOC]
 
 ## Behavior
 
-This extension creates an iframe and displays a [gist from GitHub](https://help.github.com/articles/about-gists/). 
+This extension creates an iframe and displays the [excerpt](https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/) of a WordPress post. 
 
-#### Example: Embedding multiple files
-
-```html
-<amp-wordpress-embed
-    data-gistid="b9bb35bc68df68259af94430f012425f"
-    layout="fixed-height"
-    height="225">
-</amp-wordpress-embed>
-```
-
-#### Example: Embedding a single file
+#### Example: Embedding a WordPress post
 
 ```html
 <amp-wordpress-embed
-    data-gistid="a19e811dcd7df10c4da0931641538497"
-    data-file="hi.c"
+    data-url="https://wordpress.example.com/post-title/"
     layout="fixed-height"
-    height="185">
+    height="240">
 </amp-wordpress-embed>
 ```
 
 ## Attributes
 
-##### data-gistid (required)
+##### data-url (required)
 
-The ID of the gist to embed.
+The URL of the post to embed.
 
 ##### layout (required)
 
@@ -74,13 +63,7 @@ Currently only supports `fixed-height`.
 
 ##### height (required)
 
-The initial height of the gist or gist file in pixels.
-
-**Note**: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.
-
-##### data-file (optional)
-
-If specified, display only one file in a gist.
+The initial height of the WordPress post embed in pixels.
 
 ## Validation
 See [amp-wordpress-embed rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii) in the AMP validator specification.

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -1,0 +1,86 @@
+<!--
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="`amp-wordpress-embed`"></a> `amp-wordpress-embed`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Displays a <a href="https://gist.github.com/">GitHub Gist</a>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-wordpress-embed" src="https://cdn.ampproject.org/v0/amp-wordpress-embed-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fixed-height</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-wordpress-embed/">Annotated code example for amp-wordpress-embed</a></td>
+  </tr>
+</table>
+
+[TOC]
+
+## Behavior
+
+This extension creates an iframe and displays a [gist from GitHub](https://help.github.com/articles/about-gists/). 
+
+#### Example: Embedding multiple files
+
+```html
+<amp-wordpress-embed
+    data-gistid="b9bb35bc68df68259af94430f012425f"
+    layout="fixed-height"
+    height="225">
+</amp-wordpress-embed>
+```
+
+#### Example: Embedding a single file
+
+```html
+<amp-wordpress-embed
+    data-gistid="a19e811dcd7df10c4da0931641538497"
+    data-file="hi.c"
+    layout="fixed-height"
+    height="185">
+</amp-wordpress-embed>
+```
+
+## Attributes
+
+##### data-gistid (required)
+
+The ID of the gist to embed.
+
+##### layout (required)
+
+Currently only supports `fixed-height`.
+
+##### height (required)
+
+The initial height of the gist or gist file in pixels.
+
+**Note**: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.
+
+##### data-file (optional)
+
+If specified, display only one file in a gist.
+
+## Validation
+See [amp-wordpress-embed rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii) in the AMP validator specification.

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -45,7 +45,7 @@ This extension creates an iframe and displays the [excerpt](https://make.wordpre
 
 ```html
 <amp-wordpress-embed
-    data-url="https://wordpress.example.com/post-title/"
+    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
     layout="fixed-height"
     height="240">
 </amp-wordpress-embed>

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -41,13 +41,23 @@ limitations under the License.
 
 This extension creates an iframe and displays the [excerpt](https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/) of a WordPress post. 
 
+As with [resizable iframes](https://amp.dev/documentation/components/amp-iframe/#iframe-resizing), you must provide an `overflow` button which is displayed to the user when the iframe loads in or above the current viewport, allowing the user to explicitly allow resizing the iframe (to avoid content shifting).
+
+You should also provide a placeholder `blockquote` that contains a link to the original post with its linked title. 
+
 #### Example: Embedding a WordPress post
 
 ```html
 <amp-wordpress-embed
-    data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
-    layout="fixed-height"
-    height="240">
+  layout="fixed-height"
+  height="200"
+  title="“New Embeds Feature in WordPress 4.4” — Make WordPress Core"
+  data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+>
+  <blockquote placeholder>
+    <a href="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/">New Embeds Feature in WordPress 4.4</a>
+  </blockquote>
+  <button overflow>Expand</button>
 </amp-wordpress-embed>
 ```
 
@@ -63,7 +73,7 @@ Currently only supports `fixed-height`.
 
 ##### height (required)
 
-The initial height of the WordPress post embed in pixels.
+The initial height of the WordPress post embed in pixels. This should be set to 200, the minimum height for a WordPress embed. When the iframe loads, WordPress sends a message to request the height of the iframe to increase to fit the contents of the embedded window.
 
 ## Validation
 See [amp-wordpress-embed rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii) in the AMP validator specification.

--- a/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
+++ b/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
+++ b/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
@@ -1,0 +1,40 @@
+#
+# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-wordpress-embed
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-wordpress-embed"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-wordpress-embed>
+  html_format: AMP
+  tag_name: "AMP-GIST"
+  requires_extension: "amp-wordpress-embed"
+  attrs: {
+    name: "data-gistid"
+    mandatory: true
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-wordpress-embed"
+  amp_layout: {
+    supported_layouts: FIXED_HEIGHT
+  }
+}

--- a/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
+++ b/extensions/amp-wordpress-embed/validator-amp-wordpress-embed.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,10 +26,14 @@ tags: {  # amp-wordpress-embed
 }
 tags: {  # <amp-wordpress-embed>
   html_format: AMP
-  tag_name: "AMP-GIST"
+  tag_name: "AMP-WORDPRESS-EMBED"
   requires_extension: "amp-wordpress-embed"
   attrs: {
-    name: "data-gistid"
+    name: "data-url"
+    value_url: {
+      protocol: "https"
+      allow_relative: false
+    }
     mandatory: true
   }
   attr_lists: "extended-amp-global"


### PR DESCRIPTION
Previously https://github.com/ampproject/amphtml/pull/18412.

Fixes #18378.

To test the component in the WordPress plugin, use the branch in this PR: https://github.com/ampproject/amp-wp/pull/3465

# Todo

- [x] Add support for `link` message.
- [x] Add support for `placeholder`.
- [x] Ensure `fallback` is supported. It should be a `blockquote`.
- [x] Add support for `overflow` so that when the resize is rejected, we can show a button.
- [x] Verify `placeholder` works.
- [x] Figure out the right way to start listening for messages, as `listenFor` may not be right.
- [x] Do we need to send a `secret`?
- [ ] Add assertions for when invalid messages are sent?