### PR TITLE
Update <amp-nested-menu> event listeners and improve RTL + arrow key support

### DIFF
--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.css
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.css
@@ -19,7 +19,7 @@ amp-nested-menu [amp-nested-submenu] {
   position: absolute !important;
   top: 0 !important;
   width: 100% !important;
-  height: 100vh !important;
+  height: 100% !important;
   transform: translateX(0) !important;
 }
 
@@ -27,8 +27,12 @@ amp-nested-menu.i-amphtml-layout-size-defined {
   overflow: visible !important;
 }
 
+amp-nested-menu ul, amp-nested-menu ol {
+  list-style-type: none;
+  padding: 0;
+}
+
 amp-nested-menu [amp-nested-submenu] {
-  left: 100% !important;
   opacity: 0 !important;
   visibility: hidden !important;
   transition: transform 233ms, opacity 233ms, visibility 0s 233ms;
@@ -43,7 +47,24 @@ amp-nested-menu [amp-nested-submenu][open] {
 
 amp-nested-menu[child-open],
 amp-nested-menu [amp-nested-submenu][child-open] {
-  transform: translateX(-100%) !important;
   visibility: hidden !important;
   transition: transform 233ms, visibility 0s 233ms;
+}
+
+amp-nested-menu[side="left"] [amp-nested-submenu] {
+  right: 100% !important;
+}
+
+amp-nested-menu[side="right"] [amp-nested-submenu] {
+  left: 100% !important;
+}
+
+amp-nested-menu[side="left"][child-open],
+amp-nested-menu[side="left"] [amp-nested-submenu][child-open] {
+  transform: translateX(100%) !important;
+}
+
+amp-nested-menu[side="right"][child-open],
+amp-nested-menu[side="right"] [amp-nested-submenu][child-open] {
+  transform: translateX(-100%) !important;
 }

--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.js
@@ -19,15 +19,22 @@ import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {
+  closest,
   closestAncestorElementBySelector,
+  isRTL,
   scopedQuerySelector,
   tryFocus,
 } from '../../../src/dom';
 import {dev, userAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {toArray} from '../../../src/types';
 
 const TAG = 'amp-nested-menu';
+
+/** @private @enum {string} */
+const Side = {
+  LEFT: 'left',
+  RIGHT: 'right',
+};
 
 /** @private @const {number} */
 const ANIMATION_TIMEOUT = 350;
@@ -40,29 +47,17 @@ export class AmpNestedMenu extends AMP.BaseElement {
     /** @private @const {!Document} */
     this.document_ = this.win.document;
 
-    /** @private @const {!Element} */
-    this.documentElement_ = this.document_.documentElement;
-
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {?Element} */
-    this.currentSubmenu_ = null;
+    /** @private {?string} */
+    this.side_ = null;
 
-    /** @private {?Array<!Element>} */
-    this.submenuElements_ = null;
-
-    /** @private {?Array<!Element>} */
-    this.submenuOpenElements_ = null;
-
-    /** @private {?Array<!Element>} */
-    this.submenuCloseElements_ = null;
+    /** @private {!Element} */
+    this.currentSubmenu_ = element;
 
     /** @private {function(!Event)} */
-    this.submenuOpenHandler_ = this.handleSubmenuOpenClick_.bind(this);
-
-    /** @private {function(!Event)} */
-    this.submenuCloseHandler_ = this.handleSubmenuCloseClick_.bind(this);
+    this.clickHandler_ = this.handleClick_.bind(this);
 
     /** @private {function(!Event)} */
     this.keydownHandler_ = this.handleKeyDown_.bind(this);
@@ -75,46 +70,38 @@ export class AmpNestedMenu extends AMP.BaseElement {
       isExperimentOn(this.win, 'amp-sidebar-v2'),
       `Turning on the amp-sidebar-v2 experiment is necessary to use the ${TAG} component.`
     );
+    const {element} = this;
 
     this.action_ = Services.actionServiceForDoc(this.element);
 
-    this.submenuElements_ = toArray(
-      this.element.querySelectorAll('[amp-nested-submenu]')
-    );
-    this.submenuElements_.forEach(submenu => {
-      // Make submenus programmatically focusable for a11y.
-      submenu.tabIndex = -1;
-    });
-    this.submenuOpenElements_ = toArray(
-      this.element.querySelectorAll('[amp-nested-submenu-open]')
-    );
-    this.submenuCloseElements_ = toArray(
-      this.element.querySelectorAll('[amp-nested-submenu-close]')
-    );
-    this.submenuOpenElements_
-      .concat(this.submenuCloseElements_)
-      .forEach(element => {
-        if (!element.hasAttribute('tabindex')) {
-          element.setAttribute('tabindex', 0);
-        }
-        element.setAttribute('role', 'button');
-        userAssert(
-          this.action_.hasAction(element, 'tap') == false,
-          'submenu open/close buttons should not have tap actions registered.'
-        );
-      });
+    this.side_ = element.getAttribute('side');
+    if (this.side_ != Side.LEFT && this.side_ != Side.RIGHT) {
+      // Submenus in RTL documents should open from the left by default.
+      this.side_ = isRTL(this.document_) ? Side.LEFT : Side.RIGHT;
+      element.setAttribute('side', this.side_);
+    }
+
+    this.registerAction('reset', this.reset_.bind(this));
+    element.addEventListener('click', this.clickHandler_);
+    element.addEventListener('keydown', this.keydownHandler_);
   }
 
   /** @override */
   layoutCallback() {
-    this.registerEventListeners_();
+    const submenuBtns = this.element.querySelectorAll(
+      '[amp-nested-submenu-open],[amp-nested-submenu-close]'
+    );
+    submenuBtns.forEach(submenuBtn => {
+      if (!submenuBtn.hasAttribute('tabindex')) {
+        submenuBtn.setAttribute('tabindex', 0);
+      }
+      submenuBtn.setAttribute('role', 'button');
+      userAssert(
+        this.action_.hasAction(submenuBtn, 'tap') == false,
+        'submenu open/close buttons should not have tap actions registered.'
+      );
+    });
     return Promise.resolve();
-  }
-
-  /** @override */
-  unlayoutCallback() {
-    this.unregisterEventListeners_();
-    return true;
   }
 
   /** @override */
@@ -123,48 +110,61 @@ export class AmpNestedMenu extends AMP.BaseElement {
   }
 
   /**
-   * Add event listeners on submenu open/close elements.
+   * Handler for click event on any element inside the component.
+   * @param {!Event} e
+   * @private
    */
-  registerEventListeners_() {
-    this.submenuOpenElements_.forEach(element => {
-      element.addEventListener('click', this.submenuOpenHandler_);
-    });
-    this.submenuCloseElements_.forEach(element => {
-      element.addEventListener('click', this.submenuCloseHandler_);
-    });
-
-    this.documentElement_.addEventListener('keydown', this.keydownHandler_);
-  }
-
-  /**
-   * Remove listeners on all submenu open/close elements.
-   */
-  unregisterEventListeners_() {
-    this.submenuOpenElements_.forEach(element => {
-      element.removeEventListener('click', this.submenuOpenHandler_);
-    });
-    this.submenuCloseElements_.forEach(element => {
-      element.removeEventListener('click', this.submenuCloseHandler_);
-    });
-
-    this.documentElement_.removeEventListener('keydown', this.keydownHandler_);
-  }
-
-  /**
-   * Handler for submenu open element click.
-   * @param {Event} e
-   */
-  handleSubmenuOpenClick_(e) {
-    const submenuParent = dev().assertElement(e.currentTarget.parentElement);
-    const submenu = scopedQuerySelector(submenuParent, '>[amp-nested-submenu]');
-    if (submenu) {
-      this.open_(submenu);
+  handleClick_(e) {
+    const target = dev().assertElement(e.target);
+    const submenuBtn = closestAncestorElementBySelector(
+      dev().assertElement(e.target),
+      '[amp-nested-submenu-open],[amp-nested-submenu-close]'
+    );
+    if (submenuBtn && this.shouldHandleClick_(target, submenuBtn)) {
+      const isOpenBtn = submenuBtn.hasAttribute('amp-nested-submenu-open');
+      if (isOpenBtn) {
+        this.handleSubmenuOpenClick_(submenuBtn);
+      } else {
+        this.handleSubmenuCloseClick_(submenuBtn);
+      }
+      return;
     }
+  }
+
+  /**
+   * We should support clicks on any children of submenu open/close except for
+   * links or elements with tap targets, which should not have their default
+   * behavior overidden.
+   * @param {!Element} target
+   * @param {!Element} submenuBtn
+   * @return {boolean}
+   * @private
+   */
+  shouldHandleClick_(target, submenuBtn) {
+    const hasAnchor = !!closest(target, e => e.tagName == 'A', submenuBtn);
+    const hasTapAction = this.action_.hasAction(target, 'tap', submenuBtn);
+    return !hasAnchor && !hasTapAction;
+  }
+
+  /**
+   * Handles click on the given element to open a submenu.
+   * @param {!Element} openElement
+   * @private
+   */
+  handleSubmenuOpenClick_(openElement) {
+    const submenuParent = dev().assertElement(openElement.parentElement);
+    const submenu = scopedQuerySelector(submenuParent, '>[amp-nested-submenu]');
+    userAssert(
+      submenu,
+      `${TAG} requires each submenu open button to have a submenu as its sibling`
+    );
+    this.open_(submenu);
   }
 
   /**
    * Open the specified submenu.
    * @param {!Element} submenu
+   * @private
    */
   open_(submenu) {
     if (submenu.hasAttribute('open')) {
@@ -177,8 +177,14 @@ export class AmpNestedMenu extends AMP.BaseElement {
       this.currentSubmenu_ = submenu;
       // move focus to close element after submenu fully opens.
       Services.timerFor(this.win).delay(() => {
-        const submenuClose = dev().assertElement(
-          submenu.querySelector('[amp-nested-submenu-close]')
+        // check that the close button is present and not in one of the child menus.
+        const submenuClose = scopedQuerySelector(
+          submenu,
+          '>[amp-nested-submenu-close], :not([amp-nested-submenu]) [amp-nested-submenu-close]'
+        );
+        userAssert(
+          submenuClose,
+          `${TAG} requires each submenu to contain at least one submenu close button`
         );
         tryFocus(submenuClose);
       }, ANIMATION_TIMEOUT);
@@ -186,23 +192,26 @@ export class AmpNestedMenu extends AMP.BaseElement {
   }
 
   /**
-   * Handler for submenu close element click.
-   * @param {Event} e
+   * Handles click on the given element to close the submenu.
+   * @param {!Element} closeElement
+   * @private
    */
-  handleSubmenuCloseClick_(e) {
-    const submenuClose = dev().assertElement(e.currentTarget);
+  handleSubmenuCloseClick_(closeElement) {
     const submenu = closestAncestorElementBySelector(
-      submenuClose,
+      closeElement,
       '[amp-nested-submenu]'
     );
-    if (submenu) {
-      this.close_(submenu);
-    }
+    userAssert(
+      submenu,
+      `${TAG}: submenu close buttons are only allowed inside submenus`
+    );
+    this.close_(submenu);
   }
 
   /**
    * Close the specified submenu.
    * @param {!Element} submenu
+   * @private
    */
   close_(submenu) {
     if (!submenu.hasAttribute('open')) {
@@ -225,35 +234,98 @@ export class AmpNestedMenu extends AMP.BaseElement {
   }
 
   /**
-   * Handles arrow key navigation.
-   * @param {Event} e
+   * Close all submenus and return to the root menu.
+   */
+  reset_() {
+    while (this.element.hasAttribute('child-open')) {
+      this.close_(this.currentSubmenu_);
+    }
+  }
+
+  /**
+   * Handler for keydown event when the component or its children has focus.
+   * @param {!Event} e
+   * @private
    */
   handleKeyDown_(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
     switch (e.key) {
-      // TODO(#24665): Add support for all arrow keys and for RTL.
-      case Keys.LEFT_ARROW:
-        const submenu = this.currentSubmenu_;
-        if (submenu) {
-          this.close_(submenu);
-        }
-        break;
+      case Keys.ENTER: /* fallthrough */
+      case Keys.SPACE:
+        this.handleClick_(e);
+        return;
+      case Keys.LEFT_ARROW: /* fallthrough */
       case Keys.RIGHT_ARROW:
+        this.handleHorizontalArrowKeyDown_(e);
         break;
-      case Keys.UP_ARROW:
-        break;
+      case Keys.UP_ARROW: /* fallthrough */
       case Keys.DOWN_ARROW:
+        this.handleVerticalArrowKeyDown_(e);
         break;
     }
   }
 
   /**
-   * Get the parent menu of specified submenu, if one exists.
-   * @param {!Element} submenu
-   * @return {?Element}
+   * Handle left/right arrow key down event to navigate between menus.
+   * @param {!Event} e
+   * @private
    */
-  getParentMenu_(submenu) {
+  handleHorizontalArrowKeyDown_(e) {
+    let back = e.key == Keys.LEFT_ARROW;
+    // Press right arrow key to go back if submenu opened from left.
+    if (this.side_ == Side.LEFT) {
+      back = !back;
+    }
+    if (back) {
+      this.close_(this.currentSubmenu_);
+    } else {
+      const target = dev().assertElement(e.target);
+      if (target.hasAttribute('amp-nested-submenu-open')) {
+        this.handleSubmenuOpenClick_(target);
+      }
+    }
+  }
+
+  /**
+   * Handle up/down arrow key down event to navigate between items;
+   * this requires each menu item to be under a li element and focusable.
+   * @param {!Event} e
+   * @private
+   */
+  handleVerticalArrowKeyDown_(e) {
+    const target = dev().assertElement(e.target);
+    const parentMenu = this.getParentMenu_(target);
+    const item = closest(target, e => e.tagName == 'LI', parentMenu);
+    // active element is not in a li that is inside the current submenu.
+    if (!item) {
+      return;
+    }
+    const nextItem =
+      e.key == Keys.UP_ARROW
+        ? item.previousElementSibling
+        : item.nextElementSibling;
+    // have reached the beginning or end of the list.
+    if (!nextItem) {
+      return;
+    }
+    const focusElement = nextItem.querySelector('button,a[href],[tabindex]');
+    if (focusElement) {
+      e.preventDefault();
+      tryFocus(focusElement);
+    }
+  }
+
+  /**
+   * Get the menu containing the given element, if one exists.
+   * @param {!Element} element
+   * @return {?Element}
+   * @private
+   */
+  getParentMenu_(element) {
     return closestAncestorElementBySelector(
-      dev().assertElement(submenu.parentElement),
+      dev().assertElement(element.parentElement),
       'amp-nested-menu,[amp-nested-submenu]'
     );
   }

--- a/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
@@ -142,7 +142,7 @@ describes.realWin(
       expect(submenuEl1.hasAttribute('child-open')).to.be.true;
       expect(submenuEl1.hasAttribute('open')).to.be.true;
       expect(submenuEl3.hasAttribute('open')).to.be.true;
-      menuEl.implementation_.reset_();
+      menuEl.implementation_.reset();
       expect(menuEl.hasAttribute('child-open')).to.be.false;
       expect(submenuEl1.hasAttribute('child-open')).to.be.false;
       expect(submenuEl1.hasAttribute('open')).to.be.false;

--- a/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
@@ -19,6 +19,7 @@ import * as lolex from 'lolex';
 import {Keys} from '../../../../src/utils/key-codes';
 import {htmlFor} from '../../../../src/static-template';
 import {toggleExperiment} from '../../../../src/experiments';
+import {tryFocus} from '../../../../src/dom';
 
 describes.realWin(
   'amp-nested-menu component',
@@ -40,10 +41,16 @@ describes.realWin(
       toggleExperiment(win, 'amp-sidebar-v2', true);
     });
 
-    async function getNestedMenu() {
+    async function getNestedMenu(options) {
+      options = options || {};
       const element = doc.createElement('amp-nested-menu');
       element.setAttribute('layout', 'fill');
+      if (options.side) {
+        element.setAttribute('side', options.side);
+      }
       const ul = doc.createElement('ul');
+      element.appendChild(ul);
+      doc.body.appendChild(element);
 
       [1, 2, 3].forEach(i => {
         const item = htmlFor(doc)`
@@ -63,54 +70,164 @@ describes.realWin(
         item
           .querySelector('[amp-nested-submenu-close]')
           .setAttribute('id', `close-${i}`);
-        ul.appendChild(item);
+
+        if (i == 3) {
+          // nest submenu 3 inside submenu 1
+          const subUl = doc.createElement('ul');
+          doc.getElementById('submenu-1').appendChild(subUl);
+          subUl.appendChild(item);
+        } else {
+          ul.appendChild(item);
+        }
       });
 
-      element.appendChild(ul);
-      doc.body.appendChild(element);
       await element.build();
       await element.layoutCallback();
       return element;
     }
 
+    it('should set side attribute to right by default, but left for RTL', async () => {
+      const menuEl1 = await getNestedMenu();
+      expect(menuEl1.getAttribute('side')).to.equal('right');
+      doc.documentElement.setAttribute('dir', 'rtl');
+      const menuEl2 = await getNestedMenu();
+      expect(menuEl2.getAttribute('side')).to.equal('left');
+    });
+
     it('should open corresponding submenu when open element is clicked', async () => {
       const menuEl = await getNestedMenu();
-      const openEl = doc.getElementById('open-1');
-      const submenuEl = doc.getElementById('submenu-1');
+      const openEl1 = doc.getElementById('open-1');
+      const submenuEl1 = doc.getElementById('submenu-1');
+      const openEl3 = doc.getElementById('open-3');
+      const submenuEl3 = doc.getElementById('submenu-3');
       expect(menuEl.hasAttribute('child-open')).to.be.false;
-      expect(submenuEl.hasAttribute('open')).to.be.false;
-      const clickEvent = new Event('click');
-      openEl.dispatchEvent(clickEvent);
+      expect(submenuEl1.hasAttribute('open')).to.be.false;
+      const clickEvent = new Event('click', {bubbles: true});
+      openEl1.dispatchEvent(clickEvent);
       expect(menuEl.hasAttribute('child-open')).to.be.true;
-      expect(submenuEl.hasAttribute('open')).to.be.true;
+      expect(submenuEl1.hasAttribute('open')).to.be.true;
+      expect(submenuEl1.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl3.hasAttribute('open')).to.be.false;
+      openEl3.dispatchEvent(clickEvent);
+      expect(submenuEl1.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl3.hasAttribute('open')).to.be.true;
     });
 
     it('should close corresponding submenu when close element is clicked', async () => {
       const menuEl = await getNestedMenu();
-      const closeEl = doc.getElementById('close-1');
-      const submenuEl = doc.getElementById('submenu-1');
-      menuEl.implementation_.open_(submenuEl);
+      const closeEl1 = doc.getElementById('close-1');
+      const submenuEl1 = doc.getElementById('submenu-1');
+      const closeEl3 = doc.getElementById('close-3');
+      const submenuEl3 = doc.getElementById('submenu-3');
+      menuEl.implementation_.open_(submenuEl1);
+      menuEl.implementation_.open_(submenuEl3);
       expect(menuEl.hasAttribute('child-open')).to.be.true;
-      expect(submenuEl.hasAttribute('open')).to.be.true;
-      const clickEvent = new Event('click');
-      closeEl.dispatchEvent(clickEvent);
+      expect(submenuEl1.hasAttribute('open')).to.be.true;
+      const clickEvent = new Event('click', {bubbles: true});
+      closeEl3.dispatchEvent(clickEvent);
+      expect(submenuEl1.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl3.hasAttribute('open')).to.be.false;
+      closeEl1.dispatchEvent(clickEvent);
       expect(menuEl.hasAttribute('child-open')).to.be.false;
-      expect(submenuEl.hasAttribute('open')).to.be.false;
+      expect(submenuEl1.hasAttribute('open')).to.be.false;
     });
 
-    it('should return to parent menu when left arrow key is pressed', async () => {
+    it('should return to root menu on reset', async () => {
       const menuEl = await getNestedMenu();
+      const submenuEl1 = doc.getElementById('submenu-1');
+      const submenuEl3 = doc.getElementById('submenu-3');
+      menuEl.implementation_.open_(submenuEl1);
+      menuEl.implementation_.open_(submenuEl3);
+      expect(menuEl.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl1.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl1.hasAttribute('open')).to.be.true;
+      expect(submenuEl3.hasAttribute('open')).to.be.true;
+      menuEl.implementation_.reset_();
+      expect(menuEl.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl1.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl1.hasAttribute('open')).to.be.false;
+      expect(submenuEl3.hasAttribute('open')).to.be.false;
+    });
+
+    it('should return to parent menu when left arrow key is pressed and side=right', async () => {
+      const menuEl = await getNestedMenu({'side': 'right'});
       const submenuEl = doc.getElementById('submenu-1');
       menuEl.implementation_.open_(submenuEl);
       expect(menuEl.hasAttribute('child-open')).to.be.true;
       expect(submenuEl.hasAttribute('open')).to.be.true;
       const keyEvent = new KeyboardEvent('keydown', {key: Keys.LEFT_ARROW});
-      doc.documentElement.dispatchEvent(keyEvent);
+      menuEl.dispatchEvent(keyEvent);
       expect(menuEl.hasAttribute('child-open')).to.be.false;
       expect(submenuEl.hasAttribute('open')).to.be.false;
     });
 
-    it('should shift focus when submenu is opened and closed', async () => {
+    it('should return to parent menu when right arrow key is pressed and side=left', async () => {
+      const menuEl = await getNestedMenu({'side': 'left'});
+      const submenuEl = doc.getElementById('submenu-1');
+      menuEl.implementation_.open_(submenuEl);
+      expect(menuEl.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl.hasAttribute('open')).to.be.true;
+      const keyEvent = new KeyboardEvent('keydown', {key: Keys.RIGHT_ARROW});
+      menuEl.dispatchEvent(keyEvent);
+      expect(menuEl.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl.hasAttribute('open')).to.be.false;
+    });
+
+    it('should open submenu when right arrow key is pressed, side=right and open button has focus', async () => {
+      const menuEl = await getNestedMenu({'side': 'right'});
+      const openEl = doc.getElementById('open-1');
+      const submenuEl = doc.getElementById('submenu-1');
+      expect(menuEl.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl.hasAttribute('open')).to.be.false;
+      tryFocus(openEl);
+      expect(doc.activeElement).to.equal(openEl);
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: Keys.RIGHT_ARROW,
+        bubbles: true,
+      });
+      openEl.dispatchEvent(keyEvent);
+      expect(menuEl.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl.hasAttribute('open')).to.be.true;
+    });
+
+    it('should open submenu when left arrow key is pressed, side=left and open button has focus', async () => {
+      const menuEl = await getNestedMenu({'side': 'left'});
+      const openEl = doc.getElementById('open-1');
+      const submenuEl = doc.getElementById('submenu-1');
+      expect(menuEl.hasAttribute('child-open')).to.be.false;
+      expect(submenuEl.hasAttribute('open')).to.be.false;
+      tryFocus(openEl);
+      expect(doc.activeElement).to.equal(openEl);
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: Keys.LEFT_ARROW,
+        bubbles: true,
+      });
+      openEl.dispatchEvent(keyEvent);
+      expect(menuEl.hasAttribute('child-open')).to.be.true;
+      expect(submenuEl.hasAttribute('open')).to.be.true;
+    });
+
+    it('should shift focus between list items when up/down arrow key is pressed', async () => {
+      await getNestedMenu();
+      const openEl1 = doc.getElementById('open-1');
+      const openEl2 = doc.getElementById('open-2');
+      tryFocus(openEl1);
+      expect(doc.activeElement).to.equal(openEl1);
+      const downKeyEvent = new KeyboardEvent('keydown', {
+        key: Keys.DOWN_ARROW,
+        bubbles: true,
+      });
+      openEl1.dispatchEvent(downKeyEvent);
+      expect(doc.activeElement).to.equal(openEl2);
+      const upKeyEvent = new KeyboardEvent('keydown', {
+        key: Keys.UP_ARROW,
+        bubbles: true,
+      });
+      openEl2.dispatchEvent(upKeyEvent);
+      expect(doc.activeElement).to.equal(openEl1);
+    });
+
+    it('should shift focus to close/open button when submenu is opened/closed, respectively', async () => {
       const menuEl = await getNestedMenu();
       const openEl = doc.getElementById('open-1');
       const closeEl = doc.getElementById('close-1');

--- a/test/manual/amp-sidebar/amp-nested-menu.amp.html
+++ b/test/manual/amp-sidebar/amp-nested-menu.amp.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="https://amp.dev/documentation/examples/components/amp-selector/index.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.2.js"></script>
+  <script async custom-element="amp-nested-menu" src="https://cdn.ampproject.org/v0/amp-nested-menu-0.1.js"></script>
+  <script async custom-element="amp-auto-lightbox" src="https://cdn.ampproject.org/v0/amp-auto-lightbox-0.1.js"></script>
+  <script async custom-element="amp-loader" src="https://cdn.ampproject.org/v0/amp-loader-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script>
+    (self.AMP=self.AMP||[]).push(function(AMP){
+        AMP.toggleExperiment('amp-sidebar-v2', true);
+    });
+  </script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    amp-sidebar {
+      width: 300px;
+    }
+    h4 {
+      margin: 0;
+      padding: 10px;
+    }
+    h4 > b {
+      float: right;
+    }
+    body > button {
+      padding: 20px;
+      margin: 20px;
+      font-size: 1em;
+    }
+    #sidebar1 {
+      display: flex;
+      flex-flow: column;
+    }
+    #sidebar1 > div {
+      flex-grow: 1;
+      position: relative;
+    }
+    .scrollable {
+      height: 100%;
+      overflow: scroll;
+    }
+  </style>
+</head>
+<body>
+  <amp-state id="data">
+    <script type="application/json">
+      {
+        "items": ["list item 1", "list item 2", "list item 3"]
+      }
+    </script>
+  </amp-state>
+
+  <button on="tap:sidebar1.open">LTR Menu</button>
+  <button on="tap:sidebar2.open">RTL Menu</button>
+
+  <amp-sidebar id="sidebar1" layout="nodisplay" on="sidebarClose:menu1.reset">
+    <amp-img src="http://placeimg.com/500/100/tech" layout="responsive" width="5" height="1"></amp-img>
+    <h4>this text sticks around</h4>
+    <div>
+    <amp-nested-menu id="menu1" layout="fill" side="right">
+      <ul>
+        <li>
+          <h4 amp-nested-submenu-open>with links & on actions<b>></b></h4>
+          <div amp-nested-submenu>
+            <ul>
+              <li>
+                <h4 amp-nested-submenu-close>
+                  <span>return to main</span>
+                  <button on="tap:sidebar1.close">close sidebar</button>
+                </h4>
+              </li>
+              <li>
+                <h4 amp-nested-submenu-open>
+                  <span>checkout links</span>
+                  <a href="https://amp.dev/">AMP</a>
+                  <b>></b>
+                </h4>
+                <div amp-nested-submenu>
+                  <ul>
+                    <li>
+                      <h4 amp-nested-submenu-close>return to previous</h4>
+                    </li>
+                    <li>
+                      <a href="https://amp.dev/">link 1</a>
+                    </li>
+                    <li>
+                      <a href="https://amp.dev/">link 2</a>
+                    </li>
+                    <li>
+                      <a href="https://amp.dev/">link 3</a>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <h4>
+                  <a href="https://amp.dev/">just another link</a>
+                </h4>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li>
+          <h4 amp-nested-submenu-open>with other components<b>></b></h4>
+          <div amp-nested-submenu>
+            <ul>
+              <li>
+                <h4 amp-nested-submenu-close>return to main</h4>
+              </li>
+              <li>
+                <h4 amp-nested-submenu-open>amp-img<b>></b></h4>
+                <div amp-nested-submenu>
+                  <div class="scrollable">
+                    <h4 amp-nested-submenu-close>return to previous</h4>
+                    <amp-img src="http://placeimg.com/300/900/tech"
+                      layout="responsive" width="1" height="3"></amp-img>
+                  </div>
+                </div>
+              </li>
+              <li>
+                <h4 amp-nested-submenu-open>amp-accordion<b>></b></h4>
+                <div amp-nested-submenu>
+                  <ul>
+                    <li>
+                      <h4 amp-nested-submenu-close>return to previous</h4>
+                    </li>
+                    <li>
+                      <amp-accordion layout="container">
+                        <section>
+                          <h4>header 1</h4>
+                          <div>content 1</div>
+                        </section>
+                        <section>
+                          <h4>header 2</h4>
+                          <div>content 2</div>
+                        </section>
+                      </amp-accordion>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <h4 amp-nested-submenu-open>amp-list<b>></b></h4>
+                <div amp-nested-submenu>
+                  <amp-list src="https://api.myjson.com/bins/v2t98"
+                    layout="fixed-height" height="100" items="." single-item>
+                    <template type="amp-mustache">
+                      <ul>
+                        {{#items}}
+                        <li>
+                          <span tabindex="0">{{title}}</span>
+                        </li>
+                        {{/items}}
+                      </ul>
+                    </template>
+                  </amp-list>
+                  <h4 amp-nested-submenu-close>back</h4>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </amp-nested-menu>
+    </div>
+  </amp-sidebar>
+
+  <amp-sidebar id="sidebar2" layout="nodisplay" side="right" dir="rtl" on="sidebarClose:menu2.reset">
+    <amp-list layout="fill" src="https://api.myjson.com/bins/v2t98" items="." single-item>
+      <template type="amp-mustache">
+        <amp-nested-menu id="menu2" layout="fill" side="left">
+            <ul>
+              {{#items}}
+              <li>
+                <h4 amp-nested-submenu-open>{{title}}</h4>
+                <div amp-nested-submenu>
+                  <h4 amp-nested-submenu-close>go back</h4>
+                  <amp-img src="{{imageUrl}}" layout="responsive" width="3" height="2"></amp-img>
+                </div>
+              </li>
+              {{/items}}
+            </ul>
+        </amp-nested-menu>
+      </template>
+    </amp-list>
+  </amp-sidebar>
+
+</body>
+</html>

--- a/test/manual/amp-sidebar/amp-nested-menu.amp.html
+++ b/test/manual/amp-sidebar/amp-nested-menu.amp.html
@@ -23,9 +23,10 @@
     amp-sidebar {
       width: 300px;
     }
-    h4 {
+    h4, li > a {
       margin: 0;
       padding: 10px;
+      display: block;
     }
     h4 > b {
       float: right;
@@ -101,9 +102,7 @@
                 </div>
               </li>
               <li>
-                <h4>
-                  <a href="https://amp.dev/">just another link</a>
-                </h4>
+                <a href="https://amp.dev/">just another link</a>
               </li>
             </ul>
           </div>
@@ -150,19 +149,25 @@
               <li>
                 <h4 amp-nested-submenu-open>amp-list<b>></b></h4>
                 <div amp-nested-submenu>
-                  <amp-list src="https://api.myjson.com/bins/v2t98"
-                    layout="fixed-height" height="100" items="." single-item>
-                    <template type="amp-mustache">
-                      <ul>
-                        {{#items}}
-                        <li>
-                          <span tabindex="0">{{title}}</span>
-                        </li>
-                        {{/items}}
-                      </ul>
-                    </template>
-                  </amp-list>
-                  <h4 amp-nested-submenu-close>back</h4>
+                  <ul>
+                    <li>
+                      <h4 amp-nested-submenu-close>return to previous</h4>
+                    </li>
+                    <li>
+                      <amp-list src="https://api.myjson.com/bins/v2t98"
+                        layout="fixed-height" height="100" items="." single-item>
+                        <template type="amp-mustache">
+                          <ul>
+                            {{#items}}
+                            <li>
+                              <h4 tabindex="0">{{title}}</h4>
+                            </li>
+                            {{/items}}
+                          </ul>
+                        </template>
+                      </amp-list>
+                    </li>
+                  </ul>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
Resolves: #25157 
Resolves: #24665 

Implement the following changes to `<amp-nested-menu>`:
- Add an optional "side" attribute that determines which side submenus should open from ("right" by default, "left" for RTL documents)
- Support all arrow keys:
  - Left arrow (or right if side=left) to go back to parent menu;
  - Right arrow (or left if side=right) to open submenu if submenu open button has focus;
  - Up/Down arrow to move focus within menu (only works for `<li>` in the same list);
- Add a public `reset()` method that sidebar can call to reset menus on close;
- Change event listeners to use event delegation;
- Add tests for the new functionalities.

Demo: https://amp-nested-menu.firebaseapp.com/