### PR TITLE
🏗 Temporarily roll back `node` version in Travis to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: xenial
 node_js:
-  - 'lts/*'
+  - '10'
 python:
   - '2.7'
 notifications:


### PR DESCRIPTION
Node just pushed out a new LTS, which [breaks](https://travis-ci.org/ampproject/amphtml/jobs/600646389#L328) our builds on Travis. It's non-trivial to upgrade all our `package.json` files.

Until then, let's roll back the version of `node` used by Travis.