### PR TITLE
🏗 Use AES-GCM instead of AES-CTR in SwG Decryption

### DIFF
--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -141,7 +141,7 @@ export class CryptoHandler {
     //    bytes.
     const encryptedBytes = base64DecodeToBytes(encryptedContent);
     const iv = encryptedBytes.slice(0, AES_GCM_IV_LENGTH);
-    const encryptedBytes = encryptedBytes.slice(AES_GCM_IV_LENGTH);
+    const content = encryptedBytes.slice(AES_GCM_IV_LENGTH);
 
     // 3. Get document Key in the correct format.
     return this.stringToCryptoKey_(decryptedDocumentKey).then(function(
@@ -155,7 +155,7 @@ export class CryptoHandler {
             iv: iv,
           },
           formattedDocKey,
-          encryptedBytes
+          content
         )
         .then(function(buffer) {
           // 5. Decryption gives us raw bytes and we need to turn them into text.

--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -21,6 +21,9 @@ import {toArray} from '../../../src/types';
 import {tryParseJson} from '../../../src/json';
 import {utf8Decode, utf8Encode} from '../../../src/utils/bytes';
 
+// Length of IV in AES-GCM encoded content.
+const AES_GCM_IV_LENGTH = 12;
+
 export class CryptoHandler {
   /**
    * Creates an instance of CryptoHandler.
@@ -137,6 +140,8 @@ export class CryptoHandler {
     // 2. Un-base64 the encrypted content. This way we get the actual encrypted
     //    bytes.
     const encryptedBytes = base64DecodeToBytes(encryptedContent);
+    const iv = encryptedBytes.slice(0, AES_GCM_IV_LENGTH);
+    const encryptedBytes = encryptedBytes.slice(AES_GCM_IV_LENGTH);
 
     // 3. Get document Key in the correct format.
     return this.stringToCryptoKey_(decryptedDocumentKey).then(function(
@@ -146,9 +151,8 @@ export class CryptoHandler {
       return crypto.subtle
         .decrypt(
           {
-            name: 'AES-CTR',
-            counter: new Uint8Array(16), // iv: all zeros.
-            length: 128, // block size (16): 1-128
+            name: 'AES-GCM',
+            iv: iv,
           },
           formattedDocKey,
           encryptedBytes
@@ -170,7 +174,7 @@ export class CryptoHandler {
     const documentKeyBytes = base64DecodeToBytes(decryptedDocumentKey);
 
     // 2. Convert bytes to CryptoKey format.
-    return crypto.subtle.importKey('raw', documentKeyBytes, 'AES-CTR', true, [
+    return crypto.subtle.importKey('raw', documentKeyBytes, 'AES-GCM', true, [
       'decrypt',
     ]);
   }

--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -152,7 +152,7 @@ export class CryptoHandler {
         .decrypt(
           {
             name: 'AES-GCM',
-            iv: iv,
+            iv,
           },
           formattedDocKey,
           content

--- a/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
@@ -40,16 +40,16 @@ describes.realWin(
     };
     // eslint-disable-next-line max-len
     const encryptedContent =
-      'PTzfydqid9+FitGB3xeQEG98u+zj6/wpZ/KMeZewGldw/pp2MCvwstHGCtqjIN5ROi61OmZkQDW9c2ezuu1WTXDANoE5UY5ED51lftywdTYmLk+rvtRL/fUVaPIOaiP/wkm+I2Ssw99cOnv4hFphOuz9Db2/RisQXVT/7yiaiHDEE5aJlxuAYqyjMnDweGhKjuXpgAOpbOOEI78t91AKpTbsQg9bxXafruB46+3jI6COfzI3e7griJ5LoQSPG4JEn7bw8jnD67djb9J3c6hak++vbSvqBxewNpSV+v9HU+w=';
+      'W03SytAJzlAhsj/XVOBtKQdVhINRBWcMIEO3ttsJgYj8GjwDRS0x8SNGu8IO4OyFB/SSpWYKOJITu4Fo98OzCF4ue3RT94XqmZf2UCjLc5i/eIl0f+jYJRl5Qfo1tnAD6z4sgF1pEHJ8H5JbaqCQXSv7rmBiD7NkdLOgcJlwYwCPBpHWmJkFBeQfMohSpuk38xEtwIDqAqN0eKGBz8aTU0jHvpC5zWBFVhjxnoSgTfYJMrmIldFqSqaXra+KlOeaXvTaMT7vZCY5bAJcuHAlmxNghv7GptrLiR02ZMEt334AjY8dPYJQBW+giMqjeU3w5i0GJHmksrfFognnjlRtS5/hOc9JVwqq';
     // eslint-disable-next-line max-len
     const decryptedContent =
       "\n      This is section is top secret.\n      You should only be able to read this if you have the correct permissions.\n      If you don't have the correct permissions, you shouldn't be able to read this section at all.\n      ";
     // eslint-disable-next-line max-len
     const encryptedKey =
-      "ENCRYPT({'accessRequirements': ['googleAccessRequirements:123'], 'key':'0noKkOifsbYqKGUyPv+1JJLygWa3PuMA8vGBvRCmkaQ='})";
-    const decryptedDocKey = '0noKkOifsbYqKGUyPv+1JJLygWa3PuMA8vGBvRCmkaQ=';
+      "ENCRYPT({'AccessRequirements': ['googleAccessRequirements:123'], 'Key':'/L2HS2v6LrJIk8iq+7AhdA=='})";
+    const decryptedDocKey = '/L2HS2v6LrJIk8iq+7AhdA==';
     const decryptedDocKeyHash =
-      '5903f44139fd3d88414b0d29c986fd0ca1572eb214e3a0d56201d06ed753c39e';
+      '9dc1e142b11338d895438a3f8c0947b57a7c368e9d7913f7df80b5491f488490';
     const encryptedKeys = {
       'local': encryptedKey,
       'google.com': encryptedKey,

--- a/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
@@ -40,16 +40,16 @@ describes.realWin(
     };
     // eslint-disable-next-line max-len
     const encryptedContent =
-      'W03SytAJzlAhsj/XVOBtKQdVhINRBWcMIEO3ttsJgYj8GjwDRS0x8SNGu8IO4OyFB/SSpWYKOJITu4Fo98OzCF4ue3RT94XqmZf2UCjLc5i/eIl0f+jYJRl5Qfo1tnAD6z4sgF1pEHJ8H5JbaqCQXSv7rmBiD7NkdLOgcJlwYwCPBpHWmJkFBeQfMohSpuk38xEtwIDqAqN0eKGBz8aTU0jHvpC5zWBFVhjxnoSgTfYJMrmIldFqSqaXra+KlOeaXvTaMT7vZCY5bAJcuHAlmxNghv7GptrLiR02ZMEt334AjY8dPYJQBW+giMqjeU3w5i0GJHmksrfFognnjlRtS5/hOc9JVwqq';
+      '8bCQpCyIBxBHwTZVRaMuA+DGXSTzVHR/Eh/l6QqfvcXQbn5uF/HzL539jw6Ok8+oppqo2eP/H9oqaYCi4Ya50uVFzdTCBzOSTlJDmeXhqO1DIBYHIQTK3z+NweOAJci7aXwSOLtJZd1KrrCesoBjAlQ55GwyPe6xPVcUESjtT15Z7Ez1GSetSE99MIbn8fWjq5CjUZn4q3jDKdNGdM6NZ86lqL5ZsbbUQRQ2dIVExrwS9GuuFsuFi8Eahe3/eZaibZY4PzPuVR6jjCrDrgF5qw+N+uacDumoA5he/1WrHiYHzoV28Xo9yuBBm5JWEcMepoUkQgKVywOFZS4otSR81va9JNwk1F1AIQ4VOqezFE6ce92qbzo+aMVzceZJqPhVqsA=';
     // eslint-disable-next-line max-len
     const decryptedContent =
-      "\n      This is section is top secret.\n      You should only be able to read this if you have the correct permissions.\n      If you don't have the correct permissions, you shouldn't be able to read this section at all.\n      ";
+      "\n              This is section is top secret.\n              You should only be able to read this if you have the correct permissions.\n              If you don't have the correct permissions, you shouldn't be able to read this section at all.\n            ";
     // eslint-disable-next-line max-len
     const encryptedKey =
-      "ENCRYPT({'AccessRequirements': ['googleAccessRequirements:123'], 'Key':'/L2HS2v6LrJIk8iq+7AhdA=='})";
-    const decryptedDocKey = '/L2HS2v6LrJIk8iq+7AhdA==';
+      "ENCRYPT({'AccessRequirements': ['googleAccessRequirements:123'], 'Key':'mSfq5tRx5omXoOX20Oqq8g=='})";
+    const decryptedDocKey = 'mSfq5tRx5omXoOX20Oqq8g==';
     const decryptedDocKeyHash =
-      '9dc1e142b11338d895438a3f8c0947b57a7c368e9d7913f7df80b5491f488490';
+      'a2de5c3d4947d3af3e9357b224220855591fa5ebecfbfcaa8a5dd8361f1c08da';
     const encryptedKeys = {
       'local': encryptedKey,
       'google.com': encryptedKey,
@@ -122,7 +122,9 @@ describes.realWin(
         return cryptoHandler
           .decryptDocumentContent_(encryptedContent, decryptedDocKey)
           .then(actualContent => {
-            expect(actualContent).to.equal(decryptedContent);
+            expect(actualContent.replace(/&#39;/g, "'")).to.equal(
+              decryptedContent
+            );
           });
       });
     });


### PR DESCRIPTION
- Uses AES-GCM instead of AES-CTR in decryption for swg-crypto
- Updates encrypted text in tests to use AES-GCM
