### PR TITLE
[amp-ad] Add a4a (fast fetch) support to myTarget amp-ads

### DIFF
--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -18,6 +18,7 @@ import {cloudflareIsA4AEnabled} from '../extensions/amp-ad-network-cloudflare-im
 import {gmosspIsA4AEnabled} from '../extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config';
 import {map} from '../src/utils/object';
 import {tripleliftIsA4AEnabled} from '../extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config';
+import {myTargetIsA4AEnabled} from '../extensions/amp-ad-network-mytarget-impl/0.1/mytarget-a4a-config';
 
 /**
  * Registry for A4A (AMP Ads for AMPHTML pages) "is supported" predicates.
@@ -45,6 +46,7 @@ export function getA4ARegistry() {
       'adzerk': () => true,
       'doubleclick': () => true,
       'triplelift': tripleliftIsA4AEnabled,
+      'mytarget': myTargetIsA4AEnabled,
       'cloudflare': cloudflareIsA4AEnabled,
       'gmossp': gmosspIsA4AEnabled,
       'fake': () => true,

--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -17,8 +17,8 @@
 import {cloudflareIsA4AEnabled} from '../extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config';
 import {gmosspIsA4AEnabled} from '../extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config';
 import {map} from '../src/utils/object';
-import {tripleliftIsA4AEnabled} from '../extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config';
 import {myTargetIsA4AEnabled} from '../extensions/amp-ad-network-mytarget-impl/0.1/mytarget-a4a-config';
+import {tripleliftIsA4AEnabled} from '../extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config';
 
 /**
  * Registry for A4A (AMP Ads for AMPHTML pages) "is supported" predicates.

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -310,6 +310,12 @@ exports.extensionBundles = [
     type: TYPES.AD,
   },
   {
+    name: 'amp-ad-network-mytarget-impl',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.AD,
+  },
+  {
     name: 'amp-ad-exit',
     version: '0.1',
     latestVersion: '0.1',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -214,6 +214,7 @@ exports.rules = [
       'extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js->extensions/amp-a4a/0.1/amp-a4a.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->extensions/amp-a4a/0.1/amp-a4a.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/amp-a4a.js',
+      'extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js->extensions/amp-a4a/0.1/amp-a4a.js',
 
       // And a few mrore things depend on a4a.
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-network-base.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -186,6 +186,8 @@ exports.rules = [
         'extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config.js',
       'ads/_a4a-config.js->' +
         'extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config.js',
+      'ads/_a4a-config.js->' +
+        'extensions/amp-ad-network-mytarget-impl/0.1/mytarget-a4a-config.js',
     ],
   },
   // Rules for extensions and main src.

--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -62,6 +62,15 @@
     <div fallback></div>
   </amp-ad>
 
+  <h2>myTarget ad network</h2>
+  <amp-ad width="300" height="250"
+      type="mytarget"
+      data-use-a4a="true"
+      data-ad-slot="197378">
+      <div placeholder></div>
+      <div fallback></div>
+  </amp-ad>
+
   <h2>Fake cloudflare as ad network ad</h2>
   <amp-ad width="300" height="150"
       type="cloudflare"

--- a/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
@@ -34,7 +34,7 @@ const MYTARGET_XORIGIN_MODE = 'nameframe';
 
 /**
  * This is a minimalistic AmpA4A implementation that primarily gets an Ad
- * through a source URL and parse HTML markup from json response. 
+ * through a source URL and parse HTML markup from json response.
  * This is then given to A4A to render via crossdomain frame.
  */
 export class AmpAdNetworkMyTargetImpl extends AmpA4A {
@@ -48,15 +48,11 @@ export class AmpAdNetworkMyTargetImpl extends AmpA4A {
     const slot = this.element.getAttribute('data-ad-slot');
     const query = this.element.getAttribute('data-ad-query');
 
-    return (
-      MYTARGET_BASE_URL_ + 
-      '?q=' + slot + 
-      (query ? '&' + query : '')
-    );
+    return MYTARGET_BASE_URL_ + '?q=' + slot + (query ? '&' + query : '');
   }
 
   /** @override */
-  getNonAmpCreativeRenderingMethod(headerValue) {
+  getNonAmpCreativeRenderingMethod() {
     return MYTARGET_XORIGIN_MODE;
   }
 
@@ -72,31 +68,29 @@ export class AmpAdNetworkMyTargetImpl extends AmpA4A {
         headers,
       } = /** @type {{status: number, headers: !Headers}} */ (response);
 
-      return response.json()
-        .then(
-          responseJson => {
-            let creativeBody = responseJson &&
-              responseJson[0] &&
-              responseJson[0].html &&
-              responseJson[0].html.trim();
+      return response
+        .json()
+        .then(responseJson => {
+          const creativeBody =
+            responseJson &&
+            responseJson[0] &&
+            responseJson[0].html &&
+            responseJson[0].html.trim();
 
-            return creativeBody
-              ? new Response(creativeBody, {status, headers})
-              : null;
-          })
-        .catch(e => null);
+          return creativeBody
+            ? new Response(creativeBody, {status, headers})
+            : null;
+        })
+        .catch(() => null);
     });
   }
 
   /** @override */
