### PR TITLE
✨ New feature: Add amp-css-validator: a component that checks for unused css selectors

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -469,6 +469,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-css-validator',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-dailymotion',
     version: '0.1',
     latestVersion: '0.1',

--- a/examples/amp-css-validator.amp.html
+++ b/examples/amp-css-validator.amp.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-css-validator example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    .blue-headline {
+      color: blue;
+      font-size: 60px;
+    }
+    .css-unused {
+      color: red;
+    }
+    @media screen and (min-width: 800px) {
+      body {
+        background-color: lavender;
+      }
+    }
+  </style>
+  <script async custom-element="amp-css-validator" src="https://cdn.ampproject.org/v0/amp-css-validator-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-css-validator layout="nodisplay" width="0" height="0"></amp-css-validator>
+  <h1 class="blue-headline">I am supposed to be blue</h1>
+</body>
+</html>

--- a/extensions/amp-css-validator/0.1/amp-css-validator.js
+++ b/extensions/amp-css-validator/0.1/amp-css-validator.js
@@ -15,6 +15,7 @@
  */
 
 import {devAssert, user} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {iterateCursor} from '../../../src/dom';
 import {whenDocumentComplete} from '../../../src/document-ready';
 
@@ -26,18 +27,20 @@ export class AmpCssValidator extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const doc = devAssert(this.element.ownerDocument);
-    whenDocumentComplete(doc).then(() => {
-      const {styleSheets} = doc;
-      if (!styleSheets) {
-        return;
-      }
-      iterateCursor(styleSheets, styleSheet => {
-        if (styleSheet.ownerNode.hasAttribute('amp-custom')) {
-          this.findStyleRule_(styleSheet.rules);
+    if (getMode().development) {
+      const doc = devAssert(this.element.ownerDocument);
+      whenDocumentComplete(doc).then(() => {
+        const {styleSheets} = doc;
+        if (!styleSheets) {
+          return;
         }
+        iterateCursor(styleSheets, styleSheet => {
+          if (styleSheet.ownerNode.hasAttribute('amp-custom')) {
+            this.findStyleRule_(styleSheet.rules);
+          }
+        });
       });
-    });
+    }
   }
 
   /**

--- a/extensions/amp-css-validator/0.1/amp-css-validator.js
+++ b/extensions/amp-css-validator/0.1/amp-css-validator.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {devAssert, user} from '../../../src/log';
+import {iterateCursor} from '../../../src/dom';
+import {whenDocumentComplete} from '../../../src/document-ready';
+
+export class AmpCssValidator extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+  }
+
+  /** @override */
+  buildCallback() {
+    const doc = devAssert(this.element.ownerDocument);
+    whenDocumentComplete(doc).then(() => {
+      const {styleSheets} = doc;
+      if (!styleSheets) {
+        return;
+      }
+      iterateCursor(styleSheets, styleSheet => {
+        if (styleSheet.ownerNode.hasAttribute('amp-custom')) {
+          this.findStyleRule_(styleSheet.rules);
+        }
+      });
+    });
+  }
+
+  /**
+   * @private
+   * @param {CSSRuleList} rules css rules
+   */
+  findStyleRule_(rules) {
+    const fn = rule => {
+      if (rule.type === CSSRule.STYLE_RULE) {
+        const nodes = this.element.ownerDocument.querySelector(
+          rule.selectorText
+        );
+        if (!nodes) {
+          const size = rule.cssText.length;
+          user().warn(
+            'AMP-CSS-VALIDATOR',
+            'Potentially unused selector found: ',
+            rule.selectorText + '.\n',
+            'Remove it to save ' + size + ' Bytes.'
+          );
+        }
+      } else if (rule.cssRules) {
+        fn(rule.cssRules);
+      }
+    };
+    if (rules) {
+      iterateCursor(rules, fn);
+    }
+  }
+}
+
+AMP.extension('amp-css-validator', '0.1', AMP => {
+  AMP.registerElement('amp-css-validator', AmpCssValidator);
+});

--- a/extensions/amp-css-validator/0.1/test/test-amp-css-validator.js
+++ b/extensions/amp-css-validator/0.1/test/test-amp-css-validator.js
@@ -15,6 +15,7 @@
  */
 
 import '../amp-css-validator';
+import * as mode from '../../../../src/mode';
 
 describes.realWin(
   'amp-css-validator',
@@ -26,9 +27,12 @@ describes.realWin(
   env => {
     let win;
     let element;
+    let modeStub;
 
     beforeEach(() => {
       win = env.win;
+      modeStub = sandbox.stub(mode, 'getMode');
+      modeStub.returns({development: true});
     });
 
     function buildAmpCssValidator() {
@@ -41,7 +45,6 @@ describes.realWin(
     }
 
     it('should warn unused styles', () => {
-      win = env.win;
       const style = win.document.createElement('style');
       const unusedStyleElement = win.document.createElement('div');
       style.setAttribute('amp-custom', '');
@@ -55,7 +58,6 @@ describes.realWin(
     });
 
     it('should not warn used styles', () => {
-      win = env.win;
       const style = win.document.createElement('style');
       const usedStyleElement = win.document.createElement('div');
       usedStyleElement.setAttribute('class', 'amp-used-style');

--- a/extensions/amp-css-validator/0.1/test/test-amp-css-validator.js
+++ b/extensions/amp-css-validator/0.1/test/test-amp-css-validator.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../amp-css-validator';
+
+describes.realWin(
+  'amp-css-validator',
+  {
+    amp: {
+      extensions: ['amp-css-validator'],
+    },
+  },
+  env => {
+    let win;
+    let element;
+
+    beforeEach(() => {
+      win = env.win;
+    });
+
+    function buildAmpCssValidator() {
+      element = win.document.createElement('amp-css-validator');
+      element.setAttribute('layout', 'nodisplay');
+      element.setAttribute('width', '0');
+      element.setAttribute('height', '0');
+      env.win.document.body.appendChild(element);
+      return element.build().then(() => element);
+    }
+
+    it('should warn unused styles', () => {
+      win = env.win;
+      const style = win.document.createElement('style');
+      const unusedStyleElement = win.document.createElement('div');
+      style.setAttribute('amp-custom', '');
+      style.innerHTML += '.amp-unused-style { font-size: 16px; }';
+      win.document.head.appendChild(style);
+      win.document.body.appendChild(unusedStyleElement);
+
+      return buildAmpCssValidator(element).then(() => {
+        expect(console.warn).to.have.been.called;
+      });
+    });
+
+    it('should not warn used styles', () => {
+      win = env.win;
+      const style = win.document.createElement('style');
+      const usedStyleElement = win.document.createElement('div');
+      usedStyleElement.setAttribute('class', 'amp-used-style');
+      style.setAttribute('amp-custom', '');
+      style.innerHTML += '.amp-used-style { font-size: 16px; }';
+      win.document.head.appendChild(style);
+      win.document.body.appendChild(usedStyleElement);
+
+      return buildAmpCssValidator(element).then(() => {
+        expect(console.warn).to.have.not.been.called;
+      });
+    });
+  }
+);

--- a/extensions/amp-css-validator/0.1/test/validator-amp-css-validator.html
+++ b/extensions/amp-css-validator/0.1/test/validator-amp-css-validator.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-css-validator example</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-css-validator {
+      color: red;
+    }
+  </style>
+  <script async custom-element="amp-css-validator" src="https://cdn.ampproject.org/v0/amp-css-validator-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-css-validator layout="responsive" width="150" height="80"></amp-css-validator>
+</body>
+</html>

--- a/extensions/amp-css-validator/0.1/test/validator-amp-css-validator.out
+++ b/extensions/amp-css-validator/0.1/test/validator-amp-css-validator.out
@@ -1,0 +1,23 @@
+FAIL
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-css-validator example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-css-validator {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-css-validator" src="https://cdn.ampproject.org/v0/amp-css-validator-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-css-validator layout="responsive" width="150" height="80"></amp-css-validator>
+>>   ^~~~~~~~~
+amp-css-validator/0.1/test/validator-amp-css-validator.html:18:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-css-validator'. (see https://amp.dev/documentation/components/amp-css-validator) [AMP_LAYOUT_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-css-validator/amp-css-validator.md
+++ b/extensions/amp-css-validator/amp-css-validator.md
@@ -1,0 +1,80 @@
+<!--
+  1. Change "category" below to one of:
+       ads-analytics
+       dynamic-content
+       layout
+       media
+       presentation
+       social
+
+  2. Remove any of the "formats" that don't apply.
+     You can also add the "ads" and "stories" formats if they apply.
+
+  3. And remove this comment! (no empty lines before "---")
+-->
+---
+$category: presentation
+formats:
+  - websites
+  - email
+teaser:
+  text: FILL THIS IN.
+---
+<!--
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# `amp-css-validator`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-css-validator" src="https://cdn.ampproject.org/v0/amp-css-validator-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td>FILL THIS IN</td>
+  </tr>
+</table>
+
+## Behavior
+
+FILL THIS IN. What does this extension do?
+
+## Attributes
+
+FILL THIS IN. Does this extension allow for properties to configure?
+
+<table>
+  <tr>
+    <td width="40%"><strong>data-my-attribute</strong></td>
+    <td>FILL THIS IN. This table <strong>must</strong> be written in HTML.</td>
+  </tr>
+</table>
+
+## Validation
+See [amp-css-validator rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-css-validator/validator-amp-css-validator.protoascii) in the AMP validator specification.

--- a/extensions/amp-css-validator/amp-css-validator.md
+++ b/extensions/amp-css-validator/amp-css-validator.md
@@ -1,24 +1,10 @@
-<!--
-  1. Change "category" below to one of:
-       ads-analytics
-       dynamic-content
-       layout
-       media
-       presentation
-       social
-
-  2. Remove any of the "formats" that don't apply.
-     You can also add the "ads" and "stories" formats if they apply.
-
-  3. And remove this comment! (no empty lines before "---")
--->
 ---
-$category: presentation
+$category: development
 formats:
   - websites
   - email
 teaser:
-  text: FILL THIS IN.
+  text: Warns developers potentially unused CSS selectors.
 ---
 <!--
 Copyright 2019 The AMP HTML Authors. All Rights Reserved.
@@ -41,38 +27,23 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>FILL THIS IN</td>
+    <td>Warns developers potentially unused CSS selectors.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>FILL THIS IN</td>
+    <td>Experimental</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-css-validator" src="https://cdn.ampproject.org/v0/amp-css-validator-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
-    <td>FILL THIS IN</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Examples</strong></td>
-    <td>FILL THIS IN</td>
-  </tr>
-</table>
-
-## Behavior
-
-FILL THIS IN. What does this extension do?
-
-## Attributes
-
-FILL THIS IN. Does this extension allow for properties to configure?
-
-<table>
-  <tr>
-    <td width="40%"><strong>data-my-attribute</strong></td>
-    <td>FILL THIS IN. This table <strong>must</strong> be written in HTML.</td>
+    <td class="col-fourty"><strong>Examples</strong></td>
+    <td>
+      <ul>
+        <li><a href="https://github.com/ampproject/amphtml/tree/master/examples/amp-css-validator.amp.html">Unannotated code samples</a></li>
+      </ul>
+    </td>
   </tr>
 </table>
 

--- a/extensions/amp-css-validator/validator-amp-css-validator.protoascii
+++ b/extensions/amp-css-validator/validator-amp-css-validator.protoascii
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-css-validator
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-css-validator"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-css-validator>
+  html_format: AMP
+  tag_name: "AMP-CSS-VALIDATOR"
+  requires_extension: "amp-css-validator"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-css-validator"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}


### PR DESCRIPTION
Add a new component that checks for unused css selectors and reports them to the developer in the console. 

This should be stripped from cached AMP pages because this is development extension.

Co-authored-by: @cjdeleon62 @nickfalcone