### PR TITLE
♻️ Delay constructing BaseElement until connectedCallback

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -383,7 +383,7 @@ function createBaseCustomElementClass(win) {
         this.implementation_ = new newImplClass(this);
       } catch (e) {
         const TAG = this.tagName;
-        dev().error(TAG, 'Failed to constrcutor BaseElement', e);
+        dev().error(TAG, 'Failed to construct BaseElement', e);
         return;
       }
       if (this.everAttached) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -35,7 +35,7 @@ import {dev, devAssert, rethrowAsync, user, userAssert} from './log';
 import {
   getImplementation,
   upgradeWhenRegistered,
-} from './custom-element-registry';
+} from './service/custom-element-registry';
 import {getIntersectionChangeEntry} from '../src/intersection-observer-polyfill';
 import {getMode} from './mode';
 import {htmlFor} from './static-template';

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -33,7 +33,7 @@ import {blockedByConsentError, isBlockedByConsent, reportError} from './error';
 import {createLoaderElement} from '../src/loader.js';
 import {dev, devAssert, rethrowAsync, user, userAssert} from './log';
 import {
-  getImplementation,
+  getImplementationClass,
   upgradeWhenRegistered,
 } from './service/custom-element-registry';
 import {getIntersectionChangeEntry} from '../src/intersection-observer-polyfill';
@@ -825,7 +825,7 @@ function createBaseCustomElementClass(win) {
 
         // Load the pre-stubbed extension if needed.
         if (isStub(this.implementation_)) {
-          const Ctor = getImplementation(win, this);
+          const Ctor = getImplementationClass(win, this);
 
           // If the registered BaseElement implementation is still the
           // ElementStub, that means the extension script hasn't been

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -376,7 +376,16 @@ function createBaseCustomElementClass(win) {
         // Already upgraded or in progress or failed.
         return;
       }
-      this.implementation_ = new newImplClass(this);
+
+      // If the implmementation fails to construct, we'll leave it as a
+      // ElementStub. The runtime will ignore the element from now on.
+      try {
+        this.implementation_ = new newImplClass(this);
+      } catch (e) {
+        const TAG = this.tagName;
+        dev().error(TAG, 'Failed to constrcutor BaseElement', e);
+        return;
+      }
       if (this.everAttached) {
         // Usually, we do an implementation upgrade when the element is
         // attached to the DOM. But, if it hadn't yet upgraded from
@@ -832,14 +841,7 @@ function createBaseCustomElementClass(win) {
               );
             }
           } else {
-            // If the implmementation fails to construct, we'll leave it as a
-            // ElementStub. The runtime will ignore the element from now on.
-            try {
-              this.implementation_ = new Ctor(this);
-            } catch (e) {
-              const TAG = this.tagName;
-              dev().error(TAG, 'Failed to constrcutor BaseElement', e);
-            }
+            this.upgrade(Ctor);
           }
         }
       }

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -17,14 +17,10 @@
 import {BaseElement} from './base-element';
 import {devAssert} from './log';
 
