### PR TITLE
Adds some more people to collaboration OWNERS 

### DIFF
--- a/contributing/OWNERS
+++ b/contributing/OWNERS
@@ -4,7 +4,12 @@
 {
   rules: [
     {
-      owners: [{name: 'mrjoro'}],
+      owners: [
+        {name: 'cathyxz', requestReviews: false},
+        {name: 'mrjoro'},
+        {name: 'ampproject/wg-infra', requestReviews: false},
+        {name: 'ampproject/wg-outreach', requestReviews: false},
+      ],
     },
   ],
 }


### PR DESCRIPTION
This gives more people who have some familiarity with our contributor documentation OWNERS powers.

This still makes me the default assignee for when people don't know who should review their PR.

/cc @cathyxz @ampproject/wg-infra @ampproject/wg-outreach 