### PR TITLE
✨ Add amp-empower component

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -506,6 +506,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-empower',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MEDIA,
+  },
+  {
     name: 'amp-experiment',
     version: ['0.1', '1.0'],
     latestVersion: '0.1',

--- a/build-system/server/app-video-testbench.js
+++ b/build-system/server/app-video-testbench.js
@@ -43,6 +43,7 @@ const requiredAttrs = {
     'data-player-id': 'SyIOV8yWM',
   },
   'amp-dailymotion': {'data-videoid': 'x2m8jpp'},
+  'amp-empower': {'data-video': 'c2abd452-453d-47e6-ab96-3796f98857d0'},
   'amp-gfycat': {'data-gfyid': 'TautWhoppingCougar'},
   'amp-ima-video': {
     'data-tag': 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=&debug_experiment_id=1269069638',
@@ -101,6 +102,7 @@ const availableExtensions = [
   'amp-brid-player',
   'amp-brightcove',
   'amp-dailymotion',
+  'amp-empower',
   'amp-gfycat',
   'amp-ima-video',
   'amp-mowplayer',

--- a/examples/empower.amp.html
+++ b/examples/empower.amp.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Empower examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js"></script>
+  <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+    .spacer {
+      height: 100vh;
+    }
+  </style>
+</head>
+<body>
+  <h1>Empower</h1>
+
+  <amp-empower
+    id="myVideo"
+    data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+    width="480"
+    height="270"
+    layout="responsive">
+  </amp-empower>
+
+  <h3>Actions</h3>
+  <button on="tap:myVideo.play">Play</button>
+  <button on="tap:myVideo.pause">Pause</button>
+  <button on="tap:myVideo.mute">Mute</button>
+  <button on="tap:myVideo.unmute">Unmute</button>
+  <button on="tap:myVideo.fullscreen">Fullscreen</button>
+
+  <h2>Autoplay</h2>
+  <amp-empower
+    autoplay
+    data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+    width="480"
+    height="270"
+    layout="responsive">
+  </amp-empower>
+  <div class="spacer"></div>
+
+  <h2>Dock</h2>
+  <amp-empower
+    dock
+    data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+    width="480"
+    height="270"
+    layout="responsive">
+  </amp-empower>
+  <div class="spacer"></div>
+
+  <h2>Rotate-to-Fullscreen</h2>
+  <amp-empower
+    rotate-to-fullscreen
+    data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+    width="480"
+    height="270"
+    layout="responsive">
+  </amp-empower>
+  <div class="spacer"></div>
+</body>
+</html>

--- a/extensions/amp-analytics/amp-video-analytics.md
+++ b/extensions/amp-analytics/amp-video-analytics.md
@@ -27,6 +27,7 @@ AMP video analytics gathers data about how users interact with videos in AMP doc
 | `<amp-brid-player>`   | Partial support<sup>[1]</sup> |
 | `<amp-brightcove>`    | Full support                  |
 | `<amp-dailymotion>`   | Partial support<sup>[1]</sup> |
+| `<amp-empower>`       | Partial support<sup>[1]</sup> |
 | `<amp-ima-video>`     | Partial support<sup>[1]</sup> |
 | `<amp-nexxtv-player>` | Partial support<sup>[1]</sup> |
 | `<amp-ooyala-player>` | Partial support<sup>[1]</sup> |

--- a/extensions/amp-empower/0.1/amp-empower.js
+++ b/extensions/amp-empower/0.1/amp-empower.js
@@ -1,0 +1,364 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Deferred} from '../../../src/utils/promise';
+import {Services} from '../../../src/services';
+import {VideoEvents} from '../../../src/video-interface';
+import {addParamsToUrl} from '../../../src/url';
+import {
+  createFrameFor,
+  isJsonOrObj,
+  mutedOrUnmutedEvent,
+  objOrParseJson,
+  originMatches,
+  redispatch,
+} from '../../../src/iframe-video';
+import {dev, devAssert, userAssert} from '../../../src/log';
+import {
+  fullscreenEnter,
+  fullscreenExit,
+  getDataParamsFromAttributes,
+  isFullscreenElement,
+  removeElement,
+} from '../../../src/dom';
+import {getData, listen} from '../../../src/event-helper';
+import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
+import {isLayoutSizeDefined} from '../../../src/layout';
+
+const TAG = 'amp-empower';
+
+const PlayerEventMap = {
+  'adStart': VideoEvents.AD_START,
+  'adComplete': VideoEvents.AD_END,
+  'videoStart': VideoEvents.PLAYING,
+  'videoComplete': [VideoEvents.ENDED, VideoEvents.PAUSE],
+  'videoResume': VideoEvents.PLAYING,
+  'videoPause': VideoEvents.PAUSE,
+  'videoReplay': VideoEvents.PLAYING,
+};
+
+/** @implements {../../../src/video-interface.VideoInterface} */
+class AmpEmpower extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.iframe_ = null;
+
+    /** @private {?boolean} */
+    this.isFirstPlay_ = true;
+
+    /** @private {?string} */
+    this.videoId_ = null;
+
+    /** @private {?string} */
+    this.videoIframeSrc_ = null;
+
+    /** @private {?Promise} */
+    this.playerReadyPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerReadyResolver_ = null;
+
+    /** @private {?Promise} */
+    this.playerLoadedPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerLoadedResolver_ = null;
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    const {preconnect} = this;
+    preconnect.url(this.getVideoIframeSrc_());
+    preconnect.url('https://cdn.empower.net', opt_onLayout);
+    preconnect.url('https://str.empower.net', opt_onLayout);
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  viewportCallback(visible) {
+    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
+  }
+
+  /** @override */
+  buildCallback() {
+    this.videoId_ = userAssert(
+      this.getVideoId_(),
+      'The data-video attribute is required for <amp-empower> %s',
+      this.element
+    );
+
+    const readyDeferred = new Deferred();
+    this.playerReadyPromise_ = readyDeferred.promise;
+    this.playerReadyResolver_ = readyDeferred.resolve;
+
+    const loadedDeferred = new Deferred();
+    this.playerLoadedPromise_ = loadedDeferred.promise;
+    this.playerLoadedResolver_ = loadedDeferred.resolve;
+
+    installVideoManagerForDoc(this.element);
+  }
+
+  /** @override */
+  layoutCallback() {
+    devAssert(this.videoId_);
+
+    this.iframe_ = createFrameFor(this, this.getVideoIframeSrc_(), null, [
+      'allow-same-origin',
+      'allow-scripts',
+    ]);
+
+    Services.videoManagerForDoc(this.element).register(this);
+
+    this.unlistenMessage_ = listen(
+      this.win,
+      'message',
+      this.handleMessage_.bind(this)
+    );
+
+    const loaded = this.loadPromise(this.iframe_).then(() => {
+      this.element.dispatchCustomEvent(VideoEvents.LOAD);
+    });
+    this.playerReadyResolver_(loaded);
+    return loaded;
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+    }
+
+    if (this.unlistenMessage_) {
+      this.unlistenMessage_();
+    }
+
+    const readyDeferred = new Deferred();
+    this.playerReadyPromise_ = readyDeferred.promise;
+    this.playerReadyResolver_ = readyDeferred.resolve;
+
+    const loadedDeferred = new Deferred();
+    this.playerLoadedPromise_ = loadedDeferred.promise;
+    this.playerLoadedResolver_ = loadedDeferred.resolve;
+
+    return true;
+  }
+
+  /** @override */
+  pauseCallback() {
+    if (this.iframe_ && this.iframe_.contentWindow) {
+      this.pause();
+    }
+  }
+
+  /**
+   * @return {?string}
+   * @private
+   */
+  getVideoId_() {
+    return this.element.getAttribute('data-video');
+  }
+
+  /** @return {string} */
+  getVideoIframeSrc_() {
+    if (this.videoIframeSrc_) {
+      return this.videoIframeSrc_;
+    }
+
+    devAssert(this.videoId_);
+    const baseSrc =
+      'https://embed.empower.net/?video=' +
+      encodeURIComponent(this.videoId_ || '') +
+      '&amp=1#amp=1';
+
+    const params = getDataParamsFromAttributes(this.element);
+    if ('autoplay' in params) {
+      // Autoplay is managed by video manager, do not pass it.
+      delete params['autoplay'];
+    }
+
+    return (this.videoIframeSrc_ = addParamsToUrl(baseSrc, params));
+  }
+
+  /**
+   * Sends a command to the player through postMessage.
+   * @param {object} command
+   * @private
+   */
+  sendCommand_(command) {
+    this.playerReadyPromise_.then(() => {
+      if (this.iframe_ && this.iframe_.contentWindow) {
+        this.iframe_.contentWindow./*OK*/ postMessage(command, '*');
+      }
+    });
+  }
+
+  /**
+   *
+   * @param {!Event} event
+   * @private
+   */
+  handleMessage_(event) {
+    if (!originMatches(event, this.iframe_, 'https://embed.empower.net')) {
+      return;
+    }
+    const eventData = getData(event);
+    if (!isJsonOrObj(eventData)) {
+      return;
+    }
+
+    const data = objOrParseJson(eventData);
+    if (data == null) {
+      return;
+    }
+
+    const eventType = data['type'];
+
+    redispatch(this.element, eventType, PlayerEventMap);
+
+    if (
+      eventType === 'statusChange' &&
+      data['status'] &&
+      data['status'] === 'loaded'
+    ) {
+      this.playerLoadedResolver_(true);
+    }
+  }
+
+  // VideoInterface Implementation. See ../src/video-interface.VideoInterface
+
+  /** @override */
+  supportsPlatform() {
+    return true;
+  }
+
+  /** @override */
+  isInteractive() {
+    return true;
+  }
+
+  /** @override */
+  play(unusedIsAutoplay) {
+    if (this.isFirstPlay_) {
+      this.isFirstPlay_ = false;
+      this.playerLoadedPromise_.then(() => {
+        this.sendCommand_({'command': 'playVideo'});
+      });
+    } else {
+      this.sendCommand_({'command': 'resume'});
+    }
+  }
+
+  /** @override */
+  pause() {
+    this.sendCommand_({'command': 'pause'});
+  }
+
+  /** @override */
+  seekTo(seconds) {
+    this.sendCommand_({'command': 'seekTo', 'time': seconds});
+  }
+
+  /** @override */
+  mute() {
+    this.sendCommand_({'command': 'mute'});
+    this.element.dispatchCustomEvent(mutedOrUnmutedEvent(true));
+  }
+
+  /** @override */
+  unmute() {
+    this.sendCommand_({'command': 'unmute'});
+    this.element.dispatchCustomEvent(mutedOrUnmutedEvent(false));
+  }
+
+  /** @override */
+  showControls() {}
+
+  /** @override */
+  hideControls() {}
+
+  /** @override */
+  fullscreenEnter() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenEnter(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  fullscreenExit() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    if (!this.iframe_) {
+      return false;
+    }
+    return isFullscreenElement(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  getMetadata() {}
+
+  /** @override */
+  preimplementsMediaSessionAPI() {
+    return false;
+  }
+
+  /** @override */
+  preimplementsAutoFullscreen() {
+    return false;
+  }
+
+  /** @override */
+  getCurrentTime() {
+    // Not supported.
+    return 0;
+  }
+
+  /** @override */
+  getDuration() {
+    // Not supported.
+    return 1;
+  }
+
+  /** @override */
+  getPlayedRanges() {
+    // Not supported.
+    return [];
+  }
+}
+
+AMP.extension(TAG, '0.1', AMP => {
+  AMP.registerElement(TAG, AmpEmpower);
+});

--- a/extensions/amp-empower/0.1/test/test-amp-empower.js
+++ b/extensions/amp-empower/0.1/test/test-amp-empower.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-empower';
+
+describes.realWin(
+  'amp-empower',
+  {
+    amp: {
+      extensions: ['amp-empower'],
+    },
+  },
+  env => {
+    let win, doc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+    });
+
+    function getEmpower(video, opt_responsive) {
+      const empower = doc.createElement('amp-empower');
+      empower.setAttribute('data-video', video);
+      empower.setAttribute('width', '111');
+      empower.setAttribute('height', '222');
+      if (opt_responsive) {
+        empower.setAttribute('layout', 'responsive');
+      }
+      doc.body.appendChild(empower);
+      return empower
+        .build()
+        .then(() => {
+          return empower.layoutCallback();
+        })
+        .then(() => empower);
+    }
+
+    it('renders', () => {
+      return getEmpower('c2abd452-453d-47e6-ab96-3796f98857d0').then(
+        empower => {
+          const iframe = empower.querySelector('iframe');
+          expect(iframe).to.not.be.null;
+          expect(iframe.tagName).to.equal('IFRAME');
+          expect(iframe.src).to.equal(
+            'https://embed.empower.net/?video=c2abd452-453d-47e6-ab96-3796f98857d0#amp=1'
+          );
+        }
+      );
+    });
+
+    it('renders responsively', () => {
+      return getEmpower('c2abd452-453d-47e6-ab96-3796f98857d0', true).then(
+        empower => {
+          const iframe = empower.querySelector('iframe');
+          expect(iframe).to.not.be.null;
+          expect(iframe.className).to.match(/i-amphtml-fill-content/);
+        }
+      );
+    });
+
+    it('requires data-video', () => {
+      return allowConsoleError(() => {
+        return getEmpower('').should.eventually.be.rejectedWith(
+          /The data-video attribute is required for/
+        );
+      });
+    });
+  }
+);

