### PR TITLE
Remove support for adding `filter=[CATEGORY]` to the `development=1`

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -21,7 +21,6 @@ import {parseQueryString_} from './url-parse-query-string';
  * @typedef {{
  *   localDev: boolean,
  *   development: boolean,
- *   filter: (string|undefined),
  *   minified: boolean,
  *   lite: boolean,
  *   test: boolean,
@@ -105,9 +104,6 @@ function getMode_(win) {
       ) >= 0 || win.AMP_DEV_MODE
     ),
     examiner: hashQuery['development'] == '2',
-    // Allows filtering validation errors by error category. For the
-    // available categories, see ErrorCategory in validator/validator.proto.
-    filter: hashQuery['filter'],
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     // amp-user-location override

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -44,7 +44,7 @@ export function maybeValidate(win) {
   if (validator) {
     loadScript(win.document, `${urls.cdn}/v0/validator.js`).then(() => {
       /* global amp: false */
-      amp.validator.validateUrlAndLog(filename, win.document, getMode().filter);
+      amp.validator.validateUrlAndLog(filename, win.document);
     });
   } else if (getMode().examiner) {
     loadScript(win.document, `${urls.cdn}/examiner.js`);


### PR DESCRIPTION
Remove support for adding `filter=[CATEGORY]` to the `development=1` request to trigger AMP Validation.

This feature was originally added in #2997, but was never documented. It
is unlikely to be significantly used if at all. Categories have not been
well maintained over time and are being deprecated/removed from the
codebase.