### PR TITLE
🏗 Log SwG page start in AMP

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -46,6 +46,7 @@ const GOOGLE_DOMAIN_RE = /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)$/;
 
 const SWG_EVENTS_TO_SUPPRESS = {
   [AnalyticsEvent.IMPRESSION_PAYWALL]: true,
+  [AnalyticsEvent.IMPRESSION_PAGE_LOAD]: true,
 };
 
 const AMP_EVENT_TO_SWG_EVENT = {
@@ -125,6 +126,12 @@ export class GoogleSubscriptionsPlatform {
     this.eventManager_.registerEventFilterer(
       GoogleSubscriptionsPlatform.filterSwgEvent_
     );
+    this.eventManager_.logEvent({
+      eventType: AnalyticsEvent.IMPRESSION_PAGE_LOAD,
+      eventOriginator: EventOriginator.AMP_CLIENT,
+      isFromUserAction: false,
+      additionalParameters: null,
+    });
     resolver();
 
     this.runtime_.setOnLoginRequest(request => {


### PR DESCRIPTION
Makes it possible for Google to know if a user was accessing SwG via AMP or a canonical page.