### PR TITLE
Proposal: automatically run realWin/ampdoc tests in multiple environments

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -800,7 +800,7 @@ export class ActionService {
    * @private
    */
   queryWhitelist_() {
-    const {head} = this.ampdoc.getRootNode();
+    const head = this.ampdoc.getHeadNode();
     if (!head) {
       return null;
     }

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -39,7 +39,10 @@ import {whenCalled} from '../../testing/test-helper.js';
  */
 function actionService() {
   const win = {
-    document: {body: {}},
+    document: {
+      body: document.createElement('body'),
+      head: document.createElement('head'),
+    },
     __AMP_SERVICES: {
       vsync: {obj: {}},
     },

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -1661,175 +1661,30 @@ describes.fakeWin('Core events', {amp: true}, env => {
   });
 });
 
-describes.ampdocs(
-  'Action whitelisting',
-  {},
-  env => {
-    let ampdoc;
-    let action;
-    let target;
-    let spy;
-    let getDefaultActionAlias;
+describes.ampdocs('Action whitelisting', {}, env => {
+  let ampdoc;
+  let action;
+  let target;
+  let spy;
+  let getDefaultActionAlias;
+  beforeEach(() => {
+    ampdoc = env.ampdoc;
+    spy = env.sandbox.spy();
+    getDefaultActionAlias = env.sandbox.stub();
+    target = createExecElement('foo', spy, getDefaultActionAlias);
+  });
+  describe('with non-empty whitelist', () => {
     beforeEach(() => {
-      ampdoc = env.ampdoc;
-      spy = env.sandbox.spy();
-      getDefaultActionAlias = env.sandbox.stub();
-      target = createExecElement('foo', spy, getDefaultActionAlias);
-    });
-    describe('with non-empty whitelist', () => {
-      beforeEach(() => {
-        const meta = createElementWithAttributes(env.win.document, 'meta', {
-          name: 'amp-action-whitelist',
-          content:
-            'AMP.pushState, AMP.setState, *.show, ' +
-            'amp-element.defaultAction',
-        });
-        ampdoc.getHeadNode().appendChild(meta);
-        action = new ActionService(ampdoc);
-      });
-
-      it('should allow whitelisted actions', () => {
-        const i = new ActionInvocation(
-          target,
-          'setState',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'tap',
-          'AMP'
-        );
-        action.invoke_(i);
-        expect(spy).to.be.calledWithExactly(i);
-      });
-
-      it('should allow whitelisted actions case insensitive', () => {
-        const i = new ActionInvocation(
-          target,
-          'setState',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'TAP',
-          'amp'
-        );
-        action.invoke_(i);
-        expect(spy).to.be.calledWithExactly(i);
-      });
-
-      it('should whitelist default actions if alias is registered default', () => {
-        // Given that 'defaultAction' is a registered default action.
-        getDefaultActionAlias.returns('defaultAction');
-        // Expect the 'activate' call to invoke it.
-        const i = new ActionInvocation(
-          target,
-          'activate',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'tap',
-          null
-        );
-        action.invoke_(i);
-        expect(spy).to.be.calledWithExactly(i);
-      });
-
-      it('should allow whitelisted actions with wildcard target', () => {
-        const i = new ActionInvocation(
-          target,
-          'show',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'tap',
-          'DIV'
-        );
-        action.invoke_(i);
-        expect(spy).to.be.calledWithExactly(i);
-      });
-
-      it('should not allow non-whitelisted actions', () => {
-        const i = new ActionInvocation(
-          target,
-          'print',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'tap',
-          'AMP'
-        );
-        sandbox.stub(action, 'error_');
-        expect(action.invoke_(i)).to.be.null;
-        expect(action.error_).to.be.calledWith(
-          '"AMP.print" is not whitelisted ' +
-            '[{"tagOrTarget":"AMP","method":"pushState"},' +
-            '{"tagOrTarget":"AMP","method":"setState"},' +
-            '{"tagOrTarget":"*","method":"show"},' +
-            '{"tagOrTarget":"amp-element","method":"defaultAction"}].'
-        );
-      });
-
-      it('should allow adding actions to the whitelist', () => {
-        const i = new ActionInvocation(
-          target,
-          'print',
-          /* args */ null,
-          'source',
-          'caller',
-          'event',
-          ActionTrust.HIGH,
-          'tap',
-          'AMP'
-        );
-        action.addToWhitelist('AMP', 'print');
-        action.invoke_(i);
-        expect(spy).to.be.calledWithExactly(i);
-      });
-    });
-
-    it('should not allow any action with empty string whitelist', () => {
       const meta = createElementWithAttributes(env.win.document, 'meta', {
         name: 'amp-action-whitelist',
-        content: '',
+        content:
+          'AMP.pushState, AMP.setState, *.show, amp-element.defaultAction',
       });
       ampdoc.getHeadNode().appendChild(meta);
       action = new ActionService(ampdoc);
-      const i = new ActionInvocation(
-        target,
-        'print',
-        /* args */ null,
-        'source',
-        'caller',
-        'event',
-        ActionTrust.HIGH,
-        'tap',
-        'AMP'
-      );
-      sandbox.stub(action, 'error_');
-      expect(action.invoke_(i)).to.be.null;
-      expect(action.error_).to.be.calledWith(
-        '"AMP.print" is not whitelisted [].'
-      );
     });
 
-    it('should ignore unparseable whitelist entries', () => {
-      const meta = createElementWithAttributes(env.win.document, 'meta', {
-        name: 'amp-action-whitelist',
-        content: 'AMP.pushState, invalidEntry, AMP.setState, *.show',
-      });
-      ampdoc.getHeadNode().appendChild(meta);
-      allowConsoleError(() => {
-        action = new ActionService(ampdoc);
-      });
+    it('should allow whitelisted actions', () => {
       const i = new ActionInvocation(
         target,
         'setState',
@@ -1844,5 +1699,145 @@ describes.ampdocs(
       action.invoke_(i);
       expect(spy).to.be.calledWithExactly(i);
     });
-  }
-);
+
+    it('should allow whitelisted actions case insensitive', () => {
+      const i = new ActionInvocation(
+        target,
+        'setState',
+        /* args */ null,
+        'source',
+        'caller',
+        'event',
+        ActionTrust.HIGH,
+        'TAP',
+        'amp'
+      );
+      action.invoke_(i);
+      expect(spy).to.be.calledWithExactly(i);
+    });
+
+    it('should whitelist default actions if alias is registered default', () => {
+      // Given that 'defaultAction' is a registered default action.
+      getDefaultActionAlias.returns('defaultAction');
+      // Expect the 'activate' call to invoke it.
+      const i = new ActionInvocation(
+        target,
+        'activate',
+        /* args */ null,
+        'source',
+        'caller',
+        'event',
+        ActionTrust.HIGH,
+        'tap',
+        null
+      );
+      action.invoke_(i);
+      expect(spy).to.be.calledWithExactly(i);
+    });
+
+    it('should allow whitelisted actions with wildcard target', () => {
+      const i = new ActionInvocation(
+        target,
+        'show',
+        /* args */ null,
+        'source',
+        'caller',
+        'event',
+        ActionTrust.HIGH,
+        'tap',
+        'DIV'
+      );
+      action.invoke_(i);
+      expect(spy).to.be.calledWithExactly(i);
+    });
+
+    it('should not allow non-whitelisted actions', () => {
+      const i = new ActionInvocation(
+        target,
+        'print',
+        /* args */ null,
+        'source',
+        'caller',
+        'event',
+        ActionTrust.HIGH,
+        'tap',
+        'AMP'
+      );
+      sandbox.stub(action, 'error_');
+      expect(action.invoke_(i)).to.be.null;
+      expect(action.error_).to.be.calledWith(
+        '"AMP.print" is not whitelisted ' +
+          '[{"tagOrTarget":"AMP","method":"pushState"},' +
+          '{"tagOrTarget":"AMP","method":"setState"},' +
+          '{"tagOrTarget":"*","method":"show"},' +
+          '{"tagOrTarget":"amp-element","method":"defaultAction"}].'
+      );
+    });
+
+    it('should allow adding actions to the whitelist', () => {
+      const i = new ActionInvocation(
+        target,
+        'print',
+        /* args */ null,
+        'source',
+        'caller',
+        'event',
+        ActionTrust.HIGH,
+        'tap',
+        'AMP'
+      );
+      action.addToWhitelist('AMP', 'print');
+      action.invoke_(i);
+      expect(spy).to.be.calledWithExactly(i);
+    });
+  });
+
+  it('should not allow any action with empty string whitelist', () => {
+    const meta = createElementWithAttributes(env.win.document, 'meta', {
+      name: 'amp-action-whitelist',
+      content: '',
+    });
+    ampdoc.getHeadNode().appendChild(meta);
+    action = new ActionService(ampdoc);
+    const i = new ActionInvocation(
+      target,
+      'print',
+      /* args */ null,
+      'source',
+      'caller',
+      'event',
+      ActionTrust.HIGH,
+      'tap',
+      'AMP'
+    );
+    sandbox.stub(action, 'error_');
+    expect(action.invoke_(i)).to.be.null;
+    expect(action.error_).to.be.calledWith(
+      '"AMP.print" is not whitelisted [].'
+    );
+  });
+
+  it('should ignore unparseable whitelist entries', () => {
+    const meta = createElementWithAttributes(env.win.document, 'meta', {
+      name: 'amp-action-whitelist',
+      content: 'AMP.pushState, invalidEntry, AMP.setState, *.show',
+    });
+    ampdoc.getHeadNode().appendChild(meta);
+    allowConsoleError(() => {
+      action = new ActionService(ampdoc);
+    });
+    const i = new ActionInvocation(
+      target,
+      'setState',
+      /* args */ null,
+      'source',
+      'caller',
+      'event',
+      ActionTrust.HIGH,
+      'tap',
+      'AMP'
+    );
+    action.invoke_(i);
+    expect(spy).to.be.calledWithExactly(i);
+  });
+});

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -1658,19 +1658,17 @@ describes.fakeWin('Core events', {amp: true}, env => {
   });
 });
 
-describes.realWin(
+describes.ampdocs(
   'Action whitelisting',
-  {
-    amp: {
-      ampdoc: 'single',
-    },
-  },
+  {},
   env => {
+    let ampdoc;
     let action;
     let target;
     let spy;
     let getDefaultActionAlias;
     beforeEach(() => {
+      ampdoc = env.ampdoc;
       spy = env.sandbox.spy();
       getDefaultActionAlias = env.sandbox.stub();
       target = createExecElement('foo', spy, getDefaultActionAlias);
@@ -1683,8 +1681,8 @@ describes.realWin(
             'AMP.pushState, AMP.setState, *.show, ' +
             'amp-element.defaultAction',
         });
-        env.win.document.head.appendChild(meta);
-        action = new ActionService(env.ampdoc, env.win.document);
+        ampdoc.getHeadNode().appendChild(meta);
+        action = new ActionService(ampdoc);
       });
 
       it('should allow whitelisted actions', () => {
@@ -1800,8 +1798,8 @@ describes.realWin(
         name: 'amp-action-whitelist',
         content: '',
       });
-      env.win.document.head.appendChild(meta);
-      action = new ActionService(env.ampdoc, env.win.document);
+      ampdoc.getHeadNode().appendChild(meta);
+      action = new ActionService(ampdoc);
       const i = new ActionInvocation(
         target,
         'print',
@@ -1825,9 +1823,9 @@ describes.realWin(
         name: 'amp-action-whitelist',
         content: 'AMP.pushState, invalidEntry, AMP.setState, *.show',
       });
-      env.win.document.head.appendChild(meta);
+      ampdoc.getHeadNode().appendChild(meta);
       allowConsoleError(() => {
-        action = new ActionService(env.ampdoc, env.win.document);
+        action = new ActionService(ampdoc);
       });
       const i = new ActionInvocation(
         target,

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -209,6 +209,59 @@ export const realWin = describeEnv(spec => [
 ]);
 
 /**
+ * A test with a real (iframed) window and multiple ampdoc scenarios:
+ * - single ampdoc
+ * - shadoc ampdoc
+ * TODO(#25419): "fie ampdoc" and "fie in shadow" ampdoc.
+ */
+export const ampdocs = (function() {
+  /**
+   * @param {string} name
+   * @param {{
+   *   fakeRegisterElement: (boolean|undefined),
+   *   amp: (boolean|!AmpTestSpec|undefined),
+   * }} spec
+   * @param {function({
+   *   win: !Window,
+   *   iframe: !HTMLIFrameElement,
+   *   amp: (!AmpTestEnv|undefined),
+   * })} fn
+   * @param {function(string, function())} describeFunc
+   */
+  const templateFunc = function(name, spec, fn, describeFunc) {
+    function run(ampdocType) {
+      const clonedSpec = JSON.parse(JSON.stringify(spec));
+      clonedSpec.amp = Object.assign(clonedSpec.amp || {}, {ampdoc: ampdocType});
+      realWin(`ampdoc:${ampdocType}`, clonedSpec, fn);
+    }
+    return describeFunc(name, function() {
+      run('single');
+      run('shadow');
+    });
+  };
+
+  /**
+   * @param {string} name
+   * @param {!Object<string, *>} variants
+   * @param {function(string, *)} fn
+   */
+  const mainFunc = function(name, variants, fn) {
+    return templateFunc(name, variants, fn, describe);
+  };
+
+  /**
+   * @param {string} name
+   * @param {!Object<string, *>} variants
+   * @param {function(string, *)} fn
+   */
+  mainFunc.only = function(name, variants, fn) {
+    return templateFunc(name, variants, fn, describe./*OK*/ only);
+  };
+
+  return mainFunc;
+})();
+
+/**
  * A test that loads HTML markup in `spec.body` into an embedded iframe.
  * @param {string} name
  * @param {{

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -232,7 +232,9 @@ export const ampdocs = (function() {
   const templateFunc = function(name, spec, fn, describeFunc) {
     function run(ampdocType) {
       const clonedSpec = JSON.parse(JSON.stringify(spec));
-      clonedSpec.amp = Object.assign(clonedSpec.amp || {}, {ampdoc: ampdocType});
+      clonedSpec.amp = Object.assign(clonedSpec.amp || {}, {
+        ampdoc: ampdocType,
+      });
       realWin(`ampdoc:${ampdocType}`, clonedSpec, fn);
     }
     return describeFunc(name, function() {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -212,7 +212,8 @@ export const realWin = describeEnv(spec => [
  * A test with a real (iframed) window and multiple ampdoc scenarios:
  * - single ampdoc
  * - shadoc ampdoc
- * TODO(#25419): "fie ampdoc" and "fie in shadow" ampdoc.
+ * TODO(#25419): "fie ampdoc" and "fie in shadow" ampdoc. Can only be added
+ * once ampdoc-fie launches.
  */
 export const ampdocs = (function() {
   /**
@@ -237,6 +238,7 @@ export const ampdocs = (function() {
     return describeFunc(name, function() {
       run('single');
       run('shadow');
+      run('fie');
     });
   };
 


### PR DESCRIPTION
Partial for #25419

PTAL at your earliest convenience. This is one approach how we can convert big percentage of our tests to cover more deployment scenarios. As you can see, I picked the first test ("actions" starts with "a") and immediately found several nuanced bugs. One can argue that some of these are not bugs because they are for features only built for one deployment scenario and not the other. But I'd argue that in the longterm, it's very hard to classify features like this and it might be easier to just assure the correct behavior in all environments.

And, of course, number of relevant tests would go up 3-4x.

An alternative approach is in #25426.