--- a/extensions/amp-empower/0.1/test/validator-amp-empower.html
+++ b/extensions/amp-empower/0.1/test/validator-amp-empower.html
@@ -1,0 +1,47 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests validation for the amp-empower tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Empower examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h2>Empower</h2>
+
+  <!-- Valid -->
+  <amp-empower data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270"></amp-empower>
+
+  <!-- Valid -->
+  <amp-empower data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270" layout="responsive"></amp-empower>
+
+  <!-- Invalid: bad data-video. -->
+  <amp-empower data-video="something else" width="480" height="270" layout="responsive"></amp-empower>
+
+  <!-- Invalid: data-video missing. -->
+  <amp-empower width="480" height="270" layout="responsive"></amp-empower>
+</body>
+</html>

--- a/extensions/amp-empower/0.1/test/validator-amp-empower.out
+++ b/extensions/amp-empower/0.1/test/validator-amp-empower.out
@@ -1,0 +1,52 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-empower tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Empower examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h2>Empower</h2>
+|
+|    <!-- Valid -->
+|    <amp-empower data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270"></amp-empower>
+|
+|    <!-- Valid -->
+|    <amp-empower data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270" layout="responsive"></amp-empower>
+|
+|    <!-- Invalid: bad data-video. -->
+|    <amp-empower data-video="something else" width="480" height="270" layout="responsive"></amp-empower>
+>>   ^~~~~~~~~
+amp-empower/0.1/test/validator-amp-empower.html:42:2 The attribute 'data-video' in tag 'amp-empower' is set to the invalid value 'something else'. (see https://amp.dev/documentation/components/amp-empower)
+|
+|    <!-- Invalid: data-video missing. -->
+|    <amp-empower width="480" height="270" layout="responsive"></amp-empower>
+>>   ^~~~~~~~~
+amp-empower/0.1/test/validator-amp-empower.html:45:2 The mandatory attribute 'data-video' is missing in tag 'amp-empower'. (see https://amp.dev/documentation/components/amp-empower)
+|  </body>
+|  </html>

--- a/extensions/amp-empower/OWNERS
+++ b/extensions/amp-empower/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{name: 'ampproject/wg-ui-and-a11y'}, {name: 'merty'}],
+    },
+  ],
+}

