### PR TITLE
[DO NOT MERGE] Prototype push animation for sidebar v0.2

### DIFF
--- a/examples/playground.amp.html
+++ b/examples/playground.amp.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    button {
+      padding: 10px;
+      margin: 10px;
+      font-size: 1em;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.2.js"></script>
+  <script>
+    (self.AMP=self.AMP||[]).push(function(AMP){
+      AMP.toggleExperiment('amp-sidebar-v2', true);
+    });
+  </script>
+</head>
+<body>
+  <amp-sidebar
+    id="sidebar1"
+    layout="nodisplay"
+    side="left"
+    width="150"
+    push-target="main"
+  >
+    <ul>
+      <li><a href="#section1">Section 1</li>
+      <li><a href="#section2">Section 2</a></li>
+    </ul>
+  </amp-sidebar>
+  <amp-sidebar
+    id="sidebar2"
+    layout="nodisplay"
+    side="right"
+    width="150"
+    push-target="main"
+  >
+    <ul>
+      <li><a href="#section1">Section 1</li>
+      <li><a href="#section2">Section 2</a></li>
+    </ul>
+  </amp-sidebar>
+  <amp-sidebar
+    id="sidebar3"
+    layout="nodisplay"
+    side="left"
+    width="150"
+  >
+    <ul>
+      <li><a href="#section1">Section 1</li>
+      <li><a href="#section2">Section 2</a></li>
+    </ul>
+  </amp-sidebar>
+  <amp-sidebar
+    id="sidebar4"
+    layout="nodisplay"
+    side="right"
+    width="150"
+  >
+    <ul>
+      <li><a href="#section1">Section 1</li>
+      <li><a href="#section2">Section 2</a></li>
+    </ul>
+  </amp-sidebar>
+  <main>
+    <h1>Sidebar Open Animation</h1>
+    <h3>Overlay</h3>
+    <button on="tap:sidebar3.toggle">open left sidebar</button>
+    <button on="tap:sidebar4.toggle">open right sidebar</button>
+    <h3>Push</h3>
+    <button on="tap:sidebar1.toggle">open left sidebar</button>
+    <button on="tap:sidebar2.toggle">open right sidebar</button>
+  
+    <article>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+        luctus nunc ut elit cursus, et imperdiet diam vehicula.
+        Duis et nisi sed urna blandit bibendum et sit amet erat.
+        Suspendisse potenti. Curabitur consequat volutpat arcu nec
+        elementum. Etiam a turpis ac libero varius condimentum.
+        Maecenas sollicitudin felis aliquam tortor vulputate,
+        ac posuere velit semper.
+      </p>
+      <p>
+        Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+        Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+        ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+        et lectus. Sed tempus eget enim eget lobortis.
+        Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+        Nullam in libero nisi.
+      </p>
+    </article>
+  </main>
+</body>
+</html>

--- a/extensions/amp-sidebar/0.2/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.css
@@ -20,6 +20,7 @@ amp-sidebar {
   top: 0;
   max-height: 100vh !important;
   height: 100vh;
+  width: var(--sidebar-width);
   max-width: 80vw;
   background-color: #efefef;
   min-width: 45px !important;
@@ -36,8 +37,8 @@ amp-sidebar[side="left"] {
   transform: translateX(-100%);
   animation-name: i-amphtml-sidebar-slide-out-left;
 }
-
 amp-sidebar[side="left"][open] {
+  transform: translateX(0);
   animation-name: i-amphtml-sidebar-slide-in-left;
 }
 
@@ -48,15 +49,39 @@ amp-sidebar[side="right"] {
 }
 
 amp-sidebar[side="right"][open] {
+  transform: translateX(0);
   animation-name: i-amphtml-sidebar-slide-in-right;
 }
 
 amp-sidebar[side][i-amphtml-sidebar-opened] {
   transform: none;
+  transition: none;
   animation: none;
 }
 
-amp-sidebar[side], .i-amphtml-sidebar-mask {
+.i-amphtml-sidebar-push-target[side="left"] {
+}
+
+.i-amphtml-sidebar-push-target[side="left"][open] {
+  transform: translateX(var(--sidebar-width));
+}
+
+.i-amphtml-sidebar-push-target[side="right"] {
+}
+
+.i-amphtml-sidebar-push-target[side="right"][open] {
+  transform: translateX(calc(-1 * var(--sidebar-width)));
+}
+
+.i-amphtml-sidebar-push-target[side][i-amphtml-sidebar-opened] {
+  transition: none;
+}
+.i-amphtml-sidebar-push-target[side][i-amphtml-sidebar-closed] {
+  transform: none;
+  transition: none;
+}
+
+amp-sidebar[side], .i-amphtml-sidebar-push-target, .i-amphtml-sidebar-mask {
   /*
    * Note: This uses animations (instead of transitions) to make sure the
    * animation always plays correctly. Previously, the display was toggled in a
@@ -65,6 +90,7 @@ amp-sidebar[side], .i-amphtml-sidebar-mask {
    * from working correctly.
    */
   /* Use same transition as PWA App-Shell https://goo.gl/AGFioO */
+  transition: transform 233ms ease, opacity 233ms;
   animation-duration: 233ms;
   animation-timing-function: cubic-bezier(0,0,.21,1);
   animation-fill-mode: forwards;
@@ -80,12 +106,13 @@ amp-sidebar[side], .i-amphtml-sidebar-mask {
   margin: 0;
 }
 
-.i-amphtml-sidebar-mask {
+.i-amphtml-sidebar-mask, .i-amphtml-sidebar-mask-nodisplay {
   position: fixed !important;
   top: 0 !important;
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
+  opacity: 0;
   /* Prevent someone from making this a full-sceen image */
   background-image: none !important;
   background-color: rgba(0, 0, 0, 0.5);
@@ -93,12 +120,16 @@ amp-sidebar[side], .i-amphtml-sidebar-mask {
   z-index: 2147483646;
 }
 
+.i-amphtml-sidebar-mask-nodisplay {
+  opacity: 0.001 !important;
+}
+
 .i-amphtml-sidebar-mask[open] {
-  animation-name: i-amphtml-sidebar-mask-fade-in;
+  opacity: 1;
 }
 
 .i-amphtml-sidebar-mask[i-amphtml-sidebar-opened] {
-  animation: none;
+  transition: none;
 }
 
 @keyframes i-amphtml-sidebar-slide-in-left {
@@ -138,25 +169,5 @@ amp-sidebar[side], .i-amphtml-sidebar-mask {
 
   to {
     transform: translateX(100%);
-  }
-}
-
-@keyframes i-amphtml-sidebar-mask-fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes i-amphtml-sidebar-mask-fade-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
   }
 }

--- a/extensions/amp-sidebar/0.2/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.css
@@ -59,14 +59,8 @@ amp-sidebar[side][i-amphtml-sidebar-opened] {
   animation: none;
 }
 
-.i-amphtml-sidebar-push-target[side="left"] {
-}
-
 .i-amphtml-sidebar-push-target[side="left"][open] {
   transform: translateX(var(--sidebar-width));
-}
-
-.i-amphtml-sidebar-push-target[side="right"] {
 }
 
 .i-amphtml-sidebar-push-target[side="right"][open] {
@@ -81,7 +75,7 @@ amp-sidebar[side][i-amphtml-sidebar-opened] {
   transition: none;
 }
 
-amp-sidebar[side], .i-amphtml-sidebar-push-target, .i-amphtml-sidebar-mask {
+amp-sidebar[side] {
   /*
    * Note: This uses animations (instead of transitions) to make sure the
    * animation always plays correctly. Previously, the display was toggled in a
@@ -90,10 +84,13 @@ amp-sidebar[side], .i-amphtml-sidebar-push-target, .i-amphtml-sidebar-mask {
    * from working correctly.
    */
   /* Use same transition as PWA App-Shell https://goo.gl/AGFioO */
-  transition: transform 233ms ease, opacity 233ms;
   animation-duration: 233ms;
   animation-timing-function: cubic-bezier(0,0,.21,1);
   animation-fill-mode: forwards;
+}
+
+.i-amphtml-sidebar-push-target, .i-amphtml-sidebar-mask {
+  transition: transform 233ms cubic-bezier(0,0,.21,1), opacity 233ms;
 }
 
 .i-amphtml-toolbar > ul, .i-amphtml-toolbar > ol {

--- a/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
@@ -255,15 +255,17 @@ export class SwipeToDismiss {
   /**
    * Adjusts the UI elements for the current swipe position in a swipe to
    * dismiss gesture. This should be called in a mutate context.
-   * @param {number} swipeDistance How to transform the swiping
+   * @param {number|string} swipeDistance How to transform the swiping
    *    element.
    * @param {number|string} maskOpacity The opacity for the mask element.
    *    container.
    * @private
    */
-  adjustForSwipePosition_(swipeDistance = 0, maskOpacity = '') {
+  adjustForSwipePosition_(swipeDistance = '', maskOpacity = '') {
     setStyles(dev().assertElement(this.swipeElement_), {
-      transform: swipeDistance && this.translateBy_(swipeDistance, 'px'),
+      transform:
+        swipeDistance &&
+        this.translateBy_(dev().assertNumber(swipeDistance), 'px'),
       transition: '',
     });
     setStyles(dev().assertElement(this.coSwipeElement_), {

--- a/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
@@ -96,6 +96,11 @@ export class SwipeToDismiss {
      * @private {?Element}
      */
     this.swipeElement_ = null;
+
+    /**
+     * The element that is moved alongside the swipe element.
+     * @private {?Element}
+     */
     this.coSwipeElement_ = null;
 
     /**
@@ -147,6 +152,7 @@ export class SwipeToDismiss {
    * Handles the start of a swipe.
    * @param {{
    *   swipeElement: !Element,
+   *   coSwipeElement: !Element,
    *   mask: !Element,
    * }} config
    */
@@ -249,19 +255,21 @@ export class SwipeToDismiss {
   /**
    * Adjusts the UI elements for the current swipe position in a swipe to
    * dismiss gesture. This should be called in a mutate context.
-   * @param {string} swipeDistance How to transform the swiping
+   * @param {number} swipeDistance How to transform the swiping
    *    element.
    * @param {number|string} maskOpacity The opacity for the mask element.
    *    container.
    * @private
    */
-  adjustForSwipePosition_(swipeDistance = '', maskOpacity = '') {
+  adjustForSwipePosition_(swipeDistance = 0, maskOpacity = '') {
     setStyles(dev().assertElement(this.swipeElement_), {
       transform: swipeDistance && this.translateBy_(swipeDistance, 'px'),
       transition: '',
     });
     setStyles(dev().assertElement(this.coSwipeElement_), {
-      transform: swipeDistance && this.translateBy_(swipeDistance-this.getSwipeElementLength_(), 'px'),
+      transform:
+        swipeDistance &&
+        this.translateBy_(swipeDistance - this.getSwipeElementLength_(), 'px'),
       transition: '',
     });
     setStyles(dev().assertElement(this.mask_), {


### PR DESCRIPTION
`<amp-sidebar>` is given a `push-target` attribute that specifies via query selector the element to move alongside the sidebar when it opens. This enables an experience similar to the push option here: https://negomi.github.io/react-burger-menu/.

[PR Deployed Demo](https://storage.googleapis.com/amp-test-website-1/amp_dist_66109/examples/playground.amp.html)