### PR TITLE
✨Manual management of `amp-next-page` document visibility

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -181,7 +181,6 @@ export class NextPageService {
       url: win.document.location.href,
       title: win.document.title,
       canonicalUrl,
-      setVisibilityState: ampDoc.overrideVisibilityState.bind(ampDoc),
     };
 
     this.documentRefs_.push(documentRef);
@@ -552,9 +551,21 @@ export class NextPageService {
    * @private
    */
   setDocumentVisibility_(documentIndex, visibilityState) {
+    // Prevent updating visibility of the host document
+    if (documentIndex === 0) {
+      return;
+    }
+
     const doc = this.documentRefs_[documentIndex];
 
     if (doc && doc.amp && doc.amp['ampdoc']) {
+      // Prevent hiding of documents that are being pre-rendered
+      if (
+        !doc.amp.ampdoc.hasBeenVisible() &&
+        visibilityState == VisibilityState.HIDDEN
+      ) {
+        return;
+      }
       doc.amp.setVisibilityState(visibilityState);
     }
   }

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -517,7 +517,7 @@ export class NextPageService {
   /**
    * Sets the specified document as active, updating the document title and URL.
    *
-   * @param {DocumentRef} ref Reference to the document to be activated
+   * @param {!DocumentRef} ref Reference to the document to be activated
    * @private
    */
   setActiveDocument_(ref) {
@@ -542,7 +542,7 @@ export class NextPageService {
   /**
    * Manually overrides the document's visible state to the given state
    *
-   * @param {DocumentRef} ref Reference to the document to change
+   * @param {!DocumentRef} ref Reference to the document to change
    * @param {!../../../src/visibility-state.VisibilityState} visibilityState
    * @private
    */
@@ -552,7 +552,7 @@ export class NextPageService {
       return;
     }
 
-    const ampDoc = ref && ref.amp && ref.amp.ampdoc;
+    const ampDoc = ref.amp && ref.amp.ampdoc;
 
     // Prevent hiding of documents that are not shadow docs
     if (!ampDoc) {

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -175,7 +175,7 @@ export class NextPageService {
       canonicalUrl
     );
 
-    // TODO(gharbiw) Establish parity with the shadow doc amp object
+    // TODO(wassgha): Establish parity with the shadow doc amp object
     documentRef.amp = {
       ampdoc: ampDoc,
       url: win.document.location.href,
@@ -325,8 +325,7 @@ export class NextPageService {
               }
               this.resources_.mutateElement(container, () => {
                 try {
-                  const amp = this.attachShadowDoc_(shadowRoot, doc);
-                  documentRef.amp = amp;
+                  documentRef.amp = this.attachShadowDoc_(shadowRoot, doc);
 
                   toggle(dev().assertElement(documentRef.recUnit.el), false);
                   this.documentQueued_ = false;
@@ -469,7 +468,7 @@ export class NextPageService {
       return;
     }
 
-    let documentIndex;
+    let documentIndex = i;
     let analyticsEvent = '';
 
     switch (position.relativePos) {
@@ -478,7 +477,6 @@ export class NextPageService {
         analyticsEvent = 'amp-next-page-scroll';
         break;
       case 'bottom':
-        documentIndex = i;
         analyticsEvent = 'amp-next-page-scroll-back';
         break;
       default:

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -41,7 +41,7 @@ const TAG = 'amp-next-page';
 /**
  * @typedef {{
  *   ampUrl: string,
- *   amp: ?Object,
+ *   amp: (?../../../src/runtime.ShadowDoc | undefined),
  *   recUnit: {el: ?Element, isObserving: boolean},
  *   cancelled: boolean
  * }}
@@ -175,13 +175,15 @@ export class NextPageService {
       canonicalUrl
     );
 
-    // TODO(wassgha): Establish parity with the shadow doc amp object
-    documentRef.amp = {
+    // TODO(wassgha): Untype as ShadowDoc and tighten the ShadowDoc type spec
+    /** @type {!../../../src/runtime.ShadowDoc} */
+    const amp = {
       ampdoc: ampDoc,
       url: win.document.location.href,
       title: win.document.title,
       canonicalUrl,
     };
+    documentRef.amp = amp;
 
     this.documentRefs_.push(documentRef);
     this.activeDocumentRef_ = this.documentRefs_[0];
@@ -208,7 +210,7 @@ export class NextPageService {
    * Attach a ShadowDoc using the given document.
    * @param {!Element} shadowRoot Root element to attach the shadow document to.
    * @param {!Document} doc Document to attach.
-   * @return {?Object} Return value of {@link MultidocManager#attachShadowDoc}
+   * @return {?../../../src/runtime.ShadowDoc} Return value of {@link MultidocManager#attachShadowDoc}
    */
   attachShadowDoc_(shadowRoot, doc) {
     if (this.hideSelector_) {
@@ -226,12 +228,16 @@ export class NextPageService {
       removeElement(item);
     }
 
+    /** @type {!../../../src/runtime.ShadowDoc} */
     const amp = this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {
       visibilityState: VisibilityState.PRERENDER,
     });
-    installStylesForDoc(amp.ampdoc, CSS, null, false, TAG);
+    const ampdoc = /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */ (dev().assert(
+      amp.ampdoc
+    ));
+    installStylesForDoc(ampdoc, CSS, null, false, TAG);
 
-    const body = amp.ampdoc.getBody();
+    const body = ampdoc.getBody();
     body.classList.add('i-amphtml-next-page-document');
 
     return amp;

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -232,9 +232,7 @@ export class NextPageService {
     const amp = this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {
       visibilityState: VisibilityState.PRERENDER,
     });
-    const ampdoc = /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */ (dev().assert(
-      amp.ampdoc
-    ));
+    const ampdoc = dev().assert(amp.ampdoc);
     installStylesForDoc(ampdoc, CSS, null, false, TAG);
 
     const body = ampdoc.getBody();

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -522,19 +522,16 @@ export class NextPageService {
   setActiveDocument_(documentIndex) {
     this.documentRefs_.forEach((docRef, index) => {
       const {amp} = docRef;
-      let updatedVisibilityState;
       // Update the title and history
-      if (index == documentIndex) {
+      if (index === documentIndex) {
         this.win_.document.title = amp.title || '';
         this.activeDocumentRef_ = docRef;
         this.setActiveDocumentInHistory_(docRef);
-        updatedVisibilityState = VisibilityState.VISIBLE;
-      } else if (index !== 0) {
-        updatedVisibilityState = VisibilityState.HIDDEN;
-      }
-      // Show the active doc and hide other docs
-      if (updatedVisibilityState) {
-        this.setDocumentVisibility_(index, updatedVisibilityState);
+        // Show the active document
+        this.setDocumentVisibility_(index, VisibilityState.VISIBLE);
+      } else {
+        // Hide other documents
+        this.setDocumentVisibility_(index, VisibilityState.HIDDEN);
       }
     });
 
@@ -555,17 +552,19 @@ export class NextPageService {
     }
 
     const doc = this.documentRefs_[documentIndex];
+    const ampDoc = doc && doc.amp && doc.amp.ampdoc;
 
-    if (doc && doc.amp && doc.amp['ampdoc']) {
-      // Prevent hiding of documents that are being pre-rendered
-      if (
-        !doc.amp.ampdoc.hasBeenVisible() &&
-        visibilityState == VisibilityState.HIDDEN
-      ) {
-        return;
-      }
-      doc.amp.setVisibilityState(visibilityState);
+    // Prevent hiding of documents that are not shadow docs
+    if (!ampDoc) {
+      return;
     }
+
+    // Prevent hiding of documents that are being pre-rendered
+    if (!ampDoc.hasBeenVisible() && visibilityState == VisibilityState.HIDDEN) {
+      return;
+    }
+
+    doc.amp.setVisibilityState(visibilityState);
   }
 
   /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -69,19 +69,19 @@ const TAG = 'runtime';
 
 /**
  * @typedef {{
- *  url: string,
- *  title: string,
- *  canonicalUrl: string,
+ *  url: (string|undefined),
+ *  title: (string|undefined),
+ *  canonicalUrl: (string|undefined),
  *  head: (Element|undefined),
- *  ampdoc: !./service/ampdoc-impl.AmpDocShadow,
- *  setVisibilityState: (function()|undefined),
+ *  ampdoc: (!./service/ampdoc-impl.AmpDoc | undefined),
+ *  setVisibilityState: (function(!VisibilityState)|undefined),
  *  postMessage: (function()|undefined),
  *  onMessage: (function()|undefined),
  *  close: (function()|undefined),
  *  getState: (function()|undefined),
  *  setState: (function()|undefined),
  *  toggleRuntime: (function()|undefined),
- *  resources: !./service/resources-interface.ResourcesInterface
+ *  resources: (!./service/resources-interface.ResourcesInterface | undefined)
  * }}
  */
 export let ShadowDoc;
@@ -598,7 +598,7 @@ export class MultidocManager {
    * @param {!Document} doc
    * @param {string} url
    * @param {!Object<string, string>=} opt_initParams
-   * @return {!Object}
+   * @return {!ShadowDoc}
    */
   attachShadowDoc(hostElement, doc, url, opt_initParams) {
     dev().fine(TAG, 'Attach shadow doc:', doc);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -70,14 +70,17 @@ const TAG = 'runtime';
 /**
  * @typedef {{
  *  url: string,
+ *  title: string,
+ *  canonicalUrl: string,
+ *  head: (Element|undefined),
  *  ampdoc: !./service/ampdoc-impl.AmpDocShadow,
- *  setVisibilityState: (Function|undefined),
- *  postMessage: (Function|undefined),
- *  onMessage: (Function|undefined),
- *  close: (Function|undefined),
- *  getState: (Function|undefined),
- *  setState: (Function|undefined),
- *  toggleRuntime: (Function|undefined),
+ *  setVisibilityState: (function()|undefined),
+ *  postMessage: (function()|undefined),
+ *  onMessage: (function()|undefined),
+ *  close: (function()|undefined),
+ *  getState: (function()|undefined),
+ *  setState: (function()|undefined),
+ *  toggleRuntime: (function()|undefined),
  *  resources: !./service/resources-interface.ResourcesInterface
  * }}
  */

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -68,6 +68,22 @@ setReportError(reportErrorForWin.bind(null, self));
 const TAG = 'runtime';
 
 /**
+ * @typedef {{
+ *  url: string,
+ *  ampdoc: !./service/ampdoc-impl.AmpDocShadow,
+ *  setVisibilityState: (Function|undefined),
+ *  postMessage: (Function|undefined),
+ *  onMessage: (Function|undefined),
+ *  close: (Function|undefined),
+ *  getState: (Function|undefined),
+ *  setState: (Function|undefined),
+ *  toggleRuntime: (Function|undefined),
+ *  resources: !./service/resources-interface.ResourcesInterface
+ * }}
+ */
+export let ShadowDoc;
+
+/**
  * Applies the runtime to a given global scope for a single-doc mode. Multi
  * frame support is currently incomplete.
  * @param {!Window} global Global scope to adopt.
@@ -420,7 +436,7 @@ export class MultidocManager {
    * @param {!Object<string, string>|undefined} params
    * @param {function(!Object, !ShadowRoot,
    * !./service/ampdoc-impl.AmpDocShadow):!Promise} builder
-   * @return {!Object}
+   * @return {!ShadowDoc}
    * @private
    */
   attachShadowDoc_(hostElement, url, params, builder) {


### PR DESCRIPTION
Closes #25069 , Partial for #15807 & #14059 

### Changes
- Patches `amp-next-page v0.1` (the change will land in `v0.2`) to allow it to override document visibility for the added shadow docs, fixing interactions with `amp-pixel` and possibly `amp-analytics` (previously all added "next" documents would be given the "visible" state even during pre-rendering which would immediately trigger an `amp-pixel` hit before the user reaches the next page).
- Adds partial testing (most tests will come after `e2e` testing is implemented, see #24610 )
- Cleans up tests
- Adds a new type `ShadowDoc` which defines the Shadow document object (already generated by the AMP runtime but typed as `Object`)

### Implementation details
Previous to this change, shadow docs appended by `amp-next-page` would follow their parent's visibility state which in most cases would be `visible` as the user is scrolling down the page. This causes multiple problems during the time between the pre-render phase (user is scrolling and the next page is loaded) and the visible phase (the user scrolled to the next page and is reading it). 

One of the problems that have surfaced is the interaction with `amp-pixel` where the analytics call is gated by the document's visibility state. In this case, as the next page has been loaded (and thus adopts its parent's `visible` state), the `amp-pixel` triggers preemptively, before the user actually scrolls to the next page.

This change corrects the behavior by having `amp-next-page` manually override the visibility state of the next pages as follows:
- Give documents an initial visibility state of `PRERENDER` (as opposed to the parent's visibility state)
- As the user scrolls, switch the current page they are reading to be `VISIBLE` while other documents (excluding the host/first document) are either in the `PRERENDER` or `HIDDEN` states
- Follow the parent's state when `HIDDEN`, `PAUSED` or `INACTIVE` but restore the previous states when the parent/first document becomes `VISIBLE`

![visbility](https://user-images.githubusercontent.com/591655/68078547-db6f4380-fd94-11e9-938d-f3cfe916b61d.png)

### Todo
- [x] Add tests (some will come at a later PR for `e2e`)
- [x] Maintain behavior after the parent's visibility state changes
- [x] Maintain the `PRERENDER` visibility state when scrolling back

### Meme
![bb6f349e0eb028e3ae9fe1ca7e15f2e73ac357e2aa7613836b29bf6f8bf3a46e](https://user-images.githubusercontent.com/591655/68080473-4894d000-fdb9-11e9-96d5-c195899df9e0.jpg)

/cc @nainar @kristoferbaxter 