### PR TITLE
📖 Add Insticator to the list of supported embed types.

### DIFF
--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -458,6 +458,7 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Dable](../../ads/dable.md)
 - [Engageya](../../ads/engageya.md)
 - [Epeex](../../ads/epeex.md)
+- [Insticator](../../ads/insticator.md)
 - [Jubna](../../ads/jubna.md)
 - [Outbrain](../../ads/outbrain.md)
 - [Postquare](../../ads/postquare.md)


### PR DESCRIPTION
Update `amp-ad / amp-embed` doc file to add Insticator to the list of supported embed types.

@CrystalOnScript 
cc @triso07
