### PR TITLE
amp-accordion: Propagate trust from action->event

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -511,14 +511,14 @@ class AmpAccordion extends AMP.BaseElement {
   /**
    * Handles accordion header activation, through clicks or enter/space presses.
    * @param {!Event} event 'click' or 'keydown' event.
-   * @param {!ActionTrust} trust
    * @private
    */
-  onHeaderPicked_(event, trust) {
+  onHeaderPicked_(event) {
     event.preventDefault();
     const header = dev().assertElement(event.currentTarget);
     const section = dev().assertElement(header.parentElement);
-    this.toggle_(section, trust);
+    // Click or keypress gestures are high trust.
+    this.toggle_(section, ActionTrust.HIGH);
   }
 
   /**

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -164,7 +164,7 @@ class AmpAccordion extends AMP.BaseElement {
   }
 
   /**
-   * @param {*} invocation
+   * @param {!../../../src/service/action-impl.ActionInvocation} invocation
    * @private
    */
   handleAction_(invocation) {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -303,18 +303,18 @@ class AmpAccordion extends AMP.BaseElement {
     if (this.element.hasAttribute('animate')) {
       if (toExpand) {
         header.setAttribute('aria-expanded', 'true');
-        this.animateExpand_(section);
+        this.animateExpand_(section, trust);
         if (this.element.hasAttribute('expand-single-section')) {
           this.sections_.forEach(sectionIter => {
             if (sectionIter != section) {
-              this.animateCollapse_(sectionIter);
+              this.animateCollapse_(sectionIter, trust);
               sectionIter.children[0].setAttribute('aria-expanded', 'false');
             }
           });
         }
       } else {
         header.setAttribute('aria-expanded', 'false');
-        this.animateCollapse_(section);
+        this.animateCollapse_(section, trust);
       }
     } else {
       // Toggle without animation
@@ -518,7 +518,7 @@ class AmpAccordion extends AMP.BaseElement {
     event.preventDefault();
     const header = dev().assertElement(event.currentTarget);
     const section = dev().assertElement(header.parentElement);
-    this.toggle_(section, trust, /* opt_forceExpand */ false);
+    this.toggle_(section, trust);
   }
 
   /**
@@ -611,6 +611,14 @@ class AmpAccordion extends AMP.BaseElement {
         this.toggle_(sectionEl, trust, /* opt_forceExpand */ toExpand);
       }
     });
+  }
+
+  /**
+   * @return {?../../../src/service/action-impl.ActionService}
+   * @visibleForTesting
+   */
+  getActionServiceForTesting() {
+    return this.action_;
   }
 }
 

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -112,49 +112,15 @@ class AmpAccordion extends AMP.BaseElement {
         content.setAttribute('id', contentId);
       }
 
