### PR TITLE
Cloudflare's AMP Cache is no longer supported

### DIFF
--- a/build-system/global-configs/caches.json
+++ b/build-system/global-configs/caches.json
@@ -9,14 +9,6 @@
       "thirdPartyFrameDomainSuffix": "ampproject.net"
     },
     {
-      "id": "cloudflare",
-      "name": "Cloudflare AMP Cache",
-      "docs": "https://amp.cloudflare.com/",
-      "cacheDomain": "amp.cloudflare.com",
-      "updateCacheApiDomainSuffix": "amp.cloudflare.com",
-      "thirdPartyFrameDomainSuffix": "cloudflareamp.net"
-    },
-    {
       "id": "bing",
       "name": "Bing AMP Cache",
       "docs": "https://www.bing.com/webmaster/help/bing-amp-cache-bc1c884c",

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -21,7 +21,7 @@ const log = require('fancy-log');
 const through2 = require('through2');
 const {jsonGlobs} = require('../test-configs/config');
 
-const expectedCaches = ['cloudflare', 'google'];
+const expectedCaches = ['google'];
 
 const cachesJsonPath = 'build-system/global-configs/caches.json';
 

--- a/spec/amp-cache-guidelines.md
+++ b/spec/amp-cache-guidelines.md
@@ -105,7 +105,6 @@ For resources (i.e., HTML, images, fonts) that are larger than 12 MB, you may no
 
 ## References
 
-* [Cloudflare AMP Cache](https://amp.cloudflare.com/)
 * [Google AMP Cache](https://developers.google.com/amp/cache/)
   * [Google AMP Cache Overview](https://developers.google.com/amp/cache/overview)
   * The [Google AMP Cache](https://developers.google.com/amp/cache/) is a proxy-based content delivery network for delivering all valid AMP documents.

--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -141,12 +141,10 @@ Endpoints should only allow requests from: (1) the publisher's own origin; and
 
 For example, endpoints should allow requests from:
   *  Google AMP Cache subdomain: `https://<publisher's domain>.cdn.ampproject.org` <br>(for example, `https://nytimes-com.cdn.ampproject.org`)
-  *  Cloudflare AMP Cache: `https://<publisher's domain>.amp.cloudflare.com`
 
 {% call callout('Read on', type='read') %}
 For information on AMP Cache URL formats, see these resources:
 - [Google AMP Cache Overview](https://developers.google.com/amp/cache/overview)
-- [Cloudflare AMP Cache](https://amp.cloudflare.com/)
 {% endcall %}
 
 
@@ -193,7 +191,6 @@ following:
 1.  If the origin does not match one of the following values, stop and return an error
     response:
     - `<publisher's domain>.cdn.ampproject.org`
-    - `<publisher's domain>.amp.cloudflare.com`
     - the publisher's origin (aka yours)
 
     where `*` represents a wildcard match, and not an actual asterisk ( * ).
@@ -227,7 +224,6 @@ Based on what we know about CORS and AMP (from [Verify CORS requests](#verify-co
 
 * `example.com` ---  Publisher's domain
 * `example-com.cdn.ampproject.org` --- Google AMP Cache subdomain
-* `example.com.amp.cloudflare.com`--- Cloudflare AMP Cache subdomain
 
 ### Response headers for allowed requests
 
@@ -273,7 +269,6 @@ function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
   const allowedOrigins = [
      "https://example.com",
      "https://example-com.cdn.ampproject.org",
-     "https://example.com.amp.cloudflare.com",
      "https://cdn.ampproject.org" ];
 
   let origin;

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -52,8 +52,8 @@ function getUrl(url) {
  */
 amp.validator.isAmpCacheUrl = function(url) {
   return (
-    url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 || // lgtm [js/incomplete-url-substring-sanitization]
-    url.toLowerCase().indexOf('amp.cloudflare.com') !== -1); // lgtm [js/incomplete-url-substring-sanitization]
+    url.toLowerCase().indexOf('cdn.ampproject.org') !== -1 // lgtm [js/incomplete-url-substring-sanitization]
+  );
 };
 
 /**

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -112,10 +112,6 @@
   <form method="post" action-xhr="https://example-com.cdn.ampproject.org/subscribe" target="_blank">
     <input type="submit" value="Subscribe">
   </form>
-  <!-- Invalid: form action must be a non-cdn link -->
-  <form method="post" action-xhr="https://example-com.amp.cloudflare.com/subscribe" target="_blank">
-    <input type="submit" value="Subscribe">
-  </form>
   <!-- Valid: disallowed domain checks subdomains, not suffix -->
   <form method="post" action-xhr="https://example-cdn.ampproject.org/subscribe" target="_blank">
     <input type="submit" value="Subscribe">


### PR DESCRIPTION
As per https://github.com/ampproject/amphtml/issues/24407, Cloudflare's AMP Cache is deprecated. This removes all reference to the cache from the repo.