### PR TITLE
✨ Add <amp-story-embed> AMP extension

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -143,9 +143,9 @@ exports.jsBundles = {
       includePolyfills: false,
     },
   },
-  'amp-story-embed.js': {
+  'amp-story-embed-v0.js': {
     srcDir: './src/',
-    srcFilename: 'amp-story-embed.js',
+    srcFilename: 'amp-story-embed-manager.js',
     destDir: './dist',
     minifiedDestDir: './dist',
     options: {
@@ -896,6 +896,12 @@ exports.extensionBundles = [
         'amp-story-auto-ads-attribution',
       ],
     },
+    type: TYPES.MISC,
+  },
+  {
+    name: 'amp-story-embed',
+    version: '0.1',
+    latestVersion: '0.1',
     type: TYPES.MISC,
   },
   {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -198,7 +198,7 @@ function compileAllJs(watch, minify) {
     doBuildJs(jsBundles, 'recaptcha.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-viewer-host.max.js', {watch, minify}),
     doBuildJs(jsBundles, 'video-iframe-integration.js', {watch, minify}),
-    doBuildJs(jsBundles, 'amp-story-embed.js', {watch, minify}),
+    doBuildJs(jsBundles, 'amp-story-embed-manager.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-inabox-host.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-shadow.js', {watch, minify}),
     doBuildJs(jsBundles, 'amp-inabox.js', {watch, minify}),

--- a/examples/visual-tests/amp-story/amp-story-embed-amp.html
+++ b/examples/visual-tests/amp-story/amp-story-embed-amp.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html amp>
+  <head>
+    <title>Story Embed (AMP)</title>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story-embed" src="https://cdn.ampproject.org/v0/amp-story-embed-0.1.js"></script>
+    <link rel="canonical" href="grid-layer-templates.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <meta charset="utf-8">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      body {
+        border: 0;
+        font-family: sans-serif;
+        margin: 0;
+        padding: 32px;
+      }
+
+      h1 {
+        margin: 0;
+      }
+
+      .highlight {
+        color: red;
+      }
+
+      amp-story-embed { all: initial; display: block; border-radius: 0 !important; width: 405px; height: 720px; overflow: auto; }
+    </style>
+    <script>
+      // TODO(#17108): Remove this when getMode().test is set.
+      __AMP_TEST = true;
+    </script>
+  </head>
+  <body>
+    <h1>This is an <span class="highlight">AMP</span> page that embeds a story below:</h1>
+    <amp-story-embed>
+      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
+          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
+          class="story">
+        <span class="title">A local’s guide to what to eat and do in New York City</span>
+      </a>
+      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/"
+          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/promo3x4.jpg"
+          class="story">
+        <span class="title">A local’s guide to what to eat and do in Miami</span>
+      </a>
+      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/"
+          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/promo3x4.jpg"
+          class="story">
+        <span class="title">A local’s guide to what to eat and do in Mexico City</span>
+      </a>
+      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/"
+          data-poster-portrait-src="https://washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-do-and-eat-in-rome/img/promo3x4.jpg"
+          class="story">
+        <span class="title">A local’s guide to what to eat and do in Rome</span>
+      </a>
+    </amp-story-embed>
+  </body>
+</html>

--- a/examples/visual-tests/amp-story/amp-story-embed-non-amp.html
+++ b/examples/visual-tests/amp-story/amp-story-embed-non-amp.html
@@ -1,44 +1,30 @@
 <html>
   <head>
-    <title>AMP Story Embed Example</title>
-    <script async src="../../dist/amp-story-embed.js"></script>
-    <style page>
+    <title>Story Embed (Non-AMP)</title>
+    <script async src="../../../dist/amp-story-embed-manager.js"></script>
+    <style>
       body {
+        border: 0;
         font-family: sans-serif;
-      }
-    </style>
-    <style injected>
-      .amp-story-embed {
-        width: 405px;
-        height: 720px;
+        margin: 0;
+        padding: 32px;
       }
 
-      .story {
-        background-size: cover;
-        display: block;
-        position: relative;
-        height: 100%;
-        width: 100%;
-        flex: 0 0 100%;
+      h1 {
+        margin: 0;
       }
 
-      .title {
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 1));
-        display: block;
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        color: #fff;
-        font-size: 40px;
-        padding: 88px 32px 32px 32px;
-        line-height: 1.25;
-        text-shadow: 3px 3px #000;
+      .highlight {
+        color: red;
       }
     </style>
+    <script>
+      // TODO(#17108): Remove this when getMode().test is set.
+      __AMP_TEST = true;
+    </script>
   </head>
   <body>
-    <h1>This is a NON-AMP page that embeds a story below:</h1>
+    <h1>This is a <span class="highlight">NON-AMP</span> page that embeds a story below:</h1>
     <amp-story-embed>
       <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
           data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"

--- a/extensions/amp-story-embed/0.1/amp-story-embed.js
+++ b/extensions/amp-story-embed/0.1/amp-story-embed.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryEmbedManager} from '../../../src/amp-story-embed-manager';
+import {Layout} from '../../../src/layout';
+
+export class AmpStoryEmbed extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    this.embedManager_ = new AmpStoryEmbedManager(
+      element.ownerDocument,
+      element
+    );
+  }
+
+  /** @override */
+  buildCallback() {
+    this.embedManager_.build();
+  }
+
+  /** @override */
+  layoutCallback() {
+    return this.embedManager_.layout();
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.CONTAINER;
+  }
+}
+
+AMP.extension('amp-story-embed', '0.1', AMP => {
+  AMP.registerElement('amp-story-embed', AmpStoryEmbed);
+});

