### PR TITLE
📖 Add / fix language identifiers in `.md` files across `amphtml`

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -349,9 +349,8 @@ Please verify your ad is fully functioning, for example, by clicking on an ad. W
 
 Please make sure your changes pass the tests:
 
-```
+```sh
 gulp unit --watch --nobuild --files=test/unit/{test-ads-config.js,test-integration.js}
-
 ```
 
 If you have non-trivial logic in `/ads/yournetwork.js`, adding a unit test at `/test/unit/ads/test-yournetwork.js` is highly recommended.

--- a/ads/custom.md
+++ b/ads/custom.md
@@ -225,7 +225,7 @@ If no slot was specified, the server returns a single template rather than an ar
 The ad server must enforce [AMP CORS](https://github.com/ampproject/amphtml/blob/master/spec/amp-cors-requests.md#cors-security-in-amp).
 Here is an example set of the relevant response headers:
 
-```
+```html
 Access-Control-Allow-Origin:https://my--ad--server-com.cdn.ampproject.org
 ```
 

--- a/ads/ix.md
+++ b/ads/ix.md
@@ -24,26 +24,31 @@ Each [amp-ad](https://amp.dev/documentation/components/amp-ad/) element that us
 
 ### Example: RTC Specification on an amp-ad
 
-```
+```html
 <!-- Note: Default timeout is 1000ms -->
-<amp-ad width="320" height="50" type="doubleclick"
-        data-slot="/1234/pos"
-        rtc-config='{
-            "vendors": {
-                "IndexExchange": {"SITE_ID": "123456"},
-            },
-            "timeoutMillis": 1000}'>
+<amp-ad
+  width="320"
+  height="50"
+  type="doubleclick"
+  data-slot="/1234/pos"
+  rtc-config='{
+                "vendors": {
+                  "IndexExchange": {"SITE_ID": "123456"}
+                },
+                "timeoutMillis": 1000
+              }'
+>
 </amp-ad>
 ```
 
 The value of `rtc-config` must conform to the following specification:
 
-```
+```json
 {
-            "vendors": {
-                "IndexExchange": {"SITE_ID": "123456"},
-            },
-            "timeoutMillis": 1000
+  "vendors": {
+    "IndexExchange": {"SITE_ID": "123456"}
+  },
+  "timeoutMillis": 1000
 }
 ```
 

--- a/ads/navegg.md
+++ b/ads/navegg.md
@@ -28,7 +28,6 @@ To get Navegg integration working you only need to specify the `rtc-config` para
   data-slot="/4119129/mobile_ad_banner"
   rtc-config="{"vendors": {"navegg": {"NVG_ACC": "NAVEGG_ACCOUNT_ID"}}}">
 </amp-ad>
-
 ```
 
 ### Configuration

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -272,7 +272,7 @@ You can also run the visual tests locally during development. You must first cre
 
 First, build the AMP runtime and run the gulp task that invokes the visual diff script:
 
-```
+```sh
 gulp build
 gulp visual-diff --nobuild
 ```
@@ -283,13 +283,13 @@ The build will use the Percy credentials set via environment variables in the pr
 
 To see debugging info during Percy runs, you can run:
 
-```
+```sh
  gulp visual-diff --chrome_debug --webserver_debug
 ```
 
 The debug flags `--chrome_debug` and `--webserver_debug` can be used independently. To enable both debug flags, you can also run:
 
-```
+```sh
  gulp visual-diff --debug
 ```
 
@@ -303,7 +303,7 @@ After each run, a new set of results will be available at `https://percy.io/<org
 
 It's much faster to debug with local build (`gulp` + `http://localhost:8000/`). In Chrome you can use [DevTools port forwarding](https://developers.google.com/web/tools/chrome-devtools/remote-debugging/local-server). However, iOS Safari does not give a similar option. Instead, you can use [ngrok](https://ngrok.com/). Just [download](https://ngrok.com/download) the ngrok binary for your platform and run it like this:
 
-```
+```sh
 ngrok http 8000
 ```
 
@@ -313,7 +313,7 @@ Once started, the ngrok will print URLs for both `http` and `https`. E.g. `http:
 
 For deploying and testing local AMP builds on [Firebase](https://firebase.google.com/), install firebase and initialize firebase within this directory\* (a `firebase` folder can be generated with the command, `gulp firebase`).
 
-```
+```sh
 npm install -g firebase-tools
 firebase login
 firebase init
@@ -331,15 +331,11 @@ firebase deploy
 
 `gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
 
-```
+```json
 {
   "hosting": {
     "public": "firebase",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }
 }
 ```
@@ -354,7 +350,7 @@ Additionally, you can create multiple projects and switch between them in the CL
 
 Testing ads in deployed demos requires whitelisting of 3p urls. You can do this by adding your intended deployment hostname as an environemnt variable `AMP_TESTING_HOST` and using the `fortesting` flag. For example:
 
-```
+```sh
 export AMP_TESTING_HOST="my-project.firebaseapp.com"
 gulp firebase --fortesting
 firebase deploy
@@ -368,7 +364,7 @@ You can run and create E2E tests locally during development. Currently tests onl
 
 Run all tests with:
 
-```
+```sh
 gulp e2e
 ```
 

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -45,7 +45,7 @@ extension. For example, video players are also suffixed with `-player`
 You create your extension's files inside the `extensions/` directory.
 The directory structure is below:
 
-```text
+```sh
 /extensions/amp-my-element/
 ├── 0.1/
 |   ├── test/
@@ -57,8 +57,7 @@ The directory structure is below:
 ├── validator-amp-my-element.protoascii  # Validator rules (req'd)
 ├── amp-my-element.md                    # Element's main documentation (req'd)
 └── More documentation in .md files (optional)
-└── OWNERS # Owners file. Primary contact(s) for the extension. More about owners [here](https://github.com/ampproject/amphtml/blob/master/contributing/CODE_OWNERSHIP.md) (req'd)
-
+└── OWNERS                               # Owners file. Primary contact(s) for the extension. (req'd)
 ```
 
 In most cases you'll only create the required (req'd) files. If your element does not need custom CSS, you don't need to create the CSS file.

--- a/contributing/component-validator-rules.md
+++ b/contributing/component-validator-rules.md
@@ -28,12 +28,12 @@ doesn't need to host the images on their server. Each image has a cat name:
 
 Common usage of this extended component might look like:
 
-```
+```html
 <!-- Display the cat named 'oscar' -->
-<amp-cat data-selected-cat="oscar" width=50 height=50></amp-cat>
+<amp-cat data-selected-cat="oscar" width="50" height="50"></amp-cat>
 
 <!-- Display a random cat -->
-<amp-cat width=50 height=50></amp-cat>
+<amp-cat width="50" height="50"></amp-cat>
 ```
 
 Your first step will be writing the extended component JavaScript code. Place
@@ -69,7 +69,7 @@ amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat</b>.out
 Start with a rules file, `validator-amp-cat.protoascii`. First, a complete rules
 file, followed by line-by-line explanations of what's inside.
 
-```
+```js
 #
 # Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 #
@@ -126,7 +126,7 @@ This rules file specifies the rules for two tags:
 
 Let's see it broken down:
 
-```
+```js
 #
 # Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 #
@@ -149,7 +149,7 @@ file.
 
 ### amp-cat extended component
 
-```
+```js
 tags: {  # amp-cat extended component
 ```
 
@@ -158,8 +158,8 @@ to validate a tag that looks something like the following:
 
 > `<script async custom-element='amp-cat' src='https://cdn.ampproject.org/v0/amp-cat-0.1.js'></script>`
 
-```
-  html_format: AMP
+```js
+html_format: AMP;
 ```
 
 This tells the validator that this tag
@@ -168,8 +168,8 @@ format documents, if the tag should be used in an ad format. If you are unsure,
 leave the tag as an `AMP` format tag only for now. Additional formats can be
 added later.
 
-```
-  tag_name: "SCRIPT"
+```js
+tag_name: 'SCRIPT';
 ```
 
 This tells the validator that we are defining a tag with the `<script>` name.
@@ -177,7 +177,7 @@ This tells the validator that we are defining a tag with the `<script>` name.
 The following fields describe the HTML Tag attributes we expect for this
 `<script>` tag to be valid:
 
-```
+```js
   extension_spec: {
     name: "amp-cat"
 ```
@@ -187,7 +187,7 @@ extension with the "amp-cat" name. This will add requirements for the
 `custom-element=amp-cat` attribute, specific values for the `src` attribute,
 as well as a link to documentation on ampproject.org for all error messages.
 
-```
+```js
     version: "0.1"
     version: "latest"
   }
@@ -200,7 +200,7 @@ The combination of the `version` and `name` fields of the
 `extension_spec` define the allowed values of the `src` attribute in the
 script tag, for example `src=https://cdn.ampproject.org/v0/amp-cat-0.1.js`.
 
-```
+```js
   attr_lists: "common-extension-attrs"
 }
 ```
@@ -210,7 +210,7 @@ That's all for the extended component script tag. Now let's look at the actual
 
 ### `<amp-cat>` tag
 
-```
+```js
 tags: {  # <amp-cat>
 ```
 
@@ -219,33 +219,33 @@ to validate a tag that looks something like the following:
 
 > `<amp-cat data-selected-cat="oscar" width=50 height=50></amp-cat>`
 
-```
-  html_format: AMP
+```js
+html_format: AMP;
 ```
 
 Same as the extended component tag above, this tells the validator that this tag is only
 valid for AMP format documents.
 
-```
-  tag_name: "AMP-CAT"
+```js
+tag_name: 'AMP-CAT';
 ```
 
 This tells the validator that the html tag name is 'AMP-CAT'.
 
-```
-  requires_extension: "amp-cat"
+```js
+requires_extension: 'amp-cat';
 ```
 
 This tells the validator that the `amp-cat` tag requires the inclusion of the
 matching extension script tag that we defined above.
 
-```
-  attrs: {
-    name: "data-selected-cat"
-    value_casei: "bella"
-    value_casei: "chloe"
-    value_casei: "oscar"
-  }
+```js
+attrs: {
+  name: 'data-selected-cat';
+  value_casei: 'bella';
+  value_casei: 'chloe';
+  value_casei: 'oscar';
+}
 ```
 
 Here we specify the rules for validating the `data-selected-cat` attribute. In
@@ -253,14 +253,14 @@ our case, we tell the validator that we want the attribute value to
 case-insensitively match for either "bella", "chloe", or "oscar" which
 essentially means the value must be one of those 3 options.
 
