### PR TITLE
amp-sidebar: Propagate trust from action->event

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -129,7 +129,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.win,
       cb => this.mutateElement(cb),
       // The sidebar is already animated by swipe to dismiss, so skip animation.
-      () => this.dismiss_(true)
+      () => this.dismiss_(true, ActionTrust.HIGH)
     );
   }
 
@@ -177,7 +177,8 @@ export class AmpSidebar extends AMP.BaseElement {
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
       if (event.key == Keys.ESCAPE) {
-        if (this.close_()) {
+        // Keypress is high trust.
+        if (this.close_(ActionTrust.HIGH)) {
           event.preventDefault();
         }
       }
@@ -194,9 +195,22 @@ export class AmpSidebar extends AMP.BaseElement {
     // always create a close button at the end of the sidebar for screen
     // readers.
     element.appendChild(this.createScreenReaderCloseButton());
-    this.registerDefaultAction(invocation => this.open_(invocation), 'open');
-    this.registerAction('toggle', this.toggle_.bind(this));
-    this.registerAction('close', this.close_.bind(this));
+
+    this.registerDefaultAction(invocation => {
+      const {trust, caller} = invocation;
+      this.open_(trust, caller);
+    }, 'open');
+    this.registerAction('close', invocation => {
+      this.close_(invocation.trust);
+    });
+    this.registerAction('toggle', invocation => {
+      const {trust, caller} = invocation;
+      if (this.opened_) {
+        this.close_(trust);
+      } else {
+        this.open_(trust, caller);
+      }
+    });
 
     element.addEventListener(
       'click',
@@ -216,9 +230,9 @@ export class AmpSidebar extends AMP.BaseElement {
           if (removeFragment(target.href) != removeFragment(currentHref)) {
             return;
           }
-
           if (tgtLoc.hash) {
-            this.close_();
+            // Click gesture is high trust.
+            this.close_(ActionTrust.HIGH);
           }
         }
       },
@@ -280,7 +294,8 @@ export class AmpSidebar extends AMP.BaseElement {
     // and would be confusing to tab to if not using a screen reader.
     screenReaderCloseButton.tabIndex = -1;
     screenReaderCloseButton.addEventListener('click', () => {
-      this.close_();
+      // Click gesture is high trust.
+      this.close_(ActionTrust.HIGH);
     });
 
     return screenReaderCloseButton;
@@ -296,19 +311,6 @@ export class AmpSidebar extends AMP.BaseElement {
           toolbar.onLayoutChange();
         });
       });
-  }
-
-  /**
-   * Toggles the open/close state of the sidebar.
-   * @param {?../../../src/service/action-impl.ActionInvocation=} opt_invocation
-   * @private
-   */
-  toggle_(opt_invocation) {
-    if (this.opened_) {
-      this.close_();
-    } else {
-      this.open_(opt_invocation);
-    }
   }
 
   /**
@@ -337,8 +339,9 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /**
    * Updates the sidebar while it is animating to the opened state.
+   * @param {!ActionTrust} trust
    */
