### PR TITLE
🐛Consider *.gmail.com trusted viewer domains

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -59,7 +59,7 @@ export const urls = {
    */
   trustedViewerHosts: [
     /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)$/,
-    /(^|\.)gmail\.dev$/,
+    /(^|\.)gmail\.(com|dev)$/,
   ],
 };
 


### PR DESCRIPTION
Gmail mobile clients use *.gmail.com as the base URL for the WebView
that embeds the AMP HTML iframe.

/to @choumx 