-```
-  attr_lists: "extended-amp-global"
+```js
+attr_lists: 'extended-amp-global';
 ```
 
 This adds the `media` and `noloading` attributes which are allowed on all amp
 tags.
 
-```
+```js
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -281,21 +281,21 @@ to determine which options make sense for your tag.
 
 We saw a very simple example of an attribute validation rule above:
 
-```
-  attrs: {
-    name: "data-selected-cat"
-    value_casei: "bella"
-    value_casei: "chloe"
-    value_casei: "oscar"
-  }
+```js
+attrs: {
+  name: 'data-selected-cat';
+  value_casei: 'bella';
+  value_casei: 'chloe';
+  value_casei: 'oscar';
+}
 ```
 
 There are many other rule types for attribute validation, some of which we will
 explore here.
 
-```
+```js
 attrs: {
-  name: "data-selected-cat"
+  name: 'data-selected-cat';
 }
 ```
 
@@ -304,34 +304,34 @@ By specifying no value rules, any value is allowed for this attribute.
 If your code expects certain values, it is best to specify them here it will
 produce helpful error messages for developers trying to debug their tag.
 
-```
-value: "oscar"
+```js
+value: 'oscar';
 ```
 
-```
-value_casei: "oscar"
+```js
+value_casei: 'oscar';
 ```
 
 Specifies that only "oscar" is an allowed value, as case-sensitive and
 case-insensitive variants.
 
-```
-  value_regex: "\\d+"
+```js
+value_regex: '\\d+';
 ```
 
-```
-  value_regex_casei: "[a-z0-9]+"
+```js
+value_regex_casei: '[a-z0-9]+';
 ```
 
 Specifies that only values matching these RegEx patterns is an allowed value,
 as case-sensitive and case-instensitive variants.
 
-```
+```js
 value_url: {
-  protocol: "https"
-  protocol: "http"
-  allow_relative: false
-  allow_empty: true
+  protocol: 'https';
+  protocol: 'http';
+  allow_relative: false;
+  allow_empty: true;
 }
 ```
 
@@ -354,25 +354,25 @@ for `value` and `value_casei` as seen in the example above.
 Unless specified, attributes are all optional. To specify that an attribute is
 mandatory, use the `mandatory` field:
 
-```
+```js
 attrs: {
-  name: "data-selected-cat"
-  mandatory: true
+  name: 'data-selected-cat';
+  mandatory: true;
 }
 ```
 
 You may also specify that exactly one of a set of attributes is present:
 
-```
+```js
 attrs: {
-  name: "data-selected-cat"
-  mandatory_oneof: "['data-selected-cat', 'img-src']"
+  name: 'data-selected-cat';
+  mandatory_oneof: "['data-selected-cat', 'img-src']";
 }
 attrs: {
-  name: "img-src"
-  mandatory_oneof: "['data-selected-cat', 'img-src']"
+  name: 'img-src';
+  mandatory_oneof: "['data-selected-cat', 'img-src']";
   value_url: {
-    protocol: "https"
+    protocol: 'https';
   }
 }
 ```
