### PR TITLE
Update amp-fit-text AMP4EMAIL tagspec

### DIFF
--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -17,7 +17,6 @@
 tags: {  # amp-fit-text
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {

--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -29,11 +29,8 @@ tags: {  # amp-fit-text
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # amp-fit-text
-  html_format: AMP
-  html_format: AMP4ADS
+tags: {  # amp-fit-text (AMP4EMAIL)
   html_format: AMP4EMAIL
-  html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)"
   extension_spec: {

--- a/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
+++ b/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
@@ -37,6 +37,8 @@ amp4email_feature_tests/no_latest_extensions.html:28:2 The attribute 'src' in ta
 >>   ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:29:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-carousel] (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-carousel-latest.js'. (see https://amp.dev/documentation/components/amp-carousel)
 |    <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-latest.js"></script>
+>>   ^~~~~~~~~
+amp4email_feature_tests/no_latest_extensions.html:30:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-fit-text-latest.js'. (see https://amp.dev/documentation/components/amp-fit-text)
 |    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-latest.js"></script>
 >>   ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:31:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-form] (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-form-latest.js'. (see https://amp.dev/documentation/components/amp-form)


### PR DESCRIPTION
Follow up to #24854 

Restrict `amp-fit-text` AMP4EMAIL tagspec to only `html_format: AMP4EMAIL`.
