### PR TITLE
✨ Allow crossorigin=anonymous on Scripts

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.html
+++ b/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests that the crossorigin=anonymous attribute is valid on the engine
+  script and extension.
+-->
+<!doctype html>
+<html ⚡4ads>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async crossorigin="anonymous" src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  <script async crossorigin="anonymous" custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+</head>
+<body>
+  Hello, world.
+</body>
+</html>

--- a/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.html
+++ b/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.html
@@ -16,7 +16,7 @@
 <!--
   Test Description:
   This tests that the crossorigin=anonymous attribute is valid on the engine
-  script and extension.
+  script and extension scripts.
 -->
 <!doctype html>
 <html ⚡4ads>

--- a/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.out
+++ b/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.out
@@ -17,7 +17,7 @@ PASS
 |  <!--
 |    Test Description:
 |    This tests that the crossorigin=anonymous attribute is valid on the engine
-|    script and extension.
+|    script and extension scripts.
 |  -->
 |  <!doctype html>
 |  <html ⚡4ads>

--- a/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.out
+++ b/validator/testdata/amp4ads_feature_tests/crossorigin_anonymous_script.out
@@ -1,0 +1,34 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that the crossorigin=anonymous attribute is valid on the engine
+|    script and extension.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async crossorigin="anonymous" src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    <script async crossorigin="anonymous" custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|  </head>
+|  <body>
+|    Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/crossorigin_anonymous_script.html
+++ b/validator/testdata/feature_tests/crossorigin_anonymous_script.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests that the crossorigin=anonymous attribute is valid on the engine
+  script and extension.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async crossorigin="anonymous" src="https://cdn.ampproject.org/v0.js"></script>
+  <script async crossorigin="anonymous"custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+</head>
+<body>
+  Hello, world.
+  <amp-ad width=300 height=250
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="abc123"
+      data-aax_src="302">
+  </amp-ad>
+</body>
+</html>

--- a/validator/testdata/feature_tests/crossorigin_anonymous_script.html
+++ b/validator/testdata/feature_tests/crossorigin_anonymous_script.html
@@ -16,7 +16,7 @@
 <!--
   Test Description:
   This tests that the crossorigin=anonymous attribute is valid on the engine
-  script and extension.
+  script and extension scripts.
 -->
 <!doctype html>
 <html ⚡>

--- a/validator/testdata/feature_tests/crossorigin_anonymous_script.out
+++ b/validator/testdata/feature_tests/crossorigin_anonymous_script.out
@@ -1,0 +1,41 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that the crossorigin=anonymous attribute is valid on the engine
+|    script and extension.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async crossorigin="anonymous" src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async crossorigin="anonymous"custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|  </head>
+|  <body>
+|    Hello, world.
+|    <amp-ad width=300 height=250
+|        type="a9"
+|        data-aax_size="300x250"
+|        data-aax_pubname="abc123"
+|        data-aax_src="302">
+|    </amp-ad>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/crossorigin_anonymous_script.out
+++ b/validator/testdata/feature_tests/crossorigin_anonymous_script.out
@@ -17,7 +17,7 @@ PASS
 |  <!--
 |    Test Description:
 |    This tests that the crossorigin=anonymous attribute is valid on the engine
-|    script and extension.
+|    script and extension scripts.
 |  -->
 |  <!doctype html>
 |  <html ⚡>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4877,6 +4877,10 @@ tags: {
     name: "type"
     value_casei: "text/javascript"
   }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
   cdata: {
     blacklisted_cdata_regex: {
       regex: "."
@@ -4913,6 +4917,10 @@ tags: {
       regex: "."
       error_message: "contents"
     }
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
 }
@@ -5369,6 +5377,10 @@ attr_lists: {
   attrs: {
     name: "type"
     value_casei: "text/javascript"
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
   }
 }
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4868,6 +4868,10 @@ tags: {
     value: ""
   }
   attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
     name: "src"
     mandatory: true
     value: "https://cdn.ampproject.org/v0.js"
@@ -4876,10 +4880,6 @@ tags: {
   attrs: {
     name: "type"
     value_casei: "text/javascript"
-  }
-  attrs: {
-    name: "crossorigin"
-    value: "anonymous"
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4903,6 +4903,10 @@ tags: {
     value: ""
   }
   attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
     name: "src"
     mandatory: true
     value: "https://cdn.ampproject.org/amp4ads-v0.js"
@@ -4917,10 +4921,6 @@ tags: {
       regex: "."
       error_message: "contents"
     }
-  }
-  attrs: {
-    name: "crossorigin"
-    value: "anonymous"
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
 }
@@ -5370,6 +5370,10 @@ attr_lists: {
     value: ""
   }
   attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
     disabled_by: "transformed"
     disabled_by: "amp4email"
     name: "nonce"
@@ -5377,10 +5381,6 @@ attr_lists: {
   attrs: {
     name: "type"
     value_casei: "text/javascript"
-  }
-  attrs: {
-    name: "crossorigin"
-    value: "anonymous"
   }
 }
 


### PR DESCRIPTION
This is a necessary step in order to fix error reporting for errors generated by crossorigin scripts. Making the script `anonymous` signals to the browser that there is no User PII in the script, and will allow the errors to be generated will full stack trace and error message.

Fixes https://github.com/ampproject/amphtml/issues/24731