### PR TITLE
🐛 Fix Custom Element instance creation in IE11

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -795,6 +795,16 @@ function polyfill(win) {
 
   // Expose the polyfilled HTMLElement constructor for everyone to extend from.
   win.HTMLElement = HTMLElementPolyfill;
+
+  // When we transpile `super` in Custom Element subclasses, we change it to
+  // `superClass.call(this)` (where `superClass` is `HTMLElementPolyfill`).
+  // That `.call` value is inherited from `Function.prototype`.
+  // But, IE11's native HTMLElement hierarchy doesn't extend from Function!
+  // And because `HTMLElementPolyfill` extends from `HTMLElement`, it doesn't
+  // have a `.call`! So we need to manually install it.
+  if (!HTMLElementPolyfill.call) {
+    HTMLElementPolyfill.call = win.Function.call;
+  }
 }
 
 /**


### PR DESCRIPTION
When we transpile `super` in Custom Element subclasses, we change it to `superClass.call(this)` (where `superClass` is `HTMLElementPolyfill`). That `.call` value is inherited from `Function.prototype`. 

But, IE11's native `HTMLElement` hierarchy doesn't extend from `Function`!  And because `HTMLElementPolyfill` extends from `HTMLElement`, it doesn't have a `.call`! So we need to manually install it.