-/** @type {!Array} */
-export const stubbedElements = [];
-
 export class ElementStub extends BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-    stubbedElements.push(this);
   }
 
   /** @override */

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -36,7 +36,7 @@ function getExtendedElements(win) {
 }
 
 /**
- * Returns the BaseElement implmementation that the element should upgrade to.
+ * Returns the BaseElement implementation that the element should upgrade to.
  * @param {!Window} win
  * @param {!Element} el
  * @return {function(new:../base-element.BaseElement, !Element)}
@@ -89,10 +89,10 @@ export function upgradeOrRegisterElement(win, name, toClass) {
   knownElements[name] = toClass;
   let pointer = 0;
 
-  // The only elements in stubbedElements are the ones that were paresed or
+  // The only elements in stubbedElements are the ones that were parsed or
   // document.createElement-and-connected after registering the CE name (eg,
   // amp-img registered as ElementStub), but before the actual BaseElement
-  // implmementation was registered. We need to go through and "upgrade" the BE
+  // implementation was registered. We need to go through and "upgrade" the BE
   // implmementation on these elements.
   for (let i = 0; i < stubbedElements.length; i++) {
     const element = stubbedElements[i];

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -16,10 +16,10 @@
 
 import {ElementStub} from '../element-stub';
 import {createCustomElementClass} from '../custom-element';
-import {extensionScriptsInNode} from '../element-service';
-import {reportError} from '../error';
 import {devAssert, userAssert} from '../log';
+import {extensionScriptsInNode} from '../element-service';
 import {getMode} from './mode';
+import {reportError} from '../error';
 
 /** @type {!Array<!Element>} */
 const stubbedElements = [];

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -54,9 +54,9 @@ export function getImplementation(win, el) {
 }
 
 /**
- * Returns the BaseElement implmementation that the element should upgrade to.
+ * Schedules the element to have its BaseElement implementation upgraded when
+ * it becomes registered.
  * @param {!Element} el
- * @return {?function(new:../base-element.BaseElement)}
  */
 export function upgradeWhenRegistered(el) {
   stubbedElements.push(el);

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -18,7 +18,7 @@ import {ElementStub} from '../element-stub';
 import {createCustomElementClass} from '../custom-element';
 import {devAssert, userAssert} from '../log';
 import {extensionScriptsInNode} from '../element-service';
-import {getMode} from './mode';
+import {getMode} from '../mode';
 import {reportError} from '../error';
 
 /** @type {!Array<!Element>} */

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -39,7 +39,7 @@ function getExtendedElements(win) {
  * Returns the BaseElement implmementation that the element should upgrade to.
  * @param {!Window} win
  * @param {!Element} el
- * @return {?function(new:../base-element.BaseElement)}
+ * @return {?function(new:../base-element.BaseElement, !Element)}
  */
 export function getImplementation(win, el) {
   // Closure compiler appears to mark HTMLElement as @struct which

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -39,7 +39,7 @@ function getExtendedElements(win) {
  * Returns the BaseElement implmementation that the element should upgrade to.
  * @param {!Window} win
  * @param {!Element} el
- * @return {?function(new:../base-element.BaseElement, !Element)}
+ * @return {function(new:../base-element.BaseElement, !Element)}
  */
 export function getImplementation(win, el) {
   // Closure compiler appears to mark HTMLElement as @struct which

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -41,7 +41,7 @@ function getExtendedElements(win) {
  * @param {!Element} el
  * @return {function(new:../base-element.BaseElement, !Element)}
  */
-export function getImplementation(win, el) {
+export function getImplementationClass(win, el) {
   // Closure compiler appears to mark HTMLElement as @struct which
   // disables bracket access. Force this with a type coercion.
   const nonStructEl = /** @type {!Object} */ (el);

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -279,7 +279,8 @@ function printWarning(...messages) {
     }
   }
 
-  const errorMessage = message.split('\n', 1)[0]; // First line.
+  originalConsoleError(message);
+
   const helpMessage =
     '    The test "' +
     testName +
@@ -295,7 +296,7 @@ function printWarning(...messages) {
     'following pattern at the top of the test:\n' +
     "        'expectAsyncConsoleError(<string or regex>[, <number of" +
     ' times the error message repeats>]);';
-  originalConsoleError(errorMessage + "'\n" + helpMessage);
+  originalConsoleError(helpMessage);
 }
 
 /**

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -260,6 +260,7 @@ describe
           klass = createFakeVideoPlayerClass(env.win);
           video = env.createAmpElement('amp-test-fake-videoplayer', klass);
           env.win.document.body.appendChild(video);
+          video.upgrade(klass);
           impl = video.implementation_;
           installVideoManagerForDoc(env.ampdoc);
           videoManager = Services.videoManagerForDoc(env.ampdoc);

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -70,12 +70,22 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     expect(getElementClassForTesting(win, 'amp-element1')).to.equal(
       ConcreteElement
     );
-    expect(element1.implementation_).to.be.instanceOf(ConcreteElement);
 
-    // Elements created post-download and immediately upgraded.
-    const element2 = doc.createElement('amp-element1');
-    doc.body.appendChild(element1);
-    expect(element2.implementation_).to.be.instanceOf(ConcreteElement);
+    return element1
+      .whenUpgraded()
+      .then(() => {
+        expect(element1.implementation_).to.be.instanceOf(ConcreteElement);
+
+        // Elements created post-download and immediately upgraded.
+        const element2 = doc.createElement('amp-element1');
+        element2.setAttribute('layout', 'nodisplay');
+        doc.body.appendChild(element2);
+
+        return element2.whenUpgraded().then(() => element2);
+      })
+      .then(element2 => {
+        expect(element2.implementation_).to.be.instanceOf(ConcreteElement);
+      });
   });
 
   it('should mark stubbed element as declared', () => {
@@ -101,6 +111,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     expect(stub).to.not.be.called;
 
     const element = doc.createElement('amp-element2');
+    element.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(element);
     expect(stub).to.be.calledOnce;
     expect(stub).to.be.calledWithExactly(ampdoc, 'amp-element2');
@@ -116,6 +127,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     expect(stub).to.not.be.called;
 
     const element = doc.createElement('amp-element2');
+    element.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(element);
     expect(stub).to.not.be.called;
   });
@@ -131,6 +143,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     expect(stub).to.not.be.called;
 
     const element = doc.createElement('amp-element1');
+    element.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(element);
     expect(stub).to.not.be.called;
   });

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -1158,12 +1158,18 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
     const promise = fie.installExtensionsInChildWindow(extensions, iframeWin, [
       'amp-test',
     ]);
+
     // Must be stubbed already.
+    const element = iframeWin.document.createElement('amp-test');
+    element.setAttribute('layout', 'nodisplay');
+    const elementSub = iframeWin.document.createElement('amp-test-sub');
+    elementSub.setAttribute('layout', 'nodisplay');
+    iframeWin.document.body.appendChild(element);
+    iframeWin.document.body.appendChild(elementSub);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
-    expect(
-      iframeWin.document.createElement('amp-test').implementation_
-    ).to.be.instanceOf(ElementStub);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+    expect(element.isUpgraded()).to.be.false;
+
     // Resolve the promise.
     extensions.registerExtension(
       'amp-test',
@@ -1175,30 +1181,33 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
       },
       parentWin.AMP
     );
-    return promise.then(() => {
-      // Main extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-      expect(iframeWin.document.querySelector('style[amp-extension=amp-test]'))
-        .to.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test').implementation_
-      ).to.be.instanceOf(AmpTest);
+    return promise
+      .then(() => {
+        expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
+        expect(
+          iframeWin.document.querySelector('style[amp-extension=amp-test]')
+        ).to.exist;
 
-      // Secondary extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
-        AmpTestSub
-      );
-      expect(
-        iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
-      ).to.not.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test-sub').implementation_
-      ).to.be.instanceOf(AmpTestSub);
-    });
+        expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
+          AmpTestSub
+        );
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
+          AmpTestSub
+        );
+        expect(
+          iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
+        ).to.not.exist;
+
+        // Will upgrade.
+        return Promise.all([element.getImpl(false), elementSub.getImpl(false)]);
+      })
+      .then(() => {
+        expect(element.isUpgraded()).to.be.true;
+        expect(element.implementation_).to.be.instanceOf(AmpTest);
+        expect(elementSub.isUpgraded()).to.be.true;
+        expect(elementSub.implementation_).to.be.instanceOf(AmpTestSub);
+      });
   });
 
   it('should adopt extension services', () => {
@@ -1442,12 +1451,18 @@ describes.realWin('installExtensionsInFie', {amp: true}, env => {
     const promise = fie.installExtensionsInFie(extensions, ampdoc, [
       'amp-test',
     ]);
+
     // Must be stubbed already.
+    const element = iframeWin.document.createElement('amp-test');
+    element.setAttribute('layout', 'nodisplay');
+    const elementSub = iframeWin.document.createElement('amp-test-sub');
+    elementSub.setAttribute('layout', 'nodisplay');
+    iframeWin.document.body.appendChild(element);
+    iframeWin.document.body.appendChild(elementSub);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
-    expect(
-      iframeWin.document.createElement('amp-test').implementation_
-    ).to.be.instanceOf(ElementStub);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+    expect(element.isUpgraded()).to.be.false;
+
     // Resolve the promise.
     extensions.registerExtension(
       'amp-test',
@@ -1459,30 +1474,31 @@ describes.realWin('installExtensionsInFie', {amp: true}, env => {
       },
       parentWin.AMP
     );
-    return promise.then(() => {
-      // Main extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-      expect(iframeWin.document.querySelector('style[amp-extension=amp-test]'))
-        .to.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test').implementation_
-      ).to.be.instanceOf(AmpTest);
+    return promise
+      .then(() => {
+        expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
+        expect(
+          iframeWin.document.querySelector('style[amp-extension=amp-test]')
+        ).to.exist;
 
-      // Secondary extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
-        AmpTestSub
-      );
-      expect(
-        iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
-      ).to.not.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test-sub').implementation_
-      ).to.be.instanceOf(AmpTestSub);
-    });
+        expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
+          AmpTestSub
+        );
+        expect(
+          iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
+        ).to.not.exist;
+
+        // Will upgrade.
+        return Promise.all([element.getImpl(false), elementSub.getImpl(false)]);
+      })
+      .then(() => {
+        expect(element.isUpgraded()).to.be.true;
+        expect(element.implementation_).to.be.instanceOf(AmpTest);
+        expect(elementSub.isUpgraded()).to.be.true;
+        expect(elementSub.implementation_).to.be.instanceOf(AmpTestSub);
+      });
   });
 
   it('should adopt extension services', () => {

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -30,6 +30,7 @@ describes.realWin(
     let children;
     let sandbox;
     let scheduleLayoutOrPreloadStub;
+    let AmpTest;
 
     beforeEach(() => {
       win = env.win;
@@ -37,7 +38,9 @@ describes.realWin(
       sandbox = env.sandbox;
       owners = Services.ownersForDoc(env.ampdoc);
       resources = Services.resourcesForDoc(env.ampdoc);
-      resources.isRuntimeOn_ = false;
+
+      AmpTest = class AmpTest extends win.AMP.BaseElement {};
+
       // DOM tree (numbers are resource IDs):
       // body -- 0 -- div -- 3
       //                  -- 4
@@ -63,9 +66,9 @@ describes.realWin(
     });
 
     function createElement() {
-      const element = env.createAmpElement('amp-test');
-      sandbox.stub(element, 'isUpgraded').returns(true);
-      return element;
+      const el = env.createAmpElement('amp-test');
+      el.upgrade(AmpTest);
+      return el;
     }
 
     function createElementWithResource(


### PR DESCRIPTION
This avoids a whole host of problems that can happen innocently inside the implementation's constructor. Eg, trying to get access to the `ampdoc` or a doc-level service.

This also wraps the construction in a try-catch, so that if the instance fails to construct, we will permanently ignore the custom element.