### PR TITLE
✅ Tests: Update `@percy/agent` to fix memory leak

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -722,17 +722,12 @@ async function visualDiff() {
  */
 async function performVisualTests() {
   setDebuggingLevel();
-  if (
-    !argv.percy_disabled &&
-    (!process.env.PERCY_PROJECT || !process.env.PERCY_TOKEN)
-  ) {
+  if (!argv.percy_disabled && !process.env.PERCY_TOKEN) {
     log(
       'fatal',
       'Could not find',
-      colors.cyan('PERCY_PROJECT'),
-      'and',
       colors.cyan('PERCY_TOKEN'),
-      'environment variables'
+      'environment variable'
     );
   } else {
     try {
@@ -851,7 +846,6 @@ visualDiff.flags = {
   'debug': '  Sets all debugging flags',
   'verbose': '  Prints verbose log statements',
   'grep': '  Runs tests that match the pattern',
-  'percy_project': '  Override the PERCY_PROJECT environment variable',
   'percy_token': '  Override the PERCY_TOKEN environment variable',
   'percy_branch': '  Override the PERCY_BRANCH environment variable',
   'percy_disabled':

--- a/build-system/tasks/visual-diff/package.json
+++ b/build-system/tasks/visual-diff/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Gulp visual diff",
   "devDependencies": {
-    "@percy/agent": "0.19.4",
+    "@percy/agent": "0.19.5",
     "@percy/puppeteer": "1.0.8",
     "puppeteer": "1.20.0"
   }

--- a/build-system/tasks/visual-diff/yarn.lock
+++ b/build-system/tasks/visual-diff/yarn.lock
@@ -118,10 +118,10 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@percy/agent@0.19.4":
-  version "0.19.4"
-  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.19.4.tgz#56490ccc71a0e19a7bc3acbde26f53967a3353eb"
-  integrity sha512-aRzdcjfHWN+mKRRqm5A0iCknEH/Mff3gSjEtmDi3qrasDVCyXGLeASZfof365D1tYeU62VxAli8eE8aAQzhmDg==
+"@percy/agent@0.19.5":
+  version "0.19.5"
+  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.19.5.tgz#ea5590ee5cd4f6d90973135ead8a701470e4b752"
+  integrity sha512-+I3VPGGCdasK1xMOMuMulQUB2PJZENkUSPtRJStFfLoTnJS7Bfm/4GXDod+uVTPh/3qlrwrK/BdxCnrc8+wG5A==
   dependencies:
     "@oclif/command" "1.5.16"
     "@oclif/config" "^1"

--- a/build-system/tasks/visual-diff/yarn.lock
+++ b/build-system/tasks/visual-diff/yarn.lock
@@ -147,14 +147,13 @@
 
 "@percy/agent@~0":
   version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.19.1.tgz#83ee56836ac701b41a9df8b14de56373d89a038d"
-  integrity sha512-3X/0AkAyoKP9Nehz5fJae4qFn3t/Pb7jKhj9aJGlMRt6GxNtKS6cYMJtv+LLFu7y2PUeur5phmUNZTUVI0ln8Q==
+  resolved "https://codeload.github.com/percy/percy-agent/tar.gz/c341109b4881165358663295df93b12a26beded0"
   dependencies:
     "@oclif/command" "1.5.16"
     "@oclif/config" "^1"
     "@oclif/plugin-help" "^2"
     "@oclif/plugin-not-found" "^1.2"
-    axios "^0.18.1"
+    axios "^0.19.0"
     body-parser "^1.18.3"
     colors "^1.3.2"
     cors "^2.8.4"
@@ -162,12 +161,12 @@
     cross-spawn "^6.0.5"
     deepmerge "^4.0.0"
     express "^4.16.3"
-    follow-redirects "^1.9.0"
+    follow-redirects "1.5.10"
     generic-pool "^3.7.1"
     globby "^10.0.1"
     image-size "^0.8.2"
     js-yaml "^3.13.1"
-    percy-client "^3.1.0"
+    percy-client "^3.2.0"
     puppeteer "^1.13.0"
     retry-axios "^1.0.1"
     winston "^3.0.0"
@@ -310,14 +309,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-axios@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 axios@^0.19.0:
   version "0.19.0"
@@ -623,7 +614,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -899,13 +890,6 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
-
-follow-redirects@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
-  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
-  dependencies:
-    debug "^3.0.0"
 
 foreachasync@^3.0.0:
   version "3.0.0"
@@ -1479,22 +1463,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
-percy-client@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.2.1.tgz#42c265fcca6b9bf8eccfc53a793098286d363a95"
-  integrity sha512-xnoLe1QNT5Y/1PEZqKdES9aOtvd1TyyaVdKPbq1sWh1ORLFhgPte3Yg9+vnmUyjplDsHEev32tzmEAx2PMMbOw==
-  dependencies:
-    base64-js "^1.2.3"
-    bluebird "^3.5.1"
-    bluebird-retry "^0.11.0"
-    dotenv "^8.1.0"
-    es6-promise-pool "^2.5.0"
-    jssha "^2.1.0"
-    regenerator-runtime "^0.13.1"
-    request "^2.87.0"
-    request-promise "^4.2.2"
-    walk "^2.3.14"
 
 percy-client@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
## What is this?

Thank you @danielrozenberg for opening up this issue: https://github.com/percy/percy-agent/issues/402 we recently shipped something that should fix this issue 👍 

This also removes the `PERCY_PROJECT` env var. I'm assuming the old Puppeteer SDK needed that env var, but all new agent based SDKs don't need that env var anymore (just `PERCY_TOKEN`). 