### PR TITLE
🚀 Break infinite loop with loading container

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -615,7 +615,8 @@ function createBaseCustomElementClass(win) {
           this.toggleLoading(true);
         } else if (
           layoutBox.top < PREPARE_LOADING_THRESHOLD &&
-          layoutBox.top >= 0
+          layoutBox.top >= 0 &&
+          !this.loadingContainer_
         ) {
           // Few top elements will also be pre-initialized with a loading
           // element.

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -270,9 +270,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         clock.tick(1);
         const element = new ElementClass();
         const buildPromise = Promise.resolve();
-        const buildStub = sandbox
-          .stub(element, 'build')
-          .returns(buildPromise);
+        const buildStub = sandbox.stub(element, 'build').returns(buildPromise);
         container.appendChild(element);
         container.removeChild(element);
 

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -172,7 +172,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('Element - createdCallback', () => {
         const element = new ElementClass();
-        const build = sandbox.stub(element, 'build');
+        const build = sandbox.stub(element, 'build').returns(Promise.resolve());
 
         expect(element.isBuilt()).to.equal(false);
         expect(element.hasAttributes()).to.equal(false);
@@ -225,9 +225,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('Element - should only add classes on first attachedCallback', () => {
         const element = new ElementClass();
         const buildPromise = Promise.resolve();
-        const buildStub = sandbox
-          .stub(element, 'build')
-          .callsFake(() => buildPromise);
+        const buildStub = sandbox.stub(element, 'build').returns(buildPromise);
 
         expect(element).to.not.have.class('i-amphtml-element');
         expect(element).to.not.have.class('i-amphtml-notbuilt');
@@ -274,7 +272,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         const buildPromise = Promise.resolve();
         const buildStub = sandbox
           .stub(element, 'build')
-          .callsFake(() => buildPromise);
+          .returns(buildPromise);
         container.appendChild(element);
         container.removeChild(element);
 
@@ -298,7 +296,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('Element - should NOT reset on 2nd attachedCallback w/o request', () => {
         clock.tick(1);
         const element = new ElementClass();
-        sandbox.stub(element, 'build');
+        sandbox.stub(element, 'build').returns(Promise.resolve());
         container.appendChild(element);
         container.removeChild(element);
 
@@ -524,10 +522,11 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
 
       it('Element - re-upgrade with a failed promised', () => {
+        expectAsyncConsoleError('upgrade failed', 1);
         const element = new ElementClass();
         expect(element.isUpgraded()).to.equal(false);
         const oldImpl = element.implementation_;
-        const promise = Promise.reject();
+        const promise = Promise.reject(new Error('upgrade failed'));
         oldImpl.upgradeCallback = () => promise;
 
         container.appendChild(element);


### PR DESCRIPTION
The loading container is created during `updateLayoutBox` (directly after a measure). It uses `mutateElement` to do it, which invalidates the layoutBox. When Resources detects that the layout box is invalid, it remeasures it, and calls `updateLayoutBox`.

Guess what happens?

We call `mutateElement` again. We invalidate the layout box. Resources measures, calls `updateLayoutBox`. On and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on...