### PR TITLE
Prerender amp-video poster image.

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -115,10 +115,12 @@ class AmpVideo extends AMP.BaseElement {
    * @override
    */
   firstAttachedCallback() {
-    // Only allow prerender if video sources are cached on CDN. Set this value
-    // in `firstAttachedCallback` since `buildCallback` is too late and the
-    // element children may not be available in the constructor.
-    this.prerenderAllowed_ = this.hasAnyCachedSources_();
+    // Only allow prerender if video sources are cached on CDN, or if video has
+    // a poster image. Set this value in `firstAttachedCallback` since
+    // `buildCallback` is too late and the element children may not be available
+    // in the constructor.
+    const posterAttr = this.element.getAttribute('poster');
+    this.prerenderAllowed_ = !!posterAttr || this.hasAnyCachedSources_();
   }
 
   /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -164,11 +164,12 @@ class AmpVideo extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {string}
+   * @return {?string}
    */
   getVideoSourceForPreconnect_() {
     if (this.getAmpDoc().getVisibilityState() === VisibilityState.PRERENDER) {
-      return this.getFirstCachedSource_();
+      const source = this.getFirstCachedSource_();
+      return (source && source.getAttribute('src')) || null;
     }
     let videoSrc = this.element.getAttribute('src');
     if (!videoSrc) {
@@ -458,7 +459,7 @@ class AmpVideo extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {string=}
+   * @return {?Element}
    */
   getFirstCachedSource_() {
     const {element} = this;

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -167,6 +167,9 @@ class AmpVideo extends AMP.BaseElement {
    * @return {string}
    */
   getVideoSourceForPreconnect_() {
+    if (this.getAmpDoc().getVisibilityState() === VisibilityState.PRERENDER) {
+      return this.getFirstCachedSource_();
+    }
     let videoSrc = this.element.getAttribute('src');
     if (!videoSrc) {
       const source = elementByTag(this.element, 'source');
@@ -450,15 +453,23 @@ class AmpVideo extends AMP.BaseElement {
    * @return {boolean}
    */
   hasAnyCachedSources_() {
+    return !!this.getFirstCachedSource_();
+  }
+
+  /**
+   * @private
+   * @return {string=}
+   */
+  getFirstCachedSource_() {
     const {element} = this;
     const sources = toArray(childElementsByTag(element, 'source'));
     sources.push(element);
     for (let i = 0; i < sources.length; i++) {
       if (this.isCachedByCDN_(sources[i])) {
-        return true;
+        return sources[i];
       }
     }
-    return false;
+    return null;
   }
 
   /**

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -19,6 +19,7 @@ import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
 import {VisibilityState} from '../../../../src/visibility-state';
 import {listenOncePromise} from '../../../../src/event-helper';
+import {registerServiceBuilder} from '../../../../src/service';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(
@@ -815,6 +816,85 @@ describes.realWin(
               }
             );
           });
+        });
+      });
+
+      describe('should preconnect to the first cached source', () => {
+        let fakePreconnect;
+
+        beforeEach(() => {
+          fakePreconnect = {url: () => {}};
+          registerServiceBuilder(win, 'preconnect', () => fakePreconnect);
+        });
+
+        it('no cached source', async () => {
+          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+
+          await getVideo({
+            src: 'https://example.com/video.mp4',
+            poster: 'https://example.com/poster.jpg',
+            width: 160,
+            height: 90,
+          });
+
+          expect(preloadStub).to.not.have.been.called;
+        });
+
+        it('cached source', async () => {
+          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+
+          const cachedSource = doc.createElement('source');
+          cachedSource.setAttribute(
+            'src',
+            'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
+          cachedSource.setAttribute(
+            'amp-orig-src',
+            'https://example.com/video.mp4'
+          );
+
+          await getVideo(
+            {
+              poster: 'https://example.com/poster.jpg',
+              width: 160,
+              height: 90,
+            },
+            [cachedSource]
+          );
+
+          expect(preloadStub).to.have.been.calledOnce;
+          expect(preloadStub.getCall(0).args[1]).to.equal(
+            'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
+        });
+
+        it('mixed sources', async () => {
+          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+
+          const source = doc.createElement('source');
+          source.setAttribute('src', 'video.mp4');
+
+          const cachedSource = doc.createElement('source');
+          cachedSource.setAttribute(
+            'src',
+            'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
+          cachedSource.setAttribute(
+            'amp-orig-src',
+            'https://example.com/video.mp4'
+          );
+          await getVideo(
+            {
+              poster: 'https://example.com/poster.jpg',
+              width: 160,
+              height: 90,
+            },
+            [source, cachedSource]
+          );
+          expect(preloadStub).to.have.been.calledOnce;
+          expect(preloadStub.getCall(0).args[1]).to.equal(
+            'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
         });
       });
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -482,6 +482,7 @@ describes.realWin(
       const v = await getVideo({
         src: 'video.mp4',
         'object-fit': 'cover',
+        layout: 'responsive',
       });
       const video = v.querySelector('video');
       expect(video.style.objectFit).to.equal('cover');
@@ -491,6 +492,7 @@ describes.realWin(
       const v = await getVideo({
         src: 'video.mp4',
         'object-fit': 'foo 80%',
+        layout: 'responsive',
       });
       const video = v.querySelector('video');
       expect(video.style.objectFit).to.be.empty;
@@ -500,6 +502,7 @@ describes.realWin(
       const v = await getVideo({
         src: 'video.mp4',
         'object-position': '20% 80%',
+        layout: 'responsive',
       });
       const video = v.querySelector('video');
       expect(video.style.objectPosition).to.equal('20% 80%');
@@ -509,6 +512,7 @@ describes.realWin(
       const v = await getVideo({
         src: 'video.mp4',
         'object-position': 'url("example.com")',
+        layout: 'responsive',
       });
       const video = v.querySelector('video');
       expect(video.style.objectPosition).to.be.empty;
@@ -785,6 +789,26 @@ describes.realWin(
                 height: 90,
               },
               [source, cachedSource],
+              element => {
+                expect(element.implementation_.prerenderAllowed()).to.be.true;
+                resolve();
+              }
+            );
+          });
+        });
+      });
+
+      describe('should prerender poster image', () => {
+        it('with just cached src', () => {
+          return new Promise(resolve => {
+            getVideo(
+              {
+                src: 'https://example.com/video.mp4',
+                poster: 'https://example.com/poster.jpg',
+                width: 160,
+                height: 90,
+              },
+              null,
               element => {
                 expect(element.implementation_.prerenderAllowed()).to.be.true;
                 resolve();


### PR DESCRIPTION
`amp-video` used to load the poster image in prerender (#1657 + #1718).
When introducing prerendering for cached videos (#12193 + #17493), we broke the case for prerendering the poster when the video is not cached.

If the video has cached sources OR a poster image, it should allow prerendering.

It is safe to prerender a video with a poster image but no cached source, as the `amp-video.layoutCallback` will only propagate the cached source until the viewer is visible ([source](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video/0.1/amp-video.js#L310-L326)).

Fixes #25446