### PR TITLE
🏗 A few minor `OWNERS` fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,6 @@ extensions/amp-a4a/0.1/test/testdata/**
 testing/local-amp-chrome-extension/**
 third_party/**
 validator/**
+
+# Lint all OWNERS files
+!**/OWNERS

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,15 +3,12 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "quoteProps": "preserve",
-
   "overrides": [{
     "files": "OWNERS",
     "options": {
       "parser": "json5",
       "bracketSpacing": true,
-      "quoteProps": "as-needed",
-      "tabWidth": 2,
-      "trailingComma": "none",
+      "trailingComma": "none"
     }
   }]
 }

--- a/OWNERS
+++ b/OWNERS
@@ -5,41 +5,23 @@
   rules: [
     {
       owners: [
-        {
-          name: 'cramforce',
-          requestReviews: false
-        },
-        {
-          name: 'dvoytenko',
-          requestReviews: false
-        },
-        {
-          name: 'jridgewell',
-          requestReviews: false
-        }
+        { name: 'cramforce', requestReviews: false },
+        { name: 'dvoytenko', requestReviews: false },
+        { name: 'jridgewell', requestReviews: false }
       ]
     },
-
     {
       pattern: '**/validator-*.{protoascii,html,out}',
-      owners: [
-        {
-          name: 'ampproject/wg-caching',
-          notify: true
-        }
-      ]
+      owners: [{ name: 'ampproject/wg-caching', notify: true }]
     },
-
     {
       pattern: '*.md',
       owners: [{ name: 'ampproject/wg-outreach' }]
     },
-
     {
       pattern: '{.*,babel.config.js,gulpfile.js}',
       owners: [{ name: 'ampproject/wg-infra' }]
     },
-
     {
       pattern: '{package.json,yarn.lock}',
       owners: [
@@ -48,7 +30,6 @@
         { name: 'ampproject/wg-performance' }
       ]
     },
-
     {
       // The below rule will be here only temporarily during the transition
       // period while many owners files are being updated as contributors and
@@ -64,12 +45,7 @@
       // TODO(#24685): Remove this once most owners files have been updated
       // and/or the Travis check is implemented.
       pattern: '**/{OWNERS.yaml,OWNERS}',
-      owners: [
-        {
-          name: 'rcebulko',
-          notify: true
-        }
-      ]
+      owners: [{ name: 'rcebulko', notify: true }]
     }
   ]
 }

--- a/css/OWNERS
+++ b/css/OWNERS
@@ -7,9 +7,7 @@
       owners: [
         { name: 'ampproject/wg-ui-and-a11y' },
         { name: 'aghassemi', requestReviews: false },
-        { name: 'camelburrito', requestReviews: false },
-        { name: 'kristoferbaxter' },
-        { name: 'sparhami' }
+        { name: 'camelburrito', requestReviews: false }
       ]
     }
   ]

--- a/css/OWNERS
+++ b/css/OWNERS
@@ -5,8 +5,9 @@
   rules: [
     {
       owners: [
-        { name: 'aghassemi' },
-        { name: 'camelburrito' },
+        { name: 'ampproject/wg-ui-and-a11y' },
+        { name: 'aghassemi', requestReviews: false },
+        { name: 'camelburrito', requestReviews: false },
         { name: 'kristoferbaxter' },
         { name: 'sparhami' }
       ]

--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -4,9 +4,7 @@
 {
   rules: [
     {
-      owners: [
-        { name: '*' }
-      ]
+      owners: [{ name: '*' }]
     }
   ]
 }

--- a/extensions/OWNERS
+++ b/extensions/OWNERS
@@ -9,14 +9,8 @@
     {
       pattern: '**/*-player.{js,md}',
       owners: [
-        {
-          name: 'alanorozco',
-          notify: true
-        },
-        {
-          name: 'wassgha',
-          notify: true
-        }
+        { name: 'alanorozco', notify: true },
+        { name: 'wassgha', notify: true }
       ]
     }
   ]

--- a/extensions/OWNERS
+++ b/extensions/OWNERS
@@ -4,7 +4,10 @@
 {
   rules: [
     {
-      owners: [{ name: 'aghassemi' }]
+      owners: [
+        { name: 'ampproject/wg-ui-and-a11y' },
+        { name: 'aghassemi', requestReviews: false }
+      ]
     },
     {
       pattern: '**/*-player.{js,md}',

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -5,10 +5,9 @@
   rules: [
     {
       owners: [
-        { name: 'aghassemi' },
-        { name: 'choumx' },
-        { name: 'erwinmombay' },
-        { name: 'rsimha' }
+        { name: 'ampproject/wg-infra' },
+        { name: 'ampproject/runtime' },
+        { name: 'ampproject/performance' }
       ]
     }
   ]

--- a/validator/OWNERS
+++ b/validator/OWNERS
@@ -4,9 +4,7 @@
 {
   rules: [
     {
-      owners: [
-        { name: 'ampproject/wg-caching' }
-      ]
+      owners: [{ name: 'ampproject/wg-caching' }]
     }
   ]
 }


### PR DESCRIPTION
- Remove default settings and unnecessary trailing comma from `.prettierrc`
- Don't ignore `OWNERS` files in `.eslintignore`
- Auto-fix a few `OWNERS` files (to be consistent with others)
- Don't auto-request reviews from contributors who no longer work on AMP full-time