### PR TITLE
🏗 Fix `gulp prettify` when there's nothing to check

### DIFF
--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -70,7 +70,7 @@ function prettify() {
     filesToCheck = getFilesChanged(prettifyGlobs);
     if (filesToCheck.length == 0) {
       log(green('INFO: ') + 'No prettifiable files in this PR');
-      return;
+      return Promise.resolve();
     } else {
       logFiles(filesToCheck);
     }


### PR DESCRIPTION
Forgot to do this in #25140
