### PR TITLE
Add crossorigin=anonymous to inserted script

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -560,6 +560,10 @@ export class Extensions {
     }
     scriptElement.setAttribute('data-script', extensionId);
     scriptElement.setAttribute('i-amphtml-inserted', '');
+
+    // Allow error information to be collected
+    // https://github.com/ampproject/amphtml/issues/7353
+    scriptElement.setAttribute('crossorigin', 'anonymous');
     let loc = this.win.location;
     if (getMode().test && this.win.testLocation) {
       loc = this.win.testLocation;

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -825,6 +825,7 @@ describes.sandboxed('Extensions', {}, () => {
         const script = doc.head.querySelector('[custom-element="amp-test"]');
         expect(script.getAttribute('data-script')).to.equal('amp-test');
         expect(script.getAttribute('async')).to.equal('');
+        expect(script.getAttribute('crossorigin')).to.equal('anonymous');
       });
 
       it('should insert special-case for amp-embed script', () => {


### PR DESCRIPTION
add `crossorigin=anonymous` to auto inserted script so that error information from those extensions can be reported. 

related to #7353