### PR TITLE
🏗 Fix team names in OWNERS of `tools`

### DIFF
--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -6,8 +6,8 @@
     {
       owners: [
         {name: 'ampproject/wg-infra'},
-        {name: 'ampproject/runtime'},
-        {name: 'ampproject/performance'},
+        {name: 'ampproject/wg-runtime'},
+        {name: 'ampproject/wg-performance'},
       ],
     },
   ],


### PR DESCRIPTION
Fixes some incorrect working group team names introduced in #24971 (see https://github.com/ampproject/amphtml/pull/24971#issuecomment-542864217)