### PR TITLE
🐛 amp-form test: fix test logic bug that would make it always pass

### DIFF
--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -260,7 +260,10 @@ describes.repeated(
               expectAsyncConsoleError(errorRe);
               return Promise.resolve()
                 .then(() => ampForm.handleSubmitEvent_(event))
-                .then(() => Promise.reject(), () => Promise.resolve());
+                .then(
+                  () => Promise.reject(),
+                  () => Promise.resolve()
+                );
             });
           });
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -258,11 +258,9 @@ describes.repeated(
 
               const errorRe = /Non-XHR GETs not supported./;
               expectAsyncConsoleError(errorRe);
-              try {
-                return ampForm.handleSubmitEvent_(event);
-              } catch (error) {
-                return Promise.resolve();
-              }
+              return Promise.resolve()
+                .then(() => ampForm.handleSubmitEvent_(event))
+                .then(() => Promise.reject(), () => Promise.resolve());
             });
           });
 


### PR DESCRIPTION
As written, the test would never fail. The test is setup to pass when the SUT fails and fail when the SUT passes.  The problem is that as written, the test won't fail even if the SUT passes.
