### PR TITLE
📖 Adapt misleading comment in validateLayout()

### DIFF
--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -4096,7 +4096,7 @@ function validateLayout(parsedTagSpec, context, encounteredTag, result) {
         getTagSpecUrl(spec), result);
     return;
   }
-  // RESPONSIVE only allows heights attribute.
+  // Height attribute is only allowed for RESPONSIVE layout.
   if (heightsAttr !== undefined &&
       layout !== amp.validator.AmpLayout.Layout.RESPONSIVE) {
     const code = layoutAttr === undefined ?

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -4096,7 +4096,7 @@ function validateLayout(parsedTagSpec, context, encounteredTag, result) {
         getTagSpecUrl(spec), result);
     return;
   }
-  // Height attribute is only allowed for RESPONSIVE layout.
+  // heights attribute is only allowed for RESPONSIVE layout.
   if (heightsAttr !== undefined &&
       layout !== amp.validator.AmpLayout.Layout.RESPONSIVE) {
     const code = layoutAttr === undefined ?


### PR DESCRIPTION
In the validator engine, one of the comments is misleading, as it implies the wrong criteria to check.

The original comment `RESPONSIVE only allows heights attribute.` makes me think the limitation is on the attributes that responsive allows for, like not allowing for a width to be set on responsive.

However, looking at the code, it becomes apparent that the limitation is that the height attribute should not be present for any of the other layouts, only for responsive. So it doesn't limit what attributes the responsive layout can have, it limits what layout the height attribute can be applied to.

Therefore I suggest changing the comment to `Height attribute is only allowed for RESPONSIVE layout.`
