### PR TITLE
🐛 Pass through applicable AMP experiments to SwG

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -32,7 +32,7 @@
   "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
-  "gpay-api": 1,
+  "swg-gpay-api": 1,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 1,
   "ios-scrollable-iframe": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -31,7 +31,7 @@
   "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
-  "gpay-native": 1,
+  "swg-gpay-native": 1,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "ios-scrollable-iframe": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -31,6 +31,7 @@
   "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
+  "gpay-native": 1,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,
   "ios-scrollable-iframe": 0,

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -39,6 +39,7 @@ import {SubscriptionsScoreFactor} from '../../amp-subscriptions/0.1/score-factor
 import {experimentToggles, isExperimentOn} from '../../../src/experiments';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {parseUrlDeprecated} from '../../../src/url';
+import {startsWith} from '../../../src/string';
 import {userAssert} from '../../../src/log';
 
 const TAG = 'amp-subscriptions-google';
@@ -114,7 +115,7 @@ export class GoogleSubscriptionsPlatform {
     // Map AMP experiments prefixed with 'swg-' to SwG experiments.
     const ampExperimentsForSwg = Object.keys(experimentToggles(ampdoc.win))
       .filter(
-        exp => exp.startsWith('swg-') && isExperimentOn(ampdoc.win, /*OK*/ exp)
+        exp => startsWith(exp, 'swg-') && isExperimentOn(ampdoc.win, /*OK*/ exp)
       )
       .map(exp => exp.substring(4));
 

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -114,8 +114,7 @@ export class GoogleSubscriptionsPlatform {
     // Map AMP experiments prefixed with 'swg-' to SwG experiments.
     const ampExperimentsForSwg = Object.keys(experimentToggles(ampdoc.win))
       .filter(
-        exp =>
-          exp.startsWith('swg-') && isExperimentOn(ampdoc.win, exp.toString())
+        exp => exp.startsWith('swg-') && isExperimentOn(ampdoc.win, /*OK*/ exp)
       )
       .map(exp => exp.substring(4));
 

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -36,8 +36,8 @@ import {
 import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
 import {SubscriptionsScoreFactor} from '../../amp-subscriptions/0.1/score-factors.js';
-import {installStylesForDoc} from '../../../src/style-installer';
 import {experimentToggles, isExperimentOn} from '../../../src/experiments';
+import {installStylesForDoc} from '../../../src/style-installer';
 import {parseUrlDeprecated} from '../../../src/url';
 import {userAssert} from '../../../src/log';
 
@@ -111,11 +111,15 @@ export class GoogleSubscriptionsPlatform {
       this.handleAnalyticsEvent_.bind(this)
     );
 
-    // Map AMP experiments to SwG experiments.
-    const enabledAmpExperiments =
-          Object.keys(experimentToggles(ampdoc.win)).
-          filter(exp => isExperimentOn(ampdoc.win, exp));
-    const swgConfig = { 'experiments': enabledAmpExperiments};
+    // Map AMP experiments prefixed with 'swg-' to SwG experiments.
+    const ampExperimentsForSwg = Object.keys(experimentToggles(ampdoc.win))
+      .filter(
+        exp =>
+          exp.startsWith('swg-') && isExperimentOn(ampdoc.win, exp.toString())
+      )
+      .map(exp => exp.substring(4));
+
+    const swgConfig = {'experiments': ampExperimentsForSwg};
     let resolver = null;
     /** @private @const {!ConfiguredRuntime} */
     this.runtime_ = new ConfiguredRuntime(

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -37,7 +37,7 @@ import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
 import {SubscriptionsScoreFactor} from '../../amp-subscriptions/0.1/score-factors.js';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {isExperimentOn} from '../../../src/experiments';
+import {experimentToggles, isExperimentOn} from '../../../src/experiments';
 import {parseUrlDeprecated} from '../../../src/url';
 import {userAssert} from '../../../src/log';
 
@@ -111,11 +111,11 @@ export class GoogleSubscriptionsPlatform {
       this.handleAnalyticsEvent_.bind(this)
     );
 
-    // Map AMP experiment to SwG experiment.
-    const swgExperiments = {};
-    if (isExperimentOn(ampdoc.win, 'gpay-api')) {
-      swgExperiments.experiments = ['gpay-api'];
-    }
+    // Map AMP experiments to SwG experiments.
+    const enabledAmpExperiments =
+          Object.keys(experimentToggles(ampdoc.win)).
+          filter(exp => isExperimentOn(ampdoc.win, exp));
+    const swgConfig = { 'experiments': enabledAmpExperiments};
     let resolver = null;
     /** @private @const {!ConfiguredRuntime} */
     this.runtime_ = new ConfiguredRuntime(
@@ -125,7 +125,7 @@ export class GoogleSubscriptionsPlatform {
         fetcher: new AmpFetcher(ampdoc.win),
         configPromise: new Promise(resolve => (resolver = resolve)),
       },
-      swgExperiments
+      swgConfig
     );
 
     /** @private @const {!../../../third_party/subscriptions-project/swg.ClientEventManagerApi} */

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -120,14 +120,15 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
       linkAccount: sandbox.stub(ConfiguredRuntime.prototype, 'linkAccount'),
     };
     ackStub = sandbox.stub(Entitlements.prototype, 'ack');
-    toggleExperiment(win, 'gpay-api', true);
+    toggleExperiment(win, 'swg-gpay-api', true);
+    toggleExperiment(win, 'nonswgexp', true);
     platform = new GoogleSubscriptionsPlatform(ampdoc, {}, serviceAdapter);
   });
 
   afterEach(() => {
     serviceAdapterMock.verify();
     analyticsMock.verify();
-    toggleExperiment(win, 'gpay-api', false);
+    toggleExperiment(win, 'swg-gpay-api', false);
   });
 
   function callback(stub) {
@@ -150,6 +151,9 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should propagate experiment', () => {
     expect(platform.runtime_.payClient_.getType()).to.equal('PAYJS');
+    expect(platform.runtime_.config()['experiments']).to.have.members([
+      'gpay-api',
+    ]);
   });
 
   it('should proxy fetch via AMP fetcher', () => {


### PR DESCRIPTION
Pass through all AMP experiments to SwG, so we don't need individual
logic per experiment flag.  Enable 'gpay-native' experiment to 100%. It
will take effect as the 'gpay' experiment is ramped up.

This does mean that AMP and SwG share experiment namespaces now.