### PR TITLE
🐛 Stub out elements that fail to upgrade

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -342,9 +342,7 @@ function createBaseCustomElementClass(win) {
           'attempted to get ampdoc before being connected'
         );
       }
-      const win = toWin(this.ownerDocument.defaultView);
-      const ampdocService = Services.ampdocServiceFor(win);
-      this.ampdoc_ = ampdocService.getAmpDoc(this);
+      this.ampdoc_ = Services.ampdoc(this);
       return devAssert(this.ampdoc_);
     }
 

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -21,10 +21,15 @@ import {devAssert} from './log';
 export const stubbedElements = [];
 
 export class ElementStub extends BaseElement {
-  /** @param {!AmpElement} element */
-  constructor(element) {
+  /**
+   * @param {!AmpElement} element
+   * @param {boolean=} exclude
+   */
+  constructor(element, exclude) {
     super(element);
-    stubbedElements.push(this);
+    if (!exclude) {
+      stubbedElements.push(this);
+    }
   }
 
   /** @override */

--- a/src/service.js
+++ b/src/service.js
@@ -346,6 +346,7 @@ export function getParentWindowFrameElement(node, opt_topWin) {
  */
 export function getAmpdoc(nodeOrDoc) {
   if (nodeOrDoc.nodeType) {
+    // TODO: isConnected check on document?
     const win = toWin(
       /** @type {!Document} */ (nodeOrDoc.ownerDocument || nodeOrDoc)
         .defaultView


### PR DESCRIPTION
I think this is what's causing #25381. If a component, eg `<amp-link-rewritter>`, accesses `this.getAmpDoc()` to get a service in it's constructor, it'll error out.

If that happens, then `this.implementation_` is still `undefined`. That causes a cascade of bugs. So, if the component fails to construct, we're now going to turn it into a stubbed `BaseElement` and pretend it doesn't exist on the page.