### PR TITLE
Catch XHR errors in SSR response in amp-list.

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -618,7 +618,22 @@ export class AmpList extends AMP.BaseElement {
       .then(
         response => {
           userAssert(
-            response && typeof response['html'] === 'string',
+            response,
+            'Error proxying amp-list templates, received no response.'
+          );
+          const init = response['init'];
+          if (init) {
+            const status = init['status'];
+            if (status >= 300) {
+              /** HTTP status codes of 300+ mean redirects and errors. */
+              throw user().createError(
+                'Error proxying amp-list templates with status: ',
+                status
+              );
+            }
+          }
+          userAssert(
+            typeof response['html'] === 'string',
             'Expected response with format {html: <string>}. Received: ',
             response
           );

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -707,7 +707,7 @@ describes.repeated(
             });
 
             it('should error if proxied fetch returns invalid data', () => {
-              expectAsyncConsoleError(/Expected response with format/, 1);
+              expectAsyncConsoleError(/received no response/, 1);
               sandbox
                 .stub(ssrTemplateHelper, 'ssr')
                 .returns(Promise.resolve(undefined));
@@ -717,7 +717,23 @@ describes.repeated(
                 .once();
               return expect(
                 list.layoutCallback()
-              ).to.eventually.be.rejectedWith(/Expected response with format/);
+              ).to.eventually.be.rejectedWith(/received no response/);
+            });
+
+            it('should error if proxied fetch returns non-2xx status (error) in the response', () => {
+              expectAsyncConsoleError(/received no response/, 1);
+              sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.resolve({init: {status: 400}}));
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+              return expect(
+                list.layoutCallback()
+              ).to.eventually.be.rejectedWith(
+                /Error proxying amp-list templates with status/
+              );
             });
 
             it('should delegate template rendering to viewer', function*() {


### PR DESCRIPTION
`amp-list` XHR failure currently results in a confusing SSR failure--the error is passed back and read as a response, leading to [an error](https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/0.1/amp-list.js#L620-L624) downstream in the promise chain.

This change adds an explicit check for `response['init']['status']` of non-2xx to reject and render the fallback, as well as adds to the test cases regarding handling SSR response. b/135069789