### PR TITLE
Story branching navigation path fixes.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1123,6 +1123,17 @@ export class AmpStoryPage extends AMP.BaseElement {
       return this.element.getAttribute('i-amphtml-return-to');
     }
 
+    const navigationPath = this.storeService_.get(
+      StateProperty.NAVIGATION_PATH
+    );
+    const previousPageId = navigationPath[navigationPath.length - 2];
+
+    if (previousPageId) {
+      return previousPageId;
+    }
+
+    // If the page was loaded with a `#page=foo` hash, it could have no
+    // navigation path but still a previous page in the DOM.
     const previousElement = this.element.previousElementSibling;
     if (previousElement && previousElement.tagName.toLowerCase() === TAG) {
       return previousElement.id;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1126,6 +1126,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     const navigationPath = this.storeService_.get(
       StateProperty.NAVIGATION_PATH
     );
+    // Navigation path is a complete list of the navigation history, including
+    // the currently active page. The previous page is the next to last element
+    // of that array.
     const previousPageId = navigationPath[navigationPath.length - 2];
 
     if (previousPageId) {

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -151,8 +151,9 @@ export const StateProperty = {
   CURRENT_PAGE_ID: 'currentPageId',
   CURRENT_PAGE_INDEX: 'currentPageIndex',
   ADVANCEMENT_MODE: 'advancementMode',
-  PAGE_IDS: 'pageIds',
+  NAVIGATION_PATH: 'navigationPath',
   NEW_PAGE_AVAILABLE_ID: 'newPageAvailableId',
+  PAGE_IDS: 'pageIds',
 };
 
 /** @private @const @enum {string} */
@@ -161,7 +162,8 @@ export const Action = {
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
-  SET_PAGE_IDS: 'addToPageIds',
+  SET_NAVIGATION_PATH: 'setNavigationPath',
+  SET_PAGE_IDS: 'setPageIds',
   TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_AFFILIATE_LINK: 'toggleAffiliateLink',
@@ -191,7 +193,6 @@ export const Action = {
  * @private @const {!Object<string, !function(*, *):boolean>}
  */
 const stateComparisonFunctions = {
-  [StateProperty.PAGE_IDS]: (old, curr) => old.length !== curr.length,
   [StateProperty.ACTIONS_WHITELIST]: (old, curr) => old.length !== curr.length,
   [StateProperty.INTERACTIVE_COMPONENT_STATE]:
     /**
@@ -199,6 +200,8 @@ const stateComparisonFunctions = {
      * @param {InteractiveComponentDef} curr
      */
     (old, curr) => old.element !== curr.element || old.state !== curr.state,
+  [StateProperty.NAVIGATION_PATH]: (old, curr) => old.length !== curr.length,
+  [StateProperty.PAGE_IDS]: (old, curr) => old.length !== curr.length,
 };
 
 /**
@@ -355,6 +358,10 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.ADVANCEMENT_MODE]: data,
       }));
+    case Action.SET_NAVIGATION_PATH:
+      return /** @type {!State} */ (Object.assign({}, state, {
+        [StateProperty.NAVIGATION_PATH]: data,
+      }));
     case Action.SET_PAGE_IDS:
       return /** @type {!State} */ (Object.assign({}, state, {
         [StateProperty.PAGE_IDS]: data,
@@ -489,8 +496,9 @@ export class AmpStoryStoreService {
       [StateProperty.CURRENT_PAGE_ID]: '',
       [StateProperty.CURRENT_PAGE_INDEX]: 0,
       [StateProperty.ADVANCEMENT_MODE]: '',
-      [StateProperty.PAGE_IDS]: [],
       [StateProperty.NEW_PAGE_AVAILABLE_ID]: '',
+      [StateProperty.NAVIGATION_PATH]: [],
+      [StateProperty.PAGE_IDS]: [],
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -282,9 +282,6 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!Array<!./amp-story-page.AmpStoryPage>} */
     this.adPages_ = [];
 
-    /** @private {Array<string>} */
-    this.storyNavigationPath_ = [];
-
     /** @const @private {!./variable-service.AmpStoryVariableService} */
     this.variableService_ = getVariableService(this.win);
 
@@ -951,9 +948,7 @@ export class AmpStory extends AMP.BaseElement {
           page.setState(PageState.NOT_ACTIVE);
           this.upgradeCtaAnchorTagsForTracking_(page, index);
         });
-        if (isExperimentOn(this.win, 'amp-story-branching')) {
-          this.initializeStoryNavigationPath_();
-        }
+        this.initializeStoryNavigationPath_();
       })
       .then(() => this.initializeBookend_())
       .then(() => {
@@ -1346,10 +1341,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   switchTo_(targetPageId, direction) {
-    const targetPage = isExperimentOn(this.win, 'amp-story-branching')
-      ? this.updateStoryNavigationPath_(targetPageId, direction)
-      : this.getPageById(targetPageId);
-
+    const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 
     // Step out if trying to navigate to the currently active page.
@@ -1378,6 +1370,9 @@ export class AmpStory extends AMP.BaseElement {
 
     const oldPage = this.activePage_;
     this.activePage_ = targetPage;
+    if (!targetPage.isAd()) {
+      this.updateNavigationPath_(targetPageId, direction);
+    }
 
     // Each step will run in a requestAnimationFrame, and wait for the next
     // frame before executing the following step.
@@ -1502,40 +1497,32 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Update the story level stack and check for navigation adherence
+   * Updates the story navigation stack and checks for navigation adherence to
    * to the path a user takes.
    * @param {string} targetPageId
-   * @param {string} direction
-   * @return {!./amp-story-page.AmpStoryPage}
+   * @param {!NavigationDirection} direction
    * @private
    */
-  updateStoryNavigationPath_(targetPageId, direction) {
+  updateNavigationPath_(targetPageId, direction) {
+    const navigationPath = /** @type {!Array<string>} */ (this.storeService_.get(
+      StateProperty.NAVIGATION_PATH
+    ));
+
     if (direction === NavigationDirection.PREVIOUS) {
-      this.storyNavigationPath_.pop();
-      if (this.storyNavigationPath_.length > 0) {
-        const pathPrevious = this.storyNavigationPath_[
-          this.storyNavigationPath_.length - 1
-        ];
-        if (pathPrevious !== targetPageId) {
-          return this.getPageById(pathPrevious);
-        }
-      }
-    } else if (direction === NavigationDirection.NEXT) {
-      const topOfStack = this.storyNavigationPath_[
-        this.storyNavigationPath_.length - 1
-      ];
-      // If the user navigates the away from the page, the top of storyStack
-      // will be the same as ampStoryPageId in the history state.
-      if (targetPageId !== topOfStack) {
-        this.storyNavigationPath_.push(targetPageId);
-      }
+      navigationPath.pop();
     }
-    setHistoryState(
-      this.win,
-      HistoryState.NAVIGATION_PATH,
-      this.storyNavigationPath_
-    );
-    return this.getPageById(targetPageId);
+
+    // Ensures the pageId is not at the top of the stack already, which could
+    // happen when reloading a page.
+    if (
+      direction === NavigationDirection.NEXT &&
+      navigationPath[navigationPath.length - 1] !== targetPageId
+    ) {
+      navigationPath.push(targetPageId);
+    }
+
+    this.storeService_.dispatch(Action.SET_NAVIGATION_PATH, navigationPath);
+    setHistoryState(this.win, HistoryState.NAVIGATION_PATH, navigationPath);
   }
 
   /**
@@ -2136,10 +2123,13 @@ export class AmpStory extends AMP.BaseElement {
       }
       // There may be other 1 skip away pages due to branching.
       if (isExperimentOn(this.win, 'amp-story-branching')) {
-        const indexInStack = this.storyNavigationPath_.indexOf(
+        const navigationPath = this.storeService_.get(
+          StateProperty.NAVIGATION_PATH
+        );
+        const indexInStack = navigationPath.indexOf(
           this.activePage_.element.id
         );
-        const maybePrev = this.storyNavigationPath_[indexInStack - 1];
+        const maybePrev = navigationPath[indexInStack - 1];
         if (indexInStack > 0 && pageId === this.activePage_.element.id) {
           if (!pagesByDistance[1]) {
             pagesByDistance[1] = [];
@@ -2545,13 +2535,10 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeStoryNavigationPath_() {
-    const historyNavigationPath = getHistoryState(
-      this.win,
-      HistoryState.NAVIGATION_PATH
+    this.storeService_.dispatch(
+      Action.SET_NAVIGATION_PATH,
+      getHistoryState(this.win, HistoryState.NAVIGATION_PATH) || []
     );
-    if (historyNavigationPath) {
-      this.storyNavigationPath_ = /** @type {!Array<string>} */ (historyNavigationPath);
-    }
   }
 
   /** @private */
@@ -2559,7 +2546,7 @@ export class AmpStory extends AMP.BaseElement {
     if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
       this.hideBookend_();
     }
-    this.storyNavigationPath_.length = 0;
+    this.storeService_.dispatch(Action.SET_NAVIGATION_PATH, []);
     const switchPromise = this.switchTo_(
       dev().assertElement(this.pages_[0].element).id,
       NavigationDirection.NEXT

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1498,7 +1498,7 @@ export class AmpStory extends AMP.BaseElement {
 
   /**
    * Updates the story navigation stack and checks for navigation adherence to
-   * to the path a user takes.
+   * the path a user takes.
    * @param {string} targetPageId
    * @param {!NavigationDirection} direction
    * @private
@@ -1512,8 +1512,8 @@ export class AmpStory extends AMP.BaseElement {
       navigationPath.pop();
     }
 
-    // Ensures the pageId is not at the top of the stack already, which could
-    // happen when reloading a page.
+    // Ensures the pageId is not at the top of the stack already, which can
+    // happen on initial page load (e.g. reloading a page).
     if (
       direction === NavigationDirection.NEXT &&
       navigationPath[navigationPath.length - 1] !== targetPageId


### PR DESCRIPTION
Fixing a few things about the story navigation path.
The `updateNavigationPath` method used to decide of the target page: you'd call `switchTo` with a page ID, but it would be overridden in some cases. This was causing different bugs with progress bar and history, as the `targetPage` was overridden but not the `targetPageId`.

Instead, the navigation path is now stored and globally accessible. Pages, when getting the previous page id, look up in the navigation path. This way `switchTo` actually navigates to the page you passed as a parameter, making its behavior easier to predict and removing the previously mentioned bugs.
`updateNavigationPath` no longer decides of the target page, but only updates the store + history.