--- a/extensions/amp-story-embed/0.1/amp-story-embed.js
+++ b/extensions/amp-story-embed/0.1/amp-story-embed.js
@@ -22,14 +22,17 @@ export class AmpStoryEmbed extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    this.embedManager_ = new AmpStoryEmbedManager(
-      element.ownerDocument,
-      element
-    );
+    /** @private {?AmpStoryEmbedManager} */
+    this.embedManager_ = null;
   }
 
   /** @override */
   buildCallback() {
+    this.embedManager_ = new AmpStoryEmbedManager(
+      this.element.ownerDocument,
+      this.element
+    );
+
     this.embedManager_.build();
   }
 

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import {setStyle} from '../src/style';
+import {getMode} from './mode';
+import {setStyle} from './style';
 
 /** @enum {string} */
 const LoadStateClass = {
-  LOADING: 'loading',
-  LOADED: 'loaded',
-  ERROR: 'error',
+  LOADING: 'i-amphtml-story-embed-loading',
+  LOADED: 'i-amphtml-story-embed-loaded',
+  ERROR: 'i-amphtml-story-embed-error',
 };
 
 /** @const {string} */
@@ -28,33 +29,37 @@ const CSS = `
   :host { all: initial; display: block; border-radius: 0 !important; width: 405px; height: 720px; overflow: auto; }
   .story { height: 100%; width: 100%; flex: 0 0 100%; border: 0; opacity: 0; transition: opacity 500ms ease; }
   main { display: flex; flex-direction: row; height: 100%; }
-  .loaded iframe { opacity: 1; }
+  .i-amphtml-story-embed-loaded iframe { opacity: 1; }
+  iframe[src=""] { display: none; }
 `;
+
+/** @const {boolean} */
+const isAMP = self.AMP && self.AMP.ampdoc;
 
 /**
  * Note that this is a vanilla JavaScript class and should not depend on AMP
  * services, as v0.js is not expected to be loaded in this context.
  */
