### PR TITLE
🐛Expose amp-form response from SSR in `submit-success` and `submit-error` events.

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -622,7 +622,7 @@ export class AmpForm {
     if (error && error.message) {
       detail['error'] = error.message;
     }
-    return this.handleSubmitFailure_(error, detail, detail);
+    return this.handleSubmitFailure_(error, detail);
   }
 
   /**
@@ -741,7 +741,7 @@ export class AmpForm {
           if (error && error.message) {
             detail['error'] = error.message;
           }
-          return this.handleSubmitFailure_(error, detail, detail);
+          return this.handleSubmitFailure_(error, detail);
         }
       );
   }
@@ -910,7 +910,7 @@ export class AmpForm {
   handleXhrSubmitSuccess_(response) {
     return response.json().then(
       /** @type {!JsonObject} */ json => {
-        return this.handleSubmitSuccess_(json, json).then(() => {
+        return this.handleSubmitSuccess_(json).then(() => {
           this.triggerFormSubmitInAnalytics_('amp-form-submit-success');
           this.maybeHandleRedirect_(response);
         });
@@ -924,15 +924,18 @@ export class AmpForm {
   /**
    * Transition the form to the submit success state.
    * @param {!JsonObject} result
-   * @param {!JsonObject} eventData
+   * @param {?JsonObject=} opt_eventData
    * @return {!Promise}
    * @private visible for testing
    */
-  handleSubmitSuccess_(result, eventData) {
+  handleSubmitSuccess_(result, opt_eventData) {
     this.setState_(FormState.SUBMIT_SUCCESS);
     return tryResolve(() => {
       this.renderTemplate_(result || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_SUCCESS, eventData);
+        this.triggerAction_(
+          FormEvents.SUBMIT_SUCCESS,
+          opt_eventData === undefined ? result : opt_eventData
+        );
         this.dirtinessHandler_.onSubmitSuccess();
       });
     });
@@ -953,7 +956,7 @@ export class AmpForm {
     }
     return promise.then(responseJson => {
       this.triggerFormSubmitInAnalytics_('amp-form-submit-error');
-      this.handleSubmitFailure_(e, responseJson, responseJson);
+      this.handleSubmitFailure_(e, responseJson);
       this.maybeHandleRedirect_(e.response);
     });
   }
@@ -962,16 +965,19 @@ export class AmpForm {
    * Transition the form the the submit error state.
    * @param {*} error
    * @param {!JsonObject} json
-   * @param {!JsonObject} eventData
+   * @param {?JsonObject=} opt_eventData
    * @return {!Promise}
    * @private
    */
-  handleSubmitFailure_(error, json, eventData) {
+  handleSubmitFailure_(error, json, opt_eventData) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
     return tryResolve(() => {
       this.renderTemplate_(json).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_ERROR, eventData);
+        this.triggerAction_(
+          FormEvents.SUBMIT_ERROR,
+          opt_eventData === undefined ? json : opt_eventData
+        );
         this.dirtinessHandler_.onSubmitError();
       });
     });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -625,7 +625,7 @@ export class AmpForm {
     return this.handleSubmitFailure_(
       error,
       detail,
-      /** opt_getSsrEventResponse */ false
+      /** getSsrEventResponse */ false
     );
   }
 
@@ -748,7 +748,7 @@ export class AmpForm {
           return this.handleSubmitFailure_(
             error,
             detail,
-            /** opt_getSsrEventResponse */ false
+            /** getSsrEventResponse */ false
           );
         }
       );
@@ -791,13 +791,13 @@ export class AmpForm {
         return this.handleSubmitFailure_(
           status,
           response,
-          /** opt_getSsrEventResponse */ true
+          /** getSsrEventResponse */ true
         );
       }
     }
     return this.handleSubmitSuccess_(
       tryResolve(() => response),
-      /** opt_getSsrEventResponse */ true
+      /** getSsrEventResponse */ true
     );
   }
 
@@ -926,7 +926,7 @@ export class AmpForm {
     const json = /** @type {!Promise<!JsonObject>} */ (response.json());
     return this.handleSubmitSuccess_(
       json,
-      /** opt_getSsrEventResponse */ false
+      /** getSsrEventResponse */ false
     ).then(() => {
       this.triggerFormSubmitInAnalytics_('amp-form-submit-success');
       this.maybeHandleRedirect_(response);
@@ -935,18 +935,18 @@ export class AmpForm {
 
   /**
    * Transition the form to the submit success state.
-   * If opt_getSsrEventResponse is true, exposes the response.body in
+   * If getSsrEventResponse is true, exposes the response.body in
    * the SUBMIT_SUCCESS event; otherwise exposes the resolved jsonPromise.
    * @param {!Promise<!JsonObject>} jsonPromise
-   * @param {?boolean} opt_getSsrEventResponse
+   * @param {boolean} getSsrEventResponse
    * @return {!Promise}
    * @private visible for testing
    */
-  handleSubmitSuccess_(jsonPromise, opt_getSsrEventResponse) {
+  handleSubmitSuccess_(jsonPromise, getSsrEventResponse) {
     return jsonPromise.then(
       json => {
         // HTTP response payload returned by the amp-form endpoint from SSR
-        const eventResponse = opt_getSsrEventResponse ? json['body'] : json;
+        const eventResponse = getSsrEventResponse ? json['body'] : json;
         this.setState_(FormState.SUBMIT_SUCCESS);
         this.renderTemplate_(json || {}).then(() => {
           this.triggerAction_(FormEvents.SUBMIT_SUCCESS, eventResponse);
@@ -977,7 +977,7 @@ export class AmpForm {
       this.handleSubmitFailure_(
         e,
         responseJson,
-        /** opt_getSsrEventResponse */ false
+        /** getSsrEventResponse */ false
       );
       this.maybeHandleRedirect_(e.response);
     });
@@ -985,21 +985,21 @@ export class AmpForm {
 
   /**
    * Transition the form the the submit error state.
-   * If opt_getSsrEventResponse is true, exposes the response.body in
+   * If getSsrEventResponse is true, exposes the response.body in
    * the SUBMIT_ERROR event; otherwise exposes the provided json.
    * @param {*} error
    * @param {!JsonObject} json
-   * @param {?boolean} opt_getSsrEventResponse
+   * @param {boolean} getSsrEventResponse
    * @return {!Promise}
    * @private
    */
-  handleSubmitFailure_(error, json, opt_getSsrEventResponse) {
+  handleSubmitFailure_(error, json, getSsrEventResponse) {
     this.setState_(FormState.SUBMIT_ERROR);
     user().error(TAG, 'Form submission failed: %s', error);
     return tryResolve(() => {
       this.renderTemplate_(json).then(() => {
         // HTTP response payload returned by the amp-form endpoint from SSR
-        const eventResponse = opt_getSsrEventResponse ? json['body'] : json;
+        const eventResponse = getSsrEventResponse ? json['body'] : json;
         this.triggerAction_(FormEvents.SUBMIT_ERROR, eventResponse);
         this.dirtinessHandler_.onSubmitError();
       });


### PR DESCRIPTION
SSR responses get passed fully to the `submit-success` and `submit-error` events on amp-form. These often include extra fields such as the HTML to render in the template. This change only exposes to the events the expected values of the amp-form response, such as data inserted into the form fields or relevant errors. b/138778080 cc/ @GoTcWang 