### PR TITLE
Remove extra String.includes helper

### DIFF
--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -70,12 +70,6 @@ requirement: {
 
 requirement: {
   type: BANNED_PROPERTY_CALL
-  error_message: 'string.prototype.includes is not allowed'
-  value: 'string.prototype.includes'
-}
-
-requirement: {
-  type: BANNED_PROPERTY_CALL
   error_message: 'string.prototype.repeat is not allowed'
   value: 'string.prototype.repeat'
 }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -422,7 +422,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.highlightUserEntry_ &&
       substring &&
       substring.length <= item.length &&
-      includes(lowerCaseItem, lowerCaseSubstring)
+      lowerCaseItem.includes(lowerCaseSubstring)
     ) {
       const loc = lowerCaseItem.indexOf(lowerCaseSubstring);
       const span = this.element.ownerDocument.createElement('span');
@@ -566,7 +566,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       item = item.toLocaleLowerCase();
       switch (this.filter_) {
         case FilterType.SUBSTRING:
-          return includes(item, input);
+          return item.includes(input);
         case FilterType.PREFIX:
           return startsWith(item, input);
         case FilterType.TOKEN_PREFIX:

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -28,9 +28,9 @@ import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user, userAssert} from '../../../src/log';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {hasOwn, map, ownProperty} from '../../../src/utils/object';
-import {includes, startsWith} from '../../../src/string';
 import {isEnumValue} from '../../../src/types';
 import {mod} from '../../../src/utils/math';
+import {startsWith} from '../../../src/string';
 import {toggle} from '../../../src/style';
 import fuzzysearch from '../../../third_party/fuzzysearch/index';
 

--- a/src/string.js
+++ b/src/string.js
@@ -83,23 +83,6 @@ export function startsWith(string, prefix) {
 }
 
 /**
- * Polyfill for String.prototype.includes.
- * @param {string} string
- * @param {string} substring
- * @param {number=} start
- * @return {boolean}
- */
-export function includes(string, substring, start) {
-  if (typeof start !== 'number') {
-    start = 0;
-  }
-  if (start + substring.length > string.length) {
-    return false;
-  }
-  return string.indexOf(substring, start) !== -1;
-}
-
-/**
  * Expands placeholders in a given template string with values.
  *
  * Placeholders use ${key-name} syntax and are replaced with the value


### PR DESCRIPTION
Stumbled across this. We already have a polyfill installed on the prototype in array-includes.js. 

/to @caroqliu @samouri /cc @jridgewell 