### PR TITLE
🏗 Pre-build JS files and extensions loaded by core runtime during `gulp` startup

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -91,11 +91,12 @@ exports.lazyBuildJs = async function(req, res, next) {
 };
 
 /**
- * Pre-builds the core runtime and returns immediately so that the user can
+ * Pre-builds some runtime files and returns immediately so that the user can
  * start using the webserver.
  */
-exports.preBuildCoreRuntime = function() {
+exports.preBuildSomeRuntimeFiles = function() {
   build(jsBundles, 'amp.js', doBuildJs);
+  build(jsBundles, 'ww.max.js', doBuildJs);
 };
 
 /**

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -74,10 +74,10 @@ async function build(bundles, bundle, buildFunc) {
  * @param {!Object} res
  * @param {function()} next
  */
-exports.lazyBuildExtensions = async function(req, res, next) {
+async function lazyBuildExtensions(req, res, next) {
   const matcher = /\/dist\/v0\/([^\/]*)\.max\.js/;
   await lazyBuild(req.url, matcher, extensionBundles, doBuildExtension, next);
-};
+}
 
 /**
  * Lazy builds a non-extension JS file when requested.
@@ -85,30 +85,35 @@ exports.lazyBuildExtensions = async function(req, res, next) {
  * @param {!Object} res
  * @param {function()} next
  */
-exports.lazyBuildJs = async function(req, res, next) {
+async function lazyBuildJs(req, res, next) {
   const matcher = /\/.*\/([^\/]*\.js)/;
   await lazyBuild(req.url, matcher, jsBundles, doBuildJs, next);
-};
+}
 
 /**
- * Pre-builds some runtime files and returns immediately so that the user can
- * start using the webserver.
+ * Pre-builds the core runtime and the JS files that it loads.
  */
-exports.preBuildSomeRuntimeFiles = function() {
-  build(jsBundles, 'amp.js', doBuildJs);
-  build(jsBundles, 'ww.max.js', doBuildJs);
-};
+async function preBuildRuntimeFiles() {
+  await build(jsBundles, 'amp.js', doBuildJs);
+  await build(jsBundles, 'ww.max.js', doBuildJs);
+}
 
 /**
- * Pre-builds some extensions (requested via command line flags) and returns
- * immediately so that the user can start using the webserver.
+ * Pre-builds default extensions and ones requested via command line flags.
  */
-exports.preBuildSomeExtensions = function() {
+async function preBuildExtensions() {
   const extensions = getExtensionsToBuild();
   for (const extensionBundle in extensionBundles) {
     const extension = extensionBundles[extensionBundle].name;
     if (extensions.includes(extension) && !extensionBundle.endsWith('latest')) {
-      build(extensionBundles, extensionBundle, doBuildExtension);
+      await build(extensionBundles, extensionBundle, doBuildExtension);
     }
   }
+}
+
+module.exports = {
+  lazyBuildExtensions,
+  lazyBuildJs,
+  preBuildExtensions,
+  preBuildRuntimeFiles,
 };

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -154,9 +154,11 @@ function maybeInitializeExtensions(
 /**
  * Process the command line arguments --noextensions, --extensions, and
  * --extensions_from and return a list of the referenced extensions.
+ *
+ * @param {boolean=} preBuild
  * @return {!Array<string>}
  */
-function getExtensionsToBuild() {
+function getExtensionsToBuild(preBuild = false) {
   if (extensionsToBuild) {
     return extensionsToBuild;
   }
@@ -175,7 +177,9 @@ function getExtensionsToBuild() {
     const extensionsFrom = getExtensionsFromArg(argv.extensions_from);
     extensionsToBuild = dedupe(extensionsToBuild.concat(extensionsFrom));
   }
-  if (!argv.noextensions && !argv.extensions && !argv.extensions_from) {
+  if (
+    !(preBuild || argv.noextensions || argv.extensions || argv.extensions_from)
+  ) {
     const allExtensions = [];
     for (const extension in extensions) {
       allExtensions.push(extensions[extension].name);
@@ -218,14 +222,10 @@ function parseExtensionFlags(preBuild = false) {
     green('.');
 
   if (preBuild) {
-    if (argv.extensions || argv.extensions_from) {
-      log(
-        green('Pre-building extension(s):'),
-        cyan(getExtensionsToBuild().join(', '))
-      );
-    } else {
-      log(green('Not pre-building any AMP extensions.'));
-    }
+    log(
+      green('Pre-building extension(s):'),
+      cyan(getExtensionsToBuild(preBuild).join(', '))
+    );
     log(extensionsMessage);
     log(inaboxSetMessage);
     log(extensionsFromMessage);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -38,6 +38,7 @@ const {
 const {altMainBundles, jsBundles} = require('../compile/bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
+const {isTravisBuild} = require('../common/travis');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
 
@@ -513,13 +514,15 @@ function printConfigHelp(command) {
     cyan(argv.config === 'canary' ? 'canary' : 'prod'),
     green('AMP config.')
   );
-  log(
-    green('⤷ Use'),
-    cyan('--config={canary|prod}'),
-    green('with your'),
-    cyan(command),
-    green('command to specify which config to apply.')
-  );
+  if (!isTravisBuild()) {
+    log(
+      green('⤷ Use'),
+      cyan('--config={canary|prod}'),
+      green('with your'),
+      cyan(command),
+      green('command to specify which config to apply.')
+    );
+  }
 }
 
 /**

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -25,7 +25,7 @@ const watch = require('gulp-watch');
 const {
   lazyBuildExtensions,
   lazyBuildJs,
-  preBuildCoreRuntime,
+  preBuildSomeRuntimeFiles,
   preBuildSomeExtensions,
 } = require('../server/lazy-build');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
@@ -135,7 +135,7 @@ function restartServer() {
  */
 function initiatePreBuildSteps() {
   if (!argv._.includes('serve')) {
-    preBuildCoreRuntime();
+    preBuildSomeRuntimeFiles();
     if (argv.extensions || argv.extensions_from) {
       preBuildSomeExtensions();
     }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -136,9 +136,7 @@ function restartServer() {
 function initiatePreBuildSteps() {
   if (!argv._.includes('serve')) {
     preBuildSomeRuntimeFiles();
-    if (argv.extensions || argv.extensions_from) {
-      preBuildSomeExtensions();
-    }
+    preBuildSomeExtensions();
   }
 }
 

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -25,8 +25,8 @@ const watch = require('gulp-watch');
 const {
   lazyBuildExtensions,
   lazyBuildJs,
-  preBuildSomeRuntimeFiles,
-  preBuildSomeExtensions,
+  preBuildRuntimeFiles,
+  preBuildExtensions,
 } = require('../server/lazy-build');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
@@ -131,12 +131,12 @@ function restartServer() {
 }
 
 /**
- * Initiates pre-build steps requested via command line args.
+ * Performs pre-build steps requested via command line args.
  */
-function initiatePreBuildSteps() {
+async function performPreBuildSteps() {
   if (!argv._.includes('serve')) {
-    preBuildSomeRuntimeFiles();
-    preBuildSomeExtensions();
+    await preBuildRuntimeFiles();
+    await preBuildExtensions();
   }
 }
 
@@ -148,7 +148,7 @@ async function serve() {
   logServeMode();
   watch(serverFiles, restartServer);
   await startServer();
-  initiatePreBuildSteps();
+  await performPreBuildSteps();
 }
 
 module.exports = {


### PR DESCRIPTION
**Background:**

The default `gulp` task pre-builds the core runtime, and lazy builds all other JS files and extensions. This results in 404 errors for files that are sometimes loaded by the core runtime without a separate server request (#25024, #24226).

**PR highlights:**

- Pre-builds `ww.js` during default `gulp` startup
- Pre-builds `amp-loader` and `amp-auto-lightbox` during default `gulp` startup
- Waits for pre-build tasks to complete before ending default `gulp` task
- Fixes logging to indicate which extensions are being pre-built
- Server startup still happens before pre-build tasks are executed


<img width="1074" alt="" src="https://user-images.githubusercontent.com/26553114/67149550-7424a000-f27a-11e9-8ea6-7183c3256135.png">

Fixes #25024
Fixes #24226