### PR TITLE
Ensure video element is upgraded to customElement before using signals.

### DIFF
--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {dev} from './log';
 import {whenUpgradedToCustomElement} from './dom';
 
 export const MIN_VISIBILITY_RATIO_FOR_AUTOPLAY = 0.5;
@@ -532,7 +533,7 @@ export const VideoServiceSignals = {
 
 /** @param {!AmpElement|!VideoOrBaseElementDef} video */
 export function delegateAutoplay(video) {
-  whenUpgradedToCustomElement(video).then(el => {
+  whenUpgradedToCustomElement(dev().assertElement(video)).then(el => {
     el.signals().signal(VideoServiceSignals.AUTOPLAY_DELEGATED);
   });
 }

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {whenUpgradedToCustomElement} from './dom';
+
 export const MIN_VISIBILITY_RATIO_FOR_AUTOPLAY = 0.5;
 
 /**
@@ -530,7 +532,9 @@ export const VideoServiceSignals = {
 
 /** @param {!AmpElement|!VideoOrBaseElementDef} video */
 export function delegateAutoplay(video) {
-  video.signals().signal(VideoServiceSignals.AUTOPLAY_DELEGATED);
+  whenUpgradedToCustomElement(video).then(el => {
+    el.signals().signal(VideoServiceSignals.AUTOPLAY_DELEGATED);
+  });
 }
 
 /** @param {!AmpElement|!VideoOrBaseElementDef} video */


### PR DESCRIPTION
Ensures video element is upgraded to customElement before using signals. Tested locally.

Details in the issue.

Fixes #25386