### PR TITLE
🐛Restrict checking cached ampDoc reference to AMP elements.

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -207,7 +207,7 @@ export class AmpSidebar extends AMP.BaseElement {
         );
         if (target && target.href) {
           const tgtLoc = Services.urlForDoc(element).parse(target.href);
-          const currentHref = this.getAmpDoc().win.location.href;
+          const currentHref = this.getAmpDoc().getUrl();
           // Important: Only close sidebar (and hence pop sidebar history entry)
           // when navigating locally, Chrome might cancel navigation request
           // due to after-navigation history manipulation inside a timer callback.

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -482,13 +482,8 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').returns({
-            win: {
-              location: {
-                href: window.location.href,
-              },
-            },
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -519,16 +514,8 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-            return {
-              win: {
-                location: {
-                  // Mocking navigating from example.com -> localhost:9876
-                  href: 'http://example.com',
-                },
-              },
-            };
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -559,17 +546,10 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-            return {
-              win: {
-                location: {
-                  // Mocking navigating from
-                  // /context.html?old=context -> /context.html
-                  href: 'http://localhost:9876/context.html?old=context',
-                },
-              },
-            };
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          sandbox
+            .stub(ampDoc, 'getUrl')
+            .returns('http://localhost:9876/context.html?old=context');
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -223,7 +223,7 @@ export class AmpSidebar extends AMP.BaseElement {
         );
         if (target && target.href) {
           const tgtLoc = Services.urlForDoc(element).parse(target.href);
-          const currentHref = this.getAmpDoc().win.location.href;
+          const currentHref = this.getAmpDoc().getUrl();
           // Important: Only close sidebar (and hence pop sidebar history entry)
           // when navigating locally, Chrome might cancel navigation request
           // due to after-navigation history manipulation inside a timer callback.

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -485,13 +485,8 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').returns({
-            win: {
-              location: {
-                href: window.location.href,
-              },
-            },
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -522,16 +517,9 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-            return {
-              win: {
-                location: {
-                  // Mocking navigating from example.com -> localhost:9876
-                  href: 'http://example.com',
-                },
-              },
-            };
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          // Mocking navigating from example.com -> localhost:9876
+          sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -562,17 +550,12 @@ describes.realWin(
           if (eventObj.initEvent) {
             eventObj.initEvent('click', true, true);
           }
-          sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-            return {
-              win: {
-                location: {
-                  // Mocking navigating from
-                  // /context.html?old=context -> /context.html
-                  href: 'http://localhost:9876/context.html?old=context',
-                },
-              },
-            };
-          });
+          const ampDoc = sidebarElement.getAmpDoc();
+          // Mocking navigating from /context.html?old=context -> /context.html
+          sandbox
+            .stub(ampDoc, 'getUrl')
+            .returns('http://localhost:9876/context.html?old=context');
+
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -131,7 +131,7 @@ export class AmpDocService {
     // element has behavior where child fields with `name` get added as
     // properties to the Element, which could have a naming conflict with
     // the renamed property for `ampDoc_` here.
-    if (node.tagName && !startsWith(node.tagName, 'AMP-')) {
+    if (!node.tagName || !startsWith(node.tagName, 'AMP-')) {
       return null;
     }
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -117,25 +117,19 @@ export class AmpDocService {
   }
 
   /**
+   * If the node is an AMP custom element, retrieves the AmpDoc reference.
    * @param {!Node} node
-   * @return {?AmpDoc}
+   * @return {?AmpDoc} The AmpDoc reference, if one exists.
    */
-  getCachedAmpDocReference_(node) {
-    const cached = node.ampdoc_;
-
-    if (!cached) {
+  getCustomElementAmpDocReference_(node) {
+    // We can only look up the AmpDoc from a custom element if it has been
+    // attached at some point. If it is not a custom element, one or both of
+    // these checks should fail.
+    if (!node.everAttached || typeof node.getAmpDoc !== 'function') {
       return null;
     }
 
-    // Note: We need to check that this is a custom AMP element. The `<form>`
-    // element has behavior where child fields with `name` get added as
-    // properties to the Element, which could have a naming conflict with
-    // the renamed property for `ampDoc_` here.
-    if (!node.tagName || !startsWith(node.tagName, 'AMP-')) {
-      return null;
-    }
-
-    return cached;
+    return node.getAmpDoc();
   }
 
   /**
@@ -159,7 +153,7 @@ export class AmpDocService {
         // global AmpDoc, which we do not want. This occurs when using
         // <amp-next-page>.
 
-        const cachedAmpDoc = this.getCachedAmpDocReference_(node);
+        const cachedAmpDoc = this.getCustomElementAmpDocReference_(node);
         if (cachedAmpDoc) {
           return cachedAmpDoc;
         }
@@ -194,7 +188,7 @@ export class AmpDocService {
       // for the closest AmpDoc, the element might have a reference to the
       // global AmpDoc, which we do not want. This occurs when using
       // <amp-next-page>.
-      const cachedAmpDoc = this.getCachedAmpDocReference_(node);
+      const cachedAmpDoc = this.getCustomElementAmpDocReference_(node);
       if (cachedAmpDoc) {
         return cachedAmpDoc;
       }

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -31,7 +31,6 @@ import {isExperimentOn} from '../experiments';
 import {map} from '../utils/object';
 import {parseQueryString} from '../url';
 import {rootNodeFor, waitForBodyOpenPromise} from '../dom';
-import {startsWith} from '../string';
 
 /** @const {string} */
 const AMPDOC_PROP = '__AMPDOC';

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -92,6 +92,17 @@ describes.sandboxed('AmpDocService', {}, () => {
       expect(service.getSingleDoc()).to.be.instanceOf(AmpDocSingle);
     });
 
+    it('should not return a conflicting value on a form', () => {
+      const node = document.createElement('form');
+      // Note: Instead of actually creating an input element with a name that
+      // conflicts, just set this directly in case the test is ever run in
+      // an compiled environment.
+      node.ampDoc_ = 5;
+
+      const ampDoc = service.getAmpDocIfAvailable(node);
+      expect(ampDoc).to.equal(service.getSingleDoc());
+    });
+
     it('should always yield the single document', () => {
       expect(() => service.getAmpDoc(null)).to.throw;
       expect(service.getAmpDoc(document)).to.equal(service.getSingleDoc());
@@ -162,7 +173,7 @@ describes.sandboxed('AmpDocService', {}, () => {
 
     beforeEach(() => {
       service = new AmpDocService(window, /* isSingleDoc */ false);
-      content = document.createElement('span');
+      content = document.createElement('amp-img');
       host = document.createElement('div');
       setShadowDomSupportedVersionForTesting(undefined);
       if (isShadowDomSupported()) {
@@ -299,7 +310,7 @@ describes.sandboxed('AmpDocService', {}, () => {
     beforeEach(() => {
       toggleExperiment(window, 'ampdoc-fie', true);
       service = new AmpDocService(window, /* isSingleDoc */ true);
-      content = document.createElement('span');
+      content = document.createElement('amp-img');
       host = document.createElement('div');
       setShadowDomSupportedVersionForTesting(undefined);
       if (isShadowDomSupported()) {

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -97,7 +97,7 @@ describes.sandboxed('AmpDocService', {}, () => {
       // Note: Instead of actually creating an input element with a name that
       // conflicts, just set this directly in case the test is ever run in
       // an compiled environment.
-      node.ampDoc_ = 5;
+      node.getAmpDoc = 5;
 
       const ampDoc = service.getAmpDocIfAvailable(node);
       expect(ampDoc).to.equal(service.getSingleDoc());
@@ -107,7 +107,7 @@ describes.sandboxed('AmpDocService', {}, () => {
       // This is a stand-in for testing a document, without actually modifying
       // the document to keep the test side-effect free.
       const frag = document.createDocumentFragment();
-      frag.ampDoc_ = 5;
+      frag.getAmpDoc = 5;
 
       const ampDoc = service.getAmpDocIfAvailable(frag);
       expect(ampDoc).to.equal(service.getSingleDoc());
@@ -210,7 +210,8 @@ describes.sandboxed('AmpDocService', {}, () => {
 
     it('should yield custom-element shadow-doc when exists', () => {
       const ampDoc = {};
-      content.ampdoc_ = ampDoc;
+      content.everAttached = true;
+      content.getAmpDoc = () => ampDoc;
       host.appendChild(content);
       expect(service.getAmpDoc(content)).to.equal(ampDoc);
     });
@@ -226,11 +227,12 @@ describes.sandboxed('AmpDocService', {}, () => {
 
       // Override via custom element.
       const ampDoc2 = {};
-      content.ampdoc_ = ampDoc2;
+      content.everAttached = true;
+      content.getAmpDoc = () => ampDoc2;
       expect(service.getAmpDoc(content)).to.equal(ampDoc2);
 
       // Fallback to cached version when custom element returns null.
-      content.ampdoc_ = null;
+      content.getAmpDoc = () => null;
       expect(service.getAmpDoc(content)).to.equal(ampDoc);
     });
 
@@ -348,7 +350,8 @@ describes.sandboxed('AmpDocService', {}, () => {
 
     it('should yield custom-element doc when exists', () => {
       const ampDoc = {};
-      content.ampdoc_ = ampDoc;
+      content.everAttached = true;
+      content.getAmpDoc = () => ampDoc;
       host.appendChild(content);
       expect(service.getAmpDoc(content)).to.equal(ampDoc);
     });
@@ -364,11 +367,12 @@ describes.sandboxed('AmpDocService', {}, () => {
 
       // Override via custom element.
       const ampDoc2 = {};
-      content.ampdoc_ = ampDoc2;
+      content.everAttached = true;
+      content.getAmpDoc = () => ampDoc2;
       expect(service.getAmpDoc(content)).to.equal(ampDoc2);
 
       // Fallback to cached version when custom element returns null.
-      content.ampdoc_ = null;
+      content.getAmpDoc = () => null;
       expect(service.getAmpDoc(content)).to.equal(ampDoc);
     });
 

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -103,6 +103,16 @@ describes.sandboxed('AmpDocService', {}, () => {
       expect(ampDoc).to.equal(service.getSingleDoc());
     });
 
+    it('should not return a conflicting value on a document fragment', () => {
+      // This is a stand-in for testing a document, without actually modifying
+      // the document to keep the test side-effect free.
+      const frag = document.createDocumentFragment();
+      frag.ampDoc_ = 5;
+
+      const ampDoc = service.getAmpDocIfAvailable(frag);
+      expect(ampDoc).to.equal(service.getSingleDoc());
+    });
+
     it('should always yield the single document', () => {
       expect(() => service.getAmpDoc(null)).to.throw;
       expect(service.getAmpDoc(document)).to.equal(service.getSingleDoc());


### PR DESCRIPTION
This fixes a bug where the compiled (renamed) property for `ampDoc_`
could conflict with a form field name. Rather than blacklist `form`,
whitelist `amp-` elements in case anything else has this behavior (like
`window` and Element `id`s).

Fixes #24995