--- a/extensions/amp-empower/amp-empower.md
+++ b/extensions/amp-empower/amp-empower.md
@@ -1,0 +1,104 @@
+---
+$category@: media
+formats:
+  - websites
+teaser:
+  text: Displays an Empower video.
+---
+
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-empower
+
+Displays an embedded <a href="https://www.empower.net/">Empower</a> video.
+
+<table>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, flex-item, responsive</td>
+  </tr>
+</table>
+
+[TOC]
+
+## Example
+
+With responsive layout the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
+
+```html
+<amp-empower
+  data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+  layout="responsive"
+  width="480"
+  height="270"
+></amp-empower>
+```
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><strong>data-video (required)</strong></td>
+    <td>The ID of the Empower video, which can be found on the Empower Console.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-param-player (optional)</strong></td>
+    <td>The ID of the Empower player configuration, which can be found on the Empower Console.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-param-site (optional)</strong></td>
+    <td>The ID of the Empower site definition, which can be found on the Empower Console.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>data-param-sitename (optional)</strong></td>
+    <td>The site name string provided by Empower, based on your domain name.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>autoplay</strong></td>
+    <td>
+      <p>If this attribute is present, and the browser supports autoplay:</p>
+      <ul>
+        <li>the video is automatically muted before autoplay starts</li>
+        <li>when the video is scrolled out of view, the video is paused</li>
+        <li>when the video is scrolled into view, the video resumes playback</li>
+        <li>when the user taps the video, the video is unmuted</li>
+        <li>if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it. For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>dock</strong></td>
+    <td><strong>Requires <code>amp-video-docking</code> extension.</strong> If this attribute is present and the video is playing manually, the video will be "minimized" and fixed to a corner or an element when the user scrolls out of the video component's visual area.
+    For more details, see <a href="https://amp.dev/documentation/components/amp-video-docking">documentation on the docking extension itself.</a></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>rotate-to-fullscreen</strong></td>
+    <td>If the video is visible, the video displays fullscreen after the user rotates their device into landscape mode. For more details, see the <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#rotate-to-fullscreen">Video in AMP spec</a>.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.</td>
+  </tr>
+</table>
+
+## Validation
+
+See [amp-empower rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-empower/validator-amp-empower.protoascii) in the AMP validator specification.

