### PR TITLE
🐛✅  <header> -> <head> to fix test flake

### DIFF
--- a/test/fixtures/e2e/amp-subscriptions-google/swg.amp.html
+++ b/test/fixtures/e2e/amp-subscriptions-google/swg.amp.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html ⚡>
-<header>
+<head>
   <meta charset="utf-8">
   <title>16 Top Spots for Hiking - The Scenic - USA</title>
   <link rel="canonical" href="amps.html">
@@ -59,7 +59,7 @@
       }
     </script>
 
-</header>
+  </head>
 <body>
     <div class="main-body">
       <main role="main">


### PR DESCRIPTION


The test fixture had `<header>` instead of `<head>` this meant that the code designed to prevent extension race conditions was failing because the scripts were not found in `<head>` resulting in a hard to track test flake.