### PR TITLE
♻️Clean up amp-form test stubs handling Promises

### DIFF
--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -83,9 +83,7 @@ describes.repeated(
 
           // This needs to be stubbed to stop the function from,
           // hanging and timing out on tests that make proper XHR requests
-          sandbox
-            .stub(xhrUtils, 'getViewerInterceptResponse')
-            .returns(Promise.resolve(null));
+          sandbox.stub(xhrUtils, 'getViewerInterceptResponse').resolves(null);
         });
 
         afterEach(() => sandbox.restore());
@@ -94,7 +92,7 @@ describes.repeated(
           new AmpFormService(env.ampdoc);
           Services.documentInfoForDoc(env.ampdoc).canonicalUrl = canonical;
           const cidService = cidServiceForDocForTesting(env.ampdoc);
-          sandbox.stub(cidService, 'get').returns(Promise.resolve('amp-cid'));
+          sandbox.stub(cidService, 'get').resolves('amp-cid');
           env.ampdoc.getBody().appendChild(form);
           const ampForm = new AmpForm(form, 'amp-form-test-id');
           sandbox
@@ -164,9 +162,7 @@ describes.repeated(
 
             // Create stubs that can be used for observing the async input
             const asyncInputValue = 'async-input-value';
-            const getValueStub = sandbox
-              .stub()
-              .returns(Promise.resolve(asyncInputValue));
+            const getValueStub = sandbox.stub().resolves(asyncInputValue);
             asyncInput.getImpl = () =>
               Promise.resolve({
                 getValue: getValueStub,
@@ -196,7 +192,7 @@ describes.repeated(
                 'async-input-value-required-action';
               const getValueStubRequiredAction = sandbox
                 .stub()
-                .returns(Promise.resolve(asyncInputValueRequiredAction));
+                .resolves(asyncInputValueRequiredAction);
               asyncInputRequiredAction.getImpl = () =>
                 Promise.resolve({
                   getValue: getValueStubRequiredAction,
@@ -294,11 +290,11 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox.stub(ampForm.viewer_, 'sendMessageAwaitResponse').returns(
-                Promise.resolve({
+              sandbox
+                .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
+                .resolves({
                   data: {html: '<div>much success</div>'},
-                })
-              );
+                });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much success';
               sandbox
@@ -308,19 +304,15 @@ describes.repeated(
               const ssr = sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
               ssr
                 .onFirstCall()
-                .returns(
-                  Promise.resolve({
-                    init: {status: 200},
-                    html: '<div>much success</div>',
-                  })
-                )
+                .resolves({
+                  init: {status: 200},
+                  html: '<div>much success</div>',
+                })
                 .onSecondCall()
-                .returns(
-                  Promise.resolve({
-                    init: {status: 200},
-                    html: '<div>much success</div>',
-                  })
-                );
+                .resolves({
+                  init: {status: 200},
+                  html: '<div>much success</div>',
+                });
 
               const handleSubmitEventPromise = ampForm.handleSubmitEvent_(
                 event
@@ -372,13 +364,13 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox.stub(ampForm.viewer_, 'sendMessageAwaitResponse').returns(
-                Promise.resolve({
+              sandbox
+                .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
+                .resolves({
                   data: {
                     html: '<div>much error</div>',
                   },
-                })
-              );
+                });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much error';
               sandbox
@@ -388,19 +380,15 @@ describes.repeated(
               const ssr = sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
               ssr
                 .onFirstCall()
-                .returns(
-                  Promise.resolve({
-                    init: {status: 404},
-                    html: '<div>much error</div>',
-                  })
-                )
+                .resolves({
+                  init: {status: 404},
+                  html: '<div>much error</div>',
+                })
                 .onSecondCall()
-                .returns(
-                  Promise.resolve({
-                    init: {status: 404},
-                    html: '<div>much error</div>',
-                  })
-                );
+                .resolves({
+                  init: {status: 404},
+                  html: '<div>much error</div>',
+                });
 
               const handleSubmitEventPromise = ampForm.handleSubmitEvent_(
                 event
@@ -452,11 +440,11 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox.stub(ampForm.viewer_, 'sendMessageAwaitResponse').returns(
-                Promise.resolve({
+              sandbox
+                .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
+                .resolves({
                   data: '<div>much success</div>',
-                })
-              );
+                });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much success';
               sandbox
@@ -469,17 +457,13 @@ describes.repeated(
               );
               ssr
                 .onFirstCall()
-                .returns(
-                  Promise.resolve({
-                    html: renderedTemplate,
-                  })
-                )
+                .resolves({
+                  html: renderedTemplate,
+                })
                 .onSecondCall()
-                .returns(
-                  Promise.resolve({
-                    html: template,
-                  })
-                );
+                .resolves({
+                  html: template,
+                });
 
               const renderTemplate = sandbox.spy(ampForm, 'renderTemplate_');
 
@@ -513,18 +497,16 @@ describes.repeated(
             messageContainer.setAttribute('template', 'successTemplate');
             form.appendChild(messageContainer);
             // Given an unsupported JSON array response.
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json: () => {
-                  return Promise.resolve([]);
-                },
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json: () => {
+                return Promise.resolve([]);
+              },
+            });
             const renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Hello,';
             sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
-              .returns(Promise.resolve(renderedTemplate));
+              .resolves(renderedTemplate);
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: form,
@@ -557,15 +539,13 @@ describes.repeated(
 
         it('should fire the form submit service', () => {
           const fireStub = sandbox.stub();
-          sandbox.stub(Services, 'formSubmitForDoc').returns(
-            Promise.resolve({
-              fire: fireStub,
-            })
-          );
+          sandbox.stub(Services, 'formSubmitForDoc').resolves({
+            fire: fireStub,
+          });
 
           const form = getForm();
           return getAmpForm(form).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             sandbox.stub(ampForm, 'handleXhrSubmitSuccess_');
 
             const event = {
@@ -683,7 +663,7 @@ describes.repeated(
             preventDefault: sandbox.spy(),
           };
 
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
           sandbox.spy(form, 'checkValidity');
           const submitEventPromise = ampForm.handleSubmitEvent_(event);
           expect(event.stopImmediatePropagation).to.be.called;
@@ -705,7 +685,7 @@ describes.repeated(
             target: form,
             preventDefault: sandbox.spy(),
           };
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
           sandbox.stub(ampForm, 'analyticsEvent_');
           sandbox.spy(form, 'checkValidity');
           const errorRe = /Only XHR based \(via action-xhr attribute\) submissions are supported/;
@@ -728,7 +708,7 @@ describes.repeated(
           emailInput.setAttribute('required', '');
           form.appendChild(emailInput);
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
           const event = {
             stopImmediatePropagation: sandbox.spy(),
             target: form,
@@ -738,9 +718,7 @@ describes.repeated(
           sandbox.spy(form, 'checkValidity');
           sandbox.spy(emailInput, 'reportValidity');
 
-          sandbox
-            .stub(ampForm, 'handleXhrSubmitSuccess_')
-            .returns(Promise.resolve());
+          sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
           return ampForm.handleSubmitEvent_(event).then(() => {
             expect(form.hasAttribute('amp-novalidate')).to.be.true;
             document.body.removeChild(form);
@@ -764,7 +742,7 @@ describes.repeated(
             target: form,
             preventDefault: sandbox.spy(),
           };
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
           sandbox.spy(form, 'checkValidity');
           const submitErrorRe = /Only XHR based \(via action-xhr attribute\) submissions are supported/;
           expectAsyncConsoleError(submitErrorRe);
@@ -784,7 +762,7 @@ describes.repeated(
             emailInput.setAttribute('required', '');
             form.appendChild(emailInput);
             sandbox.spy(form, 'checkValidity');
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: ampForm.form_,
@@ -832,9 +810,7 @@ describes.repeated(
             // Check xhr goes through when form is valid.
             emailInput.value = 'cool@bea.ns';
 
-            sandbox
-              .stub(ampForm, 'handleXhrSubmitSuccess_')
-              .returns(Promise.resolve());
+            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
 
             return whenCalled(ampForm.xhr_.fetch).then(() => {
@@ -855,16 +831,14 @@ describes.repeated(
             emailInput.setAttribute('required', '');
             form.appendChild(emailInput);
             sandbox.spy(form, 'checkValidity');
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: ampForm.form_,
               preventDefault: sandbox.spy(),
             };
 
-            sandbox
-              .stub(ampForm, 'handleXhrSubmitSuccess_')
-              .returns(Promise.resolve());
+            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
 
             return whenCalled(ampForm.xhr_.fetch).then(() => {
@@ -879,7 +853,7 @@ describes.repeated(
 
         it('should allow verifying elements with a presubmit request', () => {
           const formPromise = getAmpForm(getVerificationForm());
-          const fetchRejectPromise = Promise.reject({
+          const fetchReject = {
             response: {
               status: 400,
               json() {
@@ -893,10 +867,10 @@ describes.repeated(
                 });
               },
             },
-          });
+          };
 
           return formPromise.then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
+            sandbox.stub(ampForm.xhr_, 'fetch').rejects(fetchReject);
 
             const form = ampForm.form_;
             const input = form.name;
@@ -916,41 +890,33 @@ describes.repeated(
 
           return formPromise.then(ampForm => {
             const xhrStub = sandbox.stub(ampForm.xhr_, 'fetch');
-            xhrStub.onCall(0).returns(
-              Promise.reject({
-                response: {
-                  status: 400,
-                  json() {
-                    return Promise.resolve({
-                      verifyErrors: [
-                        {name: 'name', message: 'First request error'},
-                      ],
-                    });
-                  },
-                },
-              })
-            );
-            xhrStub.onCall(1).returns(
-              new Promise((res, reject) => {
-                setTimeout(() => {
-                  reject({
-                    response: {
-                      status: 400,
-                      json() {
-                        return Promise.resolve({
-                          verifyErrors: [
-                            {
-                              name: 'name',
-                              message: 'Second request error',
-                            },
-                          ],
-                        });
-                      },
-                    },
+            xhrStub.onCall(0).rejects({
+              response: {
+                status: 400,
+                json() {
+                  return Promise.resolve({
+                    verifyErrors: [
+                      {name: 'name', message: 'First request error'},
+                    ],
                   });
-                }, 10);
-              })
-            );
+                },
+              },
+            });
+            xhrStub.onCall(1).rejects({
+              response: {
+                status: 400,
+                json() {
+                  return Promise.resolve({
+                    verifyErrors: [
+                      {
+                        name: 'name',
+                        message: 'Second request error',
+                      },
+                    ],
+                  });
+                },
+              },
+            });
             const form = ampForm.form_;
             const input = form.name;
             input.value = 'Carlos';
@@ -972,7 +938,7 @@ describes.repeated(
 
         it('should not send verifying elements with a no-verify attribute', () => {
           const formPromise = getAmpForm(getVerificationForm());
-          const fetchRejectPromise = Promise.reject({
+          const fetchReject = {
             response: {
               status: 400,
               json() {
@@ -986,12 +952,12 @@ describes.repeated(
                 });
               },
             },
-          });
+          };
 
           return formPromise.then(ampForm => {
             const fetchStub = sandbox
               .stub(ampForm.xhr_, 'fetch')
-              .returns(fetchRejectPromise);
+              .rejects(fetchReject);
 
             const form = ampForm.form_;
             const input = form.name;
@@ -1029,19 +995,17 @@ describes.repeated(
             errorContainer.appendChild(errorTemplate);
             let renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Error: hello there';
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.reject({
-                response: {
-                  status: 400,
-                  json() {
-                    return Promise.resolve({message: 'hello there'});
-                  },
+            sandbox.stub(ampForm.xhr_, 'fetch').rejects({
+              response: {
+                status: 400,
+                json() {
+                  return Promise.resolve({message: 'hello there'});
                 },
-              })
-            );
+              },
+            });
             sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
-              .returns(Promise.resolve(renderedTemplate));
+              .resolves(renderedTemplate);
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: form,
@@ -1085,18 +1049,16 @@ describes.repeated(
             messageContainer.setAttribute('submit-success', '');
             messageContainer.setAttribute('template', 'successTemplate');
             form.appendChild(messageContainer);
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json: () => {
-                  return Promise.resolve({'name': 'John Smith'});
-                },
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json: () => {
+                return Promise.resolve({'name': 'John Smith'});
+              },
+            });
             const renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Hello, John Smith';
             sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
-              .returns(Promise.resolve(renderedTemplate));
+              .resolves(renderedTemplate);
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: form,
@@ -1146,18 +1108,16 @@ describes.repeated(
             const newRender = createElement('div');
             newRender.innerText = 'New Success: What What';
 
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json: () => {
-                  return Promise.resolve({'message': 'What What'});
-                },
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json: () => {
+                return Promise.resolve({'message': 'What What'});
+              },
+            });
             const findAndRenderTemplateStub = sandbox.stub(
               ampForm.templates_,
               'findAndRenderTemplate'
             );
-            findAndRenderTemplateStub.returns(Promise.resolve(newRender));
+            findAndRenderTemplateStub.resolves(newRender);
             const event = {
               stopImmediatePropagation: sandbox.spy(),
               target: form,
@@ -1207,20 +1167,16 @@ describes.repeated(
               successContainer,
               'appendChild'
             );
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json() {
-                  return Promise.resolve({'message': 'What What'});
-                },
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json() {
+                return Promise.resolve({'message': 'What What'});
+              },
+            });
             const findAndRenderTemplateStub = sandbox.stub(
               ampForm.templates_,
               'findAndRenderTemplate'
             );
-            findAndRenderTemplateStub.returns(
-              Promise.resolve(renderedTemplate)
-            );
+            findAndRenderTemplateStub.resolves(renderedTemplate);
 
             const event = {
               stopImmediatePropagation: sandbox.spy(),
@@ -1248,7 +1204,7 @@ describes.repeated(
 
         it('should call fetch with the xhr action and form data', () => {
           return getAmpForm(getForm()).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
             const event = {
               stopImmediatePropagation: sandbox.spy(),
@@ -1256,9 +1212,7 @@ describes.repeated(
               preventDefault: sandbox.spy(),
             };
 
-            sandbox
-              .stub(ampForm, 'handleXhrSubmitSuccess_')
-              .returns(Promise.resolve());
+            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
             expect(event.preventDefault).to.be.calledOnce;
 
@@ -1287,11 +1241,9 @@ describes.repeated(
 
         it('should trigger amp-form-submit analytics event with form data', () => {
           return getAmpForm(getForm()).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json: () => Promise.resolve({}),
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json: () => Promise.resolve({}),
+            });
             sandbox.stub(ampForm, 'analyticsEvent_');
 
             const event = {
@@ -1346,11 +1298,9 @@ describes.repeated(
             form.appendChild(canonicalUrlField);
 
             sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
-              Promise.resolve({
-                json: () => Promise.resolve({}),
-              })
-            );
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+              json: () => Promise.resolve({}),
+            });
             sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
             sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
             sandbox.stub(ampForm, 'analyticsEvent_');
@@ -1563,16 +1513,14 @@ describes.repeated(
               ampForm.method_ = 'GET';
               ampForm.form_.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const event = {
                 stopImmediatePropagation: sandbox.spy(),
                 target: ampForm.form_,
                 preventDefault: sandbox.spy(),
               };
 
-              sandbox
-                .stub(ampForm, 'handleXhrSubmitSuccess_')
-                .returns(Promise.resolve());
+              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
 
@@ -1599,7 +1547,7 @@ describes.repeated(
               ampForm.method_ = 'GET';
               form.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const fieldset = createElement('fieldset');
               const emailInput = createElement('input');
               emailInput.setAttribute('name', 'email');
@@ -1621,9 +1569,7 @@ describes.repeated(
               usernameInput.value = 'coolbeans';
               emailInput.value = 'cool@bea.ns';
 
-              sandbox
-                .stub(ampForm, 'handleXhrSubmitSuccess_')
-                .returns(Promise.resolve());
+              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               let submitEventPromise;
               submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
@@ -1639,7 +1585,7 @@ describes.repeated(
                 .then(() => {
                   ampForm.setState_('submit-success');
                   ampForm.xhr_.fetch.reset();
-                  ampForm.xhr_.fetch.returns(Promise.resolve());
+                  ampForm.xhr_.fetch.resolves();
                   usernameInput.removeAttribute('disabled');
                   usernameInput.value = 'coolbeans';
                   emailInput.value = 'cool@bea.ns';
@@ -1660,7 +1606,7 @@ describes.repeated(
                 .then(() => {
                   ampForm.setState_('submit-success');
                   ampForm.xhr_.fetch.reset();
-                  ampForm.xhr_.fetch.returns(Promise.resolve());
+                  ampForm.xhr_.fetch.resolves();
                   fieldset.disabled = true;
 
                   submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -1677,7 +1623,7 @@ describes.repeated(
                 .then(() => {
                   ampForm.setState_('submit-success');
                   ampForm.xhr_.fetch.reset();
-                  ampForm.xhr_.fetch.returns(Promise.resolve());
+                  ampForm.xhr_.fetch.resolves();
 
                   fieldset.removeAttribute('disabled');
                   usernameInput.removeAttribute('name');
@@ -1702,7 +1648,7 @@ describes.repeated(
               ampForm.method_ = 'GET';
               form.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               const otherNamesFS = createElement('fieldset');
               const otherName1Input = createElement('input');
@@ -1766,9 +1712,7 @@ describes.repeated(
                 preventDefault: sandbox.spy(),
               };
 
-              sandbox
-                .stub(ampForm, 'handleXhrSubmitSuccess_')
-                .returns(Promise.resolve());
+              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               let submitEventPromise;
               submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
@@ -1785,7 +1729,7 @@ describes.repeated(
                 .then(() => {
                   ampForm.setState_('submit-success');
                   ampForm.xhr_.fetch.reset();
-                  ampForm.xhr_.fetch.returns(Promise.resolve());
+                  ampForm.xhr_.fetch.resolves();
                   foodCB.checked = true;
                   footballCB.checked = true;
                   submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -1805,7 +1749,7 @@ describes.repeated(
                   femaleRadio.checked = true;
                   otherName1Input.value = 'John Maller';
                   ampForm.xhr_.fetch.reset();
-                  ampForm.xhr_.fetch.returns(Promise.resolve());
+                  ampForm.xhr_.fetch.resolves();
 
                   submitEventPromise = ampForm.handleSubmitEvent_(event);
                   return whenCalled(ampForm.xhr_.fetch);
@@ -1891,7 +1835,7 @@ describes.repeated(
               sandbox.spy(form, 'checkValidity');
               sandbox.spy(emailInput, 'checkValidity');
               sandbox.spy(fieldset, 'checkValidity');
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               checkUserValidityAfterInteraction_(emailInput);
               expect(form.checkValidity).to.be.called;
@@ -1954,7 +1898,7 @@ describes.repeated(
               sandbox.spy(form, 'checkValidity');
               sandbox.spy(emailInput, 'checkValidity');
               sandbox.spy(fieldset, 'checkValidity');
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               emailInput.value = 'cool@bea.ns';
               checkUserValidityAfterInteraction_(emailInput);
@@ -1975,7 +1919,7 @@ describes.repeated(
 
           sandbox.stub(actions, 'installActionHandler');
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
           expect(actions.installActionHandler).to.be.calledWith(form);
           sandbox.spy(ampForm, 'handleSubmitAction_');
@@ -2000,7 +1944,7 @@ describes.repeated(
           document.body.appendChild(form);
 
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
           sandbox.spy(ampForm, 'handleSubmitAction_');
           ampForm.actionHandler_({
@@ -2155,7 +2099,7 @@ describes.repeated(
                 builtPromiseResolver_ = resolve;
               })
             );
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             sandbox.spy(ampForm, 'handleSubmitAction_');
 
             ampForm.actionHandler_({
@@ -2201,7 +2145,7 @@ describes.repeated(
               form.appendChild(canonicalUrlField);
 
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               sandbox.stub(ampForm, 'handleSubmitSuccess_');
               sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
               sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -2252,7 +2196,7 @@ describes.repeated(
               form.appendChild(canonicalUrlField);
 
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               sandbox.stub(ampForm, 'handleSubmitSuccess_');
               sandbox
                 .stub(ampForm.urlReplacement_, 'expandInputValueAsync')
@@ -2263,9 +2207,7 @@ describes.repeated(
                 );
               sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
 
-              sandbox
-                .stub(ampForm, 'handleXhrSubmitSuccess_')
-                .returns(Promise.resolve());
+              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitPromise = ampForm.submit_(ActionTrust.HIGH);
 
               expect(ampForm.xhr_.fetch).to.have.not.been.called;
@@ -2320,9 +2262,7 @@ describes.repeated(
                 sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
                 sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
 
-                sandbox
-                  .stub(ampForm, 'handleNonXhrGet_')
-                  .returns(Promise.resolve());
+                sandbox.stub(ampForm, 'handleNonXhrGet_').resolves();
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
                 );
@@ -2375,10 +2315,10 @@ describes.repeated(
                 }
               },
             };
-            const fetchResolvePromise = Promise.resolve({
+            const fetchResolve = {
               json: () => Promise.resolve(),
               headers: headersMock,
-            });
+            };
             const error = new Error('Error');
             error.response = {
               headers: headersMock,
@@ -2386,10 +2326,6 @@ describes.repeated(
                 return Promise.resolve();
               },
             };
-            const fetchRejectPromise = Promise.reject(error);
-            fetchRejectPromise.catch(() => {
-              // Just avoiding a global uncaught promise exception.
-            });
             let navigateTo;
 
             beforeEach(() => {
@@ -2408,9 +2344,7 @@ describes.repeated(
 
             describe('AMP-Redirect-To', () => {
               it('should redirect users if header is set', () => {
-                sandbox
-                  .stub(ampForm.xhr_, 'fetch')
-                  .returns(fetchResolvePromise);
+                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'https://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2427,12 +2361,10 @@ describes.repeated(
               });
 
               it('should redirect users if header is set but json rejects', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').returns(
-                  Promise.resolve({
-                    json: () => Promise.reject(),
-                    headers: headersMock,
-                  })
-                );
+                sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+                  json: () => Promise.reject(),
+                  headers: headersMock,
+                });
                 redirectToValue = 'https://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2449,9 +2381,7 @@ describes.repeated(
               });
 
               it('should fail to redirect to non-secure urls', () => {
-                sandbox
-                  .stub(ampForm.xhr_, 'fetch')
-                  .returns(fetchResolvePromise);
+                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'http://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2471,9 +2401,7 @@ describes.repeated(
               });
 
               it('should fail to redirect to non-absolute urls', () => {
-                sandbox
-                  .stub(ampForm.xhr_, 'fetch')
-                  .returns(fetchResolvePromise);
+                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = '/hello';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2494,9 +2422,7 @@ describes.repeated(
 
               it('should fail to redirect to when target != _top', () => {
                 ampForm.target_ = '_blank';
-                sandbox
-                  .stub(ampForm.xhr_, 'fetch')
-                  .returns(fetchResolvePromise);
+                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'http://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2515,8 +2441,8 @@ describes.repeated(
                 );
               });
 
-              it('should redirect on error and header is set', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
+              it('should redirect on error if header is set', () => {
+                sandbox.stub(ampForm.xhr_, 'fetch').rejects(error);
                 redirectToValue = 'https://example2.com/hello';
                 const logSpy = sandbox.stub(user(), 'error');
 
@@ -2550,11 +2476,9 @@ describes.repeated(
               ampForm.xhrAction_ = null;
               sandbox.stub(form, 'submit');
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
-              sandbox
-                .stub(ampForm, 'handleXhrSubmitSuccess_')
-                .returns(Promise.resolve());
+              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitActionPromise = ampForm.handleSubmitAction_(
                 /* invocation */ {}
               );
@@ -2572,7 +2496,7 @@ describes.repeated(
               ampForm.xhrAction_ = null;
               sandbox.stub(form, 'submit');
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const event = {
                 stopImmediatePropagation: sandbox.spy(),
                 target: form,
@@ -2596,7 +2520,7 @@ describes.repeated(
               ampForm.xhrAction_ = null;
               sandbox.stub(form, 'submit');
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               allowConsoleError(() => {
                 expect(() =>
                   ampForm.handleSubmitAction_(/* invocation */ {})
@@ -2618,7 +2542,7 @@ describes.repeated(
               ampForm.xhrAction_ = null;
               sandbox.stub(form, 'submit');
               sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               allowConsoleError(() => {
                 expect(() =>
                   ampForm.handleSubmitAction_(/* invocation */ {})
@@ -2650,12 +2574,10 @@ describes.repeated(
             ampForm.xhrAction_ = null;
             sandbox.stub(form, 'submit');
             sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             sandbox.stub(ampForm, 'analyticsEvent_');
 
-            sandbox
-              .stub(ampForm, 'handleXhrSubmitSuccess_')
-              .returns(Promise.resolve());
+            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitActionPromise = ampForm.handleSubmitAction_(
               /* invocation */ {}
             );
@@ -2806,7 +2728,7 @@ describes.repeated(
 
             sandbox.stub(form, 'submit');
             sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
             sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
             sandbox.stub(ampForm, 'analyticsEvent_');
@@ -2843,11 +2765,9 @@ describes.repeated(
         });
 
         it('should attach auth token with crossorigin attribute', () => {
-          sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
-            Promise.resolve({
-              getIdTokenPromise: () => Promise.resolve('idToken'),
-            })
-          );
+          sandbox.stub(Services, 'viewerAssistanceForDocOrNull').resolves({
+            getIdTokenPromise: () => Promise.resolve('idToken'),
+          });
           return getAmpForm(getForm()).then(ampForm => {
             const form = ampForm.form_;
             form.id = 'registration';
@@ -2870,7 +2790,7 @@ describes.repeated(
             );
             sandbox
               .stub(ampForm.xhr_, 'fetch')
-              .returns(Promise.resolve({json: () => Promise.resolve()}));
+              .resolves({json: () => Promise.resolve()});
 
             return ampForm.handleSubmitAction_(/* invocation */ {}).then(() => {
               return ampForm.xhrSubmitPromiseForTesting().then(() => {
@@ -3005,7 +2925,7 @@ describes.repeated(
                     const value = hiddenInput.getAttribute('value');
                     expect(value).to.be.equal(asyncInputValue);
 
-                    getValueStub.returns(Promise.resolve(newAsyncInputValue));
+                    getValueStub.resolves(newAsyncInputValue);
                     return ampForm.submit_(ActionTrust.HIGH);
                   })
                   .then(() => {
@@ -3069,7 +2989,7 @@ describes.repeated(
                 const {ampForm, getValueStub} = response;
 
                 const getValueError = new Error('amp-async-input-error');
-                getValueStub.returns(Promise.reject(getValueError));
+                getValueStub.rejects(getValueError);
 
                 const stub = sandbox.stub(ampForm, 'handleSubmitFailure_');
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
@@ -3124,7 +3044,7 @@ describes.repeated(
                 const {ampForm, getValueStub} = response;
 
                 const getValueError = new Error('amp-async-input-error');
-                getValueStub.returns(Promise.reject(getValueError));
+                getValueStub.rejects(getValueError);
                 const setStateStub = sandbox.stub(ampForm, 'setState_');
 
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
@@ -3168,7 +3088,7 @@ describes.repeated(
           it('clears dirtiness class when submitted successfully with XHR', async () => {
             sandbox
               .stub(ampForm.xhr_, 'fetch')
-              .returns(Promise.resolve({json: async () => {}}));
+              .resolves({json: async () => {}});
 
             changeInput(input, 'Another Name');
             await ampForm.submit_(ActionTrust.HIGH);
@@ -3177,7 +3097,7 @@ describes.repeated(
           });
 
           it('does not clear dirtiness class when submission XHR fails', async () => {
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.reject({}));
+            sandbox.stub(ampForm.xhr_, 'fetch').rejects({});
 
             changeInput(input, 'Another Name');
             await ampForm.submit_(ActionTrust.HIGH);


### PR DESCRIPTION
Replace `stub.returns(Promise.resolve(x))` with `stub.resolves(x)`. Same goes for `Promise.reject`.