### PR TITLE
🐛Hide type="carousel" arrows after swiping to a new slide.

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -625,17 +625,19 @@ class AmpCarousel extends AMP.BaseElement {
    * @param {!Event} event
    */
   onIndexChanged_(event) {
-    if (this.type_ == CarouselType.CAROUSEL) {
-      return;
-    }
-
     const detail = getDetail(event);
     const index = detail['index'];
     const actionSource = detail['actionSource'];
 
     this.hadTouch_ = this.hadTouch_ || actionSource == ActionSource.TOUCH;
-    this.updateCurrentIndex_(index, actionSource);
     this.updateUi_();
+
+    // Do not fire events, analytics for type="carousel".
+    if (this.type_ == CarouselType.CAROUSEL) {
+      return;
+    }
+
+    this.updateCurrentIndex_(index, actionSource);
   }
 }
 


### PR DESCRIPTION
Prior to this change, the carousel arrows would never hide for
amp-carousel 0.2, regardless of the `controls` attribute.

Fixes #25004