### PR TITLE
Update Swg Amp extension to use new callbacks

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -200,14 +200,14 @@ export class GoogleSubscriptionsPlatform {
     this.runtime_.setOnNativeSubscribeRequest(() => {
       this.onNativeSubscribeRequest_();
     });
-    this.runtime_.setOnSubscribeResponse(promise => {
+    this.runtime_.setOnPaymentResponse(promise => {
       promise.then(response => {
-        this.onSubscribeResponse_(response, Action.SUBSCRIBE);
-      });
-    });
-    this.runtime_.setOnContributionResponse(promise => {
-      promise.then(response => {
-        this.onSubscribeResponse_(response, Action.CONTRIBUTE);
+        this.onSubscribeResponse_(
+          response,
+          response.productType === 'CONTRIBUTION'
+            ? Action.CONTRIBUTE
+            : Action.SUBSCRIBE
+        );
       });
     });
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -103,7 +103,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
       ),
       subscribeResponse: sandbox.stub(
         ConfiguredRuntime.prototype,
-        'setOnSubscribeResponse'
+        'setOnPaymentResponse'
       ),
     };
     methods = {


### PR DESCRIPTION
Update extension to use new setOnPaymentResponse callback instead of setOnSubscribeResponse.
