### PR TITLE
Remove the branching share page checkbox.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share.css
+++ b/extensions/amp-story/1.0/amp-story-share.css
@@ -167,22 +167,3 @@
   font-size: 11px !important;
   text-align: center !important;
 }
-
-.i-amphtml-story-page-share {
-  display: flex !important;
-  margin: 0 24px 12px !important;
-  align-items: center !important;
-}
-
-.i-amphtml-story-page-share-input {
-  height: 18px !important;
-  width: 18px !important;
-  margin: 0 !important;
-}
-
-.i-amphtml-story-page-share-label {
-  color: rgba(0, 0, 0, 0.87) !important;
-  margin-left: 8px !important;
-  font-family: 'Roboto', regular !important;
-  font-size: 13px !important;
-}

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -15,7 +15,6 @@
  */
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {Services} from '../../../src/services';
-import {StateProperty, getStoreService} from './amp-story-store-service';
 import {Toast} from './toast';
 import {
   copyTextToClipboard,
@@ -226,9 +225,6 @@ export class ShareWidget {
 
     /** @private @const {!./amp-story-request-service.AmpStoryRequestService} */
     this.requestService_ = getRequestService(this.win, storyEl);
-
-    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win);
   }
 
   /**
@@ -292,8 +288,6 @@ export class ShareWidget {
    * @private
    */
   copyUrlToClipboard_() {
-    const currentPageId = this.storeService_.get(StateProperty.CURRENT_PAGE_ID);
-
     const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl;
 
     if (!copyTextToClipboard(this.win, url)) {

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -24,7 +24,6 @@ import {
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
 import {getRequestService} from './amp-story-request-service';
-import {isExperimentOn} from '../../../src/experiments';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
 import {px, setImportantStyles} from '../../../src/style';
@@ -89,32 +88,6 @@ const TEMPLATE = {
           attrs: dict({'class': 'i-amphtml-story-share-system'}),
         },
       ],
-    },
-  ],
-};
-
-/** @private @const {!./simple-template.ElementDef} */
-const SHARE_PAGE_TEMPLATE = {
-  tag: 'div',
-  attrs: dict({
-    'class': 'i-amphtml-story-page-share',
-  }),
-  children: [
-    {
-      tag: 'input',
-      attrs: dict({
-        'class': 'i-amphtml-story-page-share-input',
-        'type': 'checkbox',
-        'id': 'page-share',
-      }),
-    },
-    {
-      tag: 'label',
-      attrs: dict({
-        'class': 'i-amphtml-story-page-share-label',
-        'for': 'page-share',
-      }),
-      localizedStringId: LocalizedStringId.AMP_STORY_SHARING_PAGE_LABEL,
     },
   ],
 };
@@ -284,7 +257,6 @@ export class ShareWidget {
     this.loadProviders();
     this.maybeAddLinkShareButton_();
     this.maybeAddSystemShareButton_();
-    this.maybeAddPageShareButton_();
 
     return this.root;
   }
@@ -312,42 +284,17 @@ export class ShareWidget {
 
     listen(linkShareButton, 'click', e => {
       e.preventDefault();
-      let shareFromCurrentPage = false;
-      if (isExperimentOn(this.win, 'amp-story-branching')) {
-        shareFromCurrentPage = this.root.querySelector('#page-share').checked;
-      }
-      this.copyUrlToClipboard_(shareFromCurrentPage);
+      this.copyUrlToClipboard_();
     });
   }
 
   /**
-   * On desktop mode, with branching, users should be able to share a story
-   * starting from a specific page.
    * @private
    */
-  maybeAddPageShareButton_() {
-    if (isExperimentOn(this.win, 'amp-story-branching')) {
-      const list = devAssert(this.root).firstChild;
-      const sharePageCheck = renderAsElement(
-        this.win.document,
-        SHARE_PAGE_TEMPLATE
-      );
-      this.root.insertBefore(sharePageCheck, list);
-    }
-  }
-
-  /**
-   * @param {boolean} shareFromCurrentPage
-   * @private
-   */
-  copyUrlToClipboard_(shareFromCurrentPage) {
+  copyUrlToClipboard_() {
     const currentPageId = this.storeService_.get(StateProperty.CURRENT_PAGE_ID);
-    const shouldAddFragment =
-      isExperimentOn(this.win, 'amp-story-branching') && shareFromCurrentPage;
 
-    const url =
-      Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl +
-      (shouldAddFragment ? '#page=' + currentPageId : '');
+    const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl;
 
     if (!copyTextToClipboard(this.win, url)) {
       this.localizationServicePromise_.then(localizationService => {


### PR DESCRIPTION
Removing this checkbox for desktop/mobile parity, as native sharing where we don't control the shared URL (unless we hack the `location.href`?) is now supported on both iOS and Android.
I'm open to discussing keeping it, but this would require UX work to get the wording + design right.