-  onNetworkFailure(error, adUrl) {
+  onNetworkFailure() {
     return {frameGetDisabled: true};
   }
 }
 
 AMP.extension('amp-ad-network-mytarget-impl', '0.1', AMP => {
-  AMP.registerElement(
-    'amp-ad-network-mytarget-impl',
-    AmpAdNetworkMyTargetImpl
-  );
+  AMP.registerElement('amp-ad-network-mytarget-impl', AmpAdNetworkMyTargetImpl);
 });

--- a/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
@@ -15,6 +15,11 @@
  */
 
 import {AmpA4A, XORIGIN_MODE} from '../../amp-a4a/0.1/amp-a4a';
+import {
+  addParamToUrl,
+  addParamsToUrl,
+  parseQueryString,
+} from '../../../src/url';
 
 /**
  * myTarget base URL
@@ -40,7 +45,15 @@ export class AmpAdNetworkMyTargetImpl extends AmpA4A {
     const slot = this.element.getAttribute('data-ad-slot');
     const query = this.element.getAttribute('data-ad-query');
 
-    return MYTARGET_BASE_URL_ + '?q=' + slot + (query ? '&' + query : '');
+    let url = addParamToUrl(MYTARGET_BASE_URL_, 'q', slot);
+
+    // Additionally encode optional parameters
+    if (query) {
+      const queryMap = parseQueryString(query);
+      url = addParamsToUrl(url, queryMap);
+    }
+
+    return url;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {AmpA4A, XORIGIN_MODE} from '../../amp-a4a/0.1/amp-a4a';
 
 /**
  * myTarget base URL
@@ -23,14 +23,6 @@ import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
  * @private
  */
 const MYTARGET_BASE_URL_ = 'https://ad.mail.ru/adp/';