-      this.registerAction('toggle', invocation => {
-        if (invocation.args) {
-          const sectionId = invocation.args['section'];
-          let sectionEl = this.getAmpDoc().getElementById(sectionId);
-          sectionEl = user().assertElement(sectionEl);
-          userAssert(sectionEl, 'No element found with id: %s', sectionId);
-          this.toggle_(sectionEl);
-        } else {
-          for (let i = 0; i < this.sections_.length; i++) {
-            this.toggle_(this.sections_[i]);
-          }
-        }
-      });
-      this.registerAction('expand', invocation => {
-        if (invocation.args) {
-          const sectionId = invocation.args['section'];
-          let sectionEl = this.getAmpDoc().getElementById(sectionId);
-          sectionEl = user().assertElement(sectionEl);
-          userAssert(sectionEl, 'No element found with id: %s', sectionId);
-          this.expand_(sectionEl);
-        } else {
-          for (let i = 0; i < this.sections_.length; i++) {
-            this.expand_(this.sections_[i]);
-          }
-        }
-      });
-      this.registerAction('collapse', invocation => {
-        if (invocation.args) {
-          const sectionId = invocation.args['section'];
-          let sectionEl = this.getAmpDoc().getElementById(sectionId);
-          sectionEl = user().assertElement(sectionEl);
-          userAssert(sectionEl, 'No element found with id: %s', sectionId);
-          this.collapse_(sectionEl);
-        } else {
-          for (let i = 0; i < this.sections_.length; i++) {
-            this.collapse_(this.sections_[i]);
-          }
-        }
-      });
+      this.registerAction('toggle', i => this.handleAction_(i));
+      this.registerAction('expand', i => this.handleAction_(i));
+      this.registerAction('collapse', i => this.handleAction_(i));
 
       // Listen for mutations on the 'data-expand' attribute.
       const expandObserver = new this.win.MutationObserver(mutations => {
-        this.toggleExpandMutations_(mutations);
+        // [data-expand] mutations can only be triggered by high trust actions
+        // i.e. AMP.setState.
+        this.toggleExpandMutations_(mutations, ActionTrust.HIGH);
       });
       expandObserver.observe(section, {
         attributes: true,
@@ -195,6 +161,33 @@ class AmpAccordion extends AMP.BaseElement {
       header.addEventListener('click', this.clickHandler_.bind(this));
       header.addEventListener('keydown', this.keyDownHandler_.bind(this));
     });
+  }
+
+  /**
+   * @param {*} invocation
+   * @private
+   */
+  handleAction_(invocation) {
+    const {method, args, trust} = invocation;
+
+    let toExpand = undefined;
+    if (method === 'expand') {
+      toExpand = true;
+    } else if (method === 'collapse') {
+      toExpand = false;
+    }
+
+    if (args) {
+      const sectionId = args['section'];
+      let sectionEl = this.getAmpDoc().getElementById(sectionId);
+      sectionEl = user().assertElement(sectionEl);
+      userAssert(sectionEl, 'No element found with id: %s', sectionId);
+      this.toggle_(sectionEl, trust, toExpand);
+    } else {
+      for (let i = 0; i < this.sections_.length; i++) {
+        this.toggle_(this.sections_[i], trust, toExpand);
+      }
+    }
   }
 
   /**
@@ -265,14 +258,15 @@ class AmpAccordion extends AMP.BaseElement {
    * Triggers event given name
    * @param {string} name
    * @param {!Element} section
+   * @param {!ActionTrust} trust
    */
