### PR TITLE
📖 Make PR template text invisible even when it is inadvertently included in a PR description

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,13 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [
+        { name: 'ampproject/wg-outreach' },
+        { name: 'ampproject/wg-infra' }
+      ]
+    }
+  ]
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+
+<!--
 # Instructions:
 
 - Pick a meaningful title for your pull request. (Use sentence case.)
@@ -15,7 +17,7 @@
 - Improve performance by B
 - Improve accessibility by C
 
-# Emojis for categorizing pull requests (copy-paste into description):
+# Emojis for categorizing pull requests (copy-paste emoji into description):
 
 ✨ New feature
 🐛 Bug fix
@@ -30,3 +32,4 @@
 ⏪ Reverting a previous change
 ♻️ Refactoring
 🚮 Deleting code
+-->


### PR DESCRIPTION
This PR hides the PR template boilerplate even if it is inadvertently included in a PR description. Note that the instructions will still be visible when developers are writing their PR descriptions, because the github editor displays raw markup.

@mrjoro @CrystalOnScript WDYT?

**For example:**

<img width="685" alt="Screen Shot 2019-10-08 at 4 23 41 PM" src="https://user-images.githubusercontent.com/26553114/66430585-65232f80-e9e8-11e9-910e-e9d5d7d5d194.png">
