### PR TITLE
🐛Fix initial sizing of the flying carpet area.

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -56,12 +56,18 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
      */
     this.container_ = null;
 
-    this.firstLayoutCompleted_ = false;
+    /** @private {boolean} */
+    this.initialPositionChecked_ = false;
   }
 
   /** @override */
   isLayoutSupported(layout) {
     return layout == Layout.FIXED_HEIGHT;
+  }
+
+  /** @override */
+  isRelayoutNeeded() {
+    return true;
   }
 
   /** @override */
@@ -93,21 +99,6 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
       container,
       /* opt_forceTransfer */ false
     );
-  }
-
-  /** @override */
-  onMeasureChanged() {
-    const width = this.getLayoutWidth();
-    this.mutateElement(() => {
-      setStyle(this.container_, 'width', width, 'px');
-    });
-    if (this.firstLayoutCompleted_) {
-      Services.ownersForDoc(this.element).scheduleLayout(
-        this.element,
-        this.children_
-      );
-      this.observeNewChildren_();
-    }
   }
 
   /** @override */
@@ -155,19 +146,24 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    try {
-      this.assertPosition_();
-    } catch (e) {
-      // Collapse the element if the effect is broken by the viewport location.
-      this./*OK*/ collapse();
-      throw e;
+    if (!this.initialPositionChecked_) {
+      try {
+        this.assertPosition_();
+      } catch (e) {
+        // Collapse the element if the effect is broken by the viewport location.
+        this./*OK*/ collapse();
+        throw e;
+      }
+      this.initialPositionChecked_ = true;
     }
+
+    const width = this.getLayoutWidth();
+    setStyle(this.container_, 'width', width, 'px');
     Services.ownersForDoc(this.element).scheduleLayout(
       this.element,
       this.children_
     );
     this.observeNewChildren_();
-    this.firstLayoutCompleted_ = true;
     return Promise.resolve();
   }
 

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -148,11 +148,11 @@ describes.realWin(
         };
         impl.getLayoutWidth = () => width;
 
-        impl.onMeasureChanged();
+        impl.layoutCallback();
         expect(container.style.width).to.equal(width + 'px');
 
         width++;
-        impl.onMeasureChanged();
+        impl.layoutCallback();
         expect(container.style.width).to.equal(width + 'px');
       });
     });
@@ -225,7 +225,7 @@ describes.realWin(
       });
     });
 
-    it('should relayout the content on onMeasureChanged', () => {
+    it('should relayout the content', () => {
       return getAmpFlyingCarpet().then(flyingCarpet => {
         const impl = flyingCarpet.implementation_;
         const scheduleLayoutSpy_ = sandbox.spy(
@@ -236,7 +236,7 @@ describes.realWin(
         impl.mutateElement = function(callback) {
           callback();
         };
-        impl.onMeasureChanged();
+        impl.layoutCallback();
         expect(scheduleLayoutSpy_).to.have.been.calledWith(
           impl.element,
           impl.children_


### PR DESCRIPTION
It seems like at some point, `onMeasureChanged` used to be called prior to the first layout, but that no longer appears to be the case, causing the container width to not be set until the first resize.

- Remove usage of `onMeasureChanged`, instead use `layoutCallback` with `isRelayoutNeeded` to keep the logic consistent.
- Make the `layoutCallback` set the container width, which will happen on the first layout as well as any subsequent resize.

Fixes #25393