### PR TITLE
Media Pool: generate HTMLSourceElement from the src attribute.

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -279,7 +279,10 @@ export class MediaPool {
         const sources = this.getDefaultSource_(type);
         mediaEl.id = POOL_ELEMENT_ID_PREFIX + poolIdCounter++;
         mediaEl[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] = MediaElementOrigin.POOL;
-        this.enqueueMediaElementTask_(mediaEl, new UpdateSourcesTask(sources));
+        this.enqueueMediaElementTask_(
+          mediaEl,
+          new UpdateSourcesTask(this.win_, sources)
+        );
         // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
         // is returned.  If so, we should adjust the pool size/distribution
         // between media types.
@@ -545,7 +548,7 @@ export class MediaPool {
         this.maybeResetAmpMedia_(ampMediaForDomEl);
         this.enqueueMediaElementTask_(
           poolMediaEl,
-          new UpdateSourcesTask(sources)
+          new UpdateSourcesTask(this.win_, sources)
         );
         this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());
       },
@@ -588,7 +591,7 @@ export class MediaPool {
 
     return this.enqueueMediaElementTask_(
       poolMediaEl,
-      new UpdateSourcesTask(defaultSources)
+      new UpdateSourcesTask(this.win_, defaultSources)
     );
   }
 
@@ -750,7 +753,7 @@ export class MediaPool {
 
     // This media element has not yet been registered.
     placeholderEl.id = id;
-    const sources = Sources.removeFrom(placeholderEl);
+    const sources = Sources.removeFrom(this.win_, placeholderEl);
     this.sources_[id] = sources;
     this.placeholderEls_[id] = placeholderEl;
 

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -353,11 +353,15 @@ export class BlessTask extends MediaTask {
  */
 export class UpdateSourcesTask extends MediaTask {
   /**
+   * @param {!Window} win
    * @param {!Sources} newSources The sources to which the media element should
    *     be updated.
    */
-  constructor(newSources) {
+  constructor(win, newSources) {
     super('update-src');
+
+    /** @private {!Window} */
+    this.win_ = win;
 
     /** @private @const {!Sources} */
     this.newSources_ = newSources;
@@ -365,8 +369,8 @@ export class UpdateSourcesTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    Sources.removeFrom(mediaEl);
-    this.newSources_.applyToElement(mediaEl);
+    Sources.removeFrom(this.win_, mediaEl);
+    this.newSources_.applyToElement(this.win_, mediaEl);
     return Promise.resolve();
   }
 }

--- a/extensions/amp-story/1.0/sources.js
+++ b/extensions/amp-story/1.0/sources.js
@@ -16,27 +16,28 @@
 
 import {ampMediaElementFor} from './utils';
 import {removeElement} from '../../../src/dom';
+import {toArray} from '../../../src/types';
 
 /**
  * Class handling HTMLMediaElements sources.
  */
 export class Sources {
   /**
-   * @param {?string=} opt_srcAttr The 'src' attribute of the media element.
-   * @param {?IArrayLike<!Element>=} opt_srcEls Any child <source> tags of the
+   * @param {?string=} srcAttr The 'src' attribute of the media element.
+   * @param {!Array<!Element>=} srcEls Any child <source> tags of the
    *     media element.
-   * @param {?IArrayLike<!Element>=} opt_trackEls Any child <track> tags of the
+   * @param {!Array<!Element>=} trackEls Any child <track> tags of the
    *     media element.
    */
-  constructor(opt_srcAttr, opt_srcEls, opt_trackEls) {
+  constructor(srcAttr = null, srcEls = [], trackEls = []) {
     /** @private @const {?string} */
-    this.srcAttr_ = opt_srcAttr !== undefined ? opt_srcAttr : null;
+    this.srcAttr_ = srcAttr;
 
-    /** @private @const {!IArrayLike<!Element>} */
-    this.srcEls_ = opt_srcEls || [];
+    /** @private @const {!Array<!Element>} */
+    this.srcEls_ = srcEls;
 
-    /** @private @const {!IArrayLike<!Element>} */
-    this.trackEls_ = opt_trackEls || [];
+    /** @private @const {!Array<!Element>} */
+    this.trackEls_ = trackEls;
   }
 
   /**
@@ -66,11 +67,12 @@ export class Sources {
 
   /**
    * Applies the src attribute and source tags to a specified element.
+   * @param {!Window} win
    * @param {!HTMLMediaElement} element The element to adopt the sources
    *     represented by this object.
    */
-  applyToElement(element) {
-    Sources.removeFrom(element);
+  applyToElement(win, element) {
+    Sources.removeFrom(win, element);
 
     if (!this.srcAttr_) {
       element.removeAttribute('src');
@@ -101,22 +103,61 @@ export class Sources {
 
   /**
    * Removes and returns the sources from a specified element.
+   * @param {!Window} win
    * @param {!Element} element The element whose sources should be removed and
    *     returned.
    * @return {!Sources} An object representing the sources of the specified
    *     element.
    */
-  static removeFrom(element) {
+  static removeFrom(win, element) {
     const elementToUse = ampMediaElementFor(element) || element;
-    const srcAttr = elementToUse.getAttribute('src');
-    elementToUse.removeAttribute('src');
 
-    const srcEls = elementToUse.querySelectorAll('source');
-    Array.prototype.forEach.call(srcEls, srcEl => removeElement(srcEl));
+    let srcEl = null;
+    // If the src attribute is specified, create a source element from it as it
+    // prevents race conditions between amp-story and amp-video propagating or
+    // removing attributes from amp-video/video elements.
+    if (elementToUse.hasAttribute('src')) {
+      srcEl = Sources.createSourceElement(win, elementToUse);
+      elementToUse.removeAttribute('src');
+    }
 
-    const trackEls = elementToUse.querySelectorAll('track');
-    Array.prototype.forEach.call(trackEls, trackEl => removeElement(trackEl));
+    const srcEls = toArray(elementToUse.querySelectorAll('source'));
+    srcEls.forEach(srcEl => removeElement(srcEl));
 
-    return new Sources(srcAttr, srcEls, trackEls);
+    const trackEls = toArray(elementToUse.querySelectorAll('track'));
+    trackEls.forEach(trackEl => removeElement(trackEl));
+
+    // If the src attribute is present, browsers will follow it and ignore the
+    // HTMLSourceElements. To ensure this behavior, drop the sources if the src
+    // was specified.
+    // cf: https://html.spec.whatwg.org/#concept-media-load-algorithm
+    const sourcesToUse = srcEl ? [srcEl] : srcEls;
+
+    return new Sources(null /** srcAttr */, sourcesToUse, trackEls);
+  }
+
+  /**
+   * Creates a HTMLSourceElement from the element src attribute.
+   * @param {!Window} win
+   * @param {!Element} element
+   * @return {!Element}
+   */
+  static createSourceElement(win, element) {
+    const srcEl = win.document.createElement('source');
+
+    const srcAttr = element.getAttribute('src');
+    srcEl.setAttribute('src', srcAttr);
+
+    const origSrcAttr = element.getAttribute('amp-orig-src');
+    if (origSrcAttr) {
+      srcEl.setAttribute('amp-orig-src', origSrcAttr);
+    }
+
+    const typeAttr = element.getAttribute('type');
+    if (typeAttr) {
+      srcEl.setAttribute('type', typeAttr);
+    }
+
+    return srcEl;
   }
 }

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -27,12 +27,14 @@ import {
 import {Sources} from '../sources';
 import {toArray} from '../../../../src/types';
 
-describes.realWin('media-tasks', {}, () => {
+describes.realWin('media-tasks', {}, env => {
+  let win;
   let sandbox;
   let el;
   let vsyncApi;
 
   beforeEach(() => {
+    win = env.win;
     sandbox = sinon.sandbox;
     el = document.createElement('video');
 
@@ -159,7 +161,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources);
+      const task = new UpdateSourcesTask(win, newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -173,7 +175,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources);
+      const task = new UpdateSourcesTask(win, newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -186,7 +188,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(NEW_SRC_URL, []);
-      const task = new UpdateSourcesTask(newSources);
+      const task = new UpdateSourcesTask(win, newSources);
       task.execute(el);
       expect(el.src).to.equal(NEW_SRC_URL);
       expect(toArray(el.children)).to.be.empty;
@@ -202,10 +204,47 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, NEW_SRC_ELS);
-      const task = new UpdateSourcesTask(newSources);
+      const task = new UpdateSourcesTask(win, newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.deep.equal(NEW_SRC_ELS);
+    });
+
+    it('should propagate the src attribute as a source', () => {
+      el.setAttribute('src', './foo.mp4');
+      const newSources = Sources.removeFrom(win, el);
+      const task = new UpdateSourcesTask(win, newSources);
+      task.execute(el);
+      expect(el).to.not.have.attribute('src');
+      expect(toArray(el.children)).to.have.length(1);
+      expect(el.firstElementChild).to.have.attribute('src');
+      expect(el.firstElementChild.getAttribute('src')).to.equal('./foo.mp4');
+    });
+
+    it('should propagate the amp-orig-src attribute as a source', () => {
+      el.setAttribute('src', './foo.mp4');
+      el.setAttribute('amp-orig-src', './bar.mp4');
+      const newSources = Sources.removeFrom(win, el);
+      const task = new UpdateSourcesTask(win, newSources);
+      task.execute(el);
+      expect(el.firstElementChild).to.have.attribute('amp-orig-src');
+      expect(el.firstElementChild.getAttribute('amp-orig-src')).to.equal(
+        './bar.mp4'
+      );
+    });
+
+    it('should drop sources if a src attribute is specified', () => {
+      el.setAttribute('src', './foo.mp4');
+      getFakeSources([1, 2, 3]).forEach(source => {
+        el.appendChild(source);
+      });
+      const newSources = Sources.removeFrom(win, el);
+      const task = new UpdateSourcesTask(win, newSources);
+      task.execute(el);
+      expect(el).to.not.have.attribute('src');
+      expect(toArray(el.children)).to.have.length(1);
+      expect(el.firstElementChild).to.have.attribute('src');
+      expect(el.firstElementChild.getAttribute('src')).to.equal('./foo.mp4');
     });
   });
 


### PR DESCRIPTION
Cached videos don't fallback to the origin video when configured as attributes of `<amp-video>`.
The media pool will remove the `src` attribute before the `amp-video.layoutCallback` runs, preventing it from propagating the cached src as a source of the new `<video>` element.

Solution is to transform the `src` attribute as a `HTMLSourceElement`, that will later be picked up by `amp-video.layoutCallback`.

This fixes stories like [this one](https://interactive-aljazeera-com.cdn.ampproject.org/v/s/interactive.aljazeera.com/aje/2018/nepal-great-plunder/index.html?amp_js_v=0.1&usqp=mq331AQCKAE%3D) (see page 2).