### PR TITLE
🐛 Replace all OWNERS file references to a4a team with wg-ads

### DIFF
--- a/ads/google/OWNERS
+++ b/ads/google/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-a4a/OWNERS
+++ b/extensions/amp-a4a/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-adsense-impl/OWNERS
+++ b/extensions/amp-ad-network-adsense-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-adzerk-impl/OWNERS
+++ b/extensions/amp-ad-network-adzerk-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-doubleclick-impl/OWNERS
+++ b/extensions/amp-ad-network-doubleclick-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-fake-impl/OWNERS
+++ b/extensions/amp-ad-network-fake-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-gmossp-impl/OWNERS
+++ b/extensions/amp-ad-network-gmossp-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-triplelift-impl/OWNERS
+++ b/extensions/amp-ad-network-triplelift-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/a4a'}, {name: 'szach'}],
+      owners: [{name: 'ampproject/wg-ads'}, {name: 'szach'}],
     },
   ],
 }


### PR DESCRIPTION
During consolidation of GitHub teams (https://github.com/ampproject/meta/issues/43), `ampproject/a4a` was removed even though it is still listed in many OWNERS files. This PR updates references to the team, replacing them with `ampproject/wg-ads` or removing them where redundant.