### PR TITLE
Enable 'remove-viewer-query-params-on-navigate' in prod

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -35,6 +35,7 @@
   "ios-fixed-no-transfer": 0,
   "macro-after-long-task": 0,
   "pump-early-frame": 1,
+  "remove-viewer-query-params-on-navigate": 1,
   "use-responsive-ads-for-responsive-sizing-in-auto-ads": 0.05,
   "version-locking": 1
 }


### PR DESCRIPTION
Launches #25179. 

Tested on device (iPhone Xs iOS 13.1) and it works as expected for _top and _blank navigation. 

Noticed that we forgot to handle contextmenu navigations however e.g. right click -> open in new tab, which is [already a gap](https://github.com/ampproject/amphtml/blob/f0e705901fc751c1e55ffb9975105813c7170544/src/service/navigation.js#L413) for other navigation features. 

/to @zhouyx