### PR TITLE
remove sp path from extension location

### DIFF
--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -46,15 +46,6 @@ export function calculateScriptBaseUrl(location, opt_isLocalDev) {
 }
 
 /**
- * Calculates if we need a single pass folder or not.
- *
- * @return {string}
- */
-function getSinglePassExperimentPath() {
-  return getMode().singlePassType ? `${getMode().singlePassType}/` : '';
-}
-
-/**
  * Calculate script url for an extension.
  * @param {!Location} location The window's location
  * @param {string} extensionId
@@ -76,8 +67,7 @@ export function calculateExtensionScriptUrl(
   const extensionVersion = opt_extensionVersion
     ? '-' + opt_extensionVersion
     : '';
-  const spPath = getSinglePassExperimentPath();
-  return `${base}/rtv/${rtv}/${spPath}v0/${extensionId}${extensionVersion}.js`;
+  return `${base}/rtv/${rtv}/v0/${extensionId}${extensionVersion}.js`;
 }
 
 /**
@@ -97,8 +87,7 @@ export function calculateEntryPointScriptUrl(
 ) {
   const base = calculateScriptBaseUrl(location, isLocalDev);
   if (opt_rtv) {
-    const spPath = getSinglePassExperimentPath();
-    return `${base}/rtv/${getMode().rtvVersion}/${spPath}${entryPoint}.js`;
+    return `${base}/rtv/${getMode().rtvVersion}/${entryPoint}.js`;
   }
   return `${base}/${entryPoint}.js`;
 }

--- a/test/unit/test-extension-location.js
+++ b/test/unit/test-extension-location.js
@@ -82,23 +82,6 @@ describes.sandboxed('Extension Location', {}, () => {
         'http://localhost:8000/dist/rtv/123/v0/no-version.js'
       );
     });
-
-    it('should handles single pass experiment', () => {
-      window.__AMP_MODE = {rtvVersion: '123', singlePassType: 'sp'};
-      const script = calculateExtensionScriptUrl(
-        {
-          pathname: 'examples/ads.amp.html',
-          host: 'localhost:8000',
-          protocol: 'http:',
-        },
-        'no-version',
-        /* version is empty but defined */ '',
-        true
-      );
-      expect(script).to.equal(
-        'http://localhost:8000/dist/rtv/123/sp/v0/no-version.js'
-      );
-    });
   });
 
   describe('get correct entry point source', () => {
@@ -151,21 +134,6 @@ describes.sandboxed('Extension Location', {}, () => {
         /* opt_rtv */ true
       );
       expect(script).to.equal('https://cdn.ampproject.org/rtv/123/ww.js');
-    });
-
-    it('should handle single pass experiment', () => {
-      window.__AMP_MODE = {rtvVersion: '123', singlePassType: 'sp'};
-      const script = calculateEntryPointScriptUrl(
-        {
-          pathname: 'examples/ads.amp.html',
-          host: 'localhost:8000',
-          protocol: 'http:',
-        },
-        'ww',
-        /* isLocalDev */ false,
-        /* opt_rtv */ true
-      );
-      expect(script).to.equal('https://cdn.ampproject.org/rtv/123/sp/ww.js');
     });
   });
 

--- a/test/unit/test-extension-location.js
+++ b/test/unit/test-extension-location.js
@@ -82,6 +82,23 @@ describes.sandboxed('Extension Location', {}, () => {
         'http://localhost:8000/dist/rtv/123/v0/no-version.js'
       );
     });
+
+    it('should handles single pass experiment', () => {
+      window.__AMP_MODE = {rtvVersion: '123', singlePassType: 'sp'};
+      const script = calculateExtensionScriptUrl(
+        {
+          pathname: 'examples/ads.amp.html',
+          host: 'localhost:8000',
+          protocol: 'http:',
+        },
+        'no-version',
+        /* version is empty but defined */ '',
+        true
+      );
+      expect(script).to.equal(
+        'http://localhost:8000/dist/rtv/123/v0/no-version.js'
+      );
+    });
   });
 
   describe('get correct entry point source', () => {
@@ -123,6 +140,21 @@ describes.sandboxed('Extension Location', {}, () => {
 
     it('with remote mode & rtv', () => {
       window.__AMP_MODE = {rtvVersion: '123'};
+      const script = calculateEntryPointScriptUrl(
+        {
+          pathname: 'examples/ads.amp.html',
+          host: 'localhost:8000',
+          protocol: 'http:',
+        },
+        'ww',
+        /* isLocalDev */ false,
+        /* opt_rtv */ true
+      );
+      expect(script).to.equal('https://cdn.ampproject.org/rtv/123/ww.js');
+    });
+
+    it('should handle single pass experiment', () => {
+      window.__AMP_MODE = {rtvVersion: '123', singlePassType: 'sp'};
       const script = calculateEntryPointScriptUrl(
         {
           pathname: 'examples/ads.amp.html',


### PR DESCRIPTION
we no longer deploy single pass extensions inside an "sp" directory under the "rtv" directory. This was previously needed as the single pass deployment did not have unique versions and were tied to the currently deployed "stable" AMP version.

Now single pass experiment js binaries have a unique version were the prefix is in the 4x range and the `--custom_version_mark` flag (`gulp dist` option) is used to have a unique ID across the single pass arms (control/singlepass/esm)