### PR TITLE
🏗 Replace `globs-to-files` with `globby`

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -44,10 +44,7 @@ function logOnSameLine(message) {
 function getFilesChanged(globs) {
   const allFiles = globby.sync(globs);
   return gitDiffNameOnlyMaster().filter(changedFile => {
-    return (
-      fs.existsSync(changedFile) &&
-      allFiles.some(file => file.endsWith(changedFile))
-    );
+    return fs.existsSync(changedFile) && allFiles.includes(changedFile);
   });
 }
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -18,8 +18,8 @@
 const argv = require('minimist')(process.argv.slice(2));
 const BBPromise = require('bluebird');
 const brotliSize = require('brotli-size');
-const deglob = require('globs-to-files');
 const fs = require('fs');
+const globby = require('globby');
 const log = require('fancy-log');
 const path = require('path');
 const requestPost = BBPromise.promisify(require('request').post);
@@ -58,7 +58,7 @@ function getBrotliBundleSizes() {
   const bundleSizes = {};
 
   log(cyan('brotli'), 'bundle sizes are:');
-  for (const filePath of deglob.sync(fileGlobs)) {
+  for (const filePath of globby.sync(fileGlobs)) {
     const normalizedFileContents = fs
       .readFileSync(filePath, 'utf8')
       .replace(new RegExp(internalRuntimeVersion, 'g'), normalizedRtvNumber);
@@ -200,7 +200,7 @@ async function reportBundleSize() {
 }
 
 function getLocalBundleSize() {
-  if (deglob.sync(fileGlobs).length === 0) {
+  if (globby.sync(fileGlobs).length === 0) {
     log('Could not find runtime files.');
     log('Run', cyan('gulp dist --noextensions'), 'and re-run this task.');
     process.exitCode = 1;

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -26,11 +26,8 @@ const fs = require('fs-extra');
 const globby = require('globby');
 const JSON5 = require('json5');
 const log = require('fancy-log');
-const path = require('path');
 const {cyan, red, green} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
-
-const rootDir = path.dirname(path.dirname(__dirname));
 
 /**
  * Checks OWNERS files for correctness using the owners bot API.
@@ -39,10 +36,7 @@ const rootDir = path.dirname(path.dirname(__dirname));
  */
 async function checkOwners() {
   const filesToCheck = globby.sync(['**/OWNERS']);
-  filesToCheck.forEach(file => {
-    const relativePath = path.relative(rootDir, file);
-    checkFile(relativePath);
-  });
+  filesToCheck.forEach(checkFile);
 }
 
 /**

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -22,8 +22,8 @@
 
 'use strict';
 
-const deglob = require('globs-to-files');
 const fs = require('fs-extra');
+const globby = require('globby');
 const JSON5 = require('json5');
 const log = require('fancy-log');
 const path = require('path');
@@ -38,7 +38,7 @@ const rootDir = path.dirname(path.dirname(__dirname));
  * so that all OWNERS files can be checked / fixed.
  */
 async function checkOwners() {
-  const filesToCheck = deglob.sync(['**/OWNERS']);
+  const filesToCheck = globby.sync(['**/OWNERS']);
   filesToCheck.forEach(file => {
     const relativePath = path.relative(rootDir, file);
     checkFile(relativePath);

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const config = require('../test-configs/config');
-const deglob = require('globs-to-files');
+const globby = require('globby');
 const Mocha = require('mocha');
 const {isTravisBuild} = require('../common/travis');
 
@@ -30,7 +30,7 @@ async function devDashboardTests() {
   });
 
   // Add our files
-  const allDevDashboardTests = deglob.sync(config.devDashboardTestPaths);
+  const allDevDashboardTests = globby.sync(config.devDashboardTestPaths);
   allDevDashboardTests.forEach(file => {
     mocha.addFile(file);
   });

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -56,7 +56,7 @@ const {green, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
 
 const babel = require('@babel/core');
-const deglob = require('globs-to-files');
+const globby = require('globby');
 
 const WEB_PUSH_PUBLISHER_FILES = [
   'amp-web-push-helper-frame',
@@ -72,7 +72,7 @@ function transferSrcsToTempDir() {
     'transforms in',
     colors.cyan(SRC_TEMP_DIR)
   );
-  const files = deglob.sync(BABEL_SRC_GLOBS);
+  const files = globby.sync(BABEL_SRC_GLOBS);
   files.forEach(file => {
     if (file.startsWith('node_modules/') || file.startsWith('third_party/')) {
       fs.copySync(file, `${SRC_TEMP_DIR}/${file}`);

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -87,7 +87,7 @@ function transferSrcsToTempDir() {
       retainLines: true,
       compact: false,
     });
-    const name = `${SRC_TEMP_DIR}${file.replace(process.cwd(), '')}`;
+    const name = `${SRC_TEMP_DIR}/${file}`;
     fs.outputFileSync(name, code);
     process.stdout.write('.');
   });

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -18,9 +18,9 @@
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const config = require('../test-configs/config');
-const deglob = require('globs-to-files');
 const eslint = require('gulp-eslint');
 const eslintIfFixed = require('gulp-eslint-if-fixed');
+const globby = require('globby');
 const gulp = require('gulp');
 const lazypipe = require('lazypipe');
 const log = require('fancy-log');
@@ -172,7 +172,7 @@ function eslintRulesChanged() {
  * @return {!Array<string>}
  */
 function getFilesToLint(files) {
-  const filesToLint = deglob.sync(files);
+  const filesToLint = globby.sync(files);
   if (!isTravisBuild()) {
     log(colors.green('INFO: ') + 'Running lint on the following files:');
     filesToLint.forEach(file => {

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -176,7 +176,7 @@ function getFilesToLint(files) {
   if (!isTravisBuild()) {
     log(colors.green('INFO: ') + 'Running lint on the following files:');
     filesToLint.forEach(file => {
-      log(colors.cyan(path.relative(rootDir, file)));
+      log(colors.cyan(file));
     });
   }
   return filesToLint;

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -25,7 +25,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const globby = require('globby');
 const log = require('fancy-log');
-const path = require('path');
 const {getFilesChanged, logOnSameLine} = require('../common/utils');
 const {getOutput} = require('../common/exec');
 const {green, cyan, red, yellow} = require('ansi-colors');
@@ -34,7 +33,6 @@ const {isTravisBuild} = require('../common/travis');
 const {maybeUpdatePackages} = require('./update-packages');
 const {prettifyGlobs} = require('../test-configs/config');
 
-const rootDir = path.dirname(path.dirname(__dirname));
 const prettierCmd = 'node_modules/.bin/prettier';
 
 /**
@@ -56,7 +54,7 @@ function logFiles(files) {
   if (!isTravisBuild()) {
     log(green('INFO: ') + 'Prettifying the following files:');
     files.forEach(file => {
-      log(cyan(path.relative(rootDir, file)));
+      log(cyan(file));
     });
   }
 }
@@ -94,9 +92,7 @@ function runPrettify(filesToCheck) {
   if (!isTravisBuild()) {
     log(green('Starting checks...'));
   }
-  filesToCheck.forEach(file => {
-    checkFile(path.relative(rootDir, file));
-  });
+  filesToCheck.forEach(checkFile);
   if (process.exitCode == 1) {
     logOnSameLine(red('ERROR: ') + 'Found errors in one or more files.');
     if (!argv.fix) {

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-const deglob = require('globs-to-files');
 const findImports = require('find-imports');
 const fs = require('fs');
+const globby = require('globby');
 const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
@@ -188,7 +188,7 @@ function unitTestsToRun(unitTestPaths = testConfig.unitTestPaths) {
   // Retrieves the set of unit tests that should be run
   // for a set of source files.
   function getTestsFor(srcFiles) {
-    const allUnitTests = deglob.sync(unitTestPaths);
+    const allUnitTests = globby.sync(unitTestPaths);
     return allUnitTests
       .filter(testFile => {
         return shouldRunTest(testFile, srcFiles);

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -189,11 +189,9 @@ function unitTestsToRun(unitTestPaths = testConfig.unitTestPaths) {
   // for a set of source files.
   function getTestsFor(srcFiles) {
     const allUnitTests = globby.sync(unitTestPaths);
-    return allUnitTests
-      .filter(testFile => {
-        return shouldRunTest(testFile, srcFiles);
-      })
-      .map(fullPath => path.relative(ROOT_DIR, fullPath));
+    return allUnitTests.filter(testFile => {
+      return shouldRunTest(testFile, srcFiles);
+    });
   }
 
   filesChanged.forEach(file => {

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -17,7 +17,7 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const connect = require('gulp-connect');
-const deglob = require('globs-to-files');
+const globby = require('globby');
 const header = require('connect-header');
 const log = require('fancy-log');
 const morgan = require('morgan');
@@ -35,7 +35,7 @@ const {getServeMode} = require('../server/app-utils');
 // Used for logging during server start / stop.
 let url = '';
 
-const serverFiles = deglob.sync(['build-system/server/**']);
+const serverFiles = globby.sync(['build-system/server/**']);
 
 /**
  * Logs the server's mode (based on command line arguments).

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -16,7 +16,7 @@
 
 const minimist = require('minimist');
 const argv = minimist(process.argv.slice(2));
-const deglob = require('globs-to-files');
+const globby = require('globby');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const gulpWatch = require('gulp-watch');
@@ -72,7 +72,7 @@ async function vendorConfigs(opt_options) {
       )
       .pipe(gulp.dest(destPath))
   ).then(() => {
-    if (deglob.sync(srcPath).length > 0) {
+    if (globby.sync(srcPath).length > 0) {
       endBuildStep(
         'Compiled all analytics vendor configs into',
         destPath,

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "fs-extra": "8.1.0",
     "fuse.js": "3.4.5",
     "globby": "10.0.1",
-    "globs-to-files": "1.0.0",
     "google-closure-compiler": "20190929.0.0",
     "gulp": "4.0.2",
     "gulp-ava": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array-uniq@^1.0.1, array-uniq@~1.0.2:
+array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
@@ -1936,13 +1936,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
-
-asyncreduce@~0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/asyncreduce/-/asyncreduce-0.1.4.tgz#18210e01978bfdcba043955497a5cd315c0a6a41"
-  integrity sha1-GCEOAZeL/cugQ5VUl6XNMVwKakE=
-  dependencies:
-    runnel "~0.5.0"
 
 atob@2.1.2, atob@^2.1.1:
   version "2.1.2"
@@ -5907,7 +5900,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.10, glob@^5.0.6:
+glob@^5.0.6:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
@@ -5999,16 +5992,6 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-globs-to-files@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/globs-to-files/-/globs-to-files-1.0.0.tgz#54490f6d1f4b9fd2de9d99445146ffb37550380d"
-  integrity sha1-VEkPbR9Ln9LenZlEUUb/s3VQOA0=
-  dependencies:
-    array-uniq "~1.0.2"
-    asyncreduce "~0.1.4"
-    glob "^5.0.10"
-    xtend "^4.0.0"
 
 glogg@^1.0.0:
   version "1.0.2"
@@ -11823,11 +11806,6 @@ run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
-
-runnel@~0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/runnel/-/runnel-0.5.3.tgz#f9362b165a05fc6f5e46e458f77a1f7ecdc0daec"
-  integrity sha1-+TYrFloF/G9eRuRY93offs3A2uw=
 
 rxjs@^6.4.0:
   version "6.5.3"


### PR DESCRIPTION
This PR replaces `globs-to-files` with `globby` across `build-system/` (and removes the now unnecessary step of converting the resulting filenames to relative paths).

- **[`globs-to-files`](https://www.npmjs.com/package/globs-to-files):**
    - ~1000 weekly downloads
    - Hasn't been updated in 4 years
    - Cannot handle negative glob patterns
- **[`globby`](https://www.npmjs.com/package/globby):**
    - ~16 million weekly downloads
    - Actively maintained
    - Significantly faster than other packages
    - Can handle negative glob patterns

Addresses https://github.com/ampproject/amphtml/pull/25093#discussion_r336072228