### PR TITLE
Override pause/resumeCallback for Stories needs.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -393,13 +393,13 @@ export class AmpStoryPage extends AMP.BaseElement {
     switch (state) {
       case PageState.NOT_ACTIVE:
         this.element.removeAttribute('active');
-        this.pauseCallback();
+        this.pause_();
         this.state_ = state;
         break;
       case PageState.PLAYING:
         if (this.state_ === PageState.NOT_ACTIVE) {
           this.element.setAttribute('active', '');
-          this.resumeCallback();
+          this.resume_();
         }
 
         if (this.state_ === PageState.PAUSED) {
@@ -430,8 +430,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
   }
 
-  /** @override */
-  pauseCallback() {
+  /**
+   * @private
+   */
+  pause_() {
     this.advancement_.stop();
 
     this.stopMeasuringVideoPerformance_();
@@ -458,8 +460,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
   }
 
-  /** @override */
-  resumeCallback() {
+  /**
+   * @private
+   */
+  resume_() {
     this.registerAllMedia_();
 
     if (this.isActive()) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -457,16 +457,24 @@ export class AmpStory extends AMP.BaseElement {
     }
   }
 
-  /** @override */
-  pauseCallback() {
+  /**
+   * Pauses the whole story on viewer visibilityState updates, or tab visibility
+   * updates.
+   * @private
+   */
+  pause_() {
     this.pausedStateToRestore_ = !!this.storeService_.get(
       StateProperty.PAUSED_STATE
     );
     this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
   }
 
-  /** @override */
-  resumeCallback() {
+  /**
+   * Resumes the whole story on viewer visibilityState updates, or tab
+   * visibility updates.
+   * @private
+   */
+  resume_() {
     this.storeService_.dispatch(
       Action.TOGGLE_PAUSED,
       this.pausedStateToRestore_
@@ -1790,7 +1798,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   onVisibilityChanged_() {
-    this.getAmpDoc().isVisible() ? this.resumeCallback() : this.pauseCallback();
+    this.getAmpDoc().isVisible() ? this.resume_() : this.pause_();
   }
 
   /**


### PR DESCRIPTION
`pauseCallback` and `resumeCallback` don't really work the way Stories expect them to. They will get triggered as the viewer `visibilityState` changes, but not when the browser tab visibility changes.

However, Stories should be paused both on `visibilityState` and browser tab changes.

`amp-story-page.resume/pauseCallback` were triggered by the AMP runtime on `visibilityState` change, which wasn't expected by our code, causing various bugs as the one reported. We've never noticed the issue because the code happened to fail in an OK way, and we don't play so much with viewers locally.

The proposed fix is to rely on `ampdoc.onVisibilityChanged()` that is triggered in both cases (viewer + browser tab), and to stop using `pause/resumeCallback()`, as discussed with @jridgewell.
`ampdoc.onVisibilityChanged()` at the `amp-story` level sets the `PAUSED` state, that is propagated to the story pages and other components as needed. 

Fixes #25274