### PR TITLE
✨amp-bind: Allow String.replace()

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -144,6 +144,7 @@ function generateFunctionWhitelist() {
       'concat': String.prototype.concat,
       'indexOf': String.prototype.indexOf,
       'lastIndexOf': String.prototype.lastIndexOf,
+      'replace': String.prototype.replace,
       'slice': String.prototype.slice,
       'split': String.prototype.split,
       'substr': String.prototype.substr,

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -232,6 +232,7 @@ describe('BindExpression', () => {
       expect(evaluate('"abc".indexOf("b")')).to.equal(1);
       expect(evaluate('"aaa".lastIndexOf("a")')).to.equal(2);
       expect(evaluate('"abc".slice(0, 2)')).to.equal('ab');
+      expect(evaluate('"abc".replace("bc", "xy")')).to.equal('axy');
       expect(evaluate('"a-b-c".split("-")')).to.deep.equal(['a', 'b', 'c']);
       expect(evaluate('"abc".substr(1)')).to.equal('bc');
       expect(evaluate('"abc".substring(0, 2)')).to.equal('ab');
@@ -251,9 +252,6 @@ describe('BindExpression', () => {
       }).to.throw(Error, unsupportedFunctionError);
       expect(() => {
         evaluate('"abc".repeat(2)');
-      }).to.throw(Error, unsupportedFunctionError);
-      expect(() => {
-        evaluate('"abc".replace("bc", "xy")');
       }).to.throw(Error, unsupportedFunctionError);
       expect(() => {
         evaluate('"abc".search()');

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -293,6 +293,7 @@ null || 'default' // 'default'
       <code>concat</code><br>
       <code>indexOf</code><br>
       <code>lastIndexOf</code><br>
+      <code>replace</code><br>
       <code>slice</code><br>
       <code>split</code><br>
       <code>substr</code><br>


### PR DESCRIPTION
Resolves #24659
Only string attributes are supported (Regex not supported)