### PR TITLE
Narrow down script matching to avoid incorrect prefix matches

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -270,12 +270,22 @@ export class Extensions {
    */
   getExtensionScript_(extensionId, includeInserted = true) {
     // Always ignore <script> elements that have a mismatched RTV.
+    // We have to match against "src" because a few extensions, such as
+    // "amp-viewer-integration", do not have "custom-element" attribute.
     const modifier =
       ':not([i-amphtml-loaded-new-version])' +
       (includeInserted ? '' : ':not([i-amphtml-inserted])');
-    return this.win.document.head./*OK*/ querySelector(
+    const matches = this.win.document.head./*OK*/ querySelectorAll(
       `script[src*="/${extensionId}-"]` + modifier
     );
+    const matcher = new RegExp(`${extensionId}-[0-9]`);
+    for (let i = 0; i < matches.length; i++) {
+      const match = matches[i];
+      if (matcher.test(match.src)) {
+        return match;
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -248,12 +248,10 @@ export class Extensions {
       /* includeInserted */ false
     );
     devAssert(el, 'Cannot find script for extension: %s', extensionId);
-    // "Disconnect" the old script element and extension record.
+    // The previously awaited extension loader must not have finished or
+    // failed.
     const holder = this.extensions_[extensionId];
-    if (holder) {
-      devAssert(!holder.loaded && !holder.error);
-      delete this.extensions_[extensionId];
-    }
+    devAssert(!holder || (!holder.loaded && !holder.error));
     el.setAttribute('i-amphtml-loaded-new-version', extensionId);
     const urlParts = parseExtensionUrl(el.src);
     return this.preloadExtension(extensionId, urlParts.extensionVersion);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -251,7 +251,10 @@ export class Extensions {
     // The previously awaited extension loader must not have finished or
     // failed.
     const holder = this.extensions_[extensionId];
-    devAssert(!holder || (!holder.loaded && !holder.error));
+    if (holder) {
+      devAssert(!holder.loaded && !holder.error);
+      holder.scriptPresent = false;
+    }
     el.setAttribute('i-amphtml-loaded-new-version', extensionId);
     const urlParts = parseExtensionUrl(el.src);
     return this.preloadExtension(extensionId, urlParts.extensionVersion);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -278,7 +278,7 @@ export class Extensions {
     const matches = this.win.document.head./*OK*/ querySelectorAll(
       `script[src*="/${extensionId}-"]` + modifier
     );
-    const matcher = new RegExp(`${extensionId}-[0-9]`);
+    const matcher = new RegExp(`${extensionId}-\\d`);
     for (let i = 0; i < matches.length; i++) {
       const match = matches[i];
       if (matcher.test(match.src)) {

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -603,6 +603,32 @@ describes.sandboxed('Extensions', {}, () => {
         expect(elementClass).to.equal(ctor);
       });
     });
+
+    it('should keep awaiting promise through reload', () => {
+      const script = document.createElement('script');
+      script.setAttribute('custom-element', 'amp-ext');
+      script.setAttribute(
+        'src',
+        'https://cdn.ampproject.org/v0/amp-ext-0.1.js'
+      );
+      win.document.head.appendChild(script);
+
+      // Start waiting immediately.
+      const initialPromise = extensions.waitForExtension(win, 'amp-ext');
+
+      // Reload the extension. E.g. due to the version mismatch.
+      const reloadPromise = extensions.reloadExtension('amp-ext');
+
+      // Register extension.
+      extensions.registerExtension('amp-ext', () => {}, {});
+
+      return reloadPromise.then(reloadedExtension => {
+        expect(reloadedExtension).to.exist;
+        return initialPromise.then(initialExtension => {
+          expect(initialExtension).to.equal(reloadedExtension);
+        });
+      });
+    });
   });
 
   describes.fakeWin('reloadExtension', {}, env => {

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -736,6 +736,20 @@ describes.sandboxed('Extensions', {}, () => {
         expect(win.customElements.elements['amp-mustache']).to.be.undefined;
       });
 
+      it('should insert extension script and not colide with prefixes', () => {
+        // First add an extension with the same suffix.
+        extensions.preloadExtension('amp-test-suffix');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test-suffix"]')
+        ).to.have.length(1);
+
+        // Then try to add the prefix-based extension.
+        extensions.preloadExtension('amp-test');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(1);
+      });
+
       it('should insert extension version correctly', () => {
         expect(
           doc.head.querySelectorAll('[custom-element="amp-test"]')

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -614,7 +614,7 @@ describes.sandboxed('Extensions', {}, () => {
       win.document.head.appendChild(script);
 
       // Start waiting immediately.
-      const initialPromise = extensions.waitForExtension(win, 'amp-ext');
+      const initialPromise = extensions.preloadExtension('amp-ext');
 
       // Reload the extension. E.g. due to the version mismatch.
       const reloadPromise = extensions.reloadExtension('amp-ext');
@@ -626,6 +626,10 @@ describes.sandboxed('Extensions', {}, () => {
         expect(reloadedExtension).to.exist;
         return initialPromise.then(initialExtension => {
           expect(initialExtension).to.equal(reloadedExtension);
+          const newScript = win.document.head.querySelector(
+            'script[custom-element="amp-ext"]:not([i-amphtml-loaded-new-version])'
+          );
+          expect(newScript).to.exist;
         });
       });
     });


### PR DESCRIPTION
Fixes #25436.

Additionally fixes a race condition on the wait->reload sequence. Rare, but manifests itself exactly the same way as described in the #25436.