### PR TITLE
🏗 Allow `amphtml-validator` to be used with `node` v8

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -10,7 +10,7 @@
     "Accelerated Mobile Pages"
   ],
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": "^8 || ^10 || ^12 || ^14"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR makes it so that `amphtml-validator` can be used with `node` v8. This will need to be followed up with a new `1.0.29` release. 

Partial mitigation for #25209
Related to https://github.com/ampproject/amphtml/pull/25161#discussion_r337182956

/cc @ampproject/wg-caching 