### PR TITLE
Update I2I to include Launch tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
@@ -36,7 +36,10 @@ A clear and concise description of any alternative solutions or features you've 
 <!--
 Add any other information that may help people understand your I2I.
 -->
-
+## Launch tracker
+<!--
+Add a link to the launch tracker for this work here. Template and instructions can be found here: bit.ly/amp-launch-tracker
+-->
 
 <!--
 Add anyone to this cc line that you want to notify about this I2I, including a reviewer once you have found one. See https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md for help in finding a reviewer.

--- a/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
@@ -38,7 +38,8 @@ Add any other information that may help people understand your I2I.
 -->
 ## Launch tracker
 <!--
-Add a link to the launch tracker for this work here. Template and instructions can be found here: bit.ly/amp-launch-tracker
+The launch tracker is meant to be an easy way of sharing a project's status with others on the AMP Project. 
+You should add a link to the launch tracker for this work here if applicable. One ideal template and instructions can be found here: bit.ly/amp-launch-tracker
 -->
 
 <!--


### PR DESCRIPTION
Launch tracker can be found here: bit.ly/amp-launch-tracker

Open question:
Should this be linked to in the I2S as well (I think so)?