### PR TITLE
Proposal: disallow document.head in preference to ampdoc

### DIFF
--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -22,6 +22,14 @@ requirement: {
   whitelist: 'src/preconnect.js'
   whitelist: 'src/experiments.js'
   whitelist: 'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js'
+
+  # DO NOT SUBMIT: remove; testing only.
+  whitelist: 'extensions/'
+  whitelist: 'src/cookies.js'
+  whitelist: 'src/element-service.js'
+  whitelist: 'src/inabox/utils.js'
+  whitelist: 'src/runtime.js'
+  whitelist: 'src/service/document-info-impl.js'
 }
 
 

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -7,6 +7,15 @@ requirement: {
   error_message: 'Should not throw a non-Error object.'
 }
 
+# Document: most of properties should be access via ampdoc for proper scoping.
+requirement: {
+  type: BANNED_PROPERTY
+  error_message: 'Use ampdoc instead'
+  value: 'Document.prototype.head'
+  whitelist: 'src/service/ampdoc-impl.js'
+}
+
+
 # Element
 
 requirement: {

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -12,7 +12,15 @@ requirement: {
   type: BANNED_PROPERTY
   error_message: 'Use ampdoc instead'
   value: 'Document.prototype.head'
+  whitelist: 'ads/'
   whitelist: 'src/service/ampdoc-impl.js'
+  whitelist: 'src/validator-integration.js'
+  whitelist: 'src/style-installer.js'
+  whitelist: 'src/shadow-embed.js'
+  whitelist: 'src/service/extensions-impl.js'
+  whitelist: 'src/preconnect.js'
+  whitelist: 'src/experiments.js'
+  whitelist: 'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js'
 }
 
 

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -12,6 +12,7 @@ requirement: {
   type: BANNED_PROPERTY
   error_message: 'Use ampdoc instead'
   value: 'Document.prototype.head'
+  whitelist: '3p/'
   whitelist: 'ads/'
   whitelist: 'src/service/ampdoc-impl.js'
   whitelist: 'src/validator-integration.js'


### PR DESCRIPTION
Partial for #25419

Alternative to #25423 is to disallow most of `Document` APIs and eventually disallow `window.document` property as well. Interestingly, this does not catch all issues I expected. In particular, [this head resolution](https://github.com/ampproject/amphtml/blob/1b2bb3a2c9d2e49c349a15b86c1d84470a3fb7a3/src/service/action-impl.js#L803) has not been caught.

Also, combination of both could be good. Compiler for most and multi-tests for the trickiest cases.

Unfortunately, this does not catch any destructuring assignment cases. See google/closure-compiler#3500 for more details.