-  triggerEvent_(name, section) {
+  triggerEvent_(name, section, trust) {
     const event = createCustomEvent(
       this.win,
       `accordionSection.${name}`,
       dict({})
     );
-    this.action_.trigger(section, name, event, ActionTrust.HIGH);
+    this.action_.trigger(section, name, event, trust);
 
     this.element.dispatchCustomEvent(name);
   }
@@ -280,10 +274,11 @@ class AmpAccordion extends AMP.BaseElement {
   /**
    * Toggles section between expanded or collapsed.
    * @param {!Element} section
-   * @param {boolean=} opt_forceExpand
+   * @param {!ActionTrust} trust
+   * @param {(boolean|undefined)=} opt_forceExpand
    * @private
    */
-  toggle_(section, opt_forceExpand) {
+  toggle_(section, trust, opt_forceExpand) {
     const sectionComponents = section.children;
     const header = sectionComponents[0];
     const content = sectionComponents[1];
@@ -325,7 +320,7 @@ class AmpAccordion extends AMP.BaseElement {
       // Toggle without animation
       this.mutateElement(() => {
         if (toExpand) {
-          this.triggerEvent_('expand', section);
+          this.triggerEvent_('expand', section, trust);
           section.setAttribute('expanded', '');
           header.setAttribute('aria-expanded', 'true');
           // if expand-single-section is set, only allow one <section> to be
@@ -334,7 +329,7 @@ class AmpAccordion extends AMP.BaseElement {
             this.sections_.forEach(sectionIter => {
               if (sectionIter != section) {
                 if (sectionIter.hasAttribute('expanded')) {
-                  this.triggerEvent_('collapse', sectionIter);
+                  this.triggerEvent_('collapse', sectionIter, trust);
                   sectionIter.removeAttribute('expanded');
                 }
                 sectionIter.children[0].setAttribute('aria-expanded', 'false');
@@ -342,7 +337,7 @@ class AmpAccordion extends AMP.BaseElement {
             });
           }
         } else {
-          this.triggerEvent_('collapse', section);
+          this.triggerEvent_('collapse', section, trust);
           section.removeAttribute('expanded');
           header.setAttribute('aria-expanded', 'false');
         }
@@ -354,10 +349,11 @@ class AmpAccordion extends AMP.BaseElement {
 
   /**
    * @param {!Element} section
+   * @param {!ActionTrust} trust
    * @return {!Promise}
    * @private
    */
-  animateExpand_(section) {
+  animateExpand_(section, trust) {
     let sectionWidth;
     let headerHeight;
     let contentHeight;
@@ -379,7 +375,7 @@ class AmpAccordion extends AMP.BaseElement {
           'opacity': '0',
         });
         if (!section.hasAttribute('expanded')) {
-          this.triggerEvent_('expand', section);
+          this.triggerEvent_('expand', section, trust);
           section.setAttribute('expanded', '');
         }
       }
@@ -445,10 +441,11 @@ class AmpAccordion extends AMP.BaseElement {
 
   /**
    * @param {!Element} section
+   * @param {!ActionTrust} trust
    * @return {!Promise}
    * @private
    */
-  animateCollapse_(section) {
+  animateCollapse_(section, trust) {
     let sectionHeight;
     let headerHeight;
     let duration;
@@ -480,7 +477,7 @@ class AmpAccordion extends AMP.BaseElement {
       ).thenAlways(() => {
         return this.mutateElement(() => {
           if (section.hasAttribute('expanded')) {
-            this.triggerEvent_('collapse', section);
+            this.triggerEvent_('collapse', section, trust);
             section.removeAttribute('expanded');
           }
           setStyles(section, {
@@ -512,33 +509,16 @@ class AmpAccordion extends AMP.BaseElement {
   }
 
   /**
-   * Force expands the accordion.
-   * @param {!Element} section
-   * @private
-   */
-  expand_(section) {
-    this.toggle_(section, true);
-  }
-
-  /**
-   * Force collapses the accordion.
-   * @param {!Element} section
-   * @private
-   */
-  collapse_(section) {
-    this.toggle_(section, false);
-  }
-
-  /**
    * Handles accordion header activation, through clicks or enter/space presses.
    * @param {!Event} event 'click' or 'keydown' event.
+   * @param {!ActionTrust} trust
    * @private
    */
-  onHeaderPicked_(event) {
+  onHeaderPicked_(event, trust) {
     event.preventDefault();
     const header = dev().assertElement(event.currentTarget);
     const section = dev().assertElement(header.parentElement);
-    this.toggle_(section);
+    this.toggle_(section, trust, /* opt_forceExpand */ false);
   }
 
   /**
@@ -620,14 +600,15 @@ class AmpAccordion extends AMP.BaseElement {
   /**
    * Callback function to execute when mutations are observed on "data-expand".
    * @param {!Array<!MutationRecord>} mutations
+   * @param {!ActionTrust} trust
    */
-  toggleExpandMutations_(mutations) {
+  toggleExpandMutations_(mutations, trust) {
     mutations.forEach(mutation => {
       const sectionEl = dev().assertElement(mutation.target);
       const toExpand = sectionEl.hasAttribute('data-expand');
       const isExpanded = sectionEl.hasAttribute('expanded');
       if (isExpanded !== toExpand) {
-        this.toggle_(sectionEl, toExpand);
+        this.toggle_(sectionEl, trust, /* opt_forceExpand */ toExpand);
       }
     });
   }

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -15,6 +15,7 @@
  */
 
 import '../amp-accordion';
+import {ActionTrust} from '../../../../src/action-constants';
 import {Keys} from '../../../../src/utils/key-codes';
 import {computedStyle} from '../../../../src/style';
 import {poll} from '../../../../testing/iframe';
@@ -70,14 +71,25 @@ describes.realWin(
     function getAmpAccordion(opt_shouldSetId) {
       const contents = [0, 1, 2].map(i => {
         return (
-          '<h2 tabindex="0">Section ' +
-          i +
-          "<span>nested stuff<span></h2><div id='test" +
-          i +
-          "'>Loreum ipsum</div>"
+          '<h2 tabindex="0">' +
+          `Section ${i}<span>nested stuff<span>` +
+          `</h2><div id='test${i}'>Lorem ipsum</div>`
         );
       });
       return getAmpAccordionWithContents(contents, opt_shouldSetId);
+    }
+
+    /** Helper for invoking expand/collapse actions on amp-accordion. */
+    function execute(impl, method, trust = ActionTrust.HIGH, opt_sectionId) {
+      const invocation = {
+        method,
+        trust,
+        satisfiesTrust: min => trust >= min,
+      };
+      if (opt_sectionId) {
+        invocation.args = {section: opt_sectionId};
+      }
+      impl.executeAction(invocation);
     }
 
     it('should expand when toggle action is triggered on a collapsed section', () => {
@@ -89,7 +101,7 @@ describes.realWin(
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'false'
         );
-        impl.toggle_(headerElements[0].parentNode);
+        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH);
         expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
           .true;
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
@@ -121,7 +133,9 @@ describes.realWin(
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
           'true'
         );
-        impl.toggle_(headerElements[1].parentNode);
+
+        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH);
+
         expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
           .false;
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
@@ -139,7 +153,7 @@ describes.realWin(
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'false'
         );
-        impl.expand_(headerElements[0].parentNode);
+        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
         expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
           .true;
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
@@ -165,17 +179,14 @@ describes.realWin(
           expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
             'true'
           );
-
           // expand the first section
-          impl.expand_(headerElements[0].parentNode);
-
+          impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
           // we expect the first section to be expanded
           expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
             .true;
           expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
             'true'
           );
-
           // we expect the second section to be collapsed
           expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
             .false;
@@ -199,7 +210,7 @@ describes.realWin(
               `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
             );
             expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[0], true);
+            impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
             return poll('wait for first section to expand', () =>
               impl.sections_[0].hasAttribute('expanded')
             );
@@ -223,7 +234,7 @@ describes.realWin(
               `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
             );
             expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[1], false);
+            impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
             return poll(
               'wait for first section to expand',
               () => !impl.sections_[1].hasAttribute('expanded')
@@ -249,7 +260,7 @@ describes.realWin(
               `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
             );
             expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[0], true);
+            impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
             return poll('wait for first section to expand', () =>
               impl.sections_[0].hasAttribute('expanded')
             );
@@ -276,7 +287,7 @@ describes.realWin(
               `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
             );
             expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[1], false);
+            impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
             return poll(
               'wait for first section to expand',
               () => !impl.sections_[1].hasAttribute('expanded')
@@ -304,7 +315,7 @@ describes.realWin(
 
       ampAccordion.setAttribute('animate', '');
       ampAccordion.style.width = '300px';
-      impl.toggle_(firstSection, true);
+      impl.toggle_(firstSection, ActionTrust.HIGH, true);
       await poll('wait for first section to finish animating', () => {
         return (
           firstSection.hasAttribute('expanded') &&
@@ -332,7 +343,7 @@ describes.realWin(
 
       ampAccordion.setAttribute('animate', '');
       ampAccordion.style.width = '400px';
-      impl.toggle_(firstSection, true);
+      impl.toggle_(firstSection, ActionTrust.HIGH, true);
       await poll('wait for first section to finish animating', () => {
         return (
           firstSection.hasAttribute('expanded') &&
@@ -355,7 +366,7 @@ describes.realWin(
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
           'true'
         );
-        impl.expand_(headerElements[1].parentNode);
+        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, true);
         expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
           .true;
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
@@ -373,7 +384,7 @@ describes.realWin(
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
           'true'
         );
-        impl.collapse_(headerElements[1].parentNode);
+        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, false);
         expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
           .false;
         expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
@@ -391,7 +402,7 @@ describes.realWin(
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'false'
         );
-        impl.collapse_(headerElements[0].parentNode);
+        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, false);
         expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
           .false;
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
@@ -758,6 +769,35 @@ describes.realWin(
             expect(headerElements2[0].parentNode.hasAttribute('expanded')).to.be
               .false;
           });
+      });
+    });
+
+    it('should trigger expand/collapse events', () => {
+      return getAmpAccordion(true).then(ampAccordion => {
+        const impl = ampAccordion.implementation_;
+
+        const actions = impl.getActionServiceForTesting();
+        sandbox.stub(actions, 'trigger');
+
+        execute(impl, 'collapse', 123, `acc${counter}sec1`);
+
+        expect(actions.trigger).to.be.calledOnce;
+        expect(actions.trigger.getCall(0)).to.be.calledWith(
+          /* element */ sinon.match.has('tagName'),
+          'collapse',
+          /* event */ sinon.match.has('detail'),
+          /* trust */ 123
+        );
+
+        execute(impl, 'expand', 456, `acc${counter}sec1`);
+
+        expect(actions.trigger).to.be.calledTwice;
+        expect(actions.trigger.getCall(1)).to.be.calledWith(
+          /* element */ sinon.match.has('tagName'),
+          'expand',
+          /* event */ sinon.match.has('detail'),
+          /* trust */ 456
+        );
       });
     });
   }


### PR DESCRIPTION
Partial for #24894.

Ensure that the same trust level expand/collapse/toggle action is called with is passed to the resulting expand/collapse event to prevent trust escalation. Similar to #24425.

/to @cathyxz 