### PR TITLE
🐛 fix getPreviousPageId

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1127,7 +1127,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       StateProperty.NAVIGATION_PATH
     );
 
-    const currentPageIndex = navigationPath.indexOf(this.element.id);
+    const currentPageIndex = navigationPath.lastIndexOf(this.element.id);
     const previousPageId = navigationPath[currentPageIndex - 1];
 
     if (previousPageId) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1126,10 +1126,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     const navigationPath = this.storeService_.get(
       StateProperty.NAVIGATION_PATH
     );
-    // Navigation path is a complete list of the navigation history, including
-    // the currently active page. The previous page is the next to last element
-    // of that array.
-    const previousPageId = navigationPath[navigationPath.length - 2];
+
+    const currentPageIndex = navigationPath.indexOf(this.element.id);
+    const previousPageId = navigationPath[currentPageIndex - 1];
 
     if (previousPageId) {
       return previousPageId;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1127,8 +1127,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       StateProperty.NAVIGATION_PATH
     );
 
-    const currentPageIndex = navigationPath.lastIndexOf(this.element.id);
-    const previousPageId = navigationPath[currentPageIndex - 1];
+    const pagePathIndex = navigationPath.lastIndexOf(this.element.id);
+    const previousPageId = navigationPath[pagePathIndex - 1];
 
     if (previousPageId) {
       return previousPageId;


### PR DESCRIPTION
fixes #25118

When we updated the `getPreviousPageId()` method to extract the previous page id from the navigation path, we forgot to consider the case when the `AmpStoryPage` calling it is not necessarily the last page. e.g. 

https://github.com/ampproject/amphtml/blob/b6c4242ace9a3d32f82550a378593527c849a460/extensions/amp-story/1.0/amp-story.js#L1538-L1547

Since the navigation path hasn't changed between the two calls of `getPreviousPageId()`, `targetPage.getPreviousPageId()` and `minusOnePage.getPreviousPageId()` return the same id.

This PR ensures that we extract the previous page id given the current page id.
