### PR TITLE
[owners] Add OWNERS syntax check to Travis gulp task 

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -90,9 +90,10 @@ function getFilesToCheck(globs, options = {}) {
 }
 
 /**
- * Checks if the correct arguments were passed in
+ * Ensures that a target is only called with `--files` or `--local_changes`
  *
- * @return {boolean}
+ * @param {string} taskName name of the gulp task.
+ * @return {boolean} if the use is valid.
  */
 function usesFilesOrLocalChanges(taskName) {
   const validUsage = argv.files || argv.local_changes;

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -19,7 +19,7 @@ const fs = require('fs-extra');
 const globby = require('globby');
 const log = require('fancy-log');
 const {gitDiffNameOnlyMaster} = require('../common/git');
-const {green, cyan} = require('ansi-colors');
+const {green, cyan, yellow} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
 
 /**
@@ -89,8 +89,36 @@ function getFilesToCheck(globs, options = {}) {
   return globby.sync(globs, options);
 }
 
+/**
+ * Checks if the correct arguments were passed in
+ *
+ * @return {boolean}
+ */
+function usesFilesOrLocalChanges(taskName) {
+  const validUsage = argv.files || argv.local_changes;
+  if (!validUsage) {
+    log(
+      yellow('NOTE 1:'),
+      'It is infeasible for',
+      cyan(`gulp ${taskName}`),
+      'to check all files in the repo at once.'
+    );
+    log(
+      yellow('NOTE 2:'),
+      'Please run',
+      cyan(`gulp ${taskName}`),
+      'with',
+      cyan('--files'),
+      'or',
+      cyan('--local_changes') + '.'
+    );
+  }
+  return validUsage;
+}
+
 module.exports = {
   getFilesChanged,
   getFilesToCheck,
   logOnSameLine,
+  usesFilesOrLocalChanges,
 };

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -55,7 +55,6 @@ async function main() {
     timedExecOrDie('gulp babel-plugin-tests');
     timedExecOrDie('gulp caches-json');
     timedExecOrDie('gulp dev-dashboard-tests');
-    timedExecOrDie('gulp check-owners');
     timedExecOrDie('gulp dep-check');
     timedExecOrDie('gulp check-types');
   } else {
@@ -91,7 +90,7 @@ async function main() {
     }
 
     if (buildTargets.has('OWNERS')) {
-      timedExecOrDie('gulp check-owners');
+      timedExecOrDie('gulp check-owners --local_changes');
     }
 
     if (buildTargets.has('RUNTIME')) {

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -89,6 +89,7 @@ async function main() {
       timedExecOrDie('gulp dev-dashboard-tests');
     }
 
+    // Validate owners syntax only for PR builds.
     if (buildTargets.has('OWNERS')) {
       timedExecOrDie('gulp check-owners --local_changes');
     }

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -15,7 +15,6 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const markdownLinkCheck = require('markdown-link-check');

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -20,7 +20,7 @@ const fs = require('fs-extra');
 const log = require('fancy-log');
 const markdownLinkCheck = require('markdown-link-check');
 const path = require('path');
-const {getFilesToCheck} = require('../common/utils');
+const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {gitDiffAddedNameOnlyMaster} = require('../common/git');
 const {green, cyan, red, yellow} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
@@ -36,7 +36,7 @@ let filesIntroducedByPr;
  */
 async function checkLinks() {
   maybeUpdatePackages();
-  if (!isValidUsage()) {
+  if (!usesFilesOrLocalChanges('check-links')) {
     return;
   }
   const filesToCheck = getFilesToCheck(linkCheckGlobs);
@@ -53,33 +53,6 @@ async function checkLinks() {
   filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
   const results = await Promise.all(filesToCheck.map(checkLinksInFile));
   reportResults(results);
-}
-
-/**
- * Checks if the correct arguments were passed in
- *
- * @return {boolean}
- */
-function isValidUsage() {
-  const validUsage = argv.files || argv.local_changes;
-  if (!validUsage) {
-    log(
-      yellow('NOTE 1:'),
-      'It is infeasible for',
-      cyan('gulp check-links'),
-      'to check for dead links in all markdown files in the repo at once.'
-    );
-    log(
-      yellow('NOTE 2:'),
-      'Please run',
-      cyan('gulp check-links'),
-      'with',
-      cyan('--files'),
-      'or',
-      cyan('--local_changes') + '.'
-    );
-  }
-  return validUsage;
 }
 
 /**

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -25,11 +25,13 @@
 const fs = require('fs-extra');
 const JSON5 = require('json5');
 const log = require('fancy-log');
+const request = require('request');
 const utils = require('bluebird');
-const requestPost = utils.promisify(require('request').post);
 const {cyan, red, green} = require('ansi-colors');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {isTravisBuild} = require('../common/travis');
+
+const requestPost = utils.promisify(request.post);
 
 const OWNERS_SYNTAX_CHECK_URI =
   'http://ampproject-owners-bot.appspot.com/v0/syntax';
@@ -102,7 +104,7 @@ async function checkFile(file) {
       green('SUCCESS:'),
       'Parsed',
       cyan(file),
-      'successfully; Produced',
+      'successfully; produced',
       cyan(rules.length),
       'rules.'
     );
@@ -119,5 +121,4 @@ module.exports = {
 checkOwners.description = 'Checks all OWNERS files in the repo for correctness';
 checkOwners.flags = {
   'files': '  Checks only the specified OWNERS files',
-  'validate': '  Validates the OWNERS files with the owners bot API',
 };

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -22,18 +22,17 @@
 
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
-const utils = require('bluebird');
-const requestPost = utils.promisify(require('request').post);
 const fs = require('fs-extra');
-const globby = require('globby');
 const JSON5 = require('json5');
 const log = require('fancy-log');
-const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
+const utils = require('bluebird');
+const requestPost = utils.promisify(require('request').post);
 const {cyan, red, green} = require('ansi-colors');
+const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {isTravisBuild} = require('../common/travis');
 
-const OWNERS_SYNTAX_CHECK_URI = 'http://ampproject-owners-bot.appspot.com/v0/syntax';
+const OWNERS_SYNTAX_CHECK_URI =
+  'http://ampproject-owners-bot.appspot.com/v0/syntax';
 
 /**
  * Checks OWNERS files for correctness using the owners bot API.
@@ -41,7 +40,7 @@ const OWNERS_SYNTAX_CHECK_URI = 'http://ampproject-owners-bot.appspot.com/v0/syn
  * so that all OWNERS files can be checked / fixed.
  */
 async function checkOwners() {
-  if (!usesFilesOrLocalChanges()) {
+  if (!usesFilesOrLocalChanges('check-owners')) {
     return;
   }
   const filesToCheck = getFilesToCheck('**/OWNERS');
@@ -93,7 +92,7 @@ async function checkFile(file) {
 
     if (requestErrors) {
       requestErrors.forEach(err => log(red(err)));
-      throw new Error('Could not reach the owners syntax check API')
+      throw new Error('Could not reach the owners syntax check API');
     } else if (fileErrors && fileErrors.length) {
       fileErrors.forEach(err => log(red(err)));
       throw new Error(`Errors encountered parsing "${file}"`);
@@ -103,7 +102,7 @@ async function checkFile(file) {
       green('SUCCESS:'),
       'Parsed',
       cyan(file),
-      'successfully! Produced rules:',
+      'successfully! Produced rules:'
     );
     rules.forEach(rule => log(rule));
   } catch (error) {

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -121,4 +121,5 @@ module.exports = {
 checkOwners.description = 'Checks all OWNERS files in the repo for correctness';
 checkOwners.flags = {
   'files': '  Checks only the specified OWNERS files',
+  'local_changes': '  Checks just the OWNERS files changed in the local branch',
 };

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -102,13 +102,13 @@ async function checkFile(file) {
       green('SUCCESS:'),
       'Parsed',
       cyan(file),
-      'successfully! Produced rules:'
+      'successfully; Produced',
+      cyan(rules.length),
+      'rules.'
     );
-    rules.forEach(rule => log(rule));
   } catch (error) {
     log(red('FAILURE:'), error);
     process.exitCode = 1;
-    return;
   }
 }
 
@@ -119,4 +119,5 @@ module.exports = {
 checkOwners.description = 'Checks all OWNERS files in the repo for correctness';
 checkOwners.flags = {
   'files': '  Checks only the specified OWNERS files',
+  'validate': '  Validates the OWNERS files with the owners bot API',
 };

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -33,7 +33,7 @@ const {getFilesToCheck} = require('../common/utils');
 const {cyan, red, yellow, green} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
 
-const OWNERS_SYNTAX_CHECK_URI = 'http://localhost:8080/v0/syntax';
+const OWNERS_SYNTAX_CHECK_URI = 'http://ampproject-owners-bot.appspot.com/v0/syntax';
 
 /**
  * Checks OWNERS files for correctness using the owners bot API.


### PR DESCRIPTION
The owners syntax check API returns a response `{requestErrors, fileErrors, rules}`. This PR makes the `gulp check-owners` task call that API for each file in `--files` or `--local_changes`, and fails if there are any file errors.

I wasn't certain on where the API URI should live, so I made it a constant for now. Also not familiar with the conventions around logging, so I pattern-matched a bit, but feel free to suggest changes.

Do I need to adjust `checks.js` or something else to actually pass the `--local_changes` flag? 

Closes #24295
Closes https://github.com/ampproject/amp-github-apps/issues/281