### PR TITLE
🏗 Don't use `eslint` to check `OWNERS` files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,3 @@ extensions/amp-a4a/0.1/test/testdata/**
 testing/local-amp-chrome-extension/**
 third_party/**
 validator/**
-
-# Lint all OWNERS files
-!**/OWNERS

--- a/.eslintrc
+++ b/.eslintrc
@@ -208,13 +208,6 @@
         "process": false,
         "require": false
       }
-    },
-    {
-      "files": ["**/OWNERS"],
-      "rules": {
-        "notice/notice": 0,
-        "no-lone-blocks": 0
-      }
     }
   ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,13 +2,5 @@
   "bracketSpacing": false,
   "singleQuote": true,
   "trailingComma": "es5",
-  "quoteProps": "preserve",
-  "overrides": [{
-    "files": "OWNERS",
-    "options": {
-      "parser": "json5",
-      "bracketSpacing": true,
-      "trailingComma": "none"
-    }
-  }]
+  "quoteProps": "preserve"
 }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -225,7 +225,7 @@ function lint() {
   } else if (!eslintRulesChanged() && argv.local_changes) {
     const lintableFiles = lintableFilesChanged();
     if (lintableFiles.length == 0) {
-      log(colors.green('INFO: ') + 'No JS or OWNERS files in this PR');
+      log(colors.green('INFO: ') + 'No JS files in this PR');
       return Promise.resolve();
     }
     filesToLint = getFilesToLint(lintableFiles);

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -102,7 +102,6 @@ const jisonPaths = ['extensions/**/*.jison'];
 
 const lintGlobs = [
   '**/*.js',
-  '**/OWNERS',
   // To ignore a file / directory, add it to .eslintignore.
 ];
 


### PR DESCRIPTION
#24938, #24943, and #24946 made it so that the formatting of `OWNERS` files was checked using `eslint` (in particular, `eslint-plugin-prettier`).

It turns out that `eslint` doesn't really work well for json5 code. For example, [this](https://github.com/ampproject/amphtml/pull/24988/files) simple change [broke](https://travis-ci.org/ampproject/amphtml/jobs/595662724#L384) the `babel-eslint` parser.

This PR rolls back the parts of #24938, #24943, and #24946 that had to do with linting `OWNERS` files, while leaving in place other improvements that were introduced (like [de-duplication](https://github.com/ampproject/amphtml/pull/24943#discussion_r332244710) of code).

With this, `OWNERS` files will no longer be checked by `eslint` or `prettier`. In future, a new workflow will be introduced to check `OWNERS` files for formatting and correctness.

Unblocks #24988