### PR TITLE
Launch amp-nested-menu to 100% of production and canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,8 +1,5 @@
 {
-  "allow-doc-opt-in": [
-    "amp-next-page",
-    "inabox-viewport-friendly"
-  ],
+  "allow-doc-opt-in": ["amp-next-page", "inabox-viewport-friendly"],
   "allow-url-opt-in": [
     "ios-scrollable-iframe",
     "pump-early-frame",

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,8 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "inabox-viewport-friendly"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "inabox-viewport-friendly"
+  ],
   "allow-url-opt-in": [
     "ios-scrollable-iframe",
     "pump-early-frame",
@@ -17,6 +20,7 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-consent-v2": 1,
   "amp-mega-menu": 1,
+  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,8 +1,5 @@
 {
-  "allow-doc-opt-in": [
-    "amp-next-page",
-    "inabox-viewport-friendly"
-  ],
+  "allow-doc-opt-in": ["amp-next-page", "inabox-viewport-friendly"],
   "allow-url-opt-in": [
     "ios-scrollable-iframe",
     "pump-early-frame",

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,8 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "inabox-viewport-friendly"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "inabox-viewport-friendly"
+  ],
   "allow-url-opt-in": [
     "ios-scrollable-iframe",
     "pump-early-frame",
@@ -17,6 +20,7 @@
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-consent-v2": 1,
   "amp-mega-menu": 1,
+  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,


### PR DESCRIPTION
Only merge this after https://github.com/ampproject/amphtml/pull/25339 has reached production (ETA 1-2 weeks from now). You can double check this by copying valid examples from the above PR into https://validator.ampproject.org/ and verifying that it validates. 