### PR TITLE
Fire fluid delayed impression ping if creative has non-zero size.

### DIFF
--- a/examples/fluid.amp.html
+++ b/examples/fluid.amp.html
@@ -20,10 +20,7 @@
   <body>
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
+    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height=300 width=300 data-multi-size="fluid" layout="fixed"></amp-ad>
     <div class="artificialfold"></div>
-    <div id="narrow" style="margin-left: 35%; margin-right: 15%; border: 1px red solid">
-      <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu0/iu1/iu2" height="fluid" layout="fluid"></amp-ad>
-    </div>
-    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height="fluid" layout="fluid"></amp-ad>
   </body>
 </html>

--- a/examples/fluid.amp.html
+++ b/examples/fluid.amp.html
@@ -20,7 +20,10 @@
   <body>
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
-    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height=300 width=300 data-multi-size="fluid" layout="fixed"></amp-ad>
     <div class="artificialfold"></div>
+    <div id="narrow" style="margin-left: 35%; margin-right: 15%; border: 1px red solid">
+      <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu0/iu1/iu2" height="fluid" layout="fluid"></amp-ad>
+    </div>
+    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height="fluid" layout="fluid"></amp-ad>
   </body>
 </html>

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -900,7 +900,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    */
   getSlotSize() {
     const {width, height} = this.getDeclaredSlotSize_();
-    return !isNaN(width) && !isNaN(height)
+    return width && height
       ? {width, height}
       : // width/height could be 'auto' in which case we fallback to measured.
         this.getIntersectionElementLayoutBox();
@@ -1199,7 +1199,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                 'creative. Will re-attempt when slot is out of the viewport.'
             );
             const {width, height} = this.getSlotSize();
