### PR TITLE
Publish amphtml-validator version 1.0.27

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Official validator for AMP HTML (www.ampproject.org)",
   "keywords": [
     "AMP",


### PR DESCRIPTION
Removed references to deleted amp.validator.categorizeError.