### PR TITLE
allow firebase for 3p frames

### DIFF
--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -47,6 +47,11 @@ async function copyAndReplaceUrls(src, dest) {
   await Promise.all(promises);
 }
 
+/**
+ * Adds the Firebase host to the prepended AMP_CONFIG in order to make ads
+ * work on deployed demos.
+ * @param {string} filePath
+ */
 async function modifyThirdPartyUrl(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
   const result = data.replace(

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -47,12 +47,12 @@ async function copyAndReplaceUrls(src, dest) {
   await Promise.all(promises);
 }
 
-async function modifyThirdPartyUrl() {
-  const filePath = 'firebase/dist/amp.js';
-  const data = await fs.readFile('firebase/dist/amp.js', 'utf8');
+async function modifyThirdPartyUrl(filePath) {
+  const data = await fs.readFile(filePath, 'utf8');
   const result = data.replace(
     'self.AMP_CONFIG={',
-    'self.AMP_CONFIG={"thirdPartyUrl":location.origin,'
+    // eslint-disable-next-line prettier/prettier
+    'self.AMP_CONFIG={"thirdPartyUrl":location.origin,"thirdPartyFrameRegex": "^.*\.firebaseapp\.com$",'
   );
   await fs.writeFile(filePath, result, 'utf8');
 }
@@ -86,7 +86,8 @@ async function firebase() {
     fs.copy('dist.3p/current', 'firebase/dist.3p/current', {overwrite: true}),
   ]);
   await Promise.all([
-    modifyThirdPartyUrl(),
+    modifyThirdPartyUrl('firebase/dist/amp.js'),
+    modifyThirdPartyUrl('firebase/dist.3p/current/integration.js'),
     fs.copyFile('firebase/dist/ww.max.js', 'firebase/dist/ww.js', {
       overwrite: true,
     }),

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -79,8 +79,10 @@ async function firebase() {
   ]);
 
   if (argv.fortesting) {
-    enableLocalTesting('firebase/dist.3p/current/integration.js');
-    enableLocalTesting('firebase/dist/amp.js');
+    await Promise.all([
+      enableLocalTesting('firebase/dist.3p/current/integration.js'),
+      enableLocalTesting('firebase/dist/amp.js'),
+    ]);
   }
 
   await Promise.all([

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -83,7 +83,13 @@ const UNMINIFIED_TARGETS = [
  * Note: keep this list in sync with release script. Contact @ampproject/wg-infra
  * for details.
  */
-const MINIFIED_TARGETS = ['alp.js', 'amp4ads-v0.js', 'shadow-v0.js', 'v0.js'];
+const MINIFIED_TARGETS = [
+  'alp.js',
+  'amp4ads-v0.js',
+  'f.js',
+  'shadow-v0.js',
+  'v0.js',
+];
 
 /**
  * Settings for the global Babelify transform while compiling unminified code

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -75,6 +75,7 @@ const UNMINIFIED_TARGETS = [
   'amp-inabox.js',
   'amp-shadow.js',
   'amp.js',
+  'integration.js',
 ];
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -75,7 +75,6 @@ const UNMINIFIED_TARGETS = [
   'amp-inabox.js',
   'amp-shadow.js',
   'amp.js',
-  'integration.js',
 ];
 
 /**
@@ -83,13 +82,7 @@ const UNMINIFIED_TARGETS = [
  * Note: keep this list in sync with release script. Contact @ampproject/wg-infra
  * for details.
  */
-const MINIFIED_TARGETS = [
-  'alp.js',
-  'amp4ads-v0.js',
-  'f.js',
-  'shadow-v0.js',
-  'v0.js',
-];
+const MINIFIED_TARGETS = ['alp.js', 'amp4ads-v0.js', 'shadow-v0.js', 'v0.js'];
 
 /**
  * Settings for the global Babelify transform while compiling unminified code

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -333,6 +333,16 @@ After deploying, you can access your project publically at its hosting URL `http
 
 Additionally, you can create multiple projects and switch between them in the CLI using `firebase use your-project-name`.
 
+#### Testing Ads
+Testing ads in deployed demos requires whitelisting of 3p urls. You can do this by adding your intended deployment hostname as an environemnt variable `AMP_TESTING_HOST` and using the `fortesting` flag. For example:
+
+```
+export AMP_TESTING_HOST="my-project.firebaseapp.com"
+gulp firebase --fortesting
+firebase deploy
+```
+This will write "my-project.firebaseapp.com" as a third party url to relevant attributes in `AMP_CONFIG`, which is prepended to `amp.js` and `integration.js` files in the firebase folder. If you're curious about how this is done, feel free to inspect `build-system/tasks/firebase.js`.
+
 ## End-to-End Tests
 
 You can run and create E2E tests locally during development. Currently tests only run on Chrome, but support for additional browsers is underway. These tests have not been added to our CI build yet - but they will be added soon.


### PR DESCRIPTION
Added a `fortesting` option to `gulp firebase` to enable testing ads on custom domains. 

## Legacy description 
The following are outdated descriptions of this PR. 
### Take 2

~~This PR does the following:~~
~~1. Re-adds `integration.js` and `f.js` to the list of files that we prepend `AMP_CONFIG` to.~~
~~2. Adds code in `firebase.js` to add `firebase` to the list of allowed 3rd party urls and 3rd party frame regexes so that ads can work on firebase.~~

Filed: 
- #25104 to @estherkim for fixing ads testing in PR deploy bot
- #25108 to @lannka for integration.js refactoring and any work to make sure that deployed demos still work with ads.

### Take 1

~~I wanted to make testing `amp-ad` work for firebase deployments. They're currently failing here: 
https://github.com/ampproject/amphtml/blob/3e6457ff825a90e76f14869197525298b67856df/3p/integration.js#L719-L740~~

~~The example that I'm using is `examples/amp-ads.amp.html`.~~

~~We currently have a section in `firebase.js` that appends `"thirdPartyUrl":location.origin` to `AMP_CONFIG`. My initial approach here was just to add another modification that would append `"thirdPartyFrameRegex": "^.*\.firebaseapp\.com$"`, which would enable it to pass this test: 
https://github.com/ampproject/amphtml/blob/3e6457ff825a90e76f14869197525298b67856df/3p/integration.js#L726~~

~~However, by inspecting the output of `urls` in `integration.js` and `urls` in `config.js` I'm noticing a race condition. I'm observing that sometimes the `urls` object reflects the contents of the `AMP_CONFIG` appended to `amp.js`, and sometimes it does not (no `localDev: "true"`, no `thirdPartyUrl`, no `thirdPartyFrameRegex`). It seems like `integration.js` is trying to access `urls` before `config.js` has had a chance to read from the `AMP_CONFIG` object. I'm wondering if there's a race condition somewhere.~~

~~I also noted that in `enableLocalDev`, there's the option to specify a TEST_HOST with env.AMP_TEST_HOST. Is there a documented way to use this to enable ads on a demo url?~~

https://github.com/ampproject/amphtml/blob/f5157605109d9b8321f3e843feaa574e12a1c1cd/build-system/tasks/prepend-global/index.js#L181-L205

