### PR TITLE
🐛Escape left and right arrow keys in amp-carousel 0.1

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -215,6 +215,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /**
    * Escapes Left and Right arrow key events on the carousel container.
+   * This is to prevent them from doubly interacting with surrounding viewer
+   * contexts such as email clients when interacting with the amp-carousel.
    * @param {!Event} event
    * @private
    */

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -17,6 +17,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {Animation} from '../../../src/animation';
 import {BaseCarousel} from './base-carousel';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {isLayoutSizeFixed} from '../../../src/layout';
@@ -70,6 +71,10 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.cancelTouchEvents_();
 
     this.container_.addEventListener('scroll', this.scrollHandler_.bind(this));
+    this.container_.addEventListener(
+      'keydown',
+      this.keydownHandler_.bind(this)
+    );
 
     this.registerAction(
       'goToSlide',
@@ -205,6 +210,18 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
     if (this.scrollTimerId_ === null) {
       this.waitForScroll_(currentScrollLeft);
+    }
+  }
+
+  /**
+   * Escapes Left and Right arrow key events on the carousel container.
+   * @param {!Event} event
+   * @private
+   */
+  keydownHandler_(event) {
+    const {key} = event;
+    if (key == Keys.LEFT_ARROW || key == Keys.RIGHT_ARROW) {
+      event.stopPropagation();
     }
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -206,7 +206,7 @@ export class AmpSlideScroll extends BaseSlides {
       'scroll',
       this.scrollHandler_.bind(this)
     );
-    this.container_.addEventListener(
+    this.slidesContainer_.addEventListener(
       'keydown',
       this.keydownHandler_.bind(this)
     );

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -417,6 +417,8 @@ export class AmpSlideScroll extends BaseSlides {
 
   /**
    * Escapes Left and Right arrow key events on the carousel container.
+   * This is to prevent them from doubly interacting with surrounding viewer
+   * contexts such as email clients when interacting with the amp-carousel.
    * @param {!Event} event
    * @private
    */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -17,6 +17,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {Animation} from '../../../src/animation';
 import {BaseSlides} from './base-slides';
+import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
 import {closestAncestorElementBySelector} from '../../../src/dom';
@@ -204,6 +205,10 @@ export class AmpSlideScroll extends BaseSlides {
     this.slidesContainer_.addEventListener(
       'scroll',
       this.scrollHandler_.bind(this)
+    );
+    this.container_.addEventListener(
+      'keydown',
+      this.keydownHandler_.bind(this)
     );
 
     listen(
@@ -408,6 +413,18 @@ export class AmpSlideScroll extends BaseSlides {
     this.waitForScrollSettled_(timeout);
 
     this.previousScrollLeft_ = currentScrollLeft;
+  }
+
+  /**
+   * Escapes Left and Right arrow key events on the carousel container.
+   * @param {!Event} event
+   * @private
+   */
+  keydownHandler_(event) {
+    const {key} = event;
+    if (key == Keys.LEFT_ARROW || key == Keys.RIGHT_ARROW) {
+      event.stopPropagation();
+    }
   }
 
   /**


### PR DESCRIPTION
Left and Right arrow keys in `amp-carousel` 0.1 currently interact with the component and the surrounding email client in the context of an AMP Email. These events should be consumed by the component. Though this change is motivated by an email use case, it is also useful generally.

b/129001654 cc/ @zhangsu 