### PR TITLE
run our custom transformers during `gulp build`

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -108,7 +108,7 @@ const BABELIFY_GLOBAL_TRANSFORM = {
  */
 const BABELIFY_PLUGINS = {
   plugins: conf.plugins({
-    isSinglePass: argv.single_pass,
+    isSinglePass: false,
     isEsmBuild: argv.esm,
     isForTesting: argv.fortesting,
   }),

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -107,7 +107,11 @@ const BABELIFY_GLOBAL_TRANSFORM = {
  * Plugins used by Babelify while compiling unminified code
  */
 const BABELIFY_PLUGINS = {
-  plugins: [conf.getReplacePlugin(), conf.getJsonConfigurationPlugin()],
+  plugins: conf.plugins({
+    isSinglePass: argv.single_pass,
+    isEsmBuild: argv.esm,
+    isForTesting: argv.fortesting,
+  }),
 };
 
 const hostname = argv.hostname || 'cdn.ampproject.org';


### PR DESCRIPTION
we need to run these transformers during `gulp build` so that the optimizations and transformation that we do during `gulp dist` is also applied to `gulp build`.

this also makes it so that message extraction can occur during `gulp build`