### PR TITLE
allowConsoleError should work with async functions

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -314,10 +314,10 @@ function warnForConsoleError() {
       Array(repeat).fill(message)
     );
   };
-  self.allowConsoleError = function(func) {
+  self.allowConsoleError = async function(func) {
     consoleErrorStub.reset();
     consoleErrorStub.callsFake(() => {});
-    const result = func();
+    const result = await func();
     try {
       expect(consoleErrorStub).to.have.been.called;
     } catch (e) {


### PR DESCRIPTION
This feels too simple. Am I missing an obvious reason why this wouldn't work 🤔.
Context: https://github.com/ampproject/amphtml/issues/15609

/to @choumx 