### PR TITLE
Fix a bug that amp-carousel is not laying out children elements for inabox-lite.

### DIFF
--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -117,7 +117,7 @@ export class InaboxResources {
 
   /** @override */
   scheduleLayoutOrPreload(unusedResource) {
-    this.schedulePass();
+    this.pass_.schedule();
   }
 
   /** @override */

--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -117,7 +117,7 @@ export class InaboxResources {
 
   /** @override */
   scheduleLayoutOrPreload(unusedResource) {
-    // all elements are immediately scheduled for layout after being added
+    this.schedulePass();
   }
 
   /** @override */


### PR DESCRIPTION
`scheduleLayoutOrPreload` is called in `owners-impl`. we should always try to layout remaining elements in this case.

This should fix the percy failure: https://percy.io/ampproject/amphtml/builds/3000829