### PR TITLE
🏗 Manually upgrade transitive validator dependencies with security vulnerabilities

### DIFF
--- a/validator/package.json
+++ b/validator/package.json
@@ -18,5 +18,10 @@
     "google-closure-compiler": "20191027.0.0",
     "google-closure-library": "20191027.0.1",
     "jasmine": "3.5.0"
+  },
+  "resolutions": {
+    "**/**/diff": "^3.5.0",
+    "**/**/debug": "^2.6.9",
+    "**/**/growl": "^1.10.0"
   }
 }

--- a/validator/yarn.lock
+++ b/validator/yarn.lock
@@ -87,12 +87,12 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
+debug@2.2.0, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
-    ms "0.7.1"
+    ms "2.0.0"
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -101,10 +101,10 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
-diff@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
-  integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
+diff@1.4.0, diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 es-abstract@^1.12.0:
   version "1.16.0"
@@ -226,10 +226,10 @@ google-closure-library@20191027.0.1:
   dependencies:
     promises-aplus-tests "^2.1.2"
 
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
+growl@1.9.2, growl@^1.10.0:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -389,10 +389,10 @@ mocha@^2.5.3:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 object-inspect@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
Validator tests use `jasmine@3.5.0`, which depends on packages with security vulnerabilities. This PR manually overrides them until such time that `jasmine` pushes an update.

Travis tests will tell us if these updates actually work.

![image](https://user-images.githubusercontent.com/26553114/68243770-3d23ed80-ffe1-11e9-9aa4-4b1fcdf4d417.png)

/cc @mrjoro @ampproject/wg-caching 