### PR TITLE
Cleanup the amp-nested-menu experiment

### DIFF
--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.js
@@ -66,11 +66,6 @@ export class AmpNestedMenu extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // TODO(#25343): remove this assert when cleaning up experiment post launch.
-    userAssert(
-      isExperimentOn(this.win, 'amp-nested-menu'),
-      `Turning on the amp-nested-menu experiment is necessary to use the ${TAG} component.`
-    );
     const {element} = this;
 
     this.action_ = Services.actionServiceForDoc(this.element);

--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.js
@@ -26,7 +26,6 @@ import {
   tryFocus,
 } from '../../../src/dom';
 import {dev, userAssert} from '../../../src/log';
-import {isExperimentOn} from '../../../src/experiments';
 import {toArray} from '../../../src/types';
 
 const TAG = 'amp-nested-menu';

--- a/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
@@ -36,9 +36,6 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       clock = lolex.install({target: win});
-
-      // TODO(#25343): remove this toggle when cleaning up experiment post launch.
-      toggleExperiment(win, 'amp-nested-menu', true);
     });
 
     async function getNestedMenu(options) {

--- a/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
@@ -18,7 +18,6 @@ import '../amp-nested-menu';
 import * as lolex from 'lolex';
 import {Keys} from '../../../../src/utils/key-codes';
 import {htmlFor} from '../../../../src/static-template';
-import {toggleExperiment} from '../../../../src/experiments';
 import {tryFocus} from '../../../../src/dom';
 
 describes.realWin(

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -157,15 +157,12 @@ export class AmpSidebar extends AMP.BaseElement {
       element.setAttribute('side', this.side_);
     }
 
-    // TODO(#25343): remove this check when cleaning up experiment post launch.
-    if (isExperimentOn(this.win, 'amp-nested-menu')) {
+    this.maybeBuildNestedMenu_();
+    // Nested menu may not be present during buildCallback if it is rendered
+    // dynamically with amp-list, in which case listen for dom update.
+    element.addEventListener(AmpEvents.DOM_UPDATE, () => {
       this.maybeBuildNestedMenu_();
-      // Nested menu may not be present during buildCallback if it is rendered
-      // dynamically with amp-list, in which case listen for dom update.
-      element.addEventListener(AmpEvents.DOM_UPDATE, () => {
-        this.maybeBuildNestedMenu_();
-      });
-    }
+    });
 
     // Get the toolbar attribute from the child navs.
     const toolbarElements = toArray(element.querySelectorAll('nav[toolbar]'));

--- a/test/manual/amp-nested-menu/amp-nested-menu.amp.html
+++ b/test/manual/amp-nested-menu/amp-nested-menu.amp.html
@@ -12,11 +12,6 @@
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
-  <script>
-    (self.AMP=self.AMP||[]).push(function(AMP){
-        AMP.toggleExperiment('amp-nested-menu', true);
-    });
-  </script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     amp-sidebar {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -68,11 +68,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24898',
   },
   {
-    id: 'amp-nested-menu',
-    name: 'AMP extension for a nested drilldown menu',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/25343',
-  },
-  {
     id: 'amp-sidebar-v2',
     name: 'Updated sidebar component with nested menu and animations',
     spec: 'https://github.com/ampproject/amphtml/issues/25049',


### PR DESCRIPTION
Closes #25343. Merge this 2 release cycles AFTER https://github.com/ampproject/amphtml/pull/25516 has been launched to production and we have fixed an major outstanding bugs. 