### PR TITLE
Disable sidebar close animation on iOS back

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -129,7 +129,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.win,
       cb => this.mutateElement(cb),
       // The sidebar is already animated by swipe to dismiss, so skip animation.
-      () => this.dismiss_(true, ActionTrust.HIGH)
+      () => this.dismiss_(/*skipAnimation*/ true, ActionTrust.HIGH)
     );
   }
 
@@ -435,7 +435,14 @@ export class AmpSidebar extends AMP.BaseElement {
     this.viewport_.enterOverlayMode();
     this.setUpdateFn_(() => this.updateForOpening_(trust));
     this.getHistory_()
-      .push(() => this.close_(trust))
+      .push(() => {
+        // In iOS, close on back without animation due to swipe-to-go-back
+        if (this.isIos_) {
+          this.dismiss_(/*skipAnimation*/ true, trust);
+        } else {
+          this.close_(trust);
+        }
+      })
       .then(historyId => {
         this.historyId_ = historyId;
       });
@@ -454,19 +461,19 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   close_(trust) {
-    return this.dismiss_(false, trust);
+    return this.dismiss_(/*skipAnimation*/ false, trust);
   }
 
   /**
    * Dismisses the sidebar.
-   * @param {boolean} immediate Whether sidebar should close immediately,
-   *     without animation.
+   * @param {boolean} skipAnimation Whether sidebar should close immediately,
+   *  skipping animation.
    * @param {!ActionTrust} trust
    * @return {boolean} Whether the sidebar actually transitioned from "visible"
    *     to "hidden".
    * @private
    */
-  dismiss_(immediate, trust) {
+  dismiss_(skipAnimation, trust) {
     if (!this.opened_) {
       return false;
     }
@@ -475,9 +482,9 @@ export class AmpSidebar extends AMP.BaseElement {
     const scrollDidNotChange =
       this.initialScrollTop_ == this.viewport_.getScrollTop();
     const sidebarIsActive = this.element.contains(this.document_.activeElement);
-    this.setUpdateFn_(() => this.updateForClosing_(immediate, trust));
+    this.setUpdateFn_(() => this.updateForClosing_(skipAnimation, trust));
     // Immediately hide the sidebar so that animation does not play.
-    if (immediate) {
+    if (skipAnimation) {
       toggle(this.element, /* display */ false);
       toggle(this.getMaskElement_(), /* display */ false);
     }

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -283,6 +283,41 @@ describes.realWin(
         execute(impl, 'close');
       });
 
+      it('close on history back', async () => {
+        const sidebarElement = await getAmpSidebar({'stubHistory': true});
+        const impl = sidebarElement.implementation_;
+
+        execute(impl, 'open');
+
+        // history "back"
+        const history = impl.getHistory_();
+        history.push.firstCall.args[0]();
+        await new Promise(resolve => {
+          sandbox.stub(impl.action_, 'trigger').callsFake((element, name) => {
+            if (name == 'sidebarClose') {
+              resolve();
+            }
+          });
+        });
+
+        expect(sidebarElement).to.have.display('none');
+      });
+
+      it('close on history back immediately for iOS', async () => {
+        sandbox.stub(platform, 'isIos').returns(true);
+        sandbox.stub(platform, 'isSafari').returns(true);
+
+        const sidebarElement = await getAmpSidebar({'stubHistory': true});
+        const impl = sidebarElement.implementation_;
+
+        execute(impl, 'open');
+        // history "back"
+        const history = impl.getHistory_();
+        history.push.firstCall.args[0]();
+
+        expect(sidebarElement).to.have.display('none');
+      });
+
       it('should close sidebar on button click', async () => {
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;


### PR DESCRIPTION
Demo here: https://amp-sidebar-no-anim.firebaseapp.com
Alternative solution to the sidebar iOS UI glitch: #25251