### PR TITLE
Bump validator npm to 1.0.28.

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Official validator for AMP HTML (www.ampproject.org)",
   "keywords": [
     "AMP",


### PR DESCRIPTION
This is so we can release the node dependency change in 7316d7c3.

I'll save downstream changes to dependents for subsequent PRs.