### PR TITLE
✅ Deflakes SwG E2E Test

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -32,10 +32,10 @@ describes.endtoend(
     // https://travis-ci.org/ampproject/amphtml/jobs/598248437#L2053-L2063
     it('Subscription offers should render correctly', async () => {
       const btn = await controller.findElement('#swg_button');
-      await expect(controller.getElementRect(btn)).to.include({
-        width: 300,
-        right: 300,
-      });
+      // Wait for button to become interactable
+      await expect(controller.getElementCssValue(btn, 'visibility')).to.equal(
+        'visible'
+      );
       await controller.click(btn);
 
       // Switch to SwG's outer iFrame

--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -30,8 +30,12 @@ describes.endtoend(
 
     // TODO(chenshay): This is failling in Chrome with "ElementNotInteractableError":
     // https://travis-ci.org/ampproject/amphtml/jobs/598248437#L2053-L2063
-    it.skip('Subscription offers should render correctly', async () => {
+    it('Subscription offers should render correctly', async () => {
       const btn = await controller.findElement('#swg_button');
+      await expect(controller.getElementRect(btn)).to.include({
+        width: 300,
+        right: 300,
+      });
       await controller.click(btn);
 
       // Switch to SwG's outer iFrame

--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -32,10 +32,11 @@ describes.endtoend(
     // https://travis-ci.org/ampproject/amphtml/jobs/598248437#L2053-L2063
     it('Subscription offers should render correctly', async () => {
       const btn = await controller.findElement('#swg_button');
-      // Wait for button to become interactable
-      await expect(controller.getElementCssValue(btn, 'visibility')).to.equal(
-        'visible'
-      );
+      // Wait for button to render
+      await expect(controller.getElementRect(btn)).to.include({
+        width: 240,
+        height: 40,
+      });
       await controller.click(btn);
 
       // Switch to SwG's outer iFrame

--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -28,11 +28,9 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    // TODO(chenshay): This is failling in Chrome with "ElementNotInteractableError":
-    // https://travis-ci.org/ampproject/amphtml/jobs/598248437#L2053-L2063
     it('Subscription offers should render correctly', async () => {
       const btn = await controller.findElement('#swg_button');
-      // Wait for button to render
+      // Wait for button to be rendered and ready to click
       await expect(controller.getElementRect(btn)).to.include({
         width: 240,
         height: 40,


### PR DESCRIPTION
This PR deflakes the SwG E2E test by waiting for the SwG button to render before triggering a click.