### PR TITLE
🏗🚀 Refactor and significantly speed up `gulp check-links`

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -51,17 +51,19 @@ function getFilesChanged(globs) {
 }
 
 /**
- * Logs the list of files that will be checked.
+ * Logs the list of files that will be checked and returns the list.
  *
  * @param {!Array<string>} files
+ * @return {!Array<string>}
  */
 function logFiles(files) {
   if (!isTravisBuild()) {
     log(green('INFO: ') + 'Checking the following files:');
-    files.forEach(file => {
+    for (const file of files) {
       log(cyan(file));
-    });
+    }
   }
+  return files;
 }
 
 /**
@@ -73,21 +75,18 @@ function logFiles(files) {
  * @return {!Array<string>}
  */
 function getFilesToCheck(globs, options = {}) {
-  let filesToCheck = [];
   if (argv.files) {
-    filesToCheck = globby.sync(argv.files.split(','));
-    logFiles(filesToCheck);
-  } else if (argv.local_changes) {
-    filesToCheck = getFilesChanged(globs);
-    if (filesToCheck.length == 0) {
-      log(green('INFO: ') + 'No files to check in this PR');
-    } else {
-      logFiles(filesToCheck);
-    }
-  } else {
-    filesToCheck = globby.sync(globs, options);
+    return logFiles(globby.sync(argv.files.split(',')));
   }
-  return filesToCheck;
+  if (argv.local_changes) {
+    const filesChanged = getFilesChanged(globs);
+    if (filesChanged.length == 0) {
+      log(green('INFO: ') + 'No files to check in this PR');
+      return [];
+    }
+    return logFiles(filesChanged);
+  }
+  return globby.sync(globs, options);
 }
 
 module.exports = {

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -83,7 +83,7 @@ async function main() {
 
     // Check document links only for PR builds.
     if (buildTargets.has('DOCS')) {
-      timedExecOrDie('gulp check-links');
+      timedExecOrDie('gulp check-links --local_changes');
     }
 
     if (buildTargets.has('DEV_DASHBOARD')) {

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -45,8 +45,8 @@ async function checkLinks() {
     log(green('Starting checks...'));
   }
   filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
-  const allResults = await Promise.all(filesToCheck.map(checkLinksInFile));
-  reportFinalResults(allResults);
+  const results = await Promise.all(filesToCheck.map(checkLinksInFile));
+  reportResults(results);
 }
 
 /**
@@ -77,28 +77,31 @@ function isValidUsage() {
 }
 
 /**
- * Reports final results after having checked all markdown files.
+ * Reports results after all markdown files have been checked.
  *
- * @param {!Array<string>} allResults
+ * @param {!Array<string>} results
  */
-function reportFinalResults(allResults) {
-  const filesWithDeadLinks = allResults
+function reportResults(results) {
+  const filesWithDeadLinks = results
     .filter(result => result.containsDeadLinks)
     .map(result => result.file);
   if (filesWithDeadLinks.length > 0) {
     log(
       red('ERROR:'),
-      'Please update dead link(s) in',
-      cyan(filesWithDeadLinks.join(',')),
-      'or add them to',
-      cyan('ignorePatterns'),
-      'in',
-      cyan('build-system/tasks/check-links.js')
+      'Please update the dead link(s) in these files:',
+      cyan(filesWithDeadLinks.join(', '))
     );
     log(
-      yellow('NOTE:'),
-      'If any of the link(s) above are not meant to resolve to a real webpage,',
-      'surrounding them with backticks will exempt them from the link checker.'
+      yellow('NOTE 1:'),
+      "Valid links that don't resolve on Travis can be ignored via",
+      cyan('ignorePatterns'),
+      'in',
+      cyan('build-system/tasks/check-links.js') + '.'
+    );
+    log(
+      yellow('NOTE 2:'),
+      "Links that aren't meant to resolve to a real webpage can be exempted",
+      'from this check by surrounding them with backticks (`).'
     );
     process.exitCode = 1;
     return;

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -16,88 +16,95 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const BBPromise = require('bluebird');
 const fs = require('fs-extra');
 const log = require('fancy-log');
-const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
+const markdownLinkCheck = require('markdown-link-check');
 const path = require('path');
-const {
-  gitDiffAddedNameOnlyMaster,
-  gitDiffNameOnlyMaster,
-} = require('../common/git');
-const {green, magenta, red, yellow} = require('ansi-colors');
+const {getFilesToCheck} = require('../common/utils');
+const {gitDiffAddedNameOnlyMaster} = require('../common/git');
+const {green, cyan, red, yellow} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
+const {linkCheckGlobs} = require('../test-configs/config');
 const {maybeUpdatePackages} = require('./update-packages');
 
-/**
- * Parses the list of files in argv, or extracts it from the commit log.
- *
- * @return {!Array<string>}
- */
-function getMarkdownFiles() {
-  if (!!argv.files) {
-    return argv.files.split(',');
-  }
-  return gitDiffNameOnlyMaster().filter(function(file) {
-    return path.extname(file) == '.md' && !file.startsWith('examples/');
-  });
-}
+let filesIntroducedByPr;
 
 /**
- * Parses the list of files in argv and checks for dead links.
- *
- * @return {Promise} Used to wait until all async link checkers finish.
+ * Checks for dead links in .md files passed in via --files or --local_changes.
  */
 async function checkLinks() {
   maybeUpdatePackages();
-  const markdownFiles = getMarkdownFiles();
-  const allResults = await Promise.all(markdownFiles.map(runLinkChecker));
+  if (!isValidUsage()) {
+    return;
+  }
+  const filesToCheck = getFilesToCheck(linkCheckGlobs);
+  if (filesToCheck.length == 0) {
+    return;
+  }
+  if (!isTravisBuild()) {
+    log(green('Starting checks...'));
+  }
+  filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
+  const filesWithDeadLinks = [];
+  await Promise.all(
+    filesToCheck.map(file => checkLinksInFile(file, filesWithDeadLinks))
+  );
+  reportFinalResults(filesWithDeadLinks);
+}
 
-  const filesWithDeadLinks = allResults
-    .map((results, index) => {
-      // Some files were ignored and have no results.
-      if (!results) {
-        return;
-      }
-      let deadLinksFoundInFile = false;
-      for (const {link, status, statusCode} of results) {
-        // Skip links to files that were introduced by the PR.
-        if (isLinkToFileIntroducedByPR(link)) {
-          continue;
-        }
-        if (status === 'dead') {
-          deadLinksFoundInFile = true;
-          log(`[${red('✖')}] ${link} (${red(statusCode)})`);
-        } else if (!isTravisBuild()) {
-          log(`[${green('✔')}] ${link}`);
-        }
-      }
-      const filename = markdownFiles[index];
-      if (deadLinksFoundInFile) {
-        log(red('ERROR'), 'Possible dead link(s) found in', magenta(filename));
-        return filename;
-      }
-      log(green('SUCCESS'), 'All links in', magenta(filename), 'are alive.');
-    })
-    .filter(filenameOrUndef => filenameOrUndef);
-
-  if (filesWithDeadLinks.length > 0) {
+/**
+ * Checks if the correct arguments were passed in
+ *
+ * @return {boolean}
+ */
+function isValidUsage() {
+  const validUsage = argv.files || argv.local_changes;
+  if (!validUsage) {
     log(
-      red('ERROR'),
-      'Please update dead link(s) in',
-      magenta(filesWithDeadLinks.join(',')),
-      'or add them to allow-list in build-system/tasks/check-links.js'
+      yellow('NOTE 1:'),
+      'It is infeasible for',
+      cyan('gulp check-links'),
+      'to check for dead links in all markdown files in the repo at once.'
     );
     log(
-      yellow('NOTE'),
-      'If the link(s) above are not meant to resolve to a real webpage,',
+      yellow('NOTE 2:'),
+      'Please run',
+      cyan('gulp check-links'),
+      'with',
+      cyan('--files'),
+      'or',
+      cyan('--local_changes') + '.'
+    );
+  }
+  return validUsage;
+}
+
+/**
+ * Reports final results after having checked all markdown files.
+ *
+ * @param {!Array<string>} filesWithDeadLinks
+ */
+function reportFinalResults(filesWithDeadLinks) {
+  if (filesWithDeadLinks.length > 0) {
+    log(
+      red('ERROR:'),
+      'Please update dead link(s) in',
+      cyan(filesWithDeadLinks.join(',')),
+      'or add them to',
+      cyan('ignorePatterns'),
+      'in',
+      cyan('build-system/tasks/check-links.js')
+    );
+    log(
+      yellow('NOTE:'),
+      'If any of the link(s) above are not meant to resolve to a real webpage,',
       'surrounding them with backticks will exempt them from the link checker.'
     );
     process.exitCode = 1;
     return;
   }
   log(
-    green('SUCCESS'),
+    green('SUCCESS:'),
     'All links in all markdown files in this branch are alive.'
   );
 }
@@ -109,66 +116,75 @@ async function checkLinks() {
  * @return {boolean} True if the link points to a file introduced by the PR.
  */
 function isLinkToFileIntroducedByPR(link) {
-  return gitDiffAddedNameOnlyMaster().some(function(file) {
+  return filesIntroducedByPr.some(function(file) {
     return file.length > 0 && link.includes(path.parse(file).base);
   });
 }
 
 /**
- * Filters out links in allow-list before running the link checker.
+ * Checks a given markdown file for dead links.
  *
- * @param {string} markdown Original markdown.
- * @return {string} Markdown after filtering out allowed links.
+ * @param {string} file
+ * @param {!Array<string>} filesWithDeadLinks
+ * @return {!Promise}
  */
-function filterAllowedLinks(markdown) {
-  let filteredMarkdown = markdown;
+function checkLinksInFile(file, filesWithDeadLinks) {
+  let markdown = fs.readFileSync(file).toString();
 
-  // localhost links optionally preceded by ( or [ (not served on Travis)
-  filteredMarkdown = filteredMarkdown.replace(
-    /(\(|\[)?http:\/\/localhost:8000/g,
-    ''
-  );
+  // Links inside <code> blocks are illustrative and not always valid. Must be
+  // removed because markdownLinkCheck() does not ignore them like <pre> blocks.
+  markdown = markdown.replace(/<code>([^]*?)<\/code>/g, '');
 
-  // Links in script tags (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/src="http.*?"/g, '');
-
-  // Links inside a <code> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<code>([^]*?)<\/code>/g, '');
-
-  // Links inside a <pre> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<pre>([^]*?)<\/pre>/g, '');
-
-  // After allow-listing is done, clean up any remaining empty blocks bounded
-  // by backticks. Otherwise, `` will be treated as the start of a code block
-  // and confuse the link extractor.
-  filteredMarkdown = filteredMarkdown.replace(/\ \`\`\ /g, '');
-
-  return filteredMarkdown;
-}
-
-/**
- * Reads the raw contents in the given markdown file, filters out localhost
- * links (because they do not resolve on Travis), and checks for dead links.
- *
- * @param {string} markdownFile Path of markdown file, relative to src root.
- * @return {Promise} Used to wait until the async link checker is done.
- */
-function runLinkChecker(markdownFile) {
-  // `.template.md` is a common suffix for files that may have interpolation
-  // tokens, possibly as part of their links. So we skip them.
-  if (path.basename(markdownFile).endsWith('.template.md')) {
-    return Promise.resolve();
-  }
-  // Skip files that were deleted by the PR.
-  if (!fs.existsSync(markdownFile)) {
-    return Promise.resolve();
-  }
-  const markdown = fs.readFileSync(markdownFile).toString();
-  const filteredMarkdown = filterAllowedLinks(markdown);
   const opts = {
-    baseUrl: 'file://' + path.dirname(path.resolve(markdownFile)),
+    // Relative links start at the markdown file's path.
+    baseUrl: 'file://' + path.dirname(path.resolve(file)),
+    ignorePatterns: [
+      // Localhost links don't work unless a `gulp` server is running.
+      {pattern: /localhost/},
+      // Templated links are merely used to generate other markdown files.
+      {pattern: /\$\{[a-z]*\}/},
+    ],
   };
-  return markdownLinkCheck(filteredMarkdown, opts);
+
+  return new Promise((resolve, reject) => {
+    const callback = (err, results) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      let deadLinksFoundInFile = false;
+      for (const {link, status, statusCode} of results) {
+        // Skip links to files that were introduced by the PR.
+        if (isLinkToFileIntroducedByPR(link)) {
+          continue;
+        }
+        switch (status) {
+          case 'alive':
+            if (!isTravisBuild()) {
+              log(`[${green('✔')}] ${link}`);
+            }
+            break;
+          case 'ignored':
+            if (!isTravisBuild()) {
+              log(`[${yellow('•')}] ${link}`);
+            }
+            break;
+          case 'dead':
+            deadLinksFoundInFile = true;
+            log(`[${red('✖')}] ${link} (${red(statusCode)})`);
+            break;
+        }
+      }
+      if (deadLinksFoundInFile) {
+        log(red('ERROR:'), 'Possible dead link(s) found in', cyan(file));
+        filesWithDeadLinks.push(file);
+      } else {
+        log(green('SUCCESS:'), 'All links in', cyan(file), 'are alive.');
+      }
+      resolve(file);
+    };
+    markdownLinkCheck(markdown, opts, callback);
+  });
 }
 
 module.exports = {
@@ -177,5 +193,6 @@ module.exports = {
 
 checkLinks.description = 'Detects dead links in markdown files';
 checkLinks.flags = {
-  'files': '  CSV list of files in which to check links',
+  'files': '  Checks only the specified files',
+  'local_changes': '  Checks just the files changed in the local branch',
 };

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -74,7 +74,7 @@ async function prCheck(cb) {
   }
 
   if (buildTargets.has('DOCS')) {
-    runCheck('gulp check-links');
+    runCheck('gulp check-links --local_changes');
   }
 
   if (buildTargets.has('DEV_DASHBOARD')) {

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -160,6 +160,15 @@ const prettifyGlobs = [
 ];
 
 /**
+ * List of markdown files that may be checked by `gulp check-links` (using
+ * markdown-link-check).
+ */
+const linkCheckGlobs = [
+  '**/*.md',
+  '!**/{examples,node_modules,build,dist,dist.3p,dist.tools}/**',
+];
+
+/**
  * Array of 3p bootstrap urls
  * Defined by the following object schema:
  * basename: the name of the 3p frame without extension
@@ -200,6 +209,7 @@ module.exports = {
   e2eTestPaths,
   integrationTestPaths,
   jisonPaths,
+  linkCheckGlobs,
   lintGlobs,
   presubmitGlobs,
   prettifyGlobs,

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -71,7 +71,8 @@ Command                                                                 | Descri
 `gulp build --extensions_from=examples/foo.amp.html`                    | Builds the AMP library, with only the extensions needed to load the listed examples.
 `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 `gulp build --fortesting`                                               | Builds the AMP library and sets the `test` field in `AMP_CONFIG` to `true`.
-`gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.
+`gulp check-links --files=<files-path-glob>`                            | Reports dead links in `.md` files.
+`gulp check-links --local_changes`                                      | Reports dead links in `.md` files changed in the local branch.
 `gulp clean`                                                            | Removes build output.
 `gulp css`                                                              | Recompiles css to the build directory and builds the embedded css into js files for the AMP library.
 `gulp compile-jison`                                                    | Compiles jison parsers for extensions to build directory.


### PR DESCRIPTION
This PR builds on #25226 and refactors / significantly speeds up `gulp check-links`

**Highlights:**
- Moves common functionality like `getFilesToCheck()` into `build-system/common/utils.js`
- Introduces the `--files` and `--local_changes` flags (`--files` now supports lists of globs)
- Makes it an error to run `gulp check-links` on *all* files in the repo (there are multiple thousands of links, so we only run the link checker on files changed by a PR)
- Uses the `ignorePatterns` option of [`markdown-link-check`](https://www.npmjs.com/package/markdown-link-check#markdownlinkcheckmarkdown-opts-callback) and deletes `filterAllowedLinks()` (addresses https://github.com/ampproject/amphtml/pull/25226#discussion_r338314998)
- Caches `gitDiffAddedNameOnlyMaster()` in `filesIntroducedByPr` (significant speed up)
- Processes and prints results for each `.md` file as soon as they are available (better UX, also faster)
- Adds support for ignored links while reporting results (yellow dots)
- Eliminates the use of `BBPromise` in favor of the native interface of `markdown-link-check`

**Usage:**
```sh
# Check all .md files changed in the local branch
gulp check-links --local_changes

# Check just the files specified
gulp check-links --files "build-system/**/*.md"
```

**Example:**

![Screenshot from 2019-10-24 12-11-47](https://user-images.githubusercontent.com/26553114/67504531-8d9d6180-f657-11e9-870e-94e8eaee7865.png)

Follow up to #25226