### PR TITLE
🐛 Upgrade shadow root contents when defining new CEs

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -260,8 +260,7 @@ class Registry {
     this.mutationObserver_ = null;
 
     /**
-     * All the observed DOM trees, including shadow trees. This is cleared out
-     * when the mutation observer is created.
+     * All the observed DOM trees, including shadow trees.
      *
      * @private @const {!Array<!Node>}
      */

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -265,7 +265,7 @@ class Registry {
      *
      * @private @const {!Array<!Node>}
      */
-    this.observed_ = [win.document];
+    this.roots_ = [win.document];
   }
 
   /**
@@ -346,7 +346,9 @@ class Registry {
     };
 
     this.observe_(name);
-    this.upgrade(this.doc_, name);
+    this.roots_.forEach(tree => {
+      this.upgrade(tree, name);
+    });
   }
 
   /**
@@ -510,10 +512,12 @@ class Registry {
     });
     this.mutationObserver_ = mo;
 
-    this.observed_.forEach(tree => {
+    // I would love to not have to hold onto all of the roots, since it's a
+    // memory leak. Unfortunately, there's no way to iterate a list and hold
+    // onto its contents weakly.
+    this.roots_.forEach(tree => {
       mo.observe(tree, TRACK_SUBTREE);
     });
-    this.observed_.length = 0;
 
     installPatches(this.win_, this);
   }
@@ -524,10 +528,9 @@ class Registry {
    * @param {!Node} tree
    */
   observe(tree) {
+    this.roots_.push(tree);
     if (this.mutationObserver_) {
       this.mutationObserver_.observe(tree, TRACK_SUBTREE);
-    } else {
-      this.observed_.push(tree);
     }
   }
 

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -228,11 +228,6 @@ class Registry {
     this.win_ = win;
 
     /**
-     * @private @const
-     */
-    this.doc_ = win.document;
-
-    /**
      * @type {!Object<string, !CustomElementDef>}
      * @private
      * @const


### PR DESCRIPTION
When we've already initialized the the custom element registry, it used to drop the list of shadow roots. When a new CE was defined, we would then only query the host `document` (since we dropped all the shadow roots from the array). Obviously, that query selector won't find CEs inside the shadow tree.

So, we need to keep the list of shadow roots, that way we can query inside them when defining new custom elements.

Note, this will mean leaking every shadow permanently. Even if the shadow's host is removed from the document, we'll still have to keep its reference. We could setup a long running interval to find disconnected trees, but it wouldn't be able to tell the difference between a temporarily disconnected shadow and a destroyed shadow.

Fixes https://github.com/ampproject/amphtml/issues/25332