### PR TITLE
✨ Update INFOnline analytics vendor configuration

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -161,7 +161,8 @@
     "pageview": "https://ibeat.indiatimes.com/iBeat/pageTrendlogAmp.html?&h=!h&d=!h&url=!url&k=!key&ts=!time&ch=!channel&sid=!uid&at=!agentType&ref=_document_referrer_&aid=!aid&loc=1&ct=1&cat=!cat&scat=!scat&ac=1&tg=!tags&ctids=!catIds&pts=!pagePublishTime&auth=!author&pos=!position&iBeatField=!ibeatFields&cid=_client_id_"
   },
   "infonline": {
-    "pageview": "!url?st=!st&sv=ke&ap=1&co=!co&cp=!cp&ps=!ps&host=_canonical_host_&path=_canonical_path_"
+    "pageview": "!url?st=!st&sv=ke&ap=1&co=!co&cp=!cp&ps=!ps&host=_canonical_host_&path=_canonical_path_&type=pageview",
+    "event": "!url?st=!st&ev=!ev&sv=ke&ap=1&co=!co&cp=!cp&ps=!ps&host=_canonical_host_&path=_canonical_path_&type=event"
   },
   "iplabel": {
     "collectorUrl": "m.col.ip-label.net",

--- a/extensions/amp-analytics/0.1/vendors/infonline.js
+++ b/extensions/amp-analytics/0.1/vendors/infonline.js
@@ -31,7 +31,19 @@ const INFONLINE_CONFIG = jsonLiteral({
       '&cp=${cp}' +
       '&ps=${ps}' +
       '&host=${canonicalHost}' +
-      '&path=${canonicalPath}',
+      '&path=${canonicalPath}' +
+      '&type=pageview',
+    'event':
+      '${url}?st=${st}' +
+      '&ev=${ev}' +
+      '&sv=${sv}' +
+      '&ap=${ap}' +
+      '&co=${co}' +
+      '&cp=${cp}' +
+      '&ps=${ps}' +
+      '&host=${canonicalHost}' +
+      '&path=${canonicalPath}' +
+      '&type=event',
   },
   'triggers': {
     'pageview': {


### PR DESCRIPTION
- Add new request type ```event``` to allow event based analytics requests
- Add ```type``` to query parameters for pageview and event requests to allow a different processing

Resolves #23276