--- a/extensions/amp-empower/validator-amp-empower.protoascii
+++ b/extensions/amp-empower/validator-amp-empower.protoascii
@@ -1,0 +1,50 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-empower
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-empower"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-empower>
+  html_format: AMP
+  tag_name: "AMP-EMPOWER"
+  requires_extension: "amp-empower"
+  attrs: {
+    name: "data-video"
+    mandatory: true
+    value_regex: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+  }
+  attrs: { name: "autoplay" }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
+  attrs: { name: "rotate-to-fullscreen" }
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}

--- a/extensions/amp-story/amp-story-page-attachment.md
+++ b/extensions/amp-story/amp-story-page-attachment.md
@@ -109,6 +109,7 @@ Story page attachments allow the same HTML elements as AMP Story along with addi
   <li><code>&lt;amp-dailymotion></code></li>
   <li><code>&lt;amp-date-countdown></code></li>
   <li><code>&lt;amp-embedly-card></code></li>
+  <li><code>&lt;amp-empower></code></li>
   <li><code>&lt;amp-facebook></code></li>
   <li><code>&lt;amp-facebook-comments></code></li>
   <li><code>&lt;amp-facebook-like></code></li>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -802,6 +802,7 @@ descendant_tag_list {
   tag: "AMP-DAILYMOTION"
   tag: "AMP-DATE-COUNTDOWN"
   tag: "AMP-EMBEDLY-CARD"
+  tag: "AMP-EMPOWER"
   tag: "AMP-FACEBOOK"
   tag: "AMP-FACEBOOK-COMMENTS"
   tag: "AMP-FACEBOOK-LIKE"

--- a/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-empower.html
+++ b/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-empower.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for amp-video-docking tag with amp-empower player.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-latest.js"></script>
+  <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-latest.js"></script>
+</head>
+<body>
+  <!-- Valid: dock with `amp-empower` and `amp-video-docking` extensions-->
+  <amp-empower dock data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270"></amp-empower>
+</body>
+</html>

--- a/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-empower.out
+++ b/extensions/amp-video-docking/0.1/test/validator-amp-video-docking-amp-empower.out
@@ -1,0 +1,36 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for amp-video-docking tag with amp-empower player.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-latest.js"></script>
+|    <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-latest.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: dock with `amp-empower` and `amp-video-docking` extensions-->
+|    <amp-empower dock data-video="c2abd452-453d-47e6-ab96-3796f98857d0" width="480" height="270"></amp-empower>
+|  </body>
+|  </html>

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -67,6 +67,7 @@ Currently, the supported players are:
 - [`amp-brightcove`](https://amp.dev/documentation/components/amp-brightcove)
 - [`amp-dailymotion`](https://amp.dev/documentation/components/amp-dailymotion)
 - [`amp-delight-player`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-delight-player/amp-delight-player.md)
+- [`amp-empower`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-empower/amp-empower.md)
 - [`amp-ima-video`](https://amp.dev/documentation/components/amp-ima-video)
 - [`amp-video`](https://amp.dev/documentation/components/amp-video)
 - [`amp-video-iframe`](https://amp.dev/documentation/components/amp-video-iframe)

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -567,7 +567,7 @@ event.response</pre></td>
 
 ### Video elements
 
-The actions below are supported in the following AMP video elements: `amp-video`, `amp-youtube`, `amp-3q-player`, `amp-brid-player`, `amp-dailymotion`, `amp-delight-player`, `amp-ima-video`.
+The actions below are supported in the following AMP video elements: `amp-video`, `amp-youtube`, `amp-3q-player`, `amp-brid-player`, `amp-dailymotion`, `amp-delight-player`, `amp-empower`, `amp-ima-video`.
 
 <table>
   <tr>

--- a/spec/amp-video-interface.md
+++ b/spec/amp-video-interface.md
@@ -12,6 +12,7 @@ These players include:
 - [amp-3q-player](https://amp.dev/documentation/components/amp-3q-player)
 - [amp-brid-player](https://amp.dev/documentation/components/amp-brid-player)
 - [amp-dailymotion](https://amp.dev/documentation/components/amp-dailymotion)
+- [amp-empower](https://amp.dev/documentation/components/amp-empower)
 - [amp-gfycat](https://amp.dev/documentation/components/amp-gfycat)
 - [amp-ima-video](https://amp.dev/documentation/components/amp-ima-video)
 - [amp-nexxtv-player](https://amp.dev/documentation/components/amp-nexxtv-player)
@@ -48,7 +49,7 @@ For an example, visit [AMP By Example](https://amp.dev/documentation/examples/co
 
 attribute: **`dock`**
 
-This attribute is currently only supported for `amp-brightcove`, `amp-dailymotion`, `amp-delight-player`, `amp-ima-video`, `amp-video`, `amp-video-iframe` and `amp-youtube`.
+This attribute is currently only supported for `amp-brightcove`, `amp-dailymotion`, `amp-delight-player`, `amp-empower`, `amp-ima-video`, `amp-video`, `amp-video-iframe` and `amp-youtube`.
 
 If this attribute is present and the video is playing manually, the video will
 be "minimized" and fixed to a corner when the user scrolls out of the video
@@ -76,7 +77,7 @@ For more details, see [documentation on the docking extension itself.](https://a
 
 attribute: **`rotate-to-fullscreen`**
 
-This attribute is currently only supported for `amp-video`, `amp-ima-video` and `amp-dailymotion`.
+This attribute is currently only supported for `amp-empower`, `amp-video`, `amp-ima-video` and `amp-dailymotion`.
 
 If this attribute is present and a video is playing manually (i.e. user initiated playback, or tapped on the video after autoplay), the video displays fullscreen after the user rotates their device into landscape mode, provided that the video is visible.
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -113,7 +113,7 @@ export const LOADING_ELEMENTS_ = {
  * reasons, so they are listed individually.
  * @private @const {!RegExp}
  */
-const videoPlayerTagNameRe = /^amp\-(video|.+player)|AMP-BRIGHTCOVE|AMP-DAILYMOTION|AMP-YOUTUBE|AMP-VIMEO|AMP-IMA-VIDEO/i;
+const videoPlayerTagNameRe = /^amp\-(video|.+player)|AMP-BRIGHTCOVE|AMP-DAILYMOTION|AMP-EMPOWER|AMP-YOUTUBE|AMP-VIMEO|AMP-IMA-VIDEO/i;
 
 /**
  * @param {string} s

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -983,6 +983,7 @@ function supportsFullscreenViaApi(video) {
   // TODO(alanorozco): Determine this via a flag in the component itself.
   return !!{
     'amp-dailymotion': true,
+    'amp-empower': true,
     'amp-ima-video': true,
   }[video.tagName.toLowerCase()];
 }

--- a/test/fixtures/video-players.html
+++ b/test/fixtures/video-players.html
@@ -9,6 +9,7 @@
   <!-- (1) Include your video player component here -->
   <script async custom-element="amp-dailymotion" src="/dist/v0/amp-dailymotion-0.1.max.js"></script>
   <script async custom-element="amp-3q-player" src="/dist/v0/amp-3q-player-0.1.max.js"></script>
+  <script async custom-element="amp-empower" src="/dist/v0/amp-empower-0.1.max.js"></script>
   <script async custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.max.js"></script>
   <script async custom-element="amp-ima-video" src="/dist/v0/amp-ima-video-0.1.max.js"></script>
   <script async custom-element="amp-video" src="/dist/v0/amp-video-0.1.max.js"></script>

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -134,3 +134,11 @@ describe.skip('amp-delight-player', () => {
     return video;
   });
 });
+
+describe.skip('amp-empower', () => {
+  runVideoPlayerIntegrationTests(fixture => {
+    const video = fixture.doc.createElement('amp-empower');
+    video.setAttribute('data-video', 'c2abd452-453d-47e6-ab96-3796f98857d0');
+    return video;
+  });
+});

--- a/test/manual/amp-carousel/0.1/slides.amp.html
+++ b/test/manual/amp-carousel/0.1/slides.amp.html
@@ -15,6 +15,7 @@
   <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
   <script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
   <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+  <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js"></script>
   <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
   <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
   <script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
@@ -80,6 +81,12 @@
         width="500"
         height="281">
     </amp-dailymotion>
+
+    <amp-empower
+      data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+      width="480"
+      height="270">
+    </amp-empower>
 
     <amp-vine
         data-vineid="MdKjXez002d"

--- a/test/manual/amp-carousel/0.2/slides.amp.html
+++ b/test/manual/amp-carousel/0.2/slides.amp.html
@@ -15,6 +15,7 @@
   <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
   <script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
   <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+  <script async custom-element="amp-empower" src="https://cdn.ampproject.org/v0/amp-empower-0.1.js"></script>
   <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
   <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
   <script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
@@ -80,6 +81,12 @@
         width="500"
         height="281">
     </amp-dailymotion>
+
+    <amp-empower
+      data-video="c2abd452-453d-47e6-ab96-3796f98857d0"
+      width="480"
+      height="270">
+    </amp-empower>
 
     <amp-vine
         data-vineid="MdKjXez002d"

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -76,6 +76,7 @@ describe('Layout', () => {
       'AMP-VIMEO',
       'AMP-BRIGHTCOVE',
       'AMP-DAILYMOTION',
+      'AMP-EMPOWER',
     ];
     elementsValidTagNames.forEach(function(tag) {
       el.tagName = tag;


### PR DESCRIPTION
We would like the users of our global ad network and video monetization platform, Empower, to be able to embed their videos hosted on our platform to their AMP pages, so we've created the `amp-empower` component.