-
-/**
- * myTarget crossorigin render method
- *
- * @type {string}
- * @private
- */
-const MYTARGET_XORIGIN_MODE = 'nameframe';
 
 /**
  * This is a minimalistic AmpA4A implementation that primarily gets an Ad
@@ -53,7 +45,7 @@ export class AmpAdNetworkMyTargetImpl extends AmpA4A {
 
   /** @override */
   getNonAmpCreativeRenderingMethod() {
-    return MYTARGET_XORIGIN_MODE;
+    return XORIGIN_MODE.NAMEFRAME;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/amp-ad-network-mytarget-impl.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+
+/**
+ * myTarget base URL
+ *
+ * @type {string}
+ * @private
+ */
+const MYTARGET_BASE_URL_ = 'https://ad.mail.ru/adp/';
+
+/**
+ * myTarget crossorigin render method
+ *
+ * @type {string}
+ * @private
+ */
+const MYTARGET_XORIGIN_MODE = 'nameframe';
+
+/**
+ * This is a minimalistic AmpA4A implementation that primarily gets an Ad
+ * through a source URL and parse HTML markup from json response. 
+ * This is then given to A4A to render via crossdomain frame.
+ */
+export class AmpAdNetworkMyTargetImpl extends AmpA4A {
+  /** @override */
+  isValidElement() {
+    return this.isAmpAdElement();
+  }
+
+  /** @override */
+  getAdUrl() {
+    const slot = this.element.getAttribute('data-ad-slot');
+    const query = this.element.getAttribute('data-ad-query');
+
+    return (
+      MYTARGET_BASE_URL_ + 
+      '?q=' + slot + 
+      (query ? '&' + query : '')
+    );
+  }
+
+  /** @override */
+  getNonAmpCreativeRenderingMethod(headerValue) {
+    return MYTARGET_XORIGIN_MODE;
+  }
+
+  /** @override */
+  sendXhrRequest(adUrl) {
+    return super.sendXhrRequest(adUrl).then(response => {
+      if (!response) {
+        return null;
+      }
+
+      const {
+        status,
+        headers,
+      } = /** @type {{status: number, headers: !Headers}} */ (response);
+
+      return response.json()
+        .then(
+          responseJson => {
+            let creativeBody = responseJson &&
+              responseJson[0] &&
+              responseJson[0].html &&
+              responseJson[0].html.trim();
+
+            return creativeBody
+              ? new Response(creativeBody, {status, headers})
+              : null;
+          })
+        .catch(e => null);
+    });
+  }
+
+  /** @override */
+  onNetworkFailure(error, adUrl) {
+    return {frameGetDisabled: true};
+  }
+}
+
+AMP.extension('amp-ad-network-mytarget-impl', '0.1', AMP => {
+  AMP.registerElement(
+    'amp-ad-network-mytarget-impl',
+    AmpAdNetworkMyTargetImpl
+  );
+});

--- a/extensions/amp-ad-network-mytarget-impl/0.1/mytarget-a4a-config.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/mytarget-a4a-config.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {!Window} win
+ * @param {!Element} element
+ * @param {boolean} useRemoteHtml
+ * @return {boolean}
+ */
+export function myTargetIsA4AEnabled(win, element, useRemoteHtml) {
+  return (
+    !useRemoteHtml &&
+    !!element.getAttribute('data-use-a4a') &&
+    !!element.getAttribute('data-ad-slot')
+  );
+}

--- a/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
@@ -84,10 +84,7 @@ describes.realWin(
       doc = win.document;
       mytargetImplElem = doc.createElement('amp-ad');
       mytargetImplElem.setAttribute('type', 'mytarget');
-      mytargetImplElem.setAttribute(
-        'data-ad-slot',
-        '197378'
-      );
+      mytargetImplElem.setAttribute('data-ad-slot', '197378');
       mytargetImplElem.setAttribute('data-use-a4a', 'true');
       sandbox
         .stub(AmpAdNetworkMyTargetImpl.prototype, 'getSigningServiceNames')
@@ -102,9 +99,7 @@ describes.realWin(
         expect(mytargetImpl.isValidElement()).to.be.true;
       });
       it('should NOT be valid (impl tag name)', () => {
-        mytargetImplElem = doc.createElement(
-          'amp-ad-network-mytarget-impl'
-        );
+        mytargetImplElem = doc.createElement('amp-ad-network-mytarget-impl');
         mytargetImplElem.setAttribute('type', 'triplelift');
         mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
         expect(mytargetImpl.isValidElement()).to.be.false;
@@ -129,10 +124,7 @@ describes.realWin(
 
     describe('#getAdUrl with query parameters', () => {
       it('should add query parameters', () => {
-        mytargetImplElem.setAttribute(
-          'data-ad-query',
-          'preview=1'
-        );
+        mytargetImplElem.setAttribute('data-ad-query', 'preview=1');
         mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
         expect(mytargetImpl.getAdUrl()).to.equal(
           'https://ad.mail.ru/adp/?q=197378&preview=1'

--- a/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpAdNetworkMyTargetImpl} from '../amp-ad-network-mytarget-impl';
+import {
+  AmpAdUIHandler, // eslint-disable-line no-unused-vars
+} from '../../../amp-ad/0.1/amp-ad-ui';
+import {
+  AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
+} from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
+import {createElementWithAttributes} from '../../../../src/dom';
+import {myTargetIsA4AEnabled} from '../mytarget-a4a-config';
+
+describes.realWin('mytarget-a4a-config', {amp: false}, env => {
+  let doc;
+  let win;
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+  it('should pass a4a config predicate', () => {
+    const element = createElementWithAttributes(doc, 'amp-ad', {
+      'data-ad-slot': '197378',
+      'data-use-a4a': 'true',
+    });
+    expect(myTargetIsA4AEnabled(win, element)).to.be.true;
+  });
+  it('should fail a4a config predicate due to useRemoteHtml', () => {
+    const element = createElementWithAttributes(doc, 'amp-ad', {
+      'data-ad-slot': '197378',
+      'data-use-a4a': 'true',
+    });
+    const useRemoteHtml = true;
+    expect(myTargetIsA4AEnabled(win, element, useRemoteHtml)).to.be.false;
+  });
+  it('should fail a4a config predicate due to missing use-a4a', () => {
+    const element = createElementWithAttributes(doc, 'amp-ad', {
+      'data-ad-slot': '197378',
+    });
+    expect(myTargetIsA4AEnabled(win, element)).to.be.false;
+  });
+  it('should fail a4a config predicate due to missing data-ad-slot', () => {
+    const element = createElementWithAttributes(doc, 'amp-ad', {
+      'data-use-a4a': 'true',
+    });
+    expect(myTargetIsA4AEnabled(win, element)).to.be.false;
+  });
+  it('should fail a4a config predicate due to empty data-ad-slot', () => {
+    const element = createElementWithAttributes(doc, 'amp-ad', {
+      'data-ad-slot': '',
+      'data-use-a4a': 'true',
+    });
+    expect(myTargetIsA4AEnabled(win, element)).to.be.false;
+  });
+});
+
+describes.realWin(
+  'amp-ad-network-mytarget-impl',
+  {
+    amp: {
+      extensions: ['amp-ad-network-mytarget-impl'],
+    },
+  },
+  env => {
+    let win, doc;
+    let mytargetImpl;
+    let mytargetImplElem;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      mytargetImplElem = doc.createElement('amp-ad');
+      mytargetImplElem.setAttribute('type', 'mytarget');
+      mytargetImplElem.setAttribute(
+        'data-ad-slot',
+        '197378'
+      );
+      mytargetImplElem.setAttribute('data-use-a4a', 'true');
+      sandbox
+        .stub(AmpAdNetworkMyTargetImpl.prototype, 'getSigningServiceNames')
+        .callsFake(() => {
+          return ['cloudflare'];
+        });
+      mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
+    });
+
+    describe('#isValidElement', () => {
+      it('should be valid', () => {
+        expect(mytargetImpl.isValidElement()).to.be.true;
+      });
+      it('should NOT be valid (impl tag name)', () => {
+        mytargetImplElem = doc.createElement(
+          'amp-ad-network-mytarget-impl'
+        );
+        mytargetImplElem.setAttribute('type', 'triplelift');
+        mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
+        expect(mytargetImpl.isValidElement()).to.be.false;
+      });
+    });
+
+    describe('#getRenderingMethod', () => {
+      it('should be equal to "nameframe"', () => {
+        expect(mytargetImpl.getNonAmpCreativeRenderingMethod()).to.equal(
+          'nameframe'
+        );
+      });
+    });
+
+    describe('#getAdUrl', () => {
+      it('should be valid', () => {
+        expect(mytargetImpl.getAdUrl()).to.equal(
+          'https://ad.mail.ru/adp/?q=197378'
+        );
+      });
+    });
+
+    describe('#getAdUrl with query parameters', () => {
+      it('should add query parameters', () => {
+        mytargetImplElem.setAttribute(
+          'data-ad-query',
+          'preview=1'
+        );
+        mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
+        expect(mytargetImpl.getAdUrl()).to.equal(
+          'https://ad.mail.ru/adp/?q=197378&preview=1'
+        );
+      });
+    });
+  }
+);

--- a/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,17 @@ describes.realWin(
         mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
         expect(mytargetImpl.getAdUrl()).to.equal(
           'https://ad.mail.ru/adp/?q=197378&preview=1'
+        );
+      });
+
+      it('should encode query parameters', () => {
+        mytargetImplElem.setAttribute(
+          'data-ad-query',
+          'preview=1&test=foo|bar'
+        );
+        mytargetImpl = new AmpAdNetworkMyTargetImpl(mytargetImplElem);
+        expect(mytargetImpl.getAdUrl()).to.equal(
+          'https://ad.mail.ru/adp/?q=197378&preview=1&test=foo%7Cbar'
         );
       });
     });

--- a/extensions/amp-ad-network-mytarget-impl/OWNERS
+++ b/extensions/amp-ad-network-mytarget-impl/OWNERS
@@ -4,7 +4,11 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'vfedoseev'}],
+      owners: [
+        {name: 'ampproject/a4a'},
+        {name: 'ampproject/wg-ads'},
+        {name: 'vfedoseev'},
+      ],
     },
   ],
 }

