### PR TITLE
remove preinstall script for node.js

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -21,9 +21,6 @@
   "bin": {
     "amphtml-validator": "index.js"
   },
-  "scripts": {
-    "preinstall": "node ../../build-system/common/check-package-manager.js"
-  },
   "dependencies": {
     "colors": "1.2.5",
     "commander": "2.15.1",


### PR DESCRIPTION
@rsimha 

In #15602 `check_package_manager.js` was added to [validator/nodejs/packages.json](https://github.com/ampproject/amphtml/blob/master/validator/nodejs/package.json). When publishing the npm module (`npm publish --access public`) we ran into an issue that this file wasn't included and it couldn't be installed (see below for error). Removing the script allowed us to publish. However I'm unsure if that is the final outcome desired given the PR that introduced it. @rsimha do you know if this file is necessary or only useful for `yarn` incantations and not `npm`?

```
user@honeybadgerdontcare:~/github/amphtml/validator$ npm install amphtml-validator@1.0.24

> amphtml-validator@1.0.24 preinstall /github/amphtml/validator/node_modules/amphtml-validator
> node ../../build-system/common/check-package-manager.js

internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module '/github/amphtml/validator/build-system/common/check-package-manager.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! amphtml-validator@1.0.24 preinstall: `node ../../build-system/common/check-package-manager.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the amphtml-validator@1.0.24 preinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /.npm/_logs/2019-10-18T22_45_40_386Z-debug.log
```
