### PR TITLE
add simple destructure plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -188,8 +188,7 @@
         "extensions/**/test/**/*.js",
         "extensions/**/test-e2e/*.js",
         "ads/**/test/**/*.js",
-        "testing/**/*.js",
-        "build-system/**/*.js"
+        "testing/**/*.js"
       ],
       "rules": {
         "require-jsdoc": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -81,6 +81,7 @@
     "local/json-configuration": 2,
     "local/no-array-destructuring": 2,
     "local/no-deep-destructuring": 2,
+    "local/no-destructure-assignment-params": 2,
     "local/no-duplicate-import": 2,
     "local/no-duplicate-name-typedef": 2,
     "local/no-es2015-number-props": 2,
@@ -187,10 +188,12 @@
         "extensions/**/test/**/*.js",
         "extensions/**/test-e2e/*.js",
         "ads/**/test/**/*.js",
-        "testing/**/*.js"
+        "testing/**/*.js",
+        "build-system/**/*.js"
       ],
       "rules": {
         "require-jsdoc": 0,
+        "local/no-destructure-assignment-params": 0,
         "jsdoc/check-param-names": 0,
         "jsdoc/check-tag-names": 0,
         "jsdoc/check-types": 0,

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,7 +29,7 @@ const minimist = require('minimist');
 const {isTravisBuild} = require('./build-system/common/travis');
 const argv = minimist(process.argv.slice(2));
 
-const isDist = argv._.includes('dist');
+const isDist = argv._.includes('dist') || argv._.includes('check-types');
 const {esm} = argv;
 const noModuleTarget = {
   'browsers': isTravisBuild()

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,7 +29,8 @@ const minimist = require('minimist');
 const {isTravisBuild} = require('./build-system/common/travis');
 const argv = minimist(process.argv.slice(2));
 
-const isDist = argv._.includes('dist') || argv._.includes('check-types');
+const isClosureCompiler =
+  argv._.includes('dist') || argv._.includes('check-types');
 const {esm} = argv;
 const noModuleTarget = {
   'browsers': isTravisBuild()
@@ -40,9 +41,9 @@ const noModuleTarget = {
 // eslint-disable-next-line local/no-module-exports
 module.exports = function(api) {
   api.cache(true);
-  // `dist` builds do not use any of the default settings below until its
+  // Closure Compiler builds do not use any of the default settings below until its
   // an esm build. (Both Multipass and Singlepass)
-  if (isDist && !esm) {
+  if (isClosureCompiler && !esm) {
     return {};
   }
   return {
@@ -57,7 +58,7 @@ module.exports = function(api) {
         : [
             '@babel/preset-env',
             {
-              'modules': isDist ? false : 'commonjs',
+              'modules': isClosureCompiler ? false : 'commonjs',
               'loose': true,
               'targets': noModuleTarget,
             },

--- a/build-system/.eslintrc
+++ b/build-system/.eslintrc
@@ -20,6 +20,7 @@
   },
   "rules": {
     "local/no-array-destructuring": 0,
+    "local/no-destructure-assignment-params": 0,
     "local/no-export-side-effect": 0,
     "local/no-for-of-statement": 0,
     "local/no-has-own-property-method": 0,

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -15,17 +15,17 @@
  */
 
 module.exports = function(babel) {
-  const { types: t } = babel;
+  const {types: t} = babel;
 
   function cloneDeepWithoutLoc(node) {
     const str = JSON.stringify(node);
     return JSON.parse(str, (key, value) => {
-      return key === "loc" ? undefined : value;
+      return key === 'loc' ? undefined : value;
     });
   }
 
   function declarator(path, parentPath) {
-    const init = parentPath.get("init");
+    const init = parentPath.get('init');
     let from = init.node;
     if (!init.isPure()) {
       from = path.scope.generateUidIdentifierBasedOnNode(init.node);
@@ -34,16 +34,16 @@ module.exports = function(babel) {
       );
     }
 
-    const properties = path.get("properties");
+    const properties = path.get('properties');
     for (const prop of properties) {
-      const { key, value, computed } = prop.node;
+      const {key, value, computed} = prop.node;
       const member = t.memberExpression(t.cloneWithoutLoc(from), key, computed);
       let expression = member;
       let newValue = value;
       if (t.isAssignmentPattern(value)) {
         newValue = t.identifier(value.left.name);
         expression = t.conditionalExpression(
-          t.binaryExpression("===", member, path.scope.buildUndefinedNode()),
+          t.binaryExpression('===', member, path.scope.buildUndefinedNode()),
           value.right,
           member
         );
@@ -53,14 +53,14 @@ module.exports = function(babel) {
     }
     // NOTE: this is a hack to remove the original path as `parentPath.remove()` causes
     // an unexplained error.
-    path.replaceWith(path.scope.generateUidIdentifier("foo"));
+    path.replaceWith(path.scope.generateUidIdentifier('foo'));
     // We try to eliminate any side effects since the original
     // initializer might have had some (method call, etc.);
     parentPath.node.init = path.scope.buildUndefinedNode();
   }
 
   return {
-    name: "simple-object-destructure",
+    name: 'simple-object-destructure',
 
     pre() {
       this.file.opts.generatorOpts.retainLines = true;
@@ -71,15 +71,15 @@ module.exports = function(babel) {
         // NOTE: We don't transform destructure operation in params as this causes
         // type parameter mismatch errors.
 
-        const { parentPath } = path;
+        const {parentPath} = path;
         if (parentPath.isObjectProperty()) {
-          throw path.buildCodeFrameError("encountered deep object destructure");
+          throw path.buildCodeFrameError('encountered deep object destructure');
         }
 
         if (parentPath.isVariableDeclarator()) {
           return declarator(path, parentPath);
         }
-      }
-    }
+      },
+    },
   };
 };

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function(babel) {
+  const { types: t } = babel;
+
+  function cloneDeepWithoutLoc(node) {
+    const str = JSON.stringify(node);
+    return JSON.parse(str, (key, value) => {
+      return key === "loc" ? undefined : value;
+    });
+  }
+
+  function declarator(path, parentPath) {
+    const init = parentPath.get("init");
+    let from = init.node;
+    if (!init.isPure()) {
+      from = path.scope.generateUidIdentifierBasedOnNode(init.node);
+      parentPath.insertBefore(
+        t.variableDeclarator(from, cloneDeepWithoutLoc(init.node))
+      );
+    }
+
+    const properties = path.get("properties");
+    for (const prop of properties) {
+      const { key, value, computed } = prop.node;
+      const member = t.memberExpression(t.cloneWithoutLoc(from), key, computed);
+      let expression = member;
+      let newValue = value;
+      if (t.isAssignmentPattern(value)) {
+        newValue = t.identifier(value.left.name);
+        expression = t.conditionalExpression(
+          t.binaryExpression("===", member, path.scope.buildUndefinedNode()),
+          value.right,
+          member
+        );
+      }
+      const declarator = t.variableDeclarator(newValue, expression);
+      parentPath.insertBefore(declarator);
+    }
+    // NOTE: this is a hack to remove the original path as `parentPath.remove()` causes
+    // an unexplained error.
+    path.replaceWith(path.scope.generateUidIdentifier("foo"));
+    // We try to eliminate any side effects since the original
+    // initializer might have had some (method call, etc.);
+    parentPath.node.init = path.scope.buildUndefinedNode();
+  }
+
+  return {
+    name: "simple-object-destructure",
+
+    pre() {
+      this.file.opts.generatorOpts.retainLines = true;
+    },
+
+    visitor: {
+      ObjectPattern(path) {
+        // NOTE: We don't transform destructure operation in params as this causes
+        // type parameter mismatch errors.
+
+        const { parentPath } = path;
+        if (parentPath.isObjectProperty()) {
+          throw path.buildCodeFrameError("encountered deep object destructure");
+        }
+
+        if (parentPath.isVariableDeclarator()) {
+          return declarator(path, parentPath);
+        }
+      }
+    }
+  };
+};

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -79,6 +79,22 @@ module.exports = function(babel) {
         if (parentPath.isVariableDeclarator()) {
           return declarator(path, parentPath);
         }
+
+        if (path.listKey === 'params') {
+          const body = parentPath.get('body');
+          if (
+            parentPath.isArrowFunctionExpression() &&
+            !body.isBlockStatement()
+          ) {
+            body.replaceWith(t.blockStatement([t.returnStatement(body.node)]));
+          }
+          const param = path.scope.generateUidIdentifier('param');
+          const declaration = t.variableDeclaration('let', [
+            t.variableDeclarator(path.node, param),
+          ]);
+          const declarationPath = body.unshiftContainer('body', declaration);
+          path.replaceWith(t.cloneNode(param));
+        }
       },
     },
   };

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -79,22 +79,6 @@ module.exports = function(babel) {
         if (parentPath.isVariableDeclarator()) {
           return declarator(path, parentPath);
         }
-
-        if (path.listKey === 'params') {
-          const body = parentPath.get('body');
-          if (
-            parentPath.isArrowFunctionExpression() &&
-            !body.isBlockStatement()
-          ) {
-            body.replaceWith(t.blockStatement([t.returnStatement(body.node)]));
-          }
-          const param = path.scope.generateUidIdentifier('param');
-          const declaration = t.variableDeclaration('let', [
-            t.variableDeclarator(path.node, param),
-          ]);
-          const declarationPath = body.unshiftContainer('body', declaration);
-          path.replaceWith(t.cloneNode(param));
-        }
       },
     },
   };

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -56,7 +56,7 @@ module.exports = function(babel) {
     path.replaceWith(path.scope.generateUidIdentifier('foo'));
     // We try to eliminate any side effects since the original
     // initializer might have had some (method call, etc.);
-    parentPath.node.init = path.scope.buildUndefinedNode();
+    parentPath.get('init').replaceWith(path.scope.buildUndefinedNode());
   }
 
   return {

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/input.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const [a, ...b] = [1, 2, 3, 4, 5];

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/array-destructure/output.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const [a, ...b] = [1, 2, 3, 4, 5];

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/input.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func({head}) {
+  console.log(head);
+}
+
+func(document);
+func({head: document.head});

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/options.json
@@ -1,4 +1,3 @@
 {
   "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
 }
-

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}
+

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/no-transform/param-destructure/output.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func({ head }) {
+  console.log(head);
+}
+
+func(document);
+func({ head: document.head });

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/input.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func() {
+  let {x = 5, y, z = document.head} = get();
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/default-values/output.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func() {
+  let _get = get(),x = _get.x === void 0 ? 5 : _get.x,y = _get.y,z = _get.z === void 0 ? document.head : _get.z,_foo = void 0;
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/input.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {head: h, body: b} = document;
+
+const {x: myX} = get();
+
+function func() {
+  const {head: h, body: b} = document;
+  let {x: myX, y: myY, z: myZ} = get();
+  myX = 3;
+  myY = 4;
+  myZ = 5;
+  console.log(document);
+  console.log(h);
+  console.log(b);
+  console.log(myX + myY + myZ);
+}
+
+console.log(document);
+console.log(h);
+console.log(b);
+console.log(myX);

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations-rename/output.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _document = document,h = _document.head,b = _document.body,_foo = void 0;
+
+const _get = get(),myX = _get.x,_foo2 = void 0;
+
+function func() {
+  const _document2 = document,h = _document2.head,b = _document2.body,_foo3 = void 0;
+  let _get2 = get(),myX = _get2.x,myY = _get2.y,myZ = _get2.z,_foo4 = void 0;
+  myX = 3;
+  myY = 4;
+  myZ = 5;
+  console.log(document);
+  console.log(h);
+  console.log(b);
+  console.log(myX + myY + myZ);
+}
+
+console.log(document);
+console.log(h);
+console.log(b);
+console.log(myX);

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/input.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {head, body} = document;
+
+const {x} = get();
+
+function func() {
+  const {head, body} = document;
+  let {x, y, z} = get();
+  x = 3;
+  y = 4;
+  z = 5;
+  console.log(document);
+  console.log(head);
+  console.log(body);
+  console.log(x + y + z);
+}
+
+console.log(document);
+console.log(head);
+console.log(body);
+console.log(x);

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/variable-declarations/output.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _document = document,head = _document.head,body = _document.body,_foo = void 0;
+
+const _get = get(),x = _get.x,_foo2 = void 0;
+
+function func() {
+  const _document2 = document,head = _document2.head,body = _document2.body,_foo3 = void 0;
+  let _get2 = get(),x = _get2.x,y = _get2.y,z = _get2.z,_foo4 = void 0;
+  x = 3;
+  y = 4;
+  z = 5;
+  console.log(document);
+  console.log(head);
+  console.log(body);
+  console.log(x + y + z);
+}
+
+console.log(document);
+console.log(head);
+console.log(body);
+console.log(x);

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/index.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const runner = require('@babel/helper-plugin-test-runner').default;
+
+runner(__dirname);

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -345,7 +345,7 @@ function compile(
       delete compilerOptions.define;
     }
 
-    if (!argv.single_pass && !options.typeCheckOnly) {
+    if (!argv.single_pass) {
       compilerOptions.js_module_root.push(SRC_TEMP_DIR);
     }
 
@@ -365,9 +365,13 @@ function compile(
       }
     });
 
+    const gulpSrcs = !argv.single_pass ? convertPathsToTmpRoot(srcs) : srcs;
+    const gulpBase = !argv.single_pass ? SRC_TEMP_DIR : '.';
+
     if (options.typeCheckOnly) {
       return gulp
-        .src(srcs, {base: '.'})
+        .src(gulpSrcs, {base: gulpBase})
+        .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(compilerOptionsArray, checkTypesNailgunPort))
         .on('error', err => {
           handleTypeCheckError();
@@ -376,8 +380,6 @@ function compile(
         .pipe(nop())
         .on('end', resolve);
     } else {
-      const gulpSrcs = argv.single_pass ? srcs : convertPathsToTmpRoot(srcs);
-      const gulpBase = argv.single_pass ? '.' : SRC_TEMP_DIR;
       timeInfo.startTime = Date.now();
       return gulp
         .src(gulpSrcs, {base: gulpBase})

--- a/build-system/eslint-rules/no-destructure-assignment-params.js
+++ b/build-system/eslint-rules/no-destructure-assignment-params.js
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-const selector =
-  'ObjectPattern[parent.type=FunctionDeclaration],' +
-  'ObjectPattern[parent.type=FunctionExpression]';
-
 module.exports = function(context) {
   return {
-    [selector]: function(node) {
+    [':function > ObjectPattern']: function(node) {
       context.report({
         node,
         message:

--- a/build-system/eslint-rules/no-destructure-assignment-params.js
+++ b/build-system/eslint-rules/no-destructure-assignment-params.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+const selector =
+  'ObjectPattern[parent.type=FunctionDeclaration],' +
+  'ObjectPattern[parent.type=FunctionExpression]';
+
 module.exports = function(context) {
   return {
-    ['ObjectPattern[parent.type=FunctionDeclaration]']: function(node) {
+    [selector]: function(node) {
       context.report({
         node,
         message:

--- a/build-system/eslint-rules/no-destructure-assignment-params.js
+++ b/build-system/eslint-rules/no-destructure-assignment-params.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function(context) {
+  return {
+    ['ObjectPattern[parent.type=FunctionDeclaration]']: function(node) {
+      context.report({
+        node,
+        message:
+          'Do not use Object Destructuring Assignment in parameters. ' +
+          'We will allow it once https://github.com/google/' +
+          'closure-compiler/issues/3500 is resolved.',
+      });
+    },
+  };
+};

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -28,6 +28,7 @@ const {cleanupBuildDir, closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
 const {maybeUpdatePackages} = require('./update-packages');
+const {transferSrcsToTempDir} = require('./helpers');
 
 /**
  * Dedicated type check path.
@@ -39,6 +40,7 @@ async function checkTypes() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   maybeInitializeExtensions();
+  transferSrcsToTempDir({isChecktypes: true});
   const compileSrcs = [
     './src/amp.js',
     './src/amp-shadow.js',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -15,7 +15,6 @@
  */
 
 const colors = require('ansi-colors');
-const conf = require('../compile/build.conf');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
@@ -30,6 +29,7 @@ const {
   printConfigHelp,
   printNobuildHelp,
   toPromise,
+  transferSrcsToTempDir,
 } = require('./helpers');
 const {
   createCtrlcHandler,
@@ -43,7 +43,6 @@ const {
   startNailgunServer,
   stopNailgunServer,
 } = require('./nailgun');
-const {BABEL_SRC_GLOBS, SRC_TEMP_DIR} = require('../compile/sources');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
@@ -55,44 +54,12 @@ const {VERSION} = require('../compile/internal-version');
 const {green, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
 
-const babel = require('@babel/core');
-const globby = require('globby');
-
 const WEB_PUSH_PUBLISHER_FILES = [
   'amp-web-push-helper-frame',
   'amp-web-push-permission-dialog',
 ];
 
 const WEB_PUSH_PUBLISHER_VERSIONS = ['0.1'];
-
-function transferSrcsToTempDir() {
-  log(
-    'Performing multi-pass',
-    colors.cyan('babel'),
-    'transforms in',
-    colors.cyan(SRC_TEMP_DIR)
-  );
-  const files = globby.sync(BABEL_SRC_GLOBS);
-  files.forEach(file => {
-    if (file.startsWith('node_modules/') || file.startsWith('third_party/')) {
-      fs.copySync(file, `${SRC_TEMP_DIR}/${file}`);
-      return;
-    }
-
-    const {code} = babel.transformFileSync(file, {
-      plugins: conf.plugins({
-        isEsmBuild: argv.esm,
-        isForTesting: argv.fortesting,
-      }),
-      retainLines: true,
-      compact: false,
-    });
-    const name = `${SRC_TEMP_DIR}/${file}`;
-    fs.outputFileSync(name, code);
-    process.stdout.write('.');
-  });
-  console.log('\n');
-}
 
 /**
  * Prints a useful help message prior to the gulp dist task
@@ -136,7 +103,7 @@ async function dist() {
   // own processing). Executed after `compileCss` and `compileJison` so their
   // results can be copied too.
   if (!argv.single_pass) {
-    transferSrcsToTempDir();
+    transferSrcsToTempDir({isForTesting: argv.fortesting});
   }
 
   await copyCss();

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const babel = require('@babel/core');
 const babelify = require('babelify');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
@@ -22,6 +23,7 @@ const conf = require('../compile/build.conf');
 const del = require('del');
 const file = require('gulp-file');
 const fs = require('fs-extra');
+const globby = require('globby');
 const gulp = require('gulp');
 const gulpWatch = require('gulp-watch');
 const log = require('fancy-log');
@@ -37,13 +39,11 @@ const {
 } = require('../compile/internal-version');
 const {altMainBundles, jsBundles} = require('../compile/bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
+const {BABEL_SRC_GLOBS, SRC_TEMP_DIR} = require('../compile/sources');
 const {closureCompile} = require('../compile/compile');
 const {isTravisBuild} = require('../common/travis');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
-const {BABEL_SRC_GLOBS, SRC_TEMP_DIR} = require('../compile/sources');
-const globby = require('globby');
-const babel = require('@babel/core');
 
 const {green, red, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -398,20 +398,3 @@ requirement: {
   value: 'DocumentType.prototype.after'
   value: 'CharacterData.prototype.after'
 }
-
-# Document: most of properties should be access via ampdoc for proper scoping.
-requirement: {
-  type: BANNED_PROPERTY
-  error_message: 'Use ampdoc instead'
-  value: 'Document.prototype.head'
-  whitelist: '3p/'
-  whitelist: 'ads/'
-  whitelist: 'src/service/ampdoc-impl.js'
-  whitelist: 'src/validator-integration.js'
-  whitelist: 'src/style-installer.js'
-  whitelist: 'src/shadow-embed.js'
-  whitelist: 'src/service/extensions-impl.js'
-  whitelist: 'src/preconnect.js'
-  whitelist: 'src/experiments.js'
-  whitelist: 'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js'
-}

--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -398,3 +398,20 @@ requirement: {
   value: 'DocumentType.prototype.after'
   value: 'CharacterData.prototype.after'
 }
+
+# Document: most of properties should be access via ampdoc for proper scoping.
+requirement: {
+  type: BANNED_PROPERTY
+  error_message: 'Use ampdoc instead'
+  value: 'Document.prototype.head'
+  whitelist: '3p/'
+  whitelist: 'ads/'
+  whitelist: 'src/service/ampdoc-impl.js'
+  whitelist: 'src/validator-integration.js'
+  whitelist: 'src/style-installer.js'
+  whitelist: 'src/shadow-embed.js'
+  whitelist: 'src/service/extensions-impl.js'
+  whitelist: 'src/preconnect.js'
+  whitelist: 'src/experiments.js'
+  whitelist: 'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js'
+}

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -90,7 +90,9 @@ export class AmpAdExit extends AMP.BaseElement {
   /**
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
    */
-  exit({args, event}) {
+  exit(invocation) {
+    const {args} = invocation;
+    let {event} = invocation;
     const target = this.targets_[args['target']];
     userAssert(target, `Exit target not found: '${args['target']}'`);
     userAssert(event, 'Unexpected null event');

--- a/extensions/amp-addthis/0.1/addthis-utils/eng.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/eng.js
@@ -26,7 +26,8 @@ import {pixelDrop} from './pixel';
  * @param {{monitors: *, loc: Location, ampDoc: !../../../../src/service/ampdoc-impl.AmpDoc, pubId: string}} params
  * @return {{al: (string|undefined), amp: number, dc: number, dp: string, dt: string, fp: string, ict: string, ivh: number, pct: number, pfm: number, ph: number, pub: string, sh: number, sid: string}}
  */
-const getEngData = ({monitors, loc, ampDoc, pubId}) => {
+const getEngData = params => {
+  const {monitors, loc, ampDoc, pubId} = params;
   const {
     dwellMonitor,
     scrollMonitor,

--- a/extensions/amp-addthis/0.1/addthis-utils/lojson.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/lojson.js
@@ -72,10 +72,11 @@ let LojsonDataDef;
 let AtConfigDef;
 
 /**
- * @param {!LojsonDataDef} param1
+ * @param {!LojsonDataDef} jsonData
  * @return {!JsonObject}
  */
-export function getLojsonData({loc, title, pubId, atConfig, referrer, ampDoc}) {
+export function getLojsonData(jsonData) {
+  const {loc, title, pubId, atConfig, referrer, ampDoc} = jsonData;
   const {href, hostname, host, search, pathname, hash, protocol, port} = loc;
   const pageInfo = {
     du: href.split('#').shift(),

--- a/extensions/amp-addthis/0.1/addthis-utils/mode.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/mode.js
@@ -42,14 +42,15 @@ export function getAddThisMode(_) {
 }
 
 /**
- * @param {{pubId: string, widgetId: string, productCode: string}} _
+ * @param {{pubId: string, widgetId: string, productCode: string}} mode
  * @return {{
- * hasPubId:boolean,
- * hasWidgetId:boolean,
- * hasProductCode:boolean
+ *   hasPubId: boolean,
+ *   hasWidgetId: boolean,
+ *   hasProductCode: boolean
  * }}
  */
-export function getAddThisModeObject({pubId, widgetId, productCode}) {
+export function getAddThisModeObject(mode) {
+  const {pubId, widgetId, productCode} = mode;
   const hasPubId = isPubId(pubId);
   // widget ids are 4-character strings with lower-case letters and numbers only
   const hasWidgetId = isWidgetId(widgetId);

--- a/extensions/amp-addthis/0.1/addthis-utils/pixel.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pixel.js
@@ -54,7 +54,8 @@ const groupPixelsByTime = pixelList => {
       }));
     })
     .reduce((a, b) => a.concat(b), []) // flatten
-    .reduce((currentDelayMap, {delay, pixels}) => {
+    .reduce((currentDelayMap, curDelay) => {
+      const {delay, pixels} = curDelay;
       if (!currentDelayMap[delay]) {
         currentDelayMap[delay] = [];
       }
@@ -87,7 +88,8 @@ const getIframeName = url =>
     .host.split('.')
     .concat(pixelatorFrameTitle.toLowerCase().replace(/\s/, '_'));
 
-const iframeDrop = (url, ampDoc, {name, title}) => {
+const iframeDrop = (url, ampDoc, data) => {
+  const {name, title} = data;
   const doc = ampDoc.win.document;
   const iframe = createElementWithAttributes(
     doc,
@@ -127,19 +129,14 @@ const dropPixelatorPixel = (url, ampDoc) => {
 
 /**
  * Requests groups of pixels at specified delays
- * @param  {Array<{
- * delay: number,
- * id: string,
- * url: string
- * }>} pixels
- * @param  {{
- * sid: string,
- * ampDoc: *
- * }} options
+ * @param  {Array<{delay: number, id: string,url: string}>} pixels
+ * @param  {{sid: string, ampDoc: *}} options
  */
-const dropPixelGroups = (pixels, {sid, ampDoc}) => {
+const dropPixelGroups = (pixels, options) => {
+  const {sid, ampDoc} = options;
   const pixelGroups = groupPixelsByTime(pixels);
-  pixelGroups.forEach(({delay, pixels}) => {
+  pixelGroups.forEach(pixelGroup => {
+    const {delay, pixels} = pixelGroup;
     setTimeout(() => {
       const pids = pixels.map(pixel => {
         dropPixelatorPixel(pixel.url, ampDoc);

--- a/extensions/amp-addthis/0.1/addthis-utils/pjson.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pjson.js
@@ -27,19 +27,17 @@ const SHARE = 300;
 
 /**
  * @param {{
- * loc:Location,
- * referrer:string,
- * title:string,
- * ampDoc: *,
- * pubId:string,
- * data: {
- *   url: string,
- *   service: string
- * }
+ *   loc:Location,
+ *   referrer:string,
+ *   title:string,
+ *   ampDoc: *,
+ *   pubId:string,
+ *   data: {url: string, service: string}
  * }} pjson
  * @return {{amp: number, cb: number, dc: number, dest: *, gen: number, mk: string, pub: *, rb: number, sid, url}}
  */
-const getPjsonData = ({loc, referrer, title, ampDoc, pubId, data}) => {
+const getPjsonData = pjson => {
+  const {loc, referrer, title, ampDoc, pubId, data} = pjson;
   const {href, hostname, search, pathname, hash, protocol, port} = loc;
   /** @typedef {{
    * du: string,

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -409,7 +409,8 @@ class AmpAddThis extends AMP.BaseElement {
    * @param {*} [input.pubId]
    * @memberof AmpAddThis
    */
-  setupListeners_({ampDoc, loc, pubId}) {
+  setupListeners_(input) {
+    const {ampDoc, loc, pubId} = input;
     // Send "engagement" analytics on page hide.
     listen(ampDoc.win, 'pagehide', () =>
       callEng({

--- a/extensions/amp-addthis/0.1/config-manager.js
+++ b/extensions/amp-addthis/0.1/config-manager.js
@@ -121,15 +121,16 @@ export class ConfigManager {
    * @param {string} [input.containerClassName]
    * @private
    */
-  sendConfiguration_({
-    iframe,
-    widgetId,
-    pubId,
-    shareConfig,
-    atConfig,
-    productCode,
-    containerClassName,
-  }) {
+  sendConfiguration_(input) {
+    const {
+      iframe,
+      widgetId,
+      pubId,
+      shareConfig,
+      atConfig,
+      productCode,
+      containerClassName,
+    } = input;
     const pubData = this.dataForPubId_[pubId];
     const {
       config: dashboardConfig,
@@ -192,28 +193,29 @@ export class ConfigManager {
    * Register relevant data with the configuration manager and prepare
    * request/response cycle between frames.
    * @param {{
-   * pubId: string,
-   * activeToolsMonitor: Object<string,string>,
-   * atConfig: Object<string,string>,
-   * widgetId: string,
-   * containerClassName: string,
-   * productCode: string,
-   * iframe: !Element,
-   * iframeLoadPromise: !Promise,
-   * shareConfig: (JsonObject|undefined)
-   * }} _
+   *   pubId: string,
+   *   activeToolsMonitor: Object<string,string>,
+   *   atConfig: Object<string,string>,
+   *   widgetId: string,
+   *   containerClassName: string,
+   *   productCode: string,
+   *   iframe: !Element,
+   *   iframeLoadPromise: !Promise,
+   *   shareConfig: (JsonObject|undefined)
+   * }} config
    */
-  register({
-    pubId,
-    widgetId,
-    productCode,
-    containerClassName,
-    iframe,
-    iframeLoadPromise,
-    shareConfig,
-    atConfig,
-    activeToolsMonitor,
-  }) {
+  register(config) {
+    const {
+      pubId,
+      widgetId,
+      productCode,
+      containerClassName,
+      iframe,
+      iframeLoadPromise,
+      shareConfig,
+      atConfig,
+      activeToolsMonitor,
+    } = config;
     if (!this.activeToolsMonitor_) {
       this.activeToolsMonitor_ = activeToolsMonitor;
     }
@@ -258,7 +260,8 @@ export class ConfigManager {
    * Relinquish as many element references as possible.
    * @param {{pubId:string, iframe:Element}} param
    */
-  unregister({pubId, iframe}) {
+  unregister(param) {
+    const {pubId, iframe} = param;
     this.configProviderIframes_ = this.configProviderIframes_.filter(
       providerFrame => providerFrame !== iframe
     );

--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -256,7 +256,10 @@ function serialize(entries, resourceTimingSpec, ampdoc) {
     Math.round(val - relativeTo).toString(encoding['base'] || 10);
 
   const promises = filterEntries(entries, resources)
-    .map(({entry, name}) => entryToExpansionOptions(entry, name, format))
+    .map(resourceTimingEntry => {
+      const {entry, name} = resourceTimingEntry;
+      return entryToExpansionOptions(entry, name, format);
+    })
     .map(expansion =>
       variableService.expandTemplate(encoding['entry'], expansion)
     );

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -285,7 +285,10 @@ export class DocMetaAnnotations {
    */
   static getAllLdJsonTypes(ampdoc) {
     return toArray(getRootNode(ampdoc).querySelectorAll(SCRIPT_LD_JSON))
-      .map(({textContent}) => (tryParseJson(textContent) || {})['@type'])
+      .map(el => {
+        const {textContent} = el;
+        return (tryParseJson(textContent) || {})['@type'];
+      })
       .filter(typeOrUndefined => typeOrUndefined);
   }
 
@@ -420,9 +423,11 @@ export function scan(ampdoc, opt_root) {
   return runCandidates(ampdoc, Scanner.getCandidates(root));
 }
 
-AMP.extension(TAG, '0.1', ({ampdoc}) => {
+AMP.extension(TAG, '0.1', AMP => {
+  const {ampdoc} = AMP;
   ampdoc.whenReady().then(() => {
-    getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, ({target}) => {
+    getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, e => {
+      const {target} = e;
       scan(ampdoc, dev().assertElement(target));
     });
     scan(ampdoc);

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
@@ -33,7 +33,8 @@ export class AutocompleteBindingInline {
    * For use when "inline_" is true.
    * @param {!AMP.BaseElement} ampElement
    */
-  constructor({element, win}) {
+  constructor(ampElement) {
+    const {element, win} = ampElement;
     /** @private {!Element} */
     this.element_ = element;
     this.win_ = win;

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -26,7 +26,8 @@ export class AutocompleteBindingSingle {
   /**
    * @param {!AMP.BaseElement} ampElement
    */
-  constructor({element}) {
+  constructor(ampElement) {
+    const {element} = ampElement;
     /** @private {!Element} */
     this.element_ = element;
 

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -371,21 +371,24 @@ class AmpCarousel extends AMP.BaseElement {
   initializeActions_() {
     this.registerAction(
       'prev',
-      ({trust}) => {
+      actionInvocation => {
+        const {trust} = actionInvocation;
         this.carousel_.prev(this.getActionSource_(trust));
       },
       ActionTrust.LOW
     );
     this.registerAction(
       'next',
-      ({trust}) => {
+      actionInvocation => {
+        const {trust} = actionInvocation;
         this.carousel_.next(this.getActionSource_(trust));
       },
       ActionTrust.LOW
     );
     this.registerAction(
       'goToSlide',
-      ({args, trust}) => {
+      actionInvocation => {
+        const {args, trust} = actionInvocation;
         this.carousel_.goToSlide(args['index'] || -1, {
           actionSource: this.getActionSource_(trust),
         });

--- a/extensions/amp-base-carousel/0.1/array-util.js
+++ b/extensions/amp-base-carousel/0.1/array-util.js
@@ -25,7 +25,8 @@ import {mod} from '../../../src/utils/math';
  * @param {!IArrayLike} arr An array like Object.
  * @return {number}
  */
-export function forwardWrappingDistance(a, b, {length}) {
+export function forwardWrappingDistance(a, b, arr) {
+  const {length} = arr;
   return a === b ? length : mod(b - a, length);
 }
 
@@ -38,6 +39,7 @@ export function forwardWrappingDistance(a, b, {length}) {
  * @param {!IArrayLike} arr An array like Object.
  * @return {number}
  */
-export function backwardWrappingDistance(a, b, {length}) {
+export function backwardWrappingDistance(a, b, arr) {
+  const {length} = arr;
   return a === b ? length : mod(a - b, length);
 }

--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -45,7 +45,8 @@ export class AutoAdvance {
    *   advanceable: !AdvanceDef
    * }} config
    */
-  constructor({win, scrollContainer, advanceable}) {
+  constructor(config) {
+    const {win, scrollContainer, advanceable} = config;
     /** @private @const */
     this.win_ = win;
 

--- a/extensions/amp-base-carousel/0.1/carousel-accessibility.js
+++ b/extensions/amp-base-carousel/0.1/carousel-accessibility.js
@@ -38,7 +38,8 @@ export class CarouselAccessibility {
    *   stoppable: !StoppableDef,
    * }} config
    */
-  constructor({win, element, scrollContainer, runMutate, stoppable}) {
+  constructor(config) {
+    const {win, element, scrollContainer, runMutate, stoppable} = config;
     /** @protected @const */
     this.win_ = win;
 

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -151,7 +151,8 @@ export class Carousel {
    *   runMutate: function(function()),
    * }} config
    */
-  constructor({win, element, scrollContainer, runMutate}) {
+  constructor(config) {
+    const {win, element, scrollContainer, runMutate} = config;
     /** @private @const */
     this.win_ = win;
 
@@ -1230,7 +1231,8 @@ export class Carousel {
    * }} options
    * @private
    */
-  scrollSlideIntoView_(slide, {smoothScroll}) {
+  scrollSlideIntoView_(slide, options) {
+    const {smoothScroll} = options;
     const runner = smoothScroll ? (el, cb) => cb() : runDisablingSmoothScroll;
     runner(this.scrollContainer_, () => {
       scrollContainerToElement(

--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -119,14 +119,15 @@ export class ChildLayoutManager {
    *  viewportIntersectionCallback: (function(!Element, boolean)|undefined)
    * }} config
    */
-  constructor({
-    ampElement,
-    intersectionElement,
-    intersectionThreshold = DEFAULT_INTERSECTION_THRESHOLD,
-    nearbyMarginInPercent = DEFAULT_NEARBY_MARGIN,
-    viewportIntersectionThreshold = intersectionThreshold,
-    viewportIntersectionCallback = () => {},
-  }) {
+  constructor(config) {
+    const {
+      ampElement,
+      intersectionElement,
+      intersectionThreshold = DEFAULT_INTERSECTION_THRESHOLD,
+      nearbyMarginInPercent = DEFAULT_NEARBY_MARGIN,
+      viewportIntersectionThreshold = intersectionThreshold,
+      viewportIntersectionCallback = () => {},
+    } = config;
     /** @private @const */
     this.ampElement_ = ampElement;
 

--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -260,8 +260,12 @@ export class ChildLayoutManager {
    */
   processNearingChanges_(entries) {
     entries
-      .filter(({isIntersecting}) => isIntersecting)
-      .forEach(({target}) => {
+      .filter(entry => {
+        const {isIntersecting} = entry;
+        return isIntersecting;
+      })
+      .forEach(entry => {
+        const {target} = entry;
         target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.ENTER;
       });
 
@@ -277,8 +281,12 @@ export class ChildLayoutManager {
    */
   processBackingAwayChanges_(entries) {
     entries
-      .filter(({isIntersecting}) => !isIntersecting)
-      .forEach(({target}) => {
+      .filter(entry => {
+        const {isIntersecting} = entry;
+        return !isIntersecting;
+      })
+      .forEach(entry => {
+        const {target} = entry;
         target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
       });
 
@@ -293,7 +301,8 @@ export class ChildLayoutManager {
    * @param {!Array<!IntersectionObserverEntry>} entries
    */
   processInViewportChanges_(entries) {
-    entries.forEach(({target, isIntersecting}) => {
+    entries.forEach(entry => {
+      const {target, isIntersecting} = entry;
       target[IN_VIEWPORT_FLAG] = isIntersecting
         ? ViewportChangeState.ENTER
         : ViewportChangeState.LEAVE;

--- a/extensions/amp-base-carousel/0.1/responsive-attributes.js
+++ b/extensions/amp-base-carousel/0.1/responsive-attributes.js
@@ -173,7 +173,8 @@ export class ResponsiveAttributes {
    * @private
    */
   setOnchange_(mediaQueryListsAndValues, fn) {
-    mediaQueryListsAndValues.forEach(({mediaQueryList}) => {
+    mediaQueryListsAndValues.forEach(mediaQueryDef => {
+      const {mediaQueryList} = mediaQueryDef;
       mediaQueryList.onchange = fn;
     });
   }

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -45,7 +45,8 @@ class AmpCarousel extends AMP.BaseElement {
   setupActions_() {
     this.registerAction(
       'goToSlide',
-      ({args, trust}) => {
+      actionInvocation => {
+        const {args, trust} = actionInvocation;
         this.carousel_.goToSlide(args['index'] || 0, {
           actionSource: this.getActionSource_(trust),
         });
@@ -54,7 +55,8 @@ class AmpCarousel extends AMP.BaseElement {
     );
     this.registerAction(
       'toggleAutoplay',
-      ({args}) => {
+      actionInvocation => {
+        const {args} = actionInvocation;
         // args will be `null` if not present, so we cannot use a default value above
         const toggle = args ? args['toggleOn'] : undefined;
         this.toggleAutoplay_(toggle);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -394,7 +394,8 @@ export class AmpForm {
     //  Form verification is not supported when SSRing templates is enabled.
     if (!this.ssrTemplateHelper_.isSupported()) {
       this.form_.addEventListener('change', e => {
-        this.verifier_.onCommit().then(({updatedElements, errors}) => {
+        this.verifier_.onCommit().then(updatedErrors => {
+          const {updatedElements, errors} = updatedErrors;
           updatedElements.forEach(checkUserValidityAfterInteraction_);
           // Tell the validation to reveal any input.validationMessage added
           // by the form verifier.

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -626,7 +626,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   setupGestures_() {
     const gestures = Gestures.get(dev().assertElement(this.carousel_));
-    gestures.onGesture(SwipeYRecognizer, ({data}) => {
+    gestures.onGesture(SwipeYRecognizer, e => {
+      const {data} = e;
       this.swipeGesture_(data);
     });
   }

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -150,7 +150,8 @@ export class LightboxManager {
     });
 
     // Process elements where the `lightbox` attr is dynamically set.
-    root.addEventListener(AutoLightboxEvents.NEWLY_SET, ({target}) => {
+    root.addEventListener(AutoLightboxEvents.NEWLY_SET, e => {
+      const {target} = e;
       this.processLightboxElement_(dev().assertElement(target));
     });
 

--- a/extensions/amp-lightbox-gallery/0.1/swipe-to-dismiss.js
+++ b/extensions/amp-lightbox-gallery/0.1/swipe-to-dismiss.js
@@ -157,7 +157,8 @@ export class SwipeToDismiss {
    *   overlay: !Element,
    * }} config
    */
-  startSwipe({swipeElement, hiddenElement, mask, overlay}) {
+  startSwipe(config) {
+    const {swipeElement, hiddenElement, mask, overlay} = config;
     this.swipeElement_ = swipeElement;
     this.hiddenElement_ = hiddenElement;
     this.mask_ = mask;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -548,7 +548,8 @@ export class AmpSidebar extends AMP.BaseElement {
       /* shouldNotPreventDefault */ false,
       /* shouldStopPropagation */ true
     );
-    gestures.onGesture(SwipeXRecognizer, ({data}) => {
+    gestures.onGesture(SwipeXRecognizer, e => {
+      const {data} = e;
       this.handleSwipe_(data);
     });
   }

--- a/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.1/swipe-to-dismiss.js
@@ -149,7 +149,8 @@ export class SwipeToDismiss {
    *   mask: !Element,
    * }} config
    */
-  startSwipe({swipeElement, mask, direction, orientation}) {
+  startSwipe(config) {
+    const {swipeElement, mask, direction, orientation} = config;
     this.swipeElement_ = swipeElement;
     this.mask_ = mask;
     this.direction_ = direction;

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -548,7 +548,8 @@ export class AmpSidebar extends AMP.BaseElement {
       /* shouldNotPreventDefault */ false,
       /* shouldStopPropagation */ true
     );
-    gestures.onGesture(SwipeXRecognizer, ({data}) => {
+    gestures.onGesture(SwipeXRecognizer, e => {
+      const {data} = e;
       this.handleSwipe_(data);
     });
   }

--- a/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
+++ b/extensions/amp-sidebar/0.2/swipe-to-dismiss.js
@@ -149,7 +149,8 @@ export class SwipeToDismiss {
    *   mask: !Element,
    * }} config
    */
-  startSwipe({swipeElement, mask, direction, orientation}) {
+  startSwipe(config) {
+    const {swipeElement, mask, direction, orientation} = config;
     this.swipeElement_ = swipeElement;
     this.mask_ = mask;
     this.direction_ = direction;

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-replacement-cache.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-replacement-cache.js
@@ -54,7 +54,8 @@ export class LinkReplacementCache {
    * @public
    */
   updateReplacementUrls(replacementList) {
-    replacementList.forEach(({anchor, replacementUrl}) => {
+    replacementList.forEach(replacementItem => {
+      const {anchor, replacementUrl} = replacementItem;
       const anchorIndex = this.anchorList_.indexOf(anchor);
       if (anchorIndex !== -1) {
         this.replacementList_[anchorIndex] = replacementUrl;

--- a/extensions/amp-skimlinks/0.1/tracking.js
+++ b/extensions/amp-skimlinks/0.1/tracking.js
@@ -284,7 +284,8 @@ export class Tracking {
     let numberAffiliateLinks = 0;
     const urls = dict({});
 
-    anchorReplacementList.forEach(({replacementUrl, anchor}) => {
+    anchorReplacementList.forEach(anchorReplacement => {
+      const {replacementUrl, anchor} = anchorReplacement;
       const isExcluded = isExcludedAnchorUrl(anchor, this.skimOptions_);
       const isAffiliate = Boolean(replacementUrl);
       // Do not track na-links since the backend doesn't use them.

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -141,7 +141,8 @@ export function getRGBFromCssColorValue(cssValue) {
  * @param  {!Object<string, number>} rgb  ie: {r: 0, g: 0, b: 0}
  * @return {string} '#fff' or '#000'
  */
-export function getTextColorForRGB({r, g, b}) {
+export function getTextColorForRGB(rgb) {
+  const {r, g, b} = rgb;
   // Calculates the relative luminance L.
   // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
   const getLinearRGBValue = x => {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1625,7 +1625,8 @@ export class AmpStory extends AMP.BaseElement {
           el.removeAttribute(Attributes.DESKTOP_POSITION);
         });
 
-        list.forEach(({page, position}) => {
+        list.forEach(entry => {
+          const {page, position} = entry;
           page.element.setAttribute(Attributes.DESKTOP_POSITION, position);
         });
       }

--- a/extensions/amp-story/1.0/bookend/components/text-box.js
+++ b/extensions/amp-story/1.0/bookend/components/text-box.js
@@ -56,7 +56,8 @@ export class TextBoxComponent {
    * @return {!TextBoxComponentDef}
    * @override
    * */
-  build({type, text}) {
+  build(textboxJson) {
+    const {type, text} = textboxJson;
     return {type, text};
   }
 

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -152,7 +152,8 @@ export function getRGBFromCssColorValue(cssValue) {
  * @param  {!Object<string, number>} rgb  ie: {r: 0, g: 0, b: 0}
  * @return {string} '#fff' or '#000'
  */
-export function getTextColorForRGB({r, g, b}) {
+export function getTextColorForRGB(rgb) {
+  const {r, g, b} = rgb;
   // Calculates the relative luminance L.
   // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
   const getLinearRGBValue = x => {

--- a/extensions/amp-subscriptions/0.1/entitlement.js
+++ b/extensions/amp-subscriptions/0.1/entitlement.js
@@ -48,15 +48,16 @@ export class Entitlement {
    * @param {?JsonObject} [input.dataObject]
    * @param {?string} [input.decryptedDocumentKey]
    */
-  constructor({
-    source,
-    raw = '',
-    service,
-    granted = false,
-    grantReason = '',
-    dataObject,
-    decryptedDocumentKey,
-  }) {
+  constructor(input) {
+    const {
+      source,
+      raw = '',
+      service,
+      granted = false,
+      grantReason = '',
+      dataObject,
+      decryptedDocumentKey,
+    } = input;
     /** @const {string} */
     this.raw = raw;
     /** @const {string} */

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -316,7 +316,8 @@ export class PlatformStore {
       this.grantStatusPromise_.resolve(false);
     } else {
       // Listen if any upcoming entitlements unblock the reader
-      this.onChange(({entitlement}) => {
+      this.onChange(e => {
+        const {entitlement} = e;
         if (entitlement.granted) {
           this.grantStatusPromise_.resolve(true);
         } else if (this.areAllPlatformsResolved_()) {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -226,7 +226,8 @@ function getIntersectionRect(element) {
  * @param {!../../../src/layout-rect.LayoutRectDef} rect
  * @return {boolean}
  */
-function isSizedLayoutRect({width, height}) {
+function isSizedLayoutRect(rect) {
+  const {width, height} = rect;
   return width > 0 && height > 0;
 }
 

--- a/extensions/amp-video-docking/0.1/breakpoints.js
+++ b/extensions/amp-video-docking/0.1/breakpoints.js
@@ -27,7 +27,8 @@ export function applyBreakpointClassname(element, width, breakpoints) {
   breakpoints = breakpoints.sort((a, b) => b.minWidth - a.minWidth);
 
   let maxBreakpoint = -1;
-  breakpoints.forEach(({className, minWidth}) => {
+  breakpoints.forEach(breakpoint => {
+    const {className, minWidth} = breakpoint;
     if (minWidth <= width && minWidth > maxBreakpoint) {
       element.classList.add(className);
       maxBreakpoint = minWidth;

--- a/src/document-fetcher.js
+++ b/src/document-fetcher.js
@@ -49,7 +49,10 @@ export function fetchDocument(win, input, opt_init) {
           .text()
           .then(body => new DOMParser().parseFromString(body, 'text/html'));
       }
-      return xhrRequest(input, init).then(({xhr}) => xhr.responseXML);
+      return xhrRequest(input, init).then(resp => {
+        const {xhr} = resp;
+        return xhr.responseXML;
+      });
     }
   );
 }

--- a/src/modal.js
+++ b/src/modal.js
@@ -234,7 +234,8 @@ export function setModalAsClosed(element) {
   devAssert(topModalElement === element);
 
   // Put aria-hidden back to how it was before the call.
-  hiddenElementInfos.forEach(({element, prevValue}) => {
+  hiddenElementInfos.forEach(hiddenElementInfo => {
+    const {element, prevValue} = hiddenElementInfo;
     restoreAttributeValue(element, 'aria-hidden', prevValue);
   });
   // Re-hide any internal elements that should be hidden.

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -542,8 +542,7 @@ export class ActionService {
     if (!action) {
       return false;
     }
-    return action.actionInfos.some(action => {
-      const {target} = action;
+    return action.actionInfos.some(({target}) => {
       return this.getActionNode_(target) == targetElement;
     });
   }
@@ -603,8 +602,8 @@ export class ActionService {
     // to complete. `currentPromise` is the i'th promise in the chain.
     /** @type {?Promise} */
     let currentPromise = null;
-    action.actionInfos.forEach(action => {
-      const {target, args, method, str} = action;
+    action.actionInfos.forEach(actionInfo => {
+      const {target, args, method, str} = actionInfo;
       const dereferencedArgs = dereferenceArgsVariables(args, event, opt_args);
       const invokeAction = () => {
         const node = this.getActionNode_(target);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -517,7 +517,10 @@ export class ActionService {
     if (!action) {
       return false;
     }
-    return action.actionInfos.some(({target}) => !!this.getActionNode_(target));
+    return action.actionInfos.some(action => {
+      const {target} = action;
+      return !!this.getActionNode_(target);
+    });
   }
 
   /**
@@ -539,7 +542,8 @@ export class ActionService {
     if (!action) {
       return false;
     }
-    return action.actionInfos.some(({target}) => {
+    return action.actionInfos.some(action => {
+      const {target} = action;
       return this.getActionNode_(target) == targetElement;
     });
   }
@@ -599,7 +603,8 @@ export class ActionService {
     // to complete. `currentPromise` is the i'th promise in the chain.
     /** @type {?Promise} */
     let currentPromise = null;
-    action.actionInfos.forEach(({target, args, method, str}) => {
+    action.actionInfos.forEach(action => {
+      const {target, args, method, str} = action;
       const dereferencedArgs = dereferenceArgsVariables(args, event, opt_args);
       const invokeAction = () => {
         const node = this.getActionNode_(target);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -542,7 +542,8 @@ export class ActionService {
     if (!action) {
       return false;
     }
-    return action.actionInfos.some(({target}) => {
+    return action.actionInfos.some(actionInfo => {
+      const {target} = actionInfo;
       return this.getActionNode_(target) == targetElement;
     });
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -337,7 +337,8 @@ export class StandardActions {
    * @return {?Promise}
    * @private Visible to tests only.
    */
-  handleShow_({node}) {
+  handleShow_(invocation) {
+    const {node} = invocation;
     const target = dev().assertElement(node);
     const ownerWindow = toWin(target.ownerDocument.defaultView);
 


### PR DESCRIPTION
There is currently a bug in closure compiler where when we do an object destructuring assignment the property access is not validated properly in closure conformance check phase. (reported in https://github.com/google/closure-compiler/issues/3500, internal b/144013285)

Ex:
```
requirement: {
  type: BANNED_PROPERTY
  error_message: 'Use ampdoc instead'
  value: 'Document.prototype.head'
}
```

This will be caught:
`const head = document.head;`

This will not be caught:
`const {head} = document;`

As a workaround until the issue is properly fixed in closure compiler we will attempt to rewrite all destructuring assignment to a normal property access **only in the check-types** phase. We also currently will **not rewrite** destructuring assignment in the parameter as this causes a type error since we will need to pull down the destructuring to the body which essentially changes the parameter signature (we will tackle this in a separate issue)