### PR TITLE
🐛 Change to using setTimeout to avoid muted unhandledrejections

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -106,7 +106,8 @@ function isPatched(win) {
  * @param {!Error} error
  */
 function rethrowAsync(error) {
-  new /*OK*/ Promise(() => {
+  setTimeout(() => {
+    self.__AMP_REPORT_ERROR(error);
     throw error;
   });
 }


### PR DESCRIPTION
It also directly calls into the globally installed error reporting function.

Re: https://github.com/ampproject/amphtml/pull/25289

It seems HTML spec is unlikely to change: https://github.com/whatwg/html/issues/5051