### PR TITLE
Move parseJson, getData and getDetail to types.js

### DIFF
--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -257,15 +257,15 @@ requirement: {
   whitelist: 'ads/mads.js'
   whitelist: 'ads/google/imaVideo.js'
   whitelist: 'ads/zen.js'
-  whitelist: 'src/json.js' # Where parseJson itself is implemented.
+  whitelist: 'src/types.js' # Where parseJson itself is implemented.
 }
 
 requirement: {
   type: BANNED_PROPERTY_READ
-  error_message: 'Use eventHelper#getData to read the data property. OK to whitelist 3p ads for now.'
+  error_message: 'Use types#getData to read the data property. OK to whitelist 3p ads for now.'
   value: 'Event.prototype.data'
   value: 'MessageEvent.prototype.data'
-  whitelist: 'src/event-helper.js' # getData is implemented here
+  whitelist: 'src/types.js' # getData is implemented here
   whitelist: 'src/web-worker/amp-worker.js' # OK to use in version bound worker
   whitelist: 'src/web-worker/web-worker.js' # OK to use in version bound worker
 
@@ -281,10 +281,10 @@ requirement: {
 
 requirement: {
   type: BANNED_PROPERTY_READ
-  error_message: 'Use eventHelper#getDetail to read the detail property. OK to whitelist 3p ads for now.'
+  error_message: 'Use types#getDetail to read the detail property. OK to whitelist 3p ads for now.'
   value: 'Event.prototype.detail'
   value: 'MessageEvent.prototype.detail'
-  whitelist: 'src/event-helper.js' # getDetail is implemented here
+  whitelist: 'src/types.js' # getDetail is implemented here
 
   # 3p ads are OK
   whitelist: 'ads/adhese.js'

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import {getData, getDetail} from './types';
 import {internalListenImplementation} from './event-helper-listen';
 import {lastChildElement} from './dom';
 import {user} from './log';
+
+export {getData, getDetail};
 
 /** @const {string}  */
 const LOAD_FAILURE_PREFIX = 'Failed to load:';
@@ -67,24 +70,6 @@ export function listen(element, eventType, listener, opt_evtListenerOpts) {
     listener,
     opt_evtListenerOpts
   );
-}
-
-/**
- * Returns the data property of an event with the correct type.
- * @param {!Event|{data: !JsonObject}} event
- * @return {?JsonObject|string|undefined}
- */
-export function getData(event) {
-  return /** @type {?JsonObject|string|undefined} */ (event.data);
-}
-
-/**
- * Returns the detail property of an event with the correct type.
- * @param {!Event|{detail: !JsonObject}} event
- * @return {?JsonObject|string|undefined}
- */
-export function getDetail(event) {
-  return /** @type {?JsonObject|string|undefined} */ (event.detail);
 }
 
 /**

--- a/src/json.js
+++ b/src/json.js
@@ -20,7 +20,9 @@
  */
 
 import {childElementsByTag, isJsonScriptTag} from './dom';
-import {isObject} from './types';
+import {isObject, parseJson} from './types';
+
+export {parseJson};
 
 // NOTE Type are changed to {*} because of
 // https://github.com/google/closure-compiler/issues/1999
@@ -99,17 +101,6 @@ export function getValueForExpr(obj, expr) {
     break;
   }
   return value;
-}
-
-/**
- * Simple wrapper around JSON.parse that casts the return value
- * to JsonObject.
- * Create a new wrapper if an array return value is desired.
- * @param {*} json JSON string to parse
- * @return {?JsonObject} May be extend to parse arrays.
- */
-export function parseJson(json) {
-  return /** @type {?JsonObject} */ (JSON.parse(/** @type {string} */ (json)));
 }
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -95,3 +95,32 @@ export function isEnumValue(enumObj, s) {
 export function toWin(winOrNull) {
   return /** @type {!Window} */ (winOrNull);
 }
+
+/**
+ * Returns the data property of an event with the correct type.
+ * @param {!Event|{data: !JsonObject}} event
+ * @return {?JsonObject|string|undefined}
+ */
+export function getData(event) {
+  return /** @type {?JsonObject|string|undefined} */ (event.data);
+}
+
+/**
+ * Returns the detail property of an event with the correct type.
+ * @param {!Event|{detail: !JsonObject}} event
+ * @return {?JsonObject|string|undefined}
+ */
+export function getDetail(event) {
+  return /** @type {?JsonObject|string|undefined} */ (event.detail);
+}
+
+/**
+ * Simple wrapper around JSON.parse that casts the return value
+ * to JsonObject.
+ * Create a new wrapper if an array return value is desired.
+ * @param {*} json JSON string to parse
+ * @return {?JsonObject} May be extend to parse arrays.
+ */
+export function parseJson(json) {
+  return /** @type {?JsonObject} */ (JSON.parse(/** @type {string} */ (json)));
+}


### PR DESCRIPTION
Currently, these functions live in `src/json.js` and `src/event-helper.js`. However, both of these files transitively depend on `src/log.js` which means if we include them in a standalone library (like [amp-viewer-messaging](https://github.com/ampproject/amphtml/tree/master/extensions/amp-viewer-integration/0.1/messaging)), it becomes hard to bundle (bundlers pull a lot of uninteded dependencies that deal with `self`).

I made `src/json.js` and `src/event-helper.js` re-export parseJson, getData and getDetail so that files that depend on them can keep doing so. But libraries like amp-viewer-messaging can now import them from `types.js`.