### PR TITLE
🐛 Only unlayout img if img exists

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -284,8 +284,8 @@ export class AmpImg extends BaseElement {
     // Interrupt retrieval of incomplete images to free network resources when
     // navigating pages in a PWA. Opt for tiny dataURI image instead of empty
     // src to prevent the viewer from detecting a load error.
-    const img = dev().assertElement(this.img_);
-    if (!img.complete) {
+    const img = this.img_;
+    if (img && !img.complete) {
       img.src =
         'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
       removeElement(img);

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -422,6 +422,17 @@ describe('amp-img', () => {
     });
   });
 
+  it('should not error on unlayoutCallback before layoutCallback', () => {
+    const el = document.createElement('amp-img');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('width', 100);
+    el.setAttribute('height', 100);
+    el.setAttribute('noprerender', '');
+    const impl = new AmpImg(el);
+    impl.buildCallback();
+    impl.unlayoutCallback();
+  });
+
   describe('blurred image placeholder', () => {
     beforeEach(() => {
       toggleExperiment(window, 'blurry-placeholder', true, true);


### PR DESCRIPTION
It appears `unlayoutCallback` can be called anytime after `build`. I had expected that it could only be called after `layoutCallback` completed.

Thankfully, it doesn't cause any real issues, but it's getting a lot of error reports.

Fixes #25511