### PR TITLE
Don't send video error metrics if autoplay was denied 

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -830,9 +830,14 @@ export class AmpStoryPage extends AMP.BaseElement {
                 // If autoplay got rejected, display a "play" button. If
                 // autoplay was supported, dispay an error message.
                 this.isAutoplaySupported_().then(isAutoplaySupported => {
-                  isAutoplaySupported
-                    ? this.toggleErrorMessage_(true)
-                    : this.togglePlayMessage_(true);
+                  if (isAutoplaySupported) {
+                    this.toggleErrorMessage_(true);
+                    return;
+                  }
+
+                  // Error was expected, don't send the performance metrics.
+                  this.stopMeasuringVideoPerformance_(false /** sendMetrics */);
+                  this.togglePlayMessage_(true);
                 });
               }
 
@@ -1320,16 +1325,18 @@ export class AmpStoryPage extends AMP.BaseElement {
   /**
    * Stops measuring video performance metrics, if performance tracking is on.
    * Computes and sends the metrics.
+   * @param {boolean=} sendMetrics
    * @private
    */
-  stopMeasuringVideoPerformance_() {
+  stopMeasuringVideoPerformance_(sendMetrics = true) {
     if (!this.mediaPerformanceMetricsService_.isPerformanceTrackingOn()) {
       return;
     }
 
     for (let i = 0; i < this.performanceTrackedVideos_.length; i++) {
       this.mediaPerformanceMetricsService_.stopMeasuring(
-        this.performanceTrackedVideos_[i]
+        this.performanceTrackedVideos_[i],
+        sendMetrics
       );
     }
   }
@@ -1456,6 +1463,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     this.playMessageEl_.addEventListener('click', () => {
       this.togglePlayMessage_(false);
+      this.startMeasuringVideoPerformance_();
       this.mediaPoolPromise_
         .then(mediaPool => mediaPool.blessAll())
         .then(() => this.playAllMedia_());

--- a/extensions/amp-story/1.0/media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/media-performance-metrics-service.js
@@ -159,8 +159,9 @@ export class MediaPerformanceMetricsService {
    * Stops recording, computes, and sends performance metrics collected for the
    * given media element.
    * @param {!HTMLMediaElement} media
+   * @param {boolean=} sendMetrics
    */
-  stopMeasuring(media) {
+  stopMeasuring(media, sendMetrics = true) {
     const mediaEntry = this.getMediaEntry_(media);
 
     if (!mediaEntry) {
@@ -179,7 +180,9 @@ export class MediaPerformanceMetricsService {
         break;
     }
 
-    this.sendMetrics_(mediaEntry);
+    if (sendMetrics) {
+      this.sendMetrics_(mediaEntry);
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -478,7 +478,10 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     page.setState(PageState.PLAYING);
     page.setState(PageState.NOT_ACTIVE);
 
-    expect(stopMeasuringStub).to.have.been.calledOnceWithExactly(videoEl);
+    expect(stopMeasuringStub).to.have.been.calledOnceWithExactly(
+      videoEl,
+      true /* sendMetrics */
+    );
   });
 
   it('should not start tracking media performance if tracking is off', async () => {

--- a/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
@@ -100,6 +100,21 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
     expect(flushStub).to.have.been.calledTwice;
   });
 
+  it('should not flush metrics if sendMetrics is false', () => {
+    const flushStub = sandbox.stub(service.performanceService_, 'flush');
+
+    const video = win.document.createElement('video');
+    service.startMeasuring(video);
+    clock.tick(20);
+    video.dispatchEvent(new Event('playing'));
+    clock.tick(100);
+    video.dispatchEvent(new Event('waiting'));
+    clock.tick(300);
+    service.stopMeasuring(video, false /** sendMetrics */);
+
+    expect(flushStub).to.not.have.been.called;
+  });
+
   describe('Joint latency', () => {
     it('should record joint latency if playback starts with no wait', () => {
       const video = win.document.createElement('video');


### PR DESCRIPTION
When autoplay is blocked by the browser, don't flush the video performance metrics.
Instead, wait until the user clicks on the "play" button to start measuring, bless, and play the videos.

We could check if the autoplay is supported before even trying to measure the video performance, but this operation is rather slow as under the hood it creates a video and tries to play it. So instead we optimize for the case where everything plays as expected, and perform the expensive check only upon error.

Fixes #25147