### PR TITLE
Remove unused experiments from config and experiments

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -14,7 +14,9 @@
     "twitter-default-placeholder-fade",
     "twitter-default-placeholder-pulse"
   ],
+
   "canary": 1,
+
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -14,9 +14,7 @@
     "twitter-default-placeholder-fade",
     "twitter-default-placeholder-pulse"
   ],
-
   "canary": 1,
-
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,
@@ -24,8 +22,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-consent-v2": 1,
-  "amp-list-load-more": 1,
-  "amp-list-viewport-resize": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,9 +14,7 @@
     "twitter-default-placeholder-fade",
     "twitter-default-placeholder-pulse"
   ],
-
   "canary": 0,
-
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,
@@ -24,8 +22,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-consent-v2": 1,
-  "amp-list-load-more": 1,
-  "amp-list-viewport-resize": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,7 +14,9 @@
     "twitter-default-placeholder-fade",
     "twitter-default-placeholder-pulse"
   ],
+
   "canary": 0,
+
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -22,7 +22,6 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-list/load-more-auto.amp.html',
-    experiments: ['amp-list-load-more'],
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(cathyxz, cvializ): figure out why 'viewer' only shows 'FALLBACK'
     // TODO(cathyxz): figure out why shadow-demo doesn't work

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -23,7 +23,6 @@ describes.endtoend(
     testUrl:
       'http://localhost:8000/test/manual/amp-list/' +
       'load-more-manual.amp.html',
-    experiments: ['amp-list-load-more'],
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(cathyxz, cvializ): figure out why 'viewer-demo' only shows 'FALLBACK'
     environments: ['single'],

--- a/test/manual/amp-list/infinite-scroll-2.amp.html
+++ b/test/manual/amp-list/infinite-scroll-2.amp.html
@@ -27,10 +27,6 @@ limitations under the License.
   <meta name="amp-google-client-id-api" content="googleanalytics">
 
   <script src="https://cdn.ampproject.org/v0.js"></script>
-  <script>
-    AMP.toggleExperiment('amp-list-load-more', true);
-  </script>
-
 
   <style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 

--- a/test/manual/amp-list/infinite-scroll-fail.amp.html
+++ b/test/manual/amp-list/infinite-scroll-fail.amp.html
@@ -6,11 +6,6 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
-  <script>
-    (self.AMP=self.AMP||[]).push(function(AMP){
-        AMP.toggleExperiment('amp-list-load-more', true);
-    });
-  </script>
   <style amp-custom>
     body {
       font-family: 'Questrial', Arial;

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -240,11 +240,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17161',
   },
   {
-    id: 'amp-list-load-more',
-    name: 'Enables load-more related functionality in amp-list',
-    spec: 'https://github.com/ampproject/amphtml/issues/13575',
-  },
-  {
     id: 'hidden-mutation-observer',
     name: "Enables FixedLayer's hidden-attribute mutation observer",
     spec: 'https://github.com/ampproject/amphtml/issues/17475',


### PR DESCRIPTION
Cleans up unused experiments `amp-list-load-more` and `amp-list-viewport-resize`. Both experiments have been launched and are no longer referenced in our codebase. 