### PR TITLE
AMP Runtime: add support to strip xssi prevention prefixes before converting fetch responses to json

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1242,6 +1242,7 @@ export class AmpList extends AMP.BaseElement {
       urlReplacement: this.getPolicy_(),
       refresh,
       token,
+      stripPrefix: this.element.getAttribute('strip-prefix') || undefined,
     });
   }
 

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -192,5 +192,11 @@
     <div></div>
   </amp-list>
   <template id="found"></template>
+  <!-- Valid: amp-list with src and strip-prefix attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            strip-prefix="while(1)">
+    <div></div>
+  </amp-list>
 </body>
 </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -227,5 +227,11 @@ amp-list/0.1/test/validator-amp-list.html:184:2 Attribute 'template' in tag 'amp
 amp-list/0.1/test/validator-amp-list.html:194:2 The mandatory attribute 'type' is missing in tag 'template'. (see https://amp.dev/documentation/components/amp-mustache)
 >>   ^~~~~~~~~
 amp-list/0.1/test/validator-amp-list.html:194:2 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://amp.dev/documentation/components/amp-mustache)
+|    <!-- Valid: amp-list with src and strip-prefix attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              strip-prefix="while(1)">
+|      <div></div>
+|    </amp-list>
 |  </body>
 |  </html>

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -88,6 +88,7 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     value: "fetch"
   }
   attrs: { name: "single-item" }
+  attrs: { name: "strip-prefix" }
   attrs: {
     name: "src"
     mandatory_anyof: "['src','[src]','data-amp-bind-src']"

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -53,6 +53,7 @@ export function batchFetchJsonFor(
     urlReplacement = UrlReplacementPolicy.NONE,
     refresh = false,
     token = undefined,
+    stripPrefix = undefined,
   } = {}
 ) {
   assertHttpsUrl(element.getAttribute('src'), element);
@@ -70,7 +71,7 @@ export function batchFetchJsonFor(
       }
       return xhr.fetchJson(data.xhrUrl, data.fetchOpt);
     })