@@ -381,7 +381,7 @@ attrs: {
 
 So let's say we want to add some additional rules to our original element validation rules:
 
-```
+```js
 tags: {  # <amp-cat>
   html_format: AMP
   tag_name: "AMP-CAT"
@@ -408,14 +408,14 @@ tags: {  # <amp-cat>
 
 Let's say we want `<amp-cat>` to ONLY be a valid element if it is a DIRECT child of a div element. We could add:
 
-```
-mandatory_parent: "DIV"
+```js
+mandatory_parent: 'DIV';
 ```
 
 as a key/value of the `tags`. If `<amp-cat>` can be a DIRECT or INDIRECT (nested) child of a div element, we could add:
 
-```
-mandatory_ancestor: "DIV"
+```js
+mandatory_ancestor: 'DIV';
 ```
 
 as a key/value of the `tags`.
@@ -453,9 +453,9 @@ In the document `<head>` section, add the extension `<script>` tag used by this 
 
 In the document `<body>` section, add a valid example of your tag.
 
-```
+```html
 <!-- Valid amp-cat tag -->
-<amp-cat data-selected-cat="oscar" width=50 height=50></amp-cat>
+<amp-cat data-selected-cat="oscar" width="50" height="50"></amp-cat>
 ```
 
 Optionally, you may add more than one valid variant and/or invalid examples.
@@ -470,14 +470,14 @@ amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
 
 After generating the `.out` file, you should check it's contents that it gives the correct validation results/errors. If you only added valid examples, this file should contain a single line:
 
-```
+```sh
 PASS
 ```
 
 If you include one or more invalid test cases, the file should look like the
 following, with errors specific to your test cases.
 
-```
+```sh
 FAIL
 amp-iframe/0.1/test/validator-amp-iframe.html:41:2 The attribute 'src' in tag 'amp-iframe' is missing or incorrect, but required by attribute '[src]'. (see https://amp.dev/documentation/components/amp-iframe) [DISALLOWED_HTML]
 ```
@@ -486,7 +486,7 @@ To test your changes, from the `amphtml/validator/` path, run `python build.py`.
 If your test case `.html` files produce the validator output in the test case
 `.out` files, then you will see:
 
-```
+```sh
 [[build.py RunTests]] - ... success
 ```
 

--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -34,7 +34,7 @@ The process for bringing a design to the design review is:
   - Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc. [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit) and [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit) are examples of past AMP design docs.
   - Add this license text to the top of your design doc before sharing it with anyone else in the community (updating the year if necessary):
 
-    ```
+    ```js
     Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -114,7 +114,7 @@ To create your fork on GitHub and your local copy of that fork:
 
   - run the `git clone` command using the address for your remote repository (your GitHub fork):
 
-    ```
+    ```sh
     git clone git@github.com:<your username>/amphtml.git
     ```
 
@@ -130,13 +130,13 @@ As described in the previous section you have three repositories you are working
 
 The `git clone` command you ran above automatically set up one alias for you. From the local amphtml directory the git clone command created, run
 
-```
+```sh
 git remote -v
 ```
 
 and you will see
 
-```
+```sh
 origin git@github.com:<your username>/amphtml.git
 ```
 
@@ -144,7 +144,7 @@ This indicates that the alias _origin_ can be used to refer to your GitHub fork 
 
 You should also set an alias for the remote amphtml repository since you'll be referring to that in some Git commands. The convention is to use the alias _upstream_ for this repository. The address for the amphtml repository looks a lot like the address for your GitHub fork except your username is replaced by `ampproject`.
 
-```
+```sh
 git remote add upstream git@github.com:ampproject/amphtml.git
 ```
 
@@ -152,7 +152,7 @@ Now run `git remote -v` again and notice that you have set up your upstream alia
 
 Each branch of your local Git repository can track a branch of a remote repository. Right now, your local `master` branch is tracking `origin/master`, which corresponds to the `master` branch of your GitHub fork. You don't actually want this, though; the upstream `master` branch is constantly being updated, and your fork's `master` branch will rapidly become outdated. Instead, it's best to make your local `master` branch track the upstream `master` branch. You can do this like so:
 
-```
+```sh
 git fetch upstream master
 git branch -u upstream/master master
 ```
@@ -163,13 +163,13 @@ Now that you have all of the files copied locally you can actually build the cod
 
 - Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). If you're on Mac or Linux, an easy way to install Node.js is with `nvm`: [here](https://github.com/creationix/nvm).
 
-  ```
+  ```sh
   nvm install --lts
   ```
 
 - Install the stable version of [Yarn](https://yarnpkg.com/) (Mac and Linux: [here](https://yarnpkg.com/en/docs/install#alternatives-stable), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
 
-  ```
+  ```sh
   curl -o- -L https://yarnpkg.com/install.sh | bash
   ```
 
@@ -179,19 +179,19 @@ Now that you have all of the files copied locally you can actually build the cod
 
   - Note: If you are using Mac OS and have multiple versions of Java installed, make sure you are using Java 8 by adding this to `~/.bashrc`:
 
-  ```
+  ```sh
   export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
   ```
 
 - If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (Instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md). See [this article](https://medium.com/gulpjs/gulp-sips-command-line-interface-e53411d4467) for why.)
 
-  ```
+  ```sh
   yarn global remove gulp
   ```
 
 - Install the [Gulp](https://gulpjs.com/) command line tool, which will automatically use the version of `gulp` packaged with the the amphtml repository. (instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md))
 
-  ```
+  ```sh
   yarn global add gulp-cli
   ```
 
@@ -205,7 +205,7 @@ Now that you have all of the files copied locally you can actually build the cod
 
 Now whenever you're ready to build amphtml and start up your local server, simply go to your local repository directory and run:
 
-```
+```sh
 gulp
 ```
 
@@ -247,7 +247,7 @@ By default you'll have a branch named _master_. You can see this if you run the 
 
 Although you could do work on the master branch, most people choose to leave the master branch unchanged and create other branches to actually do work in. Creating a branch is easy; simply run:
 
-```
+```sh
 git checkout -b <branch_name> master
 ```
 
@@ -257,13 +257,13 @@ This will move you to the new branch, which uses `master` as its start point, me
 
 Whenever you want to move to a different branch, run the checkout command:
 
-```
+```sh
 git checkout <branch_name>
 ```
 
 You can see a list of your branches and which one you're currently in by running:
 
-```
+```sh
 git branch
 ```
 
@@ -275,7 +275,7 @@ Since your local repository is just a copy of the amphtml repository it can quic
 
 In the workflow we will be using you'll go to the master branch on your local repository and pull the latest changes in from the remote amphtml repository's master branch. (Remember that you set up the alias _upstream_ to refer to the remote amphtml repository, and you set your local `master` branch to track `upstream/master`.)
 
-```
+```sh
 # make sure you are in your local repo's master branch
 git checkout master
 
@@ -287,7 +287,7 @@ If there have been any changes you'll see the details of what changed, otherwise
 
 After running that `git pull` command your local master branch has the latest files, but your other local branches won't get automatically updated. To get a local branch in sync:
 
-```
+```sh
 # go to the branch you want to sync
 git checkout <branch name>
 
@@ -319,13 +319,13 @@ You can think of a commit as a checkpoint in your branch. It's a good idea to cr
 
 Let's walk through creating a commit after editing a file. First, go to the branch you created earlier:
 
-```
+```sh
 git checkout <branch name>
 ```
 
 Edit a file in this branch using your favorite editor. After editing the file, run
 
-```
+```sh
 git status
 ```
 
@@ -333,7 +333,7 @@ and you should see the file you modified in a section that says `Changes not sta
 
 Git knows that there's a modified file, but isn't sure what you want to do with it. (In Git terms, this file is _unstaged_.) You have to tell Git that this is a change you care about by using the `git add` command.
 
-```
+```sh
 git add <filename>
 ```
 
@@ -341,7 +341,7 @@ Now run `git status` again and you'll see the file listed under a `Changes to be
 
 Since you're done with changes to that file, go ahead and create a commit:
 
-```
+```sh
 git commit -m "<a brief description of your commit>"
 ```
 
@@ -349,7 +349,7 @@ Now run `git status` again, and you'll see the message `nothing to commit` and `
 
 Note that you can optionally skip using `git add` commands and just use the `git commit -a` flag to say "add all of the modified/deleted files to this commit," e.g.
 
-```
+```sh
 git commit -a -m "<a brief description of your commit>"
 ```
 
@@ -393,13 +393,13 @@ Alternatively, you can manually fix most quality and style errors in your code b
 
 For JS files:
 
-```
+```sh
 gulp lint --local_changes --fix
 ```
 
 For non-JS files:
 
-```
+```sh
 gulp prettify --local_changes --fix
 ```
 
@@ -413,7 +413,7 @@ Note: You can automatically run critical checks before `git push` by enabling ou
 
 To run the tests that are affected by the changes on your feature branch:
 
-```
+```sh
 gulp unit --local_changes
 ```
 
@@ -425,7 +425,7 @@ If you need help with fixing failing tests, please ask on the GitHub issue you'r
 
 To avoid repeatedly waiting for Travis to run all pull-request checks, you can run them locally:
 
-```
+```sh
 gulp pr-check
 ```
 
@@ -444,13 +444,13 @@ Existing components will usually have existing tests that you can follow as an e
 
 To run tests in a single file, use `gulp unit --files=<path>`:
 
-```
+```sh
 gulp unit --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
 ```
 
 To run tests in multiple files, use `gulp unit --files=<path-1> --files=<path-2>`:
 
-```
+```sh
 gulp unit --files=extensions/amp-story/1.0/test/test-amp-story-embedded-component.js --files=extensions/amp-story/1.0/test/test-amp-story-hint.js
 ```
 
@@ -467,7 +467,7 @@ Up to this point you've been making changes in a branch on your local repository
 
 Before pushing your changes, make sure you have the latest changes in the amphtml repository on your branch by running the commands we described above:
 
-```
+```sh
 git checkout master
 git pull
 git checkout <branch name>
@@ -476,19 +476,19 @@ git merge master
 
 Now push your changes to `origin` (the alias for your GitHub fork):
 
-```
+```sh
 git push -u origin <branch name>
 ```
 
 `-u origin <branch name>` tells Git to create a remote branch with the specified name in `origin` and to make your local branch track that remote branch from now on. You only have to do this the first time you push each branch. For subsequent pushes on the same branch, you can use a shorter command:
 
-```
+```sh
 git push
 ```
 
 The changes you've made are now visible on GitHub! Go to your fork on GitHub:
 
-```
+```http
 https://github.com/<your username>/amphtml
 ```
 
@@ -496,7 +496,7 @@ If you recently pushed the branch you will see a message bar at the top that lis
 
 Instead of using that button take a look at the "Branch" dropdown on the top left. Click it and then select the branch you just pushed. This will take you to your branch on GitHub:
 
-```
+```http
 https://github.com/<your username>/amphtml/tree/<branch name>
 ```
 
@@ -515,7 +515,7 @@ Once your code is ready for a review, go to [https://github.com/ampproject/ampht
 
 On the "Open a pull request" page, you will see dropdowns at the top indicating the proposed merge. It will look something like:
 
-```
+```sh
 amproject/amphtml / master … <username>/amphtml / <branch name>
 ```
 
@@ -561,7 +561,7 @@ Creating, deleting and moving between branches in Git is cheap. Reusing branches
 
 GitHub offers a convenient "Delete branch" button on the PR page after the changes in your branch have been merged into the amphtml repository. You can click this button to delete your branch in the GitHub fork if you prefer, but you will also want to delete the branch in your local repository:
 
-```
+```sh
 # go back to the master branch
 git checkout master
 

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -434,7 +434,7 @@ In addition to vendor-defined macros, with publishers specifying the values for 
 
 For example, Ad Network AmpAdCom overrides the property in their Fast Fetch Implementation:
 
-```
+```js
 /** amp-ad-network-ampadcom-impl.js */
 
 export class AmpAdNetworkAmpAdComImpl extends AmpA4A {
@@ -458,7 +458,7 @@ It is possible for a vendor to specify macros in their URL into which the Fast F
 
 Vendor1 wants to allow publishers to substitute in the value of the slot_id, and allow the Fast Fetch network implementation to substitute in the start time. Thus, they define their URL in [callout-vendors.js ](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/callout-vendors.js) as follows. Note, the vendor only lists SLOT_ID in the macros array, even though SLOT_ID and START are both macros in their URL. The macros array is a list of macros that can be utilized by the publisher. Fast Fetch will always attempt to substitute in network-defined macros, regardless of whether they are defined in the macros array.
 
-```text
+```js
 /** amp-a4a/0.1/callout-vendors.js */
 vendors: {
    "vendor1": {
@@ -470,7 +470,7 @@ vendors: {
 
 The Fast Fetch implementation has overridden **getCustomRealTimeConfigMacros**, and supports the macro 'START', as seen here:
 
-```text
+```js
 /** amp-ad-network-ampadcom-impl.js */
 
 export class AmpAdNetworkAmpAdComImpl extends AmpA4A {
@@ -485,23 +485,25 @@ getCustomRealTimeConfigMacros() {
 
 Finally, a publisher who wishes to use Vendor1 with AmpAdCom's Fast Fetch implementation defines their rtc-config as:
 
-```
+```html
 <!-- ampPublisher.biz/some/example/page.html -->
-<amp-ad width="320" height="50"
-            type="network-foo"
-            data-slot="/1234/5678"
-            rtc-config='{
-            "vendors": {
-              "vendor1": {"SLOT_ID": "1234"}
-              }
-             }'>
+<amp-ad
+  width="320"
+  height="50"
+  type="network-foo"
+  data-slot="/1234/5678"
+  rtc-config='{
+                "vendors": {
+                  "vendor1": {"SLOT_ID": "1234"}
+                }
+              }'
+>
 </amp-ad>
-
 ```
 
 After URL macro expansion, the resulting URL is then
 
-```
+```http
 https://vendor1.com/slot_id=1234&start_time=1508508227577
 ```
 
@@ -509,7 +511,7 @@ https://vendor1.com/slot_id=1234&start_time=1508508227577
 
 It is possible, but inadvisable, to have a situation where a vendor specifies the same macro as the Fast Fetch network, i.e. in the above example if **getCustomRealTimeConfigMacros** was defined as
 
-```
+```js
 /** amp-ad-network-ampadcom-impl.js */
 
 export class AmpAdNetworkAmpAdComImpl extends AmpA4A {
@@ -525,7 +527,7 @@ getCustomRealTimeConfigMacros() {
 
 There is a collision in this case, because the Fast Fetch network is specifying a value to substitute for SLOT_ID, but the vendor has declared SLOT_ID as their custom macro, and the publisher is then trying to substitute in '1234' as the value. In a case like this, the Fast Fetch implementation always wins, i.e. the final URL would be:
 
-```
+```http
 https://vendor1.com/slot_id=5678&start_time=1508508227577
 ```
 
@@ -613,7 +615,7 @@ AmpPublisher.biz uses FadNetwork's Fast Fetch implementation for all of their AM
 
 First, AmpPublisher's developer opens up callout-vendors.js to make sure that all of their desired vendors actually support RTC, and find:
 
-```
+```js
 /** amp-a4a/0.1/callout-vendors.js */
 vendors: {
    "vendor-a": {
@@ -634,7 +636,7 @@ All of the desired vendors are supported, thus they can use all of them.
 
 AmpPublisher now wants to check what macros they have available to use from FadNetwork's Fast Implementation, so they open up **amp-ad-network-fadnetwork-impl.js** and check the implementation of **getCustomRealTimeConfigMacros**:
 
-```
+```js
 /** amp-ad-network-fadnetwork-impl.js */
 
 export class AmpAdNetworkFadNetworkImpl extends AmpA4A {
@@ -655,30 +657,33 @@ AmpPublisher has also decided that the default timeout of 1000ms per callout is 
 
 Thus, they define their rtc-config:
 
-```
-<amp-ad width="320" height="50"
-            type="fadnetwork"
-            data-slot="/1234/5678"
-            rtc-config='{
-            "vendors": {
-              "vendor-a": {"SLOT_ID": "1"},
-              "vendor-b": {"PAGE_ID": "61393", "AD_W": "320"},
-              "vendorc": {}
-              },
-            "urls": [
-              "https://www.AmpPublisher.biz/A",
-              "https://www.amptgt.biz/B?d=START&vht=V_HT&vwt=V_WT"
-            ],
-            "timeoutMillis": 750}'>
+```html
+<amp-ad
+  width="320"
+  height="50"
+  type="fadnetwork"
+  data-slot="/1234/5678"
+  rtc-config='{
+                "vendors": {
+                  "vendor-a": {"SLOT_ID": "1"},
+                  "vendor-b": {"PAGE_ID": "61393", "AD_W": "320"},
+                  "vendorc": {}
+                },
+                "urls": [
+                  "https://www.AmpPublisher.biz/A",
+                  "https://www.amptgt.biz/B?d=START&vht=V_HT&vwt=V_WT"
+                ],
+                "timeoutMillis": 750
+              }'
+>
 </amp-ad>
-
 ```
 
 The setup of the HTML page is now done. At runtime, the next steps happen:
 
 Real-time-config-manager parses the rtc-config from the ad slot, and uses macro substitution to construct the following 5 URLs:
 
-```
+```http
 https://vendora.com?slot_id=1&start_time=1508779857330
 https://vendor-b.net/rtc?p_id=61393&adw=320
 https://www.vendorC.co.uk/ept
@@ -692,7 +697,7 @@ These 5 URLs are then called out to as quickly as possible in parallel. A publis
 
 The results of the 5 callouts are:
 
-```
+```js
 /** Callout 1 response https://www.AmpPublisher.biz/A */
 {"targeting": {"ages": "18-24", "g":["m", "f", "o"]}}
 
@@ -711,7 +716,7 @@ No Response, request was timed out due to surpassing 750ms.
 
 AmpA4a builds a promise to an array of RTC Response Objects, and passes that Promise to **getAdUrl** in FadNetwork's Fast Fetch Implementation, which then resolves this promise.
 
-```
+```js
 /** amp-ad-network-fadnetwork-impl.js */
 
 export class AmpAdNetworkFadNetworkImpl extends AmpA4A {
@@ -724,7 +729,6 @@ export class AmpAdNetworkFadNetworkImpl extends AmpA4A {
     });
   }
 }
-
 ```
 
 In this specific case, the Promise resolves to the following array:
@@ -772,17 +776,21 @@ _Callout 1, 4, and 5 all return valid JSON and cause no errors_
 
 The Fast Fetch Implementation for FadNetwork then uses this array of RTC response objects to build and send the ad request URL. It is at the discretion of FadNetwork to merge these parameters however they see fit. In this example, FadNetwork simply does a deep merge of all the successful RTC callout responses, with the last response given precedence in case of collision, and gets the resulting JSON:
 
-```js
-{"targeting": {"ages": "35-45",
-               "g":["m", "f", "o"],
-               "i": {"sport": "baseball", "city": "NYC"}}}
+```json
+{
+  "targeting": {
+    "ages": "35-45",
+    "g": ["m", "f", "o"],
+    "i": {"sport": "baseball", "city": "NYC"}
+  }
+}
 ```
 
 **Result of merging successful RTC Callouts 1, 4, and 5**
 
 FadNetwork then constructs and encodes their Ad URL as:
 
-```js
+```http
 https://www.fadnetwork.biz/adServer?%7B%E2%80%9Ctargeting%E2%80%9D:%20%7B%E2%80%9Cages%E2%80%9D:%20%E2%80%9C35-45%E2%80%9D,%20%E2%80%9Cg%E2%80%9D:%5B%E2%80%9Cm%E2%80%9D,%20%E2%80%9Cf%E2%80%9D,%20%E2%80%9Co%E2%80%9D%5D,%20%E2%80%9Ci%E2%80%9D:%20%7B%E2%80%9Csport%E2%80%9D:%20%E2%80%9Cbaseball%E2%80%9D,%20%E2%80%9Ccity%E2%80%9D:%20%E2%80%9CNYC%E2%80%9D%7D%7D
 ```
 

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -169,7 +169,7 @@ AmpPublisher.biz uses FadNetwork's Fast Fetch implementation for all of their AM
 
 First, AmpPublisher's developer opens up callout-vendors.js to make sure that all of their desired vendors actually support RTC, and find:
 
-```
+```js
 /** amp-a4a/0.1/callout-vendors.js */
 vendors: {
    "vendor-a": {
@@ -190,7 +190,7 @@ All of the desired vendors are supported, thus they can use all of them.
 
 AmpPublisher now wants to check what macros they have available to use from FadNetwork's Fast Implementation, so they open up amp-ad-network-fadnetwork-impl.js and check the implementation of getCustomRealTimeConfigMacros:
 
-```
+```js
 /** amp-ad-network-fadnetwork-impl.js */
 
 export class AmpAdNetworkFadNetworkImpl extends AmpA4A {
@@ -236,7 +236,7 @@ The setup of the HTML page is now done. At runtime, the next steps happen:
 
 Real-time-config-manager parses the rtc-config from the ad slot, and uses macro substitution to construct the following 5 URLs:
 
-```text
+```http
 https://vendora.com?slot_id=1&start_time=1508779857330
 https://vendor-b.net/rtc?p_id=61393&adw=320
 https://www.vendorC.co.uk/ept
@@ -250,7 +250,7 @@ These 5 URLs are then called out to as quickly as possible in parallel. A publis
 
 The results of the 5 callouts are:
 
-```
+```js
 /** Callout 1 response https://www.AmpPublisher.biz/A */
 {"targeting": {"ages": "18-24", "g":["m", "f", "o"]}}
 

--- a/extensions/amp-access/0.1/iframe-api/DEVELOPING.md
+++ b/extensions/amp-access/0.1/iframe-api/DEVELOPING.md
@@ -22,6 +22,6 @@ Make sure not to use any of the non-iframe-api dependencies.
 
 ## Build
 
-```
+```sh
 npm run build
 ```

--- a/extensions/amp-access/0.1/iframe-api/README.md
+++ b/extensions/amp-access/0.1/iframe-api/README.md
@@ -25,7 +25,7 @@ The `AmpAccessIframeApi` is the entry point for access iframe implementation. As
 
 The document's access configuration would use the "iframe" type. For example when used with `amp-access`:
 
-```
+```html
 <script id="amp-access" type="application/json">
   {
     "type": "iframe",
@@ -44,34 +44,34 @@ The document's access configuration would use the "iframe" type. For example whe
 
 and with `amp-subscriptions`:
 
-```
+```html
 <script type="application/json" id="amp-subscriptions">
-{
-  "services": [
-    {
-      "type": "iframe",
-      "iframeSrc": "https://example.org/access-controller-iframe",
-      "iframeVars": [
-        "READER_ID",
-        "CANONICAL_URL",
-        "AMPDOC_URL",
-        "SOURCE_URL",
-        "DOCUMENT_REFERRER"
-      ],
-      "actions":{
-        "login": "https://...",
-        "subscribe": "https://..."
-      }
-    },
-    ...
-  ]
-}
+  {
+    "services": [
+      {
+        "type": "iframe",
+        "iframeSrc": "https://example.org/access-controller-iframe",
+        "iframeVars": [
+          "READER_ID",
+          "CANONICAL_URL",
+          "AMPDOC_URL",
+          "SOURCE_URL",
+          "DOCUMENT_REFERRER"
+        ],
+        "actions":{
+          "login": "https://...",
+          "subscribe": "https://..."
+        }
+      },
+      ...
+    ]
+  }
 </script>
 ```
 
 The instrumentation would normally look like this:
 
-```
+```js
 /** Implements AccessController interface */
 class Controller {
   connect(origin, protocol, config) {
@@ -104,7 +104,7 @@ The `protocol` argument in the connect method will be one of
 
 The `config` argument in the `connect` method will contain the original document config with `iframeVars` replace with the map of resolved AMP variables. See [Access URL Variables](../../amp-access.md#access-url-variables) for more details. For instance, for the example, using `amp-access`, above the `config` value could look like this:
 
-```
+```js
 {
   "type": "iframe",
   "iframeSrc": "https://example.org/access-controller-iframe",
@@ -123,7 +123,7 @@ to `amp-subscriptions` and a `pageConfig` object is included.
 
 Example:
 
-```
+```js
 {
   "type": "iframe",
   "pageConfig": {

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -278,7 +278,7 @@ When configuring the URLs for various endpoints, the Publisher can use substitut
 
 Here’s an example of the URL extended with Reader ID, Canonical URL, Referrer information and random cachebuster:
 
-```text
+```http
 https://pub.com/access?
    rid=READER_ID
   &url=CANONICAL_URL
@@ -369,7 +369,7 @@ This endpoint produces the authorization response that can be used in the conten
 
 The request format is:
 
-```text
+```http
 https://publisher.com/amp-access.json?
    rid=READER_ID
   &url=SOURCE_URL
@@ -453,7 +453,7 @@ The publisher may choose to use the pingback:
 
 The request format is:
 
-```text
+```http
 https://publisher.com/amp-pingback?
    rid=READER_ID
   &url=SOURCE_URL
@@ -488,7 +488,7 @@ Login Page is simply a normal web page with no special constraints, other than i
 
 The request format is:
 
-```text
+```http
 https://publisher.com/amp-login.html?
    rid=READER_ID
   &url=SOURCE_URL

--- a/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
+++ b/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
@@ -73,7 +73,7 @@ The RTC responses will be merged with whatever JSON targeting is specified on th
 
 ## Merging RTC targeting data and categoryExclusions into Ad Requests
 
-The results of the RTC callouts will be merged with any existing, static JSON targeting on the amp-ad element, and then sent on the **scp **parameter of the DFP ad request.
+The results of the RTC callouts will be merged with any existing, static JSON targeting on the amp-ad element, and then sent on the **scp** parameter of the DFP ad request.
 
 ### Merging targeting data for custom URLs
 
@@ -83,33 +83,38 @@ Keys for targeting data should be named differently to avoid collision. In case 
 
 For example, take the following amp-ad:
 
-```
-<amp-ad width="320" height="50"
-            type="doubleclick"
-            data-slot="/4119129/mobile_ad_banner"
-            rtc-config='{"urls": ["https://rtcEndpoint.biz/"}'
-            json='{"targeting":{"loc": "usa", "animal": "cat"},
-                   "categoryExclusions":["sports", "food", "fun"]}'>
+```html
+<amp-ad
+  width="320"
+  height="50"
+  type="doubleclick"
+  data-slot="/4119129/mobile_ad_banner"
+  rtc-config='{"urls": ["https://rtcEndpoint.biz/"}'
+  json='{
+          "targeting":{"loc": "usa", "animal": "cat"},
+          "categoryExclusions":["sports", "food", "fun"]
+        }'
+>
 </amp-ad>
 ```
 
 And let the response from the callout to `https://rtcEndpoint.biz/` be:
 
-```
-{"targeting":{"animal": "dog"}}
+```json
+{"targeting": {"animal": "dog"}}
 ```
 
 The results will be merged with the value set on the amp-ad element, and the result will be:
 
-```
-{"targeting":{"loc": "usa", "animal": "dog"}}
+```json
+{"targeting": {"loc": "usa", "animal": "dog"}}
 ```
 
 _Note: the ordering of items is not guaranteed._
 
-This resulting object will then be sent on the **scp **parameter of the ad request, as
+This resulting object will then be sent on the **scp** parameter of the ad request, as
 
-```
+```http
 https://securepubads.g.doubleclick.net/gampad/ads?.....&scp=loc%3Dusa%26animal%3Ddog%26excl_cat%3Dsports,food,fun…...
 ```
 
@@ -119,50 +124,53 @@ To prevent malicious vendors from naming the keys in their RTC response to match
 
 For instance, take this example where we call out to vendors, VendorA and VendorB:
 
-```
-<amp-ad width="320" height="50"
-            type="doubleclick"
-            data-slot="/4119129/mobile_ad_banner"
-            rtc-config='{"vendors": {"vendorA": {}, "vendorB": {}}'
-            json='{"targeting":{"abc":"123"}'>
+```html
+<amp-ad
+  width="320"
+  height="50"
+  type="doubleclick"
+  data-slot="/4119129/mobile_ad_banner"
+  rtc-config='{"vendors": {"vendorA": {}, "vendorB": {}}'
+  json='{"targeting":{"abc":"123"}'
+>
 </amp-ad>
 ```
 
 Let the response from VendorA be:
 
-```
-{"targeting":{"abc": "456"}}
+```json
+{"targeting": {"abc": "456"}}
 ```
 
 And let the response from VendorB be:
 
-```
-{"targeting":{"abc": "FOO"}}
+```json
+{"targeting": {"abc": "FOO"}}
 ```
 
 The Google Ad Manager Fast Fetch implementation automatically converts both of these responses to:
 
 Rewritten VendorA Response
 
-```
-{"targeting":{"abc_vendorA": "456"}}
+```json
+{"targeting": {"abc_vendorA": "456"}}
 ```
 
 Rewritten VendorB Response
 
-```
-{"targeting":{"abc_vendorB": "FOO"}}
+```json
+{"targeting": {"abc_vendorB": "FOO"}}
 ```
 
 Thus, when the merging happens, the final object is:
 
-```
-{"targeting":{"abc":"123", "abc_vendorA": "456", "abc_vendorB": "FOO"}}
+```json
+{"targeting": {"abc": "123", "abc_vendorA": "456", "abc_vendorB": "FOO"}}
 ```
 
 To disable key appending, within callout-vendors.js set the option `disableKeyAppend: true` as seen in the following example:
 
-```
+```js
 export const RTC_VENDORS = {
  ...
  ...
@@ -182,40 +190,44 @@ Any values for categoryExclusions returned by the RTC callouts (either from cust
 
 For example, take the following amp-ad:
 
-```
-<amp-ad width="320" height="50"
-            type="doubleclick"
-            data-slot="/4119129/mobile_ad_banner"
-             rtc-config='{"vendors": {"vendorA": {}},
-                         "urls": ["https://rtcEndpoint.biz/"]}'
-            json='{"categoryExclusions":["sports", "food", "fun"]}'>
+```html
+<amp-ad
+  width="320"
+  height="50"
+  type="doubleclick"
+  data-slot="/4119129/mobile_ad_banner"
+  rtc-config='{
+                "vendors": {"vendorA": {}},
+                "urls": ["https://rtcEndpoint.biz/"]
+              }'
+  json='{"categoryExclusions":["sports", "food", "fun"]}'
+>
 </amp-ad>
-
 ```
 
 Let the response from the callout to `https://rtcEndpoint.biz/` be:
 
-```
-{"categoryExclusions":["health", "sports"]}
+```json
+{"categoryExclusions": ["health", "sports"]}
 ```
 
 Let the response from VendorA be:
 
-```
-{"categoryExclusions":["abc","fun"]}
+```json
+{"categoryExclusions": ["abc", "fun"]}
 ```
 
 The results will be merged with the value set on the amp-ad element, and the result will be:
 
-```
-{"categoryExclusions":["abc", "health", "sports", "food", "fun"]}
+```json
+{"categoryExclusions": ["abc", "health", "sports", "food", "fun"]}
 ```
 
 _Note: the ordering of items is not guaranteed._
 
-This resulting object will then be sent on the **scp **parameter of the ad request, as
+This resulting object will then be sent on the **scp** parameter of the ad request, as
 
-```
+```http
 https://securepubads.g.doubleclick.net/gampad/ads?.....&scp=excl_cat%3Dabc,health,sports,food,fun…...
 ```
 
@@ -225,41 +237,47 @@ The RTC responses from vendors and custom URLs are ultimately all merged togethe
 
 For example, take the following amp-ad:
 
-```
-<amp-ad width="320" height="50"
-            type="doubleclick"
-            data-slot="/4119129/mobile_ad_banner"
-            rtc-config='{"vendors": {"vendorA": {}},
-                         "urls": ["https://rtcEndpoint.biz/"]}'
-            json='{"targeting":{"loc": "usa"},
-                   "categoryExclusions":["sports"]}'>
+```html
+<amp-ad
+  width="320"
+  height="50"
+  type="doubleclick"
+  data-slot="/4119129/mobile_ad_banner"
+  rtc-config='{
+                "vendors": {"vendorA": {}},
+                "urls": ["https://rtcEndpoint.biz/"]
+              }'
+  json='{"targeting":{"loc": "usa"}, "categoryExclusions":["sports"]}'
+>
 </amp-ad>
 ```
 
 Let the response from the callout to `https://rtcEndpoint.biz/` be:
 
-```
-{"targeting":{"gender": "f"}, "categoryExclusions":["dating"]}
+```json
+{"targeting": {"gender": "f"}, "categoryExclusions": ["dating"]}
 ```
 
 Let the response from VendorA be:
 
-```
-{"targeting":{"r": "h"}, "categoryExclusions":["autos"]}
+```json
+{"targeting": {"r": "h"}, "categoryExclusions": ["autos"]}
 ```
 
 The results will be merged with the value set on the amp-ad element, and the result will be:
 
-```
-{"targeting":{"loc": "usa", "gender":"f", "r":"h"},
- "categoryExclusions":["sports", "dating", "autos"]}
+```json
+{
+  "targeting": {"loc": "usa", "gender": "f", "r": "h"},
+  "categoryExclusions": ["sports", "dating", "autos"]
+}
 ```
 
 _Note: the ordering of items is not guaranteed._
 
 This resulting object will then be sent on the **scp** parameter of the ad request, as
 
-```
+```http
 https://securepubads.g.doubleclick.net/...scp=loc%3Dusa%26gender%3Df%26r%3Dh%26excl_cat%3Dsports%2Cdating%2Cautos&...
 ```
 

--- a/extensions/amp-ad-network-doubleclick-impl/refresh.md
+++ b/extensions/amp-ad-network-doubleclick-impl/refresh.md
@@ -34,10 +34,8 @@ Where `refresh_interval` is the time, in seconds, in between refresh cycles. Thi
 
 An individual slot is eligible to be refreshed if it is configured as:
 
-```
-<amp-ad
- ...
- data-enable-refresh=refresh_interval>
+```html
+<amp-ad ... data-enable-refresh="refresh_interval"></amp-ad>
 ```
 
 `refresh_interval` must be a number greater than or equal to 30, or `false`. If `refresh_interval` is set to `false`, then this slot will not be refresh-enabled, even if page-level configurations are set. Otherwise, if `refresh_interval` is a numeric value, then it will represent the time, in seconds, between refresh events on this particular slot.

--- a/extensions/amp-ad-network-doubleclick-impl/safeframe.md
+++ b/extensions/amp-ad-network-doubleclick-impl/safeframe.md
@@ -30,7 +30,7 @@ For best results, only modify sizes for the b and r parameters, i.e. instead of 
 
 This is a synchronous call for the ad slot's geometry. Geometry is continuously updated in the background to keep the data fresh, with updates being sent from AMP at a maximum of once per second. Returns an object formatted as follows:
 
-```
+```js
 {
   win: { // The measurement of the application window.
     t: 0,

--- a/extensions/amp-analytics/amp-components-analytics.md
+++ b/extensions/amp-analytics/amp-components-analytics.md
@@ -36,7 +36,7 @@ Example
 
 In the following example, the component creates a **`customEventReporter`** object that sends pings to example.com on **`layout`** and **`id`** events.
 
-```
+```js
   buildCallback() {
     const builder = new customEventReporterBuilder(this.element);
     builder.track('layout', 'example.come/layout');
@@ -51,7 +51,7 @@ Example
 
 In the following example, the component triggers two custom events: **`layout`** and **`id`**. The **`id`** event is triggered with the value of the id, after the id is ready.
 
-```
+```js
   layoutCallback() {
     this.reporter_.trigger('layout');
     getIdPromise.then(id => {
@@ -70,7 +70,7 @@ To send analytics pings, third-party AMP components must call the `useAnalyticsI
 
 Example
 
-```
+```js
 useAnalyticsInSandbox(this.element, configPromise);
 ```
 

--- a/extensions/amp-analytics/linker-id-receiving.md
+++ b/extensions/amp-analytics/linker-id-receiving.md
@@ -70,7 +70,7 @@ The `<amp-analytics>`'s `cookies` feature can be used to extract information fro
 
 A `cookies` example configuration looks like
 
-```
+```js
 'cookies': {
   'enabled': true,
   'cookieName1': {

--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -127,7 +127,7 @@ supports condition will match the current environment.
 
 In some cases it's convenient to combine multiple [conditional animations](#conditions) with an optional default into a single animation. This can be done using `switch` animation statement in this format:
 
-```
+```js
 {
   // Optional selector, vars, timing
   ...
@@ -151,7 +151,7 @@ In `switch` animation, the candidates are evaluated in the defined order and the
 
 For instance, this animation runs motion-path animation if supported and falls back to transform:
 
-```
+```json
 {
   "selector": "#target1",
   "duration": "1s",
@@ -159,12 +159,12 @@ For instance, this animation runs motion-path animation if supported and falls b
     {
       "supports": "offset-distance: 0",
       "keyframes": {
-        "offsetDistance": [0, '300px']
+        "offsetDistance": [0, "300px"]
       }
     },
     {
       "keyframes": {
-        "transform": [0, '300px']
+        "transform": [0, "300px"]
       }
     }
   ]
@@ -580,7 +580,7 @@ The `index()` function returns an index of the current target element in the ani
 
 Among other things, this property can be combined with `calc()` expressions and be used to create staggered effect. For instance:
 
-```
+```json
 {
   "selector": ".class-x",
   "delay": "calc(200ms * index())"
@@ -591,7 +591,7 @@ Among other things, this property can be combined with `calc()` expressions and 
 
 The `length()` function returns the number of target elements in the animation effect. This is most relevant when combined with `index()`:
 
-```
+```json
 {
   "selector": ".class-x",
   "delay": "calc(200ms * (length() - index()))"
@@ -604,7 +604,7 @@ The `rand()` function returns a random CSS value. There are two forms.
 
 The form without arguments simply returns the random number between 0 and 1.
 
-```
+```json
 {
   "delay": "calc(10s * rand())"
 }
@@ -612,7 +612,7 @@ The form without arguments simply returns the random number between 0 and 1.
 
 The second form has two arguments and returns the random value between these two arguments.
 
-```
+```json
 {
   "delay": "rand(5s, 10s)"
 }
@@ -632,7 +632,7 @@ The `width()` and `height()` are epsecially useful for transforms. The `left`, `
 
 These functions can be combined with `calc()`, `var()` and other CSS expressions. For instance:
 
-```
+```json
 {
   "transform": "translateX(calc(width('#container') + 10px))"
 }
@@ -648,7 +648,7 @@ The `num()` function returns a number representation of a CSS value. For instanc
 
 For instance, the following expression calculates the delay in seconds proportional to the element's width:
 
-```
+```json
 {
   "delay": "calc(1s * num(width()) / 100)"
 }

--- a/extensions/amp-app-banner/amp-app-banner.md
+++ b/extensions/amp-app-banner/amp-app-banner.md
@@ -65,7 +65,7 @@ android-app://${appId}/${protocol}/${host}${pathname}
 
 ### App manifest example
 
-```java
+```xml
 <activity
     android:name="com.example.android.GizmosActivity"
     android:label="@string/title_gizmos" >

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -137,7 +137,7 @@ URL rewrite works as following:
 
 A URL is rewritten in the form `shell-url#href={encodeURIComponent(href)}`. For example:
 
-```text
+```http
 https://pub.com/doc.amp.html
 -->
 https://pub.com/shell#href=%2Fdoc.amp.html

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -355,7 +355,7 @@ This attribute accepts two values: "auto" or "manual". Setting the value of this
 
 This attribute specifies a field name in the returned data that will give the url of the next items to load. If this attribute is not specified, `<amp-list>` expects the json payload to have the `load-more-src` field, which corresponds to the next url to load. In the case where this field is called something else, you can specify the name of that field via the `load-more-bookmark` field.E.g. In the following sample payload, we would specify `load-more-bookmark="next"`.
 
-```
+```js
 { "items": [...], "next": "https://url.to.load" }
 ```
 

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -136,7 +136,7 @@ Assuming that there is an `<amp-pan-zoom>` component with the id `pan-zoom` on t
 
 The following public CSS classes are exposed to allow customization for the zoom buttons:
 
-```
+```css
 .amp-pan-zoom-button
 .amp-pan-zoom-in-icon
 .amp-pan-zoom-out-icon
@@ -147,7 +147,7 @@ Use `.amp-pan-zoom-in-icon` to customize the icon for the zoom in button.
 Use `.amp-pan-zoom-out-icon` to customize the icon for the zoom out button.
 You can also hide these buttons entirely and create your own using the `transform` action. To hide them, just apply
 
-```
+```css
 .amp-pan-zoom-button {
   display: none;
 }

--- a/extensions/amp-recaptcha-input/amp-recaptcha-input.md
+++ b/extensions/amp-recaptcha-input/amp-recaptcha-input.md
@@ -53,7 +53,7 @@ This example demonstrates how `<amp-recaptcha-input>` usage on an AMP page corre
 
 **`<amp-recaptcha-input>` usage**
 
-```
+```html
 <form amp-form-attributes-go-here>
   ...
   <amp-recaptcha-input layout="nodisplay" name="reCAPTCHA_body_key" data-sitekey=”reCAPTCHA_site_key" data-action="reCAPTCHA_example_action">
@@ -64,13 +64,13 @@ This example demonstrates how `<amp-recaptcha-input>` usage on an AMP page corre
 
 **Corresponding `grecaptcha` call**
 
-```
+```js
 grecaptcha.execute('reCAPTCHA_site_key', {action: 'reCAPTCHA_example_action'});
 ```
 
 **Corresponding AMP form submit body**
 
-```
+```js
 {
   ...other form params
   “reCAPTCHA_body_key”: “returned_reCAPTCHA_response_token”

--- a/extensions/amp-story/amp-story-bookend.md
+++ b/extensions/amp-story/amp-story-bookend.md
@@ -87,7 +87,7 @@ If you don't want to fetch the bookend configuration from a server, you can also
 
 Next, you must fill in the JSON configuration. This is where you customize the bookend. The overall structure of the config looks like so:
 
-```text
+```json
 {
   "bookendVersion": "v1.0",
   "shareProviders": [
@@ -97,7 +97,6 @@ Next, you must fill in the JSON configuration. This is where you customize the b
     ...
   ]
 }
-
 ```
 
 It is required to specify you are using the v1.0 version by including the first line.

--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -94,23 +94,23 @@ The JSON-LD and Microdata formats are supported.
 
 Using JSON-LD, the markup would look like:
 
-```
+```html
 <script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "NewsArticle",
-  "isAccessibleForFree": false,
-  "publisher": {
-    "@type": "Organization",
-    "name": "The Norcal Tribune"
-  },
-  "hasPart": {...},
-  "isPartOf": {
-    "@type": ["CreativeWork", "Product"],
-    "name" : "The Norcal Tribune",
-    "productID": "norcal_tribune.com:basic"
+  {
+    "@context": "http://schema.org",
+    "@type": "NewsArticle",
+    "isAccessibleForFree": false,
+    "publisher": {
+      "@type": "Organization",
+      "name": "The Norcal Tribune"
+    },
+    "hasPart": {...},
+    "isPartOf": {
+      "@type": ["CreativeWork", "Product"],
+      "name" : "The Norcal Tribune",
+      "productID": "norcal_tribune.com:basic"
+    }
   }
-}
 </script>
 ```
 
@@ -123,12 +123,16 @@ Thus, notice that:
 
 Using Microdata, the markup could look like this:
 
-```
+```html
 <div itemscope itemtype="http://schema.org/NewsArticle">
-  <meta itemprop="isAccessibleForFree" content="false"/>
-  <div itemprop="isPartOf" itemscope itemtype="http://schema.org/CreativeWork http://schema.org/Product">
-    <meta itemprop="name" content="The Norcal Tribune"/>
-    <meta itemprop="productID" content="norcal_tribute.com:basic"/>
+  <meta itemprop="isAccessibleForFree" content="false" />
+  <div
+    itemprop="isPartOf"
+    itemscope
+    itemtype="http://schema.org/CreativeWork http://schema.org/Product"
+  >
+    <meta itemprop="name" content="The Norcal Tribune" />
+    <meta itemprop="productID" content="norcal_tribute.com:basic" />
   </div>
 </div>
 ```
@@ -146,28 +150,28 @@ The configuration is resolved as soon as `productID` and `isAccessibleForFree` a
 
 The `amp-subscriptions` extension must be configured using JSON configuration:
 
-```
+```html
 <script type="application/json" id="amp-subscriptions">
-{
-  "services": [
-    {
-      // Service 1 (local service)
+  {
+    "services": [
+      {
+        // Service 1 (local service)
+      },
+      {
+        // Service 2 (a vendor service)
+      }
+    ],
+    "score": {
+      "supportsViewer": 10,
+      "isReadyToPay": 9
     },
-    {
-      // Service 2 (a vendor service)
+    "fallbackEntitlement": {
+      "source": "fallback",
+      "granted": true,
+      "grantReason": "SUBSCRIBER/METERING",
+      "data": {...}
     }
-  ],
-  "score": {
-    "supportsViewer": 10,
-    "isReadyToPay": 9
-  },
-  "fallbackEntitlement": {
-    "source": "fallback",
-    "granted": true,
-    "grantReason": "SUBSCRIBER/METERING",
-    "data": {...}
   }
-}
 </script>
 ```
 
@@ -208,48 +212,48 @@ The "local" service is configured as following
 
 remote mode:
 
-```
+```html
 <script type="application/json" id="amp-subscriptions">
-{
-  "services": [
-    {
-      "authorizationUrl": "https://...",
-      "pingbackUrl": "https://...",
-      "actions":{
-        "login": "https://...",
-        "subscribe": "https://..."
-      }
-    },
-    ...
-  ]
-}
+  {
+    "services": [
+      {
+        "authorizationUrl": "https://...",
+        "pingbackUrl": "https://...",
+        "actions":{
+          "login": "https://...",
+          "subscribe": "https://..."
+        }
+      },
+      ...
+    ]
+  }
 </script>
 ```
 
 iframe mode:
 
-```
+```html
 <script type="application/json" id="amp-subscriptions">
-{
-  "services": [
-    {
-      "type": "iframe",
-      "iframeSrc": "https://...",
-      "iframeVars": [
-        "READER_ID",
-        "CANONICAL_URL",
-        "AMPDOC_URL",
-        "SOURCE_URL",
-        "DOCUMENT_REFERRER"
-      ],
-      "actions":{
-        "login": "https://...",
-        "subscribe": "https://..."
-      }
-    },
-    ...
-  ]
-}
+  {
+    "services": [
+      {
+        "type": "iframe",
+        "iframeSrc": "https://...",
+        "iframeVars": [
+          "READER_ID",
+          "CANONICAL_URL",
+          "AMPDOC_URL",
+          "SOURCE_URL",
+          "DOCUMENT_REFERRER"
+        ],
+        "actions":{
+          "login": "https://...",
+          "subscribe": "https://..."
+        }
+      },
+      ...
+    ]
+  }
 </script>
 ```
 
@@ -273,16 +277,16 @@ See [amp-access-iframe](../amp-access/0.1/iframe-api/README.md) for details of t
 
 The vendor service configuration must reference the service ID and can contain any additional properties allowed by the vendor service.
 
-```
+```html
 <script type="application/json" id="amp-subscriptions">
-{
-  "services": [
-    ...,
-    {
-      "serviceId": "subscribe.google.com"
-    }
-  ]
-}
+  {
+    "services": [
+      ...,
+      {
+        "serviceId": "subscribe.google.com"
+      }
+    ]
+  }
 </script>
 ```
 
@@ -294,7 +298,7 @@ Authorization is an endpoint provided by the local service and called by the AMP
 
 The Entitlement response returned by the authorization endpoint must conform to the predefined format:
 
-```
+```js
 {
   "granted": true/false,
   "grantReason": "SUBSCRIBER/METERING",
@@ -338,7 +342,7 @@ In the markup the actions can be delegated to other services for them to execute
 
 e.g. In order to ask google subscriptions to perform subscribe even when `local` service is selected:
 
-```
+```html
   <button subscriptions-action='subscribe' subscriptions-service='subscribe.google.com>Subscribe</button>
 ```
 
@@ -346,14 +350,14 @@ e.g. In order to ask google subscriptions to perform subscribe even when `local`
 
 In addition to delegation of the action to another service, you can also ask another service to decorate the element. Just add the attribute `subsciptions-decorate` to get the element decorated.
 
-```
-  <button
-    subscriptions-action='subscribe'
-    subscriptions-service='subscribe.google.com
-    subscriptions-decorate
-  >
-    Subscribe
-  </button>
+```html
+<button
+  subscriptions-action="subscribe"
+  subscriptions-service="subscribe.google.com"
+  subscriptions-decorate
+>
+  Subscribe
+</button>
 ```
 
 ## Showing/hiding premium and fallback content
@@ -362,7 +366,7 @@ The premium sections are shown/hidden automatically based on the authorization/e
 
 The premium content is marked up using `subscriptions-section="content"` attribute. For instance:
 
-```
+```html
 <section subscriptions-section="content">
   This content will be hidden unless the reader is authorized.
 </section>
@@ -372,7 +376,7 @@ _Important_: Do not apply `subscriptions-section="content"` to the whole page. D
 
 The fallback content is marked up using `subscriptions-section="content-not-granted"` attribute. For instance:
 
-```
+```html
 <section subscriptions-section="content-not-granted">
   You are not allowed to currently view this content.
 </section>
@@ -403,8 +407,10 @@ An action declared in the "actions" configuration can be marked up using `subscr
 
 For instance, this button will execute the "subscribe" action:
 
-```
-<button subscriptions-action="subscribe" subscriptions-display="EXPR">Subscribe now</button>
+```html
+<button subscriptions-action="subscribe" subscriptions-display="EXPR">
+  Subscribe now
+</button>
 ```
 
 By default, the actions are hidden and must be explicitly shown using the `subscriptions-display` expression.
@@ -415,16 +421,16 @@ The paywall dialogs are shown automatically based on the authorization/entitleme
 
 A dialog is marked up using the `subscriptions-dialog` and `subscriptions-display` attributes:
 
-```
+```html
 <div subscriptions-dialog subscriptions-display="EXPR">
-  This content will be shown as a dialog when "subscription-display"
-  expression matches.
+  This content will be shown as a dialog when "subscription-display" expression
+  matches.
 </div>
 ```
 
 The element on which `subscriptions-dialog` dialog is specified can also be a `<template>` element in which case it will be initially rendered before being displayed as a dialog. For instance:
 
-```
+```html
 <template type="amp-mustache" subscriptions-dialog subscriptions-display="EXPR">
   <div>
     You have {{metering.left}} articles left this month.
@@ -440,15 +446,23 @@ The `subscriptions-display` attribute uses expressions for actions and dialogs. 
 
 Values in the `data` object of an Entitlements response can be used to build expressions. In this example the values of `isLoggedIn` and `isSubscriber` are in the `data` object and are used to conditionally show UI for login and upgrading your account:
 
-```
+```html
 <section>
-  <button subscriptions-action="login" subscriptions-display="NOT data.isLoggedIn">Login</button>
+  <button
+    subscriptions-action="login"
+    subscriptions-display="NOT data.isLoggedIn"
+  >
+    Login
+  </button>
   <div subscriptions-actions subscriptions-display="data.isLoggedIn">
     <div>My Account</div>
     <div>Sign out</div>
   </div>
-  <div subscriptions-actions subscriptions-display="data.isLoggedIn AND NOT data.isSubscriber">
-    <a href='...'>Upgrade your account</a>
+  <div
+    subscriptions-actions
+    subscriptions-display="data.isLoggedIn AND NOT data.isSubscriber"
+  >
+    <a href="...">Upgrade your account</a>
   </div>
 </section>
 ```

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -114,7 +114,7 @@ For handling CORS requests and responses, see the [AMP CORS spec](https://amp.de
 
 Example:
 
-```text
+```http
 https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
 ```
 

--- a/extensions/amp-viewer-assistance/amp-viewer-assistance.md
+++ b/extensions/amp-viewer-assistance/amp-viewer-assistance.md
@@ -76,10 +76,9 @@ The `amp-viewer-assistance` extension currently has two functions that can be in
 
 A valid `amp-viewer-assistance.updateActionState` payload can either be an `update` object of the format:
 
-```
+```js
 {
-  "actionStatus": "COMPLETED_ACTION_STATUS" | "ACTIVE_ACTION_STATUS" |
-      "FAILED_ACTION_STATUS",
+  "actionStatus": "COMPLETED_ACTION_STATUS" | "ACTIVE_ACTION_STATUS" | "FAILED_ACTION_STATUS",
   "result": { ... }, // optional field used with COMPLETED_ACTION_STATUS
 }
 ```
@@ -180,7 +179,7 @@ Here are some examples:
 
 yields a POST request body:
 
-```
+```http
 ampViewerAuthToken=AUTH_TOKEN_FROM_VIEWER_ASSISTANCE
 ```
 
@@ -204,7 +203,7 @@ ampViewerAuthToken=AUTH_TOKEN_FROM_VIEWER_ASSISTANCE
 
 yields a POST request form-data payload of:
 
-```
+```http
 --------formDataBoundary--------
 Content Disposition: form-data; name="name"
 Default name value

--- a/extensions/amp-viewer-integration/integrating-viewer-with-amp-doc-guide.md
+++ b/extensions/amp-viewer-integration/integrating-viewer-with-amp-doc-guide.md
@@ -174,7 +174,7 @@ The AMP Viewer integration API must be enabled in the Viewer and in the AMP cach
 
 If the Viewer uses the Google AMP Cache, the AMP Cache URL in the Viewer must be as follows:
 
-```html
+```http
 https://...cdn.ampproject.org/v/s/origin?amp_js_v=0.1
 ```
 
@@ -284,7 +284,7 @@ To establish a handshake initiated by the AMP Document:
 
 To enable the Webview messaging protocol with port exchange, the Viewer Init Params should include `webview=1` and the AMP Cache URLs should be in the following format:
 
-```html
+```http
 https://cdn.ampproject.org/v/s/origin?amp_js_v=0.1#webview=1
 ```
 
@@ -355,7 +355,7 @@ var initParams = {
 
 _Example: Parameters in a query string in the fragment part of the URL_
 
-```html
+```http
 https://cdn.ampproject.org/v/s/origin?amp_js_v=0.1#origin=http%3A%2F%2FyourAmpDocsOrigin.com&cap=handshakepoll
 ```
 
@@ -436,7 +436,7 @@ var initParams = {
 
 By specifying `cap=swipe` as an init parameter (fyi, `"cap"` stands for capabilities) , `#cap=swipe` will be added to the AMP Cache URL:
 
-```html
+```http
 https://cdn.ampproject.org/v/s/origin?amp_js_v=0.1#origin=http%3A%2F%2FyourAmpDocsOrigin.com&cap=foo%2Cswipe
 ```
 

--- a/spec/amp-boilerplate.md
+++ b/spec/amp-boilerplate.md
@@ -14,15 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# AMP Boilerplate Code ('head > style[amp-boilerplate]' and 'noscript > style[amp-boilerplate]')
+# AMP Boilerplate Code
+
+## `head > style[amp-boilerplate]` and `noscript > style[amp-boilerplate]`
 
 AMP HTML documents must contain the following boilerplate in their `head` tag.
 Validation is currently done with regular expressions, so it's important to keep
-mutations as minimal as possible. Currently, allowed mutations are: (1)
-inserting arbitrary whitespace immediately after the `style` tag opens, and
-immediately before it closes; (2) replacing any space in the snippet below with
-arbitrary whitespace.
+mutations as minimal as possible. Currently, the allowed mutations are:
 
-```
+1. Inserting arbitrary whitespace immediately after the `style` tag opens, and immediately before it closes
+2. Replacing any space in the snippet below with arbitrary whitespace.
+
+<!-- prettier-ignore-start -->
+```html
 <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 ```
+<!-- prettier-ignore-end -->

--- a/spec/amp-cache-transform.md
+++ b/spec/amp-cache-transform.md
@@ -117,7 +117,7 @@ and the "sh-" rules in [header-structure-07](https://tools.ietf.org/html/draft-i
 The `v` parameter value must be a string. Its value (after parsing as a string)
 must conform to the following ABNF:
 
-```
+```text
 v_spec = #v_range
 v_range = sh-integer / sh-integer OWS ".." OWS sh-integer
 ```
@@ -205,7 +205,7 @@ selected a resource of content type `application/signed-exchange`. In theory,
 there may be an interaction with content negotation. For instance, assume the
 request is:
 
-```
+```http
 Accept-Language: en, de
 AMP-Cache-Transform: google
 ```
@@ -275,7 +275,7 @@ feel free to get involved.
 A requestor wishing to receive an SXG, without any constraints on its
 subresource URLs, would send:
 
-```
+```http
 AMP-Cache-Transform: any
 ```
 
@@ -286,7 +286,7 @@ A requestor wishing to receive an SXG to be served from and prefetched from the
 Google AMP Cache (e.g. [Googlebot](https://support.google.com/webmasters/answer/182072))
 would send:
 
-```
+```http
 AMP-Cache-Transform: google
 ```
 
@@ -296,7 +296,7 @@ Google AMP Cache, or a non-SXG response.
 A requestor wishing to receive transformed AMP of a specific version may send a
 request like:
 
-```
+```http
 AMP-Cache-Transform: google;v="1..3,5"
 ```
 

--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -389,7 +389,7 @@ curl 'https://amp.dev/static/samples/json/examples.json' -H 'AMP-Same-Origin: tr
 
 The results from the command show the correct response headers (note: extra information was trimmed):
 
-```text
+```http
 HTTP/2 200
 access-control-allow-headers: Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token
 access-control-allow-credentials: true
@@ -409,7 +409,7 @@ curl 'https://amp.dev/static/samples/json/examples.json' -H 'origin: https://amp
 
 The results from the command show the correct response headers:
 
-```text
+```http
 HTTP/2 200
 access-control-allow-headers: Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token
 access-control-allow-credentials: true

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -505,7 +505,7 @@ The script URL must start with `https://cdn.ampproject.org` and must follow a ve
 
 The URL for extended components is of the form:
 
-```html
+```http
 https://cdn.ampproject.org/$RUNTIME_VERSION/$ELEMENT_NAME-$ELEMENT_VERSION.js
 ```
 
@@ -554,7 +554,7 @@ To learn about the syntax and restrictions for an template, visit the [template'
 
 The URL for extended components is of the form:
 
-```html
+```http
 https://cdn.ampproject.org/$RUNTIME_VERSION/$TEMPLATE_TYPE-$TEMPLATE_VERSION.js
 ```
 

--- a/spec/amp-localstorage.md
+++ b/spec/amp-localstorage.md
@@ -37,14 +37,14 @@ Information entry can be passed between the AMP page and the supported AMP Viewe
 
 localStorage entry will be formatted as following
 
-```
+```js
 const entry = {
   'key': {
     'v': 'value',
     't': timestamp,
-  }
-}
-blob = btoa(JSON.stringify(entry))
+  },
+};
+blob = btoa(JSON.stringify(entry));
 ```
 
 ## Current Usage

--- a/spec/amp-managing-user-state.md
+++ b/spec/amp-managing-user-state.md
@@ -196,7 +196,7 @@ Once you’ve set up an identifier, you can now incorporate it in analytics ping
 
 The specific implementation will depend on your desired configuration, but generally you’ll be looking to send pings (requests) to your analytics server, which include useful data within the URL of the request itself. Here’s an example, which also indicates how you’d include your cookie value inside of the request:
 
-```text
+```http
 https://analytics.example.com/ping?type=pageview&user_id=$publisher_origin_identifier
 ```
 
@@ -308,7 +308,7 @@ Our mapping table will associate AMP Client ID values that are seen in the analy
 
 Immediately after determining that you were unsuccessful in reading the publisher origin identifier, check if the AMP Client ID contained within the analytics ping is already used in a mapping. To do this, first consult the incoming amp-analytics request to get the Client ID value. For example, from this request:
 
-```text
+```http
 https://analytics.example.com/ping?type=pageview&user_id=$amp_client_id
 ```
 
@@ -418,7 +418,7 @@ For passing multiple query parameters through `data-amp-addparams` have those `&
 
 By taking these steps, the Client ID is available to the target server and/or as a URL parameter on the page the user lands on after the link click or form submission (the **destination context**). The name (or “key”) will be `ref_id` because that’s how we’ve defined it in the above implementations and will have an associated value equal to the Client ID. For instance, by following the link (`<a>` tag) defined above, the user will navigate to this URL:
 
-```text
+```http
 https://example.com/step2.html?ref_id=$amp_client_id
 ```
 
@@ -457,13 +457,13 @@ To process on the landing page, the approach will vary depending on whether that
 
 _Updates to AMP page:_ Use the Query Parameter substitution feature in your amp-analytics configuration to obtain the `ref_id` identifier value within the URL. The Query Parameter feature takes a parameter that indicates the “key” of the desired key-value pair in the URL and returns the corresponding value. Use the Client ID feature as we have been doing to get the identifier for the AMP page context.
 
-```text
+```http
 https://analytics.example.com/ping?type=pageview&orig_user_id=${queryParam(ref_id)}&user_id=${clientId(uid)}
 ```
 
 When this gets transmitted across the network, actual values will be replaced:
 
-```text
+```http
 https://analytics.example.com/ping?type=pageview&orig_user_id=$referrer_page_identifier&user_id=$current_page_identifier
 ```
 
@@ -476,7 +476,7 @@ $current_page_identifier is $publisher_origin_id
 
 so the ping is actually:
 
-```text
+```http
 https://analytics.example.com/ping?type=pageview&orig_user_id=$amp_client_id&user_id=$publisher_origin_id
 ```
 
@@ -575,13 +575,13 @@ Values contained in a URL can be maliciously changed, malformed, or somehow othe
 
 For instance, in the steps above, we constructed the following URL, intended for the user to click on and navigate to the corresponding page:
 
-```text
+```http
 https://example.com/step2.html?orig_user_id=$amp_client_id
 ```
 
 However, it’s just as possible that the user or some attacker change this URL to be:
 
-```text
+```http
 https://example.com/step2.html?orig_user_id=$malicious_value
 ```
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -20,13 +20,13 @@ limitations under the License.
 
 Various AMP features allow variables to be used inside of strings and substituted with the corresponding actual values. For example, `amp-pixel` allows expressions like this:
 
-```text
+```html
 <amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
 ```
 
 `RANDOM` gets resolved to a randomly generated value and AMP replaces it in the request string:
 
-```text
+```http
 https://foo.com/pixel?0.8390278471201
 ```
 
@@ -110,16 +110,25 @@ Only these variables are supported:
 
 Link substitution requires per-use opt-in as an added security measure and to affirm the intention to use variable substitution. This is done by specifying an additional attribute called `data-amp-replace` with a string value containing a space-delimited listing of the desired variables to substitute. An example is below.
 
-```text
-<a href="https://example.com?client_id=CLIENT_ID(bar)&abc=QUERY_PARAM(abc)" data-amp-replace="CLIENT_ID QUERY_PARAM">Go to my site</a>
+```html
+<a
+  href="https://example.com?client_id=CLIENT_ID(bar)&abc=QUERY_PARAM(abc)"
+  data-amp-replace="CLIENT_ID QUERY_PARAM"
+  >Go to my site</a
+>
 ```
 
 #### Appending parameters to the href
 
 If you need to append dynamic parameters to the href, specify the parameters by using the `data-amp-addparams` attribute. Any substitution parameters that you specify in `data-amp-addparams` must also be specified in `data-amp-replace`, as in the following example
 
-```text
-<a href="https://example.com?abc=QUERY_PARAM(abc)" data-amp-replace="CLIENT_ID QUERY_PARAM" data-amp-addparams="client_id=CLIENT_ID(bar)&linkid=l123">Go to my site</a>
+```html
+<a
+  href="https://example.com?abc=QUERY_PARAM(abc)"
+  data-amp-replace="CLIENT_ID QUERY_PARAM"
+  data-amp-addparams="client_id=CLIENT_ID(bar)&linkid=l123"
+  >Go to my site</a
+>
 ```
 
 ### White listed domains for link substitution
@@ -132,8 +141,11 @@ Link substitutions are restricted and will only be fulfilled for URLs matching:
 
 To whitelist an origin, include a `amp-link-variable-allowed-origin` `meta` tag in the `head` of your document. To specify multiple domains, separate each domain with a space.
 
-```text
-<meta name="amp-link-variable-allowed-origin" content="https://example.com https://example.org">
+```html
+<meta
+  name="amp-link-variable-allowed-origin"
+  content="https://example.com https://example.org"
+/>
 ```
 
 ## Variables
@@ -751,7 +763,7 @@ of one ad to be seen by the provider of another ad on the page.
 
 Example:
 
-```
+```json
 "requests": {
     "sample_visibility_request": "//somewhere/imgData=${htmlAttr(img,src,decoding)}"
 },

--- a/spec/amp-video-interface.md
+++ b/spec/amp-video-interface.md
@@ -60,8 +60,12 @@ component's visual area.
 In order to use this attribute, the [`amp-video-docking`](https://amp.dev/documentation/components/amp-video-docking)
 extension script must be present:
 
-```
-<script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
+```html
+<script
+  async
+  custom-element="amp-video-docking"
+  src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"
+></script>
 ```
 
 For more details, see [documentation on the docking extension itself.](https://amp.dev/documentation/components/amp-video-docking)

--- a/spec/email/amp-email-structure.md
+++ b/spec/email/amp-email-structure.md
@@ -54,7 +54,8 @@ case, emails will display the `text/html` or `text/plain` part.
 
 ## Example
 
-```
+<!-- prettier-ignore-start -->
+```html
 From:  Person A <persona@gmail.com>
 To: Person B <personb@gmail.com>
 Subject: An AMP email!
@@ -85,3 +86,4 @@ Content-Type: text/html; charset="UTF-8"
 <span>Hello World in HTML!</span>
 --001a114634ac3555ae05525685ae
 ```
+<!-- prettier-ignore-end -->

--- a/testing/local-amp-chrome-extension/README.md
+++ b/testing/local-amp-chrome-extension/README.md
@@ -40,7 +40,7 @@ What this extension does already is to intercept network requests to `https://cd
 
 One useful thing this extension can do is to add code that modifies another production website on your local browser. This is a good way to QA extensions in development in real life use cases. To do this, you write a [content-script](https://developer.chrome.com/extensions/content_scripts) and register it in [manifest.json](./manifest.json) like so:
 
-```
+```json
   "content_scripts": [
     {
       "matches": ["https://website-you-intend-to-test.com/*"],
@@ -54,23 +54,24 @@ Matches is a regex for all the websites that you want this script to run on.
 
 The following example adds the new `<amp-lightbox-gallery>` component to a website, and uses the lightbox attribute on all carousels and images. To add an extension, just create a script element and append it to the head:
 
-```
+```js
 var lightboxScript = document.createElement('script');
-lightboxScript.type = "text/javascript";
-lightboxScript.src = "https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js";
+lightboxScript.type = 'text/javascript';
+lightboxScript.src =
+  'https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js';
 lightboxScript.setAttribute('custom-element', 'amp-lightbox-gallery');
 document.head.appendChild(lightboxScript);
 ```
 
 To modify their code, just write normal javascript for DOM mutations:
 
-```
+```js
 document.querySelectorAll('amp-img').forEach(ampImg => {
- ampImg.removeAttribute('on');
- ampImg.setAttribute('lightbox', '');
+  ampImg.removeAttribute('on');
+  ampImg.setAttribute('lightbox', '');
 });
 
 document.querySelectorAll('amp-carousel').forEach(carousel => {
- carousel.setAttribute('lightbox', '');
+  carousel.setAttribute('lightbox', '');
 });
 ```

--- a/validator/README.md
+++ b/validator/README.md
@@ -104,7 +104,7 @@ to run all of the validator tests in the amphtml repo.
 To create/update `validator-*.out` files that are used in the test,
 run `python build.py --update_tests`.
 
-```
+```sh
 $ amphtml-validator --validator_js dist/validator_minified.js testdata/feature_tests/several_errors.html
 testdata/feature_tests/several_errors.html:23:2 The attribute 'charset' may not appear in tag 'meta name= and content='.
 testdata/feature_tests/several_errors.html:26:2 The tag 'script' is disallowed except in specific forms.
@@ -123,14 +123,14 @@ _Note: This is for building the validator from source. If you are simply running
 
 To verify that you have the necessary prerequisites, run and verify:
 
-```
+```sh
 $ protoc --version
 libprotoc 3.5.1
 ```
 
 and
 
-```
+```sh
 $ python
 >>> import google.protobuf
 >>>

--- a/validator/gulpjs/README.md
+++ b/validator/gulpjs/README.md
@@ -6,7 +6,7 @@ A Gulp plugin for validating [AMPHTML files](https://ampproject.org) using the o
 
 Install package with NPM and add it to your development dependencies:
 
-```
+```sh
 npm install --save-dev gulp-amphtml-validator
 ```
 
@@ -37,7 +37,6 @@ To treat warnings as errors, replace the last line of the validation closure wit
 // Exit the process with error code (1) if an AMP validation warning or
 // error occurred.
 .pipe(gulpAmpValidator.failAfterWarningOrError());
-
 ```
 
 ## Release Notes

--- a/validator/nodejs/README.md
+++ b/validator/nodejs/README.md
@@ -41,7 +41,7 @@ amphtmlValidator.getInstance().then(function(validator) {
 
 Now try running it:
 
-```
+```sh
 $ node demo.js
 FAIL
 line 1, col 0: The mandatory attribute '⚡' is missing in tag 'html ⚡ for top-level html'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)

--- a/validator/webui/README.md
+++ b/validator/webui/README.md
@@ -22,7 +22,7 @@ If you'd like to use the web UI, simply visit [validator.amp.dev](https://valida
 
 In this directory, run
 
-```
+```sh
 $ npm install
 $ go build serve-standalone.go
 $ ./serve-standalone
@@ -49,7 +49,7 @@ function utoa(str) {
 
 By default this tool will assume you want to validate an `AMPHTML` document. If you would like to validate another format you can chose one of the following:
 
-```
+```http
 #htmlFormat=AMP4ADS
 #htmlFormat=AMP4EMAIL
 #htmlFormat=ACTIONS


### PR DESCRIPTION
Auto-formatting of `.md` files was introduced in #25182. This exposed several code blocks in our documentation with missing or incorrect language identifiers, and therefore missing or incorrect syntax highlighting.

**PR highlights:**
- Adds several missing language identifiers
- Fixes several incorrect language identifiers
- Fixes some formatting bugs / typos
- Adds `prettier-ignore` annotations where required
- Reformats updated `.md` files with Prettier

**Example before / after:**

<img width="560" alt="" src="https://user-images.githubusercontent.com/26553114/67571851-f857a700-f702-11e9-99e2-f4261e3c55f2.png">


**Reference:** Github [documentation](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) for highlighting code blocks

Follow up to #25182

