### PR TITLE
Add validation and documentation for <amp-nested-menu>

### DIFF
--- a/examples/sidebar-nested-menu.html
+++ b/examples/sidebar-nested-menu.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP nested menu example</title>
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp-custom>
+    header {
+      position: sticky;
+      top: 0;
+      background: #336;
+    }
+    .hamburger{
+      font-size: 2em;
+      cursor: pointer;
+      width: 50px;
+      height: 50px;
+      color: white;
+      border: none;
+      background: none;
+    }
+    ul {
+      margin: 0;
+    }
+    .scrollable {
+      height: 100%;
+      overflow: scroll;
+    }
+    #sidebar1 {
+      width: 330px;
+    }
+    #sidebar1 li > h4,
+    #sidebar1 li > a {
+      margin: 5px;
+      padding: 5px;
+    }
+    #sidebar1 li > a {
+      font-size: 1em;
+      display: block;
+      color: black;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    #sidebar1 li > a:hover {
+      color: #008;
+      text-decoration: underline;
+    }
+    #sidebar1 li > h3,
+    #sidebar1 [amp-nested-submenu-close] {
+      background: #336;
+      color: white;
+      margin: 0;
+      padding: 10px;
+    }
+    #sidebar1 .right-arrow {
+      float: right;
+    }
+    #sidebar1 .left-arrow {
+      margin-right: 10px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <button class="hamburger" on="tap:sidebar1.open">=</button>
+  </header>
+  <amp-sidebar id="sidebar1" layout="nodisplay" on="sidebarClose:menu1.reset">
+    <amp-list layout="fill" src="/list/ecommerce-nested-menu" items="." single-item>
+      <template type="amp-mustache">
+        <amp-nested-menu id="menu1" layout="fill">
+          <ul class="scrollable">
+            <li>
+              <h3 tabindex="-1">Categories</h3>
+            </li>
+            {{#menu}}
+            <li>
+              <h4 amp-nested-submenu-open>
+                <span>{{title}}</span>
+                <span class="right-arrow" aria-hidden="true">&gt;</span>
+              </h4>
+              <div amp-nested-submenu>
+                <ul>
+                  <li>
+                    <h4 amp-nested-submenu-close>
+                      <span class="left-arrow" aria-hidden="true">&lt;</span>
+                      <span>back</span>
+                    </h4>
+                    <amp-img src="{{image}}" alt="{{title}}" layout="responsive" width="5" height="3"></amp-img>
+                  </li>
+                  {{#content}}
+                  <li>
+                    <h4 amp-nested-submenu-open>
+                      <span>{{title}}</span>
+                      <span class="right-arrow" aria-hidden="true">></span>
+                    </h4>
+                    <div amp-nested-submenu>
+                      <ul>
+                        <li>
+                          <h4 amp-nested-submenu-close>
+                            <span class="left-arrow" aria-hidden="true">&lt;</span>
+                            <span>back</span>
+                          </h4>
+                        </li>
+                        {{#content}}
+                        <li>
+                          <a href="https://www.google.com/search?q={{.}}" tabindex="0">{{.}}</a>
+                        </li>
+                        {{/content}}
+                      </ul>
+                    </div>
+                  </li>
+                  {{/content}}
+                </ul>
+              </div>
+            </li>
+            {{/menu}}
+            <li>
+              <a href="https://www.google.com/" tabindex="0">See More</a>
+            </li>
+            <li>
+              <amp-img src="http://placeimg.com/300/200/tech" alt="tech image" layout="responsive" width="3" height="2"></amp-img>
+              <h3 tabindex="-1">Information</h3>
+            </li>
+            <li>
+              <a href="https://amp.dev/" tabindex="0">Visit AMP</a>
+            </li>
+          </ul>
+        </amp-nested-menu>
+      </template>
+    </amp-list>
+  </amp-sidebar>
+
+  <article>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+      luctus nunc ut elit cursus, et imperdiet diam vehicula.
+      Duis et nisi sed urna blandit bibendum et sit amet erat.
+      Suspendisse potenti. Curabitur consequat volutpat arcu nec
+      elementum. Etiam a turpis ac libero varius condimentum.
+      Maecenas sollicitudin felis aliquam tortor vulputate,
+      ac posuere velit semper.
+    </p>
+    <p>
+      Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+      Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+      ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+      et lectus. Sed tempus eget enim eget lobortis.
+      Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+      Nullam in libero nisi.
+    </p>
+    <p>
+      Sed pharetra semper fringilla. Nulla fringilla, neque eget
+      varius suscipit, mi turpis congue odio, quis dignissim nisi
+      nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+      vel velit. Donec congue augue magna, nec eleifend dui porttitor
+      sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+      Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+      ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+      lorem ultrices nibh, in tristique mauris justo sed ante.
+      Nunc commodo purus feugiat metus bibendum consequat. Duis
+      finibus urna ut ligula auctor, sed vehicula ex aliquam.
+      Sed sed augue auctor, porta turpis ultrices, cursus diam.
+      In venenatis aliquet porta. Sed volutpat fermentum quam,
+      ac molestie nulla porttitor ac. Donec porta risus ut enim
+      pellentesque, id placerat elit ornare.
+    </p>
+  </article>
+</body>
+</html>

--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.css
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.css
@@ -20,6 +20,8 @@ amp-nested-menu [amp-nested-submenu] {
   top: 0 !important;
   width: 100% !important;
   height: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
   transform: translateX(0) !important;
 }
 
@@ -30,6 +32,11 @@ amp-nested-menu.i-amphtml-layout-size-defined {
 amp-nested-menu ul, amp-nested-menu ol {
   list-style-type: none;
   padding: 0;
+}
+
+amp-nested-menu [amp-nested-submenu-open],
+amp-nested-menu [amp-nested-submenu-close] {
+  cursor: pointer;
 }
 
 amp-nested-menu [amp-nested-submenu] {

--- a/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html
+++ b/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests support for the amp-nested-menu tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+</head>
+<body>
+  <!-- Invalid: nested menu must be inside sidebar -->
+  <amp-nested-menu layout="fill"></amp-nested-menu>
+  <amp-sidebar layout="nodisplay">
+    <!-- Invalid: incorrect side value -->
+    <amp-nested-menu layout="fill" side="center">
+      <!-- Invalid: no element can include more than one submenu attributes -->
+      <div>
+        <h4 amp-nested-submenu-open amp-nested-submenu-close></h4>
+        <div amp-nested-submenu amp-nested-submenu-close></div>
+        <div amp-nested-submenu amp-nested-submenu-open></div>
+      </div>
+      <!-- Invalid: only divs may include the amp-nested-submenu attribute -->
+      <div>
+        <span amp-nested-submenu></span>
+        <button amp-nested-submenu></button>
+      </div>
+      <!-- Invalid: only buttons, divs, spans and h2-h6 may have submenu open/close attribute -->
+      <div>
+        <a amp-nested-submenu-open></a>
+        <h1 amp-nested-submenu-close></h1>
+      </div>
+      <!-- Invalid: submenus cannot be inside an amp-accordion -->
+      <amp-accordion>
+        <section>
+          <h4>accordion header</h4>
+          <div>
+            <h4 amp-nested-submenu-open></h4>
+            <div amp-nested-submenu></div>
+          </div>
+        </section>
+      </amp-accordion>
+    </amp-nested-menu>
+  </amp-sidebar>
+</body>
+</html>

--- a/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.out
+++ b/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.out
@@ -1,0 +1,87 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-nested-menu tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|    <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: nested menu must be inside sidebar -->
+|    <amp-nested-menu layout="fill"></amp-nested-menu>
+>>   ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:33:2 The tag 'amp-nested-menu' may only appear as a descendant of tag 'amp-sidebar'. (see https://amp.dev/documentation/components/amp-nested-menu)
+|    <amp-sidebar layout="nodisplay">
+|      <!-- Invalid: incorrect side value -->
+|      <amp-nested-menu layout="fill" side="center">
+>>     ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:36:4 The attribute 'side' in tag 'amp-nested-menu' is set to the invalid value 'center'. (see https://amp.dev/documentation/components/amp-nested-menu)
+|        <!-- Invalid: no element can include more than one submenu attributes -->
+|        <div>
+|          <h4 amp-nested-submenu-open amp-nested-submenu-close></h4>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:39:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU H4' - pick one of ['amp-nested-submenu-close', 'amp-nested-submenu-open'].
+|          <div amp-nested-submenu amp-nested-submenu-close></div>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:40:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU DIV' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
+|          <div amp-nested-submenu amp-nested-submenu-open></div>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:41:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU DIV' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
+|        </div>
+|        <!-- Invalid: only divs may include the amp-nested-submenu attribute -->
+|        <div>
+|          <span amp-nested-submenu></span>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:45:8 The attribute 'amp-nested-submenu' may not appear in tag 'span'.
+|          <button amp-nested-submenu></button>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:46:8 The attribute 'amp-nested-submenu' may not appear in tag 'button'.
+|        </div>
+|        <!-- Invalid: only buttons, divs, spans and h2-h6 may have submenu open/close attribute -->
+|        <div>
+|          <a amp-nested-submenu-open></a>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:50:8 The attribute 'amp-nested-submenu-open' may not appear in tag 'a'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#links)
+|          <h1 amp-nested-submenu-close></h1>
+>>         ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:51:8 The attribute 'amp-nested-submenu-close' may not appear in tag 'h1'.
+|        </div>
+|        <!-- Invalid: submenus cannot be inside an amp-accordion -->
+|        <amp-accordion>
+|          <section>
+|            <h4>accordion header</h4>
+|            <div>
+|              <h4 amp-nested-submenu-open></h4>
+|              <div amp-nested-submenu></div>
+>>             ^~~~~~~~~
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:59:12 The attribute 'amp-nested-submenu' may not appear in tag 'div'.
+|            </div>
+|          </section>
+|        </amp-accordion>
+|      </amp-nested-menu>
+|    </amp-sidebar>
+|  </body>
+|  </html>

--- a/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.out
+++ b/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu-error.out
@@ -43,13 +43,13 @@ amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:36:4 The attribute
 |        <div>
 |          <h4 amp-nested-submenu-open amp-nested-submenu-close></h4>
 >>         ^~~~~~~~~
-amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:39:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU H4' - pick one of ['amp-nested-submenu-close', 'amp-nested-submenu-open'].
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:39:8 Mutually exclusive attributes encountered in tag 'h4 amp-nested-menu' - pick one of ['amp-nested-submenu-close', 'amp-nested-submenu-open'].
 |          <div amp-nested-submenu amp-nested-submenu-close></div>
 >>         ^~~~~~~~~
-amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:40:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU DIV' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:40:8 Mutually exclusive attributes encountered in tag 'div amp-nested-menu' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
 |          <div amp-nested-submenu amp-nested-submenu-open></div>
 >>         ^~~~~~~~~
-amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:41:8 Mutually exclusive attributes encountered in tag 'AMP-NESTED-MENU DIV' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
+amp-nested-menu/0.1/test/validator-amp-nested-menu-error.html:41:8 Mutually exclusive attributes encountered in tag 'div amp-nested-menu' - pick one of ['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open'].
 |        </div>
 |        <!-- Invalid: only divs may include the amp-nested-submenu attribute -->
 |        <div>

--- a/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu.html
+++ b/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu.html
@@ -1,0 +1,116 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests support for the amp-nested-menu tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+</head>
+<body>
+  <!-- Valid: Example of amp-nested-menu with all allowed submenu tags -->
+  <amp-sidebar layout="nodisplay">
+    <amp-nested-menu layout="fill" side="left">
+      <ul>
+        <li>
+          <div amp-nested-submenu-open>open submenu 1</div>
+          <div amp-nested-submenu>
+            <div amp-nested-submenu-close>close submenu 1</div>
+            <amp-img layout="fill" src="img"></amp-img>
+          </div>
+        </li>
+        <li>
+          <h2 amp-nested-submenu-open>open submenu 2</h2>
+          <div amp-nested-submenu>
+            <h2 amp-nested-submenu-close>close submenu 2</h2>
+            <amp-accordion></amp-accordion>
+          </div>
+        </li>
+        <li>
+          <h3 amp-nested-submenu-open>open submenu 3</h3>
+          <div amp-nested-submenu>
+            <h3 amp-nested-submenu-close>close submenu 3</h3>
+            <amp-list layout="fill" src="list"></amp-list>
+          </div>
+        </li>
+        <li>
+          <h4 amp-nested-submenu-open>open submenu 4</h4>
+          <div amp-nested-submenu>
+            <h4 amp-nested-submenu-close>close submenu 4</h4>
+            <h4></h4>
+          </div>
+        </li>
+        <li>
+          <h5 amp-nested-submenu-open>open submenu 5</h5>
+          <div amp-nested-submenu>
+            <h5 amp-nested-submenu-close>close submenu 5</h5>
+            <h5></h5>
+          </div>
+        </li>
+        <li>
+          <h6 amp-nested-submenu-open>open submenu 6</h6>
+          <div amp-nested-submenu>
+            <h6 amp-nested-submenu-close>close submenu 6</h6>
+            <h6></h6>
+          </div>
+        </li>
+        <li>
+          <button amp-nested-submenu-open>open submenu 7</button>
+          <div amp-nested-submenu>
+            <button amp-nested-submenu-close>close submenu 7</button>
+            <button></button>
+          </div>
+        </li>
+        <li>
+          <span amp-nested-submenu-open>open submenu 8</span>
+          <div amp-nested-submenu>
+            <span amp-nested-submenu-close>close submenu 8</span>
+            <span></span>
+          </div>
+        </li>
+      </ul>
+    </amp-nested-menu>
+  </amp-sidebar>
+  <!-- Valid: Example of amp-nested-menu with dynamic template rendering -->
+  <amp-sidebar layout="nodisplay">
+    <amp-list layout="fill" src="list" single-item>
+      <template type="amp-mustache">
+        <amp-nested-menu layout="fill">
+          {{#items}}
+          <div>
+            <h4 amp-nested-submenu-open>{{name}}</h4>
+            <div amp-nested-submenu>
+              <button amp-nested-submenu-close>back</button>
+              <a href="{{link}}">link</a>
+            </div>
+          </div>
+          {{/items}}
+        </amp-nested-menu>
+      </template>
+    </amp-list>
+  </amp-sidebar>
+</body>
+</html>

--- a/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu.out
+++ b/extensions/amp-nested-menu/0.1/test/validator-amp-nested-menu.out
@@ -1,0 +1,117 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-nested-menu tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|    <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+|    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-nested-menu with all allowed submenu tags -->
+|    <amp-sidebar layout="nodisplay">
+|      <amp-nested-menu layout="fill" side="left">
+|        <ul>
+|          <li>
+|            <div amp-nested-submenu-open>open submenu 1</div>
+|            <div amp-nested-submenu>
+|              <div amp-nested-submenu-close>close submenu 1</div>
+|              <amp-img layout="fill" src="img"></amp-img>
+|            </div>
+|          </li>
+|          <li>
+|            <h2 amp-nested-submenu-open>open submenu 2</h2>
+|            <div amp-nested-submenu>
+|              <h2 amp-nested-submenu-close>close submenu 2</h2>
+|              <amp-accordion></amp-accordion>
+|            </div>
+|          </li>
+|          <li>
+|            <h3 amp-nested-submenu-open>open submenu 3</h3>
+|            <div amp-nested-submenu>
+|              <h3 amp-nested-submenu-close>close submenu 3</h3>
+|              <amp-list layout="fill" src="list"></amp-list>
+|            </div>
+|          </li>
+|          <li>
+|            <h4 amp-nested-submenu-open>open submenu 4</h4>
+|            <div amp-nested-submenu>
+|              <h4 amp-nested-submenu-close>close submenu 4</h4>
+|              <h4></h4>
+|            </div>
+|          </li>
+|          <li>
+|            <h5 amp-nested-submenu-open>open submenu 5</h5>
+|            <div amp-nested-submenu>
+|              <h5 amp-nested-submenu-close>close submenu 5</h5>
+|              <h5></h5>
+|            </div>
+|          </li>
+|          <li>
+|            <h6 amp-nested-submenu-open>open submenu 6</h6>
+|            <div amp-nested-submenu>
+|              <h6 amp-nested-submenu-close>close submenu 6</h6>
+|              <h6></h6>
+|            </div>
+|          </li>
+|          <li>
+|            <button amp-nested-submenu-open>open submenu 7</button>
+|            <div amp-nested-submenu>
+|              <button amp-nested-submenu-close>close submenu 7</button>
+|              <button></button>
+|            </div>
+|          </li>
+|          <li>
+|            <span amp-nested-submenu-open>open submenu 8</span>
+|            <div amp-nested-submenu>
+|              <span amp-nested-submenu-close>close submenu 8</span>
+|              <span></span>
+|            </div>
+|          </li>
+|        </ul>
+|      </amp-nested-menu>
+|    </amp-sidebar>
+|    <!-- Valid: Example of amp-nested-menu with dynamic template rendering -->
+|    <amp-sidebar layout="nodisplay">
+|      <amp-list layout="fill" src="list" single-item>
+|        <template type="amp-mustache">
+|          <amp-nested-menu layout="fill">
+|            {{#items}}
+|            <div>
+|              <h4 amp-nested-submenu-open>{{name}}</h4>
+|              <div amp-nested-submenu>
+|                <button amp-nested-submenu-close>back</button>
+|                <a href="{{link}}">link</a>
+|              </div>
+|            </div>
+|            {{/items}}
+|          </amp-nested-menu>
+|        </template>
+|      </amp-list>
+|    </amp-sidebar>
+|  </body>
+|  </html>

--- a/extensions/amp-nested-menu/amp-nested-menu.md
+++ b/extensions/amp-nested-menu/amp-nested-menu.md
@@ -44,23 +44,23 @@ Drilldown menu component with items that open nested submenus on tap.
 
 ## Overview
 
-`<amp-nested-menu>` provides a way to organize and display multiple levels of menu content inside an [`<amp-sidebar>`](../amp-sidebar/0.1/amp-sidebar.md). The component can be used jointly with [`<amp-mega-menu>`](../amp-mega-menu/amp-mega-menu.md) to create a responsive menu.
+`<amp-nested-menu>` enables layered content organization within [`<amp-sidebar>`](../amp-sidebar/0.1/amp-sidebar.md). A sidebar with `<amp-nested-menu>` can be used jointly with [`<amp-mega-menu>`](../amp-mega-menu/amp-mega-menu.md) to create a responsive menu.
 
 ## Usage
 
 The `<amp-nested-menu>` component must be placed inside `<amp-sidebar>`. The component may contain the following AMP elements:
 
-- `<amp-img>`
-- `<amp-list>`
-- `<amp-accordion>`
+- [`<amp-img>`](../../builtins/amp-img.md)
+- [`<amp-list>`](../amp-list/amp-list.md)
+- [`<amp-accordion>`](../amp-accordion/amp-accordion.md)
 
 ### Nested submenus
 
 `<amp-nested-menu>` supports nesting one or more layers of submenus. It uses the following attributes on its descendants as identifiers for the submenu functionality:
 
-- `amp-nested-submenu`: this identifies a submenu container. The element is initially out of view but, when opened, slides in and takes the place of the parent menu (either `<amp-nested-menu>` or another submenu).
+- `amp-nested-submenu`: this identifies a hidden submenu container. When opened, the element slides in and takes the place of its parent menu (either `<amp-nested-menu>` or another submenu).
 - `amp-nested-submenu-open`: this identifies an element that opens a submenu on tap. It must be a sibling of the said submenu.
-- `amp-nested-submenu-close`: this identifies an element that finds the closest containing submenu and closes it on tap. The element must be the descendant of a submenu.
+- `amp-nested-submenu-close`: this identifies an element that closes the closest containing submenu. The element must be the descendant of a submenu.
 
 Only `<div>` tags may receive the `amp-nested-submenu` attribute. The submenu open/close attributes can be applied to any of the tags below:
 

--- a/extensions/amp-nested-menu/amp-nested-menu.md
+++ b/extensions/amp-nested-menu/amp-nested-menu.md
@@ -1,0 +1,217 @@
+---
+$category@: layout
+formats:
+  - websites
+teaser:
+  text: Displays a drilldown menu with arbitrary levels of nested submenus.
+experimental: true
+---
+
+<!--
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# `amp-nested-menu`
+
+Drilldown menu component with items that open nested submenus on tap.
+
+<table>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td><div><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a>; activated by the <code>amp-nested-menu</code> experiment.</div></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><div>None (<code>amp-sidebar</code> lazy loads the component)</div></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
+    <td>fill</td>
+  </tr>
+</table>
+
+## Overview
+
+`<amp-nested-menu>` provides a way to organize and display multiple levels of menu content inside an [`<amp-sidebar>`](../amp-sidebar/0.1/amp-sidebar.md). The component can be used jointly with [`<amp-mega-menu>`](../amp-mega-menu/amp-mega-menu.md) to create a responsive menu.
+
+## Usage
+
+The `<amp-nested-menu>` component must be placed inside `<amp-sidebar>`. The component may contain the following AMP elements:
+
+- `<amp-img>`
+- `<amp-list>`
+- `<amp-accordion>`
+
+### Nested submenus
+
+`<amp-nested-menu>` supports nesting one or more layers of submenus. It uses the following attributes on its descendants as identifiers for the submenu functionality:
+
+- `amp-nested-submenu`: this identifies a submenu container. The element is initially out of view but, when opened, slides in and takes the place of the parent menu (either `<amp-nested-menu>` or another submenu).
+- `amp-nested-submenu-open`: this identifies an element that opens a submenu on tap. It must be a sibling of the said submenu.
+- `amp-nested-submenu-close`: this identifies an element that finds the closest containing submenu and closes it on tap. The element must be the descendant of a submenu.
+
+Only `<div>` tags may receive the `amp-nested-submenu` attribute. The submenu open/close attributes can be applied to any of the tags below:
+
+- `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`
+- `<button>`
+- `<span>`
+- `<div>`
+
+The following example demonstrates an `<amp-nested-menu>` with two levels of nested submenus.
+
+[tip type="note"]
+We recommend wrapping every menu item in a `li` element to improve accessibility and keyboard support.
+[/tip]
+
+[example playground="true" preview="top-frame" imports="amp-sidebar"]
+
+```html
+<button on="tap:sidebar1">Open Sidebar</button>
+<amp-sidebar id="sidebar1" layout="nodisplay" style="width:300px">
+  <amp-nested-menu layout="fill">
+    <ul>
+      <li>
+        <h4 amp-nested-submenu-open>Open Sub-Menu</h4>
+        <div amp-nested-submenu>
+          <ul>
+            <li>
+              <h4 amp-nested-submenu-close>go back</h4>
+            </li>
+            <li>
+              <h4 amp-nested-submenu-open>Open Another Sub-Menu</h4>
+              <div amp-nested-submenu>
+                <h4 amp-nested-submenu-close>go back</h4>
+                <amp-img
+                  src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+                  layout="responsive"
+                  width="450"
+                  height="300"
+                ></amp-img>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <a href="https://amp.dev/">Link</a>
+      </li>
+    </ul>
+  </amp-nested-menu>
+</amp-sidebar>
+```
+
+[/example]
+
+### Dynamic content rendering
+
+Fetch content of `<amp-nested-menu>` dynamically from a JSON endpoint using [`<amp-list>`](../amp-list/amp-list.md) and [`amp-mustache`](../amp-mustache/amp-mustache.md) template.
+
+The example below demonstrates this ability by nesting `<amp-nested-menu>` inside `<amp-list>`.
+
+[example playground="true" preview="top-frame" imports="amp-sidebar,amp-list" template="amp-mustache"]
+
+```html
+<button on="tap:sidebar2">Open Sidebar</button>
+<amp-sidebar id="sidebar2" layout="nodisplay" style="width:300px">
+  <amp-list
+    layout="fill"
+    src="{{server_for_email}}/static/inline-examples/data/amp-list-data.json"
+    items="."
+    single-item
+  >
+    <template type="amp-mustache">
+      <amp-nested-menu layout="fill">
+        <ul>
+          {{#items}}
+          <li>
+            <h3 amp-nested-submenu-open>{{title}}</h3>
+            <div amp-nested-submenu>
+              <button amp-nested-submenu-close>close</button>
+              <amp-img
+                src="{{imageUrl}}"
+                layout="responsive"
+                width="400"
+                height="300"
+              ></amp-img>
+            </div>
+          </li>
+          {{/items}}
+        </ul>
+      </nav>
+    </template>
+  </amp-list>
+</amp-sidebar>
+```
+
+[/example]
+
+Here is the JSON file used:
+
+```json
+{
+  "items": [
+    {
+      "title": "Image 01",
+      "imageUrl": "https://preview.amp.dev/static/inline-examples/images/flowers.jpg"
+    },
+    {
+      "title": "Image 02",
+      "imageUrl": "https://preview.amp.dev/static/inline-examples/images/sunset.jpg"
+    }
+  ]
+}
+```
+
+## Attributes
+
+<table>
+  <tr>
+    <td width="40%"><strong>side (optional)</strong></td>
+    <td>Optional attribute that indicates from which side the submenus open from, either `left` or `right`. Set to `right` by default, or `left` if the document is RTL.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>common attributes</strong></td>
+    <td>This element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.</td>
+  </tr>
+</table>
+
+## Actions
+
+<table>
+  <tr>
+    <td width="40%"><strong><code>reset</code></strong></td>
+    <td>Closes any open submenus and returns to the root menu. Use this in conjunction with sidebar's <code>sidebarClose</code> event to reset the menu after sidebar is closed.</td>
+  </tr>
+</table>
+
+## Styling
+
+The `<amp-nested-menu>` component can be styled with standard CSS.
+
+## Accessibility
+
+`<amp-nested-menu>` assigns `role=button` and `tabindex=0` on each submenu open/close element. When a submenu opens, focus shifts to the submenu close element inside it. When the submenu closes, focus shifts back to the submenu open element that opened it.
+
+The component supports arrow key navigation as follows:
+
+- `LEFT`: if a submenu is open, close it and return to the parent menu.
+- `RIGHT`: if a submenu open element has focus, open the corresponding submenu.
+- `UP/DOWN`: shift focus between items within a menu (this works only if all menu items are wrapped inside `li` elements under the same list).
+
+If `side=left`, then the functionalities of `LEFT` and `RIGHT` arrow keys are reversed.
+
+## Validation
+
+See [amp-nested-menu rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii) in the AMP validator specification.

--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -45,7 +45,7 @@ tags: {  # amp-nested-menu
 tags: {  # <amp-nested-menu> <div amp-nested-submenu(-open/-close)>
   html_format: AMP
   tag_name: "DIV"
-  spec_name: "AMP-NESTED-MENU DIV"
+  spec_name: "div amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   # submenus inside accordion do not display correctly due to styling of <amp-accordion>.
   disallowed_ancestor: "AMP-ACCORDION"
@@ -77,49 +77,49 @@ attr_lists {
 tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "BUTTON"
-  spec_name: "AMP-NESTED-MENU BUTTON"
+  spec_name: "button amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h2 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H2"
-  spec_name: "AMP-NESTED-MENU H2"
+  spec_name: "h2 amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h3 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H3"
-  spec_name: "AMP-NESTED-MENU H3"
+  spec_name: "h3 amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h4 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H4"
-  spec_name: "AMP-NESTED-MENU H4"
+  spec_name: "h4 amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h5 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H5"
-  spec_name: "AMP-NESTED-MENU H5"
+  spec_name: "h5 amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h6 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H6"
-  spec_name: "AMP-NESTED-MENU H6"
+  spec_name: "h6 amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <span amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "SPAN"
-  spec_name: "AMP-NESTED-MENU SPAN"
+  spec_name: "span amp-nested-menu"
   mandatory_ancestor: "AMP-NESTED-MENU"
   attr_lists: "amp-nested-menu-actions"
 }

--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -20,7 +20,6 @@ tags: {  # amp-nested-menu
     name: "amp-nested-menu"
     version: "0.1"
     version: "latest"
-    requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"
 }

--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -62,11 +62,9 @@ tags: {  # <amp-nested-menu> <div amp-nested-submenu(-open/-close)>
     mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
   }
 }
-tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
-  html_format: AMP
-  tag_name: "BUTTON"
-  spec_name: "AMP-NESTED-MENU BUTTON"
-  mandatory_ancestor: "AMP-NESTED-MENU"
+
+attr_lists {
+  name: "amp-nested-menu-actions"
   attrs: {
     name: "amp-nested-submenu-close"
     mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
@@ -75,90 +73,55 @@ tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
     name: "amp-nested-submenu-open"
     mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
   }
+}
+tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "BUTTON"
+  spec_name: "AMP-NESTED-MENU BUTTON"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h2 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H2"
   spec_name: "AMP-NESTED-MENU H2"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h3 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H3"
   spec_name: "AMP-NESTED-MENU H3"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h4 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H4"
   spec_name: "AMP-NESTED-MENU H4"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h5 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H5"
   spec_name: "AMP-NESTED-MENU H5"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <h6 amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "H6"
   spec_name: "AMP-NESTED-MENU H6"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 tags: {  # <amp-nested-menu> <span amp-nested-submenu-open/close>
   html_format: AMP
   tag_name: "SPAN"
   spec_name: "AMP-NESTED-MENU SPAN"
   mandatory_ancestor: "AMP-NESTED-MENU"
-  attrs: {
-    name: "amp-nested-submenu-close"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
-  attrs: {
-    name: "amp-nested-submenu-open"
-    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
-  }
+  attr_lists: "amp-nested-menu-actions"
 }
 descendant_tag_list {
   # Purposefully being restrictive when whitelisting child components;

--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -1,0 +1,211 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+tags: {  # amp-nested-menu
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-nested-menu"
+    version: "0.1"
+    version: "latest"
+    requires_usage: NONE
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-nested-menu
+  html_format: AMP
+  tag_name: "AMP-NESTED-MENU"
+  # nested menu can be lazy loaded by sidebar.
+  requires_extension: "amp-sidebar"
+  mandatory_ancestor: "AMP-SIDEBAR"
+  attrs: {
+    name: "side"
+    value: "left"
+    value: "right"
+  }
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+  }
+  descendant_tag_list: "amp-nested-menu-allowed-descendants"
+  spec_url: "https://amp.dev/documentation/components/amp-nested-menu"
+}
+tags: {  # <amp-nested-menu> <div amp-nested-submenu(-open/-close)>
+  html_format: AMP
+  tag_name: "DIV"
+  spec_name: "AMP-NESTED-MENU DIV"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  # submenus inside accordion do not display correctly due to styling of <amp-accordion>.
+  disallowed_ancestor: "AMP-ACCORDION"
+  attrs: {
+    name: "amp-nested-submenu"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "BUTTON"
+  spec_name: "AMP-NESTED-MENU BUTTON"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <h2 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H2"
+  spec_name: "AMP-NESTED-MENU H2"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <h3 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H3"
+  spec_name: "AMP-NESTED-MENU H3"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <h4 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H4"
+  spec_name: "AMP-NESTED-MENU H4"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <h5 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H5"
+  spec_name: "AMP-NESTED-MENU H5"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <h6 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H6"
+  spec_name: "AMP-NESTED-MENU H6"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <span amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "SPAN"
+  spec_name: "AMP-NESTED-MENU SPAN"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+descendant_tag_list {
+  # Purposefully being restrictive when whitelisting child components;
+  # On demand, add more components to this list after manual testing.
+  name: "amp-nested-menu-allowed-descendants"
+  tag: "A"
+  tag: "AMP-ACCORDION"
+  tag: "AMP-IMG"
+  tag: "AMP-LIST"
+  tag: "B"
+  tag: "BR"
+  tag: "BUTTON"
+  tag: "COL"
+  tag: "COLGROUP"
+  tag: "DIV"
+  tag: "EM"
+  tag: "FIELDSET"
+  tag: "FORM"
+  tag: "H1"
+  tag: "H2"
+  tag: "H3"
+  tag: "H4"
+  tag: "H5"
+  tag: "H6"
+  tag: "I"
+  tag: "INPUT"
+  tag: "LABEL"
+  tag: "LI"
+  tag: "MARK"
+  tag: "NAV"
+  tag: "OL"
+  tag: "OPTION"
+  tag: "P"
+  tag: "SECTION"
+  tag: "SPAN"
+  tag: "STRIKE"
+  tag: "STRONG"
+  tag: "SUB"
+  tag: "SUP"
+  tag: "TABLE"
+  tag: "TBODY"
+  tag: "TD"
+  tag: "TEMPLATE"
+  tag: "TH"
+  tag: "TIME"
+  tag: "TITLE"
+  tag: "TR"
+  tag: "U"
+  tag: "UL"
+}


### PR DESCRIPTION
I2I: #25049 

Add validation and test files for the `<amp-nested-menu>` extension.

The following items are enforced via validation:
- Nested menu must be inside `<amp-sidebar>`.
- Support only `layout=fill`.
- Whitelist the components below inside mega menu:
  - `<amp-list>`
  - `<amp-accordion>`
  - `<amp-img>`
- Each element inside the component may have at most one of the following attributes:
  - `amp-nested-submenu`: can be applied to `div`'s only, and cannot be the descendant of `<amp-accordion>`
  - `amp-nested-submenu-open`: can be applied to `div`, `span`, `button` or heading tags
  - `amp-nested-submenu-close`: same as above

/cc @nainar we decided to not support ads for now since [according to documentation](https://amp.dev/documentation/components/amp-sidebar/#behavior) it's not among the allowed components inside sidebar.

Demo: https://amp-sidebar-nested.firebaseapp.com/