-    .then(res => res.json())
+    .then(res => Services.xhrFor(ampdoc.win).xssiJson(res, stripPrefix))
     .then(data => {
       if (data == null) {
         throw new Error('Response is undefined.');

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -42,6 +42,8 @@ export const UrlReplacementPolicy = {
  *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
  * @param {boolean|undefined} options.refresh Forces refresh of browser cache.
  * @param {string|undefined} options.token Auth token that forces a POST request.
+ * @param {string|undefined} options.stripPrefix Prefix to optionally
+ *     strip from the response before calling parseJson.
  * @return {!Promise<!JsonObject|!Array<JsonObject>>} Resolved with JSON
  *     result or rejected if response is invalid.
  */

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -154,7 +154,7 @@ export class Xhr {
    *
    * @param {!Response} res fetch response to convert to json.
    * @param {string|undefined} prefix to strip away.
-   * @return {JsonObject}
+   * @return {Promise<*>}
    */
   xssiJson(res, prefix) {
     if (!prefix) {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -162,10 +162,13 @@ export class Xhr {
     }
 
     return res.text().then(txt => {
-      const stripped = startsWith(txt, dev().assertString(prefix))
-        ? txt.slice(prefix.length)
-        : txt;
-      return parseJson(stripped);
+      if (!startsWith(txt, dev().assertString(prefix))) {
+        user().warn(
+          `Attempted to strip prefix "${prefix}" from xhr request, but prefix was not present.`
+        );
+        return parseJson(txt);
+      }
+      return parseJson(txt.slice(prefix.length));
     });
   }
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -23,12 +23,12 @@ import {
   setupInput,
   setupJsonFetchInit,
 } from '../utils/xhr-utils';
+import {dev, user} from '../log';
 import {getCorsUrl, parseUrlDeprecated} from '../url';
-import {parseJson} from '../json';
-import {startsWith} from '../string';
 import {getService, registerServiceBuilder} from '../service';
 import {isFormDataWrapper} from '../form-data-wrapper';
-import {user, dev} from '../log';
+import {parseJson} from '../json';
+import {startsWith} from '../string';
 
 /**
  * A service that polyfills Fetch API for use within AMP.
@@ -154,6 +154,7 @@ export class Xhr {
    *
    * @param {!Response} res fetch response to convert to json.
    * @param {string|undefined} prefix to strip away.
+   * @return {JsonObject}
    */
   xssiJson(res, prefix) {
     if (!prefix) {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -165,7 +165,7 @@ export class Xhr {
       if (!startsWith(txt, dev().assertString(prefix))) {
         user().warn(
           'XHR',
-          `Attempted to strip prefix "${prefix}" from xhr request, but prefix was not present.`
+          `Failed to strip missing prefix "${prefix}" in fetch response.`
         );
         return parseJson(txt);
       }

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -164,6 +164,7 @@ export class Xhr {
     return res.text().then(txt => {
       if (!startsWith(txt, dev().assertString(prefix))) {
         user().warn(
+          'XHR',
           `Attempted to strip prefix "${prefix}" from xhr request, but prefix was not present.`
         );
         return parseJson(txt);

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -24,6 +24,7 @@ describe('batchFetchJsonFor', () => {
   // Service fakes.
   let urlReplacements;
   let batchedXhr;
+  let xhr;
   // Function stubs.
   let fetchJson;
   // Mutable return variables.
@@ -54,6 +55,10 @@ describe('batchFetchJsonFor', () => {
         json: () => Promise.resolve(data),
       })
     );
+
+    xhr = {xssiJson: () => Promise.resolve(data)};
+    window.sandbox.stub(Services, 'xhrFor').returns(xhr);
+
     batchedXhr = {fetchJson};
     window.sandbox.stub(Services, 'batchedXhrFor').returns(batchedXhr);
   });

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -28,7 +28,6 @@ describe('batchFetchJsonFor', () => {
   let fetchJson;
   // Mutable return variables.
   const data = {'foo': 'bar'};
-  const xssiPrefix = ")]}'\n";
 
   /**
    * @param {string} src
@@ -53,7 +52,6 @@ describe('batchFetchJsonFor', () => {
     fetchJson = window.sandbox.stub().returns(
       Promise.resolve({
         json: () => Promise.resolve(data),
-        text: () => Promise.resolve(xssiPrefix + JSON.stringify(data)),
       })
     );
     batchedXhr = {fetchJson};
@@ -174,41 +172,5 @@ describe('batchFetchJsonFor', () => {
       });
     });
   });
-
-  describe('Should respect strip-prefix', () => {
-    it('empty string has no effect', () => {
-      const el = element('https://data.com');
-      el.setAttribute('strip-prefix', '');
-      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
-        json => {
-          expect(json).to.be.equal(data);
-        }
-      );
-    });
-
-    it('strip-prefix on an element where the response does not actually start with that prefix will have no effect', () => {
-      const el = element('https://data.com');
-      el.setAttribute('strip-prefix', 'cats');
-      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
-        () => {
-          throw new Error(
-            'parseJson should have failed due to presence of the xssi prefix.'
-          );
-        },
-        () => 'success' // TODO(friedj): is there a better way of writing this?
-      );
-    });
-
-    it('strip-prefix on the element ensures text is stripped prior to JSON.parse', () => {
-      const el = element('https://data.com');
-      el.setAttribute('strip-prefix', xssiPrefix);
-      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
-        json => {
-          expect(json).to.be.deep.equal(data);
-        }
-      );
-    });
-  });
-
   // TODO(choumx): Add tests for normal fetch functionality.
 });

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -28,6 +28,7 @@ describe('batchFetchJsonFor', () => {
   let fetchJson;
   // Mutable return variables.
   const data = {'foo': 'bar'};
+  const xssiPrefix = ")]}'\n";
 
   /**
    * @param {string} src
@@ -52,6 +53,7 @@ describe('batchFetchJsonFor', () => {
     fetchJson = window.sandbox.stub().returns(
       Promise.resolve({
         json: () => Promise.resolve(data),
+        text: () => Promise.resolve(xssiPrefix + JSON.stringify(data)),
       })
     );
     batchedXhr = {fetchJson};
@@ -172,5 +174,41 @@ describe('batchFetchJsonFor', () => {
       });
     });
   });
+
+  describe('Should respect strip-prefix', () => {
+    it('empty string has no effect', () => {
+      const el = element('https://data.com');
+      el.setAttribute('strip-prefix', '');
+      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
+        json => {
+          expect(json).to.be.equal(data);
+        }
+      );
+    });
+
+    it('strip-prefix on an element where the response does not actually start with that prefix will have no effect', () => {
+      const el = element('https://data.com');
+      el.setAttribute('strip-prefix', 'cats');
+      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
+        () => {
+          throw new Error(
+            'parseJson should have failed due to presence of the xssi prefix.'
+          );
+        },
+        () => 'success' // TODO(friedj): is there a better way of writing this?
+      );
+    });
+
+    it('strip-prefix on the element ensures text is stripped prior to JSON.parse', () => {
+      const el = element('https://data.com');
+      el.setAttribute('strip-prefix', xssiPrefix);
+      return batchFetchJsonFor(ampdoc, el, null, undefined, false).then(
+        json => {
+          expect(json).to.be.deep.equal(data);
+        }
+      );
+    });
+  });
+
   // TODO(choumx): Add tests for normal fetch functionality.
 });


### PR DESCRIPTION
Partially fixes https://github.com/ampproject/amphtml/issues/17691, https://github.com/ampproject/amphtml/issues/22689, and b/143896641

**summary**
Creates a new helper within the `xhr` service called `xssiJson`. It is meant to be logically equivalent to a standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response)'s json() function, except this one also optionally takes in a prefix to strip.

This PR also adds support to this feature via a `strip-prefix` attribute _just_ to the `amp-list` component. After this is submitted we can discuss which other components should also have this option.