--- a/extensions/amp-ad-network-mytarget-impl/OWNERS
+++ b/extensions/amp-ad-network-mytarget-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'mailru'}],
+      owners: [{name: 'ampproject/a4a'}, {name: 'vfedoseev'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-mytarget-impl/OWNERS
+++ b/extensions/amp-ad-network-mytarget-impl/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{name: 'ampproject/a4a'}, {name: 'mailru'}],
+    },
+  ],
+}

--- a/extensions/amp-ad-network-mytarget-impl/OWNERS
+++ b/extensions/amp-ad-network-mytarget-impl/OWNERS
@@ -4,11 +4,7 @@
 {
   rules: [
     {
-      owners: [
-        {name: 'ampproject/a4a'},
-        {name: 'ampproject/wg-ads'},
-        {name: 'vfedoseev'},
-      ],
+      owners: [{name: 'ampproject/wg-ads'}, {name: 'vfedoseev'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
+++ b/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# amp-ad-network-mytarget-impl
+# myTarget Ad Network
+
+### amp-ad-network-mytarget-impl
 
 myTarget implementation of AMP Ad tag which requests early by XHR and renders natively within the page if a valid AMP Ad is returned. Should not be directly referenced by pages and instead is dynamically loaded via the amp-ad tag. However, in order to remove an async script load of this library, publishers can include its script declaration.
 

--- a/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
+++ b/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
@@ -34,10 +34,13 @@ myTarget implementation of AMP Ad tag which requests early by XHR and renders na
 ## Example
 
 ```html
-<amp-ad width="300" height="250"
-    type="mytarget"
-    data-use-a4a="true"
-    data-ad-slot="197378">
+<amp-ad
+  width="300"
+  height="250"
+  type="mytarget"
+  data-use-a4a="true"
+  data-ad-slot="197378"
+>
 </amp-ad>
 ```
 

--- a/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
+++ b/extensions/amp-ad-network-mytarget-impl/amp-ad-network-mytarget-impl-internal.md
@@ -1,0 +1,61 @@
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-ad-network-mytarget-impl
+
+myTarget implementation of AMP Ad tag which requests early by XHR and renders natively within the page if a valid AMP Ad is returned. Should not be directly referenced by pages and instead is dynamically loaded via the amp-ad tag. However, in order to remove an async script load of this library, publishers can include its script declaration.
+
+<table>
+  <tr>
+    <td class="col-fourty" width="40%"><strong>Availability</strong></td>
+    <td>In Development</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js">&lt;/script></code></td>
+  </tr>
+</table>
+
+## Example
+
+```html
+<amp-ad width="300" height="250"
+    type="mytarget"
+    data-use-a4a="true"
+    data-ad-slot="197378">
+</amp-ad>
+```
+
+## Attributes
+
+myTarget impl uses the same tags as `<amp-ad>`.
+
+<table>
+  <tr>
+    <td width="40%"><strong>data-use-a4a</strong></td>
+    <td>If non-empty, myTarget will attempt to render via the A4A
+    pathway (i.e., fast rendering for AMP creatives).  Otherwise, it will attempt
+    to render via the delayed iframe path.</td>
+  </tr>
+  <tr>
+    <td><strong>data-ad-slot</strong></td>
+    <td>My target AdSlot ID</td>
+  </tr>
+  <tr>
+    <td><strong>data-ad-query</strong></td>
+    <td>Optional Ad query</td>
+  </tr>
+</table>


### PR DESCRIPTION
myTarget is going to implement Fast-Fetch and A4A.

In the first iteration myTarget adapter supports fast-fetch, but we don't verify and sign creatives yet - so we assign rendering method to crossorigin iframe ('nameframe').
Signed creatives are in development.

Current adapter workflow:

Ad request returns the JSON for the selected slot;
JSON is parsed to get the ad markup;
Ad markup is rendered via crossdomain frame ('nameframe' method).
Example tag is presented in a4a.amp.html
`<amp-ad width="300" height="250" type="mytarget" data-use-a4a="true" data-ad-slot="197378"> <div placeholder></div> <div fallback></div> </amp-ad>`

Please, check the implementation. Thank you in advance.