### PR TITLE
Avoid swipe to dismiss errors being logged.

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -633,6 +633,13 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @param {!SwipeDef} data
    */
   swipeGesture_(data) {
+    // Check if the carousel has been cleared out due to close. It is unclear
+    // how this is happening, but there are errors where the carousel is null
+    // at this point.
+    if (!this.carousel_) {
+      return;
+    }
+
     if (data.first) {
       const {sourceElement} = this.getCurrentElement_();
       const parentCarousel = this.getSourceElementParentCarousel_(


### PR DESCRIPTION
It does not seem like this error should be causing any problems (since the error will just occur in the touch handler for the carousel, which has been nulled out due to the lightbox closing), but adding a check here to avoid logging errors.

I have not been able to reproduce the original error message through testing, but it seems like this change should avoid it.

Closes #22533