-            if (width > 0 && height > 0) {
+            if (width && height) {
               // This call is idempotent, so it's okay to make it multiple
               // times.
               this.fireFluidDelayedImpression();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1198,8 +1198,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               'Attempt to change size failed on fluid ' +
                 'creative. Will re-attempt when slot is out of the viewport.'
             );
-            const slotHeight = this.getSlotSize().height;
-            if (slotHeight >= 0.5 * creativeHeight) {
+            const {width, height} = this.getSlotSize();
+            if (width > 0 && height > 0) {
               // This call is idempotent, so it's okay to make it multiple
               // times.
               this.fireFluidDelayedImpression();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1185,9 +1185,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         return Promise.reject('Cannot access body of friendly frame');
       }
       return this.setCssPosition_('static').then(() => {
-        const creativeHeight = this.iframe.contentWindow.document.body
-          ./*OK*/ clientHeight;
-        return this.attemptChangeHeight(creativeHeight)
+        return this.attemptChangeHeight(
+          this.iframe.contentWindow.document.body./*OK*/ clientHeight
+        )
           .then(() => {
             this.fireFluidDelayedImpression();
             this.reattemptToExpandFluidCreative_ = false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -748,9 +748,9 @@ export class SafeframeHostApi {
       })
       .catch(err => {
         user().warn(TAG, err);
-        const slotHeight = this.baseInstance_.getSlotSize().height;
-        if (slotHeight >= 0.5 * newHeight) {
-          this.onFluidResize_(slotHeight);
+        const {width, height} = this.baseInstance_.getSlotSize();
+        if (width > 0 && height > 0) {
+          this.onFluidResize_(height);
         }
       });
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -746,7 +746,13 @@ export class SafeframeHostApi {
         this.checkStillCurrent_();
         this.onFluidResize_(newHeight);
       })
-      .catch(err => user().warn(TAG, err));
+      .catch(err => {
+        user().warn(TAG, err);
+        const slotHeight = this.baseInstance_.getSlotSize().height;
+        if (slotHeight >= 0.5 * newHeight) {
+          this.onFluidResize_(slotHeight);
+        }
+      });
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -749,7 +749,7 @@ export class SafeframeHostApi {
       .catch(err => {
         user().warn(TAG, err);
         const {width, height} = this.baseInstance_.getSlotSize();
-        if (width > 0 && height > 0) {
+        if (width && height) {
           this.onFluidResize_(height);
         }
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -298,6 +298,10 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should fire impression for AMP fluid creative, if partly visible', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
+    const creativeHeight = parseInt(
+      impl.iframe.contentWindow.document.body.clientHeight,
+      10
+    );
     sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
     sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
@@ -306,7 +310,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
     // Height needs to be >= half of the creative height to fire impression.
-    impl.element.setAttribute('height', 125);
+    impl.element.setAttribute('height', creativeHeight / 2 + 1);
     return impl.expandFluidCreative_().then(() => {
       expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.be
         .calledOnce;
@@ -316,6 +320,10 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should not fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
+    const creativeHeight = parseInt(
+      impl.iframe.contentWindow.document.body.clientHeight,
+      10
+    );
     sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
     sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
@@ -323,6 +331,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
+    // Height needs to be >= half of the creative height to fire impression.
+    impl.element.setAttribute('height', creativeHeight / 2 - 1);
     return impl.expandFluidCreative_().then(() => {
       expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.not.be
         .calledOnce;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -299,10 +299,6 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should fire impression for AMP fluid creative, if partly visible', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const creativeHeight = parseInt(
-      impl.iframe.contentWindow.document.body.clientHeight,
-      10
-    );
     sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
     sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
@@ -322,10 +318,6 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should not fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const creativeHeight = parseInt(
-      impl.iframe.contentWindow.document.body.clientHeight,
-      10
-    );
     sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
     sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -67,8 +67,9 @@ const mockPromise = {
  * tests.
  * @param {!AmpAdNetworkDoubleclickImpl} impl
  * @param {!Object} sandbox Sinon sandbox to mock out properties.
+ * @param {boolean=} resize Whether resize is permitted.
  */
-function createScaffoldingForFluidRendering(impl, sandbox) {
+function createScaffoldingForFluidRendering(impl, sandbox, resize = true) {
   impl.getVsync = () => {
     return {
       run: runArgs => {
@@ -77,7 +78,9 @@ function createScaffoldingForFluidRendering(impl, sandbox) {
     };
   };
   impl.buildCallback();
-  impl.attemptChangeHeight = () => Promise.resolve();
+  impl.attemptChangeHeight = resize
+    ? () => Promise.resolve()
+    : () => Promise.reject('Creative in viewport');
   sandbox.stub(impl, 'sendXhrRequest').returns(
     Promise.resolve({
       arrayBuffer: () => Promise.resolve(utf8Encode(rawCreative)),
@@ -248,6 +251,26 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     });
   });
 
+  it('should fire delayed impression ping, if creative partly visible', () => {
+    createScaffoldingForFluidRendering(impl, sandbox, false);
+    const connectMessagingChannelSpy = sandbox./*OK*/ spy(
+      impl.safeframeApi_,
+      'connectMessagingChannel'
+    );
+    const onFluidResizeSpy = sandbox./*OK*/ spy(
+      impl.safeframeApi_,
+      'onFluidResize_'
+    );
+    // Height needs to be >= half of the creative height to fire impression.
+    impl.element.setAttribute('height', 125);
+    return impl.adPromise_.then(() => {
+      return impl.layoutCallback().then(() => {
+        expect(connectMessagingChannelSpy).to.be.calledOnce;
+        expect(onFluidResizeSpy).to.be.calledOnce;
+      });
+    });
+  });
+
   it('should set height on iframe', () => {
     createScaffoldingForFluidRendering(impl, sandbox);
     return impl.adPromise_.then(() => {
@@ -270,6 +293,40 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.onCreativeRender(null, mockPromise);
     expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.be
       .calledOnce;
+  });
+
+  it('should fire impression for AMP fluid creative, if partly visible', () => {
+    impl.iframe = impl.win.document.createElement('iframe');
+    impl.win.document.body.appendChild(impl.iframe);
+    sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
+    impl.buildCallback();
+    impl.isFluidRequest_ = true;
+    impl.isVerifiedAmpCreative_ = true;
+    impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
+    // Height needs to be >= half of the creative height to fire impression.
+    impl.element.setAttribute('height', 125);
+    return impl.expandFluidCreative_().then(() => {
+      expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.be
+        .calledOnce;
+    });
+  });
+
+  it('should not fire impression for AMP fluid creative', () => {
+    impl.iframe = impl.win.document.createElement('iframe');
+    impl.win.document.body.appendChild(impl.iframe);
+    sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
+    impl.buildCallback();
+    impl.isFluidRequest_ = true;
+    impl.isVerifiedAmpCreative_ = true;
+    impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
+    return impl.expandFluidCreative_().then(() => {
+      expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.not.be
+        .calledOnce;
+    });
   });
 
   it('should set expansion re-attempt flag after initial failure', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -261,8 +261,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
       impl.safeframeApi_,
       'onFluidResize_'
     );
-    // Height needs to be >= half of the creative height to fire impression.
-    impl.element.setAttribute('height', 125);
+    // Size must be non-zero to fire impression.
+    impl.element.setAttribute('height', 1);
+    impl.element.setAttribute('width', 1);
     return impl.adPromise_.then(() => {
       return impl.layoutCallback().then(() => {
         expect(connectMessagingChannelSpy).to.be.calledOnce;
@@ -309,8 +310,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
     impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
-    // Height needs to be >= half of the creative height to fire impression.
-    impl.element.setAttribute('height', creativeHeight / 2 + 1);
+    // Size must be non-zero to fire impression.
+    impl.element.setAttribute('height', 1);
+    impl.element.setAttribute('width', 1);
     return impl.expandFluidCreative_().then(() => {
       expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.be
         .calledOnce;
@@ -330,9 +332,6 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
-    impl.fluidImpressionUrl_ = 'http://www.foo.co.uk';
-    // Height needs to be >= half of the creative height to fire impression.
-    impl.element.setAttribute('height', creativeHeight / 2 - 1);
     return impl.expandFluidCreative_().then(() => {
       expect(delayedImpressionSpy.withArgs('http://www.foo.co.uk')).to.not.be
         .calledOnce;


### PR DESCRIPTION
Currently, fluid impressions are only fired if the creative expands fully. This seems overly restrictive, as in some cases the creative may load within the viewport with a non-zero size. In these cases, it makes sense to fire a delayed impression ping as well.