### PR TITLE
Add directory, OWNERS for amp-stream-gallery.

### DIFF
--- a/extensions/amp-stream-gallery/OWNERS
+++ b/extensions/amp-stream-gallery/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{ name: 'ampproject/wg-ui-and-a11y' }]
+    }
+  ]
+}


### PR DESCRIPTION
Context: For #24388, I want to create a new UI component, to be owned by the UI working group. The OWNERS check fails due to the new files added in the PR. Creating the OWNERS file as a separate PR, so that PR will have valid ownership.

