### PR TITLE
♻️Refactor error handling for amp-list load-more as not to throw needless errors

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -540,6 +540,7 @@ export class AmpList extends AMP.BaseElement {
     const actions = Services.actionServiceForDoc(this.element);
     actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
   }
+
   /**
    * Request list data from `src` and return a promise that resolves when
    * the list has been populated with rendered list items. If the viewer is

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -561,7 +561,9 @@ export class AmpList extends AMP.BaseElement {
         if (this.loadMoreEnabled_) {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
         }
-        return this.scheduleRender_(items).then(() => this.maybeSetLoadMore_());
+        return this.scheduleRender_(items, /*opt_append*/ false, data).then(
+          () => this.maybeSetLoadMore_()
+        );
       });
     }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -572,6 +572,7 @@ export class AmpList extends AMP.BaseElement {
     return fetch.catch(error => {
       this.triggerFetchErrorEvent_(error);
       this.showFallback_();
+      throw error;
     });
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -500,6 +500,7 @@ export class AmpList extends AMP.BaseElement {
    * attribute is set, and truncates the list-items to a length defined
    * by max-items.
    * @param {!JsonObject|!Array<JsonObject>} data
+   * @throws {!Error} If response is undefined
    * @return {!Array}
    */
   computeListItems_(data) {
@@ -1320,7 +1321,6 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @throws {!Error} If fallback element is not present.
    * @private
    */
   showFallback_() {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -551,9 +551,10 @@ export class AmpList extends AMP.BaseElement {
       actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
 
       if (opt_append) {
-        throw error;
+        this.handleLoadMoreFailed_();
+      } else {
+        this.showFallback_();
       }
-      this.showFallbackOrThrow_(error);
     });
   }
 
@@ -1168,9 +1169,6 @@ export class AmpList extends AMP.BaseElement {
       .then(() => {
         // Necessary since load-more elements are toggled in the above block
         this.attemptToFitLoadMore_(dev().assertElement(this.container_));
-      })
-      .catch(() => {
-        this.handleLoadMoreFailed_();
       });
   }
 
@@ -1279,11 +1277,10 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * @param {*=} error
    * @throws {!Error} If fallback element is not present.
    * @private
    */
-  showFallbackOrThrow_(error) {
+  showFallback_() {
     this.element.classList.add('i-amphtml-list-fetch-error');
     // Displaying [fetch-error] may offset initial content, so resize to fit.
     if (childElementByAttr(this.element, 'fetch-error')) {
@@ -1294,8 +1291,6 @@ export class AmpList extends AMP.BaseElement {
     if (this.getFallback()) {
       this.toggleFallback_(true);
       this.togglePlaceholder(false);
-    } else {
-      throw error;
     }
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -527,7 +527,7 @@ export class AmpList extends AMP.BaseElement {
 
   /**
    * Trigger a fetch-error event
-   * @param {!Error} error
+   * @param {*} error
    */
   triggerFetchErrorEvent_(error) {
     const event = error

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -561,7 +561,7 @@ export class AmpList extends AMP.BaseElement {
         if (this.loadMoreEnabled_) {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
         }
-        return this.scheduleRender_(items);
+        return this.scheduleRender_(items).then(() => this.maybeSetLoadMore_());
       });
     }
 
@@ -746,9 +746,9 @@ export class AmpList extends AMP.BaseElement {
       .then(elements => this.render_(elements, current.append));
     if (!isSSR) {
       const payload = /** @type {!JsonObject} */ (current.payload);
-      renderPromise = renderPromise
-        .then(() => this.maybeRenderLoadMoreTemplates_(payload))
-        .then(() => this.maybeSetLoadMore_());
+      renderPromise = renderPromise.then(() =>
+        this.maybeRenderLoadMoreTemplates_(payload)
+      );
     }
     renderPromise.then(onFulfilledCallback, onRejectedCallback);
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -161,10 +161,7 @@ export class AmpList extends AMP.BaseElement {
       () => {
         if (this.layoutCompleted_) {
           this.resetIfNecessary_();
-          return this.fetchList_(
-            /* opt_append */ false,
-            /* opt_refresh */ true
-          );
+          return this.fetchList_(/* opt_refresh */ true);
         }
       },
       ActionTrust.HIGH
@@ -496,16 +493,62 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * Given JSON payload data fetched from the server, modifies the
+   * data according to developer-defined parameters. Extracts the correct
+   * list items according to the 'items' attribute, asserts that this
+   * contains an array or object, put object in an array if the single-item
+   * attribute is set, and truncates the list-items to a length defined
+   * by max-items.
+   * @param {!JsonObject|!Array<JsonObject>} data
+   * @return {!Array}
+   */
+  computeListItems_(data) {
+    const itemsExpr = this.element.getAttribute('items') || 'items';
+    let items = data;
+    if (itemsExpr != '.') {
+      items = getValueForExpr(/**@type {!JsonObject}*/ (data), itemsExpr);
+    }
+    userAssert(
+      typeof items !== 'undefined',
+      'Response must contain an array or object at "%s". %s',
+      itemsExpr,
+      this.element
+    );
+    if (this.element.hasAttribute('single-item') && !isArray(items)) {
+      items = [items];
+    }
+    items = user().assertArray(items);
+    if (this.element.hasAttribute('max-items')) {
+      items = this.truncateToMaxLen_(items);
+    }
+    return items;
+  }
+
+  /**
+   * Trigger a fetch-error event
+   * @param {!Error} error
+   */
+  triggerFetchErrorEvent_(error) {
+    const event = error
+      ? createCustomEvent(
+          this.win,
+          `${TAG}.error`,
+          dict({'response': error.response})
+        )
+      : null;
+    const actions = Services.actionServiceForDoc(this.element);
+    actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
+  }
+  /**
    * Request list data from `src` and return a promise that resolves when
    * the list has been populated with rendered list items. If the viewer is
    * capable of rendering the templates, then the fetching of the list and
    * transformation of the template is handled by the viewer.
-   * @param {boolean=} opt_append
    * @param {boolean=} opt_refresh
    * @return {!Promise}
    * @private
    */
-  fetchList_(opt_append = false, opt_refresh = false) {
+  fetchList_(opt_refresh = false) {
     if (!this.element.getAttribute('src')) {
       return Promise.resolve();
     }
@@ -513,48 +556,37 @@ export class AmpList extends AMP.BaseElement {
     if (this.ssrTemplateHelper_.isSupported()) {
       fetch = this.ssrTemplate_(opt_refresh);
     } else {
-      const itemsExpr = this.element.getAttribute('items') || 'items';
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
-        let items = data;
-        if (itemsExpr != '.') {
-          items = getValueForExpr(/**@type {!JsonObject}*/ (data), itemsExpr);
-        }
-        userAssert(
-          typeof items !== 'undefined',
-          'Response must contain an array or object at "%s". %s',
-          itemsExpr,
-          this.element
-        );
-        if (this.element.hasAttribute('single-item') && !isArray(items)) {
-          items = [items];
-        }
-        items = user().assertArray(items);
-        if (this.element.hasAttribute('max-items')) {
-          items = this.truncateToMaxLen_(items);
-        }
+        const items = this.computeListItems_(data);
         if (this.loadMoreEnabled_) {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
         }
-        return this.scheduleRender_(items, opt_append, /* opt_payload */ data);
+        return this.scheduleRender_(items);
       });
     }
 
     return fetch.catch(error => {
-      const event = error
-        ? createCustomEvent(
-            this.win,
-            `${TAG}.error`,
-            dict({'response': error.response})
-          )
-        : null;
-      const actions = Services.actionServiceForDoc(this.element);
-      actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
+      this.triggerFetchErrorEvent_(error);
+      this.showFallback_();
+    });
+  }
 
-      if (opt_append) {
-        this.handleLoadMoreFailed_();
-      } else {
-        this.showFallback_();
-      }
+  /**
+   * Fetch and render items intended to be appended to the current list
+   * @return {!Promise}
+   */
+  fetchListAndAppend_() {
+    if (!this.element.getAttribute('src')) {
+      return Promise.resolve();
+    }
+    return this.prepareAndSendFetch_().then(data => {
+      const items = this.computeListItems_(data);
+      this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
+      return this.scheduleRender_(
+        items,
+        /*opt_append*/ true,
+        /*opt_payload*/ data
+      );
     });
   }
 
@@ -1106,6 +1138,10 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * Sets up auto-load-more if automatic load-more is on. Otherwise, sets up
+   * manual load-more. In manual, shows the load-more button if there are more
+   * elements to load and the load-more-end element if otherwise. Called on
+   * the first fetch if load-more is on. Only called once.
    * @return {!Promise}
    * @private
    */
@@ -1153,7 +1189,7 @@ export class AmpList extends AMP.BaseElement {
     this.mutateElement(() => {
       this.getLoadMoreService_().toggleLoadMoreLoading(true);
     });
-    return this.fetchList_(/* opt_append */ true)
+    return this.fetchListAndAppend_()
       .then(() => {
         return this.mutateElement(() => {
           if (this.loadMoreSrc_) {
@@ -1169,6 +1205,10 @@ export class AmpList extends AMP.BaseElement {
       .then(() => {
         // Necessary since load-more elements are toggled in the above block
         this.attemptToFitLoadMore_(dev().assertElement(this.container_));
+      })
+      .catch(error => {
+        this.triggerFetchErrorEvent_(error);
+        this.handleLoadMoreFailed_();
       });
   }
 
@@ -1204,6 +1244,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * Sets up a listener on viewport change to load more items
    * @private
    */
   setupLoadMoreAuto_() {

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -29,7 +29,7 @@ const HAS_MORE_ITEMS_PAYLOAD = {
 };
 
 describes.realWin(
-  'amp-list component',
+  'amp-list with load-more',
   {
     amp: {
       ampdoc: 'single',
@@ -175,19 +175,15 @@ describes.realWin(
       });
 
       it('should update the next loading src', async () => {
-        const fetchListSpy = sandbox.spy(list, 'fetchList_');
         sandbox.stub(list, 'scheduleRender_').returns(Promise.resolve());
         await list.layoutCallback();
         expect(element.getAttribute('src')).to.equal(
           '/list/infinite-scroll?items=2&left=1'
         );
-        expect(fetchListSpy).to.be.calledOnce;
         await list.loadMoreCallback_();
         expect(element.getAttribute('src')).to.equal(
           '/list/infinite-scroll?items=2&left=0'
         );
-        expect(fetchListSpy).to.be.calledTwice;
-        expect(fetchListSpy).to.be.calledWith(true);
       });
 
       it('should append items to the existing list', async () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -535,7 +535,7 @@ describes.repeated(
             yield list.layoutCallback();
 
             expect(actions.trigger).to.be.calledWithExactly(
-              list,
+              list.element,
               'fetch-error',
               sinon.match.any,
               ActionTrust.LOW

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -414,9 +414,7 @@ describes.repeated(
               .expects('toggleLoading')
               .withExactArgs(false)
               .once();
-            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
-              /Response must contain an array/
-            );
+            return list.layoutCallback();
           });
 
           it('should fail to load b/c data single-item object is absent', () => {
@@ -433,9 +431,7 @@ describes.repeated(
               .expects('toggleLoading')
               .withExactArgs(false)
               .once();
-            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
-              /Response must contain an array or object/
-            );
+            return list.layoutCallback();
           });
 
           it('should load and render with a different root', () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -414,7 +414,9 @@ describes.repeated(
               .expects('toggleLoading')
               .withExactArgs(false)
               .once();
-            return list.layoutCallback();
+            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
+              /Response must contain an array/
+            );
           });
 
           it('should fail to load b/c data single-item object is absent', () => {
@@ -431,7 +433,9 @@ describes.repeated(
               .expects('toggleLoading')
               .withExactArgs(false)
               .once();
-            return list.layoutCallback();
+            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
+              /Response must contain an array or object/
+            );
           });
 
           it('should load and render with a different root', () => {

--- a/test/manual/amp-list/infinite-scroll-fail.amp.html
+++ b/test/manual/amp-list/infinite-scroll-fail.amp.html
@@ -143,7 +143,7 @@
 
   <amp-list width="auto" height="200" id="list"
     layout="fixed-height"
-    src="/infinite-scroll-faulty?code=404"
+    src="/list/infinite-scroll-faulty?code=404"
     [src]="data.url"
     load-more="auto"
     reset-on-refresh

--- a/test/manual/amp-list/infinite-scroll-fail.amp.html
+++ b/test/manual/amp-list/infinite-scroll-fail.amp.html
@@ -16,65 +16,6 @@
       margin: 8px;
     }
 
-    [load-more-button], [load-more-failed], [load-more-loading] {
-      --light-color: rgba(255,255,255,.8);
-      --dark-color: rgba(51,51,51,.75);
-      --dark-color-transparent: rgba(51,51,51,0);
-
-      font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-      font-weight: bold;
-      text-transform: uppercase;
-      letter-spacing: .1em;
-      text-align: center;
-      height: 80px;
-      padding: 12px 0px;
-      box-sizing: border-box;
-    }
-
-    [load-more-loading] .spinner {
-      display: inline-block;
-      width: 40px;
-      height: 40px;
-      margin: 8px 0px;
-    }
-
-    [load-more-loading] .spinner svg.arc {
-      stroke-width: 1.725px;
-
-      fill: none;
-      transform-origin: 50% 50%;
-      animation: 1000ms spin linear infinite;
-    }
-
-    [load-more-loading] .spinner svg linearGradient stop:first-of-type { stop-color: var(--dark-color); }
-    [load-more-loading] .spinner svg linearGradient stop:last-of-type { stop-color: var(--dark-color-transparent); }
-
-    @keyframes spin {
-      0% { transform: rotate(0deg); }
-      100% { transform: rotate(360deg); }
-    }
-
-    .amp-list-load-more-button {
-      display: inline-block;
-      background-color: var(--dark-color);
-      box-shadow: 0px 0px 0px 1.5px var(--light-color);
-      color: var(--light-color);
-      cursor: pointer;
-      margin: 4px 0px;
-      padding: 0px 32px;
-      box-sizing: border-box;
-
-      height: 48px;
-      line-height: 48px;
-      border-radius: 24px;
-    }
-
-    .amp-list-load-more-button.amp-small {
-      padding: 0px 16px;
-      height: 32px;
-      line-height: 32px;
-    }
-
     .pin-container {
       border-radius: 8px;
       background-color: #fefefe;
@@ -157,35 +98,6 @@
         </div>
       </div>
     </template>
-    <div load-more-button>
-      <div class="amp-list-load-more-button">
-        See More
-      </div>
-    </div>
-    <div load-more-loading>
-      <div class="spinner">
-        <svg class="arc" viewbox="0 0 40 40">
-          <defs>
-            <lineargradient id="grad">
-              <stop></stop>
-              <stop offset="100%"></stop>
-            </lineargradient>
-          </defs>
-          <path d="M11,4.4 A18,18, 0,1,0, 38,20" stroke="url(#grad)"></path>
-        </svg>
-      </div>
-    </div>
-    <div load-more-failed>
-      <div class="amp-list-load-more-message">
-        <div class="amp-list-load-more-message-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
-        </div>
-        Unable to Load More
-      </div>
-      <div class="amp-list-load-more-button amp-small">
-        Retry
-      </div>
-    </div>
   </amp-list>
 
 </article>


### PR DESCRIPTION
Should fix https://github.com/ampproject/amphtml/issues/20690#issuecomment-473480167.

Context: the code relating to the load-more-failed element logic was originally pretty hacky. I hacked some code onto the `fetchList` function, but needed to know in `loadMoreCallback` if the fetch failed so we could `catch` the error and show the `load-more-failed` element. I think we can just make this code cleaner by providing a separate fetch-and-render function with a different codepath for the load-more case. I wonder if there's actually any benefit from throwing that error, or can we just do without it since we address both cases by triggering a `fetch-error` action already and showing a fallback / load-more-failed-and-retry element. 

Note: see inline conversation regarding the `throw error` behavior. 