### PR TITLE
OWNERS set for video files in src

### DIFF
--- a/src/OWNERS
+++ b/src/OWNERS
@@ -7,7 +7,7 @@
       owners: [{name: 'dvoytenko'}, {name: 'ampproject/wg-runtime'}],
     },
     {
-      pattern: '{iframe-video.js,mediasession-helper.js,video-*.js}',
+      pattern: '{iframe-video,mediasession-helper,video-*}.js',
       owners: [{name: 'ampproject/wg-ui-and-a11y'}],
     },
   ],

--- a/src/service/OWNERS
+++ b/src/service/OWNERS
@@ -4,10 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'dvoytenko'}, {name: 'ampproject/wg-runtime'}],
-    },
-    {
-      pattern: '{iframe-video.js,mediasession-helper.js,video-*.js}',
+      pattern: 'video-*.js',
       owners: [{name: 'ampproject/wg-ui-and-a11y'}],
     },
   ],

--- a/src/service/video/OWNERS
+++ b/src/service/video/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'alanorozco'}, {name: 'wassgha'}],
+      owners: [{name: 'ampproject/wg-ui-and-a11y'}],
     },
   ],
 }


### PR DESCRIPTION
Realized that video service files are really touched when creating 3p player contributions, so they can be set to the broader `ampproject/wg-ui-and-a11y` group (rather than the specific set from #24908).

Added missing ownership for other video/media related files in `src`.