### PR TITLE
📖Cleanup scary red text in analytics docs

### DIFF
--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -131,7 +131,7 @@ In the `<amp-analytics>` element, you specify a JSON configuration object that c
 
 The configuration object for `<amp-analytics>` uses the following format:
 
-```json
+```javascript
 {
   "requests": {
     "request-name": request-value,

--- a/extensions/amp-analytics/linker-id-forwarding.md
+++ b/extensions/amp-analytics/linker-id-forwarding.md
@@ -8,7 +8,7 @@ This document outlines the configuration options that will determine in which co
 
 #### Format
 
-```json
+```javascript
 "linkers": {
   "<paramName>": {
     "ids": <Object>,
@@ -102,7 +102,7 @@ Some items in the configuration objects have default values. However, you may ov
 
 Example:
 
-```json
+```javascript
 "linkers": {
   "enabled": true, // This enables all child linkers contained in this object.
   "proxyOnly" : false,


### PR DESCRIPTION
Matt introduced some unfriendly documentation changes in PR #25071 by
denoting some fields as JSON that are not real JSON. Viewing the
markdown makes these fields stand out more than they should. Revert
non-JSON fields to javascript linguist hint for the sake of readability.