### PR TITLE
Add reviewers team to root OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 // https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
 
 {
+  reviewerTeam: 'ampproject/reviewers-amphtml',
   rules: [
     {
       owners: [


### PR DESCRIPTION
Defines the reviewer team for the repository. Will cause the owners bot to enforce that every PR must have approval from at least one member of the `ampproject/reviewers-amphtml` team.

Closes https://github.com/ampproject/amp-github-apps/issues/522