-export class AmpStoryEmbed {
+export class AmpStoryEmbedManager {
   /**
    * @param {!Document} doc
-   * @param {!Element} element
+   * @param {!Element} hostEl
    * @constructor
    */
-  constructor(doc, element) {
+  constructor(doc, hostEl) {
     console./*OK*/ assert(
-      element.childElementCount > 0,
+      hostEl.childElementCount > 0,
       'Missing configuration.'
     );
 
     /** @private {!Element} */
-    this.element_ = element;
+    this.hostEl_ = hostEl;
 
     /** @private {!Document} */
     this.doc_ = doc;
 
     /** @private {!Array<!HTMLAnchorElement>} */
-    this.stories_ = Array.prototype.slice.call(element.querySelectorAll('a'));
+    this.stories_ = Array.prototype.slice.call(hostEl.querySelectorAll('a'));
 
     /** @private {?Element} */
     this.rootEl_;
@@ -73,15 +78,15 @@ export class AmpStoryEmbed {
 
   /** @private */
   initializeShadowRoot_() {
+    this.rootEl_ = this.doc_.createElement('main');
+
     // Create shadow root
-    const shadowRoot = this.element_.attachShadow({mode: 'open'});
+    const shadowRoot = this.hostEl_.attachShadow({mode: 'open'});
 
     // Inject default styles
     const styleEl = this.doc_.createElement('style');
     styleEl.textContent = CSS;
     shadowRoot.appendChild(styleEl);
-
-    this.rootEl_ = this.doc_.createElement('main');
     shadowRoot.appendChild(this.rootEl_);
   }
 
@@ -92,7 +97,6 @@ export class AmpStoryEmbed {
   buildIframe_(index) {
     const story = this.stories_[index];
     this.iframeEl_ = this.doc_.createElement('iframe');
-    this.iframeEl_.setAttribute('src', story.href);
     setStyle(
       this.iframeEl_,
       'backgroundImage',
@@ -109,19 +113,46 @@ export class AmpStoryEmbed {
 
     this.iframeEl_.onload = () => {
       this.rootEl_.classList.remove(LoadStateClass.LOADING);
+      this.hostEl_.classList.remove(LoadStateClass.LOADING);
       this.rootEl_.classList.add(LoadStateClass.LOADED);
+      this.hostEl_.classList.add(LoadStateClass.LOADED);
     };
     this.iframeEl_.onerror = () => {
       this.rootEl_.classList.remove(LoadStateClass.LOADING);
+      this.hostEl_.classList.remove(LoadStateClass.LOADING);
       this.rootEl_.classList.add(LoadStateClass.ERROR);
+      this.hostEl_.classList.add(LoadStateClass.ERROR);
     };
+  }
+
+  /**
+   * @return {!Promise}
+   * @public
+   */
+  layout() {
+    // TODO: Layout all child iframes.
+    return this.layoutIframe_(0);
+  }
+
+  /**
+   * @param {number} index
+   * @return {!Promise}
+   * @private
+   */
+  layoutIframe_(index) {
+    const story = this.stories_[index];
+    this.iframeEl_.setAttribute('src', story.href);
+    return Promise.resolve();
   }
 }
 
-const doc = self.document;
-const embeds = doc.getElementsByTagName('amp-story-embed');
-for (let i = 0; i < embeds.length; i++) {
-  const embed = embeds[i];
-  const embedImpl = new AmpStoryEmbed(doc, embed);
-  embedImpl.build();
+if (!isAMP) {
+  const doc = self.document;
+  const embeds = doc.getElementsByTagName('amp-story-embed');
+  for (let i = 0; i < embeds.length; i++) {
+    const embed = embeds[i];
+    const embedImpl = new AmpStoryEmbedManager(doc, embed);
+    embedImpl.build();
+    embedImpl.layout();
+  }
 }

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -58,8 +58,8 @@ export class AmpStoryEmbedManager {
     /** @private {!Document} */
     this.doc_ = doc;
 
-    /** @private {!Array<!HTMLAnchorElement>} */
-    this.stories_ = Array.prototype.slice.call(hostEl.querySelectorAll('a'));
+    /** @private {?Array<!HTMLAnchorElement>} */
+    this.stories_;
 
     /** @private {?Element} */
     this.rootEl_;
@@ -70,6 +70,10 @@ export class AmpStoryEmbedManager {
 
   /** @public */
   build() {
+    this.stories_ = Array.prototype.slice.call(
+      this.hostEl_.querySelectorAll('a')
+    );
+
     this.initializeShadowRoot_();
 
     // TODO: Build all child iframes.

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getMode} from './mode';
+import {isExperimentOn} from './experiments';
 import {setStyle} from './style';
 
 /** @enum {string} */
@@ -42,11 +42,12 @@ const isAMP = self.AMP && self.AMP.ampdoc;
  */
 export class AmpStoryEmbedManager {
   /**
+   * @param {!Window} win
    * @param {!Document} doc
    * @param {!Element} hostEl
    * @constructor
    */
-  constructor(doc, hostEl) {
+  constructor(win, doc, hostEl) {
     console./*OK*/ assert(
       hostEl.childElementCount > 0,
       'Missing configuration.'
@@ -66,10 +67,19 @@ export class AmpStoryEmbedManager {
 
     /** @private {?HTMLIframeElement} */
     this.iframeEl_;
+
+    this.isAmpStoryEmbedExperimentEnabled_ = isExperimentOn(
+      win,
+      'amp-story-embed'
+    );
   }
 
   /** @public */
   build() {
+    if (!this.isAmpStoryEmbedExperimentEnabled_) {
+      return;
+    }
+
     this.stories_ = Array.prototype.slice.call(
       this.hostEl_.querySelectorAll('a')
     );
@@ -134,6 +144,10 @@ export class AmpStoryEmbedManager {
    * @public
    */
   layout() {
+    if (!this.isAmpStoryEmbedExperimentEnabled_) {
+      return;
+    }
+
     // TODO: Layout all child iframes.
     return this.layoutIframe_(0);
   }

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -684,6 +684,26 @@
       ],
     },
     {
+      "flaky": true, // Skip this until shadow DOM the embeds support shadow DOM
+      "url": "examples/visual-tests/amp-story/amp-story-embed-amp.html",
+      "name": "amp-story-embed: embedded in an AMP page",
+      "viewport": {"width": 1440, "height": 900},
+      "loading_complete_selectors": [
+        ".i-amphtml-story-embed-loaded",
+      ],
+      "loading_complete_delay_ms": 1000,
+    },
+    {
+      "flaky": true, // Skip this until shadow DOM the embeds support shadow DOM
+      "url": "examples/visual-tests/amp-story/amp-story-embed-non-amp.html",
+      "name": "amp-story-embed: embedded in an non-AMP page",
+      "viewport": {"width": 1440, "height": 900},
+      "loading_complete_selectors": [
+        ".i-amphtml-story-embed-loaded",
+      ],
+      "loading_complete_delay_ms": 1000,
+    },
+    {
       "flaky": true,
       // See https://percy.io/ampproject/amphtml/builds/1434487/view/95137509/375?browser=firefox&mode=diff
       "url": "examples/visual-tests/amp-date-picker/amp-date-picker.amp.html",

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -259,6 +259,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/20128',
   },
   {
+    id: 'amp-story-embed',
+    name: 'Allow for stories to be embedded in other (AMP and non-AMP) pages',
+    spec: 'https://github.com/ampproject/amphtml/issues/24539',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/25037',
+  },
+  {
     id: 'iframe-messaging',
     name: 'Enables "postMessage" action on amp-iframe.',
     spec: 'https://github.com/ampproject/amphtml/issues/9074',


### PR DESCRIPTION
This adds an AMP component that has the same API/behavior as the non-AMP component, for embedding AMP stories.

As a side note, visual diff tests don't work for anything in shadow DOM, so they're disabled for now.

This also puts the AMP and non-AMP variants behind an experiment.