### PR TITLE
✨ Install an unhandled rejection listener on the Promise polyfill

### DIFF
--- a/src/polyfills/promise.js
+++ b/src/polyfills/promise.js
@@ -36,6 +36,7 @@ export function install(win) {
     win.Promise.all = Promise.all;
     win.Promise.race = Promise.race;
 
+    // https://github.com/jridgewell/PJs/blob/v1.1.5/promise.js#L177-L182
     win.Promise._overrideUnhandledExceptionHandler(error => {
       win.__AMP_REPORT_ERROR(error);
     });

--- a/src/polyfills/promise.js
+++ b/src/polyfills/promise.js
@@ -35,5 +35,9 @@ export function install(win) {
     win.Promise.reject = Promise.reject;
     win.Promise.all = Promise.all;
     win.Promise.race = Promise.race;
+
+    win.Promise._overrideUnhandledExceptionHandler(error => {
+      win.__AMP_REPORT_ERROR(error);
+    });
   }
 }


### PR DESCRIPTION
The promise polyfill doesn't fire an `unhandledrejection` Error event, because there is no way to match the `PromiseRejectionEvent` API. Instead, the polyfill exposes a `_overrideUnhandledExceptionHandler` that is called with unhandled promise rejections.