-  updateForOpening_() {
+  updateForOpening_(trust) {
     toggle(this.element, /* display */ true);
     toggle(this.getMaskElement_(), /* display */ true);
     this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
@@ -355,14 +358,16 @@ export class AmpSidebar extends AMP.BaseElement {
     this.element./*OK*/ scrollTop = 1;
     this.element.setAttribute('open', '');
     this.getMaskElement_().setAttribute('open', '');
-    this.setUpdateFn_(() => this.updateForOpened_(), ANIMATION_TIMEOUT);
+    this.setUpdateFn_(() => this.updateForOpened_(trust), ANIMATION_TIMEOUT);
     handleAutoscroll(this.getAmpDoc(), this.element);
   }
 
   /**
    * Updates the sidebar for when it has finished opening.
+   * @param {!ActionTrust} trust
+   * @private
    */
-  updateForOpened_() {
+  updateForOpened_(trust) {
     // On open sidebar
     const children = this.getRealChildren();
     const owners = Services.ownersForDoc(this.element);
@@ -376,7 +381,7 @@ export class AmpSidebar extends AMP.BaseElement {
       // experience, so we also just focus the first close button.
       tryFocus(devAssert(this.closeButton_));
     }
-    this.triggerEvent_(SidebarEvents.OPEN);
+    this.triggerEvent_(SidebarEvents.OPEN, trust);
     this.element.setAttribute('i-amphtml-sidebar-opened', '');
     this.getMaskElement_().setAttribute('i-amphtml-sidebar-opened', '');
   }
@@ -384,8 +389,10 @@ export class AmpSidebar extends AMP.BaseElement {
   /**
    * Updates the sidebar for when it is animating to the closed state.
    * @param {boolean} immediate
+   * @param {!ActionTrust} trust
+   * @private
    */
-  updateForClosing_(immediate) {
+  updateForClosing_(immediate, trust) {
     this.getMaskElement_().removeAttribute('open');
     this.getMaskElement_().removeAttribute('i-amphtml-sidebar-opened');
     this.mutateElement(() => {
@@ -394,66 +401,72 @@ export class AmpSidebar extends AMP.BaseElement {
     this.element.removeAttribute('open');
     this.element.removeAttribute('i-amphtml-sidebar-opened');
     this.setUpdateFn_(
-      () => this.updateForClosed_(),
+      () => this.updateForClosed_(trust),
       immediate ? 0 : ANIMATION_TIMEOUT
     );
   }
 
   /**
    * Updates the sidebar for when it has finished closing.
+   * @param {!ActionTrust} trust
+   * @private
    */
-  updateForClosed_() {
+  updateForClosed_(trust) {
     toggle(this.element, /* display */ false);
     toggle(this.getMaskElement_(), /* display */ false);
     Services.ownersForDoc(this.element).schedulePause(
       this.element,
       this.getRealChildren()
     );
-    this.triggerEvent_(SidebarEvents.CLOSE);
+    this.triggerEvent_(SidebarEvents.CLOSE, trust);
   }
 
   /**
    * Reveals the sidebar.
-   * @param {?../../../src/service/action-impl.ActionInvocation=} opt_invocation
+   * @param {!ActionTrust} trust
+   * @param {?Element} openerElement
    * @private
    */
-  open_(opt_invocation) {
+  open_(trust, openerElement) {
     if (this.opened_) {
       return;
     }
     this.opened_ = true;
     this.viewport_.enterOverlayMode();
-    this.setUpdateFn_(() => this.updateForOpening_());
+    this.setUpdateFn_(() => this.updateForOpening_(trust));
     this.getHistory_()
-      .push(this.close_.bind(this))
+      .push(() => this.close_(trust))
       .then(historyId => {
         this.historyId_ = historyId;
       });
-    if (opt_invocation) {
-      this.openerElement_ = opt_invocation.caller;
+
+    if (openerElement) {
+      this.openerElement_ = openerElement;
       this.initialScrollTop_ = this.viewport_.getScrollTop();
     }
   }
 
   /**
    * Hides the sidebar.
+   * @param {!ActionTrust} trust
    * @return {boolean} Whether the sidebar actually transitioned from "visible"
    *     to "hidden".
    * @private
    */
-  close_() {
-    return this.dismiss_(false);
+  close_(trust) {
+    return this.dismiss_(false, trust);
   }
 
   /**
    * Dismisses the sidebar.
    * @param {boolean} immediate Whether sidebar should close immediately,
    *     without animation.
+   * @param {!ActionTrust} trust
    * @return {boolean} Whether the sidebar actually transitioned from "visible"
    *     to "hidden".
    * @private
    */
-  dismiss_(immediate) {
+  dismiss_(immediate, trust) {
     if (!this.opened_) {
       return false;
     }
@@ -462,7 +475,7 @@ export class AmpSidebar extends AMP.BaseElement {
     const scrollDidNotChange =
       this.initialScrollTop_ == this.viewport_.getScrollTop();
     const sidebarIsActive = this.element.contains(this.document_.activeElement);
-    this.setUpdateFn_(() => this.updateForClosing_(immediate));
+    this.setUpdateFn_(() => this.updateForClosing_(immediate, trust));
     // Immediately hide the sidebar so that animation does not play.
     if (immediate) {
       toggle(this.element, /* display */ false);
@@ -549,7 +562,8 @@ export class AmpSidebar extends AMP.BaseElement {
       const mask = this.document_.createElement('div');
       mask.classList.add('i-amphtml-sidebar-mask');
       mask.addEventListener('click', () => {
-        this.close_();
+        // Click gesture is high trust.
+        this.close_(ActionTrust.HIGH);
       });
       this.getAmpDoc()
         .getBody()
@@ -610,11 +624,12 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /**
    * @param {string} name
+   * @param {!ActionTrust} trust
    * @private
    */
-  triggerEvent_(name) {
+  triggerEvent_(name, trust) {
     const event = createCustomEvent(this.win, `${TAG}.${name}`, dict({}));
-    this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
+    this.action_.trigger(this.element, name, event, trust);
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -16,6 +16,7 @@
 
 import '../amp-sidebar';
 import * as lolex from 'lolex';
+import {ActionTrust} from '../../../../src/action-constants';
 import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
@@ -145,6 +146,11 @@ describes.realWin(
       });
     }
 
+    /** Helper for invoking open/close/toggle actions on amp-sidebar. */
+    function execute(impl, method, trust = ActionTrust.HIGH) {
+      impl.executeAction({method, trust, satisfiesTrust: min => trust >= min});
+    }
+
     describe('amp-sidebar', () => {
       it('should apply overlay class', () => {
         return getAmpSidebar().then(sidebarElement => {
@@ -182,7 +188,7 @@ describes.realWin(
       it('should create mask element in DOM', () => {
         return getAmpSidebar({'stubHistory': true}).then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          impl.open_();
+          execute(impl, 'open');
           expect(
             doc.querySelectorAll('.i-amphtml-sidebar-mask').length
           ).to.equal(1);
@@ -232,7 +238,7 @@ describes.realWin(
 
         impl.openOrCloseTimeOut_ = 10;
 
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -250,7 +256,7 @@ describes.realWin(
 
         // second call to open_() should be a no-op and not increase call
         // counts.
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
         expect(owners.scheduleLayout).to.be.calledOnce;
         expect(historyPushSpy).to.be.calledOnce;
@@ -261,9 +267,9 @@ describes.realWin(
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
 
-        impl.open_();
+        execute(impl, 'open');
         expect(getModalStackLength()).to.equal(1);
-        impl.open_();
+        execute(impl, 'open');
         expect(getModalStackLength()).to.equal(1);
       });
 
@@ -271,10 +277,10 @@ describes.realWin(
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
 
-        impl.open_();
-        impl.close_();
+        execute(impl, 'open');
+        execute(impl, 'close');
         // If this was not ignored, it would throw an error.
-        impl.close_();
+        execute(impl, 'close');
       });
 
       it('should close sidebar on button click', async () => {
@@ -302,11 +308,11 @@ describes.realWin(
         };
         impl.historyId_ = 100;
 
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
 
         impl.openOrCloseTimeOut_ = 10;
-        impl.close_();
+        execute(impl, 'close');
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
         clock.tick(600);
@@ -317,7 +323,7 @@ describes.realWin(
 
         // second call to close_() should be a no-op and not increase call
         // counts.
-        impl.close_();
+        execute(impl, 'close');
         expect(owners.schedulePause).to.be.calledOnce;
         expect(historyPopSpy).to.be.calledOnce;
       });
@@ -339,7 +345,9 @@ describes.realWin(
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
         expect(sidebarElement.getAttribute('role')).to.equal('menu');
         expect(doc.activeElement).to.not.equal(screenReaderCloseButton);
-        impl.toggle_();
+
+        execute(impl, 'toggle');
+
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -347,7 +355,9 @@ describes.realWin(
         expect(doc.activeElement).to.equal(screenReaderCloseButton);
         expect(sidebarElement).to.not.have.display('none');
         expect(owners.scheduleLayout).to.be.calledOnce;
-        impl.toggle_();
+
+        execute(impl, 'toggle');
+
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -366,7 +376,7 @@ describes.realWin(
           owners.schedulePause = sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -403,22 +413,30 @@ describes.realWin(
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.have.not.been.called;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.be.calledOnce;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.be.calledOnce;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.have.callCount(2);
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.have.callCount(2);
@@ -453,7 +471,7 @@ describes.realWin(
             'compensateIosBottombar_'
           );
           const initalChildrenCount = sidebarElement.children.length;
-          impl.open_();
+          execute(impl, 'open');
           expect(compensateIosBottombarSpy).to.be.calledOnce;
           // 10 lis + one top padding element inserted
           expect(sidebarElement.children.length).to.equal(
@@ -473,7 +491,7 @@ describes.realWin(
           });
           owners.schedulePause = sandbox.spy();
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -510,7 +528,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -550,7 +568,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -590,7 +608,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -618,13 +636,23 @@ describes.realWin(
           });
           owners.scheduleLayout = sandbox.stub();
 
-          impl.open_();
+          execute(impl, 'open', /* trust */ 123);
           expect(triggerSpy).to.be.calledOnce;
-          expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarOpen');
+          expect(triggerSpy).to.be.calledWith(
+            impl.element,
+            'sidebarOpen',
+            sinon.match.any,
+            /* trust */ 123
+          );
 
-          impl.close_();
+          execute(impl, 'close', /* trust */ 456);
           expect(triggerSpy).to.be.calledTwice;
-          expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarClose');
+          expect(triggerSpy).to.be.calledWith(
+            impl.element,
+            'sidebarClose',
+            sinon.match.any,
+            /* trust */ 456
+          );
         });
       });
     });

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -193,6 +193,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.documentElement_.addEventListener('keydown', event => {
       // Close sidebar on ESC.
       if (event.key == Keys.ESCAPE) {
+        // Keypress is high trust.
         if (this.close_(ActionTrust.HIGH)) {
           event.preventDefault();
         }
@@ -461,7 +462,7 @@ export class AmpSidebar extends AMP.BaseElement {
   /**
    * Reveals the sidebar.
    * @param {!ActionTrust} trust
-   * @param {!Element} openerElement
+   * @param {?Element} openerElement
    * @private
    */
   open_(trust, openerElement) {
@@ -477,8 +478,10 @@ export class AmpSidebar extends AMP.BaseElement {
         this.historyId_ = historyId;
       });
 
-    this.openerElement_ = openerElement;
-    this.initialScrollTop_ = this.viewport_.getScrollTop();
+    if (openerElement) {
+      this.openerElement_ = openerElement;
+      this.initialScrollTop_ = this.viewport_.getScrollTop();
+    }
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -16,6 +16,7 @@
 
 import '../amp-sidebar';
 import * as lolex from 'lolex';
+import {ActionTrust} from '../../../../src/action-constants';
 import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
@@ -148,6 +149,11 @@ describes.realWin(
       });
     }
 
+    /** Helper for invoking open/close/toggle actions on amp-sidebar. */
+    function execute(impl, method, trust = ActionTrust.HIGH) {
+      impl.executeAction({method, trust, satisfiesTrust: min => trust >= min});
+    }
+
     describe('amp-sidebar', () => {
       it('should apply overlay class', () => {
         return getAmpSidebar().then(sidebarElement => {
@@ -185,7 +191,7 @@ describes.realWin(
       it('should create mask element in DOM', () => {
         return getAmpSidebar({'stubHistory': true}).then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          impl.open_();
+          execute(impl, 'open');
           expect(
             doc.querySelectorAll('.i-amphtml-sidebar-mask').length
           ).to.equal(1);
@@ -235,7 +241,7 @@ describes.realWin(
 
         impl.openOrCloseTimeOut_ = 10;
 
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -253,7 +259,7 @@ describes.realWin(
 
         // second call to open_() should be a no-op and not increase call
         // counts.
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
         expect(owners.scheduleLayout).to.be.calledOnce;
         expect(historyPushSpy).to.be.calledOnce;
@@ -264,9 +270,9 @@ describes.realWin(
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
 
-        impl.open_();
+        execute(impl, 'open');
         expect(getModalStackLength()).to.equal(1);
-        impl.open_();
+        execute(impl, 'open');
         expect(getModalStackLength()).to.equal(1);
       });
 
@@ -274,10 +280,10 @@ describes.realWin(
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
 
-        impl.open_();
-        impl.close_();
+        execute(impl, 'open');
+        execute(impl, 'close');
         // If this was not ignored, it would throw an error.
-        impl.close_();
+        execute(impl, 'close');
       });
 
       it('should close sidebar on button click', async () => {
@@ -305,11 +311,11 @@ describes.realWin(
         };
         impl.historyId_ = 100;
 
-        impl.open_();
+        execute(impl, 'open');
         await impl.mutateElement(() => {});
 
         impl.openOrCloseTimeOut_ = 10;
-        impl.close_();
+        execute(impl, 'close');
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
         clock.tick(600);
@@ -320,7 +326,7 @@ describes.realWin(
 
         // second call to close_() should be a no-op and not increase call
         // counts.
-        impl.close_();
+        execute(impl, 'close');
         expect(owners.schedulePause).to.be.calledOnce;
         expect(historyPopSpy).to.be.calledOnce;
       });
@@ -342,7 +348,9 @@ describes.realWin(
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
         expect(sidebarElement.getAttribute('role')).to.equal('menu');
         expect(doc.activeElement).to.not.equal(screenReaderCloseButton);
-        impl.toggle_();
+
+        execute(impl, 'toggle');
+
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -350,7 +358,9 @@ describes.realWin(
         expect(doc.activeElement).to.equal(screenReaderCloseButton);
         expect(sidebarElement).to.not.have.display('none');
         expect(owners.scheduleLayout).to.be.calledOnce;
-        impl.toggle_();
+
+        execute(impl, 'toggle');
+
         await impl.mutateElement(() => {});
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -369,7 +379,7 @@ describes.realWin(
           owners.schedulePause = sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -406,22 +416,30 @@ describes.realWin(
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.have.not.been.called;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.have.not.been.called;
           expect(owners.scheduleResume).to.be.calledOnce;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.be.calledOnce;
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           clock.tick(600);
           expect(owners.schedulePause).to.be.calledOnce;
           expect(owners.scheduleResume).to.have.callCount(2);
-          impl.toggle_();
+
+          execute(impl, 'toggle');
+
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
           expect(owners.schedulePause).to.have.callCount(2);
@@ -456,7 +474,7 @@ describes.realWin(
             'compensateIosBottombar_'
           );
           const initalChildrenCount = sidebarElement.children.length;
-          impl.open_();
+          execute(impl, 'open');
           expect(compensateIosBottombarSpy).to.be.calledOnce;
           // 10 lis + one top padding element inserted
           expect(sidebarElement.children.length).to.equal(
@@ -476,7 +494,7 @@ describes.realWin(
           });
           owners.schedulePause = sandbox.spy();
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -513,7 +531,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -553,7 +571,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -593,7 +611,7 @@ describes.realWin(
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
-          impl.open_();
+          execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
           expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
           const eventObj = doc.createEventObject
@@ -621,13 +639,23 @@ describes.realWin(
           });
           owners.scheduleLayout = sandbox.stub();
 
-          impl.open_();
+          execute(impl, 'open', /* trust */ 123);
           expect(triggerSpy).to.be.calledOnce;
-          expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarOpen');
+          expect(triggerSpy).to.be.calledWith(
+            impl.element,
+            'sidebarOpen',
+            sinon.match.any,
+            /* trust */ 123
+          );
 
-          impl.close_();
+          execute(impl, 'close', /* trust */ 456);
           expect(triggerSpy).to.be.calledTwice;
-          expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarClose');
+          expect(triggerSpy).to.be.calledWith(
+            impl.element,
+            'sidebarClose',
+            sinon.match.any,
+            /* trust */ 456
+          );
         });
       });
     });


### PR DESCRIPTION
Partial for #24894. 

Ensure that the same trust level open/close/toggle action is called with is passed to the resulting open/close event to prevent trust escalation. Similar to #24425.

/to